### PR TITLE
Make `cargo fix` also remove unneeded braces when removing all but one nested import

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2537,9 +2537,18 @@ pub enum UseTreeKind {
     /// `use prefix` or `use prefix as rename`
     Simple(Option<Ident>),
     /// `use prefix::{...}`
-    Nested(ThinVec<(UseTree, NodeId)>),
+    Nested(UseTreeNested),
     /// `use prefix::*`
     Glob,
+}
+
+/// The `use` trees inside of a nested import, including the surrounding braces. The span of the
+/// braces are used to improve diagnostic messages that suggest removing all but one import from a
+/// group.
+#[derive(Clone, Encodable, Decodable, Debug)]
+pub struct UseTreeNested {
+    pub items: ThinVec<(UseTree, NodeId)>,
+    pub span: Span,
 }
 
 /// A tree of paths sharing common prefixes.

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2537,18 +2537,9 @@ pub enum UseTreeKind {
     /// `use prefix` or `use prefix as rename`
     Simple(Option<Ident>),
     /// `use prefix::{...}`
-    Nested(UseTreeNested),
+    Nested(ThinVec<(UseTree, NodeId)>, Span),
     /// `use prefix::*`
     Glob,
-}
-
-/// The `use` trees inside of a nested import, including the surrounding braces. The span of the
-/// braces are used to improve diagnostic messages that suggest removing all but one import from a
-/// group.
-#[derive(Clone, Encodable, Decodable, Debug)]
-pub struct UseTreeNested {
-    pub items: ThinVec<(UseTree, NodeId)>,
-    pub span: Span,
 }
 
 /// A tree of paths sharing common prefixes.

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -431,8 +431,8 @@ pub fn noop_visit_use_tree<T: MutVisitor>(use_tree: &mut UseTree, vis: &mut T) {
     vis.visit_path(prefix);
     match kind {
         UseTreeKind::Simple(rename) => visit_opt(rename, |rename| vis.visit_ident(rename)),
-        UseTreeKind::Nested(items) => {
-            for (tree, id) in items {
+        UseTreeKind::Nested(nested) => {
+            for (tree, id) in nested.items.iter_mut() {
                 vis.visit_use_tree(tree);
                 vis.visit_id(id);
             }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -431,8 +431,8 @@ pub fn noop_visit_use_tree<T: MutVisitor>(use_tree: &mut UseTree, vis: &mut T) {
     vis.visit_path(prefix);
     match kind {
         UseTreeKind::Simple(rename) => visit_opt(rename, |rename| vis.visit_ident(rename)),
-        UseTreeKind::Nested(nested) => {
-            for (tree, id) in nested.items.iter_mut() {
+        UseTreeKind::Nested(items, _) => {
+            for (tree, id) in items {
                 vis.visit_use_tree(tree);
                 vis.visit_id(id);
             }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -450,8 +450,8 @@ pub fn walk_use_tree<'a, V: Visitor<'a>>(visitor: &mut V, use_tree: &'a UseTree,
             }
         }
         UseTreeKind::Glob => {}
-        UseTreeKind::Nested(nested) => {
-            for &(ref nested_tree, nested_id) in nested.items.iter() {
+        UseTreeKind::Nested(use_trees, _) => {
+            for &(ref nested_tree, nested_id) in use_trees {
                 visitor.visit_use_tree(nested_tree, nested_id, true);
             }
         }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -450,8 +450,8 @@ pub fn walk_use_tree<'a, V: Visitor<'a>>(visitor: &mut V, use_tree: &'a UseTree,
             }
         }
         UseTreeKind::Glob => {}
-        UseTreeKind::Nested(use_trees) => {
-            for &(ref nested_tree, nested_id) in use_trees {
+        UseTreeKind::Nested(nested) => {
+            for &(ref nested_tree, nested_id) in nested.items.iter() {
                 visitor.visit_use_tree(nested_tree, nested_id, true);
             }
         }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -180,8 +180,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     fn lower_item_id_use_tree(&mut self, tree: &UseTree, vec: &mut SmallVec<[hir::ItemId; 1]>) {
         match &tree.kind {
-            UseTreeKind::Nested(nested_vec) => {
-                for &(ref nested, id) in nested_vec {
+            UseTreeKind::Nested(nested) => {
+                for &(ref nested, id) in nested.items.iter() {
                     vec.push(hir::ItemId {
                         owner_id: hir::OwnerId { def_id: self.local_def_id(id) },
                     });
@@ -503,7 +503,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let path = self.lower_use_path(res, &path, ParamMode::Explicit);
                 hir::ItemKind::Use(path, hir::UseKind::Glob)
             }
-            UseTreeKind::Nested(ref trees) => {
+            UseTreeKind::Nested(ref nested) => {
                 // Nested imports are desugared into simple imports.
                 // So, if we start with
                 //
@@ -531,7 +531,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let prefix = Path { segments, span: prefix.span.to(path.span), tokens: None };
 
                 // Add all the nested `PathListItem`s to the HIR.
-                for &(ref use_tree, id) in trees {
+                for &(ref use_tree, id) in nested.items.iter() {
                     let new_hir_id = self.local_def_id(id);
 
                     let mut prefix = prefix.clone();

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -180,8 +180,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     fn lower_item_id_use_tree(&mut self, tree: &UseTree, vec: &mut SmallVec<[hir::ItemId; 1]>) {
         match &tree.kind {
-            UseTreeKind::Nested(nested) => {
-                for &(ref nested, id) in nested.items.iter() {
+            UseTreeKind::Nested(nested_vec, _) => {
+                for &(ref nested, id) in nested_vec {
                     vec.push(hir::ItemId {
                         owner_id: hir::OwnerId { def_id: self.local_def_id(id) },
                     });
@@ -503,7 +503,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let path = self.lower_use_path(res, &path, ParamMode::Explicit);
                 hir::ItemKind::Use(path, hir::UseKind::Glob)
             }
-            UseTreeKind::Nested(ref nested) => {
+            UseTreeKind::Nested(ref trees, _) => {
                 // Nested imports are desugared into simple imports.
                 // So, if we start with
                 //
@@ -531,7 +531,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let prefix = Path { segments, span: prefix.span.to(path.span), tokens: None };
 
                 // Add all the nested `PathListItem`s to the HIR.
-                for &(ref use_tree, id) in nested.items.iter() {
+                for &(ref use_tree, id) in trees {
                     let new_hir_id = self.local_def_id(id);
 
                     let mut prefix = prefix.clone();

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -675,21 +675,21 @@ impl<'a> State<'a> {
                 }
                 self.word("*");
             }
-            ast::UseTreeKind::Nested(items) => {
+            ast::UseTreeKind::Nested(nested) => {
                 if !tree.prefix.segments.is_empty() {
                     self.print_path(&tree.prefix, false, 0);
                     self.word("::");
                 }
-                if items.is_empty() {
+                if nested.items.is_empty() {
                     self.word("{}");
-                } else if items.len() == 1 {
-                    self.print_use_tree(&items[0].0);
+                } else if nested.items.len() == 1 {
+                    self.print_use_tree(&nested.items[0].0);
                 } else {
                     self.cbox(INDENT_UNIT);
                     self.word("{");
                     self.zerobreak();
                     self.ibox(0);
-                    for use_tree in items.iter().delimited() {
+                    for use_tree in nested.items.iter().delimited() {
                         self.print_use_tree(&use_tree.0);
                         if !use_tree.is_last {
                             self.word(",");

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -675,25 +675,25 @@ impl<'a> State<'a> {
                 }
                 self.word("*");
             }
-            ast::UseTreeKind::Nested(nested) => {
+            ast::UseTreeKind::Nested(items, _) => {
                 if !tree.prefix.segments.is_empty() {
                     self.print_path(&tree.prefix, false, 0);
                     self.word("::");
                 }
-                if nested.items.is_empty() {
+                if items.is_empty() {
                     self.word("{}");
-                } else if nested.items.len() == 1 {
-                    self.print_use_tree(&nested.items[0].0);
+                } else if items.len() == 1 {
+                    self.print_use_tree(&items[0].0);
                 } else {
                     self.cbox(INDENT_UNIT);
                     self.word("{");
                     self.zerobreak();
                     self.ibox(0);
-                    for use_tree in nested.items.iter().delimited() {
+                    for use_tree in items.iter().delimited() {
                         self.print_use_tree(&use_tree.0);
                         if !use_tree.is_last {
                             self.word(",");
-                            if let ast::UseTreeKind::Nested(_) = use_tree.0.kind {
+                            if let ast::UseTreeKind::Nested(..) = use_tree.0.kind {
                                 self.hardbreak();
                             } else {
                                 self.space();

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -3,7 +3,8 @@ use rustc_ast::{
     token,
     tokenstream::{DelimSpan, TokenStream, TokenTree},
     BinOpKind, BorrowKind, DelimArgs, Expr, ExprKind, ItemKind, MacCall, MacDelimiter, MethodCall,
-    Mutability, Path, PathSegment, Stmt, StructRest, UnOp, UseTree, UseTreeKind, DUMMY_NODE_ID,
+    Mutability, Path, PathSegment, Stmt, StructRest, UnOp, UseTree, UseTreeKind, UseTreeNested,
+    DUMMY_NODE_ID,
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashSet;
@@ -120,10 +121,13 @@ impl<'cx, 'a> Context<'cx, 'a> {
                 thin_vec![self.cx.attr_nested_word(sym::allow, sym::unused_imports, self.span)],
                 ItemKind::Use(UseTree {
                     prefix: self.cx.path(self.span, self.cx.std_path(&[sym::asserting])),
-                    kind: UseTreeKind::Nested(thin_vec![
-                        nested_tree(self, sym::TryCaptureGeneric),
-                        nested_tree(self, sym::TryCapturePrintable),
-                    ]),
+                    kind: UseTreeKind::Nested(UseTreeNested {
+                        items: thin_vec![
+                            nested_tree(self, sym::TryCaptureGeneric),
+                            nested_tree(self, sym::TryCapturePrintable),
+                        ],
+                        span: self.span, // TODO
+                    }),
                     span: self.span,
                 }),
             ),

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -3,8 +3,7 @@ use rustc_ast::{
     token,
     tokenstream::{DelimSpan, TokenStream, TokenTree},
     BinOpKind, BorrowKind, DelimArgs, Expr, ExprKind, ItemKind, MacCall, MacDelimiter, MethodCall,
-    Mutability, Path, PathSegment, Stmt, StructRest, UnOp, UseTree, UseTreeKind, UseTreeNested,
-    DUMMY_NODE_ID,
+    Mutability, Path, PathSegment, Stmt, StructRest, UnOp, UseTree, UseTreeKind, DUMMY_NODE_ID,
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashSet;
@@ -121,13 +120,13 @@ impl<'cx, 'a> Context<'cx, 'a> {
                 thin_vec![self.cx.attr_nested_word(sym::allow, sym::unused_imports, self.span)],
                 ItemKind::Use(UseTree {
                     prefix: self.cx.path(self.span, self.cx.std_path(&[sym::asserting])),
-                    kind: UseTreeKind::Nested(UseTreeNested {
-                        items: thin_vec![
+                    kind: UseTreeKind::Nested(
+                        thin_vec![
                             nested_tree(self, sym::TryCaptureGeneric),
                             nested_tree(self, sym::TryCapturePrintable),
                         ],
-                        span: self.span,
-                    }),
+                        self.span,
+                    ),
                     span: self.span,
                 }),
             ),

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -126,7 +126,7 @@ impl<'cx, 'a> Context<'cx, 'a> {
                             nested_tree(self, sym::TryCaptureGeneric),
                             nested_tree(self, sym::TryCapturePrintable),
                         ],
-                        span: self.span, // TODO
+                        span: self.span,
                     }),
                     span: self.span,
                 }),

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1302,21 +1302,21 @@ declare_lint_pass!(UnusedImportBraces => [UNUSED_IMPORT_BRACES]);
 
 impl UnusedImportBraces {
     fn check_use_tree(&self, cx: &EarlyContext<'_>, use_tree: &ast::UseTree, item: &ast::Item) {
-        if let ast::UseTreeKind::Nested(ref items) = use_tree.kind {
+        if let ast::UseTreeKind::Nested(ref nested) = use_tree.kind {
             // Recursively check nested UseTrees
-            for (tree, _) in items {
+            for (tree, _) in nested.items.iter() {
                 self.check_use_tree(cx, tree, item);
             }
 
             // Trigger the lint only if there is one nested item
-            if items.len() != 1 {
+            if nested.items.len() != 1 {
                 return;
             }
 
             // Trigger the lint if the nested item is a non-self single item
-            let node_name = match items[0].0.kind {
+            let node_name = match nested.items[0].0.kind {
                 ast::UseTreeKind::Simple(rename) => {
-                    let orig_ident = items[0].0.prefix.segments.last().unwrap().ident;
+                    let orig_ident = nested.items[0].0.prefix.segments.last().unwrap().ident;
                     if orig_ident.name == kw::SelfLower {
                         return;
                     }

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1302,28 +1302,28 @@ declare_lint_pass!(UnusedImportBraces => [UNUSED_IMPORT_BRACES]);
 
 impl UnusedImportBraces {
     fn check_use_tree(&self, cx: &EarlyContext<'_>, use_tree: &ast::UseTree, item: &ast::Item) {
-        if let ast::UseTreeKind::Nested(ref nested) = use_tree.kind {
+        if let ast::UseTreeKind::Nested(ref items, _) = use_tree.kind {
             // Recursively check nested UseTrees
-            for (tree, _) in nested.items.iter() {
+            for (tree, _) in items {
                 self.check_use_tree(cx, tree, item);
             }
 
             // Trigger the lint only if there is one nested item
-            if nested.items.len() != 1 {
+            if items.len() != 1 {
                 return;
             }
 
             // Trigger the lint if the nested item is a non-self single item
-            let node_name = match nested.items[0].0.kind {
+            let node_name = match items[0].0.kind {
                 ast::UseTreeKind::Simple(rename) => {
-                    let orig_ident = nested.items[0].0.prefix.segments.last().unwrap().ident;
+                    let orig_ident = items[0].0.prefix.segments.last().unwrap().ident;
                     if orig_ident.name == kw::SelfLower {
                         return;
                     }
                     rename.unwrap_or(orig_ident).name
                 }
                 ast::UseTreeKind::Glob => Symbol::intern("*"),
-                ast::UseTreeKind::Nested(_) => return,
+                ast::UseTreeKind::Nested(..) => return,
             };
 
             cx.emit_spanned_lint(

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -985,12 +985,14 @@ impl<'a> Parser<'a> {
     /// ```text
     /// USE_TREE_LIST = Ø | (USE_TREE `,`)* USE_TREE [`,`]
     /// ```
-    fn parse_use_tree_list(&mut self) -> PResult<'a, ThinVec<(UseTree, ast::NodeId)>> {
-        self.parse_delim_comma_seq(Delimiter::Brace, |p| {
-            p.recover_diff_marker();
-            Ok((p.parse_use_tree()?, DUMMY_NODE_ID))
+    fn parse_use_tree_list(&mut self) -> PResult<'a, ast::UseTreeNested> {
+        Ok(ast::UseTreeNested {
+            items: self.parse_delim_comma_seq(Delimiter::Brace, |p| {
+                p.recover_diff_marker();
+                Ok((p.parse_use_tree()?, DUMMY_NODE_ID))
+            }).map(|(r, _)| r)?,
+            span: self.prev_token.span, // TODO
         })
-        .map(|(r, _)| r)
     }
 
     fn parse_rename(&mut self) -> PResult<'a, Option<Ident>> {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -988,14 +988,11 @@ impl<'a> Parser<'a> {
     /// ```
     fn parse_use_tree_list(&mut self) -> PResult<'a, (ThinVec<(UseTree, ast::NodeId)>, Span)> {
         let open_brace_span = self.token.span;
-        Ok((
-            self.parse_delim_comma_seq(Delimiter::Brace, |p| {
-                p.recover_diff_marker();
-                Ok((p.parse_use_tree()?, DUMMY_NODE_ID))
-            })
-            .map(|(r, _)| r)?,
-            open_brace_span.to(self.prev_token.span),
-        ))
+        self.parse_delim_comma_seq(Delimiter::Brace, |p| {
+            p.recover_diff_marker();
+            Ok((p.parse_use_tree()?, DUMMY_NODE_ID))
+        })
+        .map(|(r, _)| (r, open_brace_span.to(self.prev_token.span)))
     }
 
     fn parse_rename(&mut self) -> PResult<'a, Option<Ident>> {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -986,12 +986,15 @@ impl<'a> Parser<'a> {
     /// USE_TREE_LIST = Ø | (USE_TREE `,`)* USE_TREE [`,`]
     /// ```
     fn parse_use_tree_list(&mut self) -> PResult<'a, ast::UseTreeNested> {
+        let open_brace_span = self.token.span;
         Ok(ast::UseTreeNested {
-            items: self.parse_delim_comma_seq(Delimiter::Brace, |p| {
-                p.recover_diff_marker();
-                Ok((p.parse_use_tree()?, DUMMY_NODE_ID))
-            }).map(|(r, _)| r)?,
-            span: self.prev_token.span, // TODO
+            items: self
+                .parse_delim_comma_seq(Delimiter::Brace, |p| {
+                    p.recover_diff_marker();
+                    Ok((p.parse_use_tree()?, DUMMY_NODE_ID))
+                })
+                .map(|(r, _)| r)?,
+            span: open_brace_span.to(self.prev_token.span),
         })
     }
 

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -566,9 +566,10 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
                 self.r.visibilities.insert(self.r.local_def_id(id), vis);
                 self.add_import(prefix, kind, use_tree.span, item, root_span, item.id, vis);
             }
-            ast::UseTreeKind::Nested(ref items) => {
+            ast::UseTreeKind::Nested(ref nested) => {
                 // Ensure there is at most one `self` in the list
-                let self_spans = items
+                let self_spans = nested
+                    .items
                     .iter()
                     .filter_map(|(use_tree, _)| {
                         if let ast::UseTreeKind::Simple(..) = use_tree.kind {
@@ -593,7 +594,7 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
                     e.emit();
                 }
 
-                for &(ref tree, id) in items {
+                for &(ref tree, id) in nested.items.iter() {
                     self.build_reduced_graph_for_use_tree(
                         // This particular use tree
                         tree, id, &prefix, true, // The whole `use` item
@@ -604,7 +605,7 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
                 // Empty groups `a::b::{}` are turned into synthetic `self` imports
                 // `a::b::c::{self as _}`, so that their prefixes are correctly
                 // resolved and checked for privacy/stability/etc.
-                if items.is_empty() && !empty_for_self(&prefix) {
+                if nested.items.is_empty() && !empty_for_self(&prefix) {
                     let new_span = prefix[prefix.len() - 1].ident.span;
                     let tree = ast::UseTree {
                         prefix: ast::Path::from_ident(Ident::new(kw::SelfLower, new_span)),

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2220,8 +2220,8 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                     None => {}
                 }
             }
-        } else if let UseTreeKind::Nested(use_trees) = &use_tree.kind {
-            for (use_tree, _) in use_trees {
+        } else if let UseTreeKind::Nested(nested) = &use_tree.kind {
+            for (use_tree, _) in nested.items.iter() {
                 self.future_proof_import(use_tree);
             }
         }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2220,8 +2220,8 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                     None => {}
                 }
             }
-        } else if let UseTreeKind::Nested(nested) = &use_tree.kind {
-            for (use_tree, _) in nested.items.iter() {
+        } else if let UseTreeKind::Nested(use_trees, _) = &use_tree.kind {
+            for (use_tree, _) in use_trees {
                 self.future_proof_import(use_tree);
             }
         }

--- a/src/tools/clippy/clippy_lints/src/single_component_path_imports.rs
+++ b/src/tools/clippy/clippy_lints/src/single_component_path_imports.rs
@@ -198,8 +198,8 @@ impl SingleComponentPathImports {
 
                 if segments.is_empty() {
                     // keep track of `use {some_module, some_other_module};` usages
-                    if let UseTreeKind::Nested(trees) = &use_tree.kind {
-                        for tree in trees {
+                    if let UseTreeKind::Nested(nested) = &use_tree.kind {
+                        for tree in nested.items.iter() {
                             let segments = &tree.0.prefix.segments;
                             if segments.len() == 1 {
                                 if let UseTreeKind::Simple(None) = tree.0.kind {
@@ -226,8 +226,8 @@ impl SingleComponentPathImports {
                         }
 
                         // nested case such as `use self::{module1::Struct1, module2::Struct2}`
-                        if let UseTreeKind::Nested(trees) = &use_tree.kind {
-                            for tree in trees {
+                        if let UseTreeKind::Nested(nested) = &use_tree.kind {
+                            for tree in nested.items.iter() {
                                 let segments = &tree.0.prefix.segments;
                                 if !segments.is_empty() {
                                     imports_reused_with_self.push(segments[0].ident.name);

--- a/src/tools/clippy/clippy_lints/src/single_component_path_imports.rs
+++ b/src/tools/clippy/clippy_lints/src/single_component_path_imports.rs
@@ -198,8 +198,8 @@ impl SingleComponentPathImports {
 
                 if segments.is_empty() {
                     // keep track of `use {some_module, some_other_module};` usages
-                    if let UseTreeKind::Nested(nested) = &use_tree.kind {
-                        for tree in nested.items.iter() {
+                    if let UseTreeKind::Nested(trees, _) = &use_tree.kind {
+                        for tree in trees {
                             let segments = &tree.0.prefix.segments;
                             if segments.len() == 1 {
                                 if let UseTreeKind::Simple(None) = tree.0.kind {
@@ -226,8 +226,8 @@ impl SingleComponentPathImports {
                         }
 
                         // nested case such as `use self::{module1::Struct1, module2::Struct2}`
-                        if let UseTreeKind::Nested(nested) = &use_tree.kind {
-                            for tree in nested.items.iter() {
+                        if let UseTreeKind::Nested(trees, _) = &use_tree.kind {
+                            for tree in trees {
                                 let segments = &tree.0.prefix.segments;
                                 if !segments.is_empty() {
                                     imports_reused_with_self.push(segments[0].ident.name);

--- a/src/tools/clippy/clippy_lints/src/unnecessary_self_imports.rs
+++ b/src/tools/clippy/clippy_lints/src/unnecessary_self_imports.rs
@@ -38,8 +38,8 @@ impl EarlyLintPass for UnnecessarySelfImports {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         if_chain! {
             if let ItemKind::Use(use_tree) = &item.kind;
-            if let UseTreeKind::Nested(nodes) = &use_tree.kind;
-            if let [(self_tree, _)] = &**nodes;
+            if let UseTreeKind::Nested(nested) = &use_tree.kind;
+            if let [(self_tree, _)] = &*nested.items;
             if let [self_seg] = &*self_tree.prefix.segments;
             if self_seg.ident.name == kw::SelfLower;
             if let Some(last_segment) = use_tree.prefix.segments.last();

--- a/src/tools/clippy/clippy_lints/src/unnecessary_self_imports.rs
+++ b/src/tools/clippy/clippy_lints/src/unnecessary_self_imports.rs
@@ -38,8 +38,8 @@ impl EarlyLintPass for UnnecessarySelfImports {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         if_chain! {
             if let ItemKind::Use(use_tree) = &item.kind;
-            if let UseTreeKind::Nested(nested) = &use_tree.kind;
-            if let [(self_tree, _)] = &*nested.items;
+            if let UseTreeKind::Nested(nodes, _) = &use_tree.kind;
+            if let [(self_tree, _)] = &**nodes;
             if let [self_seg] = &*self_tree.prefix.segments;
             if self_seg.ident.name == kw::SelfLower;
             if let Some(last_segment) = use_tree.prefix.segments.last();

--- a/src/tools/clippy/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/src/tools/clippy/clippy_lints/src/unsafe_removed_from_name.rs
@@ -49,8 +49,8 @@ fn check_use_tree(use_tree: &UseTree, cx: &EarlyContext<'_>, span: Span) {
             unsafe_to_safe_check(old_name, new_name, cx, span);
         },
         UseTreeKind::Simple(None) | UseTreeKind::Glob => {},
-        UseTreeKind::Nested(ref nested_use_tree) => {
-            for (use_tree, _) in nested_use_tree {
+        UseTreeKind::Nested(ref nested) => {
+            for (use_tree, _) in nested.items.iter() {
                 check_use_tree(use_tree, cx, span);
             }
         },

--- a/src/tools/clippy/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/src/tools/clippy/clippy_lints/src/unsafe_removed_from_name.rs
@@ -49,8 +49,8 @@ fn check_use_tree(use_tree: &UseTree, cx: &EarlyContext<'_>, span: Span) {
             unsafe_to_safe_check(old_name, new_name, cx, span);
         },
         UseTreeKind::Simple(None) | UseTreeKind::Glob => {},
-        UseTreeKind::Nested(ref nested) => {
-            for (use_tree, _) in nested.items.iter() {
+        UseTreeKind::Nested(ref nested_use_tree, _) => {
+            for (use_tree, _) in nested_use_tree {
                 check_use_tree(use_tree, cx, span);
             }
         },

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -601,7 +601,7 @@ pub fn eq_use_tree_kind(l: &UseTreeKind, r: &UseTreeKind) -> bool {
     match (l, r) {
         (Glob, Glob) => true,
         (Simple(l), Simple(r)) => both(l, r, |l, r| eq_id(*l, *r)),
-        (Nested(l), Nested(r)) => over(&l.items, &r.items, |(l, _), (r, _)| eq_use_tree(l, r)),
+        (Nested(l, _), Nested(r, _)) => over(l, r, |(l, _), (r, _)| eq_use_tree(l, r)),
         _ => false,
     }
 }

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -601,7 +601,7 @@ pub fn eq_use_tree_kind(l: &UseTreeKind, r: &UseTreeKind) -> bool {
     match (l, r) {
         (Glob, Glob) => true,
         (Simple(l), Simple(r)) => both(l, r, |l, r| eq_id(*l, *r)),
-        (Nested(l), Nested(r)) => over(l, r, |(l, _), (r, _)| eq_use_tree(l, r)),
+        (Nested(l), Nested(r)) => over(&l.items, &r.items, |(l, _), (r, _)| eq_use_tree(l, r)),
         _ => false,
     }
 }

--- a/src/tools/rustfmt/src/imports.rs
+++ b/src/tools/rustfmt/src/imports.rs
@@ -458,12 +458,12 @@ impl UseTree {
                     version,
                 });
             }
-            UseTreeKind::Nested(ref list) => {
+            UseTreeKind::Nested(ref nested) => {
                 // Extract comments between nested use items.
                 // This needs to be done before sorting use items.
                 let items = itemize_list(
                     context.snippet_provider,
-                    list.iter().map(|(tree, _)| tree),
+                    nested.items.iter().map(|(tree, _)| tree),
                     "}",
                     ",",
                     |tree| tree.span.lo(),
@@ -481,7 +481,8 @@ impl UseTree {
                     result.path.push(UseSegment { kind, version });
                 }
                 let kind = UseSegmentKind::List(
-                    list.iter()
+                    nested.items
+                        .iter()
                         .zip(items)
                         .map(|(t, list_item)| {
                             Self::from_ast(context, &t.0, Some(list_item), None, None, None)

--- a/src/tools/rustfmt/src/imports.rs
+++ b/src/tools/rustfmt/src/imports.rs
@@ -458,12 +458,12 @@ impl UseTree {
                     version,
                 });
             }
-            UseTreeKind::Nested(ref nested) => {
+            UseTreeKind::Nested(ref list, _) => {
                 // Extract comments between nested use items.
                 // This needs to be done before sorting use items.
                 let items = itemize_list(
                     context.snippet_provider,
-                    nested.items.iter().map(|(tree, _)| tree),
+                    list.iter().map(|(tree, _)| tree),
                     "}",
                     ",",
                     |tree| tree.span.lo(),
@@ -481,8 +481,7 @@ impl UseTree {
                     result.path.push(UseSegment { kind, version });
                 }
                 let kind = UseSegmentKind::List(
-                    nested.items
-                        .iter()
+                    list.iter()
                         .zip(items)
                         .map(|(t, list_item)| {
                             Self::from_ast(context, &t.0, Some(list_item), None, None, None)

--- a/tests/ui/imports/unused-partial-nested-import.fixed
+++ b/tests/ui/imports/unused-partial-nested-import.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+// check-pass
+
+// Check that rustfix removes the braces around partial nested imports, if possible.
+
+#![warn(unused_imports)]
+
+use std::{collections::HashMap, io::Read}; //~ WARN unused imports: `HashSet`, `Write`, `self`
+use std::collections::BTreeMap; //~ WARN unused import: `BTreeSet`
+
+fn main() {
+    let _: HashMap<(), ()> = HashMap::new();
+    let _: BTreeMap<(), ()> = BTreeMap::new();
+    let _ = (&*vec![1, 2, 3]).read(&mut [0, 0, 0]);
+}

--- a/tests/ui/imports/unused-partial-nested-import.rs
+++ b/tests/ui/imports/unused-partial-nested-import.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+// check-pass
+
+// Check that rustfix removes the braces around partial nested imports, if possible.
+
+#![warn(unused_imports)]
+
+use std::{collections::{HashMap, HashSet}, io::{Write, self, Read}}; //~ WARN unused imports: `HashSet`, `Write`, `self`
+use std::collections::{BTreeMap, BTreeSet}; //~ WARN unused import: `BTreeSet`
+
+fn main() {
+    let _: HashMap<(), ()> = HashMap::new();
+    let _: BTreeMap<(), ()> = BTreeMap::new();
+    let _ = (&*vec![1, 2, 3]).read(&mut [0, 0, 0]);
+}

--- a/tests/ui/imports/unused-partial-nested-import.stderr
+++ b/tests/ui/imports/unused-partial-nested-import.stderr
@@ -1,0 +1,20 @@
+warning: unused imports: `HashSet`, `Write`, `self`
+  --> $DIR/unused-partial-nested-import.rs:8:34
+   |
+LL | use std::{collections::{HashMap, HashSet}, io::{Write, self, Read}};
+   |                                  ^^^^^^^        ^^^^^  ^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-partial-nested-import.rs:6:9
+   |
+LL | #![warn(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+warning: unused import: `BTreeSet`
+  --> $DIR/unused-partial-nested-import.rs:9:34
+   |
+LL | use std::collections::{BTreeMap, BTreeSet};
+   |                                  ^^^^^^^^
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
In the current / nightly version of `rustc`, `cargo fix` will not remove braces in nested imports, if all but one nested import is removed. For example, running `cargo fix` (rustc 1.71) on:

```rs
use std::sync::{mpsc, Arc};
use std::thread::{self};
use std::time::Duration;
use std::collections::{
    hash_map::{Drain, HashMap, IntoIter},
    HashSet,
};

use std::cell::{RefCell, RefMut};

fn main() {
    let _x = Arc::new(5);
    let _y: HashMap<(), ()> = HashMap::new();
    let _z = RefCell::new(());
}
```

Will result in:

```rs
use std::sync::{Arc};


use std::collections::{
    hash_map::{HashMap},
};

use std::cell::{RefCell};

fn main() {
    let _x = Arc::new(5);
    let _y: HashMap<(), ()> = HashMap::new();
    let _z = RefCell::new(());
}
```

Which is not ideal. This PR modifies the output of `rustc` in these scenarios to also include the braces of the nested imports where applicable. The result of `cargo fix` with these changes is:

```rs
use std::sync::Arc;


use std::collections::{
    hash_map::HashMap,
};

use std::cell::RefCell;

fn main() {
    let _x = Arc::new(5);
    let _y: HashMap<(), ()> = HashMap::new();
    let _z = RefCell::new(());
}
```

~~I believe I need to write tests for this, but I'm not exactly sure where to put them~~