### PR TITLE
Emit an error when return-type-notation is used with type/const params

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -195,6 +195,13 @@ hir_analysis_return_type_notation_conflicting_bound =
 hir_analysis_return_type_notation_equality_bound =
     return type notation is not allowed to use type equality
 
+hir_analysis_return_type_notation_illegal_param_const =
+    return type notation is not allowed for functions that have const parameters
+    .label = const parameter declared here
+hir_analysis_return_type_notation_illegal_param_type =
+    return type notation is not allowed for functions that have type parameters
+    .label = type parameter declared here
+
 hir_analysis_return_type_notation_missing_method =
     cannot find associated function `{$assoc_name}` for `{$ty_name}`
 

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -857,3 +857,21 @@ pub(crate) enum DropImplPolarity {
         span: Span,
     },
 }
+
+#[derive(Diagnostic)]
+pub(crate) enum ReturnTypeNotationIllegalParam {
+    #[diag(hir_analysis_return_type_notation_illegal_param_type)]
+    Type {
+        #[primary_span]
+        span: Span,
+        #[label]
+        param_span: Span,
+    },
+    #[diag(hir_analysis_return_type_notation_illegal_param_const)]
+    Const {
+        #[primary_span]
+        span: Span,
+        #[label]
+        param_span: Span,
+    },
+}

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -9,7 +9,6 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
-use rustc_hir_analysis::astconv::InferCtxtExt as _;
 use rustc_hir_analysis::autoderef::{self, Autoderef};
 use rustc_infer::infer::canonical::OriginalQueryValues;
 use rustc_infer::infer::canonical::{Canonical, QueryResponse};
@@ -954,7 +953,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         trait_def_id: DefId,
     ) {
         debug!("assemble_extension_candidates_for_trait(trait_def_id={:?})", trait_def_id);
-        let trait_substs = self.fresh_item_substs(trait_def_id);
+        let trait_substs = self.fresh_substs_for_item(self.span, trait_def_id);
         let trait_ref = ty::TraitRef::new(self.tcx, trait_def_id, trait_substs);
 
         if self.tcx.is_trait_alias(trait_def_id) {
@@ -1899,7 +1898,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         &self,
         impl_def_id: DefId,
     ) -> (ty::EarlyBinder<Ty<'tcx>>, SubstsRef<'tcx>) {
-        (self.tcx.type_of(impl_def_id), self.fresh_item_substs(impl_def_id))
+        (self.tcx.type_of(impl_def_id), self.fresh_substs_for_item(self.span, impl_def_id))
     }
 
     /// Replaces late-bound-regions bound by `value` with `'static` using

--- a/compiler/rustc_infer/src/infer/type_variable.rs
+++ b/compiler/rustc_infer/src/infer/type_variable.rs
@@ -129,7 +129,6 @@ pub enum TypeVariableOriginKind {
     /// (before it has been determined).
     // FIXME(eddyb) distinguish upvar inference variables from the rest.
     ClosureSynthetic,
-    SubstitutionPlaceholder,
     AutoDeref,
     AdjustmentType,
 

--- a/compiler/rustc_middle/src/infer/unify_key.rs
+++ b/compiler/rustc_middle/src/infer/unify_key.rs
@@ -116,7 +116,6 @@ pub enum ConstVariableOriginKind {
     MiscVariable,
     ConstInference,
     ConstParameterDefinition(Symbol, DefId),
-    SubstitutionPlaceholder,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.rs
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.rs
@@ -1,0 +1,20 @@
+// edition: 2021
+
+#![feature(async_fn_in_trait, return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Foo {
+    async fn bar<T>() {}
+
+    async fn baz<const N: usize>() {}
+}
+
+fn test<T>()
+where
+    T: Foo<bar(): Send, baz(): Send>,
+    //~^ ERROR return type notation is not allowed for functions that have const parameters
+    //~| ERROR return type notation is not allowed for functions that have type parameters
+{
+}
+
+fn main() {}

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.stderr
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.stderr
@@ -1,0 +1,29 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/ty-or-ct-params.rs:3:31
+   |
+LL | #![feature(async_fn_in_trait, return_type_notation)]
+   |                               ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation is not allowed for functions that have type parameters
+  --> $DIR/ty-or-ct-params.rs:14:12
+   |
+LL |     async fn bar<T>() {}
+   |                  - type parameter declared here
+...
+LL |     T: Foo<bar(): Send, baz(): Send>,
+   |            ^^^^^^^^^^^
+
+error: return type notation is not allowed for functions that have const parameters
+  --> $DIR/ty-or-ct-params.rs:14:25
+   |
+LL |     async fn baz<const N: usize>() {}
+   |                  -------------- const parameter declared here
+...
+LL |     T: Foo<bar(): Send, baz(): Send>,
+   |                         ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+


### PR DESCRIPTION
These are not intended to be supported initially, even though the compiler supports them internally...