### PR TITLE
Fix problems with backtraces in two ui tests.

### DIFF
--- a/tests/ui/impl-trait/issues/issue-86800.rs
+++ b/tests/ui/impl-trait/issues/issue-86800.rs
@@ -1,14 +1,12 @@
 #![feature(type_alias_impl_trait)]
 
 // edition:2021
-// unset-rustc-env:RUST_BACKTRACE
 // compile-flags:-Z treat-err-as-bug=1
-// error-pattern:stack backtrace:
+// error-pattern: aborting due to `-Z treat-err-as-bug=1`
 // failure-status:101
-// normalize-stderr-test "note: .*" -> ""
-// normalize-stderr-test "thread 'rustc' .*" -> ""
-// normalize-stderr-test " +[0-9]+:.*\n" -> ""
-// normalize-stderr-test " +at .*\n" -> ""
+// normalize-stderr-test ".*note: .*\n\n" -> ""
+// normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+// rustc-env:RUST_BACKTRACE=0
 
 use std::future::Future;
 

--- a/tests/ui/impl-trait/issues/issue-86800.stderr
+++ b/tests/ui/impl-trait/issues/issue-86800.stderr
@@ -1,24 +1,12 @@
 error: unconstrained opaque type
-  --> $DIR/issue-86800.rs:33:34
+  --> $DIR/issue-86800.rs:31:34
    |
 LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResult<O>>;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = 
-
-
-stack backtrace:
-
 error: the compiler unexpectedly panicked. this is a bug.
-
-
-
-
-
-
 
 query stack during panic:
 #0 [type_of] computing type of `TransactionFuture::{opaque#0}`
 #1 [check_mod_item_types] checking item types in top-level module
-#2 [analysis] running analysis passes on this crate
 end of query stack

--- a/tests/ui/panics/default-backtrace-ice.rs
+++ b/tests/ui/panics/default-backtrace-ice.rs
@@ -2,8 +2,20 @@
 // compile-flags:-Z treat-err-as-bug=1
 // error-pattern:stack backtrace:
 // failure-status:101
+// ignore-msvc
 // normalize-stderr-test "note: .*" -> ""
 // normalize-stderr-test "thread 'rustc' .*" -> ""
-// normalize-stderr-test "  .*\n" -> ""
+// normalize-stderr-test " +\d+:.*__rust_begin_short_backtrace.*" -> "(begin_short_backtrace)"
+// normalize-stderr-test " +\d+:.*__rust_end_short_backtrace.*" -> "(end_short_backtrace)"
+// normalize-stderr-test " +\d+:.*\n" -> ""
+// normalize-stderr-test " +at .*\n" -> ""
+//
+// This test makes sure that full backtraces are used for ICEs when
+// RUST_BACKTRACE is not set. It does this by checking for the presence of
+// `__rust_{begin,end}_short_backtrace` markers, which only appear in full
+// backtraces. The rest of the backtrace is filtered out.
+//
+// Ignored on msvc becaue the `__rust_{begin,end}_short_backtrace` symbols
+// aren't reliable.
 
 fn main() { missing_ident; }

--- a/tests/ui/panics/default-backtrace-ice.stderr
+++ b/tests/ui/panics/default-backtrace-ice.stderr
@@ -1,8 +1,13 @@
 error[E0425]: cannot find value `missing_ident` in this scope
+  --> $DIR/default-backtrace-ice.rs:21:13
+   |
 LL | fn main() { missing_ident; }
+   |             ^^^^^^^^^^^^^ not found in this scope
 
 
 stack backtrace:
+(end_short_backtrace)
+(begin_short_backtrace)
 
 error: the compiler unexpectedly panicked. this is a bug.
 


### PR DESCRIPTION
`default-backtrace-ice.rs` started started failing for me recently,
because on my Ubuntu 23.04 system there are 100 stack frames, and the
current stack filtering pattern doesn't match on a stack frame with a
three digit number.

`issue-86800.rs` can also be improved, backtrace-wise.

r? @Nilstrieb 