### PR TITLE
Do not recover when parsing stmt in cfg-eval.

### DIFF
--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -166,7 +166,9 @@ impl CfgEval<'_, '_> {
                     ))
                 },
                 Annotatable::Stmt(_) => |parser| {
-                    Ok(Annotatable::Stmt(P(parser.parse_stmt(ForceCollect::Yes)?.unwrap())))
+                    Ok(Annotatable::Stmt(P(parser
+                        .parse_stmt_without_recovery(false, ForceCollect::Yes)?
+                        .unwrap())))
                 },
                 Annotatable::Expr(_) => {
                     |parser| Ok(Annotatable::Expr(parser.parse_expr_force_collect()?))

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -37,7 +37,8 @@ impl<'a> Parser<'a> {
 
     /// If `force_collect` is [`ForceCollect::Yes`], forces collection of tokens regardless of whether
     /// or not we have attributes
-    pub(crate) fn parse_stmt_without_recovery(
+    // Public for `cfg_eval` macro expansion.
+    pub fn parse_stmt_without_recovery(
         &mut self,
         capture_semi: bool,
         force_collect: ForceCollect,

--- a/tests/ui/cfg/cfg-stmt-recovery.rs
+++ b/tests/ui/cfg/cfg-stmt-recovery.rs
@@ -1,0 +1,13 @@
+// Verify that we do not ICE when failing to parse a statement in `cfg_eval`.
+
+#![feature(cfg_eval)]
+#![feature(stmt_expr_attributes)]
+
+#[cfg_eval]
+fn main() {
+    #[cfg_eval]
+    let _ = #[cfg(FALSE)] 0;
+    //~^ ERROR removing an expression is not supported in this position
+    //~| ERROR expected expression, found `;`
+    //~| ERROR removing an expression is not supported in this position
+}

--- a/tests/ui/cfg/cfg-stmt-recovery.stderr
+++ b/tests/ui/cfg/cfg-stmt-recovery.stderr
@@ -1,0 +1,20 @@
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-stmt-recovery.rs:9:13
+   |
+LL |     let _ = #[cfg(FALSE)] 0;
+   |             ^^^^^^^^^^^^^
+
+error: expected expression, found `;`
+  --> $DIR/cfg-stmt-recovery.rs:9:28
+   |
+LL |     let _ = #[cfg(FALSE)] 0;
+   |                            ^ expected expression
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-stmt-recovery.rs:9:13
+   |
+LL |     let _ = #[cfg(FALSE)] 0;
+   |             ^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
`parse_stmt` does recovery on its own. When parsing the statement fails, we always get `Ok(None)` instead of an `Err` variant with the diagnostic that we can emit.

To avoid this behaviour, we need to opt-out of recovery for cfg_eval.

Fixes https://github.com/rust-lang/rust/issues/105228