### PR TITLE
Make sure the implementation of TcpStream::as_raw_fd is fully inlined

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -709,6 +709,7 @@ impl File {
 // `AsRawHandle`/`IntoRawHandle`/`FromRawHandle` on Windows.
 
 impl AsInner<fs_imp::File> for File {
+    #[inline]
     fn as_inner(&self) -> &fs_imp::File {
         &self.inner
     }
@@ -1087,12 +1088,14 @@ impl OpenOptions {
 }
 
 impl AsInner<fs_imp::OpenOptions> for OpenOptions {
+    #[inline]
     fn as_inner(&self) -> &fs_imp::OpenOptions {
         &self.0
     }
 }
 
 impl AsInnerMut<fs_imp::OpenOptions> for OpenOptions {
+    #[inline]
     fn as_inner_mut(&mut self) -> &mut fs_imp::OpenOptions {
         &mut self.0
     }
@@ -1352,6 +1355,7 @@ impl fmt::Debug for Metadata {
 }
 
 impl AsInner<fs_imp::FileAttr> for Metadata {
+    #[inline]
     fn as_inner(&self) -> &fs_imp::FileAttr {
         &self.0
     }
@@ -1604,6 +1608,7 @@ impl FileType {
 }
 
 impl AsInner<fs_imp::FileType> for FileType {
+    #[inline]
     fn as_inner(&self) -> &fs_imp::FileType {
         &self.0
     }
@@ -1616,6 +1621,7 @@ impl FromInner<fs_imp::FilePermissions> for Permissions {
 }
 
 impl AsInner<fs_imp::FilePermissions> for Permissions {
+    #[inline]
     fn as_inner(&self) -> &fs_imp::FilePermissions {
         &self.0
     }
@@ -1770,6 +1776,7 @@ impl fmt::Debug for DirEntry {
 }
 
 impl AsInner<fs_imp::DirEntry> for DirEntry {
+    #[inline]
     fn as_inner(&self) -> &fs_imp::DirEntry {
         &self.0
     }
@@ -2510,6 +2517,7 @@ impl DirBuilder {
 }
 
 impl AsInnerMut<fs_imp::DirBuilder> for DirBuilder {
+    #[inline]
     fn as_inner_mut(&mut self) -> &mut fs_imp::DirBuilder {
         &mut self.inner
     }

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -691,6 +691,7 @@ impl Write for &TcpStream {
 }
 
 impl AsInner<net_imp::TcpStream> for TcpStream {
+    #[inline]
     fn as_inner(&self) -> &net_imp::TcpStream {
         &self.0
     }
@@ -1033,6 +1034,7 @@ impl Iterator for IntoIncoming {
 impl FusedIterator for IntoIncoming {}
 
 impl AsInner<net_imp::TcpListener> for TcpListener {
+    #[inline]
     fn as_inner(&self) -> &net_imp::TcpListener {
         &self.0
     }

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -788,6 +788,7 @@ impl UdpSocket {
 // `AsRawSocket`/`IntoRawSocket`/`FromRawSocket` on Windows.
 
 impl AsInner<net_imp::UdpSocket> for UdpSocket {
+    #[inline]
     fn as_inner(&self) -> &net_imp::UdpSocket {
         &self.0
     }

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -71,6 +71,7 @@ impl IntoInner<FileDesc> for PidFd {
 }
 
 impl AsRawFd for PidFd {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().as_raw_fd()
     }

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -52,6 +52,7 @@ pub struct PidFd {
 }
 
 impl AsInner<FileDesc> for PidFd {
+    #[inline]
     fn as_inner(&self) -> &FileDesc {
         &self.inner
     }

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -211,6 +211,7 @@ pub struct Child {
 impl crate::sealed::Sealed for Child {}
 
 impl AsInner<imp::Process> for Child {
+    #[inline]
     fn as_inner(&self) -> &imp::Process {
         &self.handle
     }
@@ -304,6 +305,7 @@ impl Write for &ChildStdin {
 }
 
 impl AsInner<AnonPipe> for ChildStdin {
+    #[inline]
     fn as_inner(&self) -> &AnonPipe {
         &self.inner
     }
@@ -373,6 +375,7 @@ impl Read for ChildStdout {
 }
 
 impl AsInner<AnonPipe> for ChildStdout {
+    #[inline]
     fn as_inner(&self) -> &AnonPipe {
         &self.inner
     }
@@ -438,6 +441,7 @@ impl Read for ChildStderr {
 }
 
 impl AsInner<AnonPipe> for ChildStderr {
+    #[inline]
     fn as_inner(&self) -> &AnonPipe {
         &self.inner
     }
@@ -1107,12 +1111,14 @@ impl fmt::Debug for Command {
 }
 
 impl AsInner<imp::Command> for Command {
+    #[inline]
     fn as_inner(&self) -> &imp::Command {
         &self.inner
     }
 }
 
 impl AsInnerMut<imp::Command> for Command {
+    #[inline]
     fn as_inner_mut(&mut self) -> &mut imp::Command {
         &mut self.inner
     }
@@ -1605,6 +1611,7 @@ impl ExitStatus {
 }
 
 impl AsInner<imp::ExitStatus> for ExitStatus {
+    #[inline]
     fn as_inner(&self) -> &imp::ExitStatus {
         &self.0
     }
@@ -1884,6 +1891,7 @@ impl From<u8> for ExitCode {
 }
 
 impl AsInner<imp::ExitCode> for ExitCode {
+    #[inline]
     fn as_inner(&self) -> &imp::ExitCode {
         &self.0
     }

--- a/library/std/src/sys/hermit/fd.rs
+++ b/library/std/src/sys/hermit/fd.rs
@@ -75,6 +75,7 @@ impl FromRawFd for FileDesc {
 }
 
 impl AsInner<OwnedFd> for FileDesc {
+    #[inline]
     fn as_inner(&self) -> &OwnedFd {
         &self.fd
     }

--- a/library/std/src/sys/hermit/fs.rs
+++ b/library/std/src/sys/hermit/fs.rs
@@ -367,12 +367,14 @@ impl DirBuilder {
 }
 
 impl AsInner<FileDesc> for File {
+    #[inline]
     fn as_inner(&self) -> &FileDesc {
         &self.0
     }
 }
 
 impl AsInnerMut<FileDesc> for File {
+    #[inline]
     fn as_inner_mut(&mut self) -> &mut FileDesc {
         &mut self.0
     }

--- a/library/std/src/sys/hermit/fs.rs
+++ b/library/std/src/sys/hermit/fs.rs
@@ -399,6 +399,7 @@ impl AsFd for File {
 }
 
 impl AsRawFd for File {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/library/std/src/sys/hermit/net.rs
+++ b/library/std/src/sys/hermit/net.rs
@@ -340,6 +340,7 @@ impl Socket {
 }
 
 impl AsInner<FileDesc> for Socket {
+    #[inline]
     fn as_inner(&self) -> &FileDesc {
         &self.0
     }

--- a/library/std/src/sys/hermit/net.rs
+++ b/library/std/src/sys/hermit/net.rs
@@ -365,6 +365,7 @@ impl AsFd for Socket {
 }
 
 impl AsRawFd for Socket {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/library/std/src/sys/sgx/fd.rs
+++ b/library/std/src/sys/sgx/fd.rs
@@ -62,6 +62,7 @@ impl FileDesc {
 }
 
 impl AsInner<Fd> for FileDesc {
+    #[inline]
     fn as_inner(&self) -> &Fd {
         &self.fd
     }

--- a/library/std/src/sys/sgx/net.rs
+++ b/library/std/src/sys/sgx/net.rs
@@ -24,6 +24,7 @@ impl Socket {
 }
 
 impl AsInner<FileDesc> for Socket {
+    #[inline]
     fn as_inner(&self) -> &FileDesc {
         &self.inner
     }
@@ -220,6 +221,7 @@ impl TcpStream {
 }
 
 impl AsInner<Socket> for TcpStream {
+    #[inline]
     fn as_inner(&self) -> &Socket {
         &self.inner
     }
@@ -304,6 +306,7 @@ impl TcpListener {
 }
 
 impl AsInner<Socket> for TcpListener {
+    #[inline]
     fn as_inner(&self) -> &Socket {
         &self.inner
     }

--- a/library/std/src/sys/solid/net.rs
+++ b/library/std/src/sys/solid/net.rs
@@ -112,6 +112,7 @@ impl FileDesc {
 }
 
 impl AsInner<c_int> for FileDesc {
+    #[inline]
     fn as_inner(&self) -> &c_int {
         &self.fd
     }
@@ -462,6 +463,7 @@ impl Socket {
 }
 
 impl AsInner<c_int> for Socket {
+    #[inline]
     fn as_inner(&self) -> &c_int {
         self.0.as_inner()
     }

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -481,6 +481,7 @@ impl<'a> Read for &'a FileDesc {
 }
 
 impl AsInner<OwnedFd> for FileDesc {
+    #[inline]
     fn as_inner(&self) -> &OwnedFd {
         &self.0
     }

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -506,6 +506,7 @@ impl AsFd for FileDesc {
 }
 
 impl AsRawFd for FileDesc {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -547,6 +547,7 @@ impl FileAttr {
 }
 
 impl AsInner<stat64> for FileAttr {
+    #[inline]
     fn as_inner(&self) -> &stat64 {
         &self.stat
     }
@@ -1254,12 +1255,14 @@ impl DirBuilder {
 }
 
 impl AsInner<FileDesc> for File {
+    #[inline]
     fn as_inner(&self) -> &FileDesc {
         &self.0
     }
 }
 
 impl AsInnerMut<FileDesc> for File {
+    #[inline]
     fn as_inner_mut(&mut self) -> &mut FileDesc {
         &mut self.0
     }

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -1287,6 +1287,7 @@ impl AsFd for File {
 }
 
 impl AsRawFd for File {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -184,6 +184,7 @@ pub mod net {
             unimpl!();
         }
 
+        #[inline]
         pub fn socket(&self) -> &Socket {
             &self.inner
         }
@@ -306,6 +307,7 @@ pub mod net {
             unimpl!();
         }
 
+        #[inline]
         pub fn socket(&self) -> &Socket {
             &self.inner
         }
@@ -372,6 +374,7 @@ pub mod net {
             unimpl!();
         }
 
+        #[inline]
         pub fn socket(&self) -> &Socket {
             &self.inner
         }

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -154,6 +154,7 @@ pub mod net {
     }
 
     impl AsRawFd for Socket {
+        #[inline]
         fn as_raw_fd(&self) -> RawFd {
             self.0.as_raw_fd()
         }

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -129,6 +129,7 @@ pub mod net {
     }
 
     impl AsInner<FileDesc> for Socket {
+        #[inline]
         fn as_inner(&self) -> &FileDesc {
             &self.0
         }

--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -490,6 +490,7 @@ impl Socket {
 }
 
 impl AsInner<FileDesc> for Socket {
+    #[inline]
     fn as_inner(&self) -> &FileDesc {
         &self.0
     }

--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -515,6 +515,7 @@ impl AsFd for Socket {
 }
 
 impl AsRawFd for Socket {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/library/std/src/sys/unix/os_str.rs
+++ b/library/std/src/sys/unix/os_str.rs
@@ -89,6 +89,7 @@ impl IntoInner<Vec<u8>> for Buf {
 }
 
 impl AsInner<[u8]> for Buf {
+    #[inline]
     fn as_inner(&self) -> &[u8] {
         &self.inner
     }

--- a/library/std/src/sys/unix/pipe.rs
+++ b/library/std/src/sys/unix/pipe.rs
@@ -135,6 +135,7 @@ pub fn read2(p1: AnonPipe, v1: &mut Vec<u8>, p2: AnonPipe, v2: &mut Vec<u8>) -> 
 }
 
 impl AsRawFd for AnonPipe {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/library/std/src/sys/wasi/fd.rs
+++ b/library/std/src/sys/wasi/fd.rs
@@ -307,6 +307,7 @@ impl AsFd for WasiFd {
 }
 
 impl AsRawFd for WasiFd {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.fd.as_raw_fd()
     }

--- a/library/std/src/sys/wasi/fd.rs
+++ b/library/std/src/sys/wasi/fd.rs
@@ -275,12 +275,14 @@ impl WasiFd {
 }
 
 impl AsInner<OwnedFd> for WasiFd {
+    #[inline]
     fn as_inner(&self) -> &OwnedFd {
         &self.fd
     }
 }
 
 impl AsInnerMut<OwnedFd> for WasiFd {
+    #[inline]
     fn as_inner_mut(&mut self) -> &mut OwnedFd {
         &mut self.fd
     }

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -498,6 +498,7 @@ impl File {
 }
 
 impl AsInner<WasiFd> for File {
+    #[inline]
     fn as_inner(&self) -> &WasiFd {
         &self.fd
     }

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -523,6 +523,7 @@ impl AsFd for File {
 }
 
 impl AsRawFd for File {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.fd.as_raw_fd()
     }

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -185,6 +185,7 @@ impl TcpStream {
         }
     }
 
+    #[inline]
     pub fn socket(&self) -> &Socket {
         &self.inner
     }
@@ -275,6 +276,7 @@ impl TcpListener {
         }
     }
 
+    #[inline]
     pub fn socket(&self) -> &Socket {
         &self.inner
     }
@@ -438,6 +440,7 @@ impl UdpSocket {
         unsupported()
     }
 
+    #[inline]
     pub fn socket(&self) -> &Socket {
         &self.inner
     }

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -17,6 +17,7 @@ pub struct TcpStream {
 }
 
 impl AsInner<WasiFd> for Socket {
+    #[inline]
     fn as_inner(&self) -> &WasiFd {
         &self.0
     }
@@ -284,6 +285,7 @@ impl TcpListener {
 }
 
 impl AsInner<Socket> for TcpListener {
+    #[inline]
     fn as_inner(&self) -> &Socket {
         &self.inner
     }
@@ -446,6 +448,7 @@ impl UdpSocket {
 }
 
 impl AsInner<Socket> for UdpSocket {
+    #[inline]
     fn as_inner(&self) -> &Socket {
         &self.inner
     }

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -42,6 +42,7 @@ impl AsFd for Socket {
 }
 
 impl AsRawFd for Socket {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -832,6 +832,7 @@ fn open_link_no_reparse(parent: &File, name: &[u16], access: u32) -> io::Result<
 }
 
 impl AsInner<Handle> for File {
+    #[inline]
     fn as_inner(&self) -> &Handle {
         &self.handle
     }

--- a/library/std/src/sys/windows/handle.rs
+++ b/library/std/src/sys/windows/handle.rs
@@ -34,6 +34,7 @@ impl Handle {
 }
 
 impl AsInner<OwnedHandle> for Handle {
+    #[inline]
     fn as_inner(&self) -> &OwnedHandle {
         &self.0
     }

--- a/library/std/src/sys/windows/net.rs
+++ b/library/std/src/sys/windows/net.rs
@@ -446,6 +446,7 @@ impl<'a> Read for &'a Socket {
 }
 
 impl AsInner<OwnedSocket> for Socket {
+    #[inline]
     fn as_inner(&self) -> &OwnedSocket {
         &self.0
     }

--- a/library/std/src/sys/windows/os_str.rs
+++ b/library/std/src/sys/windows/os_str.rs
@@ -27,6 +27,7 @@ impl FromInner<Wtf8Buf> for Buf {
 }
 
 impl AsInner<Wtf8> for Buf {
+    #[inline]
     fn as_inner(&self) -> &Wtf8 {
         &self.inner
     }

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -239,6 +239,7 @@ impl TcpStream {
         Ok(TcpStream { inner: sock })
     }
 
+    #[inline]
     pub fn socket(&self) -> &Socket {
         &self.inner
     }
@@ -428,6 +429,7 @@ impl TcpListener {
         Ok(TcpListener { inner: sock })
     }
 
+    #[inline]
     pub fn socket(&self) -> &Socket {
         &self.inner
     }
@@ -518,6 +520,7 @@ impl UdpSocket {
         Ok(UdpSocket { inner: sock })
     }
 
+    #[inline]
     pub fn socket(&self) -> &Socket {
         &self.inner
     }

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -352,6 +352,7 @@ impl TcpStream {
 }
 
 impl AsInner<Socket> for TcpStream {
+    #[inline]
     fn as_inner(&self) -> &Socket {
         &self.inner
     }

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -501,6 +501,7 @@ pub struct Wtf8 {
 }
 
 impl AsInner<[u8]> for Wtf8 {
+    #[inline]
     fn as_inner(&self) -> &[u8] {
         &self.bytes
     }


### PR DESCRIPTION
Currently the following function:

```rust
use std::os::fd::{AsRawFd, RawFd};
use std::net::TcpStream;

pub fn as_raw_fd(socket: &TcpStream) -> RawFd {
    socket.as_raw_fd()
}
```

Is optimized to the following:

```asm
example::as_raw_fd:
        push    rax
        call    qword ptr [rip + <std::net::tcp::TcpStream as std::sys_common::AsInner<std::sys_common::net::TcpStream>>::as_inner@GOTPCREL]
        mov     rdi, rax
        call    qword ptr [rip + std::sys_common::net::TcpStream::socket@GOTPCREL]
        mov     rdi, rax
        pop     rax
        jmp     qword ptr [rip + _ZN73_$LT$std..sys..unix..net..Socket$u20$as$u20$std..os..fd..raw..AsRawFd$GT$9as_raw_fd17h633bcf7e481df8bbE@GOTPCREL]
```

I think it would make more sense to inline trivial functions used within `TcpStream::AsRawFd`.