### PR TITLE
Correct fortanix LVI test print function

### DIFF
--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/print.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/print.checks
@@ -1,6 +1,6 @@
 CHECK: print
 CHECK:      lfence
-CHECK:      lfence
-CHECK:      lfence
-CHECK:      callq 0x{{[[:xdigit:]]*}} <_Unwind_Resume>
-CHECK-NEXT: ud2
+CHECK:      popq
+CHECK-NEXT: popq [[REGISTER:%[a-z]+]]
+CHECK-NEXT: lfence
+CHECK-NEXT: jmpq *[[REGISTER]]

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/script.sh
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/script.sh
@@ -33,6 +33,15 @@ function check {
     ${objdump} --disassemble-symbols="${func}" --demangle \
       ${enclave} > ${asm}
     ${filecheck} --input-file ${asm} ${checks}
+
+    if [ "${func_re}" != "rust_plus_one_global_asm" &&
+         "${func_re}" != "cmake_plus_one_c_global_asm" ]; then
+        # The assembler cannot avoid explicit `ret` instructions. Sequences
+        # of `shlq $0x0, (%rsp); lfence; retq` are used instead.
+        # https://www.intel.com/content/www/us/en/developer/articles/technical/
+        #     software-security-guidance/technical-documentation/load-value-injection.html
+        ${filecheck} --implicit-check-not ret --input-file ${asm} ${checks}
+    fi
 }
 
 build


### PR DESCRIPTION
A recent change resulted in a different machine code for the `print` function. This caused the LVI test for this function to fail. This PR:

- Fixes the test for the `print` function
- Simplified the test a bit so future modifications are more unlikely

cc: @jethrogb 