### PR TITLE
Add `OsStr` methods for testing, stripping, and splitting Unicode prefixes.

### DIFF
--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -178,6 +178,34 @@ impl OsString {
         self.inner.into_string().map_err(|buf| OsString { inner: buf })
     }
 
+    /// Splits the `OsString` into a Unicode prefix and non-Unicode suffix.
+    ///
+    /// The returned `String` is the longest prefix of the `OsString` that
+    /// contained valid Unicode. The returned `OsString` is the rest of the
+    /// original value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(osstr_str_prefix_ops)]
+    ///
+    /// use std::ffi::OsString;
+    ///
+    /// let os_string = OsString::from("foo");
+    /// let (prefix, suffix) = os_string.clone().into_string_split();
+    ///
+    /// let mut rejoined = OsString::from(prefix);
+    /// rejoined.push(suffix);
+    /// assert_eq!(rejoined, os_string);
+    /// ```
+    #[unstable(feature = "osstr_str_prefix_ops", issue = "none")]
+    #[must_use]
+    #[inline]
+    pub fn into_string_split(self) -> (String, OsString) {
+        let (prefix, suffix) = self.inner.into_string_split();
+        (prefix, OsString { inner: suffix })
+    }
+
     /// Extends the string with the given <code>&[OsStr]</code> slice.
     ///
     /// # Examples
@@ -701,6 +729,34 @@ impl OsStr {
     #[inline]
     pub fn to_str(&self) -> Option<&str> {
         self.inner.to_str()
+    }
+
+    /// Splits the `OsStr` into a Unicode prefix and non-Unicode suffix.
+    ///
+    /// The returned `str` is the longest prefix of the `OsStr` that
+    /// contained valid Unicode. The returned `OsStr` is the rest of the
+    /// original value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(osstr_str_prefix_ops)]
+    ///
+    /// use std::ffi::{OsStr, OsString};
+    ///
+    /// let os_str = OsStr::new("foo");
+    /// let (prefix, suffix) = os_str.to_str_split();
+    ///
+    /// let mut rejoined = OsString::from(prefix);
+    /// rejoined.push(suffix);
+    /// assert_eq!(rejoined, os_str);
+    /// ```
+    #[unstable(feature = "osstr_str_prefix_ops", issue = "none")]
+    #[must_use]
+    #[inline]
+    pub fn to_str_split(&self) -> (&str, &OsStr) {
+        let (prefix, suffix) = self.inner.to_str_split();
+        (prefix, Self::from_inner(suffix))
     }
 
     /// Converts an `OsStr` to a <code>[Cow]<[str]></code>.

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -264,6 +264,7 @@
 #![feature(needs_panic_runtime)]
 #![feature(negative_impls)]
 #![feature(never_type)]
+#![feature(pattern)]
 #![feature(platform_intrinsics)]
 #![feature(prelude_import)]
 #![feature(rustc_attrs)]

--- a/library/std/src/sys/unix/os_str/tests.rs
+++ b/library/std/src/sys/unix/os_str/tests.rs
@@ -16,3 +16,37 @@ fn display() {
         Slice::from_u8_slice(b"Hello\xC0\x80 There\xE6\x83 Goodbye").to_string(),
     );
 }
+
+#[test]
+fn buf_into_string_split() {
+    let mut string = Buf::from_string(String::from("héllô wørld"));
+    {
+        let (prefix, suffix) = string.clone().into_string_split();
+        assert_eq!(prefix, String::from("héllô wørld"));
+        assert_eq!(suffix.into_inner(), Vec::new());
+    }
+
+    string.push_slice(Slice::from_u8_slice(b"\xFF"));
+    {
+        let (prefix, suffix) = string.clone().into_string_split();
+        assert_eq!(prefix, String::from("héllô wørld"));
+        assert_eq!(suffix.into_inner(), vec![0xFF]);
+    }
+}
+
+#[test]
+fn slice_to_str_split() {
+    let mut string = Buf::from_string(String::from("héllô wørld"));
+    {
+        let (prefix, suffix) = string.as_slice().to_str_split();
+        assert_eq!(prefix, "héllô wørld");
+        assert_eq!(&suffix.inner, b"");
+    }
+
+    string.push_slice(Slice::from_u8_slice(b"\xFF"));
+    {
+        let (prefix, suffix) = string.as_slice().to_str_split();
+        assert_eq!(prefix, String::from("héllô wørld"));
+        assert_eq!(&suffix.inner, b"\xFF");
+    }
+}

--- a/library/std/src/sys/unix/os_str/tests.rs
+++ b/library/std/src/sys/unix/os_str/tests.rs
@@ -50,3 +50,64 @@ fn slice_to_str_split() {
         assert_eq!(&suffix.inner, b"\xFF");
     }
 }
+
+#[test]
+fn slice_starts_with_str() {
+    let mut string = Buf::from_string(String::from("héllô="));
+    string.push_slice(Slice::from_u8_slice(b"\xFF"));
+    string.push_slice(Slice::from_str("wørld"));
+    let slice = string.as_slice();
+
+    assert!(slice.starts_with_str("héllô"));
+    assert!(!slice.starts_with_str("héllô=wørld"));
+}
+
+#[test]
+fn slice_strip_prefix() {
+    let mut string = Buf::from_string(String::from("héllô="));
+    string.push_slice(Slice::from_u8_slice(b"\xFF"));
+    string.push_slice(Slice::from_str("wørld"));
+    let slice = string.as_slice();
+
+    assert!(slice.strip_prefix("héllô=wørld").is_none());
+
+    {
+        let suffix = slice.strip_prefix('h');
+        assert!(suffix.is_some());
+        assert_eq!(&suffix.unwrap().inner, b"\xC3\xA9ll\xC3\xB4=\xFFw\xC3\xB8rld",);
+    }
+
+    {
+        let suffix = slice.strip_prefix("héllô");
+        assert!(suffix.is_some());
+        assert_eq!(&suffix.unwrap().inner, b"=\xFFw\xC3\xB8rld");
+    }
+}
+
+#[test]
+fn slice_strip_prefix_str() {
+    let mut string = Buf::from_string(String::from("héllô="));
+    string.push_slice(Slice::from_u8_slice(b"\xFF"));
+    string.push_slice(Slice::from_str("wørld"));
+    let slice = string.as_slice();
+
+    assert!(slice.strip_prefix_str("héllô=wørld").is_none());
+
+    let suffix = slice.strip_prefix_str("héllô");
+    assert!(suffix.is_some());
+    assert_eq!(&suffix.unwrap().inner, b"=\xFFw\xC3\xB8rld");
+}
+
+#[test]
+fn slice_split_once() {
+    let mut string = Buf::from_string(String::from("héllô="));
+    string.push_slice(Slice::from_u8_slice(b"\xFF"));
+    string.push_slice(Slice::from_str("wørld"));
+    let slice = string.as_slice();
+
+    let split = slice.split_once('=');
+    assert!(split.is_some());
+    let (prefix, suffix) = split.unwrap();
+    assert_eq!(prefix, "héllô");
+    assert_eq!(&suffix.inner, b"\xFFw\xC3\xB8rld");
+}

--- a/library/std/src/sys/windows/os_str.rs
+++ b/library/std/src/sys/windows/os_str.rs
@@ -98,6 +98,11 @@ impl Buf {
         self.inner.into_string().map_err(|buf| Buf { inner: buf })
     }
 
+    pub fn into_string_split(self) -> (String, Buf) {
+        let (prefix, suffix) = self.inner.into_string_split();
+        (prefix, Buf { inner: suffix })
+    }
+
     pub fn push_slice(&mut self, s: &Slice) {
         self.inner.push_wtf8(&s.inner)
     }
@@ -157,6 +162,11 @@ impl Slice {
 
     pub fn to_str(&self) -> Option<&str> {
         self.inner.as_str()
+    }
+
+    pub fn to_str_split(&self) -> (&str, &Slice) {
+        let (prefix, suffix) = self.inner.to_str_split();
+        (prefix, Slice { inner: suffix })
     }
 
     pub fn to_string_lossy(&self) -> Cow<'_, str> {

--- a/library/std/src/sys_common/wtf8/tests.rs
+++ b/library/std/src/sys_common/wtf8/tests.rs
@@ -698,3 +698,64 @@ fn wtf8_to_owned() {
     assert_eq!(string.bytes, b"\xED\xA0\x80");
     assert!(!string.is_known_utf8);
 }
+
+#[test]
+fn wtf8_starts_with_str() {
+    let mut string = Wtf8Buf::from_str("héllô=");
+    string.push(CodePoint::from_u32(0xD800).unwrap());
+    string.push_str("wørld");
+    let slice = string.as_slice();
+
+    assert!(slice.starts_with_str("héllô"));
+    assert!(!slice.starts_with_str("héllô=wørld"));
+}
+
+#[test]
+fn wtf8_strip_prefix() {
+    let mut string = Wtf8Buf::from_str("héllô=");
+    string.push(CodePoint::from_u32(0xD800).unwrap());
+    string.push_str("wørld");
+    let slice = string.as_slice();
+
+    assert!(slice.strip_prefix("héllô=wørld").is_none());
+
+    {
+        let suffix = slice.strip_prefix('h');
+        assert!(suffix.is_some());
+        assert_eq!(&suffix.unwrap().bytes, b"\xC3\xA9ll\xC3\xB4=\xED\xA0\x80w\xC3\xB8rld",);
+    }
+
+    {
+        let suffix = slice.strip_prefix("héllô");
+        assert!(suffix.is_some());
+        assert_eq!(&suffix.unwrap().bytes, b"=\xED\xA0\x80w\xC3\xB8rld");
+    }
+}
+
+#[test]
+fn wtf8_strip_prefix_str() {
+    let mut string = Wtf8Buf::from_str("héllô=");
+    string.push(CodePoint::from_u32(0xD800).unwrap());
+    string.push_str("wørld");
+    let slice = string.as_slice();
+
+    assert!(slice.strip_prefix_str("héllô=wørld").is_none());
+
+    let suffix = slice.strip_prefix_str("héllô");
+    assert!(suffix.is_some());
+    assert_eq!(&suffix.unwrap().bytes, b"=\xED\xA0\x80w\xC3\xB8rld");
+}
+
+#[test]
+fn wtf8_split_once() {
+    let mut string = Wtf8Buf::from_str("héllô=");
+    string.push(CodePoint::from_u32(0xD800).unwrap());
+    string.push_str("wørld");
+    let slice = string.as_slice();
+
+    let split = slice.split_once('=');
+    assert!(split.is_some());
+    let (prefix, suffix) = split.unwrap();
+    assert_eq!(prefix, "héllô");
+    assert_eq!(&suffix.bytes, b"\xED\xA0\x80w\xC3\xB8rld");
+}


### PR DESCRIPTION
ACP: https://github.com/rust-lang/libs-team/issues/114

Discussion on that ACP seems to have quieted down without a clear consensus, so I'm going to throw this PR out for consideration. The general idea is that it's difficult to write prefix/suffix manipulations for `OsStr` that accept non-Unicode patterns[0], but the most pressing need (inspecting contents of `args_os`) are all based around Unicode patterns, and a big chunk of *those* operate exclusively on prefixes.

The first commit in this PR adds the `OsStr::to_str_split()` and `OsString::into_string_split()` methods, which extract the longest prefix from an `OsStr` / `OsString` that is valid Unicode. This prefix can then be parsed like normal, in platform-independent logic.

The second commit is based on discussion in the above ACP. I had considered this to be separate functionality, but there was some concern that extracting a Unicode prefix wasn't useful on its own, so I added some helper functions:

* `OsStr::starts_with()` tests whether an `OsStr` has a prefix matching the given `Pattern`.
  * It can be used as: `if arg.starts_with("--") {`
* `OsStr::strip_prefix()` returns the `OsStr` after removing a prefix matching the given `Pattern`.
  * It can be used as: `if let Some(arg_value) = arg.strip_prefix("--some-flag=") {`
* `OsStr::split_once()` splits an `OsStr` into a `(&str, &OsStr)` pair, where the delimiter matches a given `Pattern`.
  * It can be used as: `let Some((flag_name, flag_value)) = arg.split_once("=") {`

`OsStr::starts_with_str()` and `OsStr::strip_prefix_str()` are specialized variants that are implemented as `&[u8]` comparisons, which I expect to be more efficient than the `Pattern` versions since they don't need to validate UTF-8.

[0] See extensive prior discussions, for example [rfcs/2295](https://github.com/rust-lang/rfcs/pull/2295).