### PR TITLE
Don't bail out early when checking invalid `repr` attr

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -101,12 +101,11 @@ impl CheckAttrVisitor<'_> {
         item: Option<ItemLike<'_>>,
     ) {
         let mut doc_aliases = FxHashMap::default();
-        let mut is_valid = true;
         let mut specified_inline = None;
         let mut seen = FxHashMap::default();
         let attrs = self.tcx.hir().attrs(hir_id);
         for attr in attrs {
-            let attr_is_valid = match attr.name_or_empty() {
+            match attr.name_or_empty() {
                 sym::do_not_recommend => self.check_do_not_recommend(attr.span, target),
                 sym::inline => self.check_inline(hir_id, attr, span, target),
                 sym::no_coverage => self.check_no_coverage(hir_id, attr, span, target),
@@ -188,7 +187,6 @@ impl CheckAttrVisitor<'_> {
                 sym::link_ordinal => self.check_link_ordinal(&attr, span, target),
                 _ => true,
             };
-            is_valid &= attr_is_valid;
 
             // lint-only checks
             match attr.name_or_empty() {
@@ -253,10 +251,6 @@ impl CheckAttrVisitor<'_> {
             }
 
             self.check_unused_attribute(hir_id, attr)
-        }
-
-        if !is_valid {
-            return;
         }
 
         self.check_repr(attrs, span, target, item, hir_id);

--- a/tests/ui/repr/invalid_repr_list_help.rs
+++ b/tests/ui/repr/invalid_repr_list_help.rs
@@ -15,3 +15,8 @@ pub struct OwO3 {
 pub enum OwO4 {
     UwU = 1,
 }
+
+#[repr(uwu)] //~ERROR: unrecognized representation hint
+#[doc(owo)]  //~WARN: unknown `doc` attribute
+             //~^ WARN: this was previously
+pub struct Owo5;

--- a/tests/ui/repr/invalid_repr_list_help.stderr
+++ b/tests/ui/repr/invalid_repr_list_help.stderr
@@ -30,6 +30,24 @@ LL | #[repr(uwu, u8)]
    |
    = help: valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
 
-error: aborting due to 4 previous errors
+warning: unknown `doc` attribute `owo`
+  --> $DIR/invalid_repr_list_help.rs:20:7
+   |
+LL | #[doc(owo)]
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+   = note: `#[warn(invalid_doc_attributes)]` on by default
+
+error[E0552]: unrecognized representation hint
+  --> $DIR/invalid_repr_list_help.rs:19:8
+   |
+LL | #[repr(uwu)]
+   |        ^^^
+   |
+   = help: valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
+
+error: aborting due to 5 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0552`.


### PR DESCRIPTION
Fixes #111051

An invalid repr delays a bug. If there are other invalid attributes on the item, we emit a warning and exit without re-checking the repr here, so no error is emitted and the delayed bug ICEs