### PR TITLE
Make std::io::copy take Read and Write by value instead of by reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/rust-lang/nomicon.git
 [submodule "src/tools/cargo"]
 	path = src/tools/cargo
-	url = https://github.com/rust-lang/cargo.git
+	url = https://github.com/est31/cargo.git
 [submodule "src/doc/reference"]
 	path = src/doc/reference
 	url = https://github.com/rust-lang/reference.git


### PR DESCRIPTION
The traits are also implemented on mutable references of types implementing that trait.

The initial goal of this PR is to get a crater run done so that impact of breakage can be estimated, then a decision can be made on #105643.