### PR TITLE
Make x.py work again in most (all?) cases

### DIFF
--- a/x.py
+++ b/x.py
@@ -4,26 +4,29 @@
 
 # This file is only a "symlink" to bootstrap.py, all logic should go there.
 
-import os
-import sys
+# Parts of `bootstrap.py` use the `multiprocessing` module, so this entry point
+# must use the normal `if __name__ == '__main__':` convention to avoid problems.
+if __name__ == '__main__':
+    import os
+    import sys
 
-# If this is python2, check if python3 is available and re-execute with that
-# interpreter. Only python3 allows downloading CI LLVM.
-#
-# This matters if someone's system `python` is python2.
-if sys.version_info.major < 3:
-    try:
-        os.execvp("py", ["py", "-3"] + sys.argv)
-    except OSError:
+    # If this is python2, check if python3 is available and re-execute with that
+    # interpreter. Only python3 allows downloading CI LLVM.
+    #
+    # This matters if someone's system `python` is python2.
+    if sys.version_info.major < 3:
         try:
-            os.execvp("python3", ["python3"] + sys.argv)
+            os.execvp("py", ["py", "-3"] + sys.argv)
         except OSError:
-            # Python 3 isn't available, fall back to python 2
-            pass
+            try:
+                os.execvp("python3", ["python3"] + sys.argv)
+            except OSError:
+                # Python 3 isn't available, fall back to python 2
+                pass
 
-rust_dir = os.path.dirname(os.path.abspath(__file__))
-# For the import below, have Python search in src/bootstrap first.
-sys.path.insert(0, os.path.join(rust_dir, "src", "bootstrap"))
+    rust_dir = os.path.dirname(os.path.abspath(__file__))
+    # For the import below, have Python search in src/bootstrap first.
+    sys.path.insert(0, os.path.join(rust_dir, "src", "bootstrap"))
 
-import bootstrap
-bootstrap.main()
+    import bootstrap
+    bootstrap.main()


### PR DESCRIPTION
Fixes #111046.

Wrap all of x.py in `if __name__ == '__main__':` to avoid problems with `multiprocessing`
Make the pool sizing better