### PR TITLE
remove pointless `FIXME` in `bootstrap::download`

### DIFF
--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -427,7 +427,6 @@ impl Config {
 
     fn download_toolchain(
         &self,
-        // FIXME(ozkanonur) use CompilerMetadata instead of `version: &str`
         version: &str,
         sysroot: &str,
         stamp_key: &str,


### PR DESCRIPTION
The suggestion given by `FIXME` to use `CompilerMetadata` for `download_toolchain` in `bootstrap::download` can result in more confusion. This is because `stamp_key` is not always a date; it can also be a commit hash. Additionally, unlike in `download_beta_toolchain`, in the `download_ci_rustc` function, `version` and `commit` values are calculated separately.