### PR TITLE
Cleaner assert_eq! & assert_ne! panic messages

### DIFF
--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -267,16 +267,14 @@ fn assert_failed_inner(
 
     match args {
         Some(args) => panic!(
-            r#"assertion failed: `(left {} right)`
-  left: `{:?}`,
- right: `{:?}`: {}"#,
-            op, left, right, args
+            r#"assertion `left {op} right` failed: {args}
+  left: {left:?}
+ right: {right:?}"#
         ),
         None => panic!(
-            r#"assertion failed: `(left {} right)`
-  left: `{:?}`,
- right: `{:?}`"#,
-            op, left, right,
+            r#"assertion `left {op} right` failed
+  left: {left:?}
+ right: {right:?}"#
         ),
     }
 }

--- a/tests/ui/macros/assert-eq-macro-msg.rs
+++ b/tests/ui/macros/assert-eq-macro-msg.rs
@@ -1,7 +1,7 @@
 // run-fail
-// error-pattern:assertion failed: `(left == right)`
-// error-pattern: left: `2`
-// error-pattern:right: `3`: 1 + 1 definitely should be 3
+// error-pattern:assertion `left == right` failed: 1 + 1 definitely should be 3
+// error-pattern:  left: 2
+// error-pattern: right: 3
 // ignore-emscripten no processes
 
 fn main() {

--- a/tests/ui/macros/assert-eq-macro-panic.rs
+++ b/tests/ui/macros/assert-eq-macro-panic.rs
@@ -1,7 +1,7 @@
 // run-fail
-// error-pattern:assertion failed: `(left == right)`
-// error-pattern: left: `14`
-// error-pattern:right: `15`
+// error-pattern:assertion `left == right` failed
+// error-pattern:  left: 14
+// error-pattern: right: 15
 // ignore-emscripten no processes
 
 fn main() {

--- a/tests/ui/macros/assert-matches-macro-msg.rs
+++ b/tests/ui/macros/assert-matches-macro-msg.rs
@@ -1,7 +1,7 @@
 // run-fail
-// error-pattern:assertion failed: `(left matches right)`
-// error-pattern: left: `2`
-// error-pattern:right: `3`: 1 + 1 definitely should be 3
+// error-pattern:assertion `left matches right` failed: 1 + 1 definitely should be 3
+// error-pattern:  left: 2
+// error-pattern: right: 3
 // ignore-emscripten no processes
 
 #![feature(assert_matches)]

--- a/tests/ui/macros/assert-ne-macro-msg.rs
+++ b/tests/ui/macros/assert-ne-macro-msg.rs
@@ -1,7 +1,7 @@
 // run-fail
-// error-pattern:assertion failed: `(left != right)`
-// error-pattern: left: `2`
-// error-pattern:right: `2`: 1 + 1 definitely should not be 2
+// error-pattern:assertion `left != right` failed: 1 + 1 definitely should not be 2
+// error-pattern:  left: 2
+// error-pattern: right: 2
 // ignore-emscripten no processes
 
 fn main() {

--- a/tests/ui/macros/assert-ne-macro-panic.rs
+++ b/tests/ui/macros/assert-ne-macro-panic.rs
@@ -1,7 +1,7 @@
 // run-fail
-// error-pattern:assertion failed: `(left != right)`
-// error-pattern: left: `14`
-// error-pattern:right: `14`
+// error-pattern:assertion `left != right` failed
+// error-pattern:  left: 14
+// error-pattern: right: 14
 // ignore-emscripten no processes
 
 fn main() {

--- a/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
+++ b/tests/ui/test-attrs/test-panic-abort-nocapture.run.stderr
@@ -1,11 +1,11 @@
 thread 'main' panicked at $DIR/test-panic-abort-nocapture.rs:33:5:
-assertion failed: `(left == right)`
-  left: `2`,
- right: `4`
+assertion `left == right` failed
+  left: 2
+ right: 4
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'main' panicked at $DIR/test-panic-abort-nocapture.rs:27:5:
-assertion failed: `(left == right)`
-  left: `2`,
- right: `4`
+assertion `left == right` failed
+  left: 2
+ right: 4
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 testing321

--- a/tests/ui/test-attrs/test-panic-abort.run.stdout
+++ b/tests/ui/test-attrs/test-panic-abort.run.stdout
@@ -18,9 +18,9 @@ testing123
 ---- it_fails stderr ----
 testing321
 thread 'main' panicked at $DIR/test-panic-abort.rs:38:5:
-assertion failed: `(left == right)`
-  left: `2`,
- right: `5`
+assertion `left == right` failed
+  left: 2
+ right: 5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 


### PR DESCRIPTION
**Note:** See https://github.com/rust-lang/rust/pull/112849#issuecomment-1678731335 for the snippet for the Rust 1.73 release blog post.

---

This PR finishes refactoring of the assert messages per #94005. The panic message format change #112849 used to be part of this PR, but has been factored out and just merged. It might be better to keep both changes in the same release once FCP vote completes.

Modify panic message for `assert_eq!`, `assert_ne!`, the currently unstable `assert_matches!`, as well as the corresponding `debug_assert_*` macros.

```rust
assert_eq!(1 + 1, 3);
assert_eq!(1 + 1, 3, "my custom message value={}!", 42);
```

#### Old messages
```plain
thread 'main' panicked at $DIR/main.rs:6:5:
assertion failed: `(left == right)`
  left: `2`,
 right: `3`
```
```plain
thread 'main' panicked at $DIR/main.rs:6:5:
assertion failed: `(left == right)`
  left: `2`,
 right: `3`: my custom message value=42!
```

#### New messages
```plain
thread 'main' panicked at $DIR/main.rs:6:5:
assertion `left == right` failed
  left: 2
 right: 3
```

```plain
thread 'main' panicked at $DIR/main.rs:6:5:
assertion `left == right` failed: my custom message value=42!
  left: 2
 right: 3
```

History of fixing #94005  
* #94016 was a lengthy PR that was abandoned
* #111030 was similar, but it stringified left and right arguments, and thus caused compile time performance issues, thus closed
* #112849 factored out the two-line formatting of all panic messages

Fixes #94005

r? @m-ou-se