### PR TITLE
Add needs-unwind annotations to tests that need stack unwinding

### DIFF
--- a/tests/incremental/change_crate_dep_kind.rs
+++ b/tests/incremental/change_crate_dep_kind.rs
@@ -2,6 +2,7 @@
 // detected then -Zincremental-verify-ich will trigger an assertion.
 
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-unwind
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph -Cpanic=unwind
 // build-pass (FIXME(62277): could be check-pass?)

--- a/tests/incremental/issue-80691-bad-eval-cache.rs
+++ b/tests/incremental/issue-80691-bad-eval-cache.rs
@@ -1,6 +1,7 @@
 // revisions: rfail1 rfail2
 // failure-status: 101
 // error-pattern: not implemented
+// needs-unwind -Cpanic=abort causes abort instead of exit(101)
 
 pub trait Interner {
     type InternedVariableKinds;

--- a/tests/run-make/c-unwind-abi-catch-lib-panic/Makefile
+++ b/tests/run-make/c-unwind-abi-catch-lib-panic/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all: archive

--- a/tests/run-make/c-unwind-abi-catch-panic/Makefile
+++ b/tests/run-make/c-unwind-abi-catch-panic/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all: $(call NATIVE_STATICLIB,add)

--- a/tests/run-make/const_fn_mir/Makefile
+++ b/tests/run-make/const_fn_mir/Makefile
@@ -1,3 +1,4 @@
+# needs-unwind -Cpanic=abort gives different MIR output
 include ../tools.mk
 
 all:

--- a/tests/run-make/debug-assertions/Makefile
+++ b/tests/run-make/debug-assertions/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all:

--- a/tests/run-make/foreign-double-unwind/Makefile
+++ b/tests/run-make/foreign-double-unwind/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all: foo

--- a/tests/run-make/foreign-exceptions/Makefile
+++ b/tests/run-make/foreign-exceptions/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all: foo

--- a/tests/run-make/foreign-rust-exceptions/Makefile
+++ b/tests/run-make/foreign-rust-exceptions/Makefile
@@ -1,5 +1,6 @@
 # ignore-cross-compile
 # ignore-i686-pc-windows-gnu
+# needs-unwind
 
 # This test doesn't work on 32-bit MinGW as cdylib has its own copy of unwinder
 # so cross-DLL unwinding does not work.

--- a/tests/run-make/libtest-json/Makefile
+++ b/tests/run-make/libtest-json/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 # Test expected libtest's JSON output

--- a/tests/run-make/static-unwinding/Makefile
+++ b/tests/run-make/static-unwinding/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all:

--- a/tests/run-make/test-benches/Makefile
+++ b/tests/run-make/test-benches/Makefile
@@ -1,6 +1,7 @@
 include ../tools.mk
 
 # ignore-cross-compile
+# needs-unwind #[bench] and -Zpanic-abort-tests can't be combined
 
 all:
 	# Smoke-test that `#[bench]` isn't entirely broken.

--- a/tests/ui/test-attrs/test-type.rs
+++ b/tests/ui/test-attrs/test-type.rs
@@ -3,6 +3,7 @@
 // check-run-results
 // normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // ignore-emscripten no threads support
+// needs-unwind
 // run-pass
 
 #[test]


### PR DESCRIPTION
This allows filtering them out when running the rustc test suite for cg_clif.