### PR TITLE
Stop caching typeck on disk

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -875,11 +875,9 @@ rustc_queries! {
 
     query typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
         desc { |tcx| "type-checking `{}`", tcx.def_path_str(key) }
-        cache_on_disk_if(tcx) { !tcx.is_typeck_child(key.to_def_id()) }
     }
     query diagnostic_only_typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
         desc { |tcx| "type-checking `{}`", tcx.def_path_str(key) }
-        cache_on_disk_if { true }
     }
 
     query used_trait_imports(key: LocalDefId) -> &'tcx UnordSet<LocalDefId> {


### PR DESCRIPTION
I would naively assume that if the inputs to typeck are unchanged, the inputs of the dependendents of typeck would also stay unchanged, making the caching redundant.

I have no data to back this up, so let's try getting some.

#111026 got some nice wins from caching less typeck, let's see what happens here. Perf results are not enough data to determine whether this is good, but it's a starting point.

r? @ghost