### PR TITLE
correctly recurse when expanding anon consts

### DIFF
--- a/compiler/rustc_middle/src/ty/abstract_const.rs
+++ b/compiler/rustc_middle/src/ty/abstract_const.rs
@@ -63,7 +63,8 @@ impl<'tcx> TyCtxt<'tcx> {
                         Err(e) => self.tcx.const_error_with_guaranteed(c.ty(), e),
                         Ok(Some(bac)) => {
                             let substs = self.tcx.erase_regions(uv.substs);
-                            bac.subst(self.tcx, substs)
+                            let bac = bac.subst(self.tcx, substs);
+                            return bac.fold_with(self);
                         }
                         Ok(None) => c,
                     },

--- a/tests/ui/const-generics/generic_const_exprs/nested_uneval_unification-2.rs
+++ b/tests/ui/const-generics/generic_const_exprs/nested_uneval_unification-2.rs
@@ -2,28 +2,30 @@
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features, unused_parens, unused_braces)]
 
-fn zero_init<const N: usize>() -> Substs1<{ (N) }>
+fn zero_init<const N: usize>() -> Substs1<{{ N }}>
 where
-    [u8; { (N) }]: ,
+    [u8; {{ N }}]: ,
 {
-    Substs1([0; { (N) }])
+    Substs1([0; {{ N }}])
 }
 
-struct Substs1<const N: usize>([u8; { (N) }])
+struct Substs1<const N: usize>([u8; {{ N }}])
 where
-    [(); { (N) }]: ;
+    [(); {{ N }}]: ;
 
-fn substs2<const M: usize>() -> Substs1<{ (M) }> {
-    zero_init::<{ (M) }>()
+fn substs2<const M: usize>() -> Substs1<{{ M }}> {
+    zero_init::<{{ M }}>()
 }
 
-fn substs3<const L: usize>() -> Substs1<{ (L) }> {
-    substs2::<{ (L) }>()
+fn substs3<const L: usize>() -> Substs1<{{ L }}> {
+    substs2::<{{ L }}>()
 }
 
 fn main() {
     assert_eq!(substs3::<2>().0, [0; 2]);
 }
 
-// Test that the implicit ``{ (L) }`` bound on ``substs3`` satisfies the
-// ``{ (N) }`` bound on ``Substs1``
+// Test that the implicit ``{{ L }}`` bound on ``substs3`` satisfies the
+// ``{{ N }}`` bound on ``Substs1``
+// FIXME(generic_const_exprs): come up with a less brittle test for this using assoc consts
+// once normalization is implemented for them.


### PR DESCRIPTION
recursing with `super_fold_with` is wrong in case `bac` is itself normalizable, the test that was supposed to test for this being wrong did not actually test for this in reality because of the usage of `{ (N) }` instead of `{{ N }}`. The former resulting in a simple `ConstKind::Param` instead of `ConstKind::Unevaluated`. Tbh generally this test seems very brittle and it will be a lot easier to test once we have normalization of assoc consts since then we can just test that `T::ASSOC` normalizes to some `U::OTHER` which normalizes to some third thing.

r? @compiler-errors 