### PR TITLE
[WIP] Make less anon consts/Do a little `min_generic_const_exprs`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1162,7 +1162,7 @@ impl Expr {
     /// `min_const_generics` as more complex expressions are not supported.
     ///
     /// Does not ensure that the path resolves to a const param, the caller should check this.
-    pub fn is_potential_trivial_const_arg(&self) -> bool {
+    pub fn is_potential_trivial_const_arg(&self) -> Option<(NodeId, &Path)> {
         let this = if let ExprKind::Block(block, None) = &self.kind
             && block.stmts.len() == 1
             && let StmtKind::Expr(expr) = &block.stmts[0].kind
@@ -1175,9 +1175,9 @@ impl Expr {
         if let ExprKind::Path(None, path) = &this.kind
             && path.is_potential_trivial_const_arg()
         {
-            true
+            Some((this.id, path))
         } else {
-            false
+            None
         }
     }
 

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -77,7 +77,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
                 ExprKind::Repeat(expr, count) => {
                     let expr = self.lower_expr(expr);
-                    let count = self.lower_array_length(count);
+                    let count = self.lower_array_length(
+                        count,
+                        &ImplTraitContext::Disallowed(ImplTraitPosition::RepeatExprs),
+                    );
                     hir::ExprKind::Repeat(expr, count)
                 }
                 ExprKind::Tup(elts) => hir::ExprKind::Tup(self.lower_exprs(elts)),

--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -168,7 +168,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         intravisit::walk_generic_param(self, param);
     }
 
-    fn visit_const_param_default(&mut self, param: HirId, ct: &'hir AnonConst) {
+    fn visit_const_param_default(&mut self, param: HirId, ct: &'hir ConstArg<'hir>) {
         self.with_parent(param, |this| {
             intravisit::walk_const_param_default(this, ct);
         })

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2393,6 +2393,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn lower_array_length(&mut self, c: &AnonConst) -> hir::ArrayLen {
+        // FIXME(const_arg_kind)
         match c.value.kind {
             ExprKind::Underscore => {
                 if self.tcx.features().generic_arg_infer {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2287,7 +2287,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     &ty,
                     &ImplTraitContext::Disallowed(ImplTraitPosition::GenericDefault),
                 );
-                let default = default.as_ref().map(|def| self.lower_anon_const(def));
+                let default = default.as_ref().map(|def| {
+                    self.lower_const_arg(
+                        def,
+                        &ImplTraitContext::Disallowed(ImplTraitPosition::GenericDefault),
+                    )
+                });
                 (
                     hir::ParamName::Plain(self.lower_ident(param.ident)),
                     hir::GenericParamKind::Const { ty, default },

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 
 use either::{Left, Right};
 
-use rustc_hir::def::DefKind;
+use rustc_hir::def::{CtorKind, DefKind};
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::mir::pretty::display_allocation;
@@ -44,6 +44,7 @@ fn eval_body_using_ecx<'mir, 'tcx>(
                     | DefKind::AnonConst
                     | DefKind::InlineConst
                     | DefKind::AssocConst
+                    | DefKind::Ctor(_, CtorKind::Const)
             ),
         "Unexpected DefKind: {:?}",
         ecx.tcx.def_kind(cid.instance.def_id())

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -259,6 +259,13 @@ impl<'hir> ConstArg<'hir> {
             ConstArgKind::Param(_, qpath) => qpath.span(),
         }
     }
+
+    pub fn hir_id(&self) -> HirId {
+        match self.kind {
+            ConstArgKind::AnonConst(_, ct) => ct.hir_id,
+            ConstArgKind::Param(id, _) => id,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, HashStable_Generic)]
@@ -295,10 +302,7 @@ impl GenericArg<'_> {
         match self {
             GenericArg::Lifetime(l) => l.hir_id,
             GenericArg::Type(t) => t.hir_id,
-            GenericArg::Const(c) => match c.kind {
-                ConstArgKind::AnonConst(_, ct) => ct.hir_id,
-                ConstArgKind::Param(id, _) => id,
-            },
+            GenericArg::Const(c) => c.hir_id(),
             GenericArg::Infer(i) => i.hir_id,
         }
     }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -522,7 +522,7 @@ pub enum GenericParamKind<'hir> {
     Const {
         ty: &'hir Ty<'hir>,
         /// Optional default value for the const generic param
-        default: Option<AnonConst>,
+        default: Option<&'hir ConstArg<'hir>>,
     },
 }
 

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -350,7 +350,7 @@ pub trait Visitor<'v>: Sized {
     fn visit_generic_param(&mut self, p: &'v GenericParam<'v>) {
         walk_generic_param(self, p)
     }
-    fn visit_const_param_default(&mut self, _param: HirId, ct: &'v AnonConst) {
+    fn visit_const_param_default(&mut self, _param: HirId, ct: &'v ConstArg<'v>) {
         walk_const_param_default(self, ct)
     }
     fn visit_generics(&mut self, g: &'v Generics<'v>) {
@@ -877,8 +877,8 @@ pub fn walk_generic_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v Generi
     }
 }
 
-pub fn walk_const_param_default<'v, V: Visitor<'v>>(visitor: &mut V, ct: &'v AnonConst) {
-    visitor.visit_anon_const(ct)
+pub fn walk_const_param_default<'v, V: Visitor<'v>>(visitor: &mut V, ct: &'v ConstArg<'v>) {
+    visitor.visit_const_arg(ct)
 }
 
 pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics<'v>) {

--- a/compiler/rustc_hir_analysis/src/astconv/generics.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/generics.rs
@@ -107,8 +107,15 @@ fn generic_arg_mismatch_err(
                 );
             }
         }
-        (GenericArg::Const(cnst), GenericParamDefKind::Type { .. }) => {
-            let body = tcx.hir().body(cnst.value.body);
+        (GenericArg::Const(cnst), GenericParamDefKind::Type { .. })
+            if matches!(cnst.kind, hir::ConstArgKind::AnonConst(_, _)) =>
+        {
+            // FIXME(const_arg_kind)
+            let body = match cnst.kind {
+                hir::ConstArgKind::AnonConst(_, cnst) => tcx.hir().body(cnst.body),
+                _ => unreachable!(),
+            };
+
             if let rustc_hir::ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) = body.value.kind
             {
                 if let Res::Def(DefKind::Fn { .. }, id) = path.res {

--- a/compiler/rustc_hir_analysis/src/astconv/generics.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/generics.rs
@@ -108,16 +108,14 @@ fn generic_arg_mismatch_err(
             }
         }
         (GenericArg::Const(cnst), GenericParamDefKind::Type { .. })
-            if matches!(cnst.kind, hir::ConstArgKind::AnonConst(_, _)) =>
+            if matches!(cnst.kind, hir::ConstArgKind::Param(_, _)) =>
         {
-            // FIXME(const_arg_kind)
-            let body = match cnst.kind {
-                hir::ConstArgKind::AnonConst(_, cnst) => tcx.hir().body(cnst.body),
+            let path = match cnst.kind {
+                hir::ConstArgKind::Param(_, path) => path,
                 _ => unreachable!(),
             };
 
-            if let rustc_hir::ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) = body.value.kind
-            {
+            if let rustc_hir::QPath::Resolved(_, path) = path {
                 if let Res::Def(DefKind::Fn { .. }, id) = path.res {
                     err.help(format!("`{}` is a function item, not a type", tcx.item_name(id)));
                     err.help("function item types cannot be named directly");

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -357,7 +357,7 @@ fn const_evaluatable_predicates_of(
             }
         }
 
-        fn visit_const_param_default(&mut self, _param: HirId, _ct: &'tcx hir::AnonConst) {
+        fn visit_const_param_default(&mut self, _param: HirId, _ct: &'tcx hir::ConstArg<'tcx>) {
             // Do not look into const param defaults,
             // these get checked when they are actually instantiated.
             //

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -918,8 +918,8 @@ impl<'a, 'tcx> Visitor<'tcx> for BoundVarContext<'a, 'tcx> {
                     }
                     GenericParamKind::Const { ty, default } => {
                         this.visit_ty(ty);
-                        if let Some(default) = default {
-                            this.visit_body(this.tcx.hir().body(default.body));
+                        if let Some(arg) = default { 
+                            this.visit_const_arg(arg);
                         }
                     }
                 }

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1588,7 +1588,7 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
                     i += 1;
                 }
                 GenericArg::Const(ct) => {
-                    self.visit_anon_const(&ct.value);
+                    self.visit_const_arg(ct);
                     i += 1;
                 }
                 GenericArg::Infer(inf) => {

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -63,7 +63,7 @@ fn anon_const_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
             def_id: param_def_id,
             kind: GenericParamKind::Const { default: Some(ct), .. },
             ..
-        }) if ct.hir_id == hir_id => {
+        }) if ct.hir_id() == hir_id => {
             return tcx.type_of(param_def_id)
                 .no_bound_vars()
                 .expect("const parameter types cannot be generic")

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -370,6 +370,16 @@ impl<'a> State<'a> {
         self.end()
     }
 
+    pub fn print_const_arg(&mut self, const_arg: &hir::ConstArg<'_>) {
+        self.maybe_print_comment(const_arg.span().lo());
+        self.ibox(0);
+        match &const_arg.kind {
+            hir::ConstArgKind::AnonConst(_, ct) => self.print_anon_const(ct),
+            hir::ConstArgKind::Param(_, path) => self.print_qpath(path, false),
+        }
+        self.end();
+    }
+
     pub fn print_foreign_item(&mut self, item: &hir::ForeignItem<'_>) {
         self.hardbreak_if_not_bol();
         self.maybe_print_comment(item.span.lo());
@@ -1708,7 +1718,7 @@ impl<'a> State<'a> {
                             GenericArg::Lifetime(lt) if !elide_lifetimes => s.print_lifetime(lt),
                             GenericArg::Lifetime(_) => {}
                             GenericArg::Type(ty) => s.print_type(ty),
-                            GenericArg::Const(ct) => s.print_anon_const(&ct.value),
+                            GenericArg::Const(ct) => s.print_const_arg(ct),
                             GenericArg::Infer(_inf) => s.word("_"),
                         }
                     });

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -2168,7 +2168,7 @@ impl<'a> State<'a> {
                 if let Some(default) = default {
                     self.space();
                     self.word_space("=");
-                    self.print_anon_const(default);
+                    self.print_const_arg(default);
                 }
             }
         }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -350,7 +350,7 @@ impl<'a> State<'a> {
                 self.word("[");
                 self.print_type(ty);
                 self.word("; ");
-                self.print_array_length(length);
+                self.print_const_arg(length);
                 self.word("]");
             }
             hir::TyKind::Typeof(ref e) => {
@@ -376,6 +376,7 @@ impl<'a> State<'a> {
         match &const_arg.kind {
             hir::ConstArgKind::AnonConst(_, ct) => self.print_anon_const(ct),
             hir::ConstArgKind::Param(_, path) => self.print_qpath(path, false),
+            hir::ConstArgKind::Infer(_, _) => self.word("_"),
         }
         self.end();
     }
@@ -1028,13 +1029,6 @@ impl<'a> State<'a> {
         self.print_else(elseopt)
     }
 
-    pub fn print_array_length(&mut self, len: &hir::ArrayLen) {
-        match len {
-            hir::ArrayLen::Infer(_, _) => self.word("_"),
-            hir::ArrayLen::Body(ct) => self.print_anon_const(ct),
-        }
-    }
-
     pub fn print_anon_const(&mut self, constant: &hir::AnonConst) {
         self.ann.nested(self, Nested::Body(constant.body))
     }
@@ -1112,12 +1106,12 @@ impl<'a> State<'a> {
         self.end()
     }
 
-    fn print_expr_repeat(&mut self, element: &hir::Expr<'_>, count: &hir::ArrayLen) {
+    fn print_expr_repeat(&mut self, element: &hir::Expr<'_>, count: &hir::ConstArg<'_>) {
         self.ibox(INDENT_UNIT);
         self.word("[");
         self.print_expr(element);
         self.word_space(";");
-        self.print_array_length(count);
+        self.print_const_arg(count);
         self.word("]");
         self.end()
     }

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -377,7 +377,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                         self.cfcx.to_ty(ty).raw.into()
                     }
                     (GenericParamDefKind::Const { .. }, GenericArg::Const(ct)) => {
-                        self.cfcx.const_arg_to_const(&ct.value, param.def_id).into()
+                        self.cfcx.const_arg_to_const(ct, param.def_id).into()
                     }
                     (GenericParamDefKind::Type { .. }, GenericArg::Infer(inf)) => {
                         self.cfcx.ty_infer(Some(param), inf.span).into()

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2058,7 +2058,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         };
         if let Some(tykind) = tykind
             && let hir::TyKind::Array(_, length) = tykind
-            && let hir::ArrayLen::Body(hir::AnonConst { hir_id, .. }) = length
+            && let hir::ConstArg { kind: hir::ConstArgKind::AnonConst(_, hir::AnonConst { hir_id, ..})} = length
             && let Some(span) = self.tcx.hir().opt_span(*hir_id)
         {
             Some(TypeErrorAdditionalDiags::ConsiderSpecifyingLength { span, length: sz.found })

--- a/compiler/rustc_lint/src/pass_by_value.rs
+++ b/compiler/rustc_lint/src/pass_by_value.rs
@@ -73,9 +73,12 @@ fn gen_args(cx: &LateContext<'_>, segment: &PathSegment<'_>) -> String {
                 GenericArg::Type(ty) => {
                     cx.tcx.sess.source_map().span_to_snippet(ty.span).unwrap_or_else(|_| "_".into())
                 }
-                GenericArg::Const(c) => {
-                    cx.tcx.sess.source_map().span_to_snippet(c.span).unwrap_or_else(|_| "_".into())
-                }
+                GenericArg::Const(c) => cx
+                    .tcx
+                    .sess
+                    .source_map()
+                    .span_to_snippet(c.span())
+                    .unwrap_or_else(|_| "_".into()),
                 GenericArg::Infer(_) => String::from("_"),
             })
             .collect::<Vec<_>>();

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -218,17 +218,3 @@ impl<'tcx> Const<'tcx> {
         matches!(self.kind(), ty::ConstKind::Infer(_))
     }
 }
-
-pub fn const_param_default(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<Const<'_>> {
-    let default_def_id = match tcx.hir().get_by_def_id(def_id) {
-        hir::Node::GenericParam(hir::GenericParam {
-            kind: hir::GenericParamKind::Const { default: Some(ac), .. },
-            ..
-        }) => ac.def_id,
-        _ => span_bug!(
-            tcx.def_span(def_id),
-            "`const_param_default` expected a generic parameter with a constant"
-        ),
-    };
-    ty::EarlyBinder(Const::from_anon_const(tcx, default_def_id))
-}

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2590,7 +2590,6 @@ pub fn provide(providers: &mut ty::query::Providers) {
     *providers = ty::query::Providers {
         trait_impls_of: trait_def::trait_impls_of_provider,
         incoherent_impls: trait_def::incoherent_impls_provider,
-        const_param_default: consts::const_param_default,
         vtable_allocation: vtable::vtable_allocation_provider,
         ..*providers
     };

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1344,7 +1344,7 @@ pub trait PrettyPrinter<'tcx>:
         match ct.kind() {
             ty::ConstKind::Unevaluated(ty::UnevaluatedConst { def, substs }) => {
                 match self.tcx().def_kind(def) {
-                    DefKind::Const | DefKind::AssocConst => {
+                    DefKind::Ctor(_, CtorKind::Const) | DefKind::Const | DefKind::AssocConst => {
                         p!(print_value_path(def, substs))
                     }
                     DefKind::AnonConst => {

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -215,7 +215,7 @@ fn mir_keys(tcx: TyCtxt<'_>, (): ()) -> FxIndexSet<LocalDefId> {
     }
     impl<'tcx> Visitor<'tcx> for GatherCtors<'_> {
         fn visit_variant_data(&mut self, v: &'tcx hir::VariantData<'tcx>) {
-            if let hir::VariantData::Tuple(_, _, def_id) = *v {
+            if let hir::VariantData::Tuple(_, _, def_id) | hir::VariantData::Unit(_, def_id) = *v {
                 self.set.insert(def_id);
             }
             intravisit::walk_struct_def(self, v)

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -434,7 +434,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         match ga {
             hir::GenericArg::Lifetime(lt) => self.visit_lifetime(lt),
             hir::GenericArg::Type(ty) => self.visit_ty(ty),
-            hir::GenericArg::Const(ct) => self.visit_anon_const(&ct.value),
+            hir::GenericArg::Const(ct) => self.visit_const_arg(ct),
             hir::GenericArg::Infer(inf) => self.visit_infer(inf),
         }
     }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3972,7 +3972,7 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
         );
 
         self.resolve_anon_const_manual(
-            constant.value.is_potential_trivial_const_arg(),
+            constant.value.is_potential_trivial_const_arg().is_some(),
             anon_const_kind,
             |this| this.resolve_expr(&constant.value, None),
         )
@@ -4118,7 +4118,7 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                     // that is how they will be later lowered to HIR.
                     if const_args.contains(&idx) {
                         self.resolve_anon_const_manual(
-                            argument.is_potential_trivial_const_arg(),
+                            argument.is_potential_trivial_const_arg().is_some(),
                             AnonConstKind::ConstArg(IsRepeatExpr::No),
                             |this| this.resolve_expr(argument, None),
                         );

--- a/tests/ui/closures/issue-52437.rs
+++ b/tests/ui/closures/issue-52437.rs
@@ -2,4 +2,5 @@ fn main() {
     [(); &(&'static: loop { |x| {}; }) as *const _ as usize]
     //~^ ERROR: invalid label name `'static`
     //~| ERROR: type annotations needed
+    //~| ERROR: mismatched types
 }

--- a/tests/ui/closures/issue-52437.stderr
+++ b/tests/ui/closures/issue-52437.stderr
@@ -15,6 +15,15 @@ help: consider giving this closure parameter an explicit type
 LL |     [(); &(&'static: loop { |x: /* Type */| {}; }) as *const _ as usize]
    |                               ++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-52437.rs:2:5
+   |
+LL | fn main() {
+   |           - expected `()` because of default return type
+LL |     [(); &(&'static: loop { |x| {}; }) as *const _ as usize]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `[(); &(&'static: loop { |x| {}; }) as *const _ as usize]`
 
-For more information about this error, try `rustc --explain E0282`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0282, E0308.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/const-generics/bad-generic-in-copy-impl.rs
+++ b/tests/ui/const-generics/bad-generic-in-copy-impl.rs
@@ -1,7 +1,7 @@
 #[derive(Copy, Clone)]
 pub struct Foo {
     x: [u8; SIZE],
-    //~^ ERROR mismatched types
+    //~^ ERROR the constant `1` is not of type `usize`
 }
 
 const SIZE: u32 = 1;

--- a/tests/ui/const-generics/bad-generic-in-copy-impl.stderr
+++ b/tests/ui/const-generics/bad-generic-in-copy-impl.stderr
@@ -1,9 +1,8 @@
-error[E0308]: mismatched types
-  --> $DIR/bad-generic-in-copy-impl.rs:3:13
+error: the constant `1` is not of type `usize`
+  --> $DIR/bad-generic-in-copy-impl.rs:3:8
    |
 LL |     x: [u8; SIZE],
-   |             ^^^^ expected `usize`, found `u32`
+   |        ^^^^^^^^^^ expected `usize`, found `u32`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/bad-subst-const-kind.rs
+++ b/tests/ui/const-generics/bad-subst-const-kind.rs
@@ -6,7 +6,7 @@ trait Q {
 }
 
 impl<const N: u64> Q for [u8; N] {
-    //~^ ERROR mismatched types
+    //~^ ERROR the constant `N` is not of type `usize`
     const ASSOC: usize = 1;
 }
 

--- a/tests/ui/const-generics/bad-subst-const-kind.stderr
+++ b/tests/ui/const-generics/bad-subst-const-kind.stderr
@@ -1,9 +1,8 @@
-error[E0308]: mismatched types
-  --> $DIR/bad-subst-const-kind.rs:8:31
+error: the constant `N` is not of type `usize`
+  --> $DIR/bad-subst-const-kind.rs:8:26
    |
 LL | impl<const N: u64> Q for [u8; N] {
-   |                               ^ expected `usize`, found `u64`
+   |                          ^^^^^^^ expected `usize`, found `u64`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
@@ -14,7 +14,7 @@ LL | pub struct SelfDependent<const N: [u8; N]>;
    |
    = note: const parameters may not be used in the type of const parameters
 
-error: `[u8; N]` is forbidden as the type of a const generic parameter
+error: `[u8; [const error]]` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-type-depends-on-const-param.rs:11:47
    |
 LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
@@ -23,7 +23,7 @@ LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(adt_const_params)]`
 
-error: `[u8; N]` is forbidden as the type of a const generic parameter
+error: `[u8; [const error]]` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-type-depends-on-const-param.rs:15:35
    |
 LL | pub struct SelfDependent<const N: [u8; N]>;

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.rs
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.rs
@@ -10,10 +10,10 @@
 
 pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
 //~^ ERROR: the type of const parameters must not depend on other generic parameters
-//[min]~^^ ERROR `[u8; N]` is forbidden
+//[min]~^^ ERROR `[u8; [const error]]` is forbidden
 
 pub struct SelfDependent<const N: [u8; N]>;
 //~^ ERROR: the type of const parameters must not depend on other generic parameters
-//[min]~^^ ERROR `[u8; N]` is forbidden
+//[min]~^^ ERROR `[u8; [const error]]` is forbidden
 
 fn main() {}

--- a/tests/ui/const-generics/issue-97007.rs
+++ b/tests/ui/const-generics/issue-97007.rs
@@ -1,4 +1,6 @@
-// check-pass
+// known-bug: unknown
+// this should pass but currently does not because `generic_const_exprs` is very prone
+// to randomly encountering cycle errors on well formed code.
 
 #![feature(adt_const_params, generic_const_exprs)]
 #![allow(incomplete_features)]

--- a/tests/ui/const-generics/issue-97007.stderr
+++ b/tests/ui/const-generics/issue-97007.stderr
@@ -1,0 +1,28 @@
+error[E0391]: cycle detected when building an abstract representation for `lib::<impl at $DIR/issue-97007.rs:55:5: 55:81>::proceed_to::{constant#0}`
+  --> $DIR/issue-97007.rs:58:25
+   |
+LL |         ) -> Walk<NEXT, { walk(REMAINING, CURRENT, NEXT) }> {
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires building THIR for `lib::<impl at $DIR/issue-97007.rs:55:5: 55:81>::proceed_to::{constant#0}`...
+  --> $DIR/issue-97007.rs:58:25
+   |
+LL |         ) -> Walk<NEXT, { walk(REMAINING, CURRENT, NEXT) }> {
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires type-checking `lib::<impl at $DIR/issue-97007.rs:55:5: 55:81>::proceed_to::{constant#0}`...
+  --> $DIR/issue-97007.rs:58:25
+   |
+LL |         ) -> Walk<NEXT, { walk(REMAINING, CURRENT, NEXT) }> {
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires building an abstract representation for `lib::<impl at $DIR/issue-97007.rs:55:5: 55:81>::proceed_to::{constant#0}`, completing the cycle
+note: cycle used when checking that `lib::<impl at $DIR/issue-97007.rs:55:5: 55:81>::proceed_to` is well-formed
+  --> $DIR/issue-97007.rs:56:9
+   |
+LL | /         pub fn proceed_to<const NEXT: usize>(
+LL | |             self,
+LL | |         ) -> Walk<NEXT, { walk(REMAINING, CURRENT, NEXT) }> {
+   | |___________________________________________________________^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/const-generics/issues/issue-62878.min.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.min.stderr
@@ -6,7 +6,7 @@ LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |
    = note: const parameters may not be used in the type of const parameters
 
-error: `[u8; N]` is forbidden as the type of a const generic parameter
+error: `[u8; [const error]]` is forbidden as the type of a const generic parameter
   --> $DIR/issue-62878.rs:5:33
    |
 LL | fn foo<const N: usize, const A: [u8; N]>() {}

--- a/tests/ui/const-generics/issues/issue-62878.rs
+++ b/tests/ui/const-generics/issues/issue-62878.rs
@@ -4,7 +4,7 @@
 
 fn foo<const N: usize, const A: [u8; N]>() {}
 //~^ ERROR the type of const parameters must not
-//[min]~| ERROR `[u8; N]` is forbidden as the type of a const generic parameter
+//[min]~| ERROR `[u8; [const error]]` is forbidden as the type of a const generic parameter
 
 fn main() {
     foo::<_, { [1] }>();

--- a/tests/ui/const-generics/issues/issue-71169.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71169.min.stderr
@@ -6,7 +6,7 @@ LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
    |
    = note: const parameters may not be used in the type of const parameters
 
-error: `[u8; LEN]` is forbidden as the type of a const generic parameter
+error: `[u8; [const error]]` is forbidden as the type of a const generic parameter
   --> $DIR/issue-71169.rs:5:38
    |
 LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}

--- a/tests/ui/const-generics/issues/issue-71169.rs
+++ b/tests/ui/const-generics/issues/issue-71169.rs
@@ -4,7 +4,7 @@
 
 fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
 //~^ ERROR the type of const parameters must not
-//[min]~^^ ERROR `[u8; LEN]` is forbidden as the type of a const generic parameter
+//[min]~^^ ERROR `[u8; [const error]]` is forbidden as the type of a const generic parameter
 fn main() {
     const DATA: [u8; 4] = *b"ABCD";
     foo::<4, DATA>();

--- a/tests/ui/const-generics/transmute-fail-2.rs
+++ b/tests/ui/const-generics/transmute-fail-2.rs
@@ -1,0 +1,12 @@
+#![feature(transmute_generic_consts)]
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
+    //~^ ERROR the constant `W` is not of type `usize`
+    unsafe {
+        std::mem::transmute(v)
+    }
+}
+
+fn main() {}

--- a/tests/ui/const-generics/transmute-fail-2.stderr
+++ b/tests/ui/const-generics/transmute-fail-2.stderr
@@ -1,0 +1,8 @@
+error: the constant `W` is not of type `usize`
+  --> $DIR/transmute-fail-2.rs:5:42
+   |
+LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
+   |                                          ^^^^^^^^^^^^^ expected `usize`, found `bool`
+
+error: aborting due to previous error
+

--- a/tests/ui/const-generics/transmute-fail.rs
+++ b/tests/ui/const-generics/transmute-fail.rs
@@ -9,15 +9,6 @@ fn foo<const W: usize, const H: usize>(v: [[u32;H+1]; W]) -> [[u32; W+1]; H] {
   }
 }
 
-fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
-  //~^ ERROR mismatched types
-  //~| ERROR mismatched types
-  unsafe {
-    std::mem::transmute(v)
-    //~^ ERROR cannot transmute between types
-  }
-}
-
 fn baz<const W: usize, const H: usize>(v: [[u32; H]; W]) -> [u32; W * H * H] {
   unsafe {
     std::mem::transmute(v)

--- a/tests/ui/const-generics/transmute-fail.stderr
+++ b/tests/ui/const-generics/transmute-fail.stderr
@@ -8,28 +8,7 @@ LL |     std::mem::transmute(v)
    = note: target type: `[[u32; W+1]; H]` (generic size [const expr])
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:16:5
-   |
-LL |     std::mem::transmute(v)
-   |     ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: source type: `[[u32; H]; W]` (this type does not have a fixed size)
-   = note: target type: `[[u32; W]; H]` (size can vary because of [u32; W])
-
-error[E0308]: mismatched types
-  --> $DIR/transmute-fail.rs:12:53
-   |
-LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
-   |                                                     ^ expected `usize`, found `bool`
-
-error[E0308]: mismatched types
-  --> $DIR/transmute-fail.rs:12:67
-   |
-LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
-   |                                                                   ^ expected `usize`, found `bool`
-
-error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:23:5
+  --> $DIR/transmute-fail.rs:14:5
    |
 LL |     std::mem::transmute(v)
    |     ^^^^^^^^^^^^^^^^^^^
@@ -38,7 +17,7 @@ LL |     std::mem::transmute(v)
    = note: target type: `[u32; W * H * H]` (generic size [const expr])
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:30:5
+  --> $DIR/transmute-fail.rs:21:5
    |
 LL |     std::mem::transmute(v)
    |     ^^^^^^^^^^^^^^^^^^^
@@ -46,7 +25,6 @@ LL |     std::mem::transmute(v)
    = note: source type: `[[[u32; 8888888]; 9999999]; 777777777]` (values of the type `[[[u32; 8888888]; 9999999]; 777777777]` are too big for the current architecture)
    = note: target type: `[[[u32; 9999999]; 777777777]; 8888888]` (values of the type `[[[u32; 9999999]; 777777777]; 8888888]` are too big for the current architecture)
 
-error: aborting due to 6 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0308, E0512.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0512`.

--- a/tests/ui/const-generics/type_mismatch.rs
+++ b/tests/ui/const-generics/type_mismatch.rs
@@ -1,10 +1,8 @@
 fn foo<const N: usize>() -> [u8; N] {
-    bar::<N>() //~ ERROR mismatched types
-    //~^ ERROR the constant `N` is not of type `u8`
+    bar::<N>()
 }
 
 fn bar<const N: u8>() -> [u8; N] {}
-//~^ ERROR mismatched types
-//~| ERROR mismatched types
+//~^ ERROR the constant `N` is not of type `usize`
 
 fn main() {}

--- a/tests/ui/const-generics/type_mismatch.stderr
+++ b/tests/ui/const-generics/type_mismatch.stderr
@@ -1,35 +1,8 @@
-error: the constant `N` is not of type `u8`
-  --> $DIR/type_mismatch.rs:2:11
-   |
-LL |     bar::<N>()
-   |           ^ expected `u8`, found `usize`
-   |
-note: required by a bound in `bar`
-  --> $DIR/type_mismatch.rs:6:8
+error: the constant `N` is not of type `usize`
+  --> $DIR/type_mismatch.rs:5:26
    |
 LL | fn bar<const N: u8>() -> [u8; N] {}
-   |        ^^^^^^^^^^^ required by this bound in `bar`
+   |                          ^^^^^^^ expected `usize`, found `u8`
 
-error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:2:11
-   |
-LL |     bar::<N>()
-   |           ^ expected `u8`, found `usize`
+error: aborting due to previous error
 
-error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:6:26
-   |
-LL | fn bar<const N: u8>() -> [u8; N] {}
-   |    ---                   ^^^^^^^ expected `[u8; N]`, found `()`
-   |    |
-   |    implicitly returns `()` as its body has no tail or `return` expression
-
-error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:6:31
-   |
-LL | fn bar<const N: u8>() -> [u8; N] {}
-   |                               ^ expected `usize`, found `u8`
-
-error: aborting due to 4 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/const-integer-bool-ops.rs
+++ b/tests/ui/consts/const-integer-bool-ops.rs
@@ -6,7 +6,6 @@ const X: usize = 42 && 39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR: [i32; X] = [99; 34];
-//~^ constant
 
 const X1: usize = 42 || 39;
 //~^ ERROR mismatched types
@@ -16,7 +15,6 @@ const X1: usize = 42 || 39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR1: [i32; X1] = [99; 47];
-//~^ constant
 
 const X2: usize = -42 || -39;
 //~^ ERROR mismatched types
@@ -26,7 +24,6 @@ const X2: usize = -42 || -39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR2: [i32; X2] = [99; 18446744073709551607];
-//~^ constant
 
 const X3: usize = -42 && -39;
 //~^ ERROR mismatched types
@@ -36,43 +33,36 @@ const X3: usize = -42 && -39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR3: [i32; X3] = [99; 6];
-//~^ constant
 
 const Y: usize = 42.0 == 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR: [i32; Y] = [99; 1];
-//~^ constant
 
 const Y1: usize = 42.0 >= 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR1: [i32; Y1] = [99; 1];
-//~^ constant
 
 const Y2: usize = 42.0 <= 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR2: [i32; Y2] = [99; 1];
-//~^ constant
 
 const Y3: usize = 42.0 > 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR3: [i32; Y3] = [99; 0];
-//~^ constant
 
 const Y4: usize = 42.0 < 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR4: [i32; Y4] = [99; 0];
-//~^ constant
 
 const Y5: usize = 42.0 != 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR5: [i32; Y5] = [99; 0];
-//~^ constant
 
 fn main() {
     let _ = ARR;

--- a/tests/ui/consts/const-integer-bool-ops.stderr
+++ b/tests/ui/consts/const-integer-bool-ops.stderr
@@ -16,155 +16,95 @@ error[E0308]: mismatched types
 LL | const X: usize = 42 && 39;
    |                  ^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:8:18
-   |
-LL | const ARR: [i32; X] = [99; 34];
-   |                  ^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:11:19
+  --> $DIR/const-integer-bool-ops.rs:10:19
    |
 LL | const X1: usize = 42 || 39;
    |                   ^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:11:25
+  --> $DIR/const-integer-bool-ops.rs:10:25
    |
 LL | const X1: usize = 42 || 39;
    |                         ^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:11:19
+  --> $DIR/const-integer-bool-ops.rs:10:19
    |
 LL | const X1: usize = 42 || 39;
    |                   ^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:18:19
-   |
-LL | const ARR1: [i32; X1] = [99; 47];
-   |                   ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:21:19
+  --> $DIR/const-integer-bool-ops.rs:19:19
    |
 LL | const X2: usize = -42 || -39;
    |                   ^^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:21:26
+  --> $DIR/const-integer-bool-ops.rs:19:26
    |
 LL | const X2: usize = -42 || -39;
    |                          ^^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:21:19
+  --> $DIR/const-integer-bool-ops.rs:19:19
    |
 LL | const X2: usize = -42 || -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
+error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:28:19
    |
-LL | const ARR2: [i32; X2] = [99; 18446744073709551607];
-   |                   ^^
-
-error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:31:19
-   |
 LL | const X3: usize = -42 && -39;
    |                   ^^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:31:26
+  --> $DIR/const-integer-bool-ops.rs:28:26
    |
 LL | const X3: usize = -42 && -39;
    |                          ^^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:31:19
+  --> $DIR/const-integer-bool-ops.rs:28:19
    |
 LL | const X3: usize = -42 && -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:38:19
-   |
-LL | const ARR3: [i32; X3] = [99; 6];
-   |                   ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:41:18
+  --> $DIR/const-integer-bool-ops.rs:37:18
    |
 LL | const Y: usize = 42.0 == 42.0;
    |                  ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:44:19
-   |
-LL | const ARRR: [i32; Y] = [99; 1];
-   |                   ^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:47:19
+  --> $DIR/const-integer-bool-ops.rs:42:19
    |
 LL | const Y1: usize = 42.0 >= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:50:20
-   |
-LL | const ARRR1: [i32; Y1] = [99; 1];
-   |                    ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:53:19
+  --> $DIR/const-integer-bool-ops.rs:47:19
    |
 LL | const Y2: usize = 42.0 <= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:56:20
-   |
-LL | const ARRR2: [i32; Y2] = [99; 1];
-   |                    ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:59:19
+  --> $DIR/const-integer-bool-ops.rs:52:19
    |
 LL | const Y3: usize = 42.0 > 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:62:20
-   |
-LL | const ARRR3: [i32; Y3] = [99; 0];
-   |                    ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:65:19
+  --> $DIR/const-integer-bool-ops.rs:57:19
    |
 LL | const Y4: usize = 42.0 < 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:68:20
-   |
-LL | const ARRR4: [i32; Y4] = [99; 0];
-   |                    ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:71:19
+  --> $DIR/const-integer-bool-ops.rs:62:19
    |
 LL | const Y5: usize = 42.0 != 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
-
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:74:20
-   |
-LL | const ARRR5: [i32; Y5] = [99; 0];
-   |                    ^^
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/consts/const-len-underflow-separate-spans.rs
+++ b/tests/ui/consts/const-len-underflow-separate-spans.rs
@@ -9,5 +9,4 @@ const LEN: usize = ONE - TWO;
 
 fn main() {
     let a: [i8; LEN] = unimplemented!();
-//~^ constant
 }

--- a/tests/ui/consts/const-len-underflow-separate-spans.stderr
+++ b/tests/ui/consts/const-len-underflow-separate-spans.stderr
@@ -4,12 +4,6 @@ error[E0080]: evaluation of constant value failed
 LL | const LEN: usize = ONE - TWO;
    |                    ^^^^^^^^^ attempt to compute `1_usize - 2_usize`, which would overflow
 
-note: erroneous constant used
-  --> $DIR/const-len-underflow-separate-spans.rs:11:17
-   |
-LL |     let a: [i8; LEN] = unimplemented!();
-   |                 ^^^
-
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/issue-39974.rs
+++ b/tests/ui/consts/issue-39974.rs
@@ -1,9 +1,9 @@
 const LENGTH: f64 = 2;
+//~^ ERROR: mismatched types
 
 struct Thing {
     f: [[f64; 2]; LENGTH],
-    //~^ ERROR mismatched types
-    //~| expected `usize`, found `f64`
+    //~^ ERROR: the constant `[const error]` is not of type `usize`
 }
 
 fn main() {

--- a/tests/ui/consts/issue-39974.stderr
+++ b/tests/ui/consts/issue-39974.stderr
@@ -1,9 +1,18 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-39974.rs:4:19
+  --> $DIR/issue-39974.rs:1:21
+   |
+LL | const LENGTH: f64 = 2;
+   |                     ^
+   |                     |
+   |                     expected `f64`, found integer
+   |                     help: use a float literal: `2.0`
+
+error: the constant `[const error]` is not of type `usize`
+  --> $DIR/issue-39974.rs:5:8
    |
 LL |     f: [[f64; 2]; LENGTH],
-   |                   ^^^^^^ expected `usize`, found `f64`
+   |        ^^^^^^^^^^^^^^^^^^ expected `usize`, found `f64`
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/issue-54954.rs
+++ b/tests/ui/consts/issue-54954.rs
@@ -9,8 +9,6 @@ trait Tt {
 }
 
 fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-  //~^ constant
-  //~| constant
     z
 }
 

--- a/tests/ui/consts/issue-54954.stderr
+++ b/tests/ui/consts/issue-54954.stderr
@@ -16,18 +16,6 @@ LL | |         core::mem::size_of::<T>()
 LL | |     }
    | |_____- `Tt::const_val` defined here
 
-note: erroneous constant used
-  --> $DIR/issue-54954.rs:11:15
-   |
-LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-   |               ^^^^^^^
-
-note: erroneous constant used
-  --> $DIR/issue-54954.rs:11:34
-   |
-LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-   |                                  ^^^^^^^
-
 error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0379, E0790.

--- a/tests/ui/consts/nested_erroneous_ctfe.rs
+++ b/tests/ui/consts/nested_erroneous_ctfe.rs
@@ -1,4 +1,5 @@
 fn main() {
     [9; || [9; []]];
     //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
 }

--- a/tests/ui/consts/nested_erroneous_ctfe.stderr
+++ b/tests/ui/consts/nested_erroneous_ctfe.stderr
@@ -7,6 +7,19 @@ LL |     [9; || [9; []]];
    = note: expected type `usize`
              found array `[_; 0]`
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/nested_erroneous_ctfe.rs:2:9
+   |
+LL |     [9; || [9; []]];
+   |         ^^^^^^^^^^ expected `usize`, found closure
+   |
+   = note: expected type `usize`
+           found closure `[closure@$DIR/nested_erroneous_ctfe.rs:2:9: 2:11]`
+help: use parentheses to call this closure
+   |
+LL |     [9; (|| [9; []])()];
+   |         +          +++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/refs_check_const_value_eq-issue-88876.rs
+++ b/tests/ui/consts/refs_check_const_value_eq-issue-88876.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 #![allow(incomplete_features)]
 #![feature(adt_const_params)]
 
@@ -9,4 +7,5 @@ const FOO_ARR: &[&'static str; 2] = &["Hello", "Friend"];
 
 fn main() {
     let _ = FooConst::<FOO_ARR> {};
+    //~^ ERROR: the constant `&["Hello", "Friend"]` is not of type `&'static [&'static str]`
 }

--- a/tests/ui/consts/refs_check_const_value_eq-issue-88876.stderr
+++ b/tests/ui/consts/refs_check_const_value_eq-issue-88876.stderr
@@ -1,0 +1,14 @@
+error: the constant `&["Hello", "Friend"]` is not of type `&'static [&'static str]`
+  --> $DIR/refs_check_const_value_eq-issue-88876.rs:9:24
+   |
+LL |     let _ = FooConst::<FOO_ARR> {};
+   |                        ^^^^^^^ expected `&'static [&'static str]`, found `&'static [&'static str; 2]`
+   |
+note: required by a bound in `FooConst`
+  --> $DIR/refs_check_const_value_eq-issue-88876.rs:4:17
+   |
+LL | struct FooConst<const ARRAY: &'static [&'static str]> {}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `FooConst`
+
+error: aborting due to previous error
+

--- a/tests/ui/issues/issue-17252.stderr
+++ b/tests/ui/issues/issue-17252.stderr
@@ -5,11 +5,11 @@ LL | const FOO: usize = FOO;
    |                    ^^^
    |
    = note: ...which immediately requires const-evaluating + checking `FOO` again
-note: cycle used when const-evaluating + checking `main::{constant#0}`
-  --> $DIR/issue-17252.rs:4:18
+note: cycle used when const-evaluating + checking `FOO`
+  --> $DIR/issue-17252.rs:1:1
    |
-LL |     let _x: [u8; FOO]; // caused stack overflow prior to fix
-   |                  ^^^
+LL | const FOO: usize = FOO;
+   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-27008.rs
+++ b/tests/ui/issues/issue-27008.rs
@@ -2,6 +2,5 @@ struct S;
 
 fn main() {
     let b = [0; S];
-    //~^ ERROR mismatched types
-    //~| expected `usize`, found `S`
+    //~^ ERROR the constant `S` is not of type `usize`
 }

--- a/tests/ui/issues/issue-27008.stderr
+++ b/tests/ui/issues/issue-27008.stderr
@@ -1,9 +1,8 @@
-error[E0308]: mismatched types
-  --> $DIR/issue-27008.rs:4:17
+error: the constant `S` is not of type `usize`
+  --> $DIR/issue-27008.rs:4:13
    |
 LL |     let b = [0; S];
-   |                 ^ expected `usize`, found `S`
+   |             ^^^^^^ expected `usize`, found `S`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/issues/issue-66706.rs
+++ b/tests/ui/issues/issue-66706.rs
@@ -2,6 +2,7 @@ fn a() {
     [0; [|_: _ &_| ()].len()]
     //~^ ERROR expected `,`, found `&`
     //~| ERROR type annotations needed
+    //~| ERROR mismatched types
 }
 
 fn b() {
@@ -12,11 +13,13 @@ fn b() {
 fn c() {
     [0; [|&_: _ &_| {}; 0 ].len()]
     //~^ ERROR expected `,`, found `&`
+    //~| ERROR mismatched types
 }
 
 fn d() {
     [0; match [|f @ &ref _| () ] {} ]
     //~^ ERROR expected identifier, found reserved identifier `_`
+    //~| ERROR mismatched types
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-66706.stderr
+++ b/tests/ui/issues/issue-66706.stderr
@@ -7,13 +7,13 @@ LL |     [0; [|_: _ &_| ()].len()]
    |               help: missing `,`
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-66706.rs:8:20
+  --> $DIR/issue-66706.rs:9:20
    |
 LL |     [0; [|f @ &ref _| {} ; 0 ].len() ];
    |                    ^ expected identifier, found reserved identifier
 
 error: expected `,`, found `&`
-  --> $DIR/issue-66706.rs:13:17
+  --> $DIR/issue-66706.rs:14:17
    |
 LL |     [0; [|&_: _ &_| {}; 0 ].len()]
    |                -^ expected `,`
@@ -21,7 +21,7 @@ LL |     [0; [|&_: _ &_| {}; 0 ].len()]
    |                help: missing `,`
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-66706.rs:18:26
+  --> $DIR/issue-66706.rs:20:26
    |
 LL |     [0; match [|f @ &ref _| () ] {} ]
    |                          ^ expected identifier, found reserved identifier
@@ -32,6 +32,31 @@ error[E0282]: type annotations needed
 LL |     [0; [|_: _ &_| ()].len()]
    |           ^ cannot infer type
 
-error: aborting due to 5 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-66706.rs:2:5
+   |
+LL | fn a() {
+   |        - help: try adding a return type: `-> [i32; [|_: _ &_| ()].len()]`
+LL |     [0; [|_: _ &_| ()].len()]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `[{integer}; [|_: _ &_| ()].len()]`
 
-For more information about this error, try `rustc --explain E0282`.
+error[E0308]: mismatched types
+  --> $DIR/issue-66706.rs:14:5
+   |
+LL | fn c() {
+   |        - help: try adding a return type: `-> [i32; [|&_: _ &_| {}; 0 ].len()]`
+LL |     [0; [|&_: _ &_| {}; 0 ].len()]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `[{integer}; [|&_: _ &_| {}; 0 ].len()]`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-66706.rs:20:5
+   |
+LL | fn d() {
+   |        - help: try adding a return type: `-> [i32; match [|f @ &ref _| () ] {}]`
+LL |     [0; match [|f @ &ref _| () ] {} ]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `[{integer}; match [|f @ &ref _| () ] {}]`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0282, E0308.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/resolve/issue-50599.rs
+++ b/tests/ui/resolve/issue-50599.rs
@@ -2,5 +2,4 @@ fn main() {
     const N: u32 = 1_000;
     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize; //~ ERROR cannot find value
     let mut digits = [0u32; M];
-    //~^ constant
 }

--- a/tests/ui/resolve/issue-50599.stderr
+++ b/tests/ui/resolve/issue-50599.stderr
@@ -16,12 +16,6 @@ LL -     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
 LL +     const M: usize = (f64::from(N) * LOG10_2) as usize;
    |
 
-note: erroneous constant used
-  --> $DIR/issue-50599.rs:4:29
-   |
-LL |     let mut digits = [0u32; M];
-   |                             ^
-
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/stats/hir-stats.rs
+++ b/tests/ui/stats/hir-stats.rs
@@ -1,6 +1,7 @@
 // check-pass
 // compile-flags: -Zhir-stats
 // only-x86_64
+// ignore-stage1
 
 // Type layouts sometimes change. When that happens, until the next bootstrap
 // bump occurs, stage1 and stage2 will give different outputs for this test.

--- a/tests/ui/symbol-names/const-generics-structural-demangling.rs
+++ b/tests/ui/symbol-names/const-generics-structural-demangling.rs
@@ -51,7 +51,7 @@ pub struct OptionUsize<const OU: Option<usize>>;
 //~^ ERROR symbol-name
 //~| ERROR demangling
 //~| ERROR demangling-alt(<c::OptionUsize<{core::option::Option::<usize>::None}>>)
-impl OptionUsize<{None}> {}
+impl OptionUsize<{None::<_>}> {}
 
 // HACK(eddyb) the full mangling is only in `.stderr` because we can normalize
 // the `core` disambiguator hash away there, but not here.

--- a/tests/ui/traits/non_lifetime_binders/capture-late-ct-in-anon.rs
+++ b/tests/ui/traits/non_lifetime_binders/capture-late-ct-in-anon.rs
@@ -1,10 +1,17 @@
-#![feature(non_lifetime_binders)]
+#![feature(non_lifetime_binders, generic_const_exprs)]
 //~^ WARN the feature `non_lifetime_binders` is incomplete
+//~| WARN the feature `generic_const_exprs` is incomplete
+
+fn a()
+where
+    for<const C: usize> [(); C + 1]: Copy,
+    //~^ ERROR cannot capture late-bound const parameter in a constant
+{    
+}
 
 fn b()
 where
     for<const C: usize> [(); C]: Copy,
-    //~^ ERROR cannot capture late-bound const parameter in a constant
 {
 }
 

--- a/tests/ui/traits/non_lifetime_binders/capture-late-ct-in-anon.stderr
+++ b/tests/ui/traits/non_lifetime_binders/capture-late-ct-in-anon.stderr
@@ -1,19 +1,27 @@
 warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/capture-late-ct-in-anon.rs:1:12
    |
-LL | #![feature(non_lifetime_binders)]
+LL | #![feature(non_lifetime_binders, generic_const_exprs)]
    |            ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error: cannot capture late-bound const parameter in a constant
-  --> $DIR/capture-late-ct-in-anon.rs:6:30
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/capture-late-ct-in-anon.rs:1:34
    |
-LL |     for<const C: usize> [(); C]: Copy,
+LL | #![feature(non_lifetime_binders, generic_const_exprs)]
+   |                                  ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+
+error: cannot capture late-bound const parameter in a constant
+  --> $DIR/capture-late-ct-in-anon.rs:7:30
+   |
+LL |     for<const C: usize> [(); C + 1]: Copy,
    |         --------------       ^
    |         |
    |         parameter defined here
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error; 2 warnings emitted
 

--- a/tests/ui/type/type-dependent-def-issue-49241.rs
+++ b/tests/ui/type/type-dependent-def-issue-49241.rs
@@ -2,5 +2,4 @@ fn main() {
     let v = vec![0];
     const l: usize = v.count(); //~ ERROR attempt to use a non-constant value in a constant
     let s: [u32; l] = v.into_iter().collect();
-    //~^ constant
 }

--- a/tests/ui/type/type-dependent-def-issue-49241.stderr
+++ b/tests/ui/type/type-dependent-def-issue-49241.stderr
@@ -6,12 +6,6 @@ LL |     const l: usize = v.count();
    |     |
    |     help: consider using `let` instead of `const`: `let l`
 
-note: erroneous constant used
-  --> $DIR/type-dependent-def-issue-49241.rs:4:18
-   |
-LL |     let s: [u32; l] = v.into_iter().collect();
-   |                  ^
-
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0435`.


### PR DESCRIPTION
Avoid creating anon consts for some arguments/attempt to implement parts of `min_generic_const_exprs`

not ready for review just opening so that i can see the list of comments and whole diff easier