### PR TITLE
Dummy PR to check instrument-coverage test failures in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
             tidy: false
             os: ubuntu-20.04-16core-64gb
             env: {}
+          - name: x86_64-gnu
+            tidy: false
+            os: ubuntu-20.04-8core-32gb
+            env: {}
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -320,6 +320,10 @@ jobs:
             <<: *job-linux-16c
             tidy: false
 
+          - name: x86_64-gnu
+            <<: *job-linux-8c
+            tidy: false
+
   auto:
     permissions:
       actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds

--- a/tests/run-make/coverage-reports/Makefile
+++ b/tests/run-make/coverage-reports/Makefile
@@ -174,7 +174,7 @@ else
 	# files are redundant, so there is no need to generate `expected_*.json` files or
 	# compare actual JSON results.)
 
-	$(DIFF) --ignore-matching-lines='^  \| .*::<.*>.*:$$' --ignore-matching-lines='^  \| <.*>::.*:$$' \
+	$(DIFF) --ignore-matching-lines='^  | .*::<.*>.*:$$' --ignore-matching-lines='^  | <.*>::.*:$$' \
 		expected_show_coverage.$@.txt "$(TMPDIR)"/actual_show_coverage.$@.txt || \
 		( grep -q '^\/\/ ignore-llvm-cov-show-diffs' $(SOURCEDIR)/$@.rs && \
 			>&2 echo 'diff failed, but suppressed with `// ignore-llvm-cov-show-diffs` in $(SOURCEDIR)/$@.rs' \


### PR DESCRIPTION
https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Do.20.60needs-profiler-support.60.20tests.20not.20run.20in.20CI.3F

Sorry for the noise; I was having some trouble getting the CI jobs to run at all, and I'm not sure how to politely avoid the auto-notifications.