### PR TITLE
Remove unnecessary Send bound

### DIFF
--- a/library/std/src/sync/mpmc/error.rs
+++ b/library/std/src/sync/mpmc/error.rs
@@ -35,7 +35,7 @@ impl<T> fmt::Display for SendTimeoutError<T> {
     }
 }
 
-impl<T: Send> error::Error for SendTimeoutError<T> {}
+impl<T> error::Error for SendTimeoutError<T> {}
 
 impl<T> From<SendError<T>> for SendTimeoutError<T> {
     fn from(err: SendError<T>) -> SendTimeoutError<T> {

--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -1124,7 +1124,7 @@ impl<T> fmt::Display for SendError<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Send> error::Error for SendError<T> {
+impl<T> error::Error for SendError<T> {
     #[allow(deprecated)]
     fn description(&self) -> &str {
         "sending on a closed channel"
@@ -1152,7 +1152,7 @@ impl<T> fmt::Display for TrySendError<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Send> error::Error for TrySendError<T> {
+impl<T> error::Error for TrySendError<T> {
     #[allow(deprecated)]
     fn description(&self) -> &str {
         match *self {


### PR DESCRIPTION
Hi,

While working on a [PR on Tokio](https://github.com/tokio-rs/tokio/pull/5666), I took inspiration from the std channel mpsc and stumbled on a `Send` bound for a `Error` impl.

Tokio's maintainer @Darksonn pointed out to me that `Error` used to required the `Send` bound long time ago (here https://github.com/rust-lang/rust/pull/23541). 

In the meantime, the `Send` bound `Error` got removed (see https://github.com/rust-lang/rust/pull/21312 and https://github.com/rust-lang/rust/pull/23799).

So here a PR to removed this bound for `SendError<T>`, `TrySendError<T>` and `SendTimeoutError<T>`.