### PR TITLE
Fix MXCSR configuration dependent timing

### DIFF
--- a/library/std/src/sys/sgx/abi/entry.S
+++ b/library/std/src/sys/sgx/abi/entry.S
@@ -26,7 +26,7 @@ IMAGE_BASE:
 .Lxsave_clear:
 .org .+24
 .Lxsave_mxcsr:
-    .short 0x1f80
+    .short 0x1fbf
 
 /*  We can store a bunch of data in the gap between MXCSR and the XSAVE header */
 
@@ -178,6 +178,7 @@ sgx_entry:
     mov $-1, %rax
     mov $-1, %rdx
     xrstor .Lxsave_clear(%rip)
+    lfence
     mov %r10, %rdx
 
 /*  check if returning from usercall */
@@ -311,6 +312,9 @@ usercall:
     movq $0,%gs:tcsls_last_rsp
 /*  restore callee-saved state, cf. "save" above */
     mov %r11,%rsp
+    /* MCDT mitigation requires an lfence after ldmxcsr _before_ any of the affected  */
+    /* vector instructions is used. We omit the lfence here as one is required before */
+    /* the jmp instruction anyway. */
     ldmxcsr (%rsp)
     fldcw 4(%rsp)
     add $8, %rsp


### PR DESCRIPTION
Dependent on the (potentially secret) data some vector instructions operate on, and the content in MXCSR, instruction retirement may be delayed by one cycle. This is a potential side channel.

This PR fixes this vulnerability for the `x86_64-fortanix-unknown-sgx` platform by loading MXCSR with `0x1fbf` through an `xrstor` instruction when the enclave is entered and executing an `lfence` immediately after. Other changes of the MXCSR happen only when the enclave is about to be exited and no vector instructions will be executed before it will actually do so. Users of EDP who change the MXCSR and do wish to defend against this side channel, will need to implement the software mitigation described [here](https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/best-practices/mxcsr-configuration-dependent-timing.html).

cc: @jethrogb @monokles