### PR TITLE
rustc_middle: Fix `opt_item_ident` for non-local def ids

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2109,10 +2109,9 @@ impl<'tcx> TyCtxt<'tcx> {
     /// See [`item_name`][Self::item_name] for more information.
     pub fn opt_item_ident(self, def_id: DefId) -> Option<Ident> {
         let def = self.opt_item_name(def_id)?;
-        let span = def_id
-            .as_local()
-            .and_then(|id| self.def_ident_span(id))
-            .unwrap_or(rustc_span::DUMMY_SP);
+        let span = self
+            .def_ident_span(def_id)
+            .unwrap_or_else(|| bug!("missing ident span for {def_id:?}"));
         Some(Ident::new(def, span))
     }
 

--- a/tests/ui/const-generics/generic_const_exprs/cross_crate_predicate.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/cross_crate_predicate.stderr
@@ -8,6 +8,9 @@ LL |     let _ = const_evaluatable_lib::test1::<T>();
 note: required by a bound in `test1`
   --> $DIR/auxiliary/const_evaluatable_lib.rs:6:10
    |
+LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
+   |        ----- required by a bound in this function
+LL | where
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
 
@@ -34,6 +37,9 @@ LL |     let _ = const_evaluatable_lib::test1::<T>();
 note: required by a bound in `test1`
   --> $DIR/auxiliary/const_evaluatable_lib.rs:6:10
    |
+LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
+   |        ----- required by a bound in this function
+LL | where
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
 

--- a/tests/ui/error-codes/E0277.stderr
+++ b/tests/ui/error-codes/E0277.stderr
@@ -5,7 +5,8 @@ LL | fn f(p: Path) { }
    |      ^ doesn't have a size known at compile-time
    |
    = help: within `Path`, the trait `Sized` is not implemented for `[u8]`
-   = note: required because it appears within the type `Path`
+note: required because it appears within the type `Path`
+  --> $SRC_DIR/std/src/path.rs:LL:COL
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |

--- a/tests/ui/fmt/send-sync.stderr
+++ b/tests/ui/fmt/send-sync.stderr
@@ -8,10 +8,12 @@ LL |     send(format_args!("{:?}", c));
    |
    = help: within `[core::fmt::rt::Argument<'_>]`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
-   = note: required because it appears within the type `Argument<'_>`
+note: required because it appears within the type `Argument<'_>`
+  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
    = note: required because it appears within the type `[Argument<'_>]`
    = note: required for `&[core::fmt::rt::Argument<'_>]` to implement `Send`
-   = note: required because it appears within the type `Arguments<'_>`
+note: required because it appears within the type `Arguments<'_>`
+  --> $SRC_DIR/core/src/fmt/mod.rs:LL:COL
 note: required by a bound in `send`
   --> $DIR/send-sync.rs:1:12
    |
@@ -28,10 +30,12 @@ LL |     sync(format_args!("{:?}", c));
    |
    = help: within `Arguments<'_>`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
-   = note: required because it appears within the type `Argument<'_>`
+note: required because it appears within the type `Argument<'_>`
+  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
    = note: required because it appears within the type `[Argument<'_>]`
    = note: required because it appears within the type `&[Argument<'_>]`
-   = note: required because it appears within the type `Arguments<'_>`
+note: required because it appears within the type `Arguments<'_>`
+  --> $SRC_DIR/core/src/fmt/mod.rs:LL:COL
 note: required by a bound in `sync`
   --> $DIR/send-sync.rs:2:12
    |

--- a/tests/ui/interior-mutability/interior-mutability.stderr
+++ b/tests/ui/interior-mutability/interior-mutability.stderr
@@ -7,7 +7,8 @@ LL |     catch_unwind(|| { x.set(23); });
    |     required by a bound introduced by this call
    |
    = help: within `Cell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
-   = note: required because it appears within the type `Cell<i32>`
+note: required because it appears within the type `Cell<i32>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `&Cell<i32>` to implement `UnwindSafe`
 note: required because it's used within this closure
   --> $DIR/interior-mutability.rs:5:18

--- a/tests/ui/issues/issue-21763.rs
+++ b/tests/ui/issues/issue-21763.rs
@@ -1,5 +1,7 @@
 // Regression test for HashMap only impl'ing Send/Sync if its contents do
 
+// normalize-stderr-test: "\S+hashbrown-\S+" -> "$$HASHBROWN_SRC_LOCATION"
+
 use std::collections::HashMap;
 use std::rc::Rc;
 

--- a/tests/ui/issues/issue-21763.stderr
+++ b/tests/ui/issues/issue-21763.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
-  --> $DIR/issue-21763.rs:9:11
+  --> $DIR/issue-21763.rs:11:11
    |
 LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    |           ^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
@@ -7,10 +7,15 @@ LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    = help: within `(Rc<()>, Rc<()>)`, the trait `Send` is not implemented for `Rc<()>`
    = note: required because it appears within the type `(Rc<()>, Rc<()>)`
    = note: required for `hashbrown::raw::RawTable<(Rc<()>, Rc<()>)>` to implement `Send`
-   = note: required because it appears within the type `HashMap<Rc<()>, Rc<()>, RandomState>`
-   = note: required because it appears within the type `HashMap<Rc<()>, Rc<()>>`
+note: required because it appears within the type `HashMap<Rc<()>, Rc<()>, RandomState>`
+  --> $HASHBROWN_SRC_LOCATION
+   |
+LL | pub struct HashMap<K, V, S = DefaultHashBuilder, A: Allocator + Clone = Global> {
+   |            ^^^^^^^
+note: required because it appears within the type `HashMap<Rc<()>, Rc<()>>`
+  --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
 note: required by a bound in `foo`
-  --> $DIR/issue-21763.rs:6:11
+  --> $DIR/issue-21763.rs:8:11
    |
 LL | fn foo<T: Send>() {}
    |           ^^^^ required by this bound in `foo`

--- a/tests/ui/issues/issue-7364.stderr
+++ b/tests/ui/issues/issue-7364.stderr
@@ -7,7 +7,8 @@ LL | static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
    = help: the trait `Sync` is not implemented for `RefCell<isize>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
    = note: required for `Unique<RefCell<isize>>` to implement `Sync`
-   = note: required because it appears within the type `Box<RefCell<isize>>`
+note: required because it appears within the type `Box<RefCell<isize>>`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
    = note: shared static variables must have a type that implements `Sync`
 
 error: aborting due to previous error

--- a/tests/ui/kindck/kindck-send-object.stderr
+++ b/tests/ui/kindck/kindck-send-object.stderr
@@ -20,7 +20,8 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
    = note: required for `Unique<dyn Dummy>` to implement `Send`
-   = note: required because it appears within the type `Box<dyn Dummy>`
+note: required because it appears within the type `Box<dyn Dummy>`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object.rs:5:18
    |

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -20,7 +20,8 @@ LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |
    = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`
    = note: required for `Unique<(dyn Dummy + 'a)>` to implement `Send`
-   = note: required because it appears within the type `Box<dyn Dummy>`
+note: required because it appears within the type `Box<dyn Dummy>`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object1.rs:5:18
    |

--- a/tests/ui/kindck/kindck-send-object2.stderr
+++ b/tests/ui/kindck/kindck-send-object2.stderr
@@ -20,7 +20,8 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
    = note: required for `Unique<dyn Dummy>` to implement `Send`
-   = note: required because it appears within the type `Box<dyn Dummy>`
+note: required because it appears within the type `Box<dyn Dummy>`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object2.rs:3:18
    |

--- a/tests/ui/kindck/kindck-send-owned.stderr
+++ b/tests/ui/kindck/kindck-send-owned.stderr
@@ -6,7 +6,8 @@ LL |     assert_send::<Box<*mut u8>>();
    |
    = help: the trait `Send` is not implemented for `*mut u8`
    = note: required for `Unique<*mut u8>` to implement `Send`
-   = note: required because it appears within the type `Box<*mut u8>`
+note: required because it appears within the type `Box<*mut u8>`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-owned.rs:3:18
    |

--- a/tests/ui/not-panic/not-panic-safe-2.stderr
+++ b/tests/ui/not-panic/not-panic-safe-2.stderr
@@ -5,7 +5,8 @@ LL |     assert::<Rc<RefCell<i32>>>();
    |              ^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
-   = note: required because it appears within the type `RefCell<i32>`
+note: required because it appears within the type `RefCell<i32>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `Rc<RefCell<i32>>` to implement `UnwindSafe`
 note: required by a bound in `assert`
   --> $DIR/not-panic-safe-2.rs:7:14
@@ -20,8 +21,10 @@ LL |     assert::<Rc<RefCell<i32>>>();
    |              ^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
-   = note: required because it appears within the type `Cell<isize>`
-   = note: required because it appears within the type `RefCell<i32>`
+note: required because it appears within the type `Cell<isize>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
+note: required because it appears within the type `RefCell<i32>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `Rc<RefCell<i32>>` to implement `UnwindSafe`
 note: required by a bound in `assert`
   --> $DIR/not-panic-safe-2.rs:7:14

--- a/tests/ui/not-panic/not-panic-safe-3.stderr
+++ b/tests/ui/not-panic/not-panic-safe-3.stderr
@@ -5,7 +5,8 @@ LL |     assert::<Arc<RefCell<i32>>>();
    |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
-   = note: required because it appears within the type `RefCell<i32>`
+note: required because it appears within the type `RefCell<i32>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `Arc<RefCell<i32>>` to implement `UnwindSafe`
 note: required by a bound in `assert`
   --> $DIR/not-panic-safe-3.rs:7:14
@@ -20,8 +21,10 @@ LL |     assert::<Arc<RefCell<i32>>>();
    |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
-   = note: required because it appears within the type `Cell<isize>`
-   = note: required because it appears within the type `RefCell<i32>`
+note: required because it appears within the type `Cell<isize>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
+note: required because it appears within the type `RefCell<i32>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `Arc<RefCell<i32>>` to implement `UnwindSafe`
 note: required by a bound in `assert`
   --> $DIR/not-panic-safe-3.rs:7:14

--- a/tests/ui/not-panic/not-panic-safe-4.stderr
+++ b/tests/ui/not-panic/not-panic-safe-4.stderr
@@ -5,7 +5,8 @@ LL |     assert::<&RefCell<i32>>();
    |              ^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
-   = note: required because it appears within the type `RefCell<i32>`
+note: required because it appears within the type `RefCell<i32>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `&RefCell<i32>` to implement `UnwindSafe`
 note: required by a bound in `assert`
   --> $DIR/not-panic-safe-4.rs:6:14
@@ -25,8 +26,10 @@ LL |     assert::<&RefCell<i32>>();
    |              ^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
-   = note: required because it appears within the type `Cell<isize>`
-   = note: required because it appears within the type `RefCell<i32>`
+note: required because it appears within the type `Cell<isize>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
+note: required because it appears within the type `RefCell<i32>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `&RefCell<i32>` to implement `UnwindSafe`
 note: required by a bound in `assert`
   --> $DIR/not-panic-safe-4.rs:6:14

--- a/tests/ui/not-panic/not-panic-safe-6.stderr
+++ b/tests/ui/not-panic/not-panic-safe-6.stderr
@@ -5,7 +5,8 @@ LL |     assert::<*mut RefCell<i32>>();
    |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
-   = note: required because it appears within the type `RefCell<i32>`
+note: required because it appears within the type `RefCell<i32>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `*mut RefCell<i32>` to implement `UnwindSafe`
 note: required by a bound in `assert`
   --> $DIR/not-panic-safe-6.rs:6:14
@@ -20,8 +21,10 @@ LL |     assert::<*mut RefCell<i32>>();
    |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
-   = note: required because it appears within the type `Cell<isize>`
-   = note: required because it appears within the type `RefCell<i32>`
+note: required because it appears within the type `Cell<isize>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
+note: required because it appears within the type `RefCell<i32>`
+  --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `*mut RefCell<i32>` to implement `UnwindSafe`
 note: required by a bound in `assert`
   --> $DIR/not-panic-safe-6.rs:6:14

--- a/tests/ui/phantom-auto-trait.stderr
+++ b/tests/ui/phantom-auto-trait.stderr
@@ -11,7 +11,8 @@ note: required for `&T` to implement `Zen`
    |
 LL | unsafe impl<'a, T: 'a> Zen for &'a T where T: Sync {}
    |                        ^^^     ^^^^^          ---- unsatisfied trait bound introduced here
-   = note: required because it appears within the type `PhantomData<&T>`
+note: required because it appears within the type `PhantomData<&T>`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `Guard<'_, T>`
   --> $DIR/phantom-auto-trait.rs:12:8
    |
@@ -40,7 +41,8 @@ note: required for `&T` to implement `Zen`
    |
 LL | unsafe impl<'a, T: 'a> Zen for &'a T where T: Sync {}
    |                        ^^^     ^^^^^          ---- unsatisfied trait bound introduced here
-   = note: required because it appears within the type `PhantomData<&T>`
+note: required because it appears within the type `PhantomData<&T>`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `Guard<'_, T>`
   --> $DIR/phantom-auto-trait.rs:12:8
    |

--- a/tests/ui/recursion/recursive-requirements.stderr
+++ b/tests/ui/recursion/recursive-requirements.stderr
@@ -28,7 +28,8 @@ note: required because it appears within the type `Bar`
    |
 LL | pub struct Bar {
    |            ^^^
-   = note: required because it appears within the type `PhantomData<Bar>`
+note: required because it appears within the type `PhantomData<Bar>`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `Foo`
   --> $DIR/recursive-requirements.rs:5:12
    |

--- a/tests/ui/suggestions/path-by-value.stderr
+++ b/tests/ui/suggestions/path-by-value.stderr
@@ -5,7 +5,8 @@ LL | fn f(p: Path) { }
    |      ^ doesn't have a size known at compile-time
    |
    = help: within `Path`, the trait `Sized` is not implemented for `[u8]`
-   = note: required because it appears within the type `Path`
+note: required because it appears within the type `Path`
+  --> $SRC_DIR/std/src/path.rs:LL:COL
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |

--- a/tests/ui/suggestions/suggest-borrow-to-dyn-object.stderr
+++ b/tests/ui/suggestions/suggest-borrow-to-dyn-object.stderr
@@ -5,7 +5,8 @@ LL |     check(s);
    |           ^ doesn't have a size known at compile-time
    |
    = help: within `OsStr`, the trait `Sized` is not implemented for `[u8]`
-   = note: required because it appears within the type `OsStr`
+note: required because it appears within the type `OsStr`
+  --> $SRC_DIR/std/src/ffi/os_str.rs:LL:COL
    = note: required for the cast from `OsStr` to the object type `dyn AsRef<Path>`
 help: consider borrowing the value, since `&OsStr` can be coerced into `dyn AsRef<Path>`
    |

--- a/tests/ui/traits/issue-7013.stderr
+++ b/tests/ui/traits/issue-7013.stderr
@@ -5,7 +5,8 @@ LL |     let a = A {v: Box::new(B{v: None}) as Box<dyn Foo + Send>};
    |                   ^^^^^^^^^^^^^^^^^^^^ `Rc<RefCell<A>>` cannot be sent between threads safely
    |
    = help: within `B`, the trait `Send` is not implemented for `Rc<RefCell<A>>`
-   = note: required because it appears within the type `Option<Rc<RefCell<A>>>`
+note: required because it appears within the type `Option<Rc<RefCell<A>>>`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
 note: required because it appears within the type `B`
   --> $DIR/issue-7013.rs:8:8
    |

--- a/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -67,7 +67,8 @@ LL |     is_send(Box::new(TestType));
    |
    = note: the trait bound `Unique<dummy2::TestType>: Send` is not satisfied
    = note: required for `Unique<dummy2::TestType>` to implement `Send`
-   = note: required because it appears within the type `Box<TestType>`
+note: required because it appears within the type `Box<TestType>`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
    |
@@ -93,7 +94,8 @@ note: required because it appears within the type `Outer2<TestType>`
 LL | struct Outer2<T>(T);
    |        ^^^^^^
    = note: required for `Unique<Outer2<dummy3::TestType>>` to implement `Send`
-   = note: required because it appears within the type `Box<Outer2<TestType>>`
+note: required because it appears within the type `Box<Outer2<TestType>>`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
    |

--- a/tests/ui/union/union-sized-field.stderr
+++ b/tests/ui/union/union-sized-field.stderr
@@ -6,7 +6,8 @@ LL | union Foo<T: ?Sized> {
 LL |     value: ManuallyDrop<T>,
    |            ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = note: required because it appears within the type `ManuallyDrop<T>`
+note: required because it appears within the type `ManuallyDrop<T>`
+  --> $SRC_DIR/core/src/mem/manually_drop.rs:LL:COL
    = note: no field of a union may have a dynamically sized type
    = help: change the field's type to have a statically known size
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -31,7 +32,8 @@ LL | struct Foo2<T: ?Sized> {
 LL |     value: ManuallyDrop<T>,
    |            ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = note: required because it appears within the type `ManuallyDrop<T>`
+note: required because it appears within the type `ManuallyDrop<T>`
+  --> $SRC_DIR/core/src/mem/manually_drop.rs:LL:COL
    = note: only the last field of a struct may have a dynamically sized type
    = help: change the field's type to have a statically known size
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -56,7 +58,8 @@ LL | enum Foo3<T: ?Sized> {
 LL |     Value(ManuallyDrop<T>),
    |           ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = note: required because it appears within the type `ManuallyDrop<T>`
+note: required because it appears within the type `ManuallyDrop<T>`
+  --> $SRC_DIR/core/src/mem/manually_drop.rs:LL:COL
    = note: no field of an enum variant may have a dynamically sized type
    = help: change the field's type to have a statically known size
 help: consider removing the `?Sized` bound to make the type parameter `Sized`


### PR DESCRIPTION
Noticed while working on https://github.com/rust-lang/rust/pull/110855.