### PR TITLE
added TraitAlias to check_item() for missing_docs

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -547,32 +547,13 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
     }
 
     fn check_item(&mut self, cx: &LateContext<'_>, it: &hir::Item<'_>) {
-        match it.kind {
-            hir::ItemKind::Trait(..) => {
-                // Issue #11592: traits are always considered exported, even when private.
-                if cx.tcx.visibility(it.owner_id)
-                    == ty::Visibility::Restricted(
-                        cx.tcx.parent_module_from_def_id(it.owner_id.def_id).to_def_id(),
-                    )
-                {
-                    return;
-                }
-            }
-            hir::ItemKind::TyAlias(..)
-            | hir::ItemKind::Fn(..)
-            | hir::ItemKind::Macro(..)
-            | hir::ItemKind::Mod(..)
-            | hir::ItemKind::Enum(..)
-            | hir::ItemKind::Struct(..)
-            | hir::ItemKind::Union(..)
-            | hir::ItemKind::Const(..)
-            | hir::ItemKind::Static(..) => {}
-
-            _ => return,
-        };
+        // Previously the Impl and Use types have been excluded from missing docs,
+        // so we will continue to exclude them for compatibility
+        if let hir::ItemKind::Impl(..) | hir::ItemKind::Use(..) = it.kind {
+            return;
+        }
 
         let (article, desc) = cx.tcx.article_and_description(it.owner_id.to_def_id());
-
         self.check_missing_docs_attrs(cx, it.owner_id.def_id, article, desc);
     }
 

--- a/tests/ui/lint/lint-missing-doc.rs
+++ b/tests/ui/lint/lint-missing-doc.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs)]
 #![allow(dead_code)]
 #![feature(associated_type_defaults, extern_types)]
+#![feature(trait_alias)]
 
 //! Some garbage docs for the crate here
 #![doc="More garbage"]
@@ -201,5 +202,7 @@ extern "C" {
     pub type ExternTyUndocumented;
     //~^ ERROR: missing documentation for a foreign type
 }
+
+pub trait T = Sync; //~ ERROR: missing documentation for a trait alias
 
 fn main() {}

--- a/tests/ui/lint/lint-missing-doc.stderr
+++ b/tests/ui/lint/lint-missing-doc.stderr
@@ -1,5 +1,5 @@
 error: missing documentation for a type alias
-  --> $DIR/lint-missing-doc.rs:11:1
+  --> $DIR/lint-missing-doc.rs:12:1
    |
 LL | pub type PubTypedef = String;
    | ^^^^^^^^^^^^^^^^^^^
@@ -11,142 +11,148 @@ LL | #![deny(missing_docs)]
    |         ^^^^^^^^^^^^
 
 error: missing documentation for a struct
-  --> $DIR/lint-missing-doc.rs:18:1
+  --> $DIR/lint-missing-doc.rs:19:1
    |
 LL | pub struct PubFoo {
    | ^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a struct field
-  --> $DIR/lint-missing-doc.rs:19:5
+  --> $DIR/lint-missing-doc.rs:20:5
    |
 LL |     pub a: isize,
    |     ^^^^^^^^^^^^
 
 error: missing documentation for a module
-  --> $DIR/lint-missing-doc.rs:30:1
+  --> $DIR/lint-missing-doc.rs:31:1
    |
 LL | pub mod pub_module_no_dox {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:34:1
+  --> $DIR/lint-missing-doc.rs:35:1
    |
 LL | pub fn foo2() {}
    | ^^^^^^^^^^^^^
 
 error: missing documentation for a trait
-  --> $DIR/lint-missing-doc.rs:52:1
+  --> $DIR/lint-missing-doc.rs:53:1
    |
 LL | pub trait C {
    | ^^^^^^^^^^^
 
 error: missing documentation for a method
-  --> $DIR/lint-missing-doc.rs:53:5
+  --> $DIR/lint-missing-doc.rs:54:5
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
 
 error: missing documentation for a method
-  --> $DIR/lint-missing-doc.rs:54:5
+  --> $DIR/lint-missing-doc.rs:55:5
    |
 LL |     fn foo_with_impl(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:55:5
+  --> $DIR/lint-missing-doc.rs:56:5
    |
 LL |     fn foo_no_self();
    |     ^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:56:5
+  --> $DIR/lint-missing-doc.rs:57:5
    |
 LL |     fn foo_no_self_with_impl() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated type
-  --> $DIR/lint-missing-doc.rs:66:5
+  --> $DIR/lint-missing-doc.rs:67:5
    |
 LL |     type AssociatedType;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated type
-  --> $DIR/lint-missing-doc.rs:67:5
+  --> $DIR/lint-missing-doc.rs:68:5
    |
 LL |     type AssociatedTypeDef = Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:83:5
+  --> $DIR/lint-missing-doc.rs:84:5
    |
 LL |     pub fn foo() {}
    |     ^^^^^^^^^^^^
 
 error: missing documentation for an enum
-  --> $DIR/lint-missing-doc.rs:120:1
+  --> $DIR/lint-missing-doc.rs:121:1
    |
 LL | pub enum PubBaz {
    | ^^^^^^^^^^^^^^^
 
 error: missing documentation for a variant
-  --> $DIR/lint-missing-doc.rs:121:5
+  --> $DIR/lint-missing-doc.rs:122:5
    |
 LL |     PubBazA {
    |     ^^^^^^^
 
 error: missing documentation for a struct field
-  --> $DIR/lint-missing-doc.rs:122:9
+  --> $DIR/lint-missing-doc.rs:123:9
    |
 LL |         a: isize,
    |         ^^^^^^^^
 
 error: missing documentation for a constant
-  --> $DIR/lint-missing-doc.rs:153:1
+  --> $DIR/lint-missing-doc.rs:154:1
    |
 LL | pub const FOO4: u32 = 0;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a static
-  --> $DIR/lint-missing-doc.rs:163:1
+  --> $DIR/lint-missing-doc.rs:164:1
    |
 LL | pub static BAR4: u32 = 0;
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:169:5
+  --> $DIR/lint-missing-doc.rs:170:5
    |
 LL |     pub fn undocumented1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:170:5
+  --> $DIR/lint-missing-doc.rs:171:5
    |
 LL |     pub fn undocumented2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:176:9
+  --> $DIR/lint-missing-doc.rs:177:9
    |
 LL |         pub fn also_undocumented1() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:191:5
+  --> $DIR/lint-missing-doc.rs:192:5
    |
 LL |     pub fn extern_fn_undocumented(f: f32) -> f32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a static
-  --> $DIR/lint-missing-doc.rs:196:5
+  --> $DIR/lint-missing-doc.rs:197:5
    |
 LL |     pub static EXTERN_STATIC_UNDOCUMENTED: u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a foreign type
-  --> $DIR/lint-missing-doc.rs:201:5
+  --> $DIR/lint-missing-doc.rs:202:5
    |
 LL |     pub type ExternTyUndocumented;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 24 previous errors
+error: missing documentation for a trait alias
+  --> $DIR/lint-missing-doc.rs:206:1
+   |
+LL | pub trait T = Sync;
+   | ^^^^^^^^^^^
+
+error: aborting due to 25 previous errors
 


### PR DESCRIPTION
As in issue #111025 the `missing_docs` was not being triggered for trait aliases.  I added `TraitAlias` to the pattern match for check_item(), and the lint seems to be behaving appropriately