### PR TITLE
check bootstrap scripts syntax

### DIFF
--- a/x
+++ b/x
@@ -7,9 +7,12 @@
 
 set -eu
 
+# syntax check
+sh -n $0
+
 realpath() {
     if [ -d "$1" ]; then
-        CDPATH='' command cd "$1" && pwd -P   
+        CDPATH='' command cd "$1" && pwd -P
     else
         echo "$(realpath "$(dirname "$1")")/$(basename "$1")"
     fi

--- a/x.ps1
+++ b/x.ps1
@@ -2,6 +2,11 @@
 
 # See ./x for why these scripts exist.
 
+$ErrorActionPreference = "Stop"
+
+# syntax check
+Get-Command -syntax ${PSCommandPath}
+
 $xpy = Join-Path $PSScriptRoot x.py
 # Start-Process for some reason splits arguments on spaces. (Isn't powershell supposed to be simpler than bash?)
 # Double-quote all the arguments so it doesn't do that.


### PR DESCRIPTION
Fails bootstrapping if `x`/`x.ps1` scripts are not valid. Currently, it keeps executing lines until the invalid one.