### PR TITLE
Diagnostic args are still args if they're documented

### DIFF
--- a/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
@@ -4,16 +4,15 @@ use crate::diagnostics::error::{
     invalid_attr, span_err, throw_invalid_attr, throw_span_err, DiagnosticDeriveError,
 };
 use crate::diagnostics::utils::{
-    build_field_mapping, is_doc_comment, new_code_ident,
-    report_error_if_not_applied_to_applicability, report_error_if_not_applied_to_span, FieldInfo,
-    FieldInnerTy, FieldMap, HasFieldMap, SetOnce, SpannedOption, SubdiagnosticKind,
+    build_field_mapping, build_suggestion_code, is_doc_comment, new_code_ident,
+    report_error_if_not_applied_to_applicability, report_error_if_not_applied_to_span,
+    should_generate_set_arg, AllowMultipleAlternatives, FieldInfo, FieldInnerTy, FieldMap,
+    HasFieldMap, SetOnce, SpannedOption, SubdiagnosticKind,
 };
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{spanned::Spanned, Attribute, Meta, MetaList, Path};
 use synstructure::{BindingInfo, Structure, VariantInfo};
-
-use super::utils::{build_suggestion_code, AllowMultipleAlternatives};
 
 /// The central struct for constructing the `add_to_diagnostic` method from an annotated struct.
 pub(crate) struct SubdiagnosticDeriveBuilder {
@@ -212,7 +211,6 @@ impl<'parent, 'a> SubdiagnosticDeriveVariantBuilder<'parent, 'a> {
     /// Generates the code for a field with no attributes.
     fn generate_field_set_arg(&mut self, binding: &BindingInfo<'_>) -> TokenStream {
         let ast = binding.ast();
-        assert_eq!(ast.attrs.len(), 0, "field with attribute used as diagnostic arg");
 
         let diag = &self.parent.diag;
         let ident = ast.ident.as_ref().unwrap();
@@ -580,7 +578,7 @@ impl<'parent, 'a> SubdiagnosticDeriveVariantBuilder<'parent, 'a> {
             .variant
             .bindings()
             .iter()
-            .filter(|binding| binding.ast().attrs.is_empty())
+            .filter(|binding| should_generate_set_arg(binding.ast()))
             .map(|binding| self.generate_field_set_arg(binding))
             .collect();
 

--- a/compiler/rustc_macros/src/diagnostics/utils.rs
+++ b/compiler/rustc_macros/src/diagnostics/utils.rs
@@ -207,6 +207,12 @@ impl<'ty> FieldInnerTy<'ty> {
             FieldInnerTy::Plain(..) => quote! { #inner },
         }
     }
+
+    pub fn span(&self) -> proc_macro2::Span {
+        match self {
+            FieldInnerTy::Option(ty) | FieldInnerTy::Vec(ty) | FieldInnerTy::Plain(ty) => ty.span(),
+        }
+    }
 }
 
 /// Field information passed to the builder. Deliberately omits attrs to discourage the

--- a/compiler/rustc_macros/src/diagnostics/utils.rs
+++ b/compiler/rustc_macros/src/diagnostics/utils.rs
@@ -851,7 +851,8 @@ impl quote::IdentFragment for SubdiagnosticKind {
 /// Returns `true` if `field` should generate a `set_arg` call rather than any other diagnostic
 /// call (like `span_label`).
 pub(super) fn should_generate_set_arg(field: &Field) -> bool {
-    field.attrs.is_empty()
+    // Perhaps this should be an exhaustive list...
+    field.attrs.iter().all(|attr| is_doc_comment(attr))
 }
 
 pub(super) fn is_doc_comment(attr: &Attribute) -> bool {

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
@@ -1,0 +1,47 @@
+// check-fail
+// Tests that a doc comment will not preclude a field from being considered a diagnostic argument
+
+// The proc_macro2 crate handles spans differently when on beta/stable release rather than nightly,
+// changing the output of this test. Since Subdiagnostic is strictly internal to the compiler
+// the test is just ignored on stable and beta:
+// ignore-stage1
+// ignore-beta
+// ignore-stable
+
+#![feature(rustc_private)]
+#![crate_type = "lib"]
+
+extern crate rustc_errors;
+extern crate rustc_fluent_macro;
+extern crate rustc_macros;
+extern crate rustc_session;
+extern crate rustc_span;
+
+use rustc_errors::{Applicability, DiagnosticMessage, SubdiagnosticMessage};
+use rustc_fluent_macro::fluent_messages;
+use rustc_macros::{Diagnostic, Subdiagnostic};
+use rustc_span::Span;
+
+fluent_messages! { "./example.ftl" }
+
+struct NotIntoDiagnosticArg;
+
+#[derive(Diagnostic)]
+//~^ ERROR the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
+#[diag(no_crate_example)]
+struct Test {
+    #[primary_span]
+    span: Span,
+    /// A doc comment
+    arg: NotIntoDiagnosticArg,
+}
+
+#[derive(Subdiagnostic)]
+//~^ ERROR the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
+#[label(no_crate_example)]
+struct SubTest {
+    #[primary_span]
+    span: Span,
+    /// A doc comment
+    arg: NotIntoDiagnosticArg,
+}

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
@@ -1,5 +1,7 @@
 // check-fail
 // Tests that a doc comment will not preclude a field from being considered a diagnostic argument
+// normalize-stderr-test "the following other types implement trait `IntoDiagnosticArg`:(?:.*\n){0,9}\s+and \d+ others" -> "normalized in stderr"
+// normalize-stderr-test "diagnostic_builder\.rs:[0-9]+:[0-9]+" -> "diagnostic_builder.rs:LL:CC"
 
 // The proc_macro2 crate handles spans differently when on beta/stable release rather than nightly,
 // changing the output of this test. Since Subdiagnostic is strictly internal to the compiler
@@ -27,21 +29,21 @@ fluent_messages! { "./example.ftl" }
 struct NotIntoDiagnosticArg;
 
 #[derive(Diagnostic)]
-//~^ ERROR the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
 #[diag(no_crate_example)]
 struct Test {
     #[primary_span]
     span: Span,
     /// A doc comment
     arg: NotIntoDiagnosticArg,
+    //~^ ERROR the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
 }
 
 #[derive(Subdiagnostic)]
-//~^ ERROR the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
 #[label(no_crate_example)]
 struct SubTest {
     #[primary_span]
     span: Span,
     /// A doc comment
     arg: NotIntoDiagnosticArg,
+    //~^ ERROR the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
 }

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
@@ -1,42 +1,29 @@
 error[E0277]: the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
-  --> $DIR/diagnostic-derive-doc-comment-field.rs:29:10
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:37:10
    |
 LL | #[derive(Diagnostic)]
-   |          ^^^^^^^^^^ the trait `IntoDiagnosticArg` is not implemented for `NotIntoDiagnosticArg`
+   |          ---------- required by a bound introduced by this call
+...
+LL |     arg: NotIntoDiagnosticArg,
+   |          ^^^^^^^^^^^^^^^^^^^^ the trait `IntoDiagnosticArg` is not implemented for `NotIntoDiagnosticArg`
    |
-   = help: the following other types implement trait `IntoDiagnosticArg`:
-             &'a T
-             &'a std::path::Path
-             &'a str
-             &rustc_target::spec::TargetTriple
-             Box<(dyn std::error::Error + 'static)>
-             CString
-             CguReuse
-             Cow<'a, str>
-           and 42 others
+   = help: normalized in stderr
 note: required by a bound in `DiagnosticBuilder::<'a, G>::set_arg`
-  --> $COMPILER_DIR/rustc_errors/src/diagnostic_builder.rs:747:5
-   = note: this error originates in the derive macro `Diagnostic` which comes from the expansion of the macro `forward` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $COMPILER_DIR/rustc_errors/src/diagnostic_builder.rs:LL:CC
+   = note: this error originates in the macro `forward` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
-  --> $DIR/diagnostic-derive-doc-comment-field.rs:39:10
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:47:10
    |
 LL | #[derive(Subdiagnostic)]
-   |          ^^^^^^^^^^^^^ the trait `IntoDiagnosticArg` is not implemented for `NotIntoDiagnosticArg`
+   |          ------------- required by a bound introduced by this call
+...
+LL |     arg: NotIntoDiagnosticArg,
+   |          ^^^^^^^^^^^^^^^^^^^^ the trait `IntoDiagnosticArg` is not implemented for `NotIntoDiagnosticArg`
    |
-   = help: the following other types implement trait `IntoDiagnosticArg`:
-             &'a T
-             &'a std::path::Path
-             &'a str
-             &rustc_target::spec::TargetTriple
-             Box<(dyn std::error::Error + 'static)>
-             CString
-             CguReuse
-             Cow<'a, str>
-           and 42 others
+   = help: normalized in stderr
 note: required by a bound in `Diagnostic::set_arg`
   --> $COMPILER_DIR/rustc_errors/src/diagnostic.rs:964:5
-   = note: this error originates in the derive macro `Subdiagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
@@ -1,0 +1,43 @@
+error[E0277]: the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:29:10
+   |
+LL | #[derive(Diagnostic)]
+   |          ^^^^^^^^^^ the trait `IntoDiagnosticArg` is not implemented for `NotIntoDiagnosticArg`
+   |
+   = help: the following other types implement trait `IntoDiagnosticArg`:
+             &'a T
+             &'a std::path::Path
+             &'a str
+             &rustc_target::spec::TargetTriple
+             Box<(dyn std::error::Error + 'static)>
+             CString
+             CguReuse
+             Cow<'a, str>
+           and 42 others
+note: required by a bound in `DiagnosticBuilder::<'a, G>::set_arg`
+  --> $COMPILER_DIR/rustc_errors/src/diagnostic_builder.rs:747:5
+   = note: this error originates in the derive macro `Diagnostic` which comes from the expansion of the macro `forward` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:39:10
+   |
+LL | #[derive(Subdiagnostic)]
+   |          ^^^^^^^^^^^^^ the trait `IntoDiagnosticArg` is not implemented for `NotIntoDiagnosticArg`
+   |
+   = help: the following other types implement trait `IntoDiagnosticArg`:
+             &'a T
+             &'a std::path::Path
+             &'a str
+             &rustc_target::spec::TargetTriple
+             Box<(dyn std::error::Error + 'static)>
+             CString
+             CguReuse
+             Cow<'a, str>
+           and 42 others
+note: required by a bound in `Diagnostic::set_arg`
+  --> $COMPILER_DIR/rustc_errors/src/diagnostic.rs:964:5
+   = note: this error originates in the derive macro `Subdiagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -339,12 +339,12 @@ struct ErrorWithDefaultLabelAttr<'a> {
 }
 
 #[derive(Diagnostic)]
-//~^ ERROR the trait bound `Hello: IntoDiagnosticArg` is not satisfied
 #[diag(no_crate_example, code = "E0123")]
 struct ArgFieldWithoutSkip {
     #[primary_span]
     span: Span,
     other: Hello,
+    //~^ ERROR the trait bound `Hello: IntoDiagnosticArg` is not satisfied
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -641,15 +641,18 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Hello: IntoDiagnosticArg` is not satisfied
-  --> $DIR/diagnostic-derive.rs:341:10
+  --> $DIR/diagnostic-derive.rs:346:12
    |
 LL | #[derive(Diagnostic)]
-   |          ^^^^^^^^^^ the trait `IntoDiagnosticArg` is not implemented for `Hello`
+   |          ---------- required by a bound introduced by this call
+...
+LL |     other: Hello,
+   |            ^^^^^ the trait `IntoDiagnosticArg` is not implemented for `Hello`
    |
    = help: normalized in stderr
 note: required by a bound in `DiagnosticBuilder::<'a, G>::set_arg`
   --> $COMPILER_DIR/rustc_errors/src/diagnostic_builder.rs:LL:CC
-   = note: this error originates in the derive macro `Diagnostic` which comes from the expansion of the macro `forward` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `forward` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 84 previous errors
 


### PR DESCRIPTION
Fixes https://rust-lang.zulipchat.com/#narrow/stream/336883-i18n/topic/.60.23.5Bderive.28Diagnostic.29.5D.60.20works.20badly.20with.20docs/near/355597997

There's a lot of really strange code incongruencies between `Diagnostic` and `Subdiagnostic` derive. Perhaps those macros need some more overhaul, but I didn't really want to do it today.