### PR TITLE
Portably escape pipe characters in `diff --ignore-matching-lines` regexes

### DIFF
--- a/tests/run-make/coverage-reports/Makefile
+++ b/tests/run-make/coverage-reports/Makefile
@@ -174,7 +174,13 @@ else
 	# files are redundant, so there is no need to generate `expected_*.json` files or
 	# compare actual JSON results.)
 
-	$(DIFF) --ignore-matching-lines='^  \| .*::<.*>.*:$$' --ignore-matching-lines='^  \| <.*>::.*:$$' \
+	# CAUTION: GNU diff and Apple/FreeBSD diff use slightly different regex dialects.
+	# GNU diff treats `|` as a literal pipe character, and `\|` as a regex OR operator.
+	# Apple/FreeBSD diff treats `|` as a regex OR operator, and `|` as a literal pipe.
+	# To match a literal pipe character in both implementations, we need to wrap it in
+	# a character class `[|]` instead. Nobody is happy about this.
+
+	$(DIFF) --ignore-matching-lines='^  [|] .*::<.*>.*:$$' --ignore-matching-lines='^  [|] <.*>::.*:$$' \
 		expected_show_coverage.$@.txt "$(TMPDIR)"/actual_show_coverage.$@.txt || \
 		( grep -q '^\/\/ ignore-llvm-cov-show-diffs' $(SOURCEDIR)/$@.rs && \
 			>&2 echo 'diff failed, but suppressed with `// ignore-llvm-cov-show-diffs` in $(SOURCEDIR)/$@.rs' \

--- a/tests/run-make/coverage-reports/expected_show_coverage.async.txt
+++ b/tests/run-make/coverage-reports/expected_show_coverage.async.txt
@@ -41,9 +41,9 @@
    41|      1|                    // executed asynchronously.
    42|      1|    match x {
    43|      1|        y if c(x).await == y + 1 => { d().await; }
-                      ^0       ^0                   ^0 ^0
+                      ^0        ^0                  ^0  ^0
    44|      1|        y if f().await == y + 1 => (),
-                      ^0      ^0                 ^0
+                      ^0       ^0                ^0
    45|      1|        _ => (),
    46|       |    }
    47|      1|}


### PR DESCRIPTION
#110942 was supposed to fix the regexes used by `diff --ignore-matching-lines` in the instrument-coverage tests.

But based on my investigations in #111116, it turns out that that change successfully fixed the tests on Mac, while silently *breaking* them on Linux (which is where they actually get run in CI).

The underlying cause is that GNU `diff` and Apple/FreeBSD `diff` use slightly different regex dialects, with a crucial difference:
- GNU diff treats `|` as a literal pipe character, and treats `\|` as a regex OR operator
- Apple/FreeBSD diff treats `|` as a regex OR operator, and treats `\|` as a literal pipe character.

This is very frustrating, and ideally I would rip out all of this code and replace it with something written in Rust or Python. But for now, my focus is on making a small fix that will restore the tests to proper working order on both Linux and Mac.

Fortunately, there is a way to portably match a literal pipe character in both `diff` implementations: wrap it in a character class `[|]`. So that's what this PR does.