### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,6 +3164,7 @@ dependencies = [
  "rustc_expand",
  "rustc_feature",
  "rustc_fluent_macro",
+ "rustc_index",
  "rustc_lexer",
  "rustc_lint_defs",
  "rustc_macros",

--- a/compiler/rustc_builtin_macros/Cargo.toml
+++ b/compiler/rustc_builtin_macros/Cargo.toml
@@ -14,6 +14,7 @@ rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_expand = { path = "../rustc_expand" }
 rustc_feature = { path = "../rustc_feature" }
+rustc_index = { path = "../rustc_index" }
 rustc_lexer = { path = "../rustc_lexer" }
 rustc_lint_defs = { path = "../rustc_lint_defs" }
 rustc_macros = { path = "../rustc_macros" }

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -2,7 +2,7 @@ use rustc_ast as ast;
 use rustc_ast::ptr::P;
 use rustc_ast::token::{self, Delimiter};
 use rustc_ast::tokenstream::TokenStream;
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::{FxHashMap, FxIndexMap, FxIndexSet};
 use rustc_errors::PResult;
 use rustc_expand::base::{self, *};
 use rustc_parse::parser::Parser;
@@ -20,8 +20,8 @@ use crate::errors;
 pub struct AsmArgs {
     pub templates: Vec<P<ast::Expr>>,
     pub operands: Vec<(ast::InlineAsmOperand, Span)>,
-    named_args: FxHashMap<Symbol, usize>,
-    reg_args: FxHashSet<usize>,
+    named_args: FxIndexMap<Symbol, usize>,
+    reg_args: FxIndexSet<usize>,
     pub clobber_abis: Vec<(Symbol, Span)>,
     options: ast::InlineAsmOptions,
     pub options_spans: Vec<Span>,
@@ -56,8 +56,8 @@ pub fn parse_asm_args<'a>(
     let mut args = AsmArgs {
         templates: vec![first_template],
         operands: vec![],
-        named_args: FxHashMap::default(),
-        reg_args: FxHashSet::default(),
+        named_args: Default::default(),
+        reg_args: Default::default(),
         clobber_abis: Vec::new(),
         options: ast::InlineAsmOptions::empty(),
         options_spans: vec![],

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -1,7 +1,6 @@
 //! This crate contains implementations of built-in macros and other code generating facilities
 //! injecting code into the crate before it is lowered to HIR.
 
-#![allow(rustc::potential_query_instability)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(array_windows)]
 #![feature(box_patterns)]

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -64,6 +64,11 @@ impl Fingerprint {
         )
     }
 
+    #[inline]
+    pub(crate) fn as_u128(self) -> u128 {
+        u128::from(self.1) << 64 | u128::from(self.0)
+    }
+
     // Combines two hashes in an order independent way. Make sure this is what
     // you want.
     #[inline]

--- a/compiler/rustc_data_structures/src/svh.rs
+++ b/compiler/rustc_data_structures/src/svh.rs
@@ -23,18 +23,18 @@ impl Svh {
         Svh { hash }
     }
 
-    pub fn as_u64(&self) -> u64 {
-        self.hash.to_smaller_hash().as_u64()
+    pub fn as_u128(self) -> u128 {
+        self.hash.as_u128()
     }
 
-    pub fn to_string(&self) -> String {
-        format!("{:016x}", self.hash.to_smaller_hash())
+    pub fn to_hex(self) -> String {
+        format!("{:032x}", self.hash.as_u128())
     }
 }
 
 impl fmt::Display for Svh {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad(&self.to_string())
+        f.pad(&self.to_hex())
     }
 }
 

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -276,3 +276,7 @@ hir_analysis_const_specialize = cannot specialize on const impl with non-const i
 hir_analysis_static_specialize = cannot specialize on `'static` lifetime
 
 hir_analysis_missing_tilde_const = missing `~const` qualifier for specialization
+
+hir_analysis_drop_impl_negative = negative `Drop` impls are not supported
+
+hir_analysis_drop_impl_reservation = reservation `Drop` impls are not supported

--- a/compiler/rustc_hir_analysis/src/check/dropck.rs
+++ b/compiler/rustc_hir_analysis/src/check/dropck.rs
@@ -1,13 +1,15 @@
 // FIXME(@lcnr): Move this module out of `rustc_hir_analysis`.
 //
 // We don't do any drop checking during hir typeck.
-use crate::hir::def_id::{DefId, LocalDefId};
 use rustc_errors::{struct_span_err, ErrorGuaranteed};
 use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::relate::{Relate, RelateResult, TypeRelation};
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::util::IgnoreRegions;
 use rustc_middle::ty::{self, Predicate, Ty, TyCtxt};
+
+use crate::errors;
+use crate::hir::def_id::{DefId, LocalDefId};
 
 /// This function confirms that the `Drop` implementation identified by
 /// `drop_impl_did` is not any more specialized than the type it is
@@ -27,6 +29,19 @@ use rustc_middle::ty::{self, Predicate, Ty, TyCtxt};
 ///    cannot do `struct S<T>; impl<T:Clone> Drop for S<T> { ... }`).
 ///
 pub fn check_drop_impl(tcx: TyCtxt<'_>, drop_impl_did: DefId) -> Result<(), ErrorGuaranteed> {
+    match tcx.impl_polarity(drop_impl_did) {
+        ty::ImplPolarity::Positive => {}
+        ty::ImplPolarity::Negative => {
+            return Err(tcx.sess.emit_err(errors::DropImplPolarity::Negative {
+                span: tcx.def_span(drop_impl_did),
+            }));
+        }
+        ty::ImplPolarity::Reservation => {
+            return Err(tcx.sess.emit_err(errors::DropImplPolarity::Reservation {
+                span: tcx.def_span(drop_impl_did),
+            }));
+        }
+    }
     let dtor_self_type = tcx.type_of(drop_impl_did).subst_identity();
     let dtor_predicates = tcx.predicates_of(drop_impl_did);
     match dtor_self_type.kind() {

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -815,3 +815,17 @@ pub(crate) struct MissingTildeConst {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+pub(crate) enum DropImplPolarity {
+    #[diag(hir_analysis_drop_impl_negative)]
+    Negative {
+        #[primary_span]
+        span: Span,
+    },
+    #[diag(hir_analysis_drop_impl_reservation)]
+    Reservation {
+        #[primary_span]
+        span: Span,
+    },
+}

--- a/compiler/rustc_incremental/src/persist/fs.rs
+++ b/compiler/rustc_incremental/src/persist/fs.rs
@@ -346,7 +346,7 @@ pub fn finalize_session_directory(sess: &Session, svh: Option<Svh>) {
     let mut new_sub_dir_name = String::from(&old_sub_dir_name[..=dash_indices[2]]);
 
     // Append the svh
-    base_n::push_str(svh.as_u64() as u128, INT_ENCODE_BASE, &mut new_sub_dir_name);
+    base_n::push_str(svh.as_u128(), INT_ENCODE_BASE, &mut new_sub_dir_name);
 
     // Create the full path
     let new_path = incr_comp_session_dir.parent().unwrap().join(new_sub_dir_name);

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -837,11 +837,12 @@ fn should_encode_span(def_kind: DefKind) -> bool {
         | DefKind::AnonConst
         | DefKind::InlineConst
         | DefKind::OpaqueTy
+        | DefKind::ImplTraitPlaceholder
         | DefKind::Field
         | DefKind::Impl { .. }
         | DefKind::Closure
         | DefKind::Generator => true,
-        DefKind::ForeignMod | DefKind::ImplTraitPlaceholder | DefKind::GlobalAsm => false,
+        DefKind::ForeignMod | DefKind::GlobalAsm => false,
     }
 }
 

--- a/compiler/rustc_middle/src/ty/abstract_const.rs
+++ b/compiler/rustc_middle/src/ty/abstract_const.rs
@@ -63,7 +63,8 @@ impl<'tcx> TyCtxt<'tcx> {
                         Err(e) => self.tcx.const_error_with_guaranteed(c.ty(), e),
                         Ok(Some(bac)) => {
                             let substs = self.tcx.erase_regions(uv.substs);
-                            bac.subst(self.tcx, substs)
+                            let bac = bac.subst(self.tcx, substs);
+                            return bac.fold_with(self);
                         }
                         Ok(None) => c,
                     },

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -360,15 +360,15 @@ impl<'tcx> TyCtxt<'tcx> {
         let ty = self.type_of(adt_did).subst_identity();
         let mut dtor_candidate = None;
         self.for_each_relevant_impl(drop_trait, ty, |impl_did| {
-            let Some(item_id) = self.associated_item_def_ids(impl_did).first() else {
-                self.sess.delay_span_bug(self.def_span(impl_did), "Drop impl without drop function");
-                return;
-            };
-
             if validate(self, impl_did).is_err() {
                 // Already `ErrorGuaranteed`, no need to delay a span bug here.
                 return;
             }
+
+            let Some(item_id) = self.associated_item_def_ids(impl_did).first() else {
+                self.sess.delay_span_bug(self.def_span(impl_did), "Drop impl without drop function");
+                return;
+            };
 
             if let Some((old_item_id, _)) = dtor_candidate {
                 self.sess

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -550,7 +550,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
                 let sm = self.tcx.sess.source_map();
                 let def_id = match outer_res {
-                    Res::SelfTyParam { .. } => {
+                    Res::SelfTyParam { .. } | Res::SelfCtor(_) => {
                         err.span_label(span, "can't use `Self` here");
                         return err;
                     }

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -323,7 +323,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             }
 
             module = match ribs[i].kind {
-                RibKind::ModuleRibKind(module) => module,
+                RibKind::Module(module) => module,
                 RibKind::MacroDefinition(def) if def == self.macro_def(ident.span.ctxt()) => {
                     // If an invocation of this macro created `ident`, give up on `ident`
                     // and switch to `ident`'s source from the macro definition.
@@ -1083,7 +1083,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         let ribs = &all_ribs[rib_index + 1..];
 
         // An invalid forward use of a generic parameter from a previous default.
-        if let RibKind::ForwardGenericParamBanRibKind = all_ribs[rib_index].kind {
+        if let RibKind::ForwardGenericParamBan = all_ribs[rib_index].kind {
             if let Some(span) = finalize {
                 let res_error = if rib_ident.name == kw::SelfUpper {
                     ResolutionError::SelfInGenericParamDefault
@@ -1103,14 +1103,14 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
                 for rib in ribs {
                     match rib.kind {
-                        RibKind::NormalRibKind
-                        | RibKind::ClosureOrAsyncRibKind
-                        | RibKind::ModuleRibKind(..)
+                        RibKind::Normal
+                        | RibKind::ClosureOrAsync
+                        | RibKind::Module(..)
                         | RibKind::MacroDefinition(..)
-                        | RibKind::ForwardGenericParamBanRibKind => {
+                        | RibKind::ForwardGenericParamBan => {
                             // Nothing to do. Continue.
                         }
-                        RibKind::ItemRibKind(_) | RibKind::AssocItemRibKind => {
+                        RibKind::Item(_) | RibKind::AssocItem => {
                             // This was an attempt to access an upvar inside a
                             // named function item. This is not allowed, so we
                             // report an error.
@@ -1122,7 +1122,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                 res_err = Some((span, CannotCaptureDynamicEnvironmentInFnItem));
                             }
                         }
-                        RibKind::ConstantItemRibKind(_, item) => {
+                        RibKind::ConstantItem(_, item) => {
                             // Still doesn't deal with upvars
                             if let Some(span) = finalize {
                                 let (span, resolution_error) =
@@ -1151,13 +1151,13 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             }
                             return Res::Err;
                         }
-                        RibKind::ConstParamTyRibKind => {
+                        RibKind::ConstParamTy => {
                             if let Some(span) = finalize {
                                 self.report_error(span, ParamInTyOfConstParam(rib_ident.name));
                             }
                             return Res::Err;
                         }
-                        RibKind::InlineAsmSymRibKind => {
+                        RibKind::InlineAsmSym => {
                             if let Some(span) = finalize {
                                 self.report_error(span, InvalidAsmSym);
                             }
@@ -1173,18 +1173,18 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             Res::Def(DefKind::TyParam, _) | Res::SelfTyParam { .. } | Res::SelfTyAlias { .. } => {
                 for rib in ribs {
                     let has_generic_params: HasGenericParams = match rib.kind {
-                        RibKind::NormalRibKind
-                        | RibKind::ClosureOrAsyncRibKind
-                        | RibKind::ModuleRibKind(..)
+                        RibKind::Normal
+                        | RibKind::ClosureOrAsync
+                        | RibKind::Module(..)
                         | RibKind::MacroDefinition(..)
-                        | RibKind::InlineAsmSymRibKind
-                        | RibKind::AssocItemRibKind
-                        | RibKind::ForwardGenericParamBanRibKind => {
+                        | RibKind::InlineAsmSym
+                        | RibKind::AssocItem
+                        | RibKind::ForwardGenericParamBan => {
                             // Nothing to do. Continue.
                             continue;
                         }
 
-                        RibKind::ConstantItemRibKind(trivial, _) => {
+                        RibKind::ConstantItem(trivial, _) => {
                             let features = self.tcx.sess.features_untracked();
                             // HACK(min_const_generics): We currently only allow `N` or `{ N }`.
                             if !(trivial == ConstantHasGenerics::Yes
@@ -1225,8 +1225,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         }
 
                         // This was an attempt to use a type parameter outside its scope.
-                        RibKind::ItemRibKind(has_generic_params) => has_generic_params,
-                        RibKind::ConstParamTyRibKind => {
+                        RibKind::Item(has_generic_params) => has_generic_params,
+                        RibKind::ConstParamTy => {
                             if let Some(span) = finalize {
                                 self.report_error(
                                     span,
@@ -1252,15 +1252,15 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             Res::Def(DefKind::ConstParam, _) => {
                 for rib in ribs {
                     let has_generic_params = match rib.kind {
-                        RibKind::NormalRibKind
-                        | RibKind::ClosureOrAsyncRibKind
-                        | RibKind::ModuleRibKind(..)
+                        RibKind::Normal
+                        | RibKind::ClosureOrAsync
+                        | RibKind::Module(..)
                         | RibKind::MacroDefinition(..)
-                        | RibKind::InlineAsmSymRibKind
-                        | RibKind::AssocItemRibKind
-                        | RibKind::ForwardGenericParamBanRibKind => continue,
+                        | RibKind::InlineAsmSym
+                        | RibKind::AssocItem
+                        | RibKind::ForwardGenericParamBan => continue,
 
-                        RibKind::ConstantItemRibKind(trivial, _) => {
+                        RibKind::ConstantItem(trivial, _) => {
                             let features = self.tcx.sess.features_untracked();
                             // HACK(min_const_generics): We currently only allow `N` or `{ N }`.
                             if !(trivial == ConstantHasGenerics::Yes
@@ -1283,8 +1283,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             continue;
                         }
 
-                        RibKind::ItemRibKind(has_generic_params) => has_generic_params,
-                        RibKind::ConstParamTyRibKind => {
+                        RibKind::Item(has_generic_params) => has_generic_params,
+                        RibKind::ConstParamTy => {
                             if let Some(span) = finalize {
                                 self.report_error(
                                     span,

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1171,7 +1171,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     return Res::Err;
                 }
             }
-            Res::Def(DefKind::TyParam, _) | Res::SelfTyParam { .. } | Res::SelfTyAlias { .. } => {
+            Res::Def(DefKind::TyParam, _)
+            | Res::SelfTyParam { .. }
+            | Res::SelfTyAlias { .. }
+            | Res::SelfCtor(_) => {
                 for rib in ribs {
                     let has_generic_params: HasGenericParams = match rib.kind {
                         NormalRibKind

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -623,7 +623,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
         }
 
         // Try to find in last block rib
-        if let Some(rib) = &self.last_block_rib && let RibKind::NormalRibKind = rib.kind {
+        if let Some(rib) = &self.last_block_rib && let RibKind::Normal = rib.kind {
             for (ident, &res) in &rib.bindings {
                 if let Res::Local(_) = res && path.len() == 1 &&
                     ident.span.eq_ctxt(path[0].ident.span) &&
@@ -1728,7 +1728,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                 }
 
                 // Items in scope
-                if let RibKind::ModuleRibKind(module) = rib.kind {
+                if let RibKind::Module(module) = rib.kind {
                     // Items from this module
                     self.r.add_module_candidates(module, &mut names, &filter_fn, Some(ctxt));
 

--- a/tests/incremental/change_crate_dep_kind.rs
+++ b/tests/incremental/change_crate_dep_kind.rs
@@ -2,6 +2,7 @@
 // detected then -Zincremental-verify-ich will trigger an assertion.
 
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-unwind
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph -Cpanic=unwind
 // build-pass (FIXME(62277): could be check-pass?)

--- a/tests/incremental/issue-80691-bad-eval-cache.rs
+++ b/tests/incremental/issue-80691-bad-eval-cache.rs
@@ -1,6 +1,7 @@
 // revisions: rfail1 rfail2
 // failure-status: 101
 // error-pattern: not implemented
+// needs-unwind -Cpanic=abort causes abort instead of exit(101)
 
 pub trait Interner {
     type InternedVariableKinds;

--- a/tests/run-make/c-unwind-abi-catch-lib-panic/Makefile
+++ b/tests/run-make/c-unwind-abi-catch-lib-panic/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all: archive

--- a/tests/run-make/c-unwind-abi-catch-panic/Makefile
+++ b/tests/run-make/c-unwind-abi-catch-panic/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all: $(call NATIVE_STATICLIB,add)

--- a/tests/run-make/const_fn_mir/Makefile
+++ b/tests/run-make/const_fn_mir/Makefile
@@ -1,3 +1,4 @@
+# needs-unwind -Cpanic=abort gives different MIR output
 include ../tools.mk
 
 all:

--- a/tests/run-make/debug-assertions/Makefile
+++ b/tests/run-make/debug-assertions/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all:

--- a/tests/run-make/foreign-double-unwind/Makefile
+++ b/tests/run-make/foreign-double-unwind/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all: foo

--- a/tests/run-make/foreign-exceptions/Makefile
+++ b/tests/run-make/foreign-exceptions/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all: foo

--- a/tests/run-make/foreign-rust-exceptions/Makefile
+++ b/tests/run-make/foreign-rust-exceptions/Makefile
@@ -1,5 +1,6 @@
 # ignore-cross-compile
 # ignore-i686-pc-windows-gnu
+# needs-unwind
 
 # This test doesn't work on 32-bit MinGW as cdylib has its own copy of unwinder
 # so cross-DLL unwinding does not work.

--- a/tests/run-make/libtest-json/Makefile
+++ b/tests/run-make/libtest-json/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 # Test expected libtest's JSON output

--- a/tests/run-make/static-unwinding/Makefile
+++ b/tests/run-make/static-unwinding/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind
 include ../tools.mk
 
 all:

--- a/tests/run-make/test-benches/Makefile
+++ b/tests/run-make/test-benches/Makefile
@@ -1,6 +1,7 @@
 include ../tools.mk
 
 # ignore-cross-compile
+# needs-unwind #[bench] and -Zpanic-abort-tests can't be combined
 
 all:
 	# Smoke-test that `#[bench]` isn't entirely broken.

--- a/tests/ui/const-generics/generic_const_exprs/nested_uneval_unification-2.rs
+++ b/tests/ui/const-generics/generic_const_exprs/nested_uneval_unification-2.rs
@@ -2,28 +2,30 @@
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features, unused_parens, unused_braces)]
 
-fn zero_init<const N: usize>() -> Substs1<{ (N) }>
+fn zero_init<const N: usize>() -> Substs1<{{ N }}>
 where
-    [u8; { (N) }]: ,
+    [u8; {{ N }}]: ,
 {
-    Substs1([0; { (N) }])
+    Substs1([0; {{ N }}])
 }
 
-struct Substs1<const N: usize>([u8; { (N) }])
+struct Substs1<const N: usize>([u8; {{ N }}])
 where
-    [(); { (N) }]: ;
+    [(); {{ N }}]: ;
 
-fn substs2<const M: usize>() -> Substs1<{ (M) }> {
-    zero_init::<{ (M) }>()
+fn substs2<const M: usize>() -> Substs1<{{ M }}> {
+    zero_init::<{{ M }}>()
 }
 
-fn substs3<const L: usize>() -> Substs1<{ (L) }> {
-    substs2::<{ (L) }>()
+fn substs3<const L: usize>() -> Substs1<{{ L }}> {
+    substs2::<{{ L }}>()
 }
 
 fn main() {
     assert_eq!(substs3::<2>().0, [0; 2]);
 }
 
-// Test that the implicit ``{ (L) }`` bound on ``substs3`` satisfies the
-// ``{ (N) }`` bound on ``Substs1``
+// Test that the implicit ``{{ L }}`` bound on ``substs3`` satisfies the
+// ``{{ N }}`` bound on ``Substs1``
+// FIXME(generic_const_exprs): come up with a less brittle test for this using assoc consts
+// once normalization is implemented for them.

--- a/tests/ui/consts/const-block-const-bound.rs
+++ b/tests/ui/consts/const-block-const-bound.rs
@@ -11,15 +11,9 @@ impl Drop for UnconstDrop {
     fn drop(&mut self) {}
 }
 
-struct NonDrop;
-
-impl !Drop for NonDrop {}
-
 fn main() {
     const {
         f(UnconstDrop);
-        //~^ ERROR can't drop
-        f(NonDrop);
         //~^ ERROR can't drop
     }
 }

--- a/tests/ui/consts/const-block-const-bound.stderr
+++ b/tests/ui/consts/const-block-const-bound.stderr
@@ -1,5 +1,5 @@
 error[E0277]: can't drop `UnconstDrop` in const contexts
-  --> $DIR/const-block-const-bound.rs:20:9
+  --> $DIR/const-block-const-bound.rs:16:9
    |
 LL |         f(UnconstDrop);
    |         ^^^^^^^^^^^^^^ the trait `~const Destruct` is not implemented for `UnconstDrop`
@@ -12,20 +12,6 @@ LL |         &f(UnconstDrop);
 LL |         &mut f(UnconstDrop);
    |         ++++
 
-error[E0277]: can't drop `NonDrop` in const contexts
-  --> $DIR/const-block-const-bound.rs:22:9
-   |
-LL |         f(NonDrop);
-   |         ^^^^^^^^^^ the trait `~const Destruct` is not implemented for `NonDrop`
-   |
-   = note: the trait bound `NonDrop: ~const Destruct` is not satisfied
-help: consider borrowing here
-   |
-LL |         &f(NonDrop);
-   |         +
-LL |         &mut f(NonDrop);
-   |         ++++
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/dropck/negative.rs
+++ b/tests/ui/dropck/negative.rs
@@ -1,0 +1,7 @@
+#![feature(negative_impls)]
+
+struct NonDrop;
+impl !Drop for NonDrop {}
+//~^ ERROR negative `Drop` impls are not supported
+
+fn main() {}

--- a/tests/ui/dropck/negative.stderr
+++ b/tests/ui/dropck/negative.stderr
@@ -1,0 +1,8 @@
+error: negative `Drop` impls are not supported
+  --> $DIR/negative.rs:4:1
+   |
+LL | impl !Drop for NonDrop {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/dropck/reservation.rs
+++ b/tests/ui/dropck/reservation.rs
@@ -1,0 +1,10 @@
+#![feature(rustc_attrs)]
+
+struct ReservedDrop;
+#[rustc_reservation_impl = "message"]
+impl Drop for ReservedDrop {
+//~^ ERROR reservation `Drop` impls are not supported
+    fn drop(&mut self) {}
+}
+
+fn main() {}

--- a/tests/ui/dropck/reservation.stderr
+++ b/tests/ui/dropck/reservation.stderr
@@ -1,0 +1,8 @@
+error: reservation `Drop` impls are not supported
+  --> $DIR/reservation.rs:5:1
+   |
+LL | impl Drop for ReservedDrop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
@@ -5,10 +5,10 @@
 use std::ops::Deref;
 
 pub trait Foo {
-    fn bar() -> impl Deref<Target = impl Sized>;
+    fn bar(self) -> impl Deref<Target = impl Sized>;
 }
 
 pub struct Foreign;
 impl Foo for Foreign {
-    fn bar() -> &'static () { &() }
+    fn bar(self) -> &'static () { &() }
 }

--- a/tests/ui/impl-trait/in-trait/foreign-dyn-error.rs
+++ b/tests/ui/impl-trait/in-trait/foreign-dyn-error.rs
@@ -1,0 +1,8 @@
+// aux-build: rpitit.rs
+
+extern crate rpitit;
+
+fn main() {
+    let _: &dyn rpitit::Foo = todo!();
+    //~^ ERROR the trait `Foo` cannot be made into an object
+}

--- a/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
+++ b/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
@@ -1,0 +1,15 @@
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/foreign-dyn-error.rs:6:12
+   |
+LL |     let _: &dyn rpitit::Foo = todo!();
+   |            ^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/auxiliary/rpitit.rs:8:21
+   |
+LL |     fn bar(self) -> impl Deref<Target = impl Sized>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait cannot be made into an object because method `bar` references an `impl Trait` type in its return type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/in-trait/foreign.rs
+++ b/tests/ui/impl-trait/in-trait/foreign.rs
@@ -5,17 +5,18 @@
 
 extern crate rpitit;
 
+use rpitit::{Foo, Foreign};
 use std::sync::Arc;
 
 // Implement an RPITIT from another crate.
 struct Local;
-impl rpitit::Foo for Local {
-    fn bar() -> Arc<String> { Arc::new(String::new()) }
+impl Foo for Local {
+    fn bar(self) -> Arc<String> { Arc::new(String::new()) }
 }
 
 fn main() {
     // Witness an RPITIT from another crate.
-    let &() = <rpitit::Foreign as rpitit::Foo>::bar();
+    let &() = Foreign.bar();
 
-    let x: Arc<String> = <Local as rpitit::Foo>::bar();
+    let x: Arc<String> = Local.bar();
 }

--- a/tests/ui/self/self-ctor-inner-const.rs
+++ b/tests/ui/self/self-ctor-inner-const.rs
@@ -1,0 +1,17 @@
+// Verify that we ban usage of `Self` as constructor from inner items.
+
+struct S0<T>(T);
+
+impl<T> S0<T> {
+    fn foo() {
+        const C: S0<u8> = Self(0);
+        //~^ ERROR can't use generic parameters from outer function
+        fn bar() -> Self {
+            //~^ ERROR can't use generic parameters from outer function
+            Self(0)
+            //~^ ERROR can't use generic parameters from outer function
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/self/self-ctor-inner-const.stderr
+++ b/tests/ui/self/self-ctor-inner-const.stderr
@@ -1,0 +1,33 @@
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-ctor-inner-const.rs:7:27
+   |
+LL |         const C: S0<u8> = Self(0);
+   |                           ^^^^
+   |                           |
+   |                           use of generic parameter from outer function
+   |                           can't use `Self` here
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-ctor-inner-const.rs:9:21
+   |
+LL | impl<T> S0<T> {
+   | ---- `Self` type implicitly declared here, by this `impl`
+...
+LL |         fn bar() -> Self {
+   |                     ^^^^
+   |                     |
+   |                     use of generic parameter from outer function
+   |                     use a type here instead
+
+error[E0401]: can't use generic parameters from outer function
+  --> $DIR/self-ctor-inner-const.rs:11:13
+   |
+LL |             Self(0)
+   |             ^^^^
+   |             |
+   |             use of generic parameter from outer function
+   |             can't use `Self` here
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0401`.

--- a/tests/ui/test-attrs/test-type.rs
+++ b/tests/ui/test-attrs/test-type.rs
@@ -3,6 +3,7 @@
 // check-run-results
 // normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // ignore-emscripten no threads support
+// needs-unwind
 // run-pass
 
 #[test]


### PR DESCRIPTION
Successful merges:

 - #110859 (Explicitly reject negative and reservation drop impls)
 - #111020 (Validate resolution for SelfCtor too.)
 - #111024 (Use the full Fingerprint when stringifying Svh)
 - #111027 (Remove `allow(rustc::potential_query_instability)` for `builtin_macros`)
 - #111039 (Encode def span for foreign return-position `impl Trait` in trait)
 - #111070 (Don't suffix `RibKind` variants)
 - #111094 (Add needs-unwind annotations to tests that need stack unwinding)
 - #111103 (correctly recurse when expanding anon consts)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=110859,111020,111024,111027,111039,111070,111094,111103)
<!-- homu-ignore:end -->