### PR TITLE
fix(parse): return unpected when current token is EOF

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -536,7 +536,9 @@ impl<'a> Parser<'a> {
         } else if inedible.contains(&self.token.kind) {
             // leave it in the input
             Ok(false)
-        } else if self.last_unexpected_token_span == Some(self.token.span) {
+        } else if self.token.kind != token::Eof
+            && self.last_unexpected_token_span == Some(self.token.span)
+        {
             FatalError.raise();
         } else {
             self.expected_one_of_not_found(edible, inedible)

--- a/tests/ui/parser/issues/issue-111148.rs
+++ b/tests/ui/parser/issues/issue-111148.rs
@@ -1,0 +1,2 @@
+fn a<<i<Y<w<>#
+//~^ ERROR expected one of `#`, `>`, `const`, identifier, or lifetime, found `<`

--- a/tests/ui/parser/issues/issue-111148.stderr
+++ b/tests/ui/parser/issues/issue-111148.stderr
@@ -1,0 +1,8 @@
+error: expected one of `#`, `>`, `const`, identifier, or lifetime, found `<`
+  --> $DIR/issue-111148.rs:1:6
+   |
+LL | fn a<<i<Y<w<>#
+   |      ^ expected one of `#`, `>`, `const`, identifier, or lifetime
+
+error: aborting due to previous error
+


### PR DESCRIPTION
close https://github.com/rust-lang/rust/issues/111148

#111148 panic occurred because [FatalError.raise()](https://github.com/bvanjoi/rust/blob/master/compiler/rustc_parse/src/parser/mod.rs#LL540C3-L540C3) was encountered which caused by `Eof` and `Pound`(the last token) had same span, when parsing `#` in `fn a<<i<Y<w<>#`.

<img width="825" alt="image" src="https://user-images.githubusercontent.com/30187863/236612589-9e2c6a0b-18cd-408c-b636-c12a51cbcf1c.png">

There are a few ways to solve this problem:

- Change the action assign for [self.last_unexpected_token_span](https://github.com/rust-lang/rust/blob/master/compiler/rustc_parse/src/parser/diagnostics.rs#L592), for example, if current token is `Eof`, then return Error directly.
- Avoid triggering the `FatalError` when the current token is `Eof`.

I have chosen the second option because executing `expected_one_of_not_found` when the token is `Eof` but not in `ediable` seems reasonable.
