### PR TITLE
bootstrap: add .gitmodules to the sources

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -976,6 +976,7 @@ impl Step for PlainSourceTarball {
             "config.example.toml",
             "Cargo.toml",
             "Cargo.lock",
+            ".gitmodules",
         ];
         let src_dirs = ["src", "compiler", "library", "tests"];
 


### PR DESCRIPTION
The bootstrap builder now expects this file to exist: https://github.com/rust-lang/rust/blob/6f8c0557e0b73c73a8a7163a15f4a5a3feca7d5c/src/bootstrap/builder.rs#L494

Zulip thread: https://rust-lang.zulipchat.com/#narrow/stream/187780-t-compiler.2Fwg-llvm/topic/missing.20llvm-project.2Fruntimes.20in.20beta.20srcs