### PR TITLE
Don't compute trait super bounds unless they're positive

### DIFF
--- a/tests/ui/traits/negative-bounds/supertrait.rs
+++ b/tests/ui/traits/negative-bounds/supertrait.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![feature(negative_bounds)]
+//~^ WARN the feature `negative_bounds` is incomplete
+
+trait A: !B {}
+trait B: !A {}
+
+fn main() {}

--- a/tests/ui/traits/negative-bounds/supertrait.stderr
+++ b/tests/ui/traits/negative-bounds/supertrait.stderr
@@ -1,0 +1,10 @@
+warning: the feature `negative_bounds` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/supertrait.rs:3:12
+   |
+LL | #![feature(negative_bounds)]
+   |            ^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes #111207

The comment is modified to explain the rationale for why we even have this recursive call to supertraits in the first place, which doesn't apply to negative bounds since they don't elaborate at all.