### PR TITLE
Add CI step to prevent new untranslatable diagnostics being added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4434,18 +4434,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4454,9 +4454,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "indexmap",
  "itoa",
@@ -5057,6 +5057,14 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "translatable-limits"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
   "src/tools/collect-license-metadata",
   "src/tools/generate-copyright",
   "src/tools/suggest-tests",
+  "src/tools/translatable-limits",
 ]
 
 exclude = [

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -683,7 +683,8 @@ impl<'a> Builder<'a> {
                 tool::Miri,
                 tool::CargoMiri,
                 llvm::Lld,
-                llvm::CrtBeginEnd
+                llvm::CrtBeginEnd,
+                tool::TranslatableLimits,
             ),
             Kind::Check | Kind::Clippy | Kind::Fix => describe!(
                 check::Std,

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -301,6 +301,7 @@ bootstrap_tool!(
     CollectLicenseMetadata, "src/tools/collect-license-metadata", "collect-license-metadata";
     GenerateCopyright, "src/tools/generate-copyright", "generate-copyright";
     SuggestTests, "src/tools/suggest-tests", "suggest-tests";
+    TranslatableLimits, "src/tools/translatable-limits", "translatable-limits";
 );
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]

--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -44,6 +44,7 @@ ENV SCRIPT python3 ../x.py --stage 2 test src/tools/expand-yaml-anchors && \
            python3 ../x.py build --stage 0 src/tools/build-manifest && \
            python3 ../x.py test --stage 0 src/tools/compiletest && \
            python3 ../x.py test --stage 0 core alloc std test proc_macro && \
+           python3 ../x.py b translatable-limits && /checkout/obj/build/host/stage0-tools-bin/translatable-limits ../x.py && \
            # Build both public and internal documentation.
            RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 0 compiler && \
            RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 0 library/test && \

--- a/src/tools/translatable-limits/Cargo.toml
+++ b/src/tools/translatable-limits/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "translatable-limits"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.160", features = ["derive"] }
+serde_json = "1.0.96"

--- a/src/tools/translatable-limits/src/main.rs
+++ b/src/tools/translatable-limits/src/main.rs
@@ -1,0 +1,56 @@
+use serde::{self, Deserialize};
+use std::collections::HashSet;
+use std::process::Command;
+const TRANSLATABLE_LIMIT: usize = 902;
+
+#[derive(Deserialize)]
+struct CompilerMessage {
+    message: CompilerMessageMessage,
+}
+
+#[derive(Deserialize)]
+struct CompilerMessageMessage {
+    spans: Vec<Span>,
+}
+
+#[derive(Deserialize)]
+struct Span {
+    expansion: Option<Box<Expansion>>,
+    file_name: String,
+    line_start: usize,
+}
+
+#[derive(Deserialize)]
+struct Expansion {
+    span: Span,
+}
+
+fn main() {
+    let Some(x_path) = std::env::args().skip(1).next() else {
+        panic!("Usage: translatable-limits <x.py path>")
+    };
+    let output = Command::new(x_path)
+        .args(["check", "compiler", "--json-output", "--warnings", "warn"])
+        .env("RUSTFLAGS_BOOTSTRAP", "-Wrustc::untranslatable_diagnostic")
+        .output()
+        .expect("executing rustc")
+        .stdout;
+    let stdout = String::from_utf8(output).expect("non-utf8 output");
+    let messages = stdout
+        .lines()
+        .filter(|l| l.starts_with('{'))
+        .filter_map(|msg| serde_json::from_str::<CompilerMessage>(&msg).ok())
+        .filter_map(|msg| {
+            let mut sp = msg.message.spans.get(0)?;
+            if let Some(exp) = &sp.expansion {
+                sp = &exp.span
+            }
+            Some((sp.file_name.clone(), sp.line_start))
+        })
+        .collect::<HashSet<_>>();
+
+    assert!(messages.len() <= TRANSLATABLE_LIMIT, "Newly added diagnostics should be translatable");
+    if messages.len() < TRANSLATABLE_LIMIT {
+        println!("Limit can be lowered to {}", messages.len());
+    }
+}


### PR DESCRIPTION
This is in order to prevent new untranslatable diagnostics from being added, as this requires additional work to migrate them later on.