### PR TITLE
Use `free-args` consistently in bootstrap

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1442,6 +1442,28 @@ impl Config {
         git
     }
 
+    pub(crate) fn test_args(&self) -> Vec<&str> {
+        let mut test_args = match self.cmd {
+            Subcommand::Test { ref test_args, .. } | Subcommand::Bench { ref test_args, .. } => {
+                test_args.iter().flat_map(|s| s.split_whitespace()).collect()
+            }
+            _ => vec![],
+        };
+        test_args.extend(self.free_args.iter().map(|s| s.as_str()));
+        test_args
+    }
+
+    pub(crate) fn args(&self) -> Vec<&str> {
+        let mut args = match self.cmd {
+            Subcommand::Run { ref args, .. } => {
+                args.iter().flat_map(|s| s.split_whitespace()).collect()
+            }
+            _ => vec![],
+        };
+        args.extend(self.free_args.iter().map(|s| s.as_str()));
+        args
+    }
+
     /// Bootstrap embeds a version number into the name of shared libraries it uploads in CI.
     /// Return the version it would have used for the given commit.
     pub(crate) fn artifact_version_part(&self, commit: &str) -> String {

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -745,28 +745,10 @@ impl Subcommand {
         }
     }
 
-    pub fn test_args(&self) -> Vec<&str> {
-        match *self {
-            Subcommand::Test { ref test_args, .. } | Subcommand::Bench { ref test_args, .. } => {
-                test_args.iter().flat_map(|s| s.split_whitespace()).collect()
-            }
-            _ => vec![],
-        }
-    }
-
     pub fn rustc_args(&self) -> Vec<&str> {
         match *self {
             Subcommand::Test { ref rustc_args, .. } => {
                 rustc_args.iter().flat_map(|s| s.split_whitespace()).collect()
-            }
-            _ => vec![],
-        }
-    }
-
-    pub fn args(&self) -> Vec<&str> {
-        match *self {
-            Subcommand::Run { ref args, .. } => {
-                args.iter().flat_map(|s| s.split_whitespace()).collect()
             }
             _ => vec![],
         }

--- a/src/bootstrap/run.rs
+++ b/src/bootstrap/run.rs
@@ -105,7 +105,7 @@ impl Step for BumpStage0 {
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let mut cmd = builder.tool_cmd(Tool::BumpStage0);
-        cmd.args(builder.config.cmd.args());
+        cmd.args(builder.config.args());
         builder.run(&mut cmd);
     }
 }
@@ -182,8 +182,7 @@ impl Step for Miri {
         miri.add_rustc_lib_path(builder, compiler);
         // Forward arguments.
         miri.arg("--").arg("--target").arg(target.rustc_target_arg());
-        miri.args(builder.config.cmd.args());
-        miri.args(&builder.config.free_args);
+        miri.args(builder.config.args());
 
         // miri tests need to know about the stage sysroot
         miri.env("MIRI_SYSROOT", &miri_sysroot);

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -263,7 +263,7 @@ impl Step for Cargotest {
             builder,
             cmd.arg(&cargo)
                 .arg(&out_dir)
-                .args(builder.config.cmd.test_args())
+                .args(builder.config.test_args())
                 .env("RUSTC", builder.rustc(compiler))
                 .env("RUSTDOC", builder.rustdoc(compiler)),
         );
@@ -634,7 +634,7 @@ impl Step for Miri {
             .arg(builder.src.join("src/tools/miri/test-cargo-miri/Cargo.toml"));
         cargo.arg("--target").arg(target.rustc_target_arg());
         cargo.arg("--tests"); // don't run doctests, they are too confused by the staging
-        cargo.arg("--").args(builder.config.cmd.test_args());
+        cargo.arg("--").args(builder.config.test_args());
 
         // Tell `cargo miri` where to find things.
         cargo.env("MIRI_SYSROOT", &miri_sysroot);
@@ -1060,7 +1060,7 @@ impl Step for RustdocGUI {
                 }
             }
         }
-        for test_arg in builder.config.cmd.test_args() {
+        for test_arg in builder.config.test_args() {
             command.arg(test_arg);
         }
         builder.run(&mut command);
@@ -1555,8 +1555,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             .filter_map(|p| util::is_valid_test_suite_arg(p, suite_path, builder))
             .collect();
 
-        test_args.append(&mut builder.config.cmd.test_args());
-        test_args.extend(builder.config.free_args.iter().map(|s| s.as_str()));
+        test_args.append(&mut builder.config.test_args());
 
         // On Windows, replace forward slashes in test-args by backslashes
         // so the correct filters are passed to libtest
@@ -1962,7 +1961,7 @@ fn markdown_test(builder: &Builder<'_>, compiler: Compiler, markdown: &Path) -> 
     cmd.arg(markdown);
     cmd.env("RUSTC_BOOTSTRAP", "1");
 
-    let test_args = builder.config.cmd.test_args().join(" ");
+    let test_args = builder.config.test_args().join(" ");
     cmd.arg("--test-args").arg(test_args);
 
     if builder.config.verbose_tests {
@@ -2099,7 +2098,7 @@ fn prepare_cargo_test(
         cargo.arg("-p").arg(krate);
     }
 
-    cargo.arg("--").args(&builder.config.cmd.test_args()).args(libtest_args);
+    cargo.arg("--").args(&builder.config.test_args()).args(libtest_args);
     if !builder.config.verbose_tests {
         cargo.arg("--quiet");
     }


### PR DESCRIPTION
Previously, this was only passed to miri and compiletest. Extended it to all other tests and binaries as well.

cc https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/Running.20a.20single.20doctest

r? @clubby789