### PR TITLE
Remove `tidy` key in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,24 +42,20 @@ jobs:
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       CACHE_DOMAIN: ci-caches.rust-lang.org
     if: "github.event_name == 'pull_request'"
-    continue-on-error: "${{ matrix.tidy }}"
+    continue-on-error: "${{ matrix.name == 'mingw-check-tidy' }}"
     strategy:
       matrix:
         include:
           - name: mingw-check
-            tidy: false
             os: ubuntu-20.04-16core-64gb
             env: {}
           - name: mingw-check-tidy
-            tidy: true
             os: ubuntu-20.04-16core-64gb
             env: {}
           - name: x86_64-gnu-llvm-14
-            tidy: false
             os: ubuntu-20.04-16core-64gb
             env: {}
           - name: x86_64-gnu-tools
-            tidy: false
             os: ubuntu-20.04-16core-64gb
             env: {}
     timeout-minutes: 600

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -300,25 +300,21 @@ jobs:
     env:
       <<: [*shared-ci-variables, *public-variables]
     if: github.event_name == 'pull_request'
-    continue-on-error: ${{ matrix.tidy }}
+    continue-on-error: ${{ matrix.name == 'mingw-check-tidy' }}
     strategy:
       matrix:
         include:
           - name: mingw-check
             <<: *job-linux-16c
-            tidy: false
 
           - name: mingw-check-tidy
             <<: *job-linux-16c
-            tidy: true
 
           - name: x86_64-gnu-llvm-14
             <<: *job-linux-16c
-            tidy: false
 
           - name: x86_64-gnu-tools
             <<: *job-linux-16c
-            tidy: false
 
   auto:
     permissions:


### PR DESCRIPTION
This avoids confusing error messages when adding an `auto` job to CI (as recommended in the dev-guide: https://rustc-dev-guide.rust-lang.org/tests/ci.html#using-ci-to-test).

cc https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Do.20.60needs-profiler-support.60.20tests.20not.20run.20in.20CI.3F/near/355302998

r? @ghost