### PR TITLE
add hint for =< as <=

### DIFF
--- a/tests/ui/parser/eq-less-to-less-eq.rs
+++ b/tests/ui/parser/eq-less-to-less-eq.rs
@@ -1,0 +1,33 @@
+fn foo() {
+    let a = 0;
+    let b = 4;
+    if a =< b { //~ERROR
+        println!("yay!");
+    }
+}
+
+fn bar() {
+    let a = 0;
+    let b = 4;
+    if a = <b { //~ERROR
+        println!("yay!");
+    }
+}
+
+fn baz() {
+    let a = 0;
+    let b = 4;
+    if a = < b { //~ERROR
+        println!("yay!");
+    }
+}
+
+fn qux() {
+    let a = 0;
+    let b = 4;
+    if a =< i32>::abs(-4) { //~ERROR: mismatched types
+        println!("yay!");
+    }
+}
+
+fn main() {}

--- a/tests/ui/parser/eq-less-to-less-eq.stderr
+++ b/tests/ui/parser/eq-less-to-less-eq.stderr
@@ -1,0 +1,34 @@
+error: expected one of `!`, `(`, `+`, `::`, `<`, `>`, or `as`, found `{`
+  --> $DIR/eq-less-to-less-eq.rs:4:15
+   |
+LL |     if a =< b {
+   |          --   ^ expected one of 7 possible tokens
+   |          |
+   |          help: did you mean: `<=`
+
+error: expected one of `!`, `(`, `+`, `::`, `<`, `>`, or `as`, found `{`
+  --> $DIR/eq-less-to-less-eq.rs:12:15
+   |
+LL |     if a = <b {
+   |               ^ expected one of 7 possible tokens
+
+error: expected one of `!`, `(`, `+`, `::`, `<`, `>`, or `as`, found `{`
+  --> $DIR/eq-less-to-less-eq.rs:20:16
+   |
+LL |     if a = < b {
+   |                ^ expected one of 7 possible tokens
+
+error[E0308]: mismatched types
+  --> $DIR/eq-less-to-less-eq.rs:28:8
+   |
+LL |     if a =< i32>::abs(-4) {
+   |        ^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if a ==< i32>::abs(-4) {
+   |           +
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Adds a compiler hint for when `=<` is typed instead of `<=`

Example hint:
```rust
fn foo() {
    if 1 =< 3 {
        println!("Hello, World!");
    }
}
```
```
error: expected type, found `3`
 --> main.rs:2:13
  |
2 |     if 1 =< 3 {
  |          -- ^ expected type
  |          |
  |          help: did you mean: `<=`
```

This PR only emits the suggestion if there is no space between the `=` and `<`.  This hopefully narrows the scope of when this error is emitted, however this still allows this error to be emitted in cases such as this:
```
error: expected expression, found `;`
 --> main.rs:2:18
  |
2 |     if 1 =< [i32;; 3]>::hello() {
  |          --      ^ expected expression
  |          |
  |          help: did you mean: `<=`
```

Which could be a good reason not to merge since I haven't been able to think of any other ways of narrowing the scope of this diagnostic.

closes #111128