### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -498,11 +498,11 @@ impl<'cx, 'tcx> BorrowckInferCtxt<'cx, 'tcx> {
         let next_region = self.infcx.next_region_var(origin);
         let vid = next_region.as_var();
 
-        if cfg!(debug_assertions) && !self.inside_canonicalization_ctxt() {
+        if cfg!(debug_assertions) {
             debug!("inserting vid {:?} with origin {:?} into var_to_origin", vid, origin);
             let ctxt = get_ctxt_fn();
             let mut var_to_origin = self.reg_var_to_origin.borrow_mut();
-            var_to_origin.insert(vid, ctxt);
+            assert_eq!(var_to_origin.insert(vid, ctxt), None);
         }
 
         next_region
@@ -520,11 +520,11 @@ impl<'cx, 'tcx> BorrowckInferCtxt<'cx, 'tcx> {
         let next_region = self.infcx.next_nll_region_var(origin);
         let vid = next_region.as_var();
 
-        if cfg!(debug_assertions) && !self.inside_canonicalization_ctxt() {
+        if cfg!(debug_assertions) {
             debug!("inserting vid {:?} with origin {:?} into var_to_origin", vid, origin);
             let ctxt = get_ctxt_fn();
             let mut var_to_origin = self.reg_var_to_origin.borrow_mut();
-            var_to_origin.insert(vid, ctxt);
+            assert_eq!(var_to_origin.insert(vid, ctxt), None);
         }
 
         next_region

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -131,9 +131,13 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> 
             ty::BoundRegionKind::BrEnv => BoundRegionInfo::Name(sym::env),
         };
 
-        if cfg!(debug_assertions) && !self.type_checker.infcx.inside_canonicalization_ctxt() {
+        if cfg!(debug_assertions) {
             let mut var_to_origin = self.type_checker.infcx.reg_var_to_origin.borrow_mut();
-            var_to_origin.insert(reg.as_var(), RegionCtxt::Placeholder(reg_info));
+            let new = RegionCtxt::Placeholder(reg_info);
+            let prev = var_to_origin.insert(reg.as_var(), new);
+            if let Some(prev) = prev {
+                assert_eq!(new, prev);
+            }
         }
 
         reg
@@ -146,9 +150,10 @@ impl<'tcx> TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> 
             universe,
         );
 
-        if cfg!(debug_assertions) && !self.type_checker.infcx.inside_canonicalization_ctxt() {
+        if cfg!(debug_assertions) {
             let mut var_to_origin = self.type_checker.infcx.reg_var_to_origin.borrow_mut();
-            var_to_origin.insert(reg.as_var(), RegionCtxt::Existential(None));
+            let prev = var_to_origin.insert(reg.as_var(), RegionCtxt::Existential(None));
+            assert_eq!(prev, None);
         }
 
         reg

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -30,8 +30,6 @@ use super::*;
 use rustc_middle::ty::relate::{Relate, TypeRelation};
 use rustc_middle::ty::{Const, ImplSubject};
 
-use std::cell::Cell;
-
 /// Whether we should define opaque types or just treat them opaquely.
 ///
 /// Currently only used to prevent predicate matching from matching anything
@@ -84,7 +82,6 @@ impl<'tcx> InferCtxt<'tcx> {
             in_snapshot: self.in_snapshot.clone(),
             universe: self.universe.clone(),
             intercrate: self.intercrate,
-            inside_canonicalization_ctxt: Cell::new(self.inside_canonicalization_ctxt()),
         }
     }
 }

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -561,8 +561,6 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
     where
         V: TypeFoldable<TyCtxt<'tcx>>,
     {
-        let _inside_canonical_ctxt_guard = infcx.set_canonicalization_ctxt();
-
         let needs_canonical_flags = if canonicalize_region_mode.any() {
             TypeFlags::HAS_INFER |
             TypeFlags::HAS_FREE_REGIONS | // `HAS_RE_PLACEHOLDER` implies `HAS_FREE_REGIONS`

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -108,11 +108,7 @@ impl<'a, 'tcx> Encoder for EncodeContext<'a, 'tcx> {
         emit_i64(i64);
         emit_i32(i32);
         emit_i16(i16);
-        emit_i8(i8);
 
-        emit_bool(bool);
-        emit_char(char);
-        emit_str(&str);
         emit_raw_bytes(&[u8]);
     }
 }

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -1026,11 +1026,7 @@ impl<'a, 'tcx> Encoder for CacheEncoder<'a, 'tcx> {
         emit_i64(i64);
         emit_i32(i32);
         emit_i16(i16);
-        emit_i8(i8);
 
-        emit_bool(bool);
-        emit_char(char);
-        emit_str(&str);
         emit_raw_bytes(&[u8]);
     }
 }

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -518,11 +518,6 @@ macro_rules! implement_ty_decoder {
                     read_i64 -> i64;
                     read_i32 -> i32;
                     read_i16 -> i16;
-                    read_i8 -> i8;
-
-                    read_bool -> bool;
-                    read_char -> char;
-                    read_str -> &str;
                 }
 
                 #[inline]

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -506,19 +506,19 @@ macro_rules! implement_ty_decoder {
 
             impl<$($typaram ),*> Decoder for $DecoderName<$($typaram),*> {
                 $crate::__impl_decoder_methods! {
+                    read_usize -> usize;
                     read_u128 -> u128;
                     read_u64 -> u64;
                     read_u32 -> u32;
                     read_u16 -> u16;
                     read_u8 -> u8;
-                    read_usize -> usize;
 
+                    read_isize -> isize;
                     read_i128 -> i128;
                     read_i64 -> i64;
                     read_i32 -> i32;
                     read_i16 -> i16;
                     read_i8 -> i8;
-                    read_isize -> isize;
 
                     read_bool -> bool;
                     read_char -> char;
@@ -531,13 +531,13 @@ macro_rules! implement_ty_decoder {
                 }
 
                 #[inline]
-                fn position(&self) -> usize {
-                    self.opaque.position()
+                fn peek_byte(&self) -> u8 {
+                    self.opaque.peek_byte()
                 }
 
                 #[inline]
-                fn peek_byte(&self) -> u8 {
-                    self.opaque.peek_byte()
+                fn position(&self) -> usize {
+                    self.opaque.position()
                 }
             }
         }

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -265,7 +265,7 @@ impl Drop for FileEncoder {
     }
 }
 
-macro_rules! file_encoder_write_leb128 {
+macro_rules! write_leb128 {
     ($enc:expr, $value:expr, $int_ty:ty, $fun:ident) => {{
         const MAX_ENCODED_LEN: usize = $crate::leb128::max_leb128_len::<$int_ty>();
 
@@ -294,22 +294,22 @@ macro_rules! file_encoder_write_leb128 {
 impl Encoder for FileEncoder {
     #[inline]
     fn emit_usize(&mut self, v: usize) {
-        file_encoder_write_leb128!(self, v, usize, write_usize_leb128)
+        write_leb128!(self, v, usize, write_usize_leb128)
     }
 
     #[inline]
     fn emit_u128(&mut self, v: u128) {
-        file_encoder_write_leb128!(self, v, u128, write_u128_leb128)
+        write_leb128!(self, v, u128, write_u128_leb128)
     }
 
     #[inline]
     fn emit_u64(&mut self, v: u64) {
-        file_encoder_write_leb128!(self, v, u64, write_u64_leb128)
+        write_leb128!(self, v, u64, write_u64_leb128)
     }
 
     #[inline]
     fn emit_u32(&mut self, v: u32) {
-        file_encoder_write_leb128!(self, v, u32, write_u32_leb128)
+        write_leb128!(self, v, u32, write_u32_leb128)
     }
 
     #[inline]
@@ -324,22 +324,22 @@ impl Encoder for FileEncoder {
 
     #[inline]
     fn emit_isize(&mut self, v: isize) {
-        file_encoder_write_leb128!(self, v, isize, write_isize_leb128)
+        write_leb128!(self, v, isize, write_isize_leb128)
     }
 
     #[inline]
     fn emit_i128(&mut self, v: i128) {
-        file_encoder_write_leb128!(self, v, i128, write_i128_leb128)
+        write_leb128!(self, v, i128, write_i128_leb128)
     }
 
     #[inline]
     fn emit_i64(&mut self, v: i64) {
-        file_encoder_write_leb128!(self, v, i64, write_i64_leb128)
+        write_leb128!(self, v, i64, write_i64_leb128)
     }
 
     #[inline]
     fn emit_i32(&mut self, v: i32) {
-        file_encoder_write_leb128!(self, v, i32, write_i32_leb128)
+        write_leb128!(self, v, i32, write_i32_leb128)
     }
 
     #[inline]

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -266,51 +266,40 @@ impl Drop for FileEncoder {
 }
 
 macro_rules! write_leb128 {
-    ($enc:expr, $value:expr, $int_ty:ty, $fun:ident) => {{
-        const MAX_ENCODED_LEN: usize = $crate::leb128::max_leb128_len::<$int_ty>();
+    ($this_fn:ident, $int_ty:ty, $write_leb_fn:ident) => {
+        #[inline]
+        fn $this_fn(&mut self, v: $int_ty) {
+            const MAX_ENCODED_LEN: usize = $crate::leb128::max_leb128_len::<$int_ty>();
 
-        // We ensure this during `FileEncoder` construction.
-        debug_assert!($enc.capacity() >= MAX_ENCODED_LEN);
+            // We ensure this during `FileEncoder` construction.
+            debug_assert!(self.capacity() >= MAX_ENCODED_LEN);
 
-        let mut buffered = $enc.buffered;
+            let mut buffered = self.buffered;
 
-        // This can't overflow. See assertion in `FileEncoder::with_capacity`.
-        if std::intrinsics::unlikely(buffered + MAX_ENCODED_LEN > $enc.capacity()) {
-            $enc.flush();
-            buffered = 0;
+            // This can't overflow. See assertion in `FileEncoder::with_capacity`.
+            if std::intrinsics::unlikely(buffered + MAX_ENCODED_LEN > self.capacity()) {
+                self.flush();
+                buffered = 0;
+            }
+
+            // SAFETY: The above check and flush ensures that there is enough
+            // room to write the encoded value to the buffer.
+            let buf = unsafe {
+                &mut *(self.buf.as_mut_ptr().add(buffered)
+                    as *mut [MaybeUninit<u8>; MAX_ENCODED_LEN])
+            };
+
+            let encoded = leb128::$write_leb_fn(buf, v);
+            self.buffered = buffered + encoded.len();
         }
-
-        // SAFETY: The above check and flush ensures that there is enough
-        // room to write the encoded value to the buffer.
-        let buf = unsafe {
-            &mut *($enc.buf.as_mut_ptr().add(buffered) as *mut [MaybeUninit<u8>; MAX_ENCODED_LEN])
-        };
-
-        let encoded = leb128::$fun(buf, $value);
-        $enc.buffered = buffered + encoded.len();
-    }};
+    };
 }
 
 impl Encoder for FileEncoder {
-    #[inline]
-    fn emit_usize(&mut self, v: usize) {
-        write_leb128!(self, v, usize, write_usize_leb128)
-    }
-
-    #[inline]
-    fn emit_u128(&mut self, v: u128) {
-        write_leb128!(self, v, u128, write_u128_leb128)
-    }
-
-    #[inline]
-    fn emit_u64(&mut self, v: u64) {
-        write_leb128!(self, v, u64, write_u64_leb128)
-    }
-
-    #[inline]
-    fn emit_u32(&mut self, v: u32) {
-        write_leb128!(self, v, u32, write_u32_leb128)
-    }
+    write_leb128!(emit_usize, usize, write_usize_leb128);
+    write_leb128!(emit_u128, u128, write_u128_leb128);
+    write_leb128!(emit_u64, u64, write_u64_leb128);
+    write_leb128!(emit_u32, u32, write_u32_leb128);
 
     #[inline]
     fn emit_u16(&mut self, v: u16) {
@@ -322,25 +311,10 @@ impl Encoder for FileEncoder {
         self.write_one(v);
     }
 
-    #[inline]
-    fn emit_isize(&mut self, v: isize) {
-        write_leb128!(self, v, isize, write_isize_leb128)
-    }
-
-    #[inline]
-    fn emit_i128(&mut self, v: i128) {
-        write_leb128!(self, v, i128, write_i128_leb128)
-    }
-
-    #[inline]
-    fn emit_i64(&mut self, v: i64) {
-        write_leb128!(self, v, i64, write_i64_leb128)
-    }
-
-    #[inline]
-    fn emit_i32(&mut self, v: i32) {
-        write_leb128!(self, v, i32, write_i32_leb128)
-    }
+    write_leb128!(emit_isize, isize, write_isize_leb128);
+    write_leb128!(emit_i128, i128, write_i128_leb128);
+    write_leb128!(emit_i64, i64, write_i64_leb128);
+    write_leb128!(emit_i32, i32, write_i32_leb128);
 
     #[inline]
     fn emit_i16(&mut self, v: i16) {
@@ -437,29 +411,19 @@ impl<'a> MemDecoder<'a> {
 }
 
 macro_rules! read_leb128 {
-    ($dec:expr, $fun:ident) => {{ leb128::$fun($dec) }};
+    ($this_fn:ident, $int_ty:ty, $read_leb_fn:ident) => {
+        #[inline]
+        fn $this_fn(&mut self) -> $int_ty {
+            leb128::$read_leb_fn(self)
+        }
+    };
 }
 
 impl<'a> Decoder for MemDecoder<'a> {
-    #[inline]
-    fn read_usize(&mut self) -> usize {
-        read_leb128!(self, read_usize_leb128)
-    }
-
-    #[inline]
-    fn read_u128(&mut self) -> u128 {
-        read_leb128!(self, read_u128_leb128)
-    }
-
-    #[inline]
-    fn read_u64(&mut self) -> u64 {
-        read_leb128!(self, read_u64_leb128)
-    }
-
-    #[inline]
-    fn read_u32(&mut self) -> u32 {
-        read_leb128!(self, read_u32_leb128)
-    }
+    read_leb128!(read_usize, usize, read_usize_leb128);
+    read_leb128!(read_u128, u128, read_u128_leb128);
+    read_leb128!(read_u64, u64, read_u64_leb128);
+    read_leb128!(read_u32, u32, read_u32_leb128);
 
     #[inline]
     fn read_u16(&mut self) -> u16 {
@@ -479,25 +443,10 @@ impl<'a> Decoder for MemDecoder<'a> {
         }
     }
 
-    #[inline]
-    fn read_isize(&mut self) -> isize {
-        read_leb128!(self, read_isize_leb128)
-    }
-
-    #[inline]
-    fn read_i128(&mut self) -> i128 {
-        read_leb128!(self, read_i128_leb128)
-    }
-
-    #[inline]
-    fn read_i64(&mut self) -> i64 {
-        read_leb128!(self, read_i64_leb128)
-    }
-
-    #[inline]
-    fn read_i32(&mut self) -> i32 {
-        read_leb128!(self, read_i32_leb128)
-    }
+    read_leb128!(read_isize, isize, read_isize_leb128);
+    read_leb128!(read_i128, i128, read_i128_leb128);
+    read_leb128!(read_i64, i64, read_i64_leb128);
+    read_leb128!(read_i32, i32, read_i32_leb128);
 
     #[inline]
     fn read_i16(&mut self) -> i16 {

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -442,9 +442,8 @@ macro_rules! read_leb128 {
 
 impl<'a> Decoder for MemDecoder<'a> {
     #[inline]
-    fn position(&self) -> usize {
-        // SAFETY: This type guarantees start <= current
-        unsafe { self.current.sub_ptr(self.start) }
+    fn read_usize(&mut self) -> usize {
+        read_leb128!(self, read_usize_leb128)
     }
 
     #[inline]
@@ -481,8 +480,8 @@ impl<'a> Decoder for MemDecoder<'a> {
     }
 
     #[inline]
-    fn read_usize(&mut self) -> usize {
-        read_leb128!(self, read_usize_leb128)
+    fn read_isize(&mut self) -> isize {
+        read_leb128!(self, read_isize_leb128)
     }
 
     #[inline]
@@ -506,11 +505,6 @@ impl<'a> Decoder for MemDecoder<'a> {
     }
 
     #[inline]
-    fn read_isize(&mut self) -> isize {
-        read_leb128!(self, read_isize_leb128)
-    }
-
-    #[inline]
     fn read_raw_bytes(&mut self, bytes: usize) -> &'a [u8] {
         if bytes > self.remaining() {
             Self::decoder_exhausted();
@@ -531,6 +525,12 @@ impl<'a> Decoder for MemDecoder<'a> {
         // SAFETY: This type guarantees current is inbounds or one-past-the-end, which is end.
         // Since we just checked current == end, the current pointer must be inbounds.
         unsafe { *self.current }
+    }
+
+    #[inline]
+    fn position(&self) -> usize {
+        // SAFETY: This type guarantees start <= current
+        unsafe { self.current.sub_ptr(self.start) }
     }
 }
 

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -31,13 +31,13 @@ const STR_SENTINEL: u8 = 0xC1;
 /// really makes sense to store floating-point values at all.
 /// (If you need it, revert <https://github.com/rust-lang/rust/pull/109984>.)
 pub trait Encoder {
-    // Primitive types:
     fn emit_usize(&mut self, v: usize);
     fn emit_u128(&mut self, v: u128);
     fn emit_u64(&mut self, v: u64);
     fn emit_u32(&mut self, v: u32);
     fn emit_u16(&mut self, v: u16);
     fn emit_u8(&mut self, v: u8);
+
     fn emit_isize(&mut self, v: isize);
     fn emit_i128(&mut self, v: i128);
     fn emit_i64(&mut self, v: i64);
@@ -89,13 +89,13 @@ pub trait Encoder {
 /// really makes sense to store floating-point values at all.
 /// (If you need it, revert <https://github.com/rust-lang/rust/pull/109984>.)
 pub trait Decoder {
-    // Primitive types:
     fn read_usize(&mut self) -> usize;
     fn read_u128(&mut self) -> u128;
     fn read_u64(&mut self) -> u64;
     fn read_u32(&mut self) -> u32;
     fn read_u16(&mut self) -> u16;
     fn read_u8(&mut self) -> u8;
+
     fn read_isize(&mut self) -> isize;
     fn read_i128(&mut self) -> i128;
     fn read_i64(&mut self) -> i64;

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -1,9 +1,5 @@
 //! Support code for encoding and decoding types.
 
-/*
-Core encoding and decoding interfaces.
-*/
-
 use std::alloc::Allocator;
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -101,7 +101,7 @@ macro_rules! tuple_impls {
             }
         }
 
-        #[stable(feature = "array_tuple_conv", since = "1.63.0")]
+        #[stable(feature = "array_tuple_conv", since = "CURRENT_RUSTC_VERSION")]
         impl<T> From<[T; ${count(T)}]> for ($(${ignore(T)} T,)+) {
             #[inline]
             #[allow(non_snake_case)]
@@ -111,7 +111,7 @@ macro_rules! tuple_impls {
             }
         }
 
-        #[stable(feature = "array_tuple_conv", since = "1.63.0")]
+        #[stable(feature = "array_tuple_conv", since = "CURRENT_RUSTC_VERSION")]
         impl<T> From<($(${ignore(T)} T,)+)> for [T; ${count(T)}] {
             #[inline]
             #[allow(non_snake_case)]

--- a/library/std/src/sys/common/thread_local/mod.rs
+++ b/library/std/src/sys/common/thread_local/mod.rs
@@ -1,5 +1,10 @@
 #![unstable(feature = "thread_local_internals", reason = "should not be necessary", issue = "none")]
 
+// There are three thread-local implementations: "static", "fast", "OS".
+// The "OS" thread local key type is accessed via platform-specific API calls and is slow, while the
+// "fast" key type is accessed via code generated via LLVM, where TLS keys are set up by the linker.
+// "static" is for single-threaded platforms where a global static is sufficient.
+
 cfg_if::cfg_if! {
     if #[cfg(all(target_family = "wasm", not(target_feature = "atomics")))] {
         #[doc(hidden)]

--- a/library/std/src/sys/common/thread_local/os_local.rs
+++ b/library/std/src/sys/common/thread_local/os_local.rs
@@ -18,7 +18,7 @@ pub macro thread_local_inner {
         ) -> $crate::option::Option<&'static $t> {
             const INIT_EXPR: $t = $init;
 
-                        // On platforms without `#[thread_local]` we fall back to the
+            // On platforms without `#[thread_local]` we fall back to the
             // same implementation as below for os thread locals.
             #[inline]
             const fn __init() -> $t { INIT_EXPR }

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -193,22 +193,22 @@ pub use scoped::{scope, Scope, ScopedJoinHandle};
 #[macro_use]
 mod local;
 
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use self::local::{AccessError, LocalKey};
+cfg_if::cfg_if! {
+    if #[cfg(test)] {
+        // Avoid duplicating the global state assoicated with thread-locals between this crate and
+        // realstd. Miri relies on this.
+        pub use realstd::thread::{local_impl, AccessError, LocalKey};
+    } else {
+        #[stable(feature = "rust1", since = "1.0.0")]
+        pub use self::local::{AccessError, LocalKey};
 
-// Provide the type used by the thread_local! macro to access TLS keys. This
-// needs to be kept in sync with the macro itself (in `local.rs`).
-// There are three types: "static", "fast", "OS". The "OS" thread local key
-// type is accessed via platform-specific API calls and is slow, while the "fast"
-// key type is accessed via code generated via LLVM, where TLS keys are set up
-// by the elf linker. "static" is for single-threaded platforms where a global
-// static is sufficient.
-
-// Implementation details used by the thread_local!{} macro.
-#[doc(hidden)]
-#[unstable(feature = "thread_local_internals", issue = "none")]
-pub mod local_impl {
-    pub use crate::sys::common::thread_local::{thread_local_inner, Key};
+        // Implementation details used by the thread_local!{} macro.
+        #[doc(hidden)]
+        #[unstable(feature = "thread_local_internals", issue = "none")]
+        pub mod local_impl {
+            pub use crate::sys::common::thread_local::{thread_local_inner, Key};
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1442,6 +1442,28 @@ impl Config {
         git
     }
 
+    pub(crate) fn test_args(&self) -> Vec<&str> {
+        let mut test_args = match self.cmd {
+            Subcommand::Test { ref test_args, .. } | Subcommand::Bench { ref test_args, .. } => {
+                test_args.iter().flat_map(|s| s.split_whitespace()).collect()
+            }
+            _ => vec![],
+        };
+        test_args.extend(self.free_args.iter().map(|s| s.as_str()));
+        test_args
+    }
+
+    pub(crate) fn args(&self) -> Vec<&str> {
+        let mut args = match self.cmd {
+            Subcommand::Run { ref args, .. } => {
+                args.iter().flat_map(|s| s.split_whitespace()).collect()
+            }
+            _ => vec![],
+        };
+        args.extend(self.free_args.iter().map(|s| s.as_str()));
+        args
+    }
+
     /// Bootstrap embeds a version number into the name of shared libraries it uploads in CI.
     /// Return the version it would have used for the given commit.
     pub(crate) fn artifact_version_part(&self, commit: &str) -> String {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -822,6 +822,8 @@ fn copy_src_dirs(
             "llvm-project\\compiler-rt",
             "llvm-project/cmake",
             "llvm-project\\cmake",
+            "llvm-project/runtimes",
+            "llvm-project\\runtimes",
         ];
         if spath.contains("llvm-project")
             && !spath.ends_with("llvm-project")

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -745,28 +745,10 @@ impl Subcommand {
         }
     }
 
-    pub fn test_args(&self) -> Vec<&str> {
-        match *self {
-            Subcommand::Test { ref test_args, .. } | Subcommand::Bench { ref test_args, .. } => {
-                test_args.iter().flat_map(|s| s.split_whitespace()).collect()
-            }
-            _ => vec![],
-        }
-    }
-
     pub fn rustc_args(&self) -> Vec<&str> {
         match *self {
             Subcommand::Test { ref rustc_args, .. } => {
                 rustc_args.iter().flat_map(|s| s.split_whitespace()).collect()
-            }
-            _ => vec![],
-        }
-    }
-
-    pub fn args(&self) -> Vec<&str> {
-        match *self {
-            Subcommand::Run { ref args, .. } => {
-                args.iter().flat_map(|s| s.split_whitespace()).collect()
             }
             _ => vec![],
         }

--- a/src/bootstrap/run.rs
+++ b/src/bootstrap/run.rs
@@ -105,7 +105,7 @@ impl Step for BumpStage0 {
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let mut cmd = builder.tool_cmd(Tool::BumpStage0);
-        cmd.args(builder.config.cmd.args());
+        cmd.args(builder.config.args());
         builder.run(&mut cmd);
     }
 }
@@ -182,8 +182,7 @@ impl Step for Miri {
         miri.add_rustc_lib_path(builder, compiler);
         // Forward arguments.
         miri.arg("--").arg("--target").arg(target.rustc_target_arg());
-        miri.args(builder.config.cmd.args());
-        miri.args(&builder.config.free_args);
+        miri.args(builder.config.args());
 
         // miri tests need to know about the stage sysroot
         miri.env("MIRI_SYSROOT", &miri_sysroot);

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -263,7 +263,7 @@ impl Step for Cargotest {
             builder,
             cmd.arg(&cargo)
                 .arg(&out_dir)
-                .args(builder.config.cmd.test_args())
+                .args(builder.config.test_args())
                 .env("RUSTC", builder.rustc(compiler))
                 .env("RUSTDOC", builder.rustdoc(compiler)),
         );
@@ -634,7 +634,7 @@ impl Step for Miri {
             .arg(builder.src.join("src/tools/miri/test-cargo-miri/Cargo.toml"));
         cargo.arg("--target").arg(target.rustc_target_arg());
         cargo.arg("--tests"); // don't run doctests, they are too confused by the staging
-        cargo.arg("--").args(builder.config.cmd.test_args());
+        cargo.arg("--").args(builder.config.test_args());
 
         // Tell `cargo miri` where to find things.
         cargo.env("MIRI_SYSROOT", &miri_sysroot);
@@ -1060,7 +1060,7 @@ impl Step for RustdocGUI {
                 }
             }
         }
-        for test_arg in builder.config.cmd.test_args() {
+        for test_arg in builder.config.test_args() {
             command.arg(test_arg);
         }
         builder.run(&mut command);
@@ -1555,8 +1555,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             .filter_map(|p| util::is_valid_test_suite_arg(p, suite_path, builder))
             .collect();
 
-        test_args.append(&mut builder.config.cmd.test_args());
-        test_args.extend(builder.config.free_args.iter().map(|s| s.as_str()));
+        test_args.append(&mut builder.config.test_args());
 
         // On Windows, replace forward slashes in test-args by backslashes
         // so the correct filters are passed to libtest
@@ -1962,7 +1961,7 @@ fn markdown_test(builder: &Builder<'_>, compiler: Compiler, markdown: &Path) -> 
     cmd.arg(markdown);
     cmd.env("RUSTC_BOOTSTRAP", "1");
 
-    let test_args = builder.config.cmd.test_args().join(" ");
+    let test_args = builder.config.test_args().join(" ");
     cmd.arg("--test-args").arg(test_args);
 
     if builder.config.verbose_tests {
@@ -2099,7 +2098,7 @@ fn prepare_cargo_test(
         cargo.arg("-p").arg(krate);
     }
 
-    cargo.arg("--").args(&builder.config.cmd.test_args()).args(libtest_args);
+    cargo.arg("--").args(&builder.config.test_args()).args(libtest_args);
     if !builder.config.verbose_tests {
         cargo.arg("--quiet");
     }

--- a/tests/mir-opt/const_prop/address_of_pair.fn0.ConstProp.diff
+++ b/tests/mir-opt/const_prop/address_of_pair.fn0.ConstProp.diff
@@ -1,0 +1,51 @@
+- // MIR for `fn0` before ConstProp
++ // MIR for `fn0` after ConstProp
+  
+  fn fn0() -> bool {
+      let mut _0: bool;                    // return place in scope 0 at $DIR/address_of_pair.rs:+0:17: +0:21
+      let mut _1: !;                       // in scope 0 at $DIR/address_of_pair.rs:+0:22: +9:2
+      let mut _2: (i32, bool);             // in scope 0 at $DIR/address_of_pair.rs:+1:9: +1:17
+      let _4: ();                          // in scope 0 at $DIR/address_of_pair.rs:+4:5: +6:6
+      let mut _6: bool;                    // in scope 0 at $DIR/address_of_pair.rs:+7:16: +7:22
+      scope 1 {
+          debug pair => _2;                // in scope 1 at $DIR/address_of_pair.rs:+1:9: +1:17
+          let _3: *mut bool;               // in scope 1 at $DIR/address_of_pair.rs:+2:9: +2:12
+          scope 2 {
+              debug ptr => _3;             // in scope 2 at $DIR/address_of_pair.rs:+2:9: +2:12
+              let _5: bool;                // in scope 2 at $DIR/address_of_pair.rs:+7:9: +7:12
+              scope 3 {
+              }
+              scope 4 {
+                  debug ret => _5;         // in scope 4 at $DIR/address_of_pair.rs:+7:9: +7:12
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/address_of_pair.rs:+1:9: +1:17
+-         _2 = (const 1_i32, const false); // scope 0 at $DIR/address_of_pair.rs:+1:20: +1:30
++         _2 = const (1_i32, false);       // scope 0 at $DIR/address_of_pair.rs:+1:20: +1:30
+          StorageLive(_3);                 // scope 1 at $DIR/address_of_pair.rs:+2:9: +2:12
+          _3 = &raw mut (_2.1: bool);      // scope 1 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+-         _2 = (const 1_i32, const false); // scope 2 at $DIR/address_of_pair.rs:+3:5: +3:22
++         _2 = const (1_i32, false);       // scope 2 at $DIR/address_of_pair.rs:+3:5: +3:22
+          StorageLive(_4);                 // scope 2 at $DIR/address_of_pair.rs:+4:5: +6:6
+          (*_3) = const true;              // scope 3 at $DIR/address_of_pair.rs:+5:9: +5:20
+          _4 = const ();                   // scope 3 at $DIR/address_of_pair.rs:+4:5: +6:6
+          StorageDead(_4);                 // scope 2 at $DIR/address_of_pair.rs:+6:5: +6:6
+          StorageLive(_5);                 // scope 2 at $DIR/address_of_pair.rs:+7:9: +7:12
+          StorageLive(_6);                 // scope 2 at $DIR/address_of_pair.rs:+7:16: +7:22
+-         _6 = (_2.1: bool);               // scope 2 at $DIR/address_of_pair.rs:+7:16: +7:22
+-         _5 = Not(move _6);               // scope 2 at $DIR/address_of_pair.rs:+7:15: +7:22
++         _6 = const false;                // scope 2 at $DIR/address_of_pair.rs:+7:16: +7:22
++         _5 = const true;                 // scope 2 at $DIR/address_of_pair.rs:+7:15: +7:22
+          StorageDead(_6);                 // scope 2 at $DIR/address_of_pair.rs:+7:21: +7:22
+-         _0 = _5;                         // scope 4 at $DIR/address_of_pair.rs:+8:12: +8:15
++         _0 = const true;                 // scope 4 at $DIR/address_of_pair.rs:+8:12: +8:15
+          StorageDead(_5);                 // scope 2 at $DIR/address_of_pair.rs:+9:1: +9:2
+          StorageDead(_3);                 // scope 1 at $DIR/address_of_pair.rs:+9:1: +9:2
+          StorageDead(_2);                 // scope 0 at $DIR/address_of_pair.rs:+9:1: +9:2
+          return;                          // scope 0 at $DIR/address_of_pair.rs:+9:2: +9:2
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/address_of_pair.fn0.ConstProp.diff
+++ b/tests/mir-opt/const_prop/address_of_pair.fn0.ConstProp.diff
@@ -23,25 +23,20 @@
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/address_of_pair.rs:+1:9: +1:17
--         _2 = (const 1_i32, const false); // scope 0 at $DIR/address_of_pair.rs:+1:20: +1:30
-+         _2 = const (1_i32, false);       // scope 0 at $DIR/address_of_pair.rs:+1:20: +1:30
+          _2 = (const 1_i32, const false); // scope 0 at $DIR/address_of_pair.rs:+1:20: +1:30
           StorageLive(_3);                 // scope 1 at $DIR/address_of_pair.rs:+2:9: +2:12
           _3 = &raw mut (_2.1: bool);      // scope 1 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
--         _2 = (const 1_i32, const false); // scope 2 at $DIR/address_of_pair.rs:+3:5: +3:22
-+         _2 = const (1_i32, false);       // scope 2 at $DIR/address_of_pair.rs:+3:5: +3:22
+          _2 = (const 1_i32, const false); // scope 2 at $DIR/address_of_pair.rs:+3:5: +3:22
           StorageLive(_4);                 // scope 2 at $DIR/address_of_pair.rs:+4:5: +6:6
           (*_3) = const true;              // scope 3 at $DIR/address_of_pair.rs:+5:9: +5:20
           _4 = const ();                   // scope 3 at $DIR/address_of_pair.rs:+4:5: +6:6
           StorageDead(_4);                 // scope 2 at $DIR/address_of_pair.rs:+6:5: +6:6
           StorageLive(_5);                 // scope 2 at $DIR/address_of_pair.rs:+7:9: +7:12
           StorageLive(_6);                 // scope 2 at $DIR/address_of_pair.rs:+7:16: +7:22
--         _6 = (_2.1: bool);               // scope 2 at $DIR/address_of_pair.rs:+7:16: +7:22
--         _5 = Not(move _6);               // scope 2 at $DIR/address_of_pair.rs:+7:15: +7:22
-+         _6 = const false;                // scope 2 at $DIR/address_of_pair.rs:+7:16: +7:22
-+         _5 = const true;                 // scope 2 at $DIR/address_of_pair.rs:+7:15: +7:22
+          _6 = (_2.1: bool);               // scope 2 at $DIR/address_of_pair.rs:+7:16: +7:22
+          _5 = Not(move _6);               // scope 2 at $DIR/address_of_pair.rs:+7:15: +7:22
           StorageDead(_6);                 // scope 2 at $DIR/address_of_pair.rs:+7:21: +7:22
--         _0 = _5;                         // scope 4 at $DIR/address_of_pair.rs:+8:12: +8:15
-+         _0 = const true;                 // scope 4 at $DIR/address_of_pair.rs:+8:12: +8:15
+          _0 = _5;                         // scope 4 at $DIR/address_of_pair.rs:+8:12: +8:15
           StorageDead(_5);                 // scope 2 at $DIR/address_of_pair.rs:+9:1: +9:2
           StorageDead(_3);                 // scope 1 at $DIR/address_of_pair.rs:+9:1: +9:2
           StorageDead(_2);                 // scope 0 at $DIR/address_of_pair.rs:+9:1: +9:2

--- a/tests/mir-opt/const_prop/address_of_pair.rs
+++ b/tests/mir-opt/const_prop/address_of_pair.rs
@@ -1,0 +1,17 @@
+// unit-test: ConstProp
+
+// EMIT_MIR address_of_pair.fn0.ConstProp.diff
+pub fn fn0() -> bool {
+    let mut pair = (1, false);
+    let ptr = core::ptr::addr_of_mut!(pair.1);
+    pair = (1, false);
+    unsafe {
+        *ptr = true;
+    }
+    let ret = !pair.1;
+    return ret;
+}
+
+pub fn main() {
+    println!("{}", fn0());
+}

--- a/tests/mir-opt/const_prop_miscompile.bar.ConstProp.diff
+++ b/tests/mir-opt/const_prop_miscompile.bar.ConstProp.diff
@@ -19,8 +19,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
--         _1 = (const 1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
-+         _1 = const (1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
+          _1 = (const 1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+2:5: +4:6
           StorageLive(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22
           _3 = &raw mut (_1.0: i32);       // scope 2 at $DIR/const_prop_miscompile.rs:+3:10: +3:22

--- a/tests/mir-opt/const_prop_miscompile.foo.ConstProp.diff
+++ b/tests/mir-opt/const_prop_miscompile.foo.ConstProp.diff
@@ -16,8 +16,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:+1:9: +1:14
--         _1 = (const 1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
-+         _1 = const (1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
+          _1 = (const 1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:+1:17: +1:21
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:+2:6: +2:14
           _2 = &mut (_1.0: i32);           // scope 1 at $DIR/const_prop_miscompile.rs:+2:6: +2:14
           (*_2) = const 5_i32;             // scope 1 at $DIR/const_prop_miscompile.rs:+2:5: +2:18

--- a/tests/ui/impl-trait/issues/issue-86800.rs
+++ b/tests/ui/impl-trait/issues/issue-86800.rs
@@ -1,14 +1,12 @@
 #![feature(type_alias_impl_trait)]
 
 // edition:2021
-// unset-rustc-env:RUST_BACKTRACE
 // compile-flags:-Z treat-err-as-bug=1
-// error-pattern:stack backtrace:
+// error-pattern: aborting due to `-Z treat-err-as-bug=1`
 // failure-status:101
-// normalize-stderr-test "note: .*" -> ""
-// normalize-stderr-test "thread 'rustc' .*" -> ""
-// normalize-stderr-test " +[0-9]+:.*\n" -> ""
-// normalize-stderr-test " +at .*\n" -> ""
+// normalize-stderr-test ".*note: .*\n\n" -> ""
+// normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+// rustc-env:RUST_BACKTRACE=0
 
 use std::future::Future;
 

--- a/tests/ui/impl-trait/issues/issue-86800.stderr
+++ b/tests/ui/impl-trait/issues/issue-86800.stderr
@@ -1,24 +1,12 @@
 error: unconstrained opaque type
-  --> $DIR/issue-86800.rs:33:34
+  --> $DIR/issue-86800.rs:31:34
    |
 LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResult<O>>;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = 
-
-
-stack backtrace:
-
 error: the compiler unexpectedly panicked. this is a bug.
-
-
-
-
-
-
 
 query stack during panic:
 #0 [type_of] computing type of `TransactionFuture::{opaque#0}`
 #1 [check_mod_item_types] checking item types in top-level module
-#2 [analysis] running analysis passes on this crate
 end of query stack

--- a/tests/ui/panics/default-backtrace-ice.rs
+++ b/tests/ui/panics/default-backtrace-ice.rs
@@ -2,8 +2,20 @@
 // compile-flags:-Z treat-err-as-bug=1
 // error-pattern:stack backtrace:
 // failure-status:101
+// ignore-msvc
 // normalize-stderr-test "note: .*" -> ""
 // normalize-stderr-test "thread 'rustc' .*" -> ""
-// normalize-stderr-test "  .*\n" -> ""
+// normalize-stderr-test " +\d+:.*__rust_begin_short_backtrace.*" -> "(begin_short_backtrace)"
+// normalize-stderr-test " +\d+:.*__rust_end_short_backtrace.*" -> "(end_short_backtrace)"
+// normalize-stderr-test " +\d+:.*\n" -> ""
+// normalize-stderr-test " +at .*\n" -> ""
+//
+// This test makes sure that full backtraces are used for ICEs when
+// RUST_BACKTRACE is not set. It does this by checking for the presence of
+// `__rust_{begin,end}_short_backtrace` markers, which only appear in full
+// backtraces. The rest of the backtrace is filtered out.
+//
+// Ignored on msvc becaue the `__rust_{begin,end}_short_backtrace` symbols
+// aren't reliable.
 
 fn main() { missing_ident; }

--- a/tests/ui/panics/default-backtrace-ice.stderr
+++ b/tests/ui/panics/default-backtrace-ice.stderr
@@ -1,8 +1,13 @@
 error[E0425]: cannot find value `missing_ident` in this scope
+  --> $DIR/default-backtrace-ice.rs:21:13
+   |
 LL | fn main() { missing_ident; }
+   |             ^^^^^^^^^^^^^ not found in this scope
 
 
 stack backtrace:
+(end_short_backtrace)
+(begin_short_backtrace)
 
 error: the compiler unexpectedly panicked. this is a bug.
 


### PR DESCRIPTION
Successful merges:

 - #110946 (avoid duplicating TLS state between test std and realstd)
 - #110954 (Reject borrows of projections in ConstProp.)
 - #111052 (Fix problems with backtraces in two ui tests.)
 - #111132 (cleanup nll generalizer)
 - #111173 (Still more encoder cleanups)
 - #111187 (bootstrap: add llvm-project/runtimes to the sources)
 - #111213 (Fixup "since" dates for `array_tuple_conv` feature)
 - #111223 (Use `free-args` consistently in bootstrap)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=110946,110954,111052,111132,111173,111187,111213,111223)
<!-- homu-ignore:end -->