### PR TITLE
Allow `read`ing a `*mut` without an internal cast

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -380,7 +380,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
             sym::likely => (0, vec![tcx.types.bool], tcx.types.bool),
             sym::unlikely => (0, vec![tcx.types.bool], tcx.types.bool),
 
-            sym::read_via_copy => (1, vec![tcx.mk_imm_ptr(param(0))], param(0)),
+            sym::read_via_copy => (2, vec![param(0)], param(1)),
             sym::write_via_move => (1, vec![tcx.mk_mut_ptr(param(0)), param(0)], tcx.mk_unit()),
 
             sym::discriminant_value => {

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -738,7 +738,7 @@ pub const fn swap<T>(x: &mut T, y: &mut T) {
         // tends to copy the whole thing to stack rather than doing it one part
         // at a time, so instead treat them as one-element slices and piggy-back
         // the slice optimizations that will split up the swaps.
-        if size_of::<T>() / align_of::<T>() > 4 {
+        if const { size_of::<T>() / align_of::<T>() > 4 } {
             // SAFETY: exclusive references always point to one non-overlapping
             // element and are non-null and properly aligned.
             return unsafe { ptr::swap_nonoverlapping(x, y, 1) };
@@ -774,11 +774,14 @@ pub(crate) const fn swap_simple<T>(x: &mut T, y: &mut T) {
     // asymmetry to the behaviour where one value went through read+write
     // whereas the other was copied over by the intrinsic (see #94371).
 
+    let x: *mut T = x;
+    let y: *mut T = y;
+
     // SAFETY: exclusive references are always valid to read/write,
     // including being aligned, and nothing here panics so it's drop-safe.
     unsafe {
-        let a = ptr::read(x);
-        let b = ptr::read(y);
+        let a = ptr::read_mut(x);
+        let b = ptr::read_mut(y);
         ptr::write(x, b);
         ptr::write(y, a);
     }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -909,11 +909,12 @@ pub fn take<T: Default>(dest: &mut T) -> T {
 #[rustc_const_unstable(feature = "const_replace", issue = "83164")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "mem_replace")]
 pub const fn replace<T>(dest: &mut T, src: T) -> T {
+    let dest: *mut T = dest;
     // SAFETY: We read from `dest` but directly write `src` into it afterwards,
     // such that the old value is not duplicated. Nothing is dropped and
     // nothing here can panic.
     unsafe {
-        let result = ptr::read(dest);
+        let result = ptr::read_mut(dest);
         ptr::write(dest, src);
         result
     }

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1168,7 +1168,23 @@ pub const unsafe fn read<T>(src: *const T) -> T {
             "ptr::read requires that the pointer argument is aligned and non-null",
             [T](src: *const T) => is_aligned_and_not_null(src)
         );
-        crate::intrinsics::read_via_copy(src)
+        intrinsics::read_via_copy(src)
+    }
+}
+
+/// Like [`read`], but on `*mut` to avoid a `&raw const*`.
+///
+/// # Safety
+///
+/// Same as [`read`].
+pub(crate) const unsafe fn read_mut<T>(src: *mut T) -> T {
+    // SAFETY: see `read` above
+    unsafe {
+        assert_unsafe_precondition!(
+            "ptr::read requires that the pointer argument is aligned and non-null",
+            [T](src: *mut T) => is_aligned_and_not_null(src)
+        );
+        intrinsics::read_via_copy(src)
     }
 }
 

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1312,8 +1312,8 @@ impl<T: ?Sized> *mut T {
     where
         T: Sized,
     {
-        // SAFETY: the caller must uphold the safety contract for ``.
-        unsafe { read(self) }
+        // SAFETY: the caller must uphold the safety contract for `read_mut`.
+        unsafe { read_mut(self) }
     }
 
     /// Performs a volatile read of the value from `self` without moving it. This

--- a/src/tools/miri/tests/fail/tree-borrows/fragile-data-race.stderr
+++ b/src/tools/miri/tests/fail/tree-borrows/fragile-data-race.stderr
@@ -20,8 +20,8 @@ LL | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
 help: the conflicting tag <TAG> then transitioned from Reserved to Frozen due to a foreign read access at offsets [0x0..0x1]
   --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
-LL |         crate::intrinsics::read_via_copy(src)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         intrinsics::read_via_copy(src)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fragile-data-race.rs:LL:CC

--- a/tests/mir-opt/lower_intrinsics.option_payload.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.option_payload.LowerIntrinsics.diff
@@ -24,7 +24,7 @@
           _4 = &raw const (*_1);           // scope 1 at $DIR/lower_intrinsics.rs:+2:55: +2:56
 -         _3 = option_payload_ptr::<usize>(move _4) -> [return: bb1, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics.rs:+2:18: +2:57
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:137:18: 137:54
+-                                          // + span: $DIR/lower_intrinsics.rs:142:18: 142:54
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const Option<usize>) -> *const usize {option_payload_ptr::<usize>}, val: Value(<ZST>) }
 +         _3 = &raw const (((*_4) as Some).0: usize); // scope 1 at $DIR/lower_intrinsics.rs:+2:18: +2:57
 +         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:+2:18: +2:57
@@ -37,7 +37,7 @@
           _6 = &raw const (*_2);           // scope 2 at $DIR/lower_intrinsics.rs:+3:55: +3:56
 -         _5 = option_payload_ptr::<String>(move _6) -> [return: bb2, unwind unreachable]; // scope 2 at $DIR/lower_intrinsics.rs:+3:18: +3:57
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:138:18: 138:54
+-                                          // + span: $DIR/lower_intrinsics.rs:143:18: 143:54
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const Option<String>) -> *const String {option_payload_ptr::<String>}, val: Value(<ZST>) }
 +         _5 = &raw const (((*_6) as Some).0: std::string::String); // scope 2 at $DIR/lower_intrinsics.rs:+3:18: +3:57
 +         goto -> bb2;                     // scope 2 at $DIR/lower_intrinsics.rs:+3:18: +3:57

--- a/tests/mir-opt/lower_intrinsics.ptr_offset.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.ptr_offset.LowerIntrinsics.diff
@@ -15,7 +15,7 @@
           _4 = _2;                         // scope 0 at $DIR/lower_intrinsics.rs:+1:33: +1:34
 -         _0 = offset::<*const i32, isize>(move _3, move _4) -> [return: bb1, unwind unreachable]; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:144:5: 144:29
+-                                          // + span: $DIR/lower_intrinsics.rs:149:5: 149:29
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const i32, isize) -> *const i32 {offset::<*const i32, isize>}, val: Value(<ZST>) }
 +         _0 = Offset(move _3, move _4);   // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35

--- a/tests/mir-opt/lower_intrinsics.ptr_offset_mut.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.ptr_offset_mut.LowerIntrinsics.diff
@@ -1,0 +1,30 @@
+- // MIR for `ptr_offset_mut` before LowerIntrinsics
++ // MIR for `ptr_offset_mut` after LowerIntrinsics
+  
+  fn ptr_offset_mut(_1: *mut i32, _2: usize) -> *mut i32 {
+      debug p => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:30: +0:31
+      debug d => _2;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:43: +0:44
+      let mut _0: *mut i32;                // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:56: +0:64
+      let mut _3: *mut i32;                // in scope 0 at $DIR/lower_intrinsics.rs:+1:30: +1:31
+      let mut _4: usize;                   // in scope 0 at $DIR/lower_intrinsics.rs:+1:33: +1:34
+  
+      bb0: {
+          StorageLive(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:30: +1:31
+          _3 = _1;                         // scope 0 at $DIR/lower_intrinsics.rs:+1:30: +1:31
+          StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:33: +1:34
+          _4 = _2;                         // scope 0 at $DIR/lower_intrinsics.rs:+1:33: +1:34
+-         _0 = offset::<*mut i32, usize>(move _3, move _4) -> [return: bb1, unwind unreachable]; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35
+-                                          // mir::Constant
+-                                          // + span: $DIR/lower_intrinsics.rs:154:5: 154:29
+-                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*mut i32, usize) -> *mut i32 {offset::<*mut i32, usize>}, val: Value(<ZST>) }
++         _0 = Offset(move _3, move _4);   // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:35
+      }
+  
+      bb1: {
+          StorageDead(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:34: +1:35
+          StorageDead(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:34: +1:35
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
+      }
+  }
+  

--- a/tests/mir-opt/lower_intrinsics.read_via_copy_mut.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.read_via_copy_mut.LowerIntrinsics.diff
@@ -1,0 +1,25 @@
+- // MIR for `read_via_copy_mut` before LowerIntrinsics
++ // MIR for `read_via_copy_mut` after LowerIntrinsics
+  
+  fn read_via_copy_mut(_1: *mut i64) -> i64 {
+      debug r => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:33: +0:34
+      let mut _0: i64;                     // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:49: +0:52
+      let mut _2: *mut i64;                // in scope 0 at $DIR/lower_intrinsics.rs:+1:37: +1:38
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:37: +1:38
+          _2 = _1;                         // scope 0 at $DIR/lower_intrinsics.rs:+1:37: +1:38
+-         _0 = read_via_copy::<*mut i64, i64>(move _2) -> [return: bb1, unwind unreachable]; // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:39
+-                                          // mir::Constant
+-                                          // + span: $DIR/lower_intrinsics.rs:129:5: 129:36
+-                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*mut i64) -> i64 {read_via_copy::<*mut i64, i64>}, val: Value(<ZST>) }
++         _0 = (*_2);                      // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:39
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:+1:5: +1:39
+      }
+  
+      bb1: {
+          StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:+1:38: +1:39
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:+2:2: +2:2
+      }
+  }
+  

--- a/tests/mir-opt/lower_intrinsics.read_via_copy_primitive.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.read_via_copy_primitive.LowerIntrinsics.diff
@@ -4,17 +4,17 @@
   fn read_via_copy_primitive(_1: &i32) -> i32 {
       debug r => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:32: +0:33
       let mut _0: i32;                     // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:44: +0:47
-      let mut _2: *const i32;              // in scope 0 at $DIR/lower_intrinsics.rs:+1:46: +1:47
+      let mut _2: &i32;                    // in scope 0 at $DIR/lower_intrinsics.rs:+1:46: +1:47
       scope 1 {
       }
   
       bb0: {
           StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+1:46: +1:47
-          _2 = &raw const (*_1);           // scope 1 at $DIR/lower_intrinsics.rs:+1:46: +1:47
--         _0 = read_via_copy::<i32>(move _2) -> [return: bb1, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
+          _2 = _1;                         // scope 1 at $DIR/lower_intrinsics.rs:+1:46: +1:47
+-         _0 = read_via_copy::<&i32, i32>(move _2) -> [return: bb1, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:119:14: 119:45
--                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const i32) -> i32 {read_via_copy::<i32>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&i32) -> i32 {read_via_copy::<&i32, i32>}, val: Value(<ZST>) }
 +         _0 = (*_2);                      // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
 +         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
       }

--- a/tests/mir-opt/lower_intrinsics.read_via_copy_uninhabited.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.read_via_copy_uninhabited.LowerIntrinsics.diff
@@ -4,17 +4,17 @@
   fn read_via_copy_uninhabited(_1: &Never) -> Never {
       debug r => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:+0:34: +0:35
       let mut _0: Never;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:+0:48: +0:53
-      let mut _2: *const Never;            // in scope 0 at $DIR/lower_intrinsics.rs:+1:46: +1:47
+      let mut _2: &Never;                  // in scope 0 at $DIR/lower_intrinsics.rs:+1:46: +1:47
       scope 1 {
       }
   
       bb0: {
           StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:+1:46: +1:47
-          _2 = &raw const (*_1);           // scope 1 at $DIR/lower_intrinsics.rs:+1:46: +1:47
--         _0 = read_via_copy::<Never>(move _2) -> unwind unreachable; // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
+          _2 = _1;                         // scope 1 at $DIR/lower_intrinsics.rs:+1:46: +1:47
+-         _0 = read_via_copy::<&Never, Never>(move _2) -> unwind unreachable; // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:124:14: 124:45
--                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*const Never) -> Never {read_via_copy::<Never>}, val: Value(<ZST>) }
+-                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&Never) -> Never {read_via_copy::<&Never, Never>}, val: Value(<ZST>) }
 +         unreachable;                     // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:48
       }
   }

--- a/tests/mir-opt/lower_intrinsics.rs
+++ b/tests/mir-opt/lower_intrinsics.rs
@@ -124,6 +124,11 @@ pub fn read_via_copy_uninhabited(r: &Never) -> Never {
     unsafe { core::intrinsics::read_via_copy(r) }
 }
 
+// EMIT_MIR lower_intrinsics.read_via_copy_mut.LowerIntrinsics.diff
+pub unsafe fn read_via_copy_mut(r: *mut i64) -> i64 {
+    core::intrinsics::read_via_copy(r)
+}
+
 // EMIT_MIR lower_intrinsics.write_via_move_string.LowerIntrinsics.diff
 pub fn write_via_move_string(r: &mut String, v: String) {
     unsafe { core::intrinsics::write_via_move(r, v) }
@@ -141,5 +146,10 @@ pub fn option_payload(o: &Option<usize>, p: &Option<String>) {
 
 // EMIT_MIR lower_intrinsics.ptr_offset.LowerIntrinsics.diff
 pub unsafe fn ptr_offset(p: *const i32, d: isize) -> *const i32 {
+    core::intrinsics::offset(p, d)
+}
+
+// EMIT_MIR lower_intrinsics.ptr_offset_mut.LowerIntrinsics.diff
+pub unsafe fn ptr_offset_mut(p: *mut i32, d: usize) -> *mut i32 {
     core::intrinsics::offset(p, d)
 }

--- a/tests/mir-opt/lower_intrinsics.write_via_move_string.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.write_via_move_string.LowerIntrinsics.diff
@@ -17,7 +17,7 @@
           _4 = move _2;                    // scope 1 at $DIR/lower_intrinsics.rs:+1:50: +1:51
 -         _0 = write_via_move::<String>(move _3, move _4) -> [return: bb1, unwind unreachable]; // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:52
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:129:14: 129:46
+-                                          // + span: $DIR/lower_intrinsics.rs:134:14: 134:46
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(*mut String, String) {write_via_move::<String>}, val: Value(<ZST>) }
 +         (*_3) = move _4;                 // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:52
 +         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:+1:14: +1:52

--- a/tests/mir-opt/pre-codegen/mem_replace.mem_replace.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_replace.mem_replace.PreCodegen.after.mir
@@ -7,28 +7,30 @@ fn mem_replace(_1: &mut u32, _2: u32) -> u32 {
     scope 1 (inlined std::mem::replace::<u32>) { // at $DIR/mem_replace.rs:16:5: 16:28
         debug dest => _1;                // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         debug src => _2;                 // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        let mut _3: *const u32;          // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        let mut _4: *mut u32;            // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let _3: *mut u32;                // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         scope 2 {
+            debug dest => _3;            // in scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
             scope 3 {
-                debug result => _0;      // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                scope 7 (inlined std::ptr::write::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    debug dst => _4;     // in scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                    debug src => _2;     // in scope 7 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                    let mut _6: *mut u32; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                    scope 8 {
-                        scope 9 (inlined std::ptr::write::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            debug dst => _6; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                scope 4 {
+                    debug result => _0;  // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 8 (inlined std::ptr::write::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        debug dst => _3; // in scope 8 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        debug src => _2; // in scope 8 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        let mut _5: *mut u32; // in scope 8 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 9 {
+                            scope 10 (inlined std::ptr::write::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug dst => _5; // in scope 10 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            }
                         }
                     }
                 }
-            }
-            scope 4 (inlined std::ptr::read::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                debug src => _3;         // in scope 4 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                let mut _5: *const u32;  // in scope 4 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                scope 5 {
-                    scope 6 (inlined std::ptr::read::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                        debug src => _5; // in scope 6 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                scope 5 (inlined ptr::read_mut::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    debug src => _3;     // in scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                    let mut _4: *mut u32; // in scope 5 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    scope 6 {
+                        scope 7 (inlined ptr::read_mut::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug src => _4; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        }
                     }
                 }
             }
@@ -36,18 +38,15 @@ fn mem_replace(_1: &mut u32, _2: u32) -> u32 {
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _3 = &raw const (*_1);           // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _0 = (*_3);                      // scope 5 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_3);                 // scope 0 at $DIR/mem_replace.rs:+1:5: +1:28
+        _3 = &raw mut (*_1);             // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         StorageLive(_4);                 // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _4 = &raw mut (*_1);             // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_6);                 // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        (*_4) = _2;                      // scope 8 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_6);                 // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _0 = (*_3);                      // scope 6 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         StorageDead(_4);                 // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_3) = _2;                      // scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 0 at $DIR/mem_replace.rs:+1:5: +1:28
         return;                          // scope 0 at $DIR/mem_replace.rs:+2:2: +2:2
     }
 }

--- a/tests/mir-opt/pre-codegen/mem_swap.rs
+++ b/tests/mir-opt/pre-codegen/mem_swap.rs
@@ -1,0 +1,20 @@
+// compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2 -Z inline-mir-hint-threshold=300
+// only-64bit
+// ignore-debug
+
+#![crate_type = "lib"]
+
+// EMIT_MIR mem_swap.swap_primitive.PreCodegen.after.mir
+pub fn swap_primitive(a: &mut i32, b: &mut i32) {
+    std::mem::swap(a, b);
+}
+
+// EMIT_MIR mem_swap.swap_generic.PreCodegen.after.mir
+pub fn swap_generic<'a, T>(a: &mut T, b: &mut T) {
+    std::mem::swap(a, b);
+}
+
+// EMIT_MIR mem_swap.swap_big.PreCodegen.after.mir
+pub fn swap_big(a: &mut [String; 9], b: &mut [String; 9]) {
+    std::mem::swap(a, b);
+}

--- a/tests/mir-opt/pre-codegen/mem_swap.rs
+++ b/tests/mir-opt/pre-codegen/mem_swap.rs
@@ -1,4 +1,4 @@
-// compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2 -Z inline-mir-hint-threshold=300
+// compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
 // only-64bit
 // ignore-debug
 

--- a/tests/mir-opt/pre-codegen/mem_swap.swap_big.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.swap_big.PreCodegen.after.mir
@@ -12,61 +12,61 @@ fn swap_big(_1: &mut [String; 9], _2: &mut [String; 9]) -> () {
         let mut _5: *mut [std::string::String; 9]; // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         scope 2 {
         }
-        scope 3 (inlined std::mem::size_of::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        }
-        scope 4 (inlined align_of::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        }
-        scope 5 (inlined mem::swap_simple::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            debug x => _1;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            debug y => _2;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _7: *const [std::string::String; 9]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _9: *const [std::string::String; 9]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _10: *mut [std::string::String; 9]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _11: *mut [std::string::String; 9]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            scope 6 {
-                let _6: [std::string::String; 9]; // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                scope 7 {
-                    debug a => _6;       // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    let _8: [std::string::String; 9]; // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    scope 8 {
-                        debug b => _8;   // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                        scope 15 (inlined std::ptr::write::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                            debug dst => _10; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            debug src => _8; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            let mut _14: *mut [std::string::String; 9]; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            scope 16 {
-                                scope 17 (inlined std::ptr::write::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                    debug dst => _14; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+        scope 3 (inlined mem::swap_simple::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug x => _1;               // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug y => _2;               // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let _6: *mut [std::string::String; 9]; // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            scope 4 {
+                debug x => _6;           // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                let _7: *mut [std::string::String; 9]; // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                scope 5 {
+                    debug y => _7;       // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 6 {
+                        let _8: [std::string::String; 9]; // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        scope 7 {
+                            debug a => _8; // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            let _9: [std::string::String; 9]; // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            scope 8 {
+                                debug b => _9; // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                scope 15 (inlined std::ptr::write::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                    debug dst => _6; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug src => _9; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    let mut _12: *mut [std::string::String; 9]; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    scope 16 {
+                                        scope 17 (inlined std::ptr::write::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                            debug dst => _12; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        }
+                                    }
+                                }
+                                scope 18 (inlined std::ptr::write::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                    debug dst => _7; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug src => _8; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    let mut _13: *mut [std::string::String; 9]; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    scope 19 {
+                                        scope 20 (inlined std::ptr::write::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                            debug dst => _13; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        }
+                                    }
+                                }
+                            }
+                            scope 12 (inlined ptr::read_mut::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                debug src => _7; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                let mut _11: *mut [std::string::String; 9]; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                scope 13 {
+                                    scope 14 (inlined ptr::read_mut::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        debug src => _11; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    }
                                 }
                             }
                         }
-                        scope 18 (inlined std::ptr::write::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                            debug dst => _11; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            debug src => _6; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            let mut _15: *mut [std::string::String; 9]; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            scope 19 {
-                                scope 20 (inlined std::ptr::write::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                    debug dst => _15; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 9 (inlined ptr::read_mut::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug src => _6; // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _10: *mut [std::string::String; 9]; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 10 {
+                                scope 11 (inlined ptr::read_mut::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug src => _10; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                                 }
                             }
-                        }
-                    }
-                    scope 12 (inlined std::ptr::read::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                        debug src => _9; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                        let mut _13: *const [std::string::String; 9]; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                        scope 13 {
-                            scope 14 (inlined std::ptr::read::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                debug src => _13; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            }
-                        }
-                    }
-                }
-                scope 9 (inlined std::ptr::read::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    debug src => _7;     // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                    let mut _12: *const [std::string::String; 9]; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                    scope 10 {
-                        scope 11 (inlined std::ptr::read::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            debug src => _12; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/mem_swap.swap_big.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.swap_big.PreCodegen.after.mir
@@ -1,0 +1,93 @@
+// MIR for `swap_big` after PreCodegen
+
+fn swap_big(_1: &mut [String; 9], _2: &mut [String; 9]) -> () {
+    debug a => _1;                       // in scope 0 at $DIR/mem_swap.rs:+0:17: +0:18
+    debug b => _2;                       // in scope 0 at $DIR/mem_swap.rs:+0:38: +0:39
+    let mut _0: ();                      // return place in scope 0 at $DIR/mem_swap.rs:+0:59: +0:59
+    let _3: ();                          // in scope 0 at $DIR/mem_swap.rs:+1:5: +1:25
+    scope 1 (inlined std::mem::swap::<[String; 9]>) { // at $DIR/mem_swap.rs:19:5: 19:25
+        debug x => _1;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        debug y => _2;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _4: *mut [std::string::String; 9]; // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _5: *mut [std::string::String; 9]; // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        scope 2 {
+        }
+        scope 3 (inlined std::mem::size_of::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 4 (inlined align_of::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 5 (inlined mem::swap_simple::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug x => _1;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug y => _2;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _7: *const [std::string::String; 9]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _9: *const [std::string::String; 9]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _10: *mut [std::string::String; 9]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _11: *mut [std::string::String; 9]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            scope 6 {
+                let _6: [std::string::String; 9]; // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                scope 7 {
+                    debug a => _6;       // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    let _8: [std::string::String; 9]; // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 8 {
+                        debug b => _8;   // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        scope 15 (inlined std::ptr::write::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _10; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _8; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _14: *mut [std::string::String; 9]; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 16 {
+                                scope 17 (inlined std::ptr::write::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _14; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                        scope 18 (inlined std::ptr::write::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _11; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _6; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _15: *mut [std::string::String; 9]; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 19 {
+                                scope 20 (inlined std::ptr::write::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _15; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                    scope 12 (inlined std::ptr::read::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        debug src => _9; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        let mut _13: *const [std::string::String; 9]; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 13 {
+                            scope 14 (inlined std::ptr::read::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug src => _13; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            }
+                        }
+                    }
+                }
+                scope 9 (inlined std::ptr::read::<[String; 9]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    debug src => _7;     // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                    let mut _12: *const [std::string::String; 9]; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    scope 10 {
+                        scope 11 (inlined std::ptr::read::runtime::<[String; 9]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug src => _12; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _4 = &raw mut (*_1);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _5 = &raw mut (*_2);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _3 = swap_nonoverlapping::<[String; 9]>(move _4, move _5, const 1_usize) -> bb1; // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                         // + literal: Const { ty: unsafe fn(*mut [String; 9], *mut [String; 9], usize) {swap_nonoverlapping::<[String; 9]>}, val: Value(<ZST>) }
+    }
+
+    bb1: {
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/pre-codegen/mem_swap.swap_generic.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.swap_generic.PreCodegen.after.mir
@@ -1,0 +1,156 @@
+// MIR for `swap_generic` after PreCodegen
+
+fn swap_generic(_1: &mut T, _2: &mut T) -> () {
+    debug a => _1;                       // in scope 0 at $DIR/mem_swap.rs:+0:28: +0:29
+    debug b => _2;                       // in scope 0 at $DIR/mem_swap.rs:+0:39: +0:40
+    let mut _0: ();                      // return place in scope 0 at $DIR/mem_swap.rs:+0:50: +0:50
+    let _3: ();                          // in scope 0 at $DIR/mem_swap.rs:+1:5: +1:25
+    scope 1 (inlined std::mem::swap::<T>) { // at $DIR/mem_swap.rs:14:5: 14:25
+        debug x => _1;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        debug y => _2;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _4: bool;                // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _5: usize;               // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _6: usize;               // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _7: usize;               // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _8: bool;                // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _9: *mut T;              // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _10: *mut T;             // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        scope 2 {
+        }
+        scope 3 (inlined std::mem::size_of::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 4 (inlined align_of::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 5 (inlined mem::swap_simple::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug x => _1;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug y => _2;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _12: *const T;       // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _14: *const T;       // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _15: *mut T;         // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _16: *mut T;         // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            scope 6 {
+                let _11: T;              // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                scope 7 {
+                    debug a => _11;      // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    let _13: T;          // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 8 {
+                        debug b => _13;  // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        scope 15 (inlined std::ptr::write::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _15; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _13; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _19: *mut T; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 16 {
+                                scope 17 (inlined std::ptr::write::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _19; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                        scope 18 (inlined std::ptr::write::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _16; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _11; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _20: *mut T; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 19 {
+                                scope 20 (inlined std::ptr::write::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _20; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                    scope 12 (inlined std::ptr::read::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        debug src => _14; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        let mut _18: *const T; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 13 {
+                            scope 14 (inlined std::ptr::read::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug src => _18; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            }
+                        }
+                    }
+                }
+                scope 9 (inlined std::ptr::read::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    debug src => _12;    // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                    let mut _17: *const T; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    scope 10 {
+                        scope 11 (inlined std::ptr::read::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug src => _17; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _6 = SizeOf(T);                  // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_7);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _7 = AlignOf(T);                 // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _8 = Eq(_7, const 0_usize);      // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        assert(!move _8, "attempt to divide `{}` by zero", _6) -> bb2; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+    }
+
+    bb1: {
+        return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
+    }
+
+    bb2: {
+        _5 = Div(move _6, move _7);      // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_7);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _4 = Gt(move _5, const 4_usize); // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        switchInt(move _4) -> [0: bb5, otherwise: bb3]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+    }
+
+    bb3: {
+        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _9 = &raw mut (*_1);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _10 = &raw mut (*_2);            // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _3 = swap_nonoverlapping::<T>(move _9, move _10, const 1_usize) -> bb4; // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                         // + literal: Const { ty: unsafe fn(*mut T, *mut T, usize) {swap_nonoverlapping::<T>}, val: Value(<ZST>) }
+    }
+
+    bb4: {
+        StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+    }
+
+    bb5: {
+        StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_11);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_13);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _12 = &raw const (*_1);          // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_17);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _11 = (*_12);                    // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_17);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _14 = &raw const (*_2);          // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_18);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _13 = (*_14);                    // scope 13 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_18);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_15);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _15 = &raw mut (*_1);            // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_19);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_15) = move _13;               // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_19);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_15);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _16 = &raw mut (*_2);            // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_20);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_16) = move _11;               // scope 19 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_20);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_13);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_11);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+    }
+}

--- a/tests/mir-opt/pre-codegen/mem_swap.swap_generic.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.swap_generic.PreCodegen.after.mir
@@ -9,69 +9,65 @@ fn swap_generic(_1: &mut T, _2: &mut T) -> () {
         debug x => _1;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         debug y => _2;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         let mut _4: bool;                // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        let mut _5: usize;               // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        let mut _6: usize;               // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        let mut _7: usize;               // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        let mut _8: bool;                // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        let mut _9: *mut T;              // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        let mut _10: *mut T;             // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _5: *mut T;              // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _6: *mut T;              // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         scope 2 {
         }
-        scope 3 (inlined std::mem::size_of::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        }
-        scope 4 (inlined align_of::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        }
-        scope 5 (inlined mem::swap_simple::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            debug x => _1;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            debug y => _2;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _12: *const T;       // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _14: *const T;       // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _15: *mut T;         // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _16: *mut T;         // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            scope 6 {
-                let _11: T;              // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                scope 7 {
-                    debug a => _11;      // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    let _13: T;          // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    scope 8 {
-                        debug b => _13;  // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                        scope 15 (inlined std::ptr::write::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                            debug dst => _15; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            debug src => _13; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            let mut _19: *mut T; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            scope 16 {
-                                scope 17 (inlined std::ptr::write::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                    debug dst => _19; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+        scope 3 (inlined mem::swap_simple::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug x => _1;               // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug y => _2;               // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let _7: *mut T;              // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            scope 4 {
+                debug x => _7;           // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                let _8: *mut T;          // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                scope 5 {
+                    debug y => _8;       // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 6 {
+                        let _9: T;       // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        scope 7 {
+                            debug a => _9; // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            let _10: T;  // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            scope 8 {
+                                debug b => _10; // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                scope 15 (inlined std::ptr::write::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                    debug dst => _7; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug src => _10; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    let mut _13: *mut T; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    scope 16 {
+                                        scope 17 (inlined std::ptr::write::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                            debug dst => _13; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        }
+                                    }
+                                }
+                                scope 18 (inlined std::ptr::write::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                    debug dst => _8; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug src => _9; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    let mut _14: *mut T; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    scope 19 {
+                                        scope 20 (inlined std::ptr::write::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                            debug dst => _14; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        }
+                                    }
+                                }
+                            }
+                            scope 12 (inlined ptr::read_mut::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                debug src => _8; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                let mut _12: *mut T; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                scope 13 {
+                                    scope 14 (inlined ptr::read_mut::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        debug src => _12; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    }
                                 }
                             }
                         }
-                        scope 18 (inlined std::ptr::write::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                            debug dst => _16; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            debug src => _11; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            let mut _20: *mut T; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            scope 19 {
-                                scope 20 (inlined std::ptr::write::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                    debug dst => _20; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 9 (inlined ptr::read_mut::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug src => _7; // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _11: *mut T; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 10 {
+                                scope 11 (inlined ptr::read_mut::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug src => _11; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                                 }
                             }
-                        }
-                    }
-                    scope 12 (inlined std::ptr::read::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                        debug src => _14; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                        let mut _18: *const T; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                        scope 13 {
-                            scope 14 (inlined std::ptr::read::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                debug src => _18; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            }
-                        }
-                    }
-                }
-                scope 9 (inlined std::ptr::read::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    debug src => _12;    // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                    let mut _17: *const T; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                    scope 10 {
-                        scope 11 (inlined std::ptr::read::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            debug src => _17; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                         }
                     }
                 }
@@ -81,13 +77,8 @@ fn swap_generic(_1: &mut T, _2: &mut T) -> () {
 
     bb0: {
         StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _6 = SizeOf(T);                  // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_7);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _7 = AlignOf(T);                 // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _8 = Eq(_7, const 0_usize);      // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        assert(!move _8, "attempt to divide `{}` by zero", _6) -> bb2; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _4 = const _;                    // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        switchInt(move _4) -> [0: bb4, otherwise: bb2]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
     }
 
     bb1: {
@@ -95,62 +86,47 @@ fn swap_generic(_1: &mut T, _2: &mut T) -> () {
     }
 
     bb2: {
-        _5 = Div(move _6, move _7);      // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_7);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _4 = Gt(move _5, const 4_usize); // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        switchInt(move _4) -> [0: bb5, otherwise: bb3]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-    }
-
-    bb3: {
-        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _9 = &raw mut (*_1);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _10 = &raw mut (*_2);            // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _3 = swap_nonoverlapping::<T>(move _9, move _10, const 1_usize) -> bb4; // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _5 = &raw mut (*_1);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _6 = &raw mut (*_2);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _3 = swap_nonoverlapping::<T>(move _5, move _6, const 1_usize) -> bb3; // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/mem/mod.rs:LL:COL
                                          // + literal: Const { ty: unsafe fn(*mut T, *mut T, usize) {swap_nonoverlapping::<T>}, val: Value(<ZST>) }
     }
 
-    bb4: {
-        StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+    bb3: {
+        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
     }
 
-    bb5: {
+    bb4: {
         StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_11);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_13);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _12 = &raw const (*_1);          // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_17);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _11 = (*_12);                    // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_17);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _14 = &raw const (*_2);          // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_18);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _13 = (*_14);                    // scope 13 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_18);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_15);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _15 = &raw mut (*_1);            // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_19);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        (*_15) = move _13;               // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_19);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_15);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _16 = &raw mut (*_2);            // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_20);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        (*_16) = move _11;               // scope 19 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_20);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_13);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_11);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_7);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_8);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_9);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_10);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _7 = &raw mut (*_1);             // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _8 = &raw mut (*_2);             // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _9 = (*_7);                      // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_12);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _10 = (*_8);                     // scope 13 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_12);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_13);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_7) = move _10;                // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_13);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_14);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_8) = move _9;                 // scope 19 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_14);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_10);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_9);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_7);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
     }
 }

--- a/tests/mir-opt/pre-codegen/mem_swap.swap_primitive.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.swap_primitive.PreCodegen.after.mir
@@ -1,0 +1,105 @@
+// MIR for `swap_primitive` after PreCodegen
+
+fn swap_primitive(_1: &mut i32, _2: &mut i32) -> () {
+    debug a => _1;                       // in scope 0 at $DIR/mem_swap.rs:+0:23: +0:24
+    debug b => _2;                       // in scope 0 at $DIR/mem_swap.rs:+0:36: +0:37
+    let mut _0: ();                      // return place in scope 0 at $DIR/mem_swap.rs:+0:49: +0:49
+    scope 1 (inlined std::mem::swap::<i32>) { // at $DIR/mem_swap.rs:9:5: 9:25
+        debug x => _1;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        debug y => _2;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        scope 2 {
+        }
+        scope 3 (inlined std::mem::size_of::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 4 (inlined align_of::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 5 (inlined mem::swap_simple::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug x => _1;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug y => _2;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _4: *const i32;      // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _6: *const i32;      // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _7: *mut i32;        // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _8: *mut i32;        // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            scope 6 {
+                let _3: i32;             // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                scope 7 {
+                    debug a => _3;       // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    let _5: i32;         // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 8 {
+                        debug b => _5;   // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        scope 15 (inlined std::ptr::write::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _7; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _5; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _11: *mut i32; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 16 {
+                                scope 17 (inlined std::ptr::write::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _11; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                        scope 18 (inlined std::ptr::write::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _8; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _3; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _12: *mut i32; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 19 {
+                                scope 20 (inlined std::ptr::write::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _12; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                    scope 12 (inlined std::ptr::read::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        debug src => _6; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        let mut _10: *const i32; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 13 {
+                            scope 14 (inlined std::ptr::read::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug src => _10; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            }
+                        }
+                    }
+                }
+                scope 9 (inlined std::ptr::read::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    debug src => _4;     // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                    let mut _9: *const i32; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    scope 10 {
+                        scope 11 (inlined std::ptr::read::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug src => _9; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_3);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_4);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _4 = &raw const (*_1);           // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _3 = (*_4);                      // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_4);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _6 = &raw const (*_2);           // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_10);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _5 = (*_6);                      // scope 13 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_10);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_6);                 // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_7);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _7 = &raw mut (*_1);             // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_11);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_7) = move _5;                 // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_11);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_7);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_8);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _8 = &raw mut (*_2);             // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_12);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_8) = move _3;                 // scope 19 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_12);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/pre-codegen/mem_swap.swap_primitive.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.swap_primitive.PreCodegen.after.mir
@@ -9,61 +9,61 @@ fn swap_primitive(_1: &mut i32, _2: &mut i32) -> () {
         debug y => _2;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         scope 2 {
         }
-        scope 3 (inlined std::mem::size_of::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        }
-        scope 4 (inlined align_of::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        }
-        scope 5 (inlined mem::swap_simple::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            debug x => _1;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            debug y => _2;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _4: *const i32;      // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _6: *const i32;      // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _7: *mut i32;        // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            let mut _8: *mut i32;        // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-            scope 6 {
-                let _3: i32;             // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                scope 7 {
-                    debug a => _3;       // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    let _5: i32;         // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    scope 8 {
-                        debug b => _5;   // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                        scope 15 (inlined std::ptr::write::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                            debug dst => _7; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            debug src => _5; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            let mut _11: *mut i32; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            scope 16 {
-                                scope 17 (inlined std::ptr::write::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                    debug dst => _11; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+        scope 3 (inlined mem::swap_simple::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug x => _1;               // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug y => _2;               // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let _3: *mut i32;            // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            scope 4 {
+                debug x => _3;           // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                let _4: *mut i32;        // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                scope 5 {
+                    debug y => _4;       // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 6 {
+                        let _5: i32;     // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        scope 7 {
+                            debug a => _5; // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            let _6: i32; // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            scope 8 {
+                                debug b => _6; // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                scope 15 (inlined std::ptr::write::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                    debug dst => _3; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug src => _6; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    let mut _9: *mut i32; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    scope 16 {
+                                        scope 17 (inlined std::ptr::write::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                            debug dst => _9; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        }
+                                    }
+                                }
+                                scope 18 (inlined std::ptr::write::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                    debug dst => _4; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug src => _5; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    let mut _10: *mut i32; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    scope 19 {
+                                        scope 20 (inlined std::ptr::write::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                            debug dst => _10; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        }
+                                    }
+                                }
+                            }
+                            scope 12 (inlined ptr::read_mut::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                debug src => _4; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                let mut _8: *mut i32; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                scope 13 {
+                                    scope 14 (inlined ptr::read_mut::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        debug src => _8; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    }
                                 }
                             }
                         }
-                        scope 18 (inlined std::ptr::write::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                            debug dst => _8; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            debug src => _3; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                            let mut _12: *mut i32; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            scope 19 {
-                                scope 20 (inlined std::ptr::write::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                    debug dst => _12; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 9 (inlined ptr::read_mut::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug src => _3; // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _7: *mut i32; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 10 {
+                                scope 11 (inlined ptr::read_mut::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug src => _7; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                                 }
                             }
-                        }
-                    }
-                    scope 12 (inlined std::ptr::read::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                        debug src => _6; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                        let mut _10: *const i32; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                        scope 13 {
-                            scope 14 (inlined std::ptr::read::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                debug src => _10; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            }
-                        }
-                    }
-                }
-                scope 9 (inlined std::ptr::read::<i32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-                    debug src => _4;     // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                    let mut _9: *const i32; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                    scope 10 {
-                        scope 11 (inlined std::ptr::read::runtime::<i32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            debug src => _9; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                         }
                     }
                 }
@@ -73,32 +73,26 @@ fn swap_primitive(_1: &mut i32, _2: &mut i32) -> () {
 
     bb0: {
         StorageLive(_3);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_4);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _4 = &raw const (*_1);           // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _3 = (*_4);                      // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_4);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_6);                 // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _6 = &raw const (*_2);           // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_10);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _5 = (*_6);                      // scope 13 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_10);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_6);                 // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_7);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _7 = &raw mut (*_1);             // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_11);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        (*_7) = move _5;                 // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_11);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_7);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_8);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        _8 = &raw mut (*_2);             // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageLive(_12);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        (*_8) = move _3;                 // scope 19 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_12);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-        StorageDead(_8);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _3 = &raw mut (*_1);             // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _4 = &raw mut (*_2);             // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _5 = (*_3);                      // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_8);                 // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _6 = (*_4);                      // scope 13 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_9);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_3) = move _6;                 // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_9);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_10);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_4) = move _5;                 // scope 19 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_10);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
     }

--- a/tests/ui/const-ptr/out_of_bounds_read.stderr
+++ b/tests/ui/const-ptr/out_of_bounds_read.stderr
@@ -31,7 +31,7 @@ error[E0080]: evaluation of constant value failed
    |
    = note: dereferencing pointer failed: alloc5 has size 4, so pointer to 4 bytes starting at offset 4 is out-of-bounds
    |
-note: inside `std::ptr::read::<u32>`
+note: inside `ptr::read_mut::<u32>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `ptr::mut_ptr::<impl *mut u32>::read`
   --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -5,7 +5,7 @@ error[E0080]: evaluation of constant value failed
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
-note: inside `std::ptr::read::<MaybeUninit<MaybeUninit<u8>>>`
+note: inside `ptr::read_mut::<MaybeUninit<MaybeUninit<u8>>>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `mem::swap_simple::<MaybeUninit<MaybeUninit<u8>>>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL


### PR DESCRIPTION
Continuing on from #110837 and #111010, another PR to

> reduce your useless MIR with this small trick!

[as pnkfelix said](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/triage.202023.2005.2002/near/355314394) 🙂 

r? @WaffleLapkin 
cc @saethlin 