### PR TITLE
Remove unnecessary attribute from a diagnostic

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -657,7 +657,6 @@ pub enum ImplNotMarkedDefault {
     #[note]
     Err {
         #[primary_span]
-        #[label]
         span: Span,
         cname: Symbol,
         ident: Symbol,

--- a/tests/ui/specialization/issue-111232.rs
+++ b/tests/ui/specialization/issue-111232.rs
@@ -1,0 +1,11 @@
+#![feature(min_specialization)]
+
+struct S;
+
+impl From<S> for S {
+    fn from(s: S) -> S { //~ ERROR `from` specializes an item from a parent `impl`, but that item is not marked `default`
+        s
+    }
+}
+
+fn main() {}

--- a/tests/ui/specialization/issue-111232.stderr
+++ b/tests/ui/specialization/issue-111232.stderr
@@ -1,0 +1,11 @@
+error[E0520]: `from` specializes an item from a parent `impl`, but that item is not marked `default`
+  --> $DIR/issue-111232.rs:6:5
+   |
+LL |     fn from(s: S) -> S {
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: parent implementation is in crate `core`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0520`.


### PR DESCRIPTION
Fixes #111232

ref: https://github.com/rust-lang/rust/commit/06ff310cf95349da078e4cac0c5377172766fa94