### PR TITLE
support set `rpath` option  for each target independently

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -750,6 +750,10 @@ changelog-seen = 2
 # This option will override the same option under [build] section.
 #profiler = build.profiler (bool)
 
+# This option supports enable `rpath` in each target independently, 
+# and will override the same option under [rust] section. It only works on Unix platforms
+#rpath = rust.rpath (bool)
+
 # Force static or dynamic linkage of the standard library for this target. If
 # this target is a host for rustc, this will also affect the linkage of the
 # compiler itself. This is useful for building rustc on targets that normally

--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   from the default rust toolchain. [#78513](https://github.com/rust-lang/rust/pull/78513)
 - Add options for enabling overflow checks, one for std (`overflow-checks-std`) and one for everything else (`overflow-checks`). Both default to false.
 - Add llvm option `enable-warnings` to have control on llvm compilation warnings. Default to false.
+- Add `rpath` option in `target` section to support set rpath option for each target independently. [#111242](https://github.com/rust-lang/rust/pull/111242)
 
 
 ## [Version 2] - 2020-09-25

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1610,7 +1610,7 @@ impl<'a> Builder<'a> {
         // argument manually via `-C link-args=-Wl,-rpath,...`. Plus isn't it
         // fun to pass a flag to a tool to pass a flag to pass a flag to a tool
         // to change a flag in a binary?
-        if self.config.rust_rpath && util::use_host_linker(target) {
+        if self.config.rpath_enabled(target) && util::use_host_linker(target) {
             let rpath = if target.contains("apple") {
                 // Note that we need to take one extra step on macOS to also pass
                 // `-Wl,-instal_name,@rpath/...` to get things to work right. To

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -455,6 +455,7 @@ pub struct Target {
     pub ndk: Option<PathBuf>,
     pub sanitizers: Option<bool>,
     pub profiler: Option<bool>,
+    pub rpath: Option<bool>,
     pub crt_static: Option<bool>,
     pub musl_root: Option<PathBuf>,
     pub musl_libdir: Option<PathBuf>,
@@ -800,6 +801,7 @@ define_config! {
         android_ndk: Option<String> = "android-ndk",
         sanitizers: Option<bool> = "sanitizers",
         profiler: Option<bool> = "profiler",
+        rpath: Option<bool> = "rpath",
         crt_static: Option<bool> = "crt-static",
         musl_root: Option<String> = "musl-root",
         musl_libdir: Option<String> = "musl-libdir",
@@ -1301,6 +1303,7 @@ impl Config {
                 target.qemu_rootfs = cfg.qemu_rootfs.map(PathBuf::from);
                 target.sanitizers = cfg.sanitizers;
                 target.profiler = cfg.profiler;
+                target.rpath = cfg.rpath;
 
                 config.target_config.insert(TargetSelection::from_user(&triple), target);
             }
@@ -1608,6 +1611,10 @@ impl Config {
 
     pub fn any_profiler_enabled(&self) -> bool {
         self.target_config.values().any(|t| t.profiler == Some(true)) || self.profiler
+    }
+
+    pub fn rpath_enabled(&self, target: TargetSelection) -> bool {
+        self.target_config.get(&target).map(|t| t.rpath).flatten().unwrap_or(self.rust_rpath)
     }
 
     pub fn llvm_enabled(&self) -> bool {


### PR DESCRIPTION
Currently  the `rpath` option is a global config and it's effect on all targets. 
But sometimes when developers edit the rustc code and try to release rust toolchains themselves, they may not want to add `rpath` in all targets  to avoid dynamically linked shared object library privilege escalation attack.
This PR supports set `rpath` option  for each target independently .
Common developers are not aware of the existence of this configuration  option and do not affect the existing development process. This configuration option takes effect only after developers explicitly sets .


r? @albertlarsan68