### PR TITLE
Fix double-free in benchmark code of `VecDeque`

### DIFF
--- a/library/alloc/benches/vec_deque.rs
+++ b/library/alloc/benches/vec_deque.rs
@@ -68,13 +68,13 @@ fn into_iter_helper<
     setup: F,
     g: G,
 ) {
-    let ptr = v.as_mut_ptr();
     let len = v.len();
     // ensure that the vec is full, to make sure that any wrapping from the deque doesn't
     // access uninitialized memory.
     assert_eq!(v.len(), v.capacity());
 
     let mut deque = VecDeque::from(mem::take(v));
+    let ptr = deque.as_mut_slices().0.as_mut_ptr();
     setup(&mut deque);
 
     let mut it = deque.into_iter();


### PR DESCRIPTION
The `into_iter_helper` reuse the vector pointer but the vector can be relocated by `VecDeque::from`.
Thus, reusing the vector pointer could raise the double-free or use-after-free for the original vector.

More specifically, under 1.67.0 nightly, the benchmark build with `-Zsanitizer=address` raise the double-free after the `into_iter_helper` function.
It was fixed after 1.68.0, but the root cause is not fixed so I open the PR.