### PR TITLE
fix(ty_utils): try normalize earsing regions

### DIFF
--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -90,6 +90,7 @@ declare_lint_pass!(QueryStability => [POTENTIAL_QUERY_INSTABILITY]);
 impl LateLintPass<'_> for QueryStability {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {
         let Some((span, def_id, substs)) = typeck_results_of_method_fn(cx, expr) else { return };
+        let substs = cx.tcx.normalize_erasing_regions(cx.param_env, substs);
         if let Ok(Some(instance)) = ty::Instance::resolve(cx.tcx, cx.param_env, def_id, substs) {
             let def_id = instance.def_id();
             if cx.tcx.has_attr(def_id, sym::rustc_lint_query_instability) {
@@ -380,6 +381,7 @@ declare_lint_pass!(Diagnostics => [ UNTRANSLATABLE_DIAGNOSTIC, DIAGNOSTIC_OUTSID
 impl LateLintPass<'_> for Diagnostics {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {
         let Some((span, def_id, substs)) = typeck_results_of_method_fn(cx, expr) else { return };
+        let substs = cx.tcx.normalize_erasing_regions(cx.param_env, substs);
         debug!(?span, ?def_id, ?substs);
         let has_attr = ty::Instance::resolve(cx.tcx, cx.param_env, def_id, substs)
             .ok()

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -18,13 +18,7 @@ fn resolve_instance<'tcx>(
 
     let result = if let Some(trait_def_id) = tcx.trait_of_item(def) {
         debug!(" => associated item, attempting to find impl in param_env {:#?}", param_env);
-        resolve_associated_item(
-            tcx,
-            def,
-            param_env,
-            trait_def_id,
-            tcx.normalize_erasing_regions(param_env, substs),
-        )
+        resolve_associated_item(tcx, def, param_env, trait_def_id, substs)
     } else {
         let ty = tcx.type_of(def);
         let item_type =

--- a/tests/ui/const-generics/issues/issue-110630.rs
+++ b/tests/ui/const-generics/issues/issue-110630.rs
@@ -1,0 +1,24 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+trait Indices<const N:usize> {
+    const NUM_ELEMS: usize = 0;
+}
+
+trait Concat {
+    type Output;
+}
+
+struct Tensor<A: Indices<42>>(A)
+where
+    [(); A::NUM_ELEMS]: Sized;
+
+impl<I: Indices<42>> Concat for Tensor<I>
+where
+    [(); I::NUM_ELEMS]: Sized
+{
+    type Output = Tensor<<I as Concat>::Output>;
+    //~^ ERROR the trait bound `I: Concat` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/const-generics/issues/issue-110630.stderr
+++ b/tests/ui/const-generics/issues/issue-110630.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `I: Concat` is not satisfied
+  --> $DIR/issue-110630.rs:20:26
+   |
+LL |     type Output = Tensor<<I as Concat>::Output>;
+   |                          ^^^^^^^^^^^^^^^^^^^^^ the trait `Concat` is not implemented for `I`
+   |
+help: consider further restricting this bound
+   |
+LL | impl<I: Indices<42> + Concat> Concat for Tensor<I>
+   |                     ++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
close https://github.com/rust-lang/rust/issues/110630

#105561 introduces `normalize_erasing_regions` for the `substs` in `resolve_instance`, this is quite general and can apply to any type. However, it poses a problem for issue #110630, where `I as Concat` will trigger a bug because `Concat` is not implemented for `I`. 

In order to solve #110630, this PR:
- had raised normalize function call, which requires that we now use the normalized `substs` when necessary.
- attempting to normalize the `substs` before resolve during  `const_eval_resolve_for_typeck`, if it failed, we will return `TooGeneric` error