### PR TITLE
Further normalize msvc-non-utf8-ouput

### DIFF
--- a/tests/ui/native-library-link-flags/msvc-non-utf8-output.rs
+++ b/tests/ui/native-library-link-flags/msvc-non-utf8-output.rs
@@ -1,6 +1,5 @@
 // build-fail
-// compile-flags:-C link-arg=märchenhaft
+// compile-flags:-C link-arg=⦺ⅈ⽯⭏⽽◃⡽⚞
 // only-msvc
-// error-pattern:= note: LINK : fatal error LNK1181:
-// normalize-stderr-test "(\s*\|\n)\s*= note: .*\n" -> "$1"
+// normalize-stderr-test "(?:.|\n)*(⦺ⅈ⽯⭏⽽◃⡽⚞)(?:.|\n)*" -> "$1"
 pub fn main() {}

--- a/tests/ui/native-library-link-flags/msvc-non-utf8-output.stderr
+++ b/tests/ui/native-library-link-flags/msvc-non-utf8-output.stderr
@@ -1,7 +1,1 @@
-error: linking with `link.exe` failed: exit code: 1181
-   |
-   = note: LINK : fatal error LNK1181: cannot open input file 'märchenhaft.obj'
-           
-
-error: aborting due to previous error
-
+⦺ⅈ⽯⭏⽽◃⡽⚞


### PR DESCRIPTION
Fixes #111256 by normalizing this tests down to the essential part so that it only tests for the Unicode output we expect. Also uses a file name that should never occur outside of this test.