### PR TITLE
Make generics_of has_self on RPITITs delegate to the opaque

### DIFF
--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -334,7 +334,7 @@ fn associated_type_for_impl_trait_in_trait(
             parent_count,
             params,
             param_def_id_to_index,
-            has_self: false,
+            has_self: opaque_ty_generics.has_self,
             has_late_bound_regions: opaque_ty_generics.has_late_bound_regions,
         }
     });


### PR DESCRIPTION
r? @compiler-errors

I couldn't come up with a test case and none of the ones in the `tests` folder is impacted by this change, but I still think is the right thing to do.

Michael, let me know if you have ideas on how to add a test that's affected by this change.