### PR TITLE
Add IoSlice::as_bytes

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1491,6 +1491,30 @@ impl<'a> IoSlice<'a> {
             bufs[0].advance(left);
         }
     }
+
+    /// Get the underlying bytes as a rust slice with the original lifetime
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::io::IoSlice;
+    ///
+    /// let data = b"abcdef";
+    ///
+    /// let mut io_slice = IoSlice::new(data);
+    /// let tail = io_slice.as_bytes()[3..];
+    ///
+    /// // This works because `tail` doesn't borrow `io_slice`
+    /// io_slice = IoSlice::new(tail);
+    ///
+    /// assert_eq!(io_slice.as_bytes(), b"def");
+    /// ```
+    #[unstable(feature = "io_slice_as_bytes")]
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &'a [u8] {
+        self.0.as_slice()
+    }
 }
 
 #[stable(feature = "iovec", since = "1.36.0")]

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1512,7 +1512,7 @@ impl<'a> IoSlice<'a> {
     #[unstable(feature = "io_slice_as_bytes", issue = "111277")]
     #[inline]
     #[must_use]
-    pub const fn as_bytes(&self) -> &'a [u8] {
+    pub const fn into_bytes(&self) -> &'a [u8] {
         self.0.as_slice()
     }
 }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1497,6 +1497,7 @@ impl<'a> IoSlice<'a> {
     /// # Example
     ///
     /// ```
+    /// #![feature(io_slice_as_bytes)]
     /// use std::io::IoSlice;
     ///
     /// let data = b"abcdef";

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1502,7 +1502,7 @@ impl<'a> IoSlice<'a> {
     /// let data = b"abcdef";
     ///
     /// let mut io_slice = IoSlice::new(data);
-    /// let tail = io_slice.into_bytes()[3..];
+    /// let tail = &io_slice.into_bytes()[3..];
     ///
     /// // This works because `tail` doesn't borrow `io_slice`
     /// io_slice = IoSlice::new(tail);

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1509,7 +1509,7 @@ impl<'a> IoSlice<'a> {
     ///
     /// assert_eq!(io_slice.as_bytes(), b"def");
     /// ```
-    #[unstable(feature = "io_slice_as_bytes")]
+    #[unstable(feature = "io_slice_as_bytes", issue = "111277")]
     #[inline]
     #[must_use]
     pub const fn as_bytes(&self) -> &'a [u8] {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1502,12 +1502,12 @@ impl<'a> IoSlice<'a> {
     /// let data = b"abcdef";
     ///
     /// let mut io_slice = IoSlice::new(data);
-    /// let tail = io_slice.as_bytes()[3..];
+    /// let tail = io_slice.into_bytes()[3..];
     ///
     /// // This works because `tail` doesn't borrow `io_slice`
     /// io_slice = IoSlice::new(tail);
     ///
-    /// assert_eq!(io_slice.as_bytes(), b"def");
+    /// assert_eq!(io_slice.into_bytes(), b"def");
     /// ```
     #[unstable(feature = "io_slice_as_bytes", issue = "111277")]
     #[inline]

--- a/library/std/src/sys/pal/solid/io.rs
+++ b/library/std/src/sys/pal/solid/io.rs
@@ -33,7 +33,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }

--- a/library/std/src/sys/pal/solid/io.rs
+++ b/library/std/src/sys/pal/solid/io.rs
@@ -33,7 +33,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub const fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }

--- a/library/std/src/sys/pal/unix/io.rs
+++ b/library/std/src/sys/pal/unix/io.rs
@@ -33,7 +33,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }

--- a/library/std/src/sys/pal/unix/io.rs
+++ b/library/std/src/sys/pal/unix/io.rs
@@ -33,7 +33,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub const fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }

--- a/library/std/src/sys/pal/unsupported/io.rs
+++ b/library/std/src/sys/pal/unsupported/io.rs
@@ -15,7 +15,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &'a [u8] {
         self.0
     }
 }

--- a/library/std/src/sys/pal/unsupported/io.rs
+++ b/library/std/src/sys/pal/unsupported/io.rs
@@ -15,7 +15,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub const fn as_slice(&self) -> &'a [u8] {
         self.0
     }
 }

--- a/library/std/src/sys/pal/wasi/io.rs
+++ b/library/std/src/sys/pal/wasi/io.rs
@@ -30,7 +30,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.buf as *const u8, self.vec.buf_len) }
     }
 }

--- a/library/std/src/sys/pal/wasi/io.rs
+++ b/library/std/src/sys/pal/wasi/io.rs
@@ -30,7 +30,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &'a [u8] {
+    pub const fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.buf as *const u8, self.vec.buf_len) }
     }
 }

--- a/library/std/src/sys/pal/windows/io.rs
+++ b/library/std/src/sys/pal/windows/io.rs
@@ -35,7 +35,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub const fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.buf, self.vec.len as usize) }
     }
 }


### PR DESCRIPTION
This PR proposes to add `IoSlice::as_bytes`. While `IoSlice` already has `Deref<Target=[u8]>`, this uses the lifetime of the `IoSlice` itself, throwing away the larger `'a` lifetime; `as_bytes` allows for getting the original slice with the original lifetime.

ACP: https://github.com/rust-lang/libs-team/issues/93
Fixes #124659