### PR TITLE
Fix mishandled `--check-cfg` arguments order

### DIFF
--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -173,12 +173,21 @@ pub fn parse_check_cfg(specs: Vec<String>) -> CheckCfg {
                                         let expected_values = check_cfg
                                             .expecteds
                                             .entry(ident.name.to_string())
+                                            .and_modify(|expected_values| match expected_values {
+                                                ExpectedValues::Some(_) => {}
+                                                ExpectedValues::Any => {
+                                                    // handle the case where names(...) was done
+                                                    // before values by changing to a list
+                                                    *expected_values =
+                                                        ExpectedValues::Some(FxHashSet::default());
+                                                }
+                                            })
                                             .or_insert_with(|| {
                                                 ExpectedValues::Some(FxHashSet::default())
                                             });
 
                                         let ExpectedValues::Some(expected_values) = expected_values else {
-                                            bug!("shoudn't be possible")
+                                            bug!("`expected_values` should be a list a values")
                                         };
 
                                         for val in values {

--- a/tests/ui/check-cfg/order-independant.names_after.stderr
+++ b/tests/ui/check-cfg/order-independant.names_after.stderr
@@ -1,0 +1,19 @@
+warning: unexpected `cfg` condition value
+  --> $DIR/order-independant.rs:8:7
+   |
+LL | #[cfg(a)]
+   |       ^- help: specify a config value: `= "b"`
+   |
+   = note: expected values for `a` are: `b`
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition value
+  --> $DIR/order-independant.rs:12:7
+   |
+LL | #[cfg(a = "unk")]
+   |       ^^^^^^^^^
+   |
+   = note: expected values for `a` are: `b`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/check-cfg/order-independant.names_before.stderr
+++ b/tests/ui/check-cfg/order-independant.names_before.stderr
@@ -1,0 +1,19 @@
+warning: unexpected `cfg` condition value
+  --> $DIR/order-independant.rs:8:7
+   |
+LL | #[cfg(a)]
+   |       ^- help: specify a config value: `= "b"`
+   |
+   = note: expected values for `a` are: `b`
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition value
+  --> $DIR/order-independant.rs:12:7
+   |
+LL | #[cfg(a = "unk")]
+   |       ^^^^^^^^^
+   |
+   = note: expected values for `a` are: `b`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/check-cfg/order-independant.rs
+++ b/tests/ui/check-cfg/order-independant.rs
@@ -1,0 +1,16 @@
+// check-pass
+// revisions: names_before names_after
+// compile-flags: -Z unstable-options
+// compile-flags: --check-cfg=names(names_before,names_after)
+// [names_before]compile-flags: --check-cfg=names(a) --check-cfg=values(a,"b")
+// [names_after]compile-flags: --check-cfg=values(a,"b") --check-cfg=names(a)
+
+#[cfg(a)]
+//~^ WARNING unexpected `cfg` condition value
+fn my_cfg() {}
+
+#[cfg(a = "unk")]
+//~^ WARNING unexpected `cfg` condition value
+fn my_cfg() {}
+
+fn main() {}


### PR DESCRIPTION
This PR fixes a bug in `--check-cfg` where the order of `--check-cfg=names(a)` and `--check-cfg=values(a,…)` would trip the compiler.

Fixes https://github.com/rust-lang/rust/issues/111291
cc @taiki-e @petrochenkov