### PR TITLE
rustc --explain E0726 - grammar fixing (it's => its + add a `the` where it felt right to do so)

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0726.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0726.md
@@ -25,7 +25,7 @@ block_on(future);
 
 Specify desired lifetime of parameter `content` or indicate the anonymous
 lifetime like `content: Content<'_>`. The anonymous lifetime tells the Rust
-compiler that `content` is only needed until the create function is done with
+compiler that `content` is only needed until the `create` function is done with
 its execution.
 
 The `implicit elision` meaning the omission of suggested lifetime that is

--- a/compiler/rustc_error_codes/src/error_codes/E0726.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0726.md
@@ -25,8 +25,8 @@ block_on(future);
 
 Specify desired lifetime of parameter `content` or indicate the anonymous
 lifetime like `content: Content<'_>`. The anonymous lifetime tells the Rust
-compiler that `content` is only needed until create function is done with
-it's execution.
+compiler that `content` is only needed until the create function is done with
+its execution.
 
 The `implicit elision` meaning the omission of suggested lifetime that is
 `pub async fn create<'a>(content: Content<'a>) {}` is not allowed here as


### PR DESCRIPTION
Very small fix