### PR TITLE
Emit while_true lint spanning the entire loop condition

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -116,8 +116,7 @@ impl EarlyLintPass for WhileTrue {
     #[inline]
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &ast::Expr) {
         if let ast::ExprKind::While(cond, _, label) = &e.kind
-            && let cond = pierce_parens(cond)
-            && let ast::ExprKind::Lit(token_lit) = cond.kind
+            && let ast::ExprKind::Lit(token_lit) = pierce_parens(cond).kind
             && let token::Lit { kind: token::Bool, symbol: kw::True, .. } = token_lit
             && !cond.span.from_expansion()
         {


### PR DESCRIPTION
The lint that suggests `loop {}` instead of `while true {}` has functionality to 'pierce' parenthesis in cases like `while (true) {}`. In these cases, the emitted span only went to the hi of the `true` itself, not spanning the entire loop condition.

Before:
```
warning: denote infinite loops with `loop { ... }`
 --> /tmp/foobar.rs:2:5
  |
2 |     while ((((((true)))))) {}
  |     ^^^^^^^^^^^^^^^^ help: use `loop`
  |
  = note: `#[warn(while_true)]` on by default
```

After:
```
warning: denote infinite loops with `loop { ... }`
 --> /tmp/foobar.rs:2:5
  |
2 |     while ((((((true)))))) {}
  |     ^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
  |
  = note: `#[warn(while_true)]` on by default
```

This is especially a problem for rustfix.