### PR TITLE
Remove calls to `mem::forget` and `mem::replace` in `Option::get_or_insert_with`.

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1641,10 +1641,8 @@ impl<T> Option<T> {
     where
         F: FnOnce() -> T,
     {
-        if let None = *self {
-            // the compiler isn't smart enough to know that we are not dropping a `T`
-            // here and wants us to ensure `T` can be dropped at compile time.
-            mem::forget(mem::replace(self, Some(f())))
+        if let None = self {
+            *self = Some(f());
         }
 
         // SAFETY: a `None` variant for `self` would have been replaced by a `Some`


### PR DESCRIPTION
This removes the unneeded calls to `mem::forget` and `mem::replace` in `Option::get_or_insert_with`.