### PR TITLE
update Rust Unstable Book docs for `--extern force`

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/extern-options.md
+++ b/src/doc/unstable-book/src/compiler-flags/extern-options.md
@@ -4,6 +4,7 @@
 * Tracking issue for `noprelude`: [#98398](https://github.com/rust-lang/rust/issues/98398)
 * Tracking issue for `priv`: [#98399](https://github.com/rust-lang/rust/issues/98399)
 * Tracking issue for `nounused`: [#98400](https://github.com/rust-lang/rust/issues/98400)
+* Tracking issue for `force`: [#111302](https://github.com/rust-lang/rust/issues/111302)
 
 The behavior of the `--extern` flag can be modified with `noprelude`, `priv` or `nounused` options.
 
@@ -25,3 +26,4 @@ To use multiple options, separate them with a comma:
   This is used by the [build-std project](https://github.com/rust-lang/wg-cargo-std-aware/) to simulate compatibility with sysroot-only crates.
 * `priv`: Mark the crate as a private dependency for the [`exported_private_dependencies`](../../rustc/lints/listing/warn-by-default.html#exported-private-dependencies) lint.
 * `nounused`: Suppress [`unused-crate-dependencies`](../../rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies) warnings for the crate.
+* `force`: Resolve the crate as if it is used, even if it is not used. This can be used to satisfy compilation session requirements like the presence of an allocator or panic handler.


### PR DESCRIPTION
Options for `--extern` are documented in [The Rust Unstable Book](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/extern-options.html). https://github.com/rust-lang/rust/pull/109421 added a new `force` option and this PR updates the documentation accordingly.