### PR TITLE
Update hashbrown from 0.12.3 to 0.13.1 for std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,9 +1546,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.4",
- "compiler_builtins",
- "rustc-std-workspace-alloc",
- "rustc-std-workspace-core",
 ]
 
 [[package]]
@@ -1558,6 +1555,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
 dependencies = [
  "ahash 0.8.2",
+ "compiler_builtins",
+ "rustc-std-workspace-alloc",
+ "rustc-std-workspace-core",
 ]
 
 [[package]]
@@ -4606,7 +4606,7 @@ dependencies = [
  "core",
  "dlmalloc",
  "fortanix-sgx-abi",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.1",
  "hermit-abi 0.3.0",
  "libc",
  "miniz_oxide",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -19,7 +19,7 @@ libc = { version = "0.2.142", default-features = false, features = ['rustc-dep-o
 compiler_builtins = { version = "0.1.91" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
-hashbrown = { version = "0.12", default-features = false, features = ['rustc-dep-of-std'] }
+hashbrown = { version = "0.13", default-features = false, features = ['rustc-dep-of-std'] }
 std_detect = { path = "../stdarch/crates/std_detect", default-features = false, features = ['rustc-dep-of-std'] }
 
 # Dependencies of the `backtrace` crate


### PR DESCRIPTION
This PR updates hashbrown from 0.12.3 to 0.13.1 for std.

r? @Amanieu