### PR TITLE
Remove `identity_future` from stdlib

### DIFF
--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -66,10 +66,3 @@ pub unsafe fn get_context<'a, 'b>(cx: ResumeTy) -> &'a mut Context<'b> {
     // that fulfills all the requirements for a mutable reference.
     unsafe { &mut *cx.0.as_ptr().cast() }
 }
-
-#[doc(hidden)]
-#[unstable(feature = "gen_future", issue = "50547")]
-#[inline]
-pub const fn identity_future<O, Fut: Future<Output = O>>(f: Fut) -> Fut {
-    f
-}

--- a/src/tools/rust-analyzer/crates/hir-def/src/lang_item.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/lang_item.rs
@@ -379,7 +379,6 @@ language_item_table! {
     // FIXME(swatinem): the following lang items are used for async lowering and
     // should become obsolete eventually.
     ResumeTy,                ResumeTy,            resume_ty,                  Target::Struct,         GenericRequirement::None;
-    IdentityFuture,          identity_future,     identity_future_fn,         Target::Fn,             GenericRequirement::None;
     GetContext,              get_context,         get_context_fn,             Target::Fn,             GenericRequirement::None;
 
     Context,                 Context,             context,                    Target::Struct,         GenericRequirement::None;


### PR DESCRIPTION
This function/lang_item was introduced in #104321 as a temporary workaround of future lowering. The usage and need for it went away in #104833.
After a bootstrap update, the function itself can be removed from `std`.