### PR TITLE
Add `OsStr` inherent fns to test for and strip `str` prefixes.

### DIFF
--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -160,6 +160,12 @@ pub trait Pattern<'a>: Sized {
             None
         }
     }
+
+    /// Return the pattern as a fixed slice of UTF-8 bytes, if possible.
+    #[inline]
+    fn as_bytes(&self) -> Option<&[u8]> {
+        None
+    }
 }
 
 // Searcher
@@ -917,6 +923,11 @@ where
 /// Delegates to the `&str` impl.
 impl<'a, 'b, 'c> Pattern<'a> for &'c &'b str {
     pattern_methods!(StrSearcher<'a, 'b>, |&s| s, |s| s);
+
+    #[inline]
+    fn as_bytes(&self) -> Option<&[u8]> {
+        (*self).as_bytes()
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1000,6 +1011,11 @@ impl<'a, 'b> Pattern<'a> for &'b str {
         } else {
             None
         }
+    }
+
+    #[inline]
+    fn as_bytes(&self) -> Option<&[u8]> {
+        Some(str::as_bytes(self))
     }
 }
 

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -8,6 +8,7 @@ use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::ops;
 use crate::rc::Rc;
+use crate::str::pattern::Pattern;
 use crate::str::FromStr;
 use crate::sync::Arc;
 
@@ -977,6 +978,69 @@ impl OsStr {
     #[stable(feature = "osstring_ascii", since = "1.53.0")]
     pub fn eq_ignore_ascii_case<S: AsRef<OsStr>>(&self, other: S) -> bool {
         self.inner.eq_ignore_ascii_case(&other.as_ref().inner)
+    }
+
+    /// Returns `true` if the given pattern matches a prefix of this `OsStr`.
+    ///
+    /// Returns `false` if it does not.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: crate::str::pattern
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(osstr_str_prefix_fns)]
+    ///
+    /// use std::ffi::OsString;
+    ///
+    /// let bananas = OsString::from("bananas");
+    ///
+    /// assert!(bananas.starts_with("bana"));
+    /// assert!(!bananas.starts_with("nana"));
+    /// ```
+    #[unstable(feature = "osstr_str_prefix_fns", issue = "none")]
+    #[must_use]
+    #[inline]
+    pub fn starts_with<'a, P: Pattern<'a>>(&'a self, pattern: P) -> bool {
+        self.inner.starts_with(pattern)
+    }
+
+    /// Returns this `OsStr` with the given prefix removed.
+    ///
+    /// If the `OsStr` starts with the pattern `prefix`, returns the substring
+    /// after the prefix, wrapped in `Some`.
+    ///
+    /// If the `OsStr` does not start with `prefix`, returns `None`.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: crate::str::pattern
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(osstr_str_prefix_fns)]
+    ///
+    /// use std::ffi::{OsStr, OsString};
+    ///
+    /// let foobar = OsString::from("foo:bar");
+    ///
+    /// assert_eq!(foobar.strip_prefix("foo:"), Some(OsStr::new("bar")));
+    /// assert_eq!(foobar.strip_prefix("bar"), None);
+    /// ```
+    #[unstable(feature = "osstr_str_prefix_fns", issue = "none")]
+    #[must_use]
+    #[inline]
+    pub fn strip_prefix<'a, P: Pattern<'a>>(&'a self, prefix: P) -> Option<&'a OsStr> {
+        Some(OsStr::from_inner(self.inner.strip_prefix(prefix)?))
     }
 }
 

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -264,6 +264,7 @@
 #![feature(needs_panic_runtime)]
 #![feature(negative_impls)]
 #![feature(never_type)]
+#![feature(pattern)]
 #![feature(platform_intrinsics)]
 #![feature(prelude_import)]
 #![feature(rustc_attrs)]

--- a/library/std/src/sys/unix/os_str.rs
+++ b/library/std/src/sys/unix/os_str.rs
@@ -288,10 +288,18 @@ impl Slice {
 
     #[inline]
     pub fn starts_with<'a, P: Pattern<'a>>(&'a self, pattern: P) -> bool {
+        if let Some(pattern_bytes) = pattern.as_bytes() {
+            return self.inner.starts_with(pattern_bytes);
+        }
         self.to_str_prefix().starts_with(pattern)
     }
 
     pub fn strip_prefix<'a, P: Pattern<'a>>(&'a self, prefix: P) -> Option<&'a Slice> {
+        if let Some(prefix_bytes) = prefix.as_bytes() {
+            let suffix = self.inner.strip_prefix(prefix_bytes)?;
+            return Some(Slice::from_u8_slice(suffix));
+        }
+
         let p = self.to_str_prefix();
         let prefix_len = match prefix.into_searcher(p).next() {
             SearchStep::Match(0, prefix_len) => prefix_len,

--- a/library/std/src/sys/unix/os_str/tests.rs
+++ b/library/std/src/sys/unix/os_str/tests.rs
@@ -16,3 +16,37 @@ fn display() {
         Slice::from_u8_slice(b"Hello\xC0\x80 There\xE6\x83 Goodbye").to_string(),
     );
 }
+
+#[test]
+fn slice_starts_with() {
+    let mut string = Buf::from_string(String::from("héllô="));
+    string.push_slice(Slice::from_u8_slice(b"\xFF"));
+    string.push_slice(Slice::from_str("wørld"));
+    let slice = string.as_slice();
+
+    assert!(slice.starts_with('h'));
+    assert!(slice.starts_with("héllô"));
+    assert!(!slice.starts_with("héllô=wørld"));
+}
+
+#[test]
+fn slice_strip_prefix() {
+    let mut string = Buf::from_string(String::from("héllô="));
+    string.push_slice(Slice::from_u8_slice(b"\xFF"));
+    string.push_slice(Slice::from_str("wørld"));
+    let slice = string.as_slice();
+
+    assert!(slice.strip_prefix("héllô=wørld").is_none());
+
+    {
+        let suffix = slice.strip_prefix('h');
+        assert!(suffix.is_some());
+        assert_eq!(&suffix.unwrap().inner, b"\xC3\xA9ll\xC3\xB4=\xFFw\xC3\xB8rld",);
+    }
+
+    {
+        let suffix = slice.strip_prefix("héllô");
+        assert!(suffix.is_some());
+        assert_eq!(&suffix.unwrap().inner, b"=\xFFw\xC3\xB8rld");
+    }
+}

--- a/library/std/src/sys/windows/os_str.rs
+++ b/library/std/src/sys/windows/os_str.rs
@@ -5,6 +5,7 @@ use crate::collections::TryReserveError;
 use crate::fmt;
 use crate::mem;
 use crate::rc::Rc;
+use crate::str::pattern::Pattern;
 use crate::sync::Arc;
 use crate::sys_common::wtf8::{Wtf8, Wtf8Buf};
 use crate::sys_common::{AsInner, FromInner, IntoInner};
@@ -156,6 +157,13 @@ impl Slice {
         unsafe { mem::transmute(Wtf8::from_str(s)) }
     }
 
+    #[inline]
+    fn from_inner(inner: &Wtf8) -> &Slice {
+        // SAFETY: Slice is just a wrapper of Wtf8,
+        // therefore converting &Wtf8 to &Slice is safe.
+        unsafe { &*(inner as *const Wtf8 as *const Slice) }
+    }
+
     pub fn to_str(&self) -> Option<&str> {
         self.inner.as_str()
     }
@@ -221,5 +229,15 @@ impl Slice {
     #[inline]
     pub fn eq_ignore_ascii_case(&self, other: &Self) -> bool {
         self.inner.eq_ignore_ascii_case(&other.inner)
+    }
+
+    #[inline]
+    pub fn starts_with<'a, P: Pattern<'a>>(&'a self, pattern: P) -> bool {
+        self.inner.starts_with(pattern)
+    }
+
+    #[inline]
+    pub fn strip_prefix<'a, P: Pattern<'a>>(&'a self, prefix: P) -> Option<&'a Slice> {
+        Some(Slice::from_inner(self.inner.strip_prefix(prefix)?))
     }
 }


### PR DESCRIPTION
A reduced subset of PR https://github.com/rust-lang/rust/pull/111059:

* `OsStr::starts_with()` tests whether an `OsStr` has a prefix matching the given `Pattern`.

* `OsStr::strip_prefix()` returns the `OsStr` after removing a prefix matching the given `Pattern`.

ACP: https://github.com/rust-lang/libs-team/issues/114