### PR TITLE
Note if the user wants to use associated items of a trait directly

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -3682,16 +3682,10 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 }
                 // note if the user wants to use associated items of a trait directly
                 if in_path && res.len() == 0 {
-                    if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(self_ty.span) {
-                        diag.note(format!(
-                            "desired associated item not found in trait `{}` if you want to use such one",
-                            snippet,
-                        ));
-                    } else {
-                        diag.note(format!(
-                            "desired associated item not found in this trait if you want to use such one",
-                        ));
-                    }
+                    diag.span_label(
+                        self_ty.span,
+                        "no desired associated item found in this trait if you want to use such one",
+                    );
                 }
                 // check if the impl trait that we are considering is a impl of a local trait
                 self.maybe_lint_blanket_trait_impl(&self_ty, &mut diag);

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -3684,7 +3684,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 if in_path && res.len() == 0 {
                     diag.span_label(
                         self_ty.span,
-                        "no desired associated item found in this trait if you want to use such one",
+                        "no desired associated item found in this trait, if you do not want to use a bare trait object here",
                     );
                 }
                 // check if the impl trait that we are considering is a impl of a local trait

--- a/tests/ui/associated-item/issue-111312.rs
+++ b/tests/ui/associated-item/issue-111312.rs
@@ -1,0 +1,12 @@
+// edition:2021
+
+trait Has {
+    fn has() {}
+}
+
+trait HasNot {}
+
+fn main() {
+    HasNot::has(); //~ ERROR E0782
+    //~^ ERROR E0599
+}

--- a/tests/ui/associated-item/issue-111312.stderr
+++ b/tests/ui/associated-item/issue-111312.stderr
@@ -2,9 +2,8 @@ error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/issue-111312.rs:10:5
    |
 LL |     HasNot::has();
-   |     ^^^^^^
+      |     ^^^^^^ no desired associated item found in this trait if you want to use such one
    |
-   = note: desired associated item not found in trait `HasNot` if you want to use such one
 help: add `dyn` keyword before this trait
    |
 LL |     <dyn HasNot>::has();

--- a/tests/ui/associated-item/issue-111312.stderr
+++ b/tests/ui/associated-item/issue-111312.stderr
@@ -2,7 +2,7 @@ error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/issue-111312.rs:10:5
    |
 LL |     HasNot::has();
-      |     ^^^^^^ no desired associated item found in this trait if you want to use such one
+   |     ^^^^^^ no desired associated item found in this trait if you want to use such one
    |
 help: add `dyn` keyword before this trait
    |

--- a/tests/ui/associated-item/issue-111312.stderr
+++ b/tests/ui/associated-item/issue-111312.stderr
@@ -2,7 +2,7 @@ error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/issue-111312.rs:10:5
    |
 LL |     HasNot::has();
-   |     ^^^^^^ no desired associated item found in this trait if you want to use such one
+   |     ^^^^^^ no desired associated item found in this trait, if you do not want to use a bare trait object here
    |
 help: add `dyn` keyword before this trait
    |

--- a/tests/ui/associated-item/issue-111312.stderr
+++ b/tests/ui/associated-item/issue-111312.stderr
@@ -1,0 +1,29 @@
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/issue-111312.rs:10:5
+   |
+LL |     HasNot::has();
+   |     ^^^^^^
+   |
+   = note: desired associated item not found in trait `HasNot` if you want to use such one
+help: add `dyn` keyword before this trait
+   |
+LL |     <dyn HasNot>::has();
+   |     ++++       +
+
+error[E0599]: no function or associated item named `has` found for trait object `dyn HasNot` in the current scope
+  --> $DIR/issue-111312.rs:10:13
+   |
+LL |     HasNot::has();
+   |             ^^^ function or associated item not found in `dyn HasNot`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Has` defines an item `has`, perhaps you need to implement it
+  --> $DIR/issue-111312.rs:3:1
+   |
+LL | trait Has {
+   | ^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0599, E0782.
+For more information about an error, try `rustc --explain E0599`.

--- a/tests/ui/editions/dyn-trait-sugg-2021.stderr
+++ b/tests/ui/editions/dyn-trait-sugg-2021.stderr
@@ -2,7 +2,7 @@ error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/dyn-trait-sugg-2021.rs:10:5
    |
 LL |     Foo::hi(123);
-   |     ^^^ no desired associated item found in this trait if you want to use such one
+   |     ^^^ no desired associated item found in this trait, if you do not want to use a bare trait object here
    |
 help: add `dyn` keyword before this trait
    |

--- a/tests/ui/editions/dyn-trait-sugg-2021.stderr
+++ b/tests/ui/editions/dyn-trait-sugg-2021.stderr
@@ -2,9 +2,8 @@ error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/dyn-trait-sugg-2021.rs:10:5
    |
 LL |     Foo::hi(123);
-   |     ^^^
+   |     ^^^ no desired associated item found in this trait if you want to use such one
    |
-   = note: desired associated item not found in trait `Foo` if you want to use such one
 help: add `dyn` keyword before this trait
    |
 LL |     <dyn Foo>::hi(123);

--- a/tests/ui/editions/dyn-trait-sugg-2021.stderr
+++ b/tests/ui/editions/dyn-trait-sugg-2021.stderr
@@ -4,6 +4,7 @@ error[E0782]: trait objects must include the `dyn` keyword
 LL |     Foo::hi(123);
    |     ^^^
    |
+   = note: desired associated item not found in trait `Foo` if you want to use such one
 help: add `dyn` keyword before this trait
    |
 LL |     <dyn Foo>::hi(123);


### PR DESCRIPTION
Fixes #111312

Furthermore, bare trait objects have been denied after edition 2021. We could not treat traits without `dyn` as bare trait objects. For such cases, there is no need to use bare trait objects as `recv_ty/self_ty` (while using `None` directly). This will lead to stop resolving early but it may require a bit more works to resolve compatibility issues.