### PR TITLE
Prevent using the default `cc` when that'd result in a broken build

### DIFF
--- a/src/bootstrap/src/bin/broken-cc.rs
+++ b/src/bootstrap/src/bin/broken-cc.rs
@@ -1,0 +1,47 @@
+// Show an error message when the wrong C compiler is detected. See the cc_detect module inside of
+// bootstrap for more context on why this binary was added.
+
+use std::process::ExitCode;
+
+const PREFIX: &str = "   ";
+
+fn main() -> ExitCode {
+    let mut target = None;
+    let mut detected_cc = None;
+    for arg in std::env::args() {
+        match arg.split_once('=') {
+            Some(("--broken-cc-target", t)) => target = Some(t.to_string()),
+            Some(("--broken-cc-detected", d)) => detected_cc = Some(d.to_string()),
+            _ => {}
+        }
+    }
+
+    let detected_cc = detected_cc.expect("broken-cc not invoked by bootstrap correctly");
+    let target = target.expect("broken-cc not invoked by bootstrap correctly");
+    let underscore_target = target.replace('-', "_");
+
+    eprintln!();
+    eprintln!("{PREFIX}Error: the automatic detection of the C compiler for cross-compiled");
+    eprintln!("{PREFIX}target {target} returned the C compiler also used for the");
+    eprintln!("{PREFIX}current host platform.");
+    eprintln!();
+    eprintln!("{PREFIX}This is likely wrong, and will likely result in a broken compilation");
+    eprintln!("{PREFIX}artifact. Please specify the correct C compiler for that target, either");
+    eprintln!("{PREFIX}with environment variables:");
+    eprintln!();
+    eprintln!("{PREFIX}    CC_{underscore_target}=path/to/cc");
+    eprintln!("{PREFIX}    CXX_{underscore_target}=path/to/cxx");
+    eprintln!();
+    eprintln!("{PREFIX}...or in config.toml:");
+    eprintln!();
+    eprintln!("{PREFIX}    [target.\"{target}\"]");
+    eprintln!("{PREFIX}    cc = \"path/to/cc\"");
+    eprintln!("{PREFIX}    cxx = \"path/to/cxx\"");
+    eprintln!();
+    eprintln!("{PREFIX}The detected C compiler was:");
+    eprintln!();
+    eprintln!("{PREFIX}    {detected_cc}");
+    eprintln!();
+
+    ExitCode::FAILURE
+}

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2960,6 +2960,9 @@ impl Step for TestHelpers {
                 cfg.archiver(ar);
             }
             cfg.compiler(builder.cc(target));
+            for flag in builder.cflags(target, GitRepo::Rustc, CLang::C) {
+                cfg.flag(&flag);
+            }
         }
         cfg.cargo_metadata(false)
             .out_dir(&dst)

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -115,6 +115,40 @@ pub fn find_target(build: &Build, target: TargetSelection) {
     }
 
     let compiler = cfg.get_compiler();
+
+    // When the cc crate cannot find the appropriate C compiler for the requested target, rather
+    // than erroring out it returns the default C compiler. In most cases, this is wrong.
+    //
+    // For example, let's say that you're cross-compiling for aarch64-unknown-none from an x86_64
+    // host, and that target is not recognized by the cc crate. In that case, the detected cc will
+    // be an x86_64 compiler, even though we're compiling for aarch64-unknown-none. If a crate then
+    // compiles some C code in its build script, the resulting rlib will have mixed AArch64 and
+    // x86_64 objects in it, and the linker will show rather unhelpful messages.
+    //
+    // To avoid the confusing error messages, we detect whether the configuration is likely broken,
+    // and if so we replace the detected C compiler with a stub binary that prints a useful error
+    // message, telling the user to manually configure their C compiler.
+    //
+    // We use a custom binary rather than erroring out directly here because some build steps might
+    // not need a C compiler at all, and it would be annoying to prevent the build in those cases.
+    let default_cc = new_cc_build(build, build.build).get_compiler();
+    if target != build.build && !compiler.is_like_clang() && compiler.path() == default_cc.path() {
+        let mut broken_cc = new_cc_build(build, target);
+        broken_cc.compiler(
+            std::env::current_exe()
+                .expect("failed to retrieve path to the bootstrap executable")
+                .parent()
+                .unwrap()
+                .join(format!("broken-cc{}", std::env::consts::EXE_SUFFIX)),
+        );
+        broken_cc.flag(&format!("--broken-cc-target={target}"));
+        broken_cc.flag(&format!("--broken-cc-detected={}", default_cc.path().display()));
+
+        build.cc.borrow_mut().insert(target, broken_cc.get_compiler());
+        build.cxx.borrow_mut().insert(target, broken_cc.get_compiler());
+        return;
+    }
+
     let ar = if let ar @ Some(..) = config.and_then(|c| c.ar.clone()) {
         ar
     } else {

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -60,7 +60,11 @@ ENV WASM_SCRIPT python3 /checkout/x.py --stage 2 test --host='' --target $WASM_T
   tests/assembly \
   library/core
 
-ENV NVPTX_TARGETS=nvptx64-nvidia-cuda
+ENV NVPTX_TARGETS=nvptx64-nvidia-cuda \
+    CC_nvptx64_nvidia_cuda=clang-11 \
+    CXX_nvptx64_nvidia_cuda=clang++-11 \
+    CFLAGS_nvptx64_nvidia_cuda=-flto \
+    CXXFLAGS_nvptx64_nvidia_cuda=-flto \
 ENV NVPTX_SCRIPT python3 /checkout/x.py --stage 2 test --host='' --target $NVPTX_TARGETS \
   tests/run-make \
   tests/assembly

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -64,7 +64,7 @@ ENV NVPTX_TARGETS=nvptx64-nvidia-cuda \
     CC_nvptx64_nvidia_cuda=clang-11 \
     CXX_nvptx64_nvidia_cuda=clang++-11 \
     CFLAGS_nvptx64_nvidia_cuda=-flto \
-    CXXFLAGS_nvptx64_nvidia_cuda=-flto \
+    CXXFLAGS_nvptx64_nvidia_cuda=-flto
 ENV NVPTX_SCRIPT python3 /checkout/x.py --stage 2 test --host='' --target $NVPTX_TARGETS \
   tests/run-make \
   tests/assembly

--- a/tests/auxiliary/rust_test_helpers.c
+++ b/tests/auxiliary/rust_test_helpers.c
@@ -271,7 +271,7 @@ float get_c_exhaust_sysv64_ints(
 // Variadic arguments are broken when using clang to compile nvptx-nvidia-cuda,
 // causing clang to ICE. As no test run on CI currently relies on these
 // functions, we don't compile them when building for nvptx-nvidia-cuda.
-#ifdef __CUDA_ARCH__
+#ifndef __CUDA_ARCH__
 
 // Calculates the average of `(x + y) / n` where x: i64, y: f64. There must be exactly n pairs
 // passed as variadic arguments. There are two versions of this function: the

--- a/tests/auxiliary/rust_test_helpers.c
+++ b/tests/auxiliary/rust_test_helpers.c
@@ -268,6 +268,11 @@ float get_c_exhaust_sysv64_ints(
     return h.c;
 }
 
+// Variadic arguments are broken when using clang to compile nvptx-nvidia-cuda,
+// causing clang to ICE. As no test run on CI currently relies on these
+// functions, we don't compile them when building for nvptx-nvidia-cuda.
+#ifdef __CUDA_ARCH__
+
 // Calculates the average of `(x + y) / n` where x: i64, y: f64. There must be exactly n pairs
 // passed as variadic arguments. There are two versions of this function: the
 // variadic one, and the one that takes a `va_list`.
@@ -289,6 +294,8 @@ double rust_interesting_average(uint64_t n, ...) {
     va_end(pairs);
     return sum;
 }
+
+#endif
 
 int32_t rust_int8_to_int32(int8_t x) {
     return (int32_t)x;


### PR DESCRIPTION
This PR adds a check in bootstrap to prevent issues like https://github.com/rust-lang/rust/issues/111142 to happen. What happened there is, no compiler for `aarch64-unknown-none` was detected by bootstrap, and so the `cc` crate defaulted to the system host C compiler. That resulted in a broken target, as `libcompiler_builtins.rlib` (or well anything compiling C code in its build script) contained half the object files compiled for aarch64 and half of them compiled for x86_64.

The check added in the PR ensures that, for cross-compilation, the detected C compiler is not the same one as the host compiler, unless the detected compiler is clang (as it supports all targets from a single binary). This should not cause too many false positives, as for example a `./x build library --target i686-unknown-linux-gnu` still works from a x86_64 host. If a false positive occurs, the error message still explains the workaround.

Example error message:

```
  running: "/home/pietro/r/github/rust-lang/rust/2/build/bootstrap/debug/broken-cc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-ffunction-sections" "-fdata-sections" "-fPIC" "--broken-cc-target=aarch64-unknown-none" "--broken-cc-detected=cc" "-I" "/home/pietro/r/github/rust-lang/rust/2/src/llvm-project/compiler-rt/lib/builtins" "-fno-builtin" "-fvisibility=hidden" "-ffreestanding" "-DVISIBILITY_HIDDEN" "-o" "/home/pietro/r/github/rust-lang/rust/2/build/x86_64-unknown-linux-gnu/stage0-std/aarch64-unknown-none/release/build/compiler_builtins-13da5a491a5cb882/out/ea072bc2688e9ac2-lse_cas1_relax.o" "-c" "/home/pietro/r/github/rust-lang/rust/2/build/x86_64-unknown-linux-gnu/stage0-std/aarch64-unknown-none/release/build/compiler_builtins-13da5a491a5cb882/out/lse_cas1_relax.S"
  cargo:warning=
  cargo:warning=   Error: the automatic detection of the C compiler for cross-compiled
  cargo:warning=   target aarch64-unknown-none returned the compiler also used for the
  cargo:warning=   current host platform.
  cargo:warning=
  cargo:warning=   This is likely wrong, and will likely result in a broken compilation
  cargo:warning=   artifact. Please specify the correct compiler for that target, either
  cargo:warning=   with environment variables:
  cargo:warning=
  cargo:warning=       CC_aarch64_unknown_none=path/to/cc
  cargo:warning=       CXX_aarch64_unknown_none=path/to/cxx
  cargo:warning=
  cargo:warning=   ...or in config.toml:
  cargo:warning=
  cargo:warning=       [target."aarch64-unknown-none"]
  cargo:warning=       cc = "path/to/cc"
  cargo:warning=       cxx = "path/to/cxx"
  cargo:warning=
  cargo:warning=   The detected C compiler was:
  cargo:warning=
  cargo:warning=       cc
  cargo:warning=
  exit status: 1

  --- stderr


  error occurred: Command "/home/pietro/r/github/rust-lang/rust/2/build/bootstrap/debug/broken-cc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-ffunction-sections" "-fdata-sections" "-fPIC" "--broken-cc-target=aarch64-unknown-none" "--broken-cc-detected=cc" "-I" "/home/pietro/r/github/rust-lang/rust/2/src/llvm-project/compiler-rt/lib/builtins" "-fno-builtin" "-fvisibility=hidden" "-ffreestanding" "-DVISIBILITY_HIDDEN" "-o" "/home/pietro/r/github/rust-lang/rust/2/build/x86_64-unknown-linux-gnu/stage0-std/aarch64-unknown-none/release/build/compiler_builtins-13da5a491a5cb882/out/ea072bc2688e9ac2-lse_cas1_relax.o" "-c" "/home/pietro/r/github/rust-lang/rust/2/build/x86_64-unknown-linux-gnu/stage0-std/aarch64-unknown-none/release/build/compiler_builtins-13da5a491a5cb882/out/lse_cas1_relax.S" with args "broken-cc" did not execute successfully (status code exit status: 1).


Build completed unsuccessfully in 0:00:02
```

Fixes #111142
r? @jyn514 