### PR TITLE
Align unsized locals

### DIFF
--- a/tests/ui/unsized-locals/align.rs
+++ b/tests/ui/unsized-locals/align.rs
@@ -1,0 +1,30 @@
+// Test that unsized locals uphold alignment requirements.
+// Regression test for #71416.
+// run-pass
+#![feature(unsized_locals)]
+#![allow(incomplete_features)]
+use std::any::Any;
+
+#[repr(align(256))]
+#[allow(dead_code)]
+struct A {
+    v: u8
+}
+
+impl A {
+    fn f(&self) -> *const A {
+        assert_eq!(self as *const A as usize % 256, 0);
+        self
+    }
+}
+
+fn mk() -> Box<dyn Any> {
+    Box::new(A { v: 4 })
+}
+
+fn main() {
+    let x = *mk();
+    let dwncst = x.downcast_ref::<A>().unwrap();
+    let addr = dwncst.f();
+    assert_eq!(addr as usize % 256, 0);
+}


### PR DESCRIPTION
Allocate an extra space for unsized locals and manually align the storage, since alloca doesn't support dynamic alignment.

Fixes #71416.
Fixes #71695.