### PR TITLE
Boost iterator intersperse(_with) performance

### DIFF
--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -200,10 +200,10 @@ where
         lo.saturating_sub(!started as usize)
             .saturating_add(next_is_some as usize)
             .saturating_add(lo),
-        hi.map(|hi| {
+        hi.and_then(|hi| {
             hi.saturating_sub(!started as usize)
                 .saturating_add(next_is_some as usize)
-                .saturating_add(hi)
+                .checked_add(hi)
         }),
     )
 }

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -1,5 +1,5 @@
-use core::fmt;
-use core::iter::{Fuse, FusedIterator};
+use crate::fmt;
+use crate::iter::{Fuse, FusedIterator};
 
 /// An iterator adapter that places a separator between all elements.
 ///

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -72,7 +72,14 @@ where
         F: FnMut(B, Self::Item) -> B,
     {
         let separator = self.separator;
-        intersperse_fold(self.iter, init, f, move || separator.clone(), self.started,self.next_item)
+        intersperse_fold(
+            self.iter,
+            init,
+            f,
+            move || separator.clone(),
+            self.started,
+            self.next_item,
+        )
     }
 }
 


### PR DESCRIPTION
I did some benchmark digging into the `intersperse` and `intersperse_with` code as part of [this discussion](https://internals.rust-lang.org/t/add-iterate-with-separators-iterator-function/18781/13), and as a result I optimized them a bit, without relying on the peekable iterator.

See also [full benchmark repo](https://github.com/nyurik/intersperse_perf)

Benchmarks show near 2x performance improvements with the simple `sum` [benchmarks](https://gist.github.com/nyurik/68b6c9b3d90f0d14746d4186bf8fa1e2):
![image](https://user-images.githubusercontent.com/1641515/237005195-16aebef4-9eed-4514-8b7c-da1d1f5bd9e0.png)