### PR TITLE
Don't force include Windows goop when documenting

### DIFF
--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -9,7 +9,7 @@ use crate::io;
 use crate::marker::PhantomData;
 use crate::mem::forget;
 use crate::ptr;
-use crate::sys::c;
+use crate::sys;
 use crate::sys::cvt;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 
@@ -190,14 +190,14 @@ impl BorrowedHandle<'_> {
     /// object as the existing `BorrowedHandle` instance.
     #[stable(feature = "io_safety", since = "1.63.0")]
     pub fn try_clone_to_owned(&self) -> crate::io::Result<OwnedHandle> {
-        self.duplicate(0, false, c::DUPLICATE_SAME_ACCESS)
+        self.duplicate(0, false, sys::c::DUPLICATE_SAME_ACCESS)
     }
 
     pub(crate) fn duplicate(
         &self,
-        access: c::DWORD,
+        access: u32,
         inherit: bool,
-        options: c::DWORD,
+        options: u32,
     ) -> io::Result<OwnedHandle> {
         let handle = self.as_raw_handle();
 
@@ -211,14 +211,14 @@ impl BorrowedHandle<'_> {
 
         let mut ret = ptr::null_mut();
         cvt(unsafe {
-            let cur_proc = c::GetCurrentProcess();
-            c::DuplicateHandle(
+            let cur_proc = sys::c::GetCurrentProcess();
+            sys::c::DuplicateHandle(
                 cur_proc,
                 handle,
                 cur_proc,
                 &mut ret,
                 access,
-                inherit as c::BOOL,
+                inherit as sys::c::BOOL,
                 options,
             )
         })?;
@@ -233,7 +233,7 @@ impl TryFrom<HandleOrInvalid> for OwnedHandle {
     #[inline]
     fn try_from(handle_or_invalid: HandleOrInvalid) -> Result<Self, InvalidHandleError> {
         let owned_handle = handle_or_invalid.0;
-        if owned_handle.handle == c::INVALID_HANDLE_VALUE {
+        if owned_handle.handle == sys::c::INVALID_HANDLE_VALUE {
             // Don't call `CloseHandle`; it'd be harmless, except that it could
             // overwrite the `GetLastError` error.
             forget(owned_handle);
@@ -365,7 +365,7 @@ impl Drop for OwnedHandle {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            let _ = c::CloseHandle(self.handle);
+            let _ = sys::c::CloseHandle(self.handle);
         }
     }
 }

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -11,7 +11,6 @@ use crate::os::windows::io::{OwnedHandle, OwnedSocket};
 use crate::os::windows::raw;
 use crate::ptr;
 use crate::sys;
-use crate::sys::c;
 use crate::sys_common::{self, AsInner, FromInner, IntoInner};
 
 /// Raw HANDLEs.
@@ -104,42 +103,42 @@ impl AsRawHandle for fs::File {
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawHandle for io::Stdin {
     fn as_raw_handle(&self) -> RawHandle {
-        stdio_handle(unsafe { c::GetStdHandle(c::STD_INPUT_HANDLE) as RawHandle })
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_INPUT_HANDLE) as RawHandle })
     }
 }
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawHandle for io::Stdout {
     fn as_raw_handle(&self) -> RawHandle {
-        stdio_handle(unsafe { c::GetStdHandle(c::STD_OUTPUT_HANDLE) as RawHandle })
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_OUTPUT_HANDLE) as RawHandle })
     }
 }
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawHandle for io::Stderr {
     fn as_raw_handle(&self) -> RawHandle {
-        stdio_handle(unsafe { c::GetStdHandle(c::STD_ERROR_HANDLE) as RawHandle })
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_ERROR_HANDLE) as RawHandle })
     }
 }
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawHandle for io::StdinLock<'a> {
     fn as_raw_handle(&self) -> RawHandle {
-        stdio_handle(unsafe { c::GetStdHandle(c::STD_INPUT_HANDLE) as RawHandle })
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_INPUT_HANDLE) as RawHandle })
     }
 }
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawHandle for io::StdoutLock<'a> {
     fn as_raw_handle(&self) -> RawHandle {
-        stdio_handle(unsafe { c::GetStdHandle(c::STD_OUTPUT_HANDLE) as RawHandle })
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_OUTPUT_HANDLE) as RawHandle })
     }
 }
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawHandle for io::StderrLock<'a> {
     fn as_raw_handle(&self) -> RawHandle {
-        stdio_handle(unsafe { c::GetStdHandle(c::STD_ERROR_HANDLE) as RawHandle })
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_ERROR_HANDLE) as RawHandle })
     }
 }
 
@@ -152,14 +151,14 @@ fn stdio_handle(raw: RawHandle) -> RawHandle {
     // console. In that case, return null to the user, which is consistent
     // with what they'd get in the parent, and which avoids the problem that
     // `INVALID_HANDLE_VALUE` aliases the current process handle.
-    if raw == c::INVALID_HANDLE_VALUE { ptr::null_mut() } else { raw }
+    if raw == sys::c::INVALID_HANDLE_VALUE { ptr::null_mut() } else { raw }
 }
 
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawHandle for fs::File {
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> fs::File {
-        let handle = handle as c::HANDLE;
+        let handle = handle as sys::c::HANDLE;
         fs::File::from_inner(sys::fs::File::from_inner(FromInner::from_inner(
             OwnedHandle::from_raw_handle(handle),
         )))

--- a/library/std/src/sys/mod.rs
+++ b/library/std/src/sys/mod.rs
@@ -52,31 +52,6 @@ cfg_if::cfg_if! {
     }
 }
 
-// Import essential modules from platforms used in `std::os` when documenting.
-//
-// Note that on some platforms those modules don't compile
-// (missing things in `libc` which is empty), so they are not included in `std::os` and can be
-// omitted here as well.
-
-#[cfg(doc)]
-#[cfg(not(any(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    all(target_vendor = "fortanix", target_env = "sgx")
-)))]
-cfg_if::cfg_if! {
-    if #[cfg(not(windows))] {
-        // On non-Windows platforms (aka linux/osx/etc) pull in a "minimal"
-        // amount of windows goop which ends up compiling
-
-        #[macro_use]
-        #[path = "windows/compat.rs"]
-        pub mod compat;
-
-        #[path = "windows/c.rs"]
-        pub mod c;
-    }
-}
-
 cfg_if::cfg_if! {
     // Fuchsia components default to full backtrace.
     if #[cfg(target_os = "fuchsia")] {


### PR DESCRIPTION
Why do we need to include all the windows bits on non-windows platforms? Let's try not doing that.

Possible alternative to #111394, if it works.