### PR TITLE
suggest `slice::swap` for `mem::swap(&mut x[0], &mut x[1])` borrowck error

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -972,7 +972,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     &msg_borrow,
                     None,
                 );
-                self.suggest_split_at_mut_if_applicable(
+                self.suggest_slice_method_if_applicable(
                     &mut err,
                     place,
                     issued_borrow.borrowed_place,
@@ -1252,7 +1252,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         );
     }
 
-    fn suggest_split_at_mut_if_applicable(
+    fn suggest_slice_method_if_applicable(
         &self,
         err: &mut Diagnostic,
         place: Place<'tcx>,
@@ -1264,7 +1264,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             err.help(
                 "consider using `.split_at_mut(position)` or similar method to obtain \
                      two mutable non-overlapping sub-slices",
-            );
+            )
+            .help("consider using `.swap(index_1, index_2)` to swap elements at the specified indices");
         }
     }
 

--- a/tests/ui/suggestions/suggest-split-at-mut.stderr
+++ b/tests/ui/suggestions/suggest-split-at-mut.stderr
@@ -9,6 +9,7 @@ LL |     *a = 5;
    |     ------ first borrow later used here
    |
    = help: consider using `.split_at_mut(position)` or similar method to obtain two mutable non-overlapping sub-slices
+   = help: consider using `.swap(index_1, index_2)` to swap elements at the specified indices
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Recently saw someone ask why this code (example slightly modified):
```rs
fn main() {
  let mut foo = [1, 2];
  std::mem::swap(&mut foo[0], &mut foo[1]);
}
```
triggers this error and how to fix it:
```
error[E0499]: cannot borrow `foo[_]` as mutable more than once at a time
 --> src/main.rs:4:33
  |
4 |     std::mem::swap(&mut foo[0], &mut foo[1]);
  |     -------------- -----------  ^^^^^^^^^^^ second mutable borrow occurs here
  |     |              |
  |     |              first mutable borrow occurs here
  |     first borrow later used by call
  |
  = help: consider using `.split_at_mut(position)` or similar method to obtain two mutable non-overlapping sub-slices
```
The current help message is nice and goes in the right direction, but I think we can do better for this specific instance and suggest `slice::swap`, which makes this compile