### PR TITLE
rustdoc: migrate `item_struct` to an Askama template

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -871,7 +871,7 @@ fn assoc_method(
         write!(w, "{}", render_attributes_in_pre(meth, indent_str, cx));
         (4, indent_str, Ending::NoNewline)
     } else {
-        render_attributes_in_code(w, meth, cx);
+        write!(w, "{}", render_attributes_in_code(meth, tcx));
         (0, "", Ending::Newline)
     };
     w.reserve(header_len + "<a href=\"\" class=\"fn\">{".len() + "</a>".len());
@@ -1075,10 +1075,16 @@ fn render_attributes_in_pre<'a, 'tcx: 'a>(
 
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
-fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, cx: &Context<'_>) {
-    for attr in it.attributes(cx.tcx(), cx.cache(), false) {
-        write!(w, "<div class=\"code-attribute\">{attr}</div>").unwrap();
-    }
+fn render_attributes_in_code<'a, 'tcx>(
+    it: &'a clean::Item,
+    tcx: TyCtxt<'tcx>,
+) -> impl fmt::Display + Captures<'a> + Captures<'tcx> {
+    display_fn(move |f| {
+        for a in it.attributes(tcx, false) {
+            write!(f, "<div class=\"code-attribute\">{}</div>", a)?;
+        }
+        Ok(())
+    })
 }
 
 #[derive(Copy, Clone)]

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -2105,7 +2105,7 @@ fn render_union<'a, 'cx: 'a>(
             f.write_str(" ")?;
         }
 
-        write!(f, "{{\n")?;
+        f.write_str("{{\n")?;
         let count_fields =
             fields.iter().filter(|field| matches!(*field.kind, clean::StructFieldItem(..))).count();
         let toggle = should_hide_fields(count_fields);
@@ -2126,7 +2126,7 @@ fn render_union<'a, 'cx: 'a>(
         }
 
         if it.has_stripped_entries().unwrap() {
-            write!(f, "    /* private fields */\n")?;
+            f.write_str("    /* private fields */\n")?;
         }
         if toggle {
             toggle_close(&mut f);
@@ -2164,14 +2164,9 @@ fn render_struct<'a, 'cx: 'a>(
                 let mut buf = Buffer::html();
                 let where_displayed =
                     g.map(|g| print_where_clause_and_check(&mut buf, g, cx)).unwrap_or(false);
-                write!(f, "{}", buf.into_inner())?;
 
                 // If there wasn't a `where` clause, we add a whitespace.
-                if !where_displayed {
-                    f.write_str(" {")?;
-                } else {
-                    f.write_str("{")?;
-                }
+                write!(f, "{}{}{{", buf.into_inner(), if !where_displayed { " " } else { "" })?;
 
                 let count_fields = fields
                     .iter()
@@ -2201,7 +2196,7 @@ fn render_struct<'a, 'cx: 'a>(
                     }
                     write!(f, "\n{}", tab)?;
                 } else if it.has_stripped_entries().unwrap() {
-                    write!(f, " /* private fields */ ")?;
+                    f.write_str(" /* private fields */ ")?;
                 }
                 if toggle {
                     toggle_close(&mut f);
@@ -2209,14 +2204,14 @@ fn render_struct<'a, 'cx: 'a>(
                 f.write_str("}")?;
             }
             Some(CtorKind::Fn) => {
-                write!(f, "(")?;
+                f.write_str("(")?;
                 for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
-                        write!(f, ", ")?;
+                        f.write_str(", ")?;
                     }
                     match *field.kind {
                         clean::StrippedItem(box clean::StructFieldItem(..)) => {
-                            write!(f, "_")?;
+                            f.write_str("_")?;
                         }
                         clean::StructFieldItem(ref ty) => {
                             write!(
@@ -2233,13 +2228,13 @@ fn render_struct<'a, 'cx: 'a>(
                         _ => unreachable!(),
                     }
                 }
-                write!(f, ")")?;
+                f.write_str(")")?;
                 if let Some(g) = g {
                     write!(f, "{}", print_where_clause(g, cx, 0, Ending::NoNewline))?;
                 }
                 // We only want a ";" when we are displaying a tuple struct, not a variant tuple struct.
                 if structhead {
-                    write!(f, ";")?;
+                    f.write_str(";")?;
                 }
             }
             Some(CtorKind::Const) => {
@@ -2247,7 +2242,7 @@ fn render_struct<'a, 'cx: 'a>(
                 if let Some(g) = g {
                     write!(f, "{}", print_where_clause(g, cx, 0, Ending::NoNewline))?;
                 }
-                write!(f, ";")?;
+                f.write_str(";")?;
             }
         }
         Ok(())

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1820,15 +1820,6 @@ fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean
     }
 
     impl<'a, 'cx: 'a> ItemStruct<'a, 'cx> {
-        fn render_attributes_in_code<'b>(
-            &'b self,
-        ) -> impl fmt::Display + Captures<'a> + 'b + Captures<'cx> {
-            display_fn(move |f| {
-                let tcx = self.cx.borrow().tcx();
-                write!(f, "{}", render_attributes_in_code(self.it, tcx))
-            })
-        }
-
         fn render_struct<'b>(&'b self) -> impl fmt::Display + Captures<'a> + 'b + Captures<'cx> {
             display_fn(move |f| {
                 let cx = self.cx.borrow();
@@ -1863,14 +1854,6 @@ fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean
         fn should_render_fields(&self) -> bool {
             matches!(self.s.ctor_kind, None | Some(CtorKind::Fn))
                 && self.fields().peekable().peek().is_some()
-        }
-
-        fn document_non_exhaustive_header(&self) -> &str {
-            document_non_exhaustive_header(self.it)
-        }
-
-        fn document_non_exhaustive(&self) -> impl fmt::Display + 'a {
-            document_non_exhaustive(self.it)
         }
 
         fn render_field_in_span<'b>(

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1413,14 +1413,14 @@ fn print_tuple_struct_fields<'a, 'cx: 'a>(
 fn item_enum(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, e: &clean::Enum) {
     let tcx = cx.tcx();
     let count_variants = e.variants().count();
-    wrap_item(w, |w| {
-        render_attributes_in_code(w, it, cx);
+    wrap_item(w, |mut w| {
         write!(
             w,
-            "{}enum {}{}",
+            "{attrs}{}enum {}{}",
             visibility_print_with_space(it.visibility(tcx), it.item_id, cx),
             it.name.unwrap(),
             e.generics.print(cx),
+            attrs = render_attributes_in_code(it, tcx),
         );
 
         render_enum_fields(
@@ -1733,11 +1733,11 @@ fn item_primitive(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Ite
 fn item_constant(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, c: &clean::Constant) {
     wrap_item(w, |w| {
         let tcx = cx.tcx();
-        render_attributes_in_code(w, it, cx);
 
         write!(
             w,
-            "{vis}const {name}{generics}: {typ}{where_clause}",
+            "{attrs}{vis}const {name}: {typ}",
+            attrs = render_attributes_in_code(it, tcx),
             vis = visibility_print_with_space(it.visibility(tcx), it.item_id, cx),
             name = it.name.unwrap(),
             generics = c.generics.print(cx),
@@ -1782,7 +1782,7 @@ fn item_constant(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, c: &cle
 
 fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean::Struct) {
     wrap_item(w, |w| {
-        render_attributes_in_code(w, it, cx);
+        write!(w, "{}", render_attributes_in_code(it, cx.tcx()));
         render_struct(w, it, Some(&s.generics), s.ctor_kind, &s.fields, "", true, cx);
     });
 
@@ -1842,10 +1842,10 @@ fn item_fields(
 
 fn item_static(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Item, s: &clean::Static) {
     wrap_item(w, |buffer| {
-        render_attributes_in_code(buffer, it, cx);
         write!(
             buffer,
-            "{vis}static {mutability}{name}: {typ}",
+            "{attrs}{vis}static {mutability}{name}: {typ}",
+            attrs = render_attributes_in_code(it, cx.tcx()),
             vis = visibility_print_with_space(it.visibility(cx.tcx()), it.item_id, cx),
             mutability = s.mutability.print_with_space(),
             name = it.name.unwrap(),
@@ -1860,12 +1860,12 @@ fn item_static(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Item, 
 fn item_foreign_type(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Item) {
     wrap_item(w, |buffer| {
         buffer.write_str("extern {\n").unwrap();
-        render_attributes_in_code(buffer, it, cx);
         write!(
             buffer,
-            "    {}type {};\n}}",
+            "{attrs}    {}type {};\n}}",
             visibility_print_with_space(it.visibility(cx.tcx()), it.item_id, cx),
             it.name.unwrap(),
+            attrs = render_attributes_in_code(it, cx.tcx()),
         )
         .unwrap();
     });

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -2105,7 +2105,7 @@ fn render_union<'a, 'cx: 'a>(
             f.write_str(" ")?;
         }
 
-        f.write_str("{{\n")?;
+        f.write_str("{\n")?;
         let count_fields =
             fields.iter().filter(|field| matches!(*field.kind, clean::StructFieldItem(..))).count();
         let toggle = should_hide_fields(count_fields);

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1831,6 +1831,15 @@ fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean
             Self { cx, it, s, should_render_fields }
         }
 
+        fn render_attributes_in_code<'b>(
+            &'b self,
+        ) -> impl fmt::Display + Captures<'a> + 'b + Captures<'cx> {
+            display_fn(move |f| {
+                let tcx = self.cx.borrow().tcx();
+                write!(f, "{}", render_attributes_in_code(self.it, tcx))
+            })
+        }
+
         fn render_struct<'b>(&'b self) -> impl fmt::Display + Captures<'a> + 'b + Captures<'cx> {
             display_fn(move |f| {
                 let cx = self.cx.borrow();

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1873,7 +1873,7 @@ fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean
             document_non_exhaustive(self.it)
         }
 
-        fn render_field<'b>(
+        fn render_field_in_span<'b>(
             &'b self,
             index: &'b usize,
             field: &'b clean::Item,
@@ -1884,16 +1884,24 @@ fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean
                 let field_name =
                     field.name.map_or_else(|| index.to_string(), |sym| sym.as_str().to_string());
                 let id = cx.derive_id(format!("{}.{}", ItemType::StructField, field_name));
+                let ty = ty.print(*cx);
                 write!(
                     f,
                     "<span id=\"{id}\" class=\"{item_type} small-section-header\">\
                         <a href=\"#{id}\" class=\"anchor field\">§</a>\
                         <code>{field_name}: {ty}</code>\
                     </span>",
-                    ty = ty.print(*cx),
                     item_type = ItemType::StructField,
-                )?;
+                )
+            })
+        }
 
+        fn document_field<'b>(
+            &'b self,
+            field: &'b clean::Item,
+        ) -> impl fmt::Display + Captures<'a> + 'b + Captures<'cx> {
+            display_fn(move |f| {
+                let mut cx = self.cx.borrow_mut();
                 let v = document(*cx, field, Some(self.it), HeadingOffset::H3);
                 write!(f, "{v}")
             })

--- a/src/librustdoc/html/templates/item_struct.html
+++ b/src/librustdoc/html/templates/item_struct.html
@@ -1,8 +1,8 @@
 <pre class="rust item-decl"><code>
-    {{ self.render_attributes_in_code() | safe }}
+    {{ self::item_template_render_attributes_in_code(self.borrow()) | safe }}
     {{ self.render_struct() | safe }}
 </code></pre>
-{{ self.document() | safe }}
+{{ self::item_template_document(self.borrow()) | safe }}
 {% if self.should_render_fields %}
     <h2 id="fields" class="fields small-section header">
         {% if self.s.ctor_kind.is_none() %}
@@ -22,5 +22,5 @@
         {{ self.document_field(field.item) | safe }}
     {% endfor %}
 {% endif %}
-{{ self.render_assoc_items() | safe }}
-{{ self.document_type_layout() | safe }}
+{{ self::item_template_render_assoc_items(self.borrow()) | safe }}
+{{ self::item_template_document_type_layout(self.borrow()) | safe }}

--- a/src/librustdoc/html/templates/item_struct.html
+++ b/src/librustdoc/html/templates/item_struct.html
@@ -3,7 +3,7 @@
     {{ self.render_struct() | safe }}
 </code></pre>
 {{ self.document() | safe }}
-{% if self.should_render_fields() %}
+{% if self.should_render_fields %}
     <h2 id="fields" class="fields small-section header">
         {% if self.s.ctor_kind.is_none() %}
             Fields
@@ -14,7 +14,7 @@
         <a href="#fields" class="anchor">§</a>
     </h2>
     {{ self::document_non_exhaustive(self.it) | safe }}
-    {% for (index, (field, ty)) in self.fields().enumerate() %}
+    {% for (index, (field, ty)) in self::struct_field_items(self.s).enumerate() %}
         {{ self.render_field_in_span(index, field, ty) | safe }}
         {{ self.document_field(field) | safe }}
     {% endfor %}

--- a/src/librustdoc/html/templates/item_struct.html
+++ b/src/librustdoc/html/templates/item_struct.html
@@ -1,5 +1,5 @@
 <pre class="rust item-decl"><code>
-    {{ self.render_attributes_in_code() | safe }}
+    {{ self::render_attributes_in_code(self.it, self.cx.borrow().tcx()) | safe }}
     {{ self.render_struct() | safe }}
 </code></pre>
 {{ self.document() | safe }}
@@ -10,10 +10,10 @@
         {% else %}
             Tuple Fields
         {% endif %}
-        {{ self.document_non_exhaustive_header() | safe }}
+        {{ self::document_non_exhaustive_header(self.it) | safe }}
         <a href="#fields" class="anchor">§</a>
     </h2>
-    {{ self.document_non_exhaustive() | safe }}
+    {{ self::document_non_exhaustive(self.it) | safe }}
     {% for (index, (field, ty)) in self.fields().enumerate() %}
         {{ self.render_field_in_span(index, field, ty) | safe }}
         {{ self.document_field(field) | safe }}

--- a/src/librustdoc/html/templates/item_struct.html
+++ b/src/librustdoc/html/templates/item_struct.html
@@ -15,7 +15,8 @@
     </h2>
     {{ self.document_non_exhaustive() | safe }}
     {% for (index, (field, ty)) in self.fields().enumerate() %}
-        {{ self.render_field(index, field, ty) | safe }}
+        {{ self.render_field_in_span(index, field, ty) | safe }}
+        {{ self.document_field(field) | safe }}
     {% endfor %}
 {% endif %}
 {{ self.render_assoc_items() | safe }}

--- a/src/librustdoc/html/templates/item_struct.html
+++ b/src/librustdoc/html/templates/item_struct.html
@@ -1,0 +1,8 @@
+<pre class="rust item-decl"><code>
+    {{ self.render_attributes_in_code() | safe }}
+    {{ self.render_struct() | safe }}
+</code></pre>
+{{ self.document() | safe }}
+{{ self.render_fields() | safe }}
+{{ self.render_assoc_items() | safe }}
+{{ self.document_type_layout() | safe }}

--- a/src/librustdoc/html/templates/item_struct.html
+++ b/src/librustdoc/html/templates/item_struct.html
@@ -1,8 +1,8 @@
 <pre class="rust item-decl"><code>
-    {{ self::item_template_render_attributes_in_code(self.borrow()) | safe }}
+    {{ self.render_attributes_in_code() | safe }}
     {{ self.render_struct() | safe }}
 </code></pre>
-{{ self::item_template_document(self.borrow()) | safe }}
+{{ self.document() | safe }}
 {% if self.should_render_fields %}
     <h2 id="fields" class="fields small-section header">
         {% if self.s.ctor_kind.is_none() %}
@@ -22,5 +22,5 @@
         {{ self.document_field(field.item) | safe }}
     {% endfor %}
 {% endif %}
-{{ self::item_template_render_assoc_items(self.borrow()) | safe }}
-{{ self::item_template_document_type_layout(self.borrow()) | safe }}
+{{ self.render_assoc_items() | safe }}
+{{ self.document_type_layout() | safe }}

--- a/src/librustdoc/html/templates/item_struct.html
+++ b/src/librustdoc/html/templates/item_struct.html
@@ -3,6 +3,20 @@
     {{ self.render_struct() | safe }}
 </code></pre>
 {{ self.document() | safe }}
-{{ self.render_fields() | safe }}
+{% if self.should_render_fields() %}
+    <h2 id="fields" class="fields small-section header">
+        {% if self.s.ctor_kind.is_none() %}
+            Fields
+        {% else %}
+            Tuple Fields
+        {% endif %}
+        {{ self.document_non_exhaustive_header() | safe }}
+        <a href="#fields" class="anchor">§</a>
+    </h2>
+    {{ self.document_non_exhaustive() | safe }}
+    {% for (index, (field, ty)) in self.fields().enumerate() %}
+        {{ self.render_field(index, field, ty) | safe }}
+    {% endfor %}
+{% endif %}
 {{ self.render_assoc_items() | safe }}
 {{ self.document_type_layout() | safe }}

--- a/src/librustdoc/html/templates/item_struct.html
+++ b/src/librustdoc/html/templates/item_struct.html
@@ -1,5 +1,5 @@
 <pre class="rust item-decl"><code>
-    {{ self::render_attributes_in_code(self.it, self.cx.borrow().tcx()) | safe }}
+    {{ self.render_attributes_in_code() | safe }}
     {{ self.render_struct() | safe }}
 </code></pre>
 {{ self.document() | safe }}

--- a/src/librustdoc/html/templates/item_struct.html
+++ b/src/librustdoc/html/templates/item_struct.html
@@ -14,9 +14,12 @@
         <a href="#fields" class="anchor">§</a>
     </h2>
     {{ self::document_non_exhaustive(self.it) | safe }}
-    {% for (index, (field, ty)) in self::struct_field_items(self.s).enumerate() %}
-        {{ self.render_field_in_span(index, field, ty) | safe }}
-        {{ self.document_field(field) | safe }}
+    {% for field in self.struct_field_items_iter() %}
+        <span id="{{ field.id }}" class="{{ ItemType::StructField ~}} small-section-header">
+            <a href="#{{ field.id }}" class="anchor field">§</a>
+            <code>{{ field.name|safe }}: {{~ field.ty|safe }}</code>
+        </span>
+        {{ self.document_field(field.item) | safe }}
     {% endfor %}
 {% endif %}
 {{ self.render_assoc_items() | safe }}


### PR DESCRIPTION
Part of #108868 