### PR TITLE
Use visit_assign to detect SSA locals.

### DIFF
--- a/tests/mir-opt/copy-prop/partial_init.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/partial_init.main.CopyProp.diff
@@ -1,0 +1,13 @@
+- // MIR for `main` before CopyProp
++ // MIR for `main` after CopyProp
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/partial_init.rs:+0:15: +0:15
+      let mut _1: (isize,);                // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+  
+      bb0: {
+          (_1.0: isize) = const 1_isize;   // scope 0 at $DIR/partial_init.rs:+4:13: +4:20
+          return;                          // scope 0 at $DIR/partial_init.rs:+5:13: +5:21
+      }
+  }
+  

--- a/tests/mir-opt/copy-prop/partial_init.rs
+++ b/tests/mir-opt/copy-prop/partial_init.rs
@@ -1,0 +1,18 @@
+// unit-test: CopyProp
+// Verify that we do not ICE on partial initializations.
+
+#![feature(custom_mir, core_intrinsics)]
+extern crate core;
+use core::intrinsics::mir::*;
+
+// EMIT_MIR partial_init.main.CopyProp.diff
+#[custom_mir(dialect = "runtime", phase = "post-cleanup")]
+pub fn main() {
+    mir! (
+        let x: (isize, );
+        {
+            x.0 = 1;
+            Return()
+        }
+    )
+}


### PR DESCRIPTION
I screwed up the logic in 3c43b61b870add2daddbd8e480477e5a8aa409c2.

Fixes https://github.com/rust-lang/rust/issues/111426