### PR TITLE
Fix backtrace normalization in ice-bug-report-url.rs

### DIFF
--- a/tests/rustdoc-ui/ice-bug-report-url.rs
+++ b/tests/rustdoc-ui/ice-bug-report-url.rs
@@ -6,8 +6,8 @@
 // normalize-stderr-test "note: compiler flags.*\n\n" -> ""
 // normalize-stderr-test "note: rustc.*running on.*" -> "note: rustc {version} running on {platform}"
 // normalize-stderr-test "thread.*panicked at .*, compiler.*" -> "thread panicked at 'aborting due to `-Z treat-err-as-bug`'"
-// normalize-stderr-test "\s*\d{1,}: .*\n" -> ""
-// normalize-stderr-test "\s at .*\n" -> ""
+// normalize-stderr-test " +\d{1,}: .*\n" -> ""
+// normalize-stderr-test " + at .*\n" -> ""
 // normalize-stderr-test ".*note: Some details are omitted.*\n" -> ""
 
 fn wrong()

--- a/tests/rustdoc-ui/ice-bug-report-url.stderr
+++ b/tests/rustdoc-ui/ice-bug-report-url.stderr
@@ -6,6 +6,7 @@ LL | fn wrong()
 
 thread panicked at 'aborting due to `-Z treat-err-as-bug`'
 stack backtrace:
+
 error: the compiler unexpectedly panicked. this is a bug.
 
 note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-rustdoc&template=ice.md


### PR DESCRIPTION
This test case currently fails on s390x, and probably other platforms where the last line of a backtrace does not contain and " at <source location>" specification.

The problem with the existing normalization lines
// normalize-stderr-test "\s*\d{1,}: .*\n" -> ""
// normalize-stderr-test "\s at .*\n" -> ""
is that \s matches all whitespace, including newlines, so the first (but not second) of these regexes may merge multiple lines.  Thus the output differs depending on which of these matches on the last line of a backtrace.

As the whitespace used in backtraces is just normal space characters, change both regexes to just match at least one space character instead:
// normalize-stderr-test " +\d{1,}: .*\n" -> ""
// normalize-stderr-test " + at .*\n" -> ""