### PR TITLE
Allow MIR debuginfo to point to a variable's address

### DIFF
--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -448,7 +448,15 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
         };
         match debuginfo.value {
             VarDebugInfoContents::Const(_) => {}
-            VarDebugInfoContents::Place(place) => check_place(place),
+            VarDebugInfoContents::Place(place) => {
+                check_place(place);
+                if debuginfo.references != 0 && place.projection.last() == Some(&PlaceElem::Deref) {
+                    self.fail(
+                        START_BLOCK.start_location(),
+                        format!("debuginfo {:?}, has both ref and deref", debuginfo),
+                    );
+                }
+            }
             VarDebugInfoContents::Composite { ty, ref fragments } => {
                 for f in fragments {
                     check_place(f.contents);

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1554,8 +1554,11 @@ impl<V, T> ProjectionElem<V, T> {
     /// Returns `true` if this is accepted inside `VarDebugInfoContents::Place`.
     pub fn can_use_in_debuginfo(&self) -> bool {
         match self {
-            Self::Deref | Self::Downcast(_, _) | Self::Field(_, _) => true,
-            Self::ConstantIndex { .. }
+            Self::ConstantIndex { from_end: false, .. }
+            | Self::Deref
+            | Self::Downcast(_, _)
+            | Self::Field(_, _) => true,
+            Self::ConstantIndex { from_end: true, .. }
             | Self::Index(_)
             | Self::OpaqueCast(_)
             | Self::Subslice { .. } => false,

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -551,8 +551,13 @@ fn write_scope_tree(
         }
 
         let indented_debug_info = format!(
-            "{0:1$}debug {2} => {3:?};",
-            INDENT, indent, var_debug_info.name, var_debug_info.value,
+            "{0:1$}debug {2} => {3:&<4$}{5:?};",
+            INDENT,
+            indent,
+            var_debug_info.name,
+            "",
+            var_debug_info.references as usize,
+            var_debug_info.value,
         );
 
         writeln!(

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -842,6 +842,7 @@ macro_rules! make_mir_visitor {
                     source_info,
                     value,
                     argument_index: _,
+                    references: _,
                 } = var_debug_info;
 
                 self.visit_source_info(source_info);

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -204,6 +204,7 @@ CloneLiftImpls! {
     (),
     bool,
     usize,
+    u8,
     u16,
     u32,
     u64,

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -2241,6 +2241,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.var_debug_info.push(VarDebugInfo {
             name,
             source_info: debug_source_info,
+            references: 0,
             value: VarDebugInfoContents::Place(for_arm_body.into()),
             argument_index: None,
         });
@@ -2260,6 +2261,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.var_debug_info.push(VarDebugInfo {
                 name,
                 source_info: debug_source_info,
+                references: 0,
                 value: VarDebugInfoContents::Place(ref_for_guard.into()),
                 argument_index: None,
             });

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -798,6 +798,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 };
                 self.var_debug_info.push(VarDebugInfo {
                     name,
+                    references: 0,
                     source_info: SourceInfo::outermost(captured_place.var_ident.span),
                     value: VarDebugInfoContents::Place(use_place),
                     argument_index: None,
@@ -828,6 +829,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.var_debug_info.push(VarDebugInfo {
                     name,
                     source_info,
+                    references: 0,
                     value: VarDebugInfoContents::Place(arg_local.into()),
                     argument_index: Some(argument_index as u16 + 1),
                 });

--- a/compiler/rustc_mir_transform/src/ref_prop.rs
+++ b/compiler/rustc_mir_transform/src/ref_prop.rs
@@ -77,11 +77,11 @@ impl<'tcx> MirPass<'tcx> for ReferencePropagation {
     #[instrument(level = "trace", skip(self, tcx, body))]
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         debug!(def_id = ?body.source.def_id());
-        propagate_ssa(tcx, body);
+        while propagate_ssa(tcx, body) {}
     }
 }
 
-fn propagate_ssa<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+fn propagate_ssa<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) -> bool {
     let ssa = SsaLocals::new(body);
 
     let mut replacer = compute_replacement(tcx, body, &ssa);
@@ -94,6 +94,8 @@ fn propagate_ssa<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     if replacer.any_replacement {
         crate::simplify::remove_unused_definitions(body);
     }
+
+    replacer.any_replacement
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/compiler/rustc_mir_transform/src/ref_prop.rs
+++ b/compiler/rustc_mir_transform/src/ref_prop.rs
@@ -363,8 +363,10 @@ impl<'tcx> MutVisitor<'tcx> for Replacer<'tcx> {
             if let Some((&PlaceElem::Deref, rest)) = target.projection.split_last() {
                 *place = Place::from(target.local).project_deeper(rest, self.tcx);
                 self.any_replacement = true;
-            } else if self.fully_replacable_locals.contains(place.local) {
-                debuginfo.references += 1;
+            } else if self.fully_replacable_locals.contains(place.local)
+                && let Some(references) = debuginfo.references.checked_add(1)
+            {
+                debuginfo.references = references;
                 *place = target;
                 self.any_replacement = true;
             }

--- a/compiler/rustc_type_ir/src/structural_impls.rs
+++ b/compiler/rustc_type_ir/src/structural_impls.rs
@@ -21,6 +21,7 @@ TrivialTypeTraversalImpls! {
     (),
     bool,
     usize,
+    u8,
     u16,
     u32,
     u64,

--- a/tests/debuginfo/reference-debuginfo.rs
+++ b/tests/debuginfo/reference-debuginfo.rs
@@ -52,6 +52,9 @@
 // gdb-command:print *f64_ref
 // gdb-check:$14 = 3.5
 
+// gdb-command:print *f64_double_ref
+// gdb-check:$15 = 3.5
+
 
 // === LLDB TESTS ==================================================================================
 
@@ -112,6 +115,10 @@
 // lldbg-check:[...]$12 = 3.5
 // lldbr-check:(f64) *f64_ref = 3.5
 
+// lldb-command:print *f64_double_ref
+// lldbg-check:[...]$13 = 3.5
+// lldbr-check:(f64) **f64_double_ref = 3.5
+
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
@@ -158,6 +165,7 @@ fn main() {
 
     let f64_val: f64 = 3.5;
     let f64_ref: &f64 = &f64_val;
+    let f64_double_ref: &f64 = &f64_ref;
 
     zzz(); // #break
 }

--- a/tests/debuginfo/reference-debuginfo.rs
+++ b/tests/debuginfo/reference-debuginfo.rs
@@ -1,0 +1,165 @@
+// Copy of `borrowed-basic.rs` which enables the `ReferencePropagation` MIR pass.
+// That pass replaces debuginfo for `a => _x` where `_x = &b` to be `a => &b`,
+// and leaves codegen to create a ladder of allocations so as `*a == b`.
+//
+// compile-flags:-g -Zmir-enable-passes=+ReferencePropagation,-ConstDebugInfo
+// min-lldb-version: 310
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+// gdb-command:print *bool_ref
+// gdb-check:$1 = true
+
+// gdb-command:print *int_ref
+// gdb-check:$2 = -1
+
+// gdb-command:print/d *char_ref
+// gdb-check:$3 = 97
+
+// gdb-command:print *i8_ref
+// gdbg-check:$4 = 68 'D'
+// gdbr-check:$4 = 68
+
+// gdb-command:print *i16_ref
+// gdb-check:$5 = -16
+
+// gdb-command:print *i32_ref
+// gdb-check:$6 = -32
+
+// gdb-command:print *i64_ref
+// gdb-check:$7 = -64
+
+// gdb-command:print *uint_ref
+// gdb-check:$8 = 1
+
+// gdb-command:print *u8_ref
+// gdbg-check:$9 = 100 'd'
+// gdbr-check:$9 = 100
+
+// gdb-command:print *u16_ref
+// gdb-check:$10 = 16
+
+// gdb-command:print *u32_ref
+// gdb-check:$11 = 32
+
+// gdb-command:print *u64_ref
+// gdb-check:$12 = 64
+
+// gdb-command:print *f32_ref
+// gdb-check:$13 = 2.5
+
+// gdb-command:print *f64_ref
+// gdb-check:$14 = 3.5
+
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+// lldb-command:print *bool_ref
+// lldbg-check:[...]$0 = true
+// lldbr-check:(bool) *bool_ref = true
+
+// lldb-command:print *int_ref
+// lldbg-check:[...]$1 = -1
+// lldbr-check:(isize) *int_ref = -1
+
+// NOTE: only rust-enabled lldb supports 32bit chars
+// lldbr-command:print *char_ref
+// lldbr-check:(char) *char_ref = 'a'
+
+// lldb-command:print *i8_ref
+// lldbg-check:[...]$2 = 'D'
+// lldbr-check:(i8) *i8_ref = 68
+
+// lldb-command:print *i16_ref
+// lldbg-check:[...]$3 = -16
+// lldbr-check:(i16) *i16_ref = -16
+
+// lldb-command:print *i32_ref
+// lldbg-check:[...]$4 = -32
+// lldbr-check:(i32) *i32_ref = -32
+
+// lldb-command:print *i64_ref
+// lldbg-check:[...]$5 = -64
+// lldbr-check:(i64) *i64_ref = -64
+
+// lldb-command:print *uint_ref
+// lldbg-check:[...]$6 = 1
+// lldbr-check:(usize) *uint_ref = 1
+
+// lldb-command:print *u8_ref
+// lldbg-check:[...]$7 = 'd'
+// lldbr-check:(u8) *u8_ref = 100
+
+// lldb-command:print *u16_ref
+// lldbg-check:[...]$8 = 16
+// lldbr-check:(u16) *u16_ref = 16
+
+// lldb-command:print *u32_ref
+// lldbg-check:[...]$9 = 32
+// lldbr-check:(u32) *u32_ref = 32
+
+// lldb-command:print *u64_ref
+// lldbg-check:[...]$10 = 64
+// lldbr-check:(u64) *u64_ref = 64
+
+// lldb-command:print *f32_ref
+// lldbg-check:[...]$11 = 2.5
+// lldbr-check:(f32) *f32_ref = 2.5
+
+// lldb-command:print *f64_ref
+// lldbg-check:[...]$12 = 3.5
+// lldbr-check:(f64) *f64_ref = 3.5
+
+#![allow(unused_variables)]
+#![feature(omit_gdb_pretty_printer_section)]
+#![omit_gdb_pretty_printer_section]
+
+fn main() {
+    let bool_val: bool = true;
+    let bool_ref: &bool = &bool_val;
+
+    let int_val: isize = -1;
+    let int_ref: &isize = &int_val;
+
+    let char_val: char = 'a';
+    let char_ref: &char = &char_val;
+
+    let i8_val: i8 = 68;
+    let i8_ref: &i8 = &i8_val;
+
+    let i16_val: i16 = -16;
+    let i16_ref: &i16 = &i16_val;
+
+    let i32_val: i32 = -32;
+    let i32_ref: &i32 = &i32_val;
+
+    let i64_val: i64 = -64;
+    let i64_ref: &i64 = &i64_val;
+
+    let uint_val: usize = 1;
+    let uint_ref: &usize = &uint_val;
+
+    let u8_val: u8 = 100;
+    let u8_ref: &u8 = &u8_val;
+
+    let u16_val: u16 = 16;
+    let u16_ref: &u16 = &u16_val;
+
+    let u32_val: u32 = 32;
+    let u32_ref: &u32 = &u32_val;
+
+    let u64_val: u64 = 64;
+    let u64_ref: &u64 = &u64_val;
+
+    let f32_val: f32 = 2.5;
+    let f32_ref: &f32 = &f32_val;
+
+    let f64_val: f64 = 3.5;
+    let f64_ref: &f64 = &f64_val;
+
+    zzz(); // #break
+}
+
+fn zzz() {()}

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -21,9 +21,9 @@
           let _13: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
           let _14: &T;                     // in scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
           scope 2 {
-              debug v1 => _12;             // in scope 2 at $DIR/issue_76432.rs:+3:10: +3:16
-              debug v2 => _13;             // in scope 2 at $DIR/issue_76432.rs:+3:18: +3:24
-              debug v3 => _14;             // in scope 2 at $DIR/issue_76432.rs:+3:26: +3:32
+              debug v1 => &(*_2)[0 of 3];  // in scope 2 at $DIR/issue_76432.rs:+3:10: +3:16
+              debug v2 => &(*_2)[1 of 3];  // in scope 2 at $DIR/issue_76432.rs:+3:18: +3:24
+              debug v3 => &(*_2)[2 of 3];  // in scope 2 at $DIR/issue_76432.rs:+3:26: +3:32
           }
       }
   
@@ -52,15 +52,6 @@
       }
   
       bb2: {
-          StorageLive(_12);                // scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
-          _12 = &(*_2)[0 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:10: +3:16
-          StorageLive(_13);                // scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
-          _13 = &(*_2)[1 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:18: +3:24
-          StorageLive(_14);                // scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
-          _14 = &(*_2)[2 of 3];            // scope 1 at $DIR/issue_76432.rs:+3:26: +3:32
-          StorageDead(_14);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
-          StorageDead(_13);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
-          StorageDead(_12);                // scope 1 at $DIR/issue_76432.rs:+3:84: +3:85
           StorageDead(_5);                 // scope 0 at $DIR/issue_76432.rs:+6:1: +6:2
           StorageDead(_2);                 // scope 0 at $DIR/issue_76432.rs:+6:1: +6:2
           return;                          // scope 0 at $DIR/issue_76432.rs:+6:2: +6:2

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -9,41 +9,50 @@
       let _6: ();                          // in scope 0 at $DIR/reference_prop.rs:+9:5: +12:6
       let mut _7: std::option::Option<i32>; // in scope 0 at $DIR/reference_prop.rs:+9:11: +9:18
       let mut _8: isize;                   // in scope 0 at $DIR/reference_prop.rs:+10:9: +10:13
-      let mut _10: &[i32];                 // in scope 0 at $DIR/reference_prop.rs:+16:82: +16:94
-      let _11: &[i32];                     // in scope 0 at $DIR/reference_prop.rs:+16:83: +16:94
-      let mut _12: &[i32; 10];             // in scope 0 at $DIR/reference_prop.rs:+16:83: +16:90
-      let _13: [i32; 10];                  // in scope 0 at $DIR/reference_prop.rs:+16:83: +16:90
-      let mut _14: std::ops::RangeFull;    // in scope 0 at $DIR/reference_prop.rs:+16:91: +16:93
-      let mut _15: usize;                  // in scope 0 at $DIR/reference_prop.rs:+16:12: +16:79
+      let _10: ();                         // in scope 0 at $DIR/reference_prop.rs:+16:5: +17:6
+      let mut _11: &[i32];                 // in scope 0 at $DIR/reference_prop.rs:+16:82: +16:94
+      let _12: &[i32];                     // in scope 0 at $DIR/reference_prop.rs:+16:83: +16:94
+      let mut _13: &[i32; 10];             // in scope 0 at $DIR/reference_prop.rs:+16:83: +16:90
+      let _14: [i32; 10];                  // in scope 0 at $DIR/reference_prop.rs:+16:83: +16:90
+      let mut _15: std::ops::RangeFull;    // in scope 0 at $DIR/reference_prop.rs:+16:91: +16:93
       let mut _16: usize;                  // in scope 0 at $DIR/reference_prop.rs:+16:12: +16:79
-      let mut _17: bool;                   // in scope 0 at $DIR/reference_prop.rs:+16:12: +16:79
+      let mut _17: usize;                  // in scope 0 at $DIR/reference_prop.rs:+16:12: +16:79
+      let mut _18: bool;                   // in scope 0 at $DIR/reference_prop.rs:+16:12: +16:79
+      let _23: &&mut u8;                   // in scope 0 at $DIR/reference_prop.rs:+19:28: +19:40
+      let _24: &mut u8;                    // in scope 0 at $DIR/reference_prop.rs:+19:29: +19:40
+      let mut _25: debuginfo::T;           // in scope 0 at $DIR/reference_prop.rs:+19:34: +19:38
       scope 1 {
 -         debug ref_mut_u8 => _1;          // in scope 1 at $DIR/reference_prop.rs:+3:9: +3:19
 +         debug ref_mut_u8 => &_2;         // in scope 1 at $DIR/reference_prop.rs:+3:9: +3:19
           let _3: &u8;                     // in scope 1 at $DIR/reference_prop.rs:+4:9: +4:14
-          let mut _23: &debuginfo::T;      // in scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
+          let mut _28: &debuginfo::T;      // in scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
           scope 2 {
 -             debug field => _3;           // in scope 2 at $DIR/reference_prop.rs:+4:9: +4:14
-+             debug field => &((*_23).0: u8); // in scope 2 at $DIR/reference_prop.rs:+4:9: +4:14
++             debug field => &((*_28).0: u8); // in scope 2 at $DIR/reference_prop.rs:+4:9: +4:14
               let _5: &u8;                 // in scope 2 at $DIR/reference_prop.rs:+7:9: +7:17
               scope 3 {
 -                 debug reborrow => _5;    // in scope 3 at $DIR/reference_prop.rs:+7:9: +7:17
 +                 debug reborrow => &_2;   // in scope 3 at $DIR/reference_prop.rs:+7:9: +7:17
                   let _9: &i32;            // in scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
-                  let mut _22: &std::option::Option<i32>; // in scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
+                  let _22: &&&mut u8;      // in scope 3 at $DIR/reference_prop.rs:+19:9: +19:24
+                  let mut _27: &std::option::Option<i32>; // in scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
                   scope 4 {
 -                     debug variant_field => _9; // in scope 4 at $DIR/reference_prop.rs:+11:14: +11:31
-+                     debug variant_field => &(((*_22) as Some).0: i32); // in scope 4 at $DIR/reference_prop.rs:+11:14: +11:31
++                     debug variant_field => &(((*_27) as Some).0: i32); // in scope 4 at $DIR/reference_prop.rs:+11:14: +11:31
                   }
                   scope 5 {
--                     debug constant_index => _18; // in scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
-+                     debug constant_index => &(*_10)[1 of 3]; // in scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
-                      debug subslice => _19; // in scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
-                      debug constant_index_from_end => _20; // in scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
-                      let _18: &i32;       // in scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
-                      let _19: &[i32];     // in scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
-                      let _20: &i32;       // in scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
-                      let mut _21: &[i32; 10]; // in scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
+-                     debug constant_index => _19; // in scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
++                     debug constant_index => &(*_11)[1 of 3]; // in scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
+                      debug subslice => _20; // in scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
+                      debug constant_index_from_end => _21; // in scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
+                      let _19: &i32;       // in scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
+                      let _20: &[i32];     // in scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
+                      let _21: &i32;       // in scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
+                      let mut _26: &[i32; 10]; // in scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
+                  }
+                  scope 6 {
+-                     debug multiple_borrow => _22; // in scope 6 at $DIR/reference_prop.rs:+19:9: +19:24
++                     debug multiple_borrow => &&&(_25.0: u8); // in scope 6 at $DIR/reference_prop.rs:+19:9: +19:24
                   }
               }
           }
@@ -55,11 +64,11 @@
           _2 = const 5_u8;                 // scope 0 at $DIR/reference_prop.rs:+3:27: +3:31
 -         _1 = &mut _2;                    // scope 0 at $DIR/reference_prop.rs:+3:22: +3:31
 -         StorageLive(_3);                 // scope 1 at $DIR/reference_prop.rs:+4:9: +4:14
-          _23 = const _;                   // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
+          _28 = const _;                   // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:535:17: 535:24
                                            // + literal: Const { ty: &T, val: Unevaluated(debuginfo, [], Some(promoted[2])) }
--         _3 = &((*_23).0: u8);            // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
+-         _3 = &((*_28).0: u8);            // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
 -         StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+7:9: +7:17
 -         _5 = &(*_1);                     // scope 2 at $DIR/reference_prop.rs:+7:20: +7:32
 -         StorageLive(_6);                 // scope 3 at $DIR/reference_prop.rs:+9:5: +12:6
@@ -71,11 +80,11 @@
   
       bb1: {
 -         StorageLive(_9);                 // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
-          _22 = const _;                   // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
+          _27 = const _;                   // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:542:14: 542:31
                                            // + literal: Const { ty: &Option<i32>, val: Unevaluated(debuginfo, [], Some(promoted[1])) }
--         _9 = &(((*_22) as Some).0: i32); // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
+-         _9 = &(((*_27) as Some).0: i32); // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
 -         _6 = const ();                   // scope 4 at $DIR/reference_prop.rs:+11:36: +11:38
 -         StorageDead(_9);                 // scope 3 at $DIR/reference_prop.rs:+11:37: +11:38
           goto -> bb4;                     // scope 3 at $DIR/reference_prop.rs:+11:37: +11:38
@@ -93,59 +102,74 @@
       bb4: {
           StorageDead(_7);                 // scope 3 at $DIR/reference_prop.rs:+12:5: +12:6
 -         StorageDead(_6);                 // scope 3 at $DIR/reference_prop.rs:+12:5: +12:6
-          StorageLive(_10);                // scope 5 at $DIR/reference_prop.rs:+16:82: +16:94
-          StorageLive(_11);                // scope 5 at $DIR/reference_prop.rs:+16:83: +16:94
-          StorageLive(_12);                // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
-          _21 = const _;                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
+-         StorageLive(_10);                // scope 3 at $DIR/reference_prop.rs:+16:5: +17:6
+          StorageLive(_11);                // scope 5 at $DIR/reference_prop.rs:+16:82: +16:94
+          StorageLive(_12);                // scope 5 at $DIR/reference_prop.rs:+16:83: +16:94
+          StorageLive(_13);                // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
+          _26 = const _;                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:547:83: 547:90
                                            // + literal: Const { ty: &[i32; 10], val: Unevaluated(debuginfo, [], Some(promoted[0])) }
-          _12 = &(*_21);                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
-          StorageLive(_14);                // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93
-          _14 = RangeFull;                 // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93
-          _11 = <[i32; 10] as Index<RangeFull>>::index(move _12, move _14) -> bb5; // scope 5 at $DIR/reference_prop.rs:+16:83: +16:94
+          _13 = &(*_26);                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
+          StorageLive(_15);                // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93
+          _15 = RangeFull;                 // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93
+          _12 = <[i32; 10] as Index<RangeFull>>::index(move _13, move _15) -> bb5; // scope 5 at $DIR/reference_prop.rs:+16:83: +16:94
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:547:83: 547:94
                                            // + literal: Const { ty: for<'a> fn(&'a [i32; 10], RangeFull) -> &'a <[i32; 10] as Index<RangeFull>>::Output {<[i32; 10] as Index<RangeFull>>::index}, val: Value(<ZST>) }
       }
   
       bb5: {
-          StorageDead(_14);                // scope 5 at $DIR/reference_prop.rs:+16:93: +16:94
-          StorageDead(_12);                // scope 5 at $DIR/reference_prop.rs:+16:93: +16:94
-          _10 = &(*_11);                   // scope 5 at $DIR/reference_prop.rs:+16:82: +16:94
-          _15 = Len((*_10));               // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
-          _16 = const 3_usize;             // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
-          _17 = Ge(move _15, move _16);    // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
-          switchInt(move _17) -> [0: bb7, otherwise: bb6]; // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
+          StorageDead(_15);                // scope 5 at $DIR/reference_prop.rs:+16:93: +16:94
+          StorageDead(_13);                // scope 5 at $DIR/reference_prop.rs:+16:93: +16:94
+          _11 = &(*_12);                   // scope 5 at $DIR/reference_prop.rs:+16:82: +16:94
+          _16 = Len((*_11));               // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
+          _17 = const 3_usize;             // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
+          _18 = Ge(move _16, move _17);    // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
+          switchInt(move _18) -> [0: bb7, otherwise: bb6]; // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
       }
   
       bb6: {
--         StorageLive(_18);                // scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
--         _18 = &(*_10)[1 of 3];           // scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
-          StorageLive(_19);                // scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
-          _19 = &(*_10)[2:-1];             // scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
-          StorageLive(_20);                // scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
-          _20 = &(*_10)[-1 of 3];          // scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
-          _0 = const ();                   // scope 5 at $DIR/reference_prop.rs:+16:95: +17:6
+-         StorageLive(_19);                // scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
+-         _19 = &(*_11)[1 of 3];           // scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
+          StorageLive(_20);                // scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
+          _20 = &(*_11)[2:-1];             // scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
+          StorageLive(_21);                // scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
+          _21 = &(*_11)[-1 of 3];          // scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
+-         _10 = const ();                  // scope 5 at $DIR/reference_prop.rs:+16:95: +17:6
+          StorageDead(_21);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
           StorageDead(_20);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
-          StorageDead(_19);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
--         StorageDead(_18);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
+-         StorageDead(_19);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
           goto -> bb8;                     // scope 3 at $DIR/reference_prop.rs:+16:5: +17:6
       }
   
       bb7: {
-          _0 = const ();                   // scope 3 at $DIR/reference_prop.rs:+17:6: +17:6
+-         _10 = const ();                  // scope 3 at $DIR/reference_prop.rs:+17:6: +17:6
           goto -> bb8;                     // scope 3 at $DIR/reference_prop.rs:+16:5: +17:6
       }
   
       bb8: {
--         StorageDead(_5);                 // scope 2 at $DIR/reference_prop.rs:+18:1: +18:2
--         StorageDead(_3);                 // scope 1 at $DIR/reference_prop.rs:+18:1: +18:2
-          StorageDead(_2);                 // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
--         StorageDead(_1);                 // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
-          StorageDead(_11);                // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
-          StorageDead(_10);                // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
-          return;                          // scope 0 at $DIR/reference_prop.rs:+18:2: +18:2
+          StorageDead(_12);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
+          StorageDead(_11);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
+-         StorageDead(_10);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
+-         StorageLive(_22);                // scope 3 at $DIR/reference_prop.rs:+19:9: +19:24
+-         StorageLive(_23);                // scope 3 at $DIR/reference_prop.rs:+19:28: +19:40
+-         StorageLive(_24);                // scope 3 at $DIR/reference_prop.rs:+19:29: +19:40
+          StorageLive(_25);                // scope 3 at $DIR/reference_prop.rs:+19:34: +19:38
+          _25 = T(const 6_u8);             // scope 3 at $DIR/reference_prop.rs:+19:34: +19:38
+-         _24 = &mut (_25.0: u8);          // scope 3 at $DIR/reference_prop.rs:+19:29: +19:40
+-         _23 = &_24;                      // scope 3 at $DIR/reference_prop.rs:+19:28: +19:40
+-         _22 = &_23;                      // scope 3 at $DIR/reference_prop.rs:+19:27: +19:40
+          _0 = const ();                   // scope 0 at $DIR/reference_prop.rs:+0:16: +20:2
+          StorageDead(_25);                // scope 3 at $DIR/reference_prop.rs:+20:1: +20:2
+-         StorageDead(_24);                // scope 3 at $DIR/reference_prop.rs:+20:1: +20:2
+-         StorageDead(_23);                // scope 3 at $DIR/reference_prop.rs:+20:1: +20:2
+-         StorageDead(_22);                // scope 3 at $DIR/reference_prop.rs:+20:1: +20:2
+-         StorageDead(_5);                 // scope 2 at $DIR/reference_prop.rs:+20:1: +20:2
+-         StorageDead(_3);                 // scope 1 at $DIR/reference_prop.rs:+20:1: +20:2
+          StorageDead(_2);                 // scope 0 at $DIR/reference_prop.rs:+20:1: +20:2
+-         StorageDead(_1);                 // scope 0 at $DIR/reference_prop.rs:+20:1: +20:2
+          return;                          // scope 0 at $DIR/reference_prop.rs:+20:2: +20:2
       }
   }
   

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -1,0 +1,151 @@
+- // MIR for `debuginfo` before ReferencePropagation
++ // MIR for `debuginfo` after ReferencePropagation
+  
+  fn debuginfo() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/reference_prop.rs:+0:16: +0:16
+      let _1: &mut u8;                     // in scope 0 at $DIR/reference_prop.rs:+3:9: +3:19
+      let mut _2: u8;                      // in scope 0 at $DIR/reference_prop.rs:+3:27: +3:31
+      let _4: debuginfo::T;                // in scope 0 at $DIR/reference_prop.rs:+4:18: +4:22
+      let _6: ();                          // in scope 0 at $DIR/reference_prop.rs:+9:5: +12:6
+      let mut _7: std::option::Option<i32>; // in scope 0 at $DIR/reference_prop.rs:+9:11: +9:18
+      let mut _8: isize;                   // in scope 0 at $DIR/reference_prop.rs:+10:9: +10:13
+      let mut _10: &[i32];                 // in scope 0 at $DIR/reference_prop.rs:+16:82: +16:94
+      let _11: &[i32];                     // in scope 0 at $DIR/reference_prop.rs:+16:83: +16:94
+      let mut _12: &[i32; 10];             // in scope 0 at $DIR/reference_prop.rs:+16:83: +16:90
+      let _13: [i32; 10];                  // in scope 0 at $DIR/reference_prop.rs:+16:83: +16:90
+      let mut _14: std::ops::RangeFull;    // in scope 0 at $DIR/reference_prop.rs:+16:91: +16:93
+      let mut _15: usize;                  // in scope 0 at $DIR/reference_prop.rs:+16:12: +16:79
+      let mut _16: usize;                  // in scope 0 at $DIR/reference_prop.rs:+16:12: +16:79
+      let mut _17: bool;                   // in scope 0 at $DIR/reference_prop.rs:+16:12: +16:79
+      scope 1 {
+-         debug ref_mut_u8 => _1;          // in scope 1 at $DIR/reference_prop.rs:+3:9: +3:19
++         debug ref_mut_u8 => &_2;         // in scope 1 at $DIR/reference_prop.rs:+3:9: +3:19
+          let _3: &u8;                     // in scope 1 at $DIR/reference_prop.rs:+4:9: +4:14
+          let mut _23: &debuginfo::T;      // in scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
+          scope 2 {
+-             debug field => _3;           // in scope 2 at $DIR/reference_prop.rs:+4:9: +4:14
++             debug field => &((*_23).0: u8); // in scope 2 at $DIR/reference_prop.rs:+4:9: +4:14
+              let _5: &u8;                 // in scope 2 at $DIR/reference_prop.rs:+7:9: +7:17
+              scope 3 {
+-                 debug reborrow => _5;    // in scope 3 at $DIR/reference_prop.rs:+7:9: +7:17
++                 debug reborrow => _1;    // in scope 3 at $DIR/reference_prop.rs:+7:9: +7:17
+                  let _9: &i32;            // in scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
+                  let mut _22: &std::option::Option<i32>; // in scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
+                  scope 4 {
+-                     debug variant_field => _9; // in scope 4 at $DIR/reference_prop.rs:+11:14: +11:31
++                     debug variant_field => &(((*_22) as Some).0: i32); // in scope 4 at $DIR/reference_prop.rs:+11:14: +11:31
+                  }
+                  scope 5 {
+-                     debug constant_index => _18; // in scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
++                     debug constant_index => &(*_10)[1 of 3]; // in scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
+                      debug subslice => _19; // in scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
+                      debug constant_index_from_end => _20; // in scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
+                      let _18: &i32;       // in scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
+                      let _19: &[i32];     // in scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
+                      let _20: &i32;       // in scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
+                      let mut _21: &[i32; 10]; // in scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/reference_prop.rs:+3:9: +3:19
+          StorageLive(_2);                 // scope 0 at $DIR/reference_prop.rs:+3:27: +3:31
+          _2 = const 5_u8;                 // scope 0 at $DIR/reference_prop.rs:+3:27: +3:31
+          _1 = &mut _2;                    // scope 0 at $DIR/reference_prop.rs:+3:22: +3:31
+-         StorageLive(_3);                 // scope 1 at $DIR/reference_prop.rs:+4:9: +4:14
+          _23 = const _;                   // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:463:17: 463:24
+                                           // + literal: Const { ty: &T, val: Unevaluated(debuginfo, [], Some(promoted[2])) }
+-         _3 = &((*_23).0: u8);            // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
+-         StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+7:9: +7:17
+-         _5 = &(*_1);                     // scope 2 at $DIR/reference_prop.rs:+7:20: +7:32
+-         StorageLive(_6);                 // scope 3 at $DIR/reference_prop.rs:+9:5: +12:6
+          StorageLive(_7);                 // scope 3 at $DIR/reference_prop.rs:+9:11: +9:18
+          _7 = Option::<i32>::Some(const 0_i32); // scope 3 at $DIR/reference_prop.rs:+9:11: +9:18
+          _8 = discriminant(_7);           // scope 3 at $DIR/reference_prop.rs:+9:11: +9:18
+          switchInt(move _8) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 3 at $DIR/reference_prop.rs:+9:5: +9:18
+      }
+  
+      bb1: {
+-         StorageLive(_9);                 // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
+          _22 = const _;                   // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:470:14: 470:31
+                                           // + literal: Const { ty: &Option<i32>, val: Unevaluated(debuginfo, [], Some(promoted[1])) }
+-         _9 = &(((*_22) as Some).0: i32); // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
+-         _6 = const ();                   // scope 4 at $DIR/reference_prop.rs:+11:36: +11:38
+-         StorageDead(_9);                 // scope 3 at $DIR/reference_prop.rs:+11:37: +11:38
+          goto -> bb4;                     // scope 3 at $DIR/reference_prop.rs:+11:37: +11:38
+      }
+  
+      bb2: {
+          unreachable;                     // scope 3 at $DIR/reference_prop.rs:+9:11: +9:18
+      }
+  
+      bb3: {
+-         _6 = const ();                   // scope 3 at $DIR/reference_prop.rs:+10:17: +10:19
+          goto -> bb4;                     // scope 3 at $DIR/reference_prop.rs:+10:17: +10:19
+      }
+  
+      bb4: {
+          StorageDead(_7);                 // scope 3 at $DIR/reference_prop.rs:+12:5: +12:6
+-         StorageDead(_6);                 // scope 3 at $DIR/reference_prop.rs:+12:5: +12:6
+          StorageLive(_10);                // scope 5 at $DIR/reference_prop.rs:+16:82: +16:94
+          StorageLive(_11);                // scope 5 at $DIR/reference_prop.rs:+16:83: +16:94
+          StorageLive(_12);                // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
+          _21 = const _;                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:475:83: 475:90
+                                           // + literal: Const { ty: &[i32; 10], val: Unevaluated(debuginfo, [], Some(promoted[0])) }
+          _12 = &(*_21);                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
+          StorageLive(_14);                // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93
+          _14 = RangeFull;                 // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93
+          _11 = <[i32; 10] as Index<RangeFull>>::index(move _12, move _14) -> bb5; // scope 5 at $DIR/reference_prop.rs:+16:83: +16:94
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:475:83: 475:94
+                                           // + literal: Const { ty: for<'a> fn(&'a [i32; 10], RangeFull) -> &'a <[i32; 10] as Index<RangeFull>>::Output {<[i32; 10] as Index<RangeFull>>::index}, val: Value(<ZST>) }
+      }
+  
+      bb5: {
+          StorageDead(_14);                // scope 5 at $DIR/reference_prop.rs:+16:93: +16:94
+          StorageDead(_12);                // scope 5 at $DIR/reference_prop.rs:+16:93: +16:94
+          _10 = &(*_11);                   // scope 5 at $DIR/reference_prop.rs:+16:82: +16:94
+          _15 = Len((*_10));               // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
+          _16 = const 3_usize;             // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
+          _17 = Ge(move _15, move _16);    // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
+          switchInt(move _17) -> [0: bb7, otherwise: bb6]; // scope 5 at $DIR/reference_prop.rs:+16:12: +16:79
+      }
+  
+      bb6: {
+-         StorageLive(_18);                // scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
+-         _18 = &(*_10)[1 of 3];           // scope 5 at $DIR/reference_prop.rs:+16:16: +16:34
+          StorageLive(_19);                // scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
+          _19 = &(*_10)[2:-1];             // scope 5 at $DIR/reference_prop.rs:+16:36: +16:44
+          StorageLive(_20);                // scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
+          _20 = &(*_10)[-1 of 3];          // scope 5 at $DIR/reference_prop.rs:+16:51: +16:78
+          _0 = const ();                   // scope 5 at $DIR/reference_prop.rs:+16:95: +17:6
+          StorageDead(_20);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
+          StorageDead(_19);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
+-         StorageDead(_18);                // scope 3 at $DIR/reference_prop.rs:+17:5: +17:6
+          goto -> bb8;                     // scope 3 at $DIR/reference_prop.rs:+16:5: +17:6
+      }
+  
+      bb7: {
+          _0 = const ();                   // scope 3 at $DIR/reference_prop.rs:+17:6: +17:6
+          goto -> bb8;                     // scope 3 at $DIR/reference_prop.rs:+16:5: +17:6
+      }
+  
+      bb8: {
+-         StorageDead(_5);                 // scope 2 at $DIR/reference_prop.rs:+18:1: +18:2
+-         StorageDead(_3);                 // scope 1 at $DIR/reference_prop.rs:+18:1: +18:2
+          StorageDead(_2);                 // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
+          StorageDead(_1);                 // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
+          StorageDead(_11);                // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
+          StorageDead(_10);                // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
+          return;                          // scope 0 at $DIR/reference_prop.rs:+18:2: +18:2
+      }
+  }
+  

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -28,7 +28,7 @@
               let _5: &u8;                 // in scope 2 at $DIR/reference_prop.rs:+7:9: +7:17
               scope 3 {
 -                 debug reborrow => _5;    // in scope 3 at $DIR/reference_prop.rs:+7:9: +7:17
-+                 debug reborrow => _1;    // in scope 3 at $DIR/reference_prop.rs:+7:9: +7:17
++                 debug reborrow => &_2;   // in scope 3 at $DIR/reference_prop.rs:+7:9: +7:17
                   let _9: &i32;            // in scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
                   let mut _22: &std::option::Option<i32>; // in scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
                   scope 4 {
@@ -50,14 +50,14 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/reference_prop.rs:+3:9: +3:19
+-         StorageLive(_1);                 // scope 0 at $DIR/reference_prop.rs:+3:9: +3:19
           StorageLive(_2);                 // scope 0 at $DIR/reference_prop.rs:+3:27: +3:31
           _2 = const 5_u8;                 // scope 0 at $DIR/reference_prop.rs:+3:27: +3:31
-          _1 = &mut _2;                    // scope 0 at $DIR/reference_prop.rs:+3:22: +3:31
+-         _1 = &mut _2;                    // scope 0 at $DIR/reference_prop.rs:+3:22: +3:31
 -         StorageLive(_3);                 // scope 1 at $DIR/reference_prop.rs:+4:9: +4:14
           _23 = const _;                   // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:463:17: 463:24
+                                           // + span: $DIR/reference_prop.rs:535:17: 535:24
                                            // + literal: Const { ty: &T, val: Unevaluated(debuginfo, [], Some(promoted[2])) }
 -         _3 = &((*_23).0: u8);            // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
 -         StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+7:9: +7:17
@@ -73,7 +73,7 @@
 -         StorageLive(_9);                 // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
           _22 = const _;                   // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:470:14: 470:31
+                                           // + span: $DIR/reference_prop.rs:542:14: 542:31
                                            // + literal: Const { ty: &Option<i32>, val: Unevaluated(debuginfo, [], Some(promoted[1])) }
 -         _9 = &(((*_22) as Some).0: i32); // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
 -         _6 = const ();                   // scope 4 at $DIR/reference_prop.rs:+11:36: +11:38
@@ -98,14 +98,14 @@
           StorageLive(_12);                // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
           _21 = const _;                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:475:83: 475:90
+                                           // + span: $DIR/reference_prop.rs:547:83: 547:90
                                            // + literal: Const { ty: &[i32; 10], val: Unevaluated(debuginfo, [], Some(promoted[0])) }
           _12 = &(*_21);                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
           StorageLive(_14);                // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93
           _14 = RangeFull;                 // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93
           _11 = <[i32; 10] as Index<RangeFull>>::index(move _12, move _14) -> bb5; // scope 5 at $DIR/reference_prop.rs:+16:83: +16:94
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:475:83: 475:94
+                                           // + span: $DIR/reference_prop.rs:547:83: 547:94
                                            // + literal: Const { ty: for<'a> fn(&'a [i32; 10], RangeFull) -> &'a <[i32; 10] as Index<RangeFull>>::Output {<[i32; 10] as Index<RangeFull>>::index}, val: Value(<ZST>) }
       }
   
@@ -142,7 +142,7 @@
 -         StorageDead(_5);                 // scope 2 at $DIR/reference_prop.rs:+18:1: +18:2
 -         StorageDead(_3);                 // scope 1 at $DIR/reference_prop.rs:+18:1: +18:2
           StorageDead(_2);                 // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
-          StorageDead(_1);                 // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
+-         StorageDead(_1);                 // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
           StorageDead(_11);                // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
           StorageDead(_10);                // scope 0 at $DIR/reference_prop.rs:+18:1: +18:2
           return;                          // scope 0 at $DIR/reference_prop.rs:+18:2: +18:2

--- a/tests/mir-opt/reference_prop.dominate_storage.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.dominate_storage.ReferencePropagation.diff
@@ -24,7 +24,7 @@
           _5 = (*_2);                      // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
           _0 = opaque::<i32>(_5) -> bb3;   // scope 0 at $DIR/reference_prop.rs:+16:13: +16:38
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:383:28: 383:34
+                                           // + span: $DIR/reference_prop.rs:455:28: 455:34
                                            // + literal: Const { ty: fn(i32) {opaque::<i32>}, val: Value(<ZST>) }
       }
   

--- a/tests/mir-opt/reference_prop.maybe_dead.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.maybe_dead.ReferencePropagation.diff
@@ -29,7 +29,7 @@
           StorageDead(_3);                 // scope 0 at $DIR/reference_prop.rs:+21:13: +21:27
           _0 = opaque::<i32>(_6) -> bb2;   // scope 0 at $DIR/reference_prop.rs:+22:13: +22:38
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:417:28: 417:34
+                                           // + span: $DIR/reference_prop.rs:489:28: 489:34
                                            // + literal: Const { ty: fn(i32) {opaque::<i32>}, val: Value(<ZST>) }
       }
   
@@ -37,7 +37,7 @@
           _7 = (*_4);                      // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
           _0 = opaque::<i32>(_7) -> bb3;   // scope 0 at $DIR/reference_prop.rs:+27:13: +27:38
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:422:28: 422:34
+                                           // + span: $DIR/reference_prop.rs:494:28: 494:34
                                            // + literal: Const { ty: fn(i32) {opaque::<i32>}, val: Value(<ZST>) }
       }
   
@@ -45,7 +45,7 @@
           _8 = (*_5);                      // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
           _0 = opaque::<i32>(_8) -> bb4;   // scope 0 at $DIR/reference_prop.rs:+33:13: +33:43
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:428:33: 428:39
+                                           // + span: $DIR/reference_prop.rs:500:33: 500:39
                                            // + literal: Const { ty: fn(i32) {opaque::<i32>}, val: Value(<ZST>) }
       }
   

--- a/tests/mir-opt/reference_prop.multiple_storage.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.multiple_storage.ReferencePropagation.diff
@@ -16,7 +16,7 @@
           _3 = (*_2);                      // scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
           _0 = opaque::<i32>(_3) -> bb1;   // scope 0 at $DIR/reference_prop.rs:+14:13: +14:43
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:357:33: 357:39
+                                           // + span: $DIR/reference_prop.rs:429:33: 429:39
                                            // + literal: Const { ty: fn(i32) {opaque::<i32>}, val: Value(<ZST>) }
       }
   

--- a/tests/mir-opt/reference_prop.mut_raw_then_mut_shr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.mut_raw_then_mut_shr.ReferencePropagation.diff
@@ -13,13 +13,16 @@
           debug x => _1;                   // in scope 1 at $DIR/reference_prop.rs:+1:9: +1:14
           let _2: &mut i32;                // in scope 1 at $DIR/reference_prop.rs:+2:9: +2:13
           scope 2 {
-              debug xref => _2;            // in scope 2 at $DIR/reference_prop.rs:+2:9: +2:13
+-             debug xref => _2;            // in scope 2 at $DIR/reference_prop.rs:+2:9: +2:13
++             debug xref => &_1;           // in scope 2 at $DIR/reference_prop.rs:+2:9: +2:13
               let _3: *mut i32;            // in scope 2 at $DIR/reference_prop.rs:+3:9: +3:13
               scope 3 {
-                  debug xraw => _3;        // in scope 3 at $DIR/reference_prop.rs:+3:9: +3:13
+-                 debug xraw => _3;        // in scope 3 at $DIR/reference_prop.rs:+3:9: +3:13
++                 debug xraw => _4;        // in scope 3 at $DIR/reference_prop.rs:+3:9: +3:13
                   let _6: &i32;            // in scope 3 at $DIR/reference_prop.rs:+4:9: +4:13
                   scope 4 {
-                      debug xshr => _6;    // in scope 4 at $DIR/reference_prop.rs:+4:9: +4:13
+-                     debug xshr => _6;    // in scope 4 at $DIR/reference_prop.rs:+4:9: +4:13
++                     debug xshr => _2;    // in scope 4 at $DIR/reference_prop.rs:+4:9: +4:13
                       let _7: i32;         // in scope 4 at $DIR/reference_prop.rs:+6:9: +6:10
                       scope 5 {
                           debug a => _7;   // in scope 5 at $DIR/reference_prop.rs:+6:9: +6:10
@@ -36,18 +39,17 @@
           _1 = const 2_i32;                // scope 0 at $DIR/reference_prop.rs:+1:17: +1:18
 -         StorageLive(_2);                 // scope 1 at $DIR/reference_prop.rs:+2:9: +2:13
           _2 = &mut _1;                    // scope 1 at $DIR/reference_prop.rs:+2:16: +2:22
-          StorageLive(_3);                 // scope 2 at $DIR/reference_prop.rs:+3:9: +3:13
+-         StorageLive(_3);                 // scope 2 at $DIR/reference_prop.rs:+3:9: +3:13
 -         StorageLive(_4);                 // scope 2 at $DIR/reference_prop.rs:+3:16: +3:36
 -         StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+3:16: +3:26
 -         _5 = &mut (*_2);                 // scope 2 at $DIR/reference_prop.rs:+3:16: +3:26
 -         _4 = &raw mut (*_5);             // scope 2 at $DIR/reference_prop.rs:+3:16: +3:26
-+         _4 = &raw mut _1;                // scope 2 at $DIR/reference_prop.rs:+3:16: +3:26
-          _3 = _4;                         // scope 2 at $DIR/reference_prop.rs:+3:16: +3:36
+-         _3 = _4;                         // scope 2 at $DIR/reference_prop.rs:+3:16: +3:36
 -         StorageDead(_5);                 // scope 2 at $DIR/reference_prop.rs:+3:36: +3:37
 -         StorageDead(_4);                 // scope 2 at $DIR/reference_prop.rs:+3:36: +3:37
-          StorageLive(_6);                 // scope 3 at $DIR/reference_prop.rs:+4:9: +4:13
+-         StorageLive(_6);                 // scope 3 at $DIR/reference_prop.rs:+4:9: +4:13
 -         _6 = &(*_2);                     // scope 3 at $DIR/reference_prop.rs:+4:16: +4:22
-+         _6 = &_1;                        // scope 3 at $DIR/reference_prop.rs:+4:16: +4:22
++         _4 = &raw mut _1;                // scope 2 at $DIR/reference_prop.rs:+3:16: +3:26
           StorageLive(_7);                 // scope 4 at $DIR/reference_prop.rs:+6:9: +6:10
 -         _7 = (*_6);                      // scope 4 at $DIR/reference_prop.rs:+6:13: +6:18
 -         StorageLive(_8);                 // scope 5 at $DIR/reference_prop.rs:+7:5: +7:26
@@ -64,8 +66,8 @@
           StorageDead(_10);                // scope 5 at $DIR/reference_prop.rs:+8:10: +8:11
           StorageDead(_9);                 // scope 5 at $DIR/reference_prop.rs:+8:10: +8:11
           StorageDead(_7);                 // scope 4 at $DIR/reference_prop.rs:+9:1: +9:2
-          StorageDead(_6);                 // scope 3 at $DIR/reference_prop.rs:+9:1: +9:2
-          StorageDead(_3);                 // scope 2 at $DIR/reference_prop.rs:+9:1: +9:2
+-         StorageDead(_6);                 // scope 3 at $DIR/reference_prop.rs:+9:1: +9:2
+-         StorageDead(_3);                 // scope 2 at $DIR/reference_prop.rs:+9:1: +9:2
 -         StorageDead(_2);                 // scope 1 at $DIR/reference_prop.rs:+9:1: +9:2
           StorageDead(_1);                 // scope 0 at $DIR/reference_prop.rs:+9:1: +9:2
           return;                          // scope 0 at $DIR/reference_prop.rs:+9:2: +9:2

--- a/tests/mir-opt/reference_prop.mut_raw_then_mut_shr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.mut_raw_then_mut_shr.ReferencePropagation.diff
@@ -18,11 +18,11 @@
               let _3: *mut i32;            // in scope 2 at $DIR/reference_prop.rs:+3:9: +3:13
               scope 3 {
 -                 debug xraw => _3;        // in scope 3 at $DIR/reference_prop.rs:+3:9: +3:13
-+                 debug xraw => _4;        // in scope 3 at $DIR/reference_prop.rs:+3:9: +3:13
++                 debug xraw => &_1;       // in scope 3 at $DIR/reference_prop.rs:+3:9: +3:13
                   let _6: &i32;            // in scope 3 at $DIR/reference_prop.rs:+4:9: +4:13
                   scope 4 {
 -                     debug xshr => _6;    // in scope 4 at $DIR/reference_prop.rs:+4:9: +4:13
-+                     debug xshr => _2;    // in scope 4 at $DIR/reference_prop.rs:+4:9: +4:13
++                     debug xshr => &_1;   // in scope 4 at $DIR/reference_prop.rs:+4:9: +4:13
                       let _7: i32;         // in scope 4 at $DIR/reference_prop.rs:+6:9: +6:10
                       scope 5 {
                           debug a => _7;   // in scope 5 at $DIR/reference_prop.rs:+6:9: +6:10
@@ -38,7 +38,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/reference_prop.rs:+1:9: +1:14
           _1 = const 2_i32;                // scope 0 at $DIR/reference_prop.rs:+1:17: +1:18
 -         StorageLive(_2);                 // scope 1 at $DIR/reference_prop.rs:+2:9: +2:13
-          _2 = &mut _1;                    // scope 1 at $DIR/reference_prop.rs:+2:16: +2:22
+-         _2 = &mut _1;                    // scope 1 at $DIR/reference_prop.rs:+2:16: +2:22
 -         StorageLive(_3);                 // scope 2 at $DIR/reference_prop.rs:+3:9: +3:13
 -         StorageLive(_4);                 // scope 2 at $DIR/reference_prop.rs:+3:16: +3:36
 -         StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+3:16: +3:26
@@ -49,7 +49,6 @@
 -         StorageDead(_4);                 // scope 2 at $DIR/reference_prop.rs:+3:36: +3:37
 -         StorageLive(_6);                 // scope 3 at $DIR/reference_prop.rs:+4:9: +4:13
 -         _6 = &(*_2);                     // scope 3 at $DIR/reference_prop.rs:+4:16: +4:22
-+         _4 = &raw mut _1;                // scope 2 at $DIR/reference_prop.rs:+3:16: +3:26
           StorageLive(_7);                 // scope 4 at $DIR/reference_prop.rs:+6:9: +6:10
 -         _7 = (*_6);                      // scope 4 at $DIR/reference_prop.rs:+6:13: +6:18
 -         StorageLive(_8);                 // scope 5 at $DIR/reference_prop.rs:+7:5: +7:26

--- a/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
@@ -17,12 +17,12 @@
       let mut _17: ();                     // in scope 0 at $DIR/reference_prop.rs:+17:16: +17:18
       let _18: ();                         // in scope 0 at $DIR/reference_prop.rs:+21:5: +27:6
       let _19: usize;                      // in scope 0 at $DIR/reference_prop.rs:+22:13: +22:14
-      let _23: ();                         // in scope 0 at $DIR/reference_prop.rs:+26:9: +26:19
-      let mut _24: ();                     // in scope 0 at $DIR/reference_prop.rs:+26:16: +26:18
+      let _23: ();                         // in scope 0 at $DIR/reference_prop.rs:+26:9: +26:18
+      let mut _24: &&usize;                // in scope 0 at $DIR/reference_prop.rs:+26:16: +26:17
       let _25: ();                         // in scope 0 at $DIR/reference_prop.rs:+30:5: +36:6
       let _26: usize;                      // in scope 0 at $DIR/reference_prop.rs:+31:13: +31:14
-      let _30: ();                         // in scope 0 at $DIR/reference_prop.rs:+35:9: +35:19
-      let mut _31: ();                     // in scope 0 at $DIR/reference_prop.rs:+35:16: +35:18
+      let _30: ();                         // in scope 0 at $DIR/reference_prop.rs:+35:9: +35:18
+      let mut _31: *mut &usize;            // in scope 0 at $DIR/reference_prop.rs:+35:16: +35:17
       let _32: ();                         // in scope 0 at $DIR/reference_prop.rs:+39:5: +44:6
       let _33: usize;                      // in scope 0 at $DIR/reference_prop.rs:+40:13: +40:14
       let _36: ();                         // in scope 0 at $DIR/reference_prop.rs:+43:9: +43:18
@@ -44,7 +44,8 @@
           debug a => _4;                   // in scope 1 at $DIR/reference_prop.rs:+3:13: +3:14
           let _5: &usize;                  // in scope 1 at $DIR/reference_prop.rs:+4:13: +4:14
           scope 2 {
-              debug b => _5;               // in scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
+-             debug b => _5;               // in scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
++             debug b => &_4;              // in scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
               let _6: usize;               // in scope 2 at $DIR/reference_prop.rs:+5:13: +5:14
               scope 3 {
                   debug c => _6;           // in scope 3 at $DIR/reference_prop.rs:+5:13: +5:14
@@ -86,7 +87,7 @@
           let mut _27: &usize;             // in scope 12 at $DIR/reference_prop.rs:+32:13: +32:18
           scope 13 {
               debug b => _27;              // in scope 13 at $DIR/reference_prop.rs:+32:13: +32:18
-              let _28: &mut &usize;        // in scope 13 at $DIR/reference_prop.rs:+33:13: +33:14
+              let _28: *mut &usize;        // in scope 13 at $DIR/reference_prop.rs:+33:13: +33:14
               scope 14 {
                   debug d => _28;          // in scope 14 at $DIR/reference_prop.rs:+33:13: +33:14
                   let _29: usize;          // in scope 14 at $DIR/reference_prop.rs:+34:13: +34:14
@@ -131,7 +132,8 @@
           }
       }
       scope 25 {
-          debug a => _48;                  // in scope 25 at $DIR/reference_prop.rs:+61:13: +61:14
+-         debug a => _48;                  // in scope 25 at $DIR/reference_prop.rs:+61:13: +61:14
++         debug a => _1;                   // in scope 25 at $DIR/reference_prop.rs:+61:13: +61:14
           let _49: T;                      // in scope 25 at $DIR/reference_prop.rs:+62:13: +62:14
           scope 26 {
               debug b => _49;              // in scope 26 at $DIR/reference_prop.rs:+62:13: +62:14
@@ -149,8 +151,8 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/reference_prop.rs:+2:5: +7:6
           StorageLive(_4);                 // scope 0 at $DIR/reference_prop.rs:+3:13: +3:14
           _4 = const 5_usize;              // scope 0 at $DIR/reference_prop.rs:+3:17: +3:24
-          StorageLive(_5);                 // scope 1 at $DIR/reference_prop.rs:+4:13: +4:14
-          _5 = &_4;                        // scope 1 at $DIR/reference_prop.rs:+4:17: +4:19
+-         StorageLive(_5);                 // scope 1 at $DIR/reference_prop.rs:+4:13: +4:14
+-         _5 = &_4;                        // scope 1 at $DIR/reference_prop.rs:+4:17: +4:19
           StorageLive(_6);                 // scope 2 at $DIR/reference_prop.rs:+5:13: +5:14
 -         _6 = (*_5);                      // scope 2 at $DIR/reference_prop.rs:+5:17: +5:19
 +         _6 = _4;                         // scope 2 at $DIR/reference_prop.rs:+5:17: +5:19
@@ -168,7 +170,7 @@
           StorageDead(_7);                 // scope 3 at $DIR/reference_prop.rs:+6:19: +6:20
 -         _3 = const ();                   // scope 0 at $DIR/reference_prop.rs:+2:5: +7:6
           StorageDead(_6);                 // scope 2 at $DIR/reference_prop.rs:+7:5: +7:6
-          StorageDead(_5);                 // scope 1 at $DIR/reference_prop.rs:+7:5: +7:6
+-         StorageDead(_5);                 // scope 1 at $DIR/reference_prop.rs:+7:5: +7:6
           StorageDead(_4);                 // scope 0 at $DIR/reference_prop.rs:+7:5: +7:6
 -         StorageDead(_3);                 // scope 0 at $DIR/reference_prop.rs:+7:5: +7:6
 -         StorageLive(_9);                 // scope 0 at $DIR/reference_prop.rs:+10:5: +18:6
@@ -215,18 +217,18 @@
           _21 = &_20;                      // scope 9 at $DIR/reference_prop.rs:+24:17: +24:19
           StorageLive(_22);                // scope 10 at $DIR/reference_prop.rs:+25:13: +25:14
           _22 = (*_20);                    // scope 10 at $DIR/reference_prop.rs:+25:17: +25:19
-          StorageLive(_23);                // scope 11 at $DIR/reference_prop.rs:+26:9: +26:19
-          StorageLive(_24);                // scope 11 at $DIR/reference_prop.rs:+26:16: +26:18
-          _24 = ();                        // scope 11 at $DIR/reference_prop.rs:+26:16: +26:18
-          _23 = opaque::<()>(move _24) -> bb3; // scope 11 at $DIR/reference_prop.rs:+26:9: +26:19
+          StorageLive(_23);                // scope 11 at $DIR/reference_prop.rs:+26:9: +26:18
+          StorageLive(_24);                // scope 11 at $DIR/reference_prop.rs:+26:16: +26:17
+          _24 = _21;                       // scope 11 at $DIR/reference_prop.rs:+26:16: +26:17
+          _23 = opaque::<&&usize>(move _24) -> bb3; // scope 11 at $DIR/reference_prop.rs:+26:9: +26:18
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:36:9: 36:15
-                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(&&usize) {opaque::<&&usize>}, val: Value(<ZST>) }
       }
   
       bb3: {
-          StorageDead(_24);                // scope 11 at $DIR/reference_prop.rs:+26:18: +26:19
-          StorageDead(_23);                // scope 11 at $DIR/reference_prop.rs:+26:19: +26:20
+          StorageDead(_24);                // scope 11 at $DIR/reference_prop.rs:+26:17: +26:18
+          StorageDead(_23);                // scope 11 at $DIR/reference_prop.rs:+26:18: +26:19
 -         _18 = const ();                  // scope 0 at $DIR/reference_prop.rs:+21:5: +27:6
           StorageDead(_22);                // scope 10 at $DIR/reference_prop.rs:+27:5: +27:6
           StorageDead(_21);                // scope 9 at $DIR/reference_prop.rs:+27:5: +27:6
@@ -239,21 +241,21 @@
           StorageLive(_27);                // scope 12 at $DIR/reference_prop.rs:+32:13: +32:18
           _27 = &_26;                      // scope 12 at $DIR/reference_prop.rs:+32:21: +32:23
           StorageLive(_28);                // scope 13 at $DIR/reference_prop.rs:+33:13: +33:14
-          _28 = &mut _27;                  // scope 13 at $DIR/reference_prop.rs:+33:17: +33:23
+          _28 = &raw mut _27;              // scope 13 at $DIR/reference_prop.rs:+33:17: +33:27
           StorageLive(_29);                // scope 14 at $DIR/reference_prop.rs:+34:13: +34:14
           _29 = (*_27);                    // scope 14 at $DIR/reference_prop.rs:+34:17: +34:19
-          StorageLive(_30);                // scope 15 at $DIR/reference_prop.rs:+35:9: +35:19
-          StorageLive(_31);                // scope 15 at $DIR/reference_prop.rs:+35:16: +35:18
-          _31 = ();                        // scope 15 at $DIR/reference_prop.rs:+35:16: +35:18
-          _30 = opaque::<()>(move _31) -> bb4; // scope 15 at $DIR/reference_prop.rs:+35:9: +35:19
+          StorageLive(_30);                // scope 15 at $DIR/reference_prop.rs:+35:9: +35:18
+          StorageLive(_31);                // scope 15 at $DIR/reference_prop.rs:+35:16: +35:17
+          _31 = _28;                       // scope 15 at $DIR/reference_prop.rs:+35:16: +35:17
+          _30 = opaque::<*mut &usize>(move _31) -> bb4; // scope 15 at $DIR/reference_prop.rs:+35:9: +35:18
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:45:9: 45:15
-                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(*mut &usize) {opaque::<*mut &usize>}, val: Value(<ZST>) }
       }
   
       bb4: {
-          StorageDead(_31);                // scope 15 at $DIR/reference_prop.rs:+35:18: +35:19
-          StorageDead(_30);                // scope 15 at $DIR/reference_prop.rs:+35:19: +35:20
+          StorageDead(_31);                // scope 15 at $DIR/reference_prop.rs:+35:17: +35:18
+          StorageDead(_30);                // scope 15 at $DIR/reference_prop.rs:+35:18: +35:19
 -         _25 = const ();                  // scope 0 at $DIR/reference_prop.rs:+30:5: +36:6
           StorageDead(_29);                // scope 14 at $DIR/reference_prop.rs:+36:5: +36:6
           StorageDead(_28);                // scope 13 at $DIR/reference_prop.rs:+36:5: +36:6
@@ -321,8 +323,8 @@
           StorageDead(_39);                // scope 0 at $DIR/reference_prop.rs:+57:5: +57:6
 -         StorageDead(_38);                // scope 0 at $DIR/reference_prop.rs:+57:5: +57:6
 -         StorageLive(_47);                // scope 0 at $DIR/reference_prop.rs:+60:5: +64:6
-          StorageLive(_48);                // scope 0 at $DIR/reference_prop.rs:+61:13: +61:14
-          _48 = &(*_1);                    // scope 0 at $DIR/reference_prop.rs:+61:17: +61:25
+-         StorageLive(_48);                // scope 0 at $DIR/reference_prop.rs:+61:13: +61:14
+-         _48 = &(*_1);                    // scope 0 at $DIR/reference_prop.rs:+61:17: +61:25
           StorageLive(_49);                // scope 25 at $DIR/reference_prop.rs:+62:13: +62:14
 -         _49 = (*_48);                    // scope 25 at $DIR/reference_prop.rs:+62:17: +62:19
 +         _49 = (*_1);                     // scope 25 at $DIR/reference_prop.rs:+62:17: +62:19
@@ -340,7 +342,7 @@
           StorageDead(_50);                // scope 26 at $DIR/reference_prop.rs:+63:19: +63:20
 -         _47 = const ();                  // scope 0 at $DIR/reference_prop.rs:+60:5: +64:6
           StorageDead(_49);                // scope 25 at $DIR/reference_prop.rs:+64:5: +64:6
-          StorageDead(_48);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
+-         StorageDead(_48);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_47);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
           StorageLive(_52);                // scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
           _52 = &(*_2);                    // scope 0 at $DIR/reference_prop.rs:+68:17: +68:27

--- a/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
@@ -35,11 +35,19 @@
       let _48: &T;                         // in scope 0 at $DIR/reference_prop.rs:+61:13: +61:14
       let _50: ();                         // in scope 0 at $DIR/reference_prop.rs:+63:9: +63:19
       let mut _51: ();                     // in scope 0 at $DIR/reference_prop.rs:+63:16: +63:18
-      let _52: &T;                         // in scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
-      let mut _53: &T;                     // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:28
-      let _54: &T;                         // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:28
-      let _56: ();                         // in scope 0 at $DIR/reference_prop.rs:+71:9: +71:19
-      let mut _57: ();                     // in scope 0 at $DIR/reference_prop.rs:+71:16: +71:18
+      let _52: ();                         // in scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
+      let _53: &T;                         // in scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
+      let mut _54: &T;                     // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:28
+      let _55: &T;                         // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:28
+      let _57: ();                         // in scope 0 at $DIR/reference_prop.rs:+71:9: +71:19
+      let mut _58: ();                     // in scope 0 at $DIR/reference_prop.rs:+71:16: +71:18
+      let _59: ();                         // in scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+      let _60: usize;                      // in scope 0 at $DIR/reference_prop.rs:+76:13: +76:14
+      let _64: ();                         // in scope 0 at $DIR/reference_prop.rs:+80:9: +80:19
+      let mut _65: ();                     // in scope 0 at $DIR/reference_prop.rs:+80:16: +80:18
+      let _66: usize;                      // in scope 0 at $DIR/reference_prop.rs:+85:13: +85:14
+      let _70: ();                         // in scope 0 at $DIR/reference_prop.rs:+89:9: +89:19
+      let mut _71: ();                     // in scope 0 at $DIR/reference_prop.rs:+89:16: +89:18
       scope 1 {
           debug a => _4;                   // in scope 1 at $DIR/reference_prop.rs:+3:13: +3:14
           let _5: &usize;                  // in scope 1 at $DIR/reference_prop.rs:+4:13: +4:14
@@ -140,10 +148,44 @@
           }
       }
       scope 27 {
-          debug a => _52;                  // in scope 27 at $DIR/reference_prop.rs:+68:13: +68:14
-          let _55: T;                      // in scope 27 at $DIR/reference_prop.rs:+70:13: +70:14
+          debug a => _53;                  // in scope 27 at $DIR/reference_prop.rs:+68:13: +68:14
+          let _56: T;                      // in scope 27 at $DIR/reference_prop.rs:+70:13: +70:14
           scope 28 {
-              debug b => _55;              // in scope 28 at $DIR/reference_prop.rs:+70:13: +70:14
+              debug b => _56;              // in scope 28 at $DIR/reference_prop.rs:+70:13: +70:14
+          }
+      }
+      scope 29 {
+          debug a => _60;                  // in scope 29 at $DIR/reference_prop.rs:+76:13: +76:14
+          let _61: &usize;                 // in scope 29 at $DIR/reference_prop.rs:+77:13: +77:14
+          scope 30 {
+-             debug b => _61;              // in scope 30 at $DIR/reference_prop.rs:+77:13: +77:14
++             debug b => &_60;             // in scope 30 at $DIR/reference_prop.rs:+77:13: +77:14
+              let _62: &&usize;            // in scope 30 at $DIR/reference_prop.rs:+78:13: +78:14
+              scope 31 {
+-                 debug d => _62;          // in scope 31 at $DIR/reference_prop.rs:+78:13: +78:14
++                 debug d => &&_60;        // in scope 31 at $DIR/reference_prop.rs:+78:13: +78:14
+                  let _63: usize;          // in scope 31 at $DIR/reference_prop.rs:+79:13: +79:14
+                  scope 32 {
+                      debug c => _63;      // in scope 32 at $DIR/reference_prop.rs:+79:13: +79:14
+                  }
+              }
+          }
+      }
+      scope 33 {
+          debug a => _66;                  // in scope 33 at $DIR/reference_prop.rs:+85:13: +85:14
+          let mut _67: &usize;             // in scope 33 at $DIR/reference_prop.rs:+86:13: +86:18
+          scope 34 {
+-             debug b => _67;              // in scope 34 at $DIR/reference_prop.rs:+86:13: +86:18
++             debug b => &_66;             // in scope 34 at $DIR/reference_prop.rs:+86:13: +86:18
+              let _68: &mut &usize;        // in scope 34 at $DIR/reference_prop.rs:+87:13: +87:14
+              scope 35 {
+-                 debug d => _68;          // in scope 35 at $DIR/reference_prop.rs:+87:13: +87:14
++                 debug d => &&_66;        // in scope 35 at $DIR/reference_prop.rs:+87:13: +87:14
+                  let _69: usize;          // in scope 35 at $DIR/reference_prop.rs:+88:13: +88:14
+                  scope 36 {
+                      debug c => _69;      // in scope 36 at $DIR/reference_prop.rs:+88:13: +88:14
+                  }
+              }
           }
       }
   
@@ -344,34 +386,90 @@
           StorageDead(_49);                // scope 25 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_48);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_47);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
-          StorageLive(_52);                // scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
-          _52 = &(*_2);                    // scope 0 at $DIR/reference_prop.rs:+68:17: +68:27
-          StorageLive(_53);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
--         StorageLive(_54);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
--         _54 = &(*_1);                    // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
--         _53 = &(*_54);                   // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
-+         _53 = &(*_1);                    // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
-          _2 = move _53;                   // scope 27 at $DIR/reference_prop.rs:+69:9: +69:28
-          StorageDead(_53);                // scope 27 at $DIR/reference_prop.rs:+69:27: +69:28
--         StorageDead(_54);                // scope 27 at $DIR/reference_prop.rs:+69:28: +69:29
-          StorageLive(_55);                // scope 27 at $DIR/reference_prop.rs:+70:13: +70:14
-          _55 = (*_52);                    // scope 27 at $DIR/reference_prop.rs:+70:17: +70:19
-          StorageLive(_56);                // scope 28 at $DIR/reference_prop.rs:+71:9: +71:19
-          StorageLive(_57);                // scope 28 at $DIR/reference_prop.rs:+71:16: +71:18
-          _57 = ();                        // scope 28 at $DIR/reference_prop.rs:+71:16: +71:18
-          _56 = opaque::<()>(move _57) -> bb8; // scope 28 at $DIR/reference_prop.rs:+71:9: +71:19
+-         StorageLive(_52);                // scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
+          StorageLive(_53);                // scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
+          _53 = &(*_2);                    // scope 0 at $DIR/reference_prop.rs:+68:17: +68:27
+          StorageLive(_54);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
+-         StorageLive(_55);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
+-         _55 = &(*_1);                    // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
+-         _54 = &(*_55);                   // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
++         _54 = &(*_1);                    // scope 27 at $DIR/reference_prop.rs:+69:20: +69:28
+          _2 = move _54;                   // scope 27 at $DIR/reference_prop.rs:+69:9: +69:28
+          StorageDead(_54);                // scope 27 at $DIR/reference_prop.rs:+69:27: +69:28
+-         StorageDead(_55);                // scope 27 at $DIR/reference_prop.rs:+69:28: +69:29
+          StorageLive(_56);                // scope 27 at $DIR/reference_prop.rs:+70:13: +70:14
+          _56 = (*_53);                    // scope 27 at $DIR/reference_prop.rs:+70:17: +70:19
+          StorageLive(_57);                // scope 28 at $DIR/reference_prop.rs:+71:9: +71:19
+          StorageLive(_58);                // scope 28 at $DIR/reference_prop.rs:+71:16: +71:18
+          _58 = ();                        // scope 28 at $DIR/reference_prop.rs:+71:16: +71:18
+          _57 = opaque::<()>(move _58) -> bb8; // scope 28 at $DIR/reference_prop.rs:+71:9: +71:19
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:81:9: 81:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
       bb8: {
-          StorageDead(_57);                // scope 28 at $DIR/reference_prop.rs:+71:18: +71:19
-          StorageDead(_56);                // scope 28 at $DIR/reference_prop.rs:+71:19: +71:20
-          _0 = const ();                   // scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
-          StorageDead(_55);                // scope 27 at $DIR/reference_prop.rs:+72:5: +72:6
-          StorageDead(_52);                // scope 0 at $DIR/reference_prop.rs:+72:5: +72:6
-          return;                          // scope 0 at $DIR/reference_prop.rs:+73:2: +73:2
+          StorageDead(_58);                // scope 28 at $DIR/reference_prop.rs:+71:18: +71:19
+          StorageDead(_57);                // scope 28 at $DIR/reference_prop.rs:+71:19: +71:20
+-         _52 = const ();                  // scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
+          StorageDead(_56);                // scope 27 at $DIR/reference_prop.rs:+72:5: +72:6
+          StorageDead(_53);                // scope 0 at $DIR/reference_prop.rs:+72:5: +72:6
+-         StorageDead(_52);                // scope 0 at $DIR/reference_prop.rs:+72:5: +72:6
+-         StorageLive(_59);                // scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+          StorageLive(_60);                // scope 0 at $DIR/reference_prop.rs:+76:13: +76:14
+          _60 = const 5_usize;             // scope 0 at $DIR/reference_prop.rs:+76:17: +76:24
+-         StorageLive(_61);                // scope 29 at $DIR/reference_prop.rs:+77:13: +77:14
+-         _61 = &_60;                      // scope 29 at $DIR/reference_prop.rs:+77:17: +77:19
+-         StorageLive(_62);                // scope 30 at $DIR/reference_prop.rs:+78:13: +78:14
+-         _62 = &_61;                      // scope 30 at $DIR/reference_prop.rs:+78:17: +78:19
+          StorageLive(_63);                // scope 31 at $DIR/reference_prop.rs:+79:13: +79:14
+-         _63 = (*_61);                    // scope 31 at $DIR/reference_prop.rs:+79:17: +79:19
++         _63 = _60;                       // scope 31 at $DIR/reference_prop.rs:+79:17: +79:19
+          StorageLive(_64);                // scope 32 at $DIR/reference_prop.rs:+80:9: +80:19
+          StorageLive(_65);                // scope 32 at $DIR/reference_prop.rs:+80:16: +80:18
+          _65 = ();                        // scope 32 at $DIR/reference_prop.rs:+80:16: +80:18
+          _64 = opaque::<()>(move _65) -> bb9; // scope 32 at $DIR/reference_prop.rs:+80:9: +80:19
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:90:9: 90:15
+                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+      }
+  
+      bb9: {
+          StorageDead(_65);                // scope 32 at $DIR/reference_prop.rs:+80:18: +80:19
+          StorageDead(_64);                // scope 32 at $DIR/reference_prop.rs:+80:19: +80:20
+-         _59 = const ();                  // scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+          StorageDead(_63);                // scope 31 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_62);                // scope 30 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_61);                // scope 29 at $DIR/reference_prop.rs:+81:5: +81:6
+          StorageDead(_60);                // scope 0 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_59);                // scope 0 at $DIR/reference_prop.rs:+81:5: +81:6
+          StorageLive(_66);                // scope 0 at $DIR/reference_prop.rs:+85:13: +85:14
+          _66 = const 5_usize;             // scope 0 at $DIR/reference_prop.rs:+85:17: +85:24
+-         StorageLive(_67);                // scope 33 at $DIR/reference_prop.rs:+86:13: +86:18
+-         _67 = &_66;                      // scope 33 at $DIR/reference_prop.rs:+86:21: +86:23
+-         StorageLive(_68);                // scope 34 at $DIR/reference_prop.rs:+87:13: +87:14
+-         _68 = &mut _67;                  // scope 34 at $DIR/reference_prop.rs:+87:17: +87:23
+          StorageLive(_69);                // scope 35 at $DIR/reference_prop.rs:+88:13: +88:14
+-         _69 = (*_67);                    // scope 35 at $DIR/reference_prop.rs:+88:17: +88:19
++         _69 = _66;                       // scope 35 at $DIR/reference_prop.rs:+88:17: +88:19
+          StorageLive(_70);                // scope 36 at $DIR/reference_prop.rs:+89:9: +89:19
+          StorageLive(_71);                // scope 36 at $DIR/reference_prop.rs:+89:16: +89:18
+          _71 = ();                        // scope 36 at $DIR/reference_prop.rs:+89:16: +89:18
+          _70 = opaque::<()>(move _71) -> bb10; // scope 36 at $DIR/reference_prop.rs:+89:9: +89:19
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:99:9: 99:15
+                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+      }
+  
+      bb10: {
+          StorageDead(_71);                // scope 36 at $DIR/reference_prop.rs:+89:18: +89:19
+          StorageDead(_70);                // scope 36 at $DIR/reference_prop.rs:+89:19: +89:20
+          _0 = const ();                   // scope 0 at $DIR/reference_prop.rs:+84:5: +90:6
+          StorageDead(_69);                // scope 35 at $DIR/reference_prop.rs:+90:5: +90:6
+-         StorageDead(_68);                // scope 34 at $DIR/reference_prop.rs:+90:5: +90:6
+-         StorageDead(_67);                // scope 33 at $DIR/reference_prop.rs:+90:5: +90:6
+          StorageDead(_66);                // scope 0 at $DIR/reference_prop.rs:+90:5: +90:6
+          return;                          // scope 0 at $DIR/reference_prop.rs:+91:2: +91:2
       }
   }
   

--- a/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
@@ -31,8 +31,14 @@
       let mut _53: *const T;               // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:38
       let _55: ();                         // in scope 0 at $DIR/reference_prop.rs:+71:9: +71:19
       let mut _56: ();                     // in scope 0 at $DIR/reference_prop.rs:+71:16: +71:18
-      let _61: ();                         // in scope 0 at $DIR/reference_prop.rs:+80:9: +80:19
-      let mut _62: ();                     // in scope 0 at $DIR/reference_prop.rs:+80:16: +80:18
+      let _57: ();                         // in scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+      let _62: ();                         // in scope 0 at $DIR/reference_prop.rs:+80:9: +80:19
+      let mut _63: ();                     // in scope 0 at $DIR/reference_prop.rs:+80:16: +80:18
+      let _64: ();                         // in scope 0 at $DIR/reference_prop.rs:+84:5: +90:6
+      let _69: ();                         // in scope 0 at $DIR/reference_prop.rs:+89:9: +89:19
+      let mut _70: ();                     // in scope 0 at $DIR/reference_prop.rs:+89:16: +89:18
+      let _75: ();                         // in scope 0 at $DIR/reference_prop.rs:+98:9: +98:19
+      let mut _76: ();                     // in scope 0 at $DIR/reference_prop.rs:+98:16: +98:18
       scope 1 {
           let _4: usize;                   // in scope 1 at $DIR/reference_prop.rs:+3:13: +3:14
           scope 2 {
@@ -164,20 +170,60 @@
           }
       }
       scope 37 {
-          let _57: usize;                  // in scope 37 at $DIR/reference_prop.rs:+76:13: +76:14
+          let _58: usize;                  // in scope 37 at $DIR/reference_prop.rs:+76:13: +76:14
           scope 38 {
-              debug a => _57;              // in scope 38 at $DIR/reference_prop.rs:+76:13: +76:14
-              let _58: *const usize;       // in scope 38 at $DIR/reference_prop.rs:+77:13: +77:14
+              debug a => _58;              // in scope 38 at $DIR/reference_prop.rs:+76:13: +76:14
+              let _59: *const usize;       // in scope 38 at $DIR/reference_prop.rs:+77:13: +77:14
               scope 39 {
--                 debug b => _58;          // in scope 39 at $DIR/reference_prop.rs:+77:13: +77:14
-+                 debug b => &_57;         // in scope 39 at $DIR/reference_prop.rs:+77:13: +77:14
-                  let _59: *const usize;   // in scope 39 at $DIR/reference_prop.rs:+78:13: +78:14
+-                 debug b => _59;          // in scope 39 at $DIR/reference_prop.rs:+77:13: +77:14
++                 debug b => &_58;         // in scope 39 at $DIR/reference_prop.rs:+77:13: +77:14
+                  let _60: *const usize;   // in scope 39 at $DIR/reference_prop.rs:+78:13: +78:14
                   scope 40 {
--                     debug c => _59;      // in scope 40 at $DIR/reference_prop.rs:+78:13: +78:14
-+                     debug c => &_57;     // in scope 40 at $DIR/reference_prop.rs:+78:13: +78:14
-                      let _60: usize;      // in scope 40 at $DIR/reference_prop.rs:+79:13: +79:14
+-                     debug c => _60;      // in scope 40 at $DIR/reference_prop.rs:+78:13: +78:14
++                     debug c => &_58;     // in scope 40 at $DIR/reference_prop.rs:+78:13: +78:14
+                      let _61: usize;      // in scope 40 at $DIR/reference_prop.rs:+79:13: +79:14
                       scope 41 {
-                          debug e => _60;  // in scope 41 at $DIR/reference_prop.rs:+79:13: +79:14
+                          debug e => _61;  // in scope 41 at $DIR/reference_prop.rs:+79:13: +79:14
+                      }
+                  }
+              }
+          }
+      }
+      scope 42 {
+          let _65: usize;                  // in scope 42 at $DIR/reference_prop.rs:+85:13: +85:14
+          scope 43 {
+              debug a => _65;              // in scope 43 at $DIR/reference_prop.rs:+85:13: +85:14
+              let _66: *const usize;       // in scope 43 at $DIR/reference_prop.rs:+86:13: +86:14
+              scope 44 {
+-                 debug b => _66;          // in scope 44 at $DIR/reference_prop.rs:+86:13: +86:14
++                 debug b => &_65;         // in scope 44 at $DIR/reference_prop.rs:+86:13: +86:14
+                  let _67: &*const usize;  // in scope 44 at $DIR/reference_prop.rs:+87:13: +87:14
+                  scope 45 {
+-                     debug d => _67;      // in scope 45 at $DIR/reference_prop.rs:+87:13: +87:14
++                     debug d => &&_65;    // in scope 45 at $DIR/reference_prop.rs:+87:13: +87:14
+                      let _68: usize;      // in scope 45 at $DIR/reference_prop.rs:+88:13: +88:14
+                      scope 46 {
+                          debug c => _68;  // in scope 46 at $DIR/reference_prop.rs:+88:13: +88:14
+                      }
+                  }
+              }
+          }
+      }
+      scope 47 {
+          let _71: usize;                  // in scope 47 at $DIR/reference_prop.rs:+94:13: +94:14
+          scope 48 {
+              debug a => _71;              // in scope 48 at $DIR/reference_prop.rs:+94:13: +94:14
+              let mut _72: *const usize;   // in scope 48 at $DIR/reference_prop.rs:+95:13: +95:18
+              scope 49 {
+-                 debug b => _72;          // in scope 49 at $DIR/reference_prop.rs:+95:13: +95:18
++                 debug b => &_71;         // in scope 49 at $DIR/reference_prop.rs:+95:13: +95:18
+                  let _73: &mut *const usize; // in scope 49 at $DIR/reference_prop.rs:+96:13: +96:14
+                  scope 50 {
+-                     debug d => _73;      // in scope 50 at $DIR/reference_prop.rs:+96:13: +96:14
++                     debug d => &&_71;    // in scope 50 at $DIR/reference_prop.rs:+96:13: +96:14
+                      let _74: usize;      // in scope 50 at $DIR/reference_prop.rs:+97:13: +97:14
+                      scope 51 {
+                          debug c => _74;  // in scope 51 at $DIR/reference_prop.rs:+97:13: +97:14
                       }
                   }
               }
@@ -198,7 +244,7 @@
           _8 = ();                         // scope 4 at $DIR/reference_prop.rs:+6:16: +6:18
           _7 = opaque::<()>(move _8) -> bb1; // scope 4 at $DIR/reference_prop.rs:+6:9: +6:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:166:9: 166:15
+                                           // + span: $DIR/reference_prop.rs:202:9: 202:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -228,7 +274,7 @@
           _16 = ();                        // scope 9 at $DIR/reference_prop.rs:+17:16: +17:18
           _15 = opaque::<()>(move _16) -> bb2; // scope 9 at $DIR/reference_prop.rs:+17:9: +17:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:177:9: 177:15
+                                           // + span: $DIR/reference_prop.rs:213:9: 213:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -255,7 +301,7 @@
           _23 = _20;                       // scope 14 at $DIR/reference_prop.rs:+26:16: +26:17
           _22 = opaque::<&*const usize>(move _23) -> bb3; // scope 14 at $DIR/reference_prop.rs:+26:9: +26:18
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:186:9: 186:15
+                                           // + span: $DIR/reference_prop.rs:222:9: 222:15
                                            // + literal: Const { ty: fn(&*const usize) {opaque::<&*const usize>}, val: Value(<ZST>) }
       }
   
@@ -282,7 +328,7 @@
           _30 = _27;                       // scope 19 at $DIR/reference_prop.rs:+35:16: +35:17
           _29 = opaque::<*mut *const usize>(move _30) -> bb4; // scope 19 at $DIR/reference_prop.rs:+35:9: +35:18
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:195:9: 195:15
+                                           // + span: $DIR/reference_prop.rs:231:9: 231:15
                                            // + literal: Const { ty: fn(*mut *const usize) {opaque::<*mut *const usize>}, val: Value(<ZST>) }
       }
   
@@ -308,7 +354,7 @@
           _36 = _33;                       // scope 23 at $DIR/reference_prop.rs:+43:16: +43:17
           _35 = opaque::<*const usize>(move _36) -> bb5; // scope 23 at $DIR/reference_prop.rs:+43:9: +43:18
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:203:9: 203:15
+                                           // + span: $DIR/reference_prop.rs:239:9: 239:15
                                            // + literal: Const { ty: fn(*const usize) {opaque::<*const usize>}, val: Value(<ZST>) }
       }
   
@@ -340,7 +386,7 @@
           _45 = _43;                       // scope 30 at $DIR/reference_prop.rs:+56:16: +56:18
           _44 = opaque::<*const usize>(move _45) -> bb6; // scope 30 at $DIR/reference_prop.rs:+56:9: +56:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:216:9: 216:15
+                                           // + span: $DIR/reference_prop.rs:252:9: 252:15
                                            // + literal: Const { ty: fn(*const usize) {opaque::<*const usize>}, val: Value(<ZST>) }
       }
   
@@ -366,7 +412,7 @@
           _50 = ();                        // scope 33 at $DIR/reference_prop.rs:+63:16: +63:18
           _49 = opaque::<()>(move _50) -> bb7; // scope 33 at $DIR/reference_prop.rs:+63:9: +63:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:223:9: 223:15
+                                           // + span: $DIR/reference_prop.rs:259:9: 259:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -391,7 +437,7 @@
           _56 = ();                        // scope 36 at $DIR/reference_prop.rs:+71:16: +71:18
           _55 = opaque::<()>(move _56) -> bb8; // scope 36 at $DIR/reference_prop.rs:+71:9: +71:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:231:9: 231:15
+                                           // + span: $DIR/reference_prop.rs:267:9: 267:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -402,33 +448,89 @@
           StorageDead(_54);                // scope 35 at $DIR/reference_prop.rs:+72:5: +72:6
           StorageDead(_52);                // scope 34 at $DIR/reference_prop.rs:+72:5: +72:6
 -         StorageDead(_51);                // scope 0 at $DIR/reference_prop.rs:+72:5: +72:6
-          StorageLive(_57);                // scope 37 at $DIR/reference_prop.rs:+76:13: +76:14
-          _57 = const 13_usize;            // scope 37 at $DIR/reference_prop.rs:+76:17: +76:25
--         StorageLive(_58);                // scope 38 at $DIR/reference_prop.rs:+77:13: +77:14
--         _58 = &raw const _57;            // scope 38 at $DIR/reference_prop.rs:+77:17: +77:29
--         StorageLive(_59);                // scope 39 at $DIR/reference_prop.rs:+78:13: +78:14
--         _59 = &raw const (*_58);         // scope 39 at $DIR/reference_prop.rs:+78:17: +78:30
-          StorageLive(_60);                // scope 40 at $DIR/reference_prop.rs:+79:13: +79:14
--         _60 = (*_59);                    // scope 40 at $DIR/reference_prop.rs:+79:17: +79:19
-+         _60 = _57;                       // scope 40 at $DIR/reference_prop.rs:+79:17: +79:19
-          StorageLive(_61);                // scope 41 at $DIR/reference_prop.rs:+80:9: +80:19
-          StorageLive(_62);                // scope 41 at $DIR/reference_prop.rs:+80:16: +80:18
-          _62 = ();                        // scope 41 at $DIR/reference_prop.rs:+80:16: +80:18
-          _61 = opaque::<()>(move _62) -> bb9; // scope 41 at $DIR/reference_prop.rs:+80:9: +80:19
+-         StorageLive(_57);                // scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+          StorageLive(_58);                // scope 37 at $DIR/reference_prop.rs:+76:13: +76:14
+          _58 = const 13_usize;            // scope 37 at $DIR/reference_prop.rs:+76:17: +76:25
+-         StorageLive(_59);                // scope 38 at $DIR/reference_prop.rs:+77:13: +77:14
+-         _59 = &raw const _58;            // scope 38 at $DIR/reference_prop.rs:+77:17: +77:29
+-         StorageLive(_60);                // scope 39 at $DIR/reference_prop.rs:+78:13: +78:14
+-         _60 = &raw const (*_59);         // scope 39 at $DIR/reference_prop.rs:+78:17: +78:30
+          StorageLive(_61);                // scope 40 at $DIR/reference_prop.rs:+79:13: +79:14
+-         _61 = (*_60);                    // scope 40 at $DIR/reference_prop.rs:+79:17: +79:19
++         _61 = _58;                       // scope 40 at $DIR/reference_prop.rs:+79:17: +79:19
+          StorageLive(_62);                // scope 41 at $DIR/reference_prop.rs:+80:9: +80:19
+          StorageLive(_63);                // scope 41 at $DIR/reference_prop.rs:+80:16: +80:18
+          _63 = ();                        // scope 41 at $DIR/reference_prop.rs:+80:16: +80:18
+          _62 = opaque::<()>(move _63) -> bb9; // scope 41 at $DIR/reference_prop.rs:+80:9: +80:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:240:9: 240:15
+                                           // + span: $DIR/reference_prop.rs:276:9: 276:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
       bb9: {
-          StorageDead(_62);                // scope 41 at $DIR/reference_prop.rs:+80:18: +80:19
-          StorageDead(_61);                // scope 41 at $DIR/reference_prop.rs:+80:19: +80:20
-          _0 = const ();                   // scope 37 at $DIR/reference_prop.rs:+75:5: +81:6
-          StorageDead(_60);                // scope 40 at $DIR/reference_prop.rs:+81:5: +81:6
--         StorageDead(_59);                // scope 39 at $DIR/reference_prop.rs:+81:5: +81:6
--         StorageDead(_58);                // scope 38 at $DIR/reference_prop.rs:+81:5: +81:6
-          StorageDead(_57);                // scope 37 at $DIR/reference_prop.rs:+81:5: +81:6
-          return;                          // scope 0 at $DIR/reference_prop.rs:+82:2: +82:2
+          StorageDead(_63);                // scope 41 at $DIR/reference_prop.rs:+80:18: +80:19
+          StorageDead(_62);                // scope 41 at $DIR/reference_prop.rs:+80:19: +80:20
+-         _57 = const ();                  // scope 37 at $DIR/reference_prop.rs:+75:5: +81:6
+          StorageDead(_61);                // scope 40 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_60);                // scope 39 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_59);                // scope 38 at $DIR/reference_prop.rs:+81:5: +81:6
+          StorageDead(_58);                // scope 37 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_57);                // scope 0 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageLive(_64);                // scope 0 at $DIR/reference_prop.rs:+84:5: +90:6
+          StorageLive(_65);                // scope 42 at $DIR/reference_prop.rs:+85:13: +85:14
+          _65 = const 5_usize;             // scope 42 at $DIR/reference_prop.rs:+85:17: +85:24
+-         StorageLive(_66);                // scope 43 at $DIR/reference_prop.rs:+86:13: +86:14
+-         _66 = &raw const _65;            // scope 43 at $DIR/reference_prop.rs:+86:17: +86:29
+-         StorageLive(_67);                // scope 44 at $DIR/reference_prop.rs:+87:13: +87:14
+-         _67 = &_66;                      // scope 44 at $DIR/reference_prop.rs:+87:17: +87:19
+          StorageLive(_68);                // scope 45 at $DIR/reference_prop.rs:+88:13: +88:14
+-         _68 = (*_66);                    // scope 45 at $DIR/reference_prop.rs:+88:17: +88:19
++         _68 = _65;                       // scope 45 at $DIR/reference_prop.rs:+88:17: +88:19
+          StorageLive(_69);                // scope 46 at $DIR/reference_prop.rs:+89:9: +89:19
+          StorageLive(_70);                // scope 46 at $DIR/reference_prop.rs:+89:16: +89:18
+          _70 = ();                        // scope 46 at $DIR/reference_prop.rs:+89:16: +89:18
+          _69 = opaque::<()>(move _70) -> bb10; // scope 46 at $DIR/reference_prop.rs:+89:9: +89:19
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:285:9: 285:15
+                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+      }
+  
+      bb10: {
+          StorageDead(_70);                // scope 46 at $DIR/reference_prop.rs:+89:18: +89:19
+          StorageDead(_69);                // scope 46 at $DIR/reference_prop.rs:+89:19: +89:20
+-         _64 = const ();                  // scope 42 at $DIR/reference_prop.rs:+84:5: +90:6
+          StorageDead(_68);                // scope 45 at $DIR/reference_prop.rs:+90:5: +90:6
+-         StorageDead(_67);                // scope 44 at $DIR/reference_prop.rs:+90:5: +90:6
+-         StorageDead(_66);                // scope 43 at $DIR/reference_prop.rs:+90:5: +90:6
+          StorageDead(_65);                // scope 42 at $DIR/reference_prop.rs:+90:5: +90:6
+-         StorageDead(_64);                // scope 0 at $DIR/reference_prop.rs:+90:5: +90:6
+          StorageLive(_71);                // scope 47 at $DIR/reference_prop.rs:+94:13: +94:14
+          _71 = const 5_usize;             // scope 47 at $DIR/reference_prop.rs:+94:17: +94:24
+-         StorageLive(_72);                // scope 48 at $DIR/reference_prop.rs:+95:13: +95:18
+-         _72 = &raw const _71;            // scope 48 at $DIR/reference_prop.rs:+95:21: +95:33
+-         StorageLive(_73);                // scope 49 at $DIR/reference_prop.rs:+96:13: +96:14
+-         _73 = &mut _72;                  // scope 49 at $DIR/reference_prop.rs:+96:17: +96:23
+          StorageLive(_74);                // scope 50 at $DIR/reference_prop.rs:+97:13: +97:14
+-         _74 = (*_72);                    // scope 50 at $DIR/reference_prop.rs:+97:17: +97:19
++         _74 = _71;                       // scope 50 at $DIR/reference_prop.rs:+97:17: +97:19
+          StorageLive(_75);                // scope 51 at $DIR/reference_prop.rs:+98:9: +98:19
+          StorageLive(_76);                // scope 51 at $DIR/reference_prop.rs:+98:16: +98:18
+          _76 = ();                        // scope 51 at $DIR/reference_prop.rs:+98:16: +98:18
+          _75 = opaque::<()>(move _76) -> bb11; // scope 51 at $DIR/reference_prop.rs:+98:9: +98:19
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:294:9: 294:15
+                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+      }
+  
+      bb11: {
+          StorageDead(_76);                // scope 51 at $DIR/reference_prop.rs:+98:18: +98:19
+          StorageDead(_75);                // scope 51 at $DIR/reference_prop.rs:+98:19: +98:20
+          _0 = const ();                   // scope 47 at $DIR/reference_prop.rs:+93:5: +99:6
+          StorageDead(_74);                // scope 50 at $DIR/reference_prop.rs:+99:5: +99:6
+-         StorageDead(_73);                // scope 49 at $DIR/reference_prop.rs:+99:5: +99:6
+-         StorageDead(_72);                // scope 48 at $DIR/reference_prop.rs:+99:5: +99:6
+          StorageDead(_71);                // scope 47 at $DIR/reference_prop.rs:+99:5: +99:6
+          return;                          // scope 0 at $DIR/reference_prop.rs:+100:2: +100:2
       }
   }
   

--- a/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
@@ -13,11 +13,11 @@
       let _15: ();                         // in scope 0 at $DIR/reference_prop.rs:+17:9: +17:19
       let mut _16: ();                     // in scope 0 at $DIR/reference_prop.rs:+17:16: +17:18
       let _17: ();                         // in scope 0 at $DIR/reference_prop.rs:+21:5: +27:6
-      let _22: ();                         // in scope 0 at $DIR/reference_prop.rs:+26:9: +26:19
-      let mut _23: ();                     // in scope 0 at $DIR/reference_prop.rs:+26:16: +26:18
+      let _22: ();                         // in scope 0 at $DIR/reference_prop.rs:+26:9: +26:18
+      let mut _23: &*const usize;          // in scope 0 at $DIR/reference_prop.rs:+26:16: +26:17
       let _24: ();                         // in scope 0 at $DIR/reference_prop.rs:+30:5: +36:6
-      let _29: ();                         // in scope 0 at $DIR/reference_prop.rs:+35:9: +35:19
-      let mut _30: ();                     // in scope 0 at $DIR/reference_prop.rs:+35:16: +35:18
+      let _29: ();                         // in scope 0 at $DIR/reference_prop.rs:+35:9: +35:18
+      let mut _30: *mut *const usize;      // in scope 0 at $DIR/reference_prop.rs:+35:16: +35:17
       let _31: ();                         // in scope 0 at $DIR/reference_prop.rs:+39:5: +44:6
       let _35: ();                         // in scope 0 at $DIR/reference_prop.rs:+43:9: +43:18
       let mut _36: *const usize;           // in scope 0 at $DIR/reference_prop.rs:+43:16: +43:17
@@ -39,7 +39,8 @@
               debug a => _4;               // in scope 2 at $DIR/reference_prop.rs:+3:13: +3:14
               let _5: *const usize;        // in scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
               scope 3 {
-                  debug b => _5;           // in scope 3 at $DIR/reference_prop.rs:+4:13: +4:14
+-                 debug b => _5;           // in scope 3 at $DIR/reference_prop.rs:+4:13: +4:14
++                 debug b => &_4;          // in scope 3 at $DIR/reference_prop.rs:+4:13: +4:14
                   let _6: usize;           // in scope 3 at $DIR/reference_prop.rs:+5:13: +5:14
                   scope 4 {
                       debug c => _6;       // in scope 4 at $DIR/reference_prop.rs:+5:13: +5:14
@@ -90,7 +91,7 @@
               let mut _26: *const usize;   // in scope 16 at $DIR/reference_prop.rs:+32:13: +32:18
               scope 17 {
                   debug b => _26;          // in scope 17 at $DIR/reference_prop.rs:+32:13: +32:18
-                  let _27: &mut *const usize; // in scope 17 at $DIR/reference_prop.rs:+33:13: +33:14
+                  let _27: *mut *const usize; // in scope 17 at $DIR/reference_prop.rs:+33:13: +33:14
                   scope 18 {
                       debug d => _27;      // in scope 18 at $DIR/reference_prop.rs:+33:13: +33:14
                       let _28: usize;      // in scope 18 at $DIR/reference_prop.rs:+34:13: +34:14
@@ -144,7 +145,8 @@
       scope 31 {
           let _47: *const T;               // in scope 31 at $DIR/reference_prop.rs:+61:13: +61:14
           scope 32 {
-              debug a => _47;              // in scope 32 at $DIR/reference_prop.rs:+61:13: +61:14
+-             debug a => _47;              // in scope 32 at $DIR/reference_prop.rs:+61:13: +61:14
++             debug a => _1;               // in scope 32 at $DIR/reference_prop.rs:+61:13: +61:14
               let _48: T;                  // in scope 32 at $DIR/reference_prop.rs:+62:13: +62:14
               scope 33 {
                   debug b => _48;          // in scope 33 at $DIR/reference_prop.rs:+62:13: +62:14
@@ -167,10 +169,12 @@
               debug a => _57;              // in scope 38 at $DIR/reference_prop.rs:+76:13: +76:14
               let _58: *const usize;       // in scope 38 at $DIR/reference_prop.rs:+77:13: +77:14
               scope 39 {
-                  debug b => _58;          // in scope 39 at $DIR/reference_prop.rs:+77:13: +77:14
+-                 debug b => _58;          // in scope 39 at $DIR/reference_prop.rs:+77:13: +77:14
++                 debug b => &_57;         // in scope 39 at $DIR/reference_prop.rs:+77:13: +77:14
                   let _59: *const usize;   // in scope 39 at $DIR/reference_prop.rs:+78:13: +78:14
                   scope 40 {
-                      debug c => _59;      // in scope 40 at $DIR/reference_prop.rs:+78:13: +78:14
+-                     debug c => _59;      // in scope 40 at $DIR/reference_prop.rs:+78:13: +78:14
++                     debug c => &_57;     // in scope 40 at $DIR/reference_prop.rs:+78:13: +78:14
                       let _60: usize;      // in scope 40 at $DIR/reference_prop.rs:+79:13: +79:14
                       scope 41 {
                           debug e => _60;  // in scope 41 at $DIR/reference_prop.rs:+79:13: +79:14
@@ -184,8 +188,8 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/reference_prop.rs:+2:5: +7:6
           StorageLive(_4);                 // scope 1 at $DIR/reference_prop.rs:+3:13: +3:14
           _4 = const 5_usize;              // scope 1 at $DIR/reference_prop.rs:+3:17: +3:24
-          StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
-          _5 = &raw const _4;              // scope 2 at $DIR/reference_prop.rs:+4:17: +4:29
+-         StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
+-         _5 = &raw const _4;              // scope 2 at $DIR/reference_prop.rs:+4:17: +4:29
           StorageLive(_6);                 // scope 3 at $DIR/reference_prop.rs:+5:13: +5:14
 -         _6 = (*_5);                      // scope 3 at $DIR/reference_prop.rs:+5:17: +5:19
 +         _6 = _4;                         // scope 3 at $DIR/reference_prop.rs:+5:17: +5:19
@@ -203,7 +207,7 @@
           StorageDead(_7);                 // scope 4 at $DIR/reference_prop.rs:+6:19: +6:20
 -         _3 = const ();                   // scope 1 at $DIR/reference_prop.rs:+2:5: +7:6
           StorageDead(_6);                 // scope 3 at $DIR/reference_prop.rs:+7:5: +7:6
-          StorageDead(_5);                 // scope 2 at $DIR/reference_prop.rs:+7:5: +7:6
+-         StorageDead(_5);                 // scope 2 at $DIR/reference_prop.rs:+7:5: +7:6
           StorageDead(_4);                 // scope 1 at $DIR/reference_prop.rs:+7:5: +7:6
 -         StorageDead(_3);                 // scope 0 at $DIR/reference_prop.rs:+7:5: +7:6
 -         StorageLive(_9);                 // scope 0 at $DIR/reference_prop.rs:+10:5: +18:6
@@ -246,18 +250,18 @@
           _20 = &_19;                      // scope 12 at $DIR/reference_prop.rs:+24:17: +24:19
           StorageLive(_21);                // scope 13 at $DIR/reference_prop.rs:+25:13: +25:14
           _21 = (*_19);                    // scope 13 at $DIR/reference_prop.rs:+25:17: +25:19
-          StorageLive(_22);                // scope 14 at $DIR/reference_prop.rs:+26:9: +26:19
-          StorageLive(_23);                // scope 14 at $DIR/reference_prop.rs:+26:16: +26:18
-          _23 = ();                        // scope 14 at $DIR/reference_prop.rs:+26:16: +26:18
-          _22 = opaque::<()>(move _23) -> bb3; // scope 14 at $DIR/reference_prop.rs:+26:9: +26:19
+          StorageLive(_22);                // scope 14 at $DIR/reference_prop.rs:+26:9: +26:18
+          StorageLive(_23);                // scope 14 at $DIR/reference_prop.rs:+26:16: +26:17
+          _23 = _20;                       // scope 14 at $DIR/reference_prop.rs:+26:16: +26:17
+          _22 = opaque::<&*const usize>(move _23) -> bb3; // scope 14 at $DIR/reference_prop.rs:+26:9: +26:18
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:186:9: 186:15
-                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(&*const usize) {opaque::<&*const usize>}, val: Value(<ZST>) }
       }
   
       bb3: {
-          StorageDead(_23);                // scope 14 at $DIR/reference_prop.rs:+26:18: +26:19
-          StorageDead(_22);                // scope 14 at $DIR/reference_prop.rs:+26:19: +26:20
+          StorageDead(_23);                // scope 14 at $DIR/reference_prop.rs:+26:17: +26:18
+          StorageDead(_22);                // scope 14 at $DIR/reference_prop.rs:+26:18: +26:19
 -         _17 = const ();                  // scope 10 at $DIR/reference_prop.rs:+21:5: +27:6
           StorageDead(_21);                // scope 13 at $DIR/reference_prop.rs:+27:5: +27:6
           StorageDead(_20);                // scope 12 at $DIR/reference_prop.rs:+27:5: +27:6
@@ -270,21 +274,21 @@
           StorageLive(_26);                // scope 16 at $DIR/reference_prop.rs:+32:13: +32:18
           _26 = &raw const _25;            // scope 16 at $DIR/reference_prop.rs:+32:21: +32:33
           StorageLive(_27);                // scope 17 at $DIR/reference_prop.rs:+33:13: +33:14
-          _27 = &mut _26;                  // scope 17 at $DIR/reference_prop.rs:+33:17: +33:23
+          _27 = &raw mut _26;              // scope 17 at $DIR/reference_prop.rs:+33:17: +33:27
           StorageLive(_28);                // scope 18 at $DIR/reference_prop.rs:+34:13: +34:14
           _28 = (*_26);                    // scope 18 at $DIR/reference_prop.rs:+34:17: +34:19
-          StorageLive(_29);                // scope 19 at $DIR/reference_prop.rs:+35:9: +35:19
-          StorageLive(_30);                // scope 19 at $DIR/reference_prop.rs:+35:16: +35:18
-          _30 = ();                        // scope 19 at $DIR/reference_prop.rs:+35:16: +35:18
-          _29 = opaque::<()>(move _30) -> bb4; // scope 19 at $DIR/reference_prop.rs:+35:9: +35:19
+          StorageLive(_29);                // scope 19 at $DIR/reference_prop.rs:+35:9: +35:18
+          StorageLive(_30);                // scope 19 at $DIR/reference_prop.rs:+35:16: +35:17
+          _30 = _27;                       // scope 19 at $DIR/reference_prop.rs:+35:16: +35:17
+          _29 = opaque::<*mut *const usize>(move _30) -> bb4; // scope 19 at $DIR/reference_prop.rs:+35:9: +35:18
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:195:9: 195:15
-                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(*mut *const usize) {opaque::<*mut *const usize>}, val: Value(<ZST>) }
       }
   
       bb4: {
-          StorageDead(_30);                // scope 19 at $DIR/reference_prop.rs:+35:18: +35:19
-          StorageDead(_29);                // scope 19 at $DIR/reference_prop.rs:+35:19: +35:20
+          StorageDead(_30);                // scope 19 at $DIR/reference_prop.rs:+35:17: +35:18
+          StorageDead(_29);                // scope 19 at $DIR/reference_prop.rs:+35:18: +35:19
 -         _24 = const ();                  // scope 15 at $DIR/reference_prop.rs:+30:5: +36:6
           StorageDead(_28);                // scope 18 at $DIR/reference_prop.rs:+36:5: +36:6
           StorageDead(_27);                // scope 17 at $DIR/reference_prop.rs:+36:5: +36:6
@@ -352,8 +356,8 @@
           StorageDead(_38);                // scope 24 at $DIR/reference_prop.rs:+57:5: +57:6
 -         StorageDead(_37);                // scope 0 at $DIR/reference_prop.rs:+57:5: +57:6
 -         StorageLive(_46);                // scope 0 at $DIR/reference_prop.rs:+60:5: +64:6
-          StorageLive(_47);                // scope 31 at $DIR/reference_prop.rs:+61:13: +61:14
-          _47 = &raw const (*_1);          // scope 31 at $DIR/reference_prop.rs:+61:17: +61:35
+-         StorageLive(_47);                // scope 31 at $DIR/reference_prop.rs:+61:13: +61:14
+-         _47 = &raw const (*_1);          // scope 31 at $DIR/reference_prop.rs:+61:17: +61:35
           StorageLive(_48);                // scope 32 at $DIR/reference_prop.rs:+62:13: +62:14
 -         _48 = (*_47);                    // scope 32 at $DIR/reference_prop.rs:+62:17: +62:19
 +         _48 = (*_1);                     // scope 32 at $DIR/reference_prop.rs:+62:17: +62:19
@@ -371,7 +375,7 @@
           StorageDead(_49);                // scope 33 at $DIR/reference_prop.rs:+63:19: +63:20
 -         _46 = const ();                  // scope 31 at $DIR/reference_prop.rs:+60:5: +64:6
           StorageDead(_48);                // scope 32 at $DIR/reference_prop.rs:+64:5: +64:6
-          StorageDead(_47);                // scope 31 at $DIR/reference_prop.rs:+64:5: +64:6
+-         StorageDead(_47);                // scope 31 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_46);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageLive(_51);                // scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
           StorageLive(_52);                // scope 34 at $DIR/reference_prop.rs:+68:13: +68:14
@@ -400,11 +404,10 @@
 -         StorageDead(_51);                // scope 0 at $DIR/reference_prop.rs:+72:5: +72:6
           StorageLive(_57);                // scope 37 at $DIR/reference_prop.rs:+76:13: +76:14
           _57 = const 13_usize;            // scope 37 at $DIR/reference_prop.rs:+76:17: +76:25
-          StorageLive(_58);                // scope 38 at $DIR/reference_prop.rs:+77:13: +77:14
-          _58 = &raw const _57;            // scope 38 at $DIR/reference_prop.rs:+77:17: +77:29
-          StorageLive(_59);                // scope 39 at $DIR/reference_prop.rs:+78:13: +78:14
+-         StorageLive(_58);                // scope 38 at $DIR/reference_prop.rs:+77:13: +77:14
+-         _58 = &raw const _57;            // scope 38 at $DIR/reference_prop.rs:+77:17: +77:29
+-         StorageLive(_59);                // scope 39 at $DIR/reference_prop.rs:+78:13: +78:14
 -         _59 = &raw const (*_58);         // scope 39 at $DIR/reference_prop.rs:+78:17: +78:30
-+         _59 = &raw const _57;            // scope 39 at $DIR/reference_prop.rs:+78:17: +78:30
           StorageLive(_60);                // scope 40 at $DIR/reference_prop.rs:+79:13: +79:14
 -         _60 = (*_59);                    // scope 40 at $DIR/reference_prop.rs:+79:17: +79:19
 +         _60 = _57;                       // scope 40 at $DIR/reference_prop.rs:+79:17: +79:19
@@ -422,8 +425,8 @@
           StorageDead(_61);                // scope 41 at $DIR/reference_prop.rs:+80:19: +80:20
           _0 = const ();                   // scope 37 at $DIR/reference_prop.rs:+75:5: +81:6
           StorageDead(_60);                // scope 40 at $DIR/reference_prop.rs:+81:5: +81:6
-          StorageDead(_59);                // scope 39 at $DIR/reference_prop.rs:+81:5: +81:6
-          StorageDead(_58);                // scope 38 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_59);                // scope 39 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_58);                // scope 38 at $DIR/reference_prop.rs:+81:5: +81:6
           StorageDead(_57);                // scope 37 at $DIR/reference_prop.rs:+81:5: +81:6
           return;                          // scope 0 at $DIR/reference_prop.rs:+82:2: +82:2
       }

--- a/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
@@ -35,11 +35,19 @@
       let _48: &mut T;                     // in scope 0 at $DIR/reference_prop.rs:+61:13: +61:14
       let _50: ();                         // in scope 0 at $DIR/reference_prop.rs:+63:9: +63:19
       let mut _51: ();                     // in scope 0 at $DIR/reference_prop.rs:+63:16: +63:18
-      let _52: &mut T;                     // in scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
-      let mut _53: &mut T;                 // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:32
+      let _52: ();                         // in scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
+      let _53: &mut T;                     // in scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
       let mut _54: &mut T;                 // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:32
-      let _56: ();                         // in scope 0 at $DIR/reference_prop.rs:+71:9: +71:19
-      let mut _57: ();                     // in scope 0 at $DIR/reference_prop.rs:+71:16: +71:18
+      let mut _55: &mut T;                 // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:32
+      let _57: ();                         // in scope 0 at $DIR/reference_prop.rs:+71:9: +71:19
+      let mut _58: ();                     // in scope 0 at $DIR/reference_prop.rs:+71:16: +71:18
+      let _59: ();                         // in scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+      let mut _60: usize;                  // in scope 0 at $DIR/reference_prop.rs:+76:13: +76:18
+      let _64: ();                         // in scope 0 at $DIR/reference_prop.rs:+80:9: +80:19
+      let mut _65: ();                     // in scope 0 at $DIR/reference_prop.rs:+80:16: +80:18
+      let mut _66: usize;                  // in scope 0 at $DIR/reference_prop.rs:+85:13: +85:18
+      let _70: ();                         // in scope 0 at $DIR/reference_prop.rs:+89:9: +89:19
+      let mut _71: ();                     // in scope 0 at $DIR/reference_prop.rs:+89:16: +89:18
       scope 1 {
           debug a => _4;                   // in scope 1 at $DIR/reference_prop.rs:+3:13: +3:18
           let _5: &mut usize;              // in scope 1 at $DIR/reference_prop.rs:+4:13: +4:14
@@ -140,10 +148,44 @@
           }
       }
       scope 27 {
-          debug a => _52;                  // in scope 27 at $DIR/reference_prop.rs:+68:13: +68:14
-          let _55: T;                      // in scope 27 at $DIR/reference_prop.rs:+70:13: +70:14
+          debug a => _53;                  // in scope 27 at $DIR/reference_prop.rs:+68:13: +68:14
+          let _56: T;                      // in scope 27 at $DIR/reference_prop.rs:+70:13: +70:14
           scope 28 {
-              debug b => _55;              // in scope 28 at $DIR/reference_prop.rs:+70:13: +70:14
+              debug b => _56;              // in scope 28 at $DIR/reference_prop.rs:+70:13: +70:14
+          }
+      }
+      scope 29 {
+          debug a => _60;                  // in scope 29 at $DIR/reference_prop.rs:+76:13: +76:18
+          let _61: &mut usize;             // in scope 29 at $DIR/reference_prop.rs:+77:13: +77:14
+          scope 30 {
+-             debug b => _61;              // in scope 30 at $DIR/reference_prop.rs:+77:13: +77:14
++             debug b => &_60;             // in scope 30 at $DIR/reference_prop.rs:+77:13: +77:14
+              let _62: &&mut usize;        // in scope 30 at $DIR/reference_prop.rs:+78:13: +78:14
+              scope 31 {
+-                 debug d => _62;          // in scope 31 at $DIR/reference_prop.rs:+78:13: +78:14
++                 debug d => &&_60;        // in scope 31 at $DIR/reference_prop.rs:+78:13: +78:14
+                  let _63: usize;          // in scope 31 at $DIR/reference_prop.rs:+79:13: +79:14
+                  scope 32 {
+                      debug c => _63;      // in scope 32 at $DIR/reference_prop.rs:+79:13: +79:14
+                  }
+              }
+          }
+      }
+      scope 33 {
+          debug a => _66;                  // in scope 33 at $DIR/reference_prop.rs:+85:13: +85:18
+          let mut _67: &mut usize;         // in scope 33 at $DIR/reference_prop.rs:+86:13: +86:18
+          scope 34 {
+-             debug b => _67;              // in scope 34 at $DIR/reference_prop.rs:+86:13: +86:18
++             debug b => &_66;             // in scope 34 at $DIR/reference_prop.rs:+86:13: +86:18
+              let _68: &mut &mut usize;    // in scope 34 at $DIR/reference_prop.rs:+87:13: +87:14
+              scope 35 {
+-                 debug d => _68;          // in scope 35 at $DIR/reference_prop.rs:+87:13: +87:14
++                 debug d => &&_66;        // in scope 35 at $DIR/reference_prop.rs:+87:13: +87:14
+                  let _69: usize;          // in scope 35 at $DIR/reference_prop.rs:+88:13: +88:14
+                  scope 36 {
+                      debug c => _69;      // in scope 36 at $DIR/reference_prop.rs:+88:13: +88:14
+                  }
+              }
           }
       }
   
@@ -161,7 +203,7 @@
           _8 = ();                         // scope 3 at $DIR/reference_prop.rs:+6:16: +6:18
           _7 = opaque::<()>(move _8) -> bb1; // scope 3 at $DIR/reference_prop.rs:+6:9: +6:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:91:9: 91:15
+                                           // + span: $DIR/reference_prop.rs:109:9: 109:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -195,7 +237,7 @@
           _17 = ();                        // scope 7 at $DIR/reference_prop.rs:+17:16: +17:18
           _16 = opaque::<()>(move _17) -> bb2; // scope 7 at $DIR/reference_prop.rs:+17:9: +17:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:102:9: 102:15
+                                           // + span: $DIR/reference_prop.rs:120:9: 120:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -222,7 +264,7 @@
           _24 = _21;                       // scope 11 at $DIR/reference_prop.rs:+26:16: +26:17
           _23 = opaque::<&&mut usize>(move _24) -> bb3; // scope 11 at $DIR/reference_prop.rs:+26:9: +26:18
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:111:9: 111:15
+                                           // + span: $DIR/reference_prop.rs:129:9: 129:15
                                            // + literal: Const { ty: fn(&&mut usize) {opaque::<&&mut usize>}, val: Value(<ZST>) }
       }
   
@@ -249,7 +291,7 @@
           _31 = _28;                       // scope 15 at $DIR/reference_prop.rs:+35:16: +35:17
           _30 = opaque::<*mut &mut usize>(move _31) -> bb4; // scope 15 at $DIR/reference_prop.rs:+35:9: +35:18
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:120:9: 120:15
+                                           // + span: $DIR/reference_prop.rs:138:9: 138:15
                                            // + literal: Const { ty: fn(*mut &mut usize) {opaque::<*mut &mut usize>}, val: Value(<ZST>) }
       }
   
@@ -274,7 +316,7 @@
           _37 = move _34;                  // scope 18 at $DIR/reference_prop.rs:+43:16: +43:17
           _36 = opaque::<&mut usize>(move _37) -> bb5; // scope 18 at $DIR/reference_prop.rs:+43:9: +43:18
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:128:9: 128:15
+                                           // + span: $DIR/reference_prop.rs:146:9: 146:15
                                            // + literal: Const { ty: fn(&mut usize) {opaque::<&mut usize>}, val: Value(<ZST>) }
       }
   
@@ -304,7 +346,7 @@
           _46 = move _44;                  // scope 24 at $DIR/reference_prop.rs:+56:16: +56:18
           _45 = opaque::<&mut usize>(move _46) -> bb6; // scope 24 at $DIR/reference_prop.rs:+56:9: +56:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:141:9: 141:15
+                                           // + span: $DIR/reference_prop.rs:159:9: 159:15
                                            // + literal: Const { ty: fn(&mut usize) {opaque::<&mut usize>}, val: Value(<ZST>) }
       }
   
@@ -330,7 +372,7 @@
           _51 = ();                        // scope 26 at $DIR/reference_prop.rs:+63:16: +63:18
           _50 = opaque::<()>(move _51) -> bb7; // scope 26 at $DIR/reference_prop.rs:+63:9: +63:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:148:9: 148:15
+                                           // + span: $DIR/reference_prop.rs:166:9: 166:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -341,34 +383,90 @@
           StorageDead(_49);                // scope 25 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_48);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_47);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
-          StorageLive(_52);                // scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
-          _52 = &mut (*_2);                // scope 0 at $DIR/reference_prop.rs:+68:17: +68:31
-          StorageLive(_53);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
--         StorageLive(_54);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
--         _54 = &mut (*_1);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
--         _53 = &mut (*_54);               // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
-+         _53 = &mut (*_1);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
-          _2 = move _53;                   // scope 27 at $DIR/reference_prop.rs:+69:9: +69:32
-          StorageDead(_53);                // scope 27 at $DIR/reference_prop.rs:+69:31: +69:32
--         StorageDead(_54);                // scope 27 at $DIR/reference_prop.rs:+69:32: +69:33
-          StorageLive(_55);                // scope 27 at $DIR/reference_prop.rs:+70:13: +70:14
-          _55 = (*_52);                    // scope 27 at $DIR/reference_prop.rs:+70:17: +70:19
-          StorageLive(_56);                // scope 28 at $DIR/reference_prop.rs:+71:9: +71:19
-          StorageLive(_57);                // scope 28 at $DIR/reference_prop.rs:+71:16: +71:18
-          _57 = ();                        // scope 28 at $DIR/reference_prop.rs:+71:16: +71:18
-          _56 = opaque::<()>(move _57) -> bb8; // scope 28 at $DIR/reference_prop.rs:+71:9: +71:19
+-         StorageLive(_52);                // scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
+          StorageLive(_53);                // scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
+          _53 = &mut (*_2);                // scope 0 at $DIR/reference_prop.rs:+68:17: +68:31
+          StorageLive(_54);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
+-         StorageLive(_55);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
+-         _55 = &mut (*_1);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
+-         _54 = &mut (*_55);               // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
++         _54 = &mut (*_1);                // scope 27 at $DIR/reference_prop.rs:+69:20: +69:32
+          _2 = move _54;                   // scope 27 at $DIR/reference_prop.rs:+69:9: +69:32
+          StorageDead(_54);                // scope 27 at $DIR/reference_prop.rs:+69:31: +69:32
+-         StorageDead(_55);                // scope 27 at $DIR/reference_prop.rs:+69:32: +69:33
+          StorageLive(_56);                // scope 27 at $DIR/reference_prop.rs:+70:13: +70:14
+          _56 = (*_53);                    // scope 27 at $DIR/reference_prop.rs:+70:17: +70:19
+          StorageLive(_57);                // scope 28 at $DIR/reference_prop.rs:+71:9: +71:19
+          StorageLive(_58);                // scope 28 at $DIR/reference_prop.rs:+71:16: +71:18
+          _58 = ();                        // scope 28 at $DIR/reference_prop.rs:+71:16: +71:18
+          _57 = opaque::<()>(move _58) -> bb8; // scope 28 at $DIR/reference_prop.rs:+71:9: +71:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:156:9: 156:15
+                                           // + span: $DIR/reference_prop.rs:174:9: 174:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
       bb8: {
-          StorageDead(_57);                // scope 28 at $DIR/reference_prop.rs:+71:18: +71:19
-          StorageDead(_56);                // scope 28 at $DIR/reference_prop.rs:+71:19: +71:20
-          _0 = const ();                   // scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
-          StorageDead(_55);                // scope 27 at $DIR/reference_prop.rs:+72:5: +72:6
-          StorageDead(_52);                // scope 0 at $DIR/reference_prop.rs:+72:5: +72:6
-          return;                          // scope 0 at $DIR/reference_prop.rs:+73:2: +73:2
+          StorageDead(_58);                // scope 28 at $DIR/reference_prop.rs:+71:18: +71:19
+          StorageDead(_57);                // scope 28 at $DIR/reference_prop.rs:+71:19: +71:20
+-         _52 = const ();                  // scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
+          StorageDead(_56);                // scope 27 at $DIR/reference_prop.rs:+72:5: +72:6
+          StorageDead(_53);                // scope 0 at $DIR/reference_prop.rs:+72:5: +72:6
+-         StorageDead(_52);                // scope 0 at $DIR/reference_prop.rs:+72:5: +72:6
+-         StorageLive(_59);                // scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+          StorageLive(_60);                // scope 0 at $DIR/reference_prop.rs:+76:13: +76:18
+          _60 = const 5_usize;             // scope 0 at $DIR/reference_prop.rs:+76:21: +76:28
+-         StorageLive(_61);                // scope 29 at $DIR/reference_prop.rs:+77:13: +77:14
+-         _61 = &mut _60;                  // scope 29 at $DIR/reference_prop.rs:+77:17: +77:23
+-         StorageLive(_62);                // scope 30 at $DIR/reference_prop.rs:+78:13: +78:14
+-         _62 = &_61;                      // scope 30 at $DIR/reference_prop.rs:+78:17: +78:19
+          StorageLive(_63);                // scope 31 at $DIR/reference_prop.rs:+79:13: +79:14
+-         _63 = (*_61);                    // scope 31 at $DIR/reference_prop.rs:+79:17: +79:19
++         _63 = _60;                       // scope 31 at $DIR/reference_prop.rs:+79:17: +79:19
+          StorageLive(_64);                // scope 32 at $DIR/reference_prop.rs:+80:9: +80:19
+          StorageLive(_65);                // scope 32 at $DIR/reference_prop.rs:+80:16: +80:18
+          _65 = ();                        // scope 32 at $DIR/reference_prop.rs:+80:16: +80:18
+          _64 = opaque::<()>(move _65) -> bb9; // scope 32 at $DIR/reference_prop.rs:+80:9: +80:19
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:183:9: 183:15
+                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+      }
+  
+      bb9: {
+          StorageDead(_65);                // scope 32 at $DIR/reference_prop.rs:+80:18: +80:19
+          StorageDead(_64);                // scope 32 at $DIR/reference_prop.rs:+80:19: +80:20
+-         _59 = const ();                  // scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+          StorageDead(_63);                // scope 31 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_62);                // scope 30 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_61);                // scope 29 at $DIR/reference_prop.rs:+81:5: +81:6
+          StorageDead(_60);                // scope 0 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_59);                // scope 0 at $DIR/reference_prop.rs:+81:5: +81:6
+          StorageLive(_66);                // scope 0 at $DIR/reference_prop.rs:+85:13: +85:18
+          _66 = const 5_usize;             // scope 0 at $DIR/reference_prop.rs:+85:21: +85:28
+-         StorageLive(_67);                // scope 33 at $DIR/reference_prop.rs:+86:13: +86:18
+-         _67 = &mut _66;                  // scope 33 at $DIR/reference_prop.rs:+86:21: +86:27
+-         StorageLive(_68);                // scope 34 at $DIR/reference_prop.rs:+87:13: +87:14
+-         _68 = &mut _67;                  // scope 34 at $DIR/reference_prop.rs:+87:17: +87:23
+          StorageLive(_69);                // scope 35 at $DIR/reference_prop.rs:+88:13: +88:14
+-         _69 = (*_67);                    // scope 35 at $DIR/reference_prop.rs:+88:17: +88:19
++         _69 = _66;                       // scope 35 at $DIR/reference_prop.rs:+88:17: +88:19
+          StorageLive(_70);                // scope 36 at $DIR/reference_prop.rs:+89:9: +89:19
+          StorageLive(_71);                // scope 36 at $DIR/reference_prop.rs:+89:16: +89:18
+          _71 = ();                        // scope 36 at $DIR/reference_prop.rs:+89:16: +89:18
+          _70 = opaque::<()>(move _71) -> bb10; // scope 36 at $DIR/reference_prop.rs:+89:9: +89:19
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:192:9: 192:15
+                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+      }
+  
+      bb10: {
+          StorageDead(_71);                // scope 36 at $DIR/reference_prop.rs:+89:18: +89:19
+          StorageDead(_70);                // scope 36 at $DIR/reference_prop.rs:+89:19: +89:20
+          _0 = const ();                   // scope 0 at $DIR/reference_prop.rs:+84:5: +90:6
+          StorageDead(_69);                // scope 35 at $DIR/reference_prop.rs:+90:5: +90:6
+-         StorageDead(_68);                // scope 34 at $DIR/reference_prop.rs:+90:5: +90:6
+-         StorageDead(_67);                // scope 33 at $DIR/reference_prop.rs:+90:5: +90:6
+          StorageDead(_66);                // scope 0 at $DIR/reference_prop.rs:+90:5: +90:6
+          return;                          // scope 0 at $DIR/reference_prop.rs:+91:2: +91:2
       }
   }
   

--- a/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
@@ -17,12 +17,12 @@
       let mut _17: ();                     // in scope 0 at $DIR/reference_prop.rs:+17:16: +17:18
       let _18: ();                         // in scope 0 at $DIR/reference_prop.rs:+21:5: +27:6
       let mut _19: usize;                  // in scope 0 at $DIR/reference_prop.rs:+22:13: +22:18
-      let _23: ();                         // in scope 0 at $DIR/reference_prop.rs:+26:9: +26:19
-      let mut _24: ();                     // in scope 0 at $DIR/reference_prop.rs:+26:16: +26:18
+      let _23: ();                         // in scope 0 at $DIR/reference_prop.rs:+26:9: +26:18
+      let mut _24: &&mut usize;            // in scope 0 at $DIR/reference_prop.rs:+26:16: +26:17
       let _25: ();                         // in scope 0 at $DIR/reference_prop.rs:+30:5: +36:6
       let mut _26: usize;                  // in scope 0 at $DIR/reference_prop.rs:+31:13: +31:18
-      let _30: ();                         // in scope 0 at $DIR/reference_prop.rs:+35:9: +35:19
-      let mut _31: ();                     // in scope 0 at $DIR/reference_prop.rs:+35:16: +35:18
+      let _30: ();                         // in scope 0 at $DIR/reference_prop.rs:+35:9: +35:18
+      let mut _31: *mut &mut usize;        // in scope 0 at $DIR/reference_prop.rs:+35:16: +35:17
       let _32: ();                         // in scope 0 at $DIR/reference_prop.rs:+39:5: +44:6
       let mut _33: usize;                  // in scope 0 at $DIR/reference_prop.rs:+40:13: +40:18
       let _36: ();                         // in scope 0 at $DIR/reference_prop.rs:+43:9: +43:18
@@ -44,7 +44,8 @@
           debug a => _4;                   // in scope 1 at $DIR/reference_prop.rs:+3:13: +3:18
           let _5: &mut usize;              // in scope 1 at $DIR/reference_prop.rs:+4:13: +4:14
           scope 2 {
-              debug b => _5;               // in scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
+-             debug b => _5;               // in scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
++             debug b => &_4;              // in scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
               let _6: usize;               // in scope 2 at $DIR/reference_prop.rs:+5:13: +5:14
               scope 3 {
                   debug c => _6;           // in scope 3 at $DIR/reference_prop.rs:+5:13: +5:14
@@ -86,7 +87,7 @@
           let mut _27: &mut usize;         // in scope 12 at $DIR/reference_prop.rs:+32:13: +32:18
           scope 13 {
               debug b => _27;              // in scope 13 at $DIR/reference_prop.rs:+32:13: +32:18
-              let _28: &mut &mut usize;    // in scope 13 at $DIR/reference_prop.rs:+33:13: +33:14
+              let _28: *mut &mut usize;    // in scope 13 at $DIR/reference_prop.rs:+33:13: +33:14
               scope 14 {
                   debug d => _28;          // in scope 14 at $DIR/reference_prop.rs:+33:13: +33:14
                   let _29: usize;          // in scope 14 at $DIR/reference_prop.rs:+34:13: +34:14
@@ -131,7 +132,8 @@
           }
       }
       scope 25 {
-          debug a => _48;                  // in scope 25 at $DIR/reference_prop.rs:+61:13: +61:14
+-         debug a => _48;                  // in scope 25 at $DIR/reference_prop.rs:+61:13: +61:14
++         debug a => _1;                   // in scope 25 at $DIR/reference_prop.rs:+61:13: +61:14
           let _49: T;                      // in scope 25 at $DIR/reference_prop.rs:+62:13: +62:14
           scope 26 {
               debug b => _49;              // in scope 26 at $DIR/reference_prop.rs:+62:13: +62:14
@@ -149,8 +151,8 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/reference_prop.rs:+2:5: +7:6
           StorageLive(_4);                 // scope 0 at $DIR/reference_prop.rs:+3:13: +3:18
           _4 = const 5_usize;              // scope 0 at $DIR/reference_prop.rs:+3:21: +3:28
-          StorageLive(_5);                 // scope 1 at $DIR/reference_prop.rs:+4:13: +4:14
-          _5 = &mut _4;                    // scope 1 at $DIR/reference_prop.rs:+4:17: +4:23
+-         StorageLive(_5);                 // scope 1 at $DIR/reference_prop.rs:+4:13: +4:14
+-         _5 = &mut _4;                    // scope 1 at $DIR/reference_prop.rs:+4:17: +4:23
           StorageLive(_6);                 // scope 2 at $DIR/reference_prop.rs:+5:13: +5:14
 -         _6 = (*_5);                      // scope 2 at $DIR/reference_prop.rs:+5:17: +5:19
 +         _6 = _4;                         // scope 2 at $DIR/reference_prop.rs:+5:17: +5:19
@@ -168,7 +170,7 @@
           StorageDead(_7);                 // scope 3 at $DIR/reference_prop.rs:+6:19: +6:20
 -         _3 = const ();                   // scope 0 at $DIR/reference_prop.rs:+2:5: +7:6
           StorageDead(_6);                 // scope 2 at $DIR/reference_prop.rs:+7:5: +7:6
-          StorageDead(_5);                 // scope 1 at $DIR/reference_prop.rs:+7:5: +7:6
+-         StorageDead(_5);                 // scope 1 at $DIR/reference_prop.rs:+7:5: +7:6
           StorageDead(_4);                 // scope 0 at $DIR/reference_prop.rs:+7:5: +7:6
 -         StorageDead(_3);                 // scope 0 at $DIR/reference_prop.rs:+7:5: +7:6
 -         StorageLive(_9);                 // scope 0 at $DIR/reference_prop.rs:+10:5: +18:6
@@ -215,18 +217,18 @@
           _21 = &_20;                      // scope 9 at $DIR/reference_prop.rs:+24:17: +24:19
           StorageLive(_22);                // scope 10 at $DIR/reference_prop.rs:+25:13: +25:14
           _22 = (*_20);                    // scope 10 at $DIR/reference_prop.rs:+25:17: +25:19
-          StorageLive(_23);                // scope 11 at $DIR/reference_prop.rs:+26:9: +26:19
-          StorageLive(_24);                // scope 11 at $DIR/reference_prop.rs:+26:16: +26:18
-          _24 = ();                        // scope 11 at $DIR/reference_prop.rs:+26:16: +26:18
-          _23 = opaque::<()>(move _24) -> bb3; // scope 11 at $DIR/reference_prop.rs:+26:9: +26:19
+          StorageLive(_23);                // scope 11 at $DIR/reference_prop.rs:+26:9: +26:18
+          StorageLive(_24);                // scope 11 at $DIR/reference_prop.rs:+26:16: +26:17
+          _24 = _21;                       // scope 11 at $DIR/reference_prop.rs:+26:16: +26:17
+          _23 = opaque::<&&mut usize>(move _24) -> bb3; // scope 11 at $DIR/reference_prop.rs:+26:9: +26:18
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:111:9: 111:15
-                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(&&mut usize) {opaque::<&&mut usize>}, val: Value(<ZST>) }
       }
   
       bb3: {
-          StorageDead(_24);                // scope 11 at $DIR/reference_prop.rs:+26:18: +26:19
-          StorageDead(_23);                // scope 11 at $DIR/reference_prop.rs:+26:19: +26:20
+          StorageDead(_24);                // scope 11 at $DIR/reference_prop.rs:+26:17: +26:18
+          StorageDead(_23);                // scope 11 at $DIR/reference_prop.rs:+26:18: +26:19
 -         _18 = const ();                  // scope 0 at $DIR/reference_prop.rs:+21:5: +27:6
           StorageDead(_22);                // scope 10 at $DIR/reference_prop.rs:+27:5: +27:6
           StorageDead(_21);                // scope 9 at $DIR/reference_prop.rs:+27:5: +27:6
@@ -239,21 +241,21 @@
           StorageLive(_27);                // scope 12 at $DIR/reference_prop.rs:+32:13: +32:18
           _27 = &mut _26;                  // scope 12 at $DIR/reference_prop.rs:+32:21: +32:27
           StorageLive(_28);                // scope 13 at $DIR/reference_prop.rs:+33:13: +33:14
-          _28 = &mut _27;                  // scope 13 at $DIR/reference_prop.rs:+33:17: +33:23
+          _28 = &raw mut _27;              // scope 13 at $DIR/reference_prop.rs:+33:17: +33:27
           StorageLive(_29);                // scope 14 at $DIR/reference_prop.rs:+34:13: +34:14
           _29 = (*_27);                    // scope 14 at $DIR/reference_prop.rs:+34:17: +34:19
-          StorageLive(_30);                // scope 15 at $DIR/reference_prop.rs:+35:9: +35:19
-          StorageLive(_31);                // scope 15 at $DIR/reference_prop.rs:+35:16: +35:18
-          _31 = ();                        // scope 15 at $DIR/reference_prop.rs:+35:16: +35:18
-          _30 = opaque::<()>(move _31) -> bb4; // scope 15 at $DIR/reference_prop.rs:+35:9: +35:19
+          StorageLive(_30);                // scope 15 at $DIR/reference_prop.rs:+35:9: +35:18
+          StorageLive(_31);                // scope 15 at $DIR/reference_prop.rs:+35:16: +35:17
+          _31 = _28;                       // scope 15 at $DIR/reference_prop.rs:+35:16: +35:17
+          _30 = opaque::<*mut &mut usize>(move _31) -> bb4; // scope 15 at $DIR/reference_prop.rs:+35:9: +35:18
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:120:9: 120:15
-                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(*mut &mut usize) {opaque::<*mut &mut usize>}, val: Value(<ZST>) }
       }
   
       bb4: {
-          StorageDead(_31);                // scope 15 at $DIR/reference_prop.rs:+35:18: +35:19
-          StorageDead(_30);                // scope 15 at $DIR/reference_prop.rs:+35:19: +35:20
+          StorageDead(_31);                // scope 15 at $DIR/reference_prop.rs:+35:17: +35:18
+          StorageDead(_30);                // scope 15 at $DIR/reference_prop.rs:+35:18: +35:19
 -         _25 = const ();                  // scope 0 at $DIR/reference_prop.rs:+30:5: +36:6
           StorageDead(_29);                // scope 14 at $DIR/reference_prop.rs:+36:5: +36:6
           StorageDead(_28);                // scope 13 at $DIR/reference_prop.rs:+36:5: +36:6
@@ -318,8 +320,8 @@
           StorageDead(_39);                // scope 0 at $DIR/reference_prop.rs:+57:5: +57:6
 -         StorageDead(_38);                // scope 0 at $DIR/reference_prop.rs:+57:5: +57:6
 -         StorageLive(_47);                // scope 0 at $DIR/reference_prop.rs:+60:5: +64:6
-          StorageLive(_48);                // scope 0 at $DIR/reference_prop.rs:+61:13: +61:14
-          _48 = &mut (*_1);                // scope 0 at $DIR/reference_prop.rs:+61:17: +61:29
+-         StorageLive(_48);                // scope 0 at $DIR/reference_prop.rs:+61:13: +61:14
+-         _48 = &mut (*_1);                // scope 0 at $DIR/reference_prop.rs:+61:17: +61:29
           StorageLive(_49);                // scope 25 at $DIR/reference_prop.rs:+62:13: +62:14
 -         _49 = (*_48);                    // scope 25 at $DIR/reference_prop.rs:+62:17: +62:19
 +         _49 = (*_1);                     // scope 25 at $DIR/reference_prop.rs:+62:17: +62:19
@@ -337,7 +339,7 @@
           StorageDead(_50);                // scope 26 at $DIR/reference_prop.rs:+63:19: +63:20
 -         _47 = const ();                  // scope 0 at $DIR/reference_prop.rs:+60:5: +64:6
           StorageDead(_49);                // scope 25 at $DIR/reference_prop.rs:+64:5: +64:6
-          StorageDead(_48);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
+-         StorageDead(_48);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_47);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
           StorageLive(_52);                // scope 0 at $DIR/reference_prop.rs:+68:13: +68:14
           _52 = &mut (*_2);                // scope 0 at $DIR/reference_prop.rs:+68:17: +68:31

--- a/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
@@ -27,9 +27,15 @@
       let _46: ();                         // in scope 0 at $DIR/reference_prop.rs:+60:5: +64:6
       let _49: ();                         // in scope 0 at $DIR/reference_prop.rs:+63:9: +63:19
       let mut _50: ();                     // in scope 0 at $DIR/reference_prop.rs:+63:16: +63:18
-      let mut _52: *mut T;                 // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:36
-      let _54: ();                         // in scope 0 at $DIR/reference_prop.rs:+71:9: +71:19
-      let mut _55: ();                     // in scope 0 at $DIR/reference_prop.rs:+71:16: +71:18
+      let _51: ();                         // in scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
+      let mut _53: *mut T;                 // in scope 0 at $DIR/reference_prop.rs:+69:20: +69:36
+      let _55: ();                         // in scope 0 at $DIR/reference_prop.rs:+71:9: +71:19
+      let mut _56: ();                     // in scope 0 at $DIR/reference_prop.rs:+71:16: +71:18
+      let _57: ();                         // in scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+      let _62: ();                         // in scope 0 at $DIR/reference_prop.rs:+80:9: +80:19
+      let mut _63: ();                     // in scope 0 at $DIR/reference_prop.rs:+80:16: +80:18
+      let _68: ();                         // in scope 0 at $DIR/reference_prop.rs:+89:9: +89:19
+      let mut _69: ();                     // in scope 0 at $DIR/reference_prop.rs:+89:16: +89:18
       scope 1 {
           let mut _4: usize;               // in scope 1 at $DIR/reference_prop.rs:+3:13: +3:18
           scope 2 {
@@ -151,12 +157,52 @@
           }
       }
       scope 34 {
-          let _51: *mut T;                 // in scope 34 at $DIR/reference_prop.rs:+68:13: +68:14
+          let _52: *mut T;                 // in scope 34 at $DIR/reference_prop.rs:+68:13: +68:14
           scope 35 {
-              debug a => _51;              // in scope 35 at $DIR/reference_prop.rs:+68:13: +68:14
-              let _53: T;                  // in scope 35 at $DIR/reference_prop.rs:+70:13: +70:14
+              debug a => _52;              // in scope 35 at $DIR/reference_prop.rs:+68:13: +68:14
+              let _54: T;                  // in scope 35 at $DIR/reference_prop.rs:+70:13: +70:14
               scope 36 {
-                  debug b => _53;          // in scope 36 at $DIR/reference_prop.rs:+70:13: +70:14
+                  debug b => _54;          // in scope 36 at $DIR/reference_prop.rs:+70:13: +70:14
+              }
+          }
+      }
+      scope 37 {
+          let mut _58: usize;              // in scope 37 at $DIR/reference_prop.rs:+76:13: +76:18
+          scope 38 {
+              debug a => _58;              // in scope 38 at $DIR/reference_prop.rs:+76:13: +76:18
+              let _59: *mut usize;         // in scope 38 at $DIR/reference_prop.rs:+77:13: +77:14
+              scope 39 {
+-                 debug b => _59;          // in scope 39 at $DIR/reference_prop.rs:+77:13: +77:14
++                 debug b => &_58;         // in scope 39 at $DIR/reference_prop.rs:+77:13: +77:14
+                  let _60: &*mut usize;    // in scope 39 at $DIR/reference_prop.rs:+78:13: +78:14
+                  scope 40 {
+-                     debug d => _60;      // in scope 40 at $DIR/reference_prop.rs:+78:13: +78:14
++                     debug d => &&_58;    // in scope 40 at $DIR/reference_prop.rs:+78:13: +78:14
+                      let _61: usize;      // in scope 40 at $DIR/reference_prop.rs:+79:13: +79:14
+                      scope 41 {
+                          debug c => _61;  // in scope 41 at $DIR/reference_prop.rs:+79:13: +79:14
+                      }
+                  }
+              }
+          }
+      }
+      scope 42 {
+          let mut _64: usize;              // in scope 42 at $DIR/reference_prop.rs:+85:13: +85:18
+          scope 43 {
+              debug a => _64;              // in scope 43 at $DIR/reference_prop.rs:+85:13: +85:18
+              let mut _65: *mut usize;     // in scope 43 at $DIR/reference_prop.rs:+86:13: +86:18
+              scope 44 {
+-                 debug b => _65;          // in scope 44 at $DIR/reference_prop.rs:+86:13: +86:18
++                 debug b => &_64;         // in scope 44 at $DIR/reference_prop.rs:+86:13: +86:18
+                  let _66: &mut *mut usize; // in scope 44 at $DIR/reference_prop.rs:+87:13: +87:14
+                  scope 45 {
+-                     debug d => _66;      // in scope 45 at $DIR/reference_prop.rs:+87:13: +87:14
++                     debug d => &&_64;    // in scope 45 at $DIR/reference_prop.rs:+87:13: +87:14
+                      let _67: usize;      // in scope 45 at $DIR/reference_prop.rs:+88:13: +88:14
+                      scope 46 {
+                          debug c => _67;  // in scope 46 at $DIR/reference_prop.rs:+88:13: +88:14
+                      }
+                  }
               }
           }
       }
@@ -175,7 +221,7 @@
           _8 = ();                         // scope 4 at $DIR/reference_prop.rs:+6:16: +6:18
           _7 = opaque::<()>(move _8) -> bb1; // scope 4 at $DIR/reference_prop.rs:+6:9: +6:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:250:9: 250:15
+                                           // + span: $DIR/reference_prop.rs:304:9: 304:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -205,7 +251,7 @@
           _16 = ();                        // scope 9 at $DIR/reference_prop.rs:+17:16: +17:18
           _15 = opaque::<()>(move _16) -> bb2; // scope 9 at $DIR/reference_prop.rs:+17:9: +17:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:261:9: 261:15
+                                           // + span: $DIR/reference_prop.rs:315:9: 315:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -232,7 +278,7 @@
           _23 = _20;                       // scope 14 at $DIR/reference_prop.rs:+26:16: +26:17
           _22 = opaque::<&*mut usize>(move _23) -> bb3; // scope 14 at $DIR/reference_prop.rs:+26:9: +26:18
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:270:9: 270:15
+                                           // + span: $DIR/reference_prop.rs:324:9: 324:15
                                            // + literal: Const { ty: fn(&*mut usize) {opaque::<&*mut usize>}, val: Value(<ZST>) }
       }
   
@@ -259,7 +305,7 @@
           _30 = _27;                       // scope 19 at $DIR/reference_prop.rs:+35:16: +35:17
           _29 = opaque::<*mut *mut usize>(move _30) -> bb4; // scope 19 at $DIR/reference_prop.rs:+35:9: +35:18
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:279:9: 279:15
+                                           // + span: $DIR/reference_prop.rs:333:9: 333:15
                                            // + literal: Const { ty: fn(*mut *mut usize) {opaque::<*mut *mut usize>}, val: Value(<ZST>) }
       }
   
@@ -284,7 +330,7 @@
           _36 = _33;                       // scope 23 at $DIR/reference_prop.rs:+43:16: +43:17
           _35 = opaque::<*mut usize>(move _36) -> bb5; // scope 23 at $DIR/reference_prop.rs:+43:9: +43:18
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:287:9: 287:15
+                                           // + span: $DIR/reference_prop.rs:341:9: 341:15
                                            // + literal: Const { ty: fn(*mut usize) {opaque::<*mut usize>}, val: Value(<ZST>) }
       }
   
@@ -314,7 +360,7 @@
           _45 = _43;                       // scope 30 at $DIR/reference_prop.rs:+56:16: +56:18
           _44 = opaque::<*mut usize>(move _45) -> bb6; // scope 30 at $DIR/reference_prop.rs:+56:9: +56:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:300:9: 300:15
+                                           // + span: $DIR/reference_prop.rs:354:9: 354:15
                                            // + literal: Const { ty: fn(*mut usize) {opaque::<*mut usize>}, val: Value(<ZST>) }
       }
   
@@ -340,7 +386,7 @@
           _50 = ();                        // scope 33 at $DIR/reference_prop.rs:+63:16: +63:18
           _49 = opaque::<()>(move _50) -> bb7; // scope 33 at $DIR/reference_prop.rs:+63:9: +63:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:307:9: 307:15
+                                           // + span: $DIR/reference_prop.rs:361:9: 361:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
@@ -351,30 +397,86 @@
           StorageDead(_48);                // scope 32 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_47);                // scope 31 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_46);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
-          StorageLive(_51);                // scope 34 at $DIR/reference_prop.rs:+68:13: +68:14
-          _51 = &raw mut (*_2);            // scope 34 at $DIR/reference_prop.rs:+68:17: +68:35
-          StorageLive(_52);                // scope 35 at $DIR/reference_prop.rs:+69:20: +69:36
-          _52 = &raw mut (*_1);            // scope 35 at $DIR/reference_prop.rs:+69:20: +69:36
-          _2 = move _52;                   // scope 35 at $DIR/reference_prop.rs:+69:9: +69:36
-          StorageDead(_52);                // scope 35 at $DIR/reference_prop.rs:+69:35: +69:36
-          StorageLive(_53);                // scope 35 at $DIR/reference_prop.rs:+70:13: +70:14
-          _53 = (*_51);                    // scope 35 at $DIR/reference_prop.rs:+70:17: +70:19
-          StorageLive(_54);                // scope 36 at $DIR/reference_prop.rs:+71:9: +71:19
-          StorageLive(_55);                // scope 36 at $DIR/reference_prop.rs:+71:16: +71:18
-          _55 = ();                        // scope 36 at $DIR/reference_prop.rs:+71:16: +71:18
-          _54 = opaque::<()>(move _55) -> bb8; // scope 36 at $DIR/reference_prop.rs:+71:9: +71:19
+-         StorageLive(_51);                // scope 0 at $DIR/reference_prop.rs:+67:5: +72:6
+          StorageLive(_52);                // scope 34 at $DIR/reference_prop.rs:+68:13: +68:14
+          _52 = &raw mut (*_2);            // scope 34 at $DIR/reference_prop.rs:+68:17: +68:35
+          StorageLive(_53);                // scope 35 at $DIR/reference_prop.rs:+69:20: +69:36
+          _53 = &raw mut (*_1);            // scope 35 at $DIR/reference_prop.rs:+69:20: +69:36
+          _2 = move _53;                   // scope 35 at $DIR/reference_prop.rs:+69:9: +69:36
+          StorageDead(_53);                // scope 35 at $DIR/reference_prop.rs:+69:35: +69:36
+          StorageLive(_54);                // scope 35 at $DIR/reference_prop.rs:+70:13: +70:14
+          _54 = (*_52);                    // scope 35 at $DIR/reference_prop.rs:+70:17: +70:19
+          StorageLive(_55);                // scope 36 at $DIR/reference_prop.rs:+71:9: +71:19
+          StorageLive(_56);                // scope 36 at $DIR/reference_prop.rs:+71:16: +71:18
+          _56 = ();                        // scope 36 at $DIR/reference_prop.rs:+71:16: +71:18
+          _55 = opaque::<()>(move _56) -> bb8; // scope 36 at $DIR/reference_prop.rs:+71:9: +71:19
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:315:9: 315:15
+                                           // + span: $DIR/reference_prop.rs:369:9: 369:15
                                            // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
       }
   
       bb8: {
-          StorageDead(_55);                // scope 36 at $DIR/reference_prop.rs:+71:18: +71:19
-          StorageDead(_54);                // scope 36 at $DIR/reference_prop.rs:+71:19: +71:20
-          _0 = const ();                   // scope 34 at $DIR/reference_prop.rs:+67:5: +72:6
-          StorageDead(_53);                // scope 35 at $DIR/reference_prop.rs:+72:5: +72:6
-          StorageDead(_51);                // scope 34 at $DIR/reference_prop.rs:+72:5: +72:6
-          return;                          // scope 0 at $DIR/reference_prop.rs:+73:2: +73:2
+          StorageDead(_56);                // scope 36 at $DIR/reference_prop.rs:+71:18: +71:19
+          StorageDead(_55);                // scope 36 at $DIR/reference_prop.rs:+71:19: +71:20
+-         _51 = const ();                  // scope 34 at $DIR/reference_prop.rs:+67:5: +72:6
+          StorageDead(_54);                // scope 35 at $DIR/reference_prop.rs:+72:5: +72:6
+          StorageDead(_52);                // scope 34 at $DIR/reference_prop.rs:+72:5: +72:6
+-         StorageDead(_51);                // scope 0 at $DIR/reference_prop.rs:+72:5: +72:6
+-         StorageLive(_57);                // scope 0 at $DIR/reference_prop.rs:+75:5: +81:6
+          StorageLive(_58);                // scope 37 at $DIR/reference_prop.rs:+76:13: +76:18
+          _58 = const 5_usize;             // scope 37 at $DIR/reference_prop.rs:+76:21: +76:28
+-         StorageLive(_59);                // scope 38 at $DIR/reference_prop.rs:+77:13: +77:14
+-         _59 = &raw mut _58;              // scope 38 at $DIR/reference_prop.rs:+77:17: +77:27
+-         StorageLive(_60);                // scope 39 at $DIR/reference_prop.rs:+78:13: +78:14
+-         _60 = &_59;                      // scope 39 at $DIR/reference_prop.rs:+78:17: +78:19
+          StorageLive(_61);                // scope 40 at $DIR/reference_prop.rs:+79:13: +79:14
+-         _61 = (*_59);                    // scope 40 at $DIR/reference_prop.rs:+79:17: +79:19
++         _61 = _58;                       // scope 40 at $DIR/reference_prop.rs:+79:17: +79:19
+          StorageLive(_62);                // scope 41 at $DIR/reference_prop.rs:+80:9: +80:19
+          StorageLive(_63);                // scope 41 at $DIR/reference_prop.rs:+80:16: +80:18
+          _63 = ();                        // scope 41 at $DIR/reference_prop.rs:+80:16: +80:18
+          _62 = opaque::<()>(move _63) -> bb9; // scope 41 at $DIR/reference_prop.rs:+80:9: +80:19
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:378:9: 378:15
+                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+      }
+  
+      bb9: {
+          StorageDead(_63);                // scope 41 at $DIR/reference_prop.rs:+80:18: +80:19
+          StorageDead(_62);                // scope 41 at $DIR/reference_prop.rs:+80:19: +80:20
+-         _57 = const ();                  // scope 37 at $DIR/reference_prop.rs:+75:5: +81:6
+          StorageDead(_61);                // scope 40 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_60);                // scope 39 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_59);                // scope 38 at $DIR/reference_prop.rs:+81:5: +81:6
+          StorageDead(_58);                // scope 37 at $DIR/reference_prop.rs:+81:5: +81:6
+-         StorageDead(_57);                // scope 0 at $DIR/reference_prop.rs:+81:5: +81:6
+          StorageLive(_64);                // scope 42 at $DIR/reference_prop.rs:+85:13: +85:18
+          _64 = const 5_usize;             // scope 42 at $DIR/reference_prop.rs:+85:21: +85:28
+-         StorageLive(_65);                // scope 43 at $DIR/reference_prop.rs:+86:13: +86:18
+-         _65 = &raw mut _64;              // scope 43 at $DIR/reference_prop.rs:+86:21: +86:31
+-         StorageLive(_66);                // scope 44 at $DIR/reference_prop.rs:+87:13: +87:14
+-         _66 = &mut _65;                  // scope 44 at $DIR/reference_prop.rs:+87:17: +87:23
+          StorageLive(_67);                // scope 45 at $DIR/reference_prop.rs:+88:13: +88:14
+-         _67 = (*_65);                    // scope 45 at $DIR/reference_prop.rs:+88:17: +88:19
++         _67 = _64;                       // scope 45 at $DIR/reference_prop.rs:+88:17: +88:19
+          StorageLive(_68);                // scope 46 at $DIR/reference_prop.rs:+89:9: +89:19
+          StorageLive(_69);                // scope 46 at $DIR/reference_prop.rs:+89:16: +89:18
+          _69 = ();                        // scope 46 at $DIR/reference_prop.rs:+89:16: +89:18
+          _68 = opaque::<()>(move _69) -> bb10; // scope 46 at $DIR/reference_prop.rs:+89:9: +89:19
+                                           // mir::Constant
+                                           // + span: $DIR/reference_prop.rs:387:9: 387:15
+                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+      }
+  
+      bb10: {
+          StorageDead(_69);                // scope 46 at $DIR/reference_prop.rs:+89:18: +89:19
+          StorageDead(_68);                // scope 46 at $DIR/reference_prop.rs:+89:19: +89:20
+          _0 = const ();                   // scope 42 at $DIR/reference_prop.rs:+84:5: +90:6
+          StorageDead(_67);                // scope 45 at $DIR/reference_prop.rs:+90:5: +90:6
+-         StorageDead(_66);                // scope 44 at $DIR/reference_prop.rs:+90:5: +90:6
+-         StorageDead(_65);                // scope 43 at $DIR/reference_prop.rs:+90:5: +90:6
+          StorageDead(_64);                // scope 42 at $DIR/reference_prop.rs:+90:5: +90:6
+          return;                          // scope 0 at $DIR/reference_prop.rs:+91:2: +91:2
       }
   }
   

--- a/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
@@ -13,11 +13,11 @@
       let _15: ();                         // in scope 0 at $DIR/reference_prop.rs:+17:9: +17:19
       let mut _16: ();                     // in scope 0 at $DIR/reference_prop.rs:+17:16: +17:18
       let _17: ();                         // in scope 0 at $DIR/reference_prop.rs:+21:5: +27:6
-      let _22: ();                         // in scope 0 at $DIR/reference_prop.rs:+26:9: +26:19
-      let mut _23: ();                     // in scope 0 at $DIR/reference_prop.rs:+26:16: +26:18
+      let _22: ();                         // in scope 0 at $DIR/reference_prop.rs:+26:9: +26:18
+      let mut _23: &*mut usize;            // in scope 0 at $DIR/reference_prop.rs:+26:16: +26:17
       let _24: ();                         // in scope 0 at $DIR/reference_prop.rs:+30:5: +36:6
-      let _29: ();                         // in scope 0 at $DIR/reference_prop.rs:+35:9: +35:19
-      let mut _30: ();                     // in scope 0 at $DIR/reference_prop.rs:+35:16: +35:18
+      let _29: ();                         // in scope 0 at $DIR/reference_prop.rs:+35:9: +35:18
+      let mut _30: *mut *mut usize;        // in scope 0 at $DIR/reference_prop.rs:+35:16: +35:17
       let _31: ();                         // in scope 0 at $DIR/reference_prop.rs:+39:5: +44:6
       let _35: ();                         // in scope 0 at $DIR/reference_prop.rs:+43:9: +43:18
       let mut _36: *mut usize;             // in scope 0 at $DIR/reference_prop.rs:+43:16: +43:17
@@ -36,7 +36,8 @@
               debug a => _4;               // in scope 2 at $DIR/reference_prop.rs:+3:13: +3:18
               let _5: *mut usize;          // in scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
               scope 3 {
-                  debug b => _5;           // in scope 3 at $DIR/reference_prop.rs:+4:13: +4:14
+-                 debug b => _5;           // in scope 3 at $DIR/reference_prop.rs:+4:13: +4:14
++                 debug b => &_4;          // in scope 3 at $DIR/reference_prop.rs:+4:13: +4:14
                   let _6: usize;           // in scope 3 at $DIR/reference_prop.rs:+5:13: +5:14
                   scope 4 {
                       debug c => _6;       // in scope 4 at $DIR/reference_prop.rs:+5:13: +5:14
@@ -87,7 +88,7 @@
               let mut _26: *mut usize;     // in scope 16 at $DIR/reference_prop.rs:+32:13: +32:18
               scope 17 {
                   debug b => _26;          // in scope 17 at $DIR/reference_prop.rs:+32:13: +32:18
-                  let _27: &mut *mut usize; // in scope 17 at $DIR/reference_prop.rs:+33:13: +33:14
+                  let _27: *mut *mut usize; // in scope 17 at $DIR/reference_prop.rs:+33:13: +33:14
                   scope 18 {
                       debug d => _27;      // in scope 18 at $DIR/reference_prop.rs:+33:13: +33:14
                       let _28: usize;      // in scope 18 at $DIR/reference_prop.rs:+34:13: +34:14
@@ -141,7 +142,8 @@
       scope 31 {
           let _47: *mut T;                 // in scope 31 at $DIR/reference_prop.rs:+61:13: +61:14
           scope 32 {
-              debug a => _47;              // in scope 32 at $DIR/reference_prop.rs:+61:13: +61:14
+-             debug a => _47;              // in scope 32 at $DIR/reference_prop.rs:+61:13: +61:14
++             debug a => _1;               // in scope 32 at $DIR/reference_prop.rs:+61:13: +61:14
               let _48: T;                  // in scope 32 at $DIR/reference_prop.rs:+62:13: +62:14
               scope 33 {
                   debug b => _48;          // in scope 33 at $DIR/reference_prop.rs:+62:13: +62:14
@@ -163,8 +165,8 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/reference_prop.rs:+2:5: +7:6
           StorageLive(_4);                 // scope 1 at $DIR/reference_prop.rs:+3:13: +3:18
           _4 = const 5_usize;              // scope 1 at $DIR/reference_prop.rs:+3:21: +3:28
-          StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
-          _5 = &raw mut _4;                // scope 2 at $DIR/reference_prop.rs:+4:17: +4:27
+-         StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+4:13: +4:14
+-         _5 = &raw mut _4;                // scope 2 at $DIR/reference_prop.rs:+4:17: +4:27
           StorageLive(_6);                 // scope 3 at $DIR/reference_prop.rs:+5:13: +5:14
 -         _6 = (*_5);                      // scope 3 at $DIR/reference_prop.rs:+5:17: +5:19
 +         _6 = _4;                         // scope 3 at $DIR/reference_prop.rs:+5:17: +5:19
@@ -182,7 +184,7 @@
           StorageDead(_7);                 // scope 4 at $DIR/reference_prop.rs:+6:19: +6:20
 -         _3 = const ();                   // scope 1 at $DIR/reference_prop.rs:+2:5: +7:6
           StorageDead(_6);                 // scope 3 at $DIR/reference_prop.rs:+7:5: +7:6
-          StorageDead(_5);                 // scope 2 at $DIR/reference_prop.rs:+7:5: +7:6
+-         StorageDead(_5);                 // scope 2 at $DIR/reference_prop.rs:+7:5: +7:6
           StorageDead(_4);                 // scope 1 at $DIR/reference_prop.rs:+7:5: +7:6
 -         StorageDead(_3);                 // scope 0 at $DIR/reference_prop.rs:+7:5: +7:6
 -         StorageLive(_9);                 // scope 0 at $DIR/reference_prop.rs:+10:5: +18:6
@@ -225,18 +227,18 @@
           _20 = &_19;                      // scope 12 at $DIR/reference_prop.rs:+24:17: +24:19
           StorageLive(_21);                // scope 13 at $DIR/reference_prop.rs:+25:13: +25:14
           _21 = (*_19);                    // scope 13 at $DIR/reference_prop.rs:+25:17: +25:19
-          StorageLive(_22);                // scope 14 at $DIR/reference_prop.rs:+26:9: +26:19
-          StorageLive(_23);                // scope 14 at $DIR/reference_prop.rs:+26:16: +26:18
-          _23 = ();                        // scope 14 at $DIR/reference_prop.rs:+26:16: +26:18
-          _22 = opaque::<()>(move _23) -> bb3; // scope 14 at $DIR/reference_prop.rs:+26:9: +26:19
+          StorageLive(_22);                // scope 14 at $DIR/reference_prop.rs:+26:9: +26:18
+          StorageLive(_23);                // scope 14 at $DIR/reference_prop.rs:+26:16: +26:17
+          _23 = _20;                       // scope 14 at $DIR/reference_prop.rs:+26:16: +26:17
+          _22 = opaque::<&*mut usize>(move _23) -> bb3; // scope 14 at $DIR/reference_prop.rs:+26:9: +26:18
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:270:9: 270:15
-                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(&*mut usize) {opaque::<&*mut usize>}, val: Value(<ZST>) }
       }
   
       bb3: {
-          StorageDead(_23);                // scope 14 at $DIR/reference_prop.rs:+26:18: +26:19
-          StorageDead(_22);                // scope 14 at $DIR/reference_prop.rs:+26:19: +26:20
+          StorageDead(_23);                // scope 14 at $DIR/reference_prop.rs:+26:17: +26:18
+          StorageDead(_22);                // scope 14 at $DIR/reference_prop.rs:+26:18: +26:19
 -         _17 = const ();                  // scope 10 at $DIR/reference_prop.rs:+21:5: +27:6
           StorageDead(_21);                // scope 13 at $DIR/reference_prop.rs:+27:5: +27:6
           StorageDead(_20);                // scope 12 at $DIR/reference_prop.rs:+27:5: +27:6
@@ -249,21 +251,21 @@
           StorageLive(_26);                // scope 16 at $DIR/reference_prop.rs:+32:13: +32:18
           _26 = &raw mut _25;              // scope 16 at $DIR/reference_prop.rs:+32:21: +32:31
           StorageLive(_27);                // scope 17 at $DIR/reference_prop.rs:+33:13: +33:14
-          _27 = &mut _26;                  // scope 17 at $DIR/reference_prop.rs:+33:17: +33:23
+          _27 = &raw mut _26;              // scope 17 at $DIR/reference_prop.rs:+33:17: +33:27
           StorageLive(_28);                // scope 18 at $DIR/reference_prop.rs:+34:13: +34:14
           _28 = (*_26);                    // scope 18 at $DIR/reference_prop.rs:+34:17: +34:19
-          StorageLive(_29);                // scope 19 at $DIR/reference_prop.rs:+35:9: +35:19
-          StorageLive(_30);                // scope 19 at $DIR/reference_prop.rs:+35:16: +35:18
-          _30 = ();                        // scope 19 at $DIR/reference_prop.rs:+35:16: +35:18
-          _29 = opaque::<()>(move _30) -> bb4; // scope 19 at $DIR/reference_prop.rs:+35:9: +35:19
+          StorageLive(_29);                // scope 19 at $DIR/reference_prop.rs:+35:9: +35:18
+          StorageLive(_30);                // scope 19 at $DIR/reference_prop.rs:+35:16: +35:17
+          _30 = _27;                       // scope 19 at $DIR/reference_prop.rs:+35:16: +35:17
+          _29 = opaque::<*mut *mut usize>(move _30) -> bb4; // scope 19 at $DIR/reference_prop.rs:+35:9: +35:18
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:279:9: 279:15
-                                           // + literal: Const { ty: fn(()) {opaque::<()>}, val: Value(<ZST>) }
+                                           // + literal: Const { ty: fn(*mut *mut usize) {opaque::<*mut *mut usize>}, val: Value(<ZST>) }
       }
   
       bb4: {
-          StorageDead(_30);                // scope 19 at $DIR/reference_prop.rs:+35:18: +35:19
-          StorageDead(_29);                // scope 19 at $DIR/reference_prop.rs:+35:19: +35:20
+          StorageDead(_30);                // scope 19 at $DIR/reference_prop.rs:+35:17: +35:18
+          StorageDead(_29);                // scope 19 at $DIR/reference_prop.rs:+35:18: +35:19
 -         _24 = const ();                  // scope 15 at $DIR/reference_prop.rs:+30:5: +36:6
           StorageDead(_28);                // scope 18 at $DIR/reference_prop.rs:+36:5: +36:6
           StorageDead(_27);                // scope 17 at $DIR/reference_prop.rs:+36:5: +36:6
@@ -328,8 +330,8 @@
           StorageDead(_38);                // scope 24 at $DIR/reference_prop.rs:+57:5: +57:6
 -         StorageDead(_37);                // scope 0 at $DIR/reference_prop.rs:+57:5: +57:6
 -         StorageLive(_46);                // scope 0 at $DIR/reference_prop.rs:+60:5: +64:6
-          StorageLive(_47);                // scope 31 at $DIR/reference_prop.rs:+61:13: +61:14
-          _47 = &raw mut (*_1);            // scope 31 at $DIR/reference_prop.rs:+61:17: +61:33
+-         StorageLive(_47);                // scope 31 at $DIR/reference_prop.rs:+61:13: +61:14
+-         _47 = &raw mut (*_1);            // scope 31 at $DIR/reference_prop.rs:+61:17: +61:33
           StorageLive(_48);                // scope 32 at $DIR/reference_prop.rs:+62:13: +62:14
 -         _48 = (*_47);                    // scope 32 at $DIR/reference_prop.rs:+62:17: +62:19
 +         _48 = (*_1);                     // scope 32 at $DIR/reference_prop.rs:+62:17: +62:19
@@ -347,7 +349,7 @@
           StorageDead(_49);                // scope 33 at $DIR/reference_prop.rs:+63:19: +63:20
 -         _46 = const ();                  // scope 31 at $DIR/reference_prop.rs:+60:5: +64:6
           StorageDead(_48);                // scope 32 at $DIR/reference_prop.rs:+64:5: +64:6
-          StorageDead(_47);                // scope 31 at $DIR/reference_prop.rs:+64:5: +64:6
+-         StorageDead(_47);                // scope 31 at $DIR/reference_prop.rs:+64:5: +64:6
 -         StorageDead(_46);                // scope 0 at $DIR/reference_prop.rs:+64:5: +64:6
           StorageLive(_51);                // scope 34 at $DIR/reference_prop.rs:+68:13: +68:14
           _51 = &raw mut (*_2);            // scope 34 at $DIR/reference_prop.rs:+68:17: +68:35

--- a/tests/mir-opt/reference_prop.rs
+++ b/tests/mir-opt/reference_prop.rs
@@ -80,6 +80,24 @@ fn reference_propagation<'a, T: Copy>(single: &'a T, mut multiple: &'a T) {
         let b = *a; // This should not be optimized.
         opaque(());
     }
+
+    // Fixed-point propagation through a borrowed reference.
+    {
+        let a = 5_usize;
+        let b = &a;
+        let d = &b; // first round promotes debuginfo for `d`
+        let c = *b; // second round propagates this dereference
+        opaque(());
+    }
+
+    // Fixed-point propagation through a borrowed reference.
+    {
+        let a = 5_usize;
+        let mut b = &a;
+        let d = &mut b; // first round promotes debuginfo for `d`
+        let c = *b; // second round propagates this dereference
+        opaque(());
+    }
 }
 
 fn reference_propagation_mut<'a, T: Copy>(single: &'a mut T, mut multiple: &'a mut T) {
@@ -153,6 +171,24 @@ fn reference_propagation_mut<'a, T: Copy>(single: &'a mut T, mut multiple: &'a m
         let a = &mut *multiple;
         multiple = &mut *single;
         let b = *a; // This should not be optimized.
+        opaque(());
+    }
+
+    // Fixed-point propagation through a borrowed reference.
+    {
+        let mut a = 5_usize;
+        let b = &mut a;
+        let d = &b; // first round promotes debuginfo for `d`
+        let c = *b; // second round propagates this dereference
+        opaque(());
+    }
+
+    // Fixed-point propagation through a borrowed reference.
+    {
+        let mut a = 5_usize;
+        let mut b = &mut a;
+        let d = &mut b; // first round promotes debuginfo for `d`
+        let c = *b; // second round propagates this dereference
         opaque(());
     }
 }
@@ -239,6 +275,24 @@ fn reference_propagation_const_ptr<T: Copy>(single: *const T, mut multiple: *con
         let e = *c;
         opaque(());
     }
+
+    // Fixed-point propagation through a borrowed reference.
+    unsafe {
+        let a = 5_usize;
+        let b = &raw const a;
+        let d = &b; // first round promotes debuginfo for `d`
+        let c = *b; // second round propagates this dereference
+        opaque(());
+    }
+
+    // Fixed-point propagation through a borrowed reference.
+    unsafe {
+        let a = 5_usize;
+        let mut b = &raw const a;
+        let d = &mut b; // first round promotes debuginfo for `d`
+        let c = *b; // second round propagates this dereference
+        opaque(());
+    }
 }
 
 fn reference_propagation_mut_ptr<T: Copy>(single: *mut T, mut multiple: *mut T) {
@@ -312,6 +366,24 @@ fn reference_propagation_mut_ptr<T: Copy>(single: *mut T, mut multiple: *mut T) 
         let a = &raw mut *multiple;
         multiple = &raw mut *single;
         let b = *a; // This should not be optimized.
+        opaque(());
+    }
+
+    // Fixed-point propagation through a borrowed reference.
+    unsafe {
+        let mut a = 5_usize;
+        let b = &raw mut a;
+        let d = &b; // first round promotes debuginfo for `d`
+        let c = *b; // second round propagates this dereference
+        opaque(());
+    }
+
+    // Fixed-point propagation through a borrowed reference.
+    unsafe {
+        let mut a = 5_usize;
+        let mut b = &raw mut a;
+        let d = &mut b; // first round promotes debuginfo for `d`
+        let c = *b; // second round propagates this dereference
         opaque(());
     }
 }

--- a/tests/mir-opt/reference_prop.rs
+++ b/tests/mir-opt/reference_prop.rs
@@ -546,6 +546,8 @@ fn debuginfo() {
     // on the slice length.
     if let [_, ref constant_index, subslice @ .., ref constant_index_from_end] = &[6; 10][..] {
     }
+
+    let multiple_borrow = &&&mut T(6).0;
 }
 
 fn many_debuginfo() {

--- a/tests/mir-opt/reference_prop.rs
+++ b/tests/mir-opt/reference_prop.rs
@@ -548,6 +548,18 @@ fn debuginfo() {
     }
 }
 
+fn many_debuginfo() {
+    let a = 0;
+
+    // Verify that we do not ICE on deeply nested borrows.
+    let many_borrow =
+        &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+        &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+        &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+        &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+        &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&a;
+}
+
 fn main() {
     let mut x = 5_usize;
     let mut y = 7_usize;
@@ -562,6 +574,7 @@ fn main() {
     mut_raw_then_mut_shr();
     unique_with_copies();
     debuginfo();
+    many_debuginfo();
 }
 
 // EMIT_MIR reference_prop.reference_propagation.ReferencePropagation.diff

--- a/tests/mir-opt/reference_prop.rs
+++ b/tests/mir-opt/reference_prop.rs
@@ -33,16 +33,16 @@ fn reference_propagation<'a, T: Copy>(single: &'a T, mut multiple: &'a T) {
         let b = &a;
         let d = &b;
         let c = *b; // `b` is immutably borrowed, we know its value, but do not propagate it
-        opaque(());
+        opaque(d); // prevent `d` from being removed.
     }
 
     // Propagation through a borrowed reference.
     {
         let a = 5_usize;
         let mut b = &a;
-        let d = &mut b;
+        let d = &raw mut b;
         let c = *b; // `b` is mutably borrowed, we cannot know its value.
-        opaque(());
+        opaque(d); // prevent `d` from being removed.
     }
 
     // Propagation through an escaping borrow.
@@ -108,16 +108,16 @@ fn reference_propagation_mut<'a, T: Copy>(single: &'a mut T, mut multiple: &'a m
         let b = &mut a;
         let d = &b;
         let c = *b; // `b` is immutably borrowed, we know its value, but cannot be removed.
-        opaque(());
+        opaque(d); // prevent `d` from being removed.
     }
 
     // Propagation through a borrowed reference.
     {
         let mut a = 5_usize;
         let mut b = &mut a;
-        let d = &mut b;
+        let d = &raw mut b;
         let c = *b; // `b` is mutably borrowed, we cannot know its value.
-        opaque(());
+        opaque(d); // prevent `d` from being removed.
     }
 
     // Propagation through an escaping borrow.
@@ -183,16 +183,16 @@ fn reference_propagation_const_ptr<T: Copy>(single: *const T, mut multiple: *con
         let b = &raw const a;
         let d = &b;
         let c = *b; // `b` is immutably borrowed, we know its value, but cannot be removed.
-        opaque(());
+        opaque(d); // prevent `d` from being removed.
     }
 
     // Propagation through a borrowed reference.
     unsafe {
         let a = 5_usize;
         let mut b = &raw const a;
-        let d = &mut b;
+        let d = &raw mut b;
         let c = *b; // `b` is mutably borrowed, we cannot know its value.
-        opaque(());
+        opaque(d); // prevent `d` from being removed.
     }
 
     // Propagation through an escaping borrow.
@@ -267,16 +267,16 @@ fn reference_propagation_mut_ptr<T: Copy>(single: *mut T, mut multiple: *mut T) 
         let b = &raw mut a;
         let d = &b;
         let c = *b; // `b` is immutably borrowed, we know its value, but cannot be removed.
-        opaque(());
+        opaque(d); // prevent `d` from being removed.
     }
 
     // Propagation through a borrowed reference.
     unsafe {
         let mut a = 5_usize;
         let mut b = &raw mut a;
-        let d = &mut b;
+        let d = &raw mut b;
         let c = *b; // `b` is mutably borrowed, we cannot know its value.
-        opaque(());
+        opaque(d); // prevent `d` from being removed.
     }
 
     // Propagation through an escaping borrow.

--- a/tests/mir-opt/reference_prop.rs
+++ b/tests/mir-opt/reference_prop.rs
@@ -456,6 +456,26 @@ fn unique_with_copies() {
     unsafe { opaque(*y) };
 }
 
+fn debuginfo() {
+    struct T(u8);
+
+    let ref_mut_u8 = &mut 5_u8;
+    let field = &T(0).0;
+
+    // Verify that we don't emit `&*` in debuginfo.
+    let reborrow = &*ref_mut_u8;
+
+    match Some(0) {
+        None => {}
+        Some(ref variant_field) => {}
+    }
+
+    // `constant_index_from_end` and `subslice` should not be promoted, as their value depends
+    // on the slice length.
+    if let [_, ref constant_index, subslice @ .., ref constant_index_from_end] = &[6; 10][..] {
+    }
+}
+
 fn main() {
     let mut x = 5_usize;
     let mut y = 7_usize;
@@ -469,6 +489,7 @@ fn main() {
     maybe_dead(true);
     mut_raw_then_mut_shr();
     unique_with_copies();
+    debuginfo();
 }
 
 // EMIT_MIR reference_prop.reference_propagation.ReferencePropagation.diff
@@ -481,3 +502,4 @@ fn main() {
 // EMIT_MIR reference_prop.maybe_dead.ReferencePropagation.diff
 // EMIT_MIR reference_prop.mut_raw_then_mut_shr.ReferencePropagation.diff
 // EMIT_MIR reference_prop.unique_with_copies.ReferencePropagation.diff
+// EMIT_MIR reference_prop.debuginfo.ReferencePropagation.diff

--- a/tests/mir-opt/reference_prop.unique_with_copies.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.unique_with_copies.ReferencePropagation.diff
@@ -10,7 +10,8 @@
       let _6: ();                          // in scope 0 at $DIR/reference_prop.rs:+9:14: +9:24
       let mut _7: i32;                     // in scope 0 at $DIR/reference_prop.rs:+9:21: +9:23
       scope 1 {
-          debug y => _1;                   // in scope 1 at $DIR/reference_prop.rs:+1:9: +1:10
+-         debug y => _1;                   // in scope 1 at $DIR/reference_prop.rs:+1:9: +1:10
++         debug y => _3;                   // in scope 1 at $DIR/reference_prop.rs:+1:9: +1:10
           scope 5 {
           }
       }
@@ -25,7 +26,7 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/reference_prop.rs:+1:9: +1:10
+-         StorageLive(_1);                 // scope 0 at $DIR/reference_prop.rs:+1:9: +1:10
           StorageLive(_2);                 // scope 0 at $DIR/reference_prop.rs:+2:13: +2:18
           _2 = const 0_i32;                // scope 0 at $DIR/reference_prop.rs:+2:21: +2:22
 -         StorageLive(_3);                 // scope 2 at $DIR/reference_prop.rs:+3:13: +3:14
@@ -42,7 +43,7 @@
       bb1: {
           StorageDead(_5);                 // scope 4 at $DIR/reference_prop.rs:+5:27: +5:28
           StorageDead(_4);                 // scope 3 at $DIR/reference_prop.rs:+5:30: +5:31
-          _1 = _3;                         // scope 3 at $DIR/reference_prop.rs:+6:9: +6:10
+-         _1 = _3;                         // scope 3 at $DIR/reference_prop.rs:+6:9: +6:10
 -         StorageDead(_3);                 // scope 2 at $DIR/reference_prop.rs:+7:5: +7:6
           StorageDead(_2);                 // scope 0 at $DIR/reference_prop.rs:+7:5: +7:6
           StorageLive(_6);                 // scope 1 at $DIR/reference_prop.rs:+9:5: +9:26
@@ -59,7 +60,7 @@
           StorageDead(_7);                 // scope 5 at $DIR/reference_prop.rs:+9:23: +9:24
           StorageDead(_6);                 // scope 1 at $DIR/reference_prop.rs:+9:26: +9:27
           _0 = const ();                   // scope 0 at $DIR/reference_prop.rs:+0:25: +10:2
-          StorageDead(_1);                 // scope 0 at $DIR/reference_prop.rs:+10:1: +10:2
+-         StorageDead(_1);                 // scope 0 at $DIR/reference_prop.rs:+10:1: +10:2
           return;                          // scope 0 at $DIR/reference_prop.rs:+10:2: +10:2
       }
   }

--- a/tests/mir-opt/reference_prop.unique_with_copies.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.unique_with_copies.ReferencePropagation.diff
@@ -36,7 +36,7 @@
           _5 = (*_3);                      // scope 4 at $DIR/reference_prop.rs:+5:25: +5:27
           _4 = opaque::<i32>(move _5) -> bb1; // scope 4 at $DIR/reference_prop.rs:+5:18: +5:28
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:452:18: 452:24
+                                           // + span: $DIR/reference_prop.rs:524:18: 524:24
                                            // + literal: Const { ty: fn(i32) {opaque::<i32>}, val: Value(<ZST>) }
       }
   
@@ -52,7 +52,7 @@
 +         _7 = (*_3);                      // scope 5 at $DIR/reference_prop.rs:+9:21: +9:23
           _6 = opaque::<i32>(move _7) -> bb2; // scope 5 at $DIR/reference_prop.rs:+9:14: +9:24
                                            // mir::Constant
-                                           // + span: $DIR/reference_prop.rs:456:14: 456:20
+                                           // + span: $DIR/reference_prop.rs:528:14: 528:20
                                            // + literal: Const { ty: fn(i32) {opaque::<i32>}, val: Value(<ZST>) }
       }
   

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
@@ -9,81 +9,77 @@
       let _6: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
       let mut _7: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:56
       let mut _8: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:46
-      let mut _9: &&usize;                 // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:41
-      let mut _10: &&usize;                // in scope 0 at $DIR/slice_filter.rs:+0:45: +0:46
-      let _11: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:45: +0:46
-      let mut _12: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:50: +0:56
-      let mut _13: &&usize;                // in scope 0 at $DIR/slice_filter.rs:+0:50: +0:51
-      let mut _14: &&usize;                // in scope 0 at $DIR/slice_filter.rs:+0:55: +0:56
-      let _15: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:55: +0:56
-      let mut _16: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:76
-      let mut _17: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:66
-      let mut _18: &&usize;                // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:61
-      let mut _19: &&usize;                // in scope 0 at $DIR/slice_filter.rs:+0:65: +0:66
-      let _20: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:65: +0:66
-      let mut _21: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:70: +0:76
-      let mut _22: &&usize;                // in scope 0 at $DIR/slice_filter.rs:+0:70: +0:71
-      let mut _23: &&usize;                // in scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
-      let _24: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
-      let mut _25: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
-      let mut _26: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
-      let mut _27: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
-      let mut _28: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
+      let _9: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:45: +0:46
+      let mut _10: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:50: +0:56
+      let _11: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:55: +0:56
+      let mut _12: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:76
+      let mut _13: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:66
+      let _14: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:65: +0:66
+      let mut _15: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:70: +0:76
+      let _16: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
+      let mut _17: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
+      let mut _18: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
+      let mut _19: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
+      let mut _20: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
       scope 1 {
 -         debug a => _3;                   // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
 -         debug b => _4;                   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
 -         debug c => _5;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
 -         debug d => _6;                   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
-+         debug a => _20;                  // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
-+         debug b => _15;                  // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
-+         debug c => _11;                  // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
-+         debug d => _24;                  // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
++         debug a => _14;                  // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
++         debug b => _11;                  // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
++         debug c => _9;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
++         debug d => _16;                  // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
           scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
-              debug self => _9;            // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _10;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _29: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _30: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug self => &_3;           // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &_14;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => &_9;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _21: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _22: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _29;       // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _30;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _31: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _32: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug self => _21;       // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug other => _22;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _23: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _24: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
           scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
-              debug self => _18;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _19;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _33: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _34: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug self => &_5;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &_9;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => &_14;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _25: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _26: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _33;       // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _34;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _35: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _36: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug self => _25;       // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug other => _26;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _27: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _28: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
           scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
-              debug self => _13;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _14;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _37: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _38: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug self => &_6;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &_16;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => &_11;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _29: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _30: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 7 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _37;       // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _38;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _39: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _40: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug self => _29;       // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug other => _30;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _31: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _32: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
           scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
-              debug self => _22;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _23;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _41: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _42: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug self => &_4;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &_11;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => &_16;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _33: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              let mut _34: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _41;       // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _42;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _43: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _44: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug self => _33;       // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug other => _34;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _35: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _36: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
       }
@@ -91,47 +87,43 @@
       bb0: {
 -         StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
 +         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-          _25 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
--         _3 = &((*_25).0: usize);         // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
+          _17 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
+-         _3 = &((*_17).0: usize);         // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
 -         StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-+         _20 = &((*_25).0: usize);        // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
++         _14 = &((*_17).0: usize);        // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
 +         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-          _26 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
--         _4 = &((*_26).1: usize);         // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
+          _18 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
+-         _4 = &((*_18).1: usize);         // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
 -         StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-+         _15 = &((*_26).1: usize);        // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
++         _11 = &((*_18).1: usize);        // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
 +         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-          _27 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
--         _5 = &((*_27).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
+          _19 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
+-         _5 = &((*_19).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
 -         StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
-+         _11 = &((*_27).2: usize);        // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
++         _9 = &((*_19).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
 +         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
-          _28 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
--         _6 = &((*_28).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
+          _20 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
+-         _6 = &((*_20).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
 -         StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
-+         _24 = &((*_28).3: usize);        // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
++         _16 = &((*_20).3: usize);        // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
           StorageLive(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
-          StorageLive(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:41
-          StorageLive(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
--         StorageLive(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
--         _11 = _5;                        // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
--         _29 = deref_copy _3;             // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         StorageLive(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
+-         _9 = _5;                         // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
+-         _21 = deref_copy _3;             // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-+         _29 = deref_copy _20;            // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _30 = deref_copy _11;            // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_31);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _31 = (*_29);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_32);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _32 = (*_30);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _8 = Le(move _31, move _32);     // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_32);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_31);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
++         _21 = deref_copy _14;            // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _22 = deref_copy _9;             // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_23);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _23 = (*_21);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_24);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _24 = (*_22);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _8 = Le(move _23, move _24);     // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_24);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_23);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         StorageDead(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          StorageDead(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           switchInt(move _8) -> [0: bb4, otherwise: bb5]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
       }
   
@@ -141,34 +133,30 @@
       }
   
       bb2: {
--         StorageLive(_16);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
+-         StorageLive(_12);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
-          StorageLive(_17);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
-          StorageLive(_18);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:61
-          StorageLive(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
--         StorageLive(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
--         _20 = _3;                        // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
--         _33 = deref_copy _5;             // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_13);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+-         StorageLive(_14);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
+-         _14 = _3;                        // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
+-         _25 = deref_copy _5;             // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-+         _33 = deref_copy _11;            // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _34 = deref_copy _20;            // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_35);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _35 = (*_33);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_36);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _36 = (*_34);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _17 = Le(move _35, move _36);    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_36);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_35);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
++         _25 = deref_copy _9;             // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _26 = deref_copy _14;            // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_27);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _27 = (*_25);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_28);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _28 = (*_26);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _13 = Le(move _27, move _28);    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_28);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_27);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         StorageDead(_14);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          StorageDead(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          StorageDead(_18);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          switchInt(move _17) -> [0: bb6, otherwise: bb7]; // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
+          switchInt(move _13) -> [0: bb6, otherwise: bb7]; // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
       }
   
       bb3: {
--         StorageDead(_16);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_12);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 -         StorageDead(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 -         StorageDead(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
 -         StorageDead(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
@@ -184,84 +172,76 @@
       }
   
       bb4: {
--         StorageDead(_12);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           StorageDead(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           goto -> bb2;                     // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
       }
   
       bb5: {
--         StorageLive(_12);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+-         StorageLive(_10);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
+-         StorageLive(_11);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         _11 = _4;                        // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         _29 = deref_copy _6;             // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
-          StorageLive(_13);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:51
-          StorageLive(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
--         StorageLive(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
--         _15 = _4;                        // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
--         _37 = deref_copy _6;             // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-+         _37 = deref_copy _24;            // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _38 = deref_copy _15;            // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_39);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _39 = (*_37);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_40);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _40 = (*_38);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _12 = Le(move _39, move _40);    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_40);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_39);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
++         _29 = deref_copy _16;            // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _30 = deref_copy _11;            // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_31);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _31 = (*_29);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_32);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _32 = (*_30);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _10 = Le(move _31, move _32);    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_32);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_31);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         StorageDead(_11);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         _7 = move _10;                   // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
+-         StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          StorageDead(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          StorageDead(_13);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
--         _7 = move _12;                   // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
--         StorageDead(_12);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           StorageDead(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 -         switchInt(move _7) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
-+         switchInt(move _12) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
++         switchInt(move _10) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
       }
   
       bb6: {
--         _16 = const false;               // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
+-         _12 = const false;               // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
 +         _0 = const false;                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
           goto -> bb8;                     // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
       }
   
       bb7: {
--         StorageLive(_21);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+-         StorageLive(_15);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
+-         StorageLive(_16);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         _16 = _6;                        // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         _33 = deref_copy _4;             // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
-          StorageLive(_22);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:71
-          StorageLive(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         StorageLive(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         _24 = _6;                        // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         _41 = deref_copy _4;             // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-+         _41 = deref_copy _15;            // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _42 = deref_copy _24;            // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_43);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _43 = (*_41);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_44);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _44 = (*_42);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _21 = Le(move _43, move _44);    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _0 = Le(move _43, move _44);     // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_44);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_43);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
++         _33 = deref_copy _11;            // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _34 = deref_copy _16;            // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_35);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _35 = (*_33);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_36);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _36 = (*_34);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _15 = Le(move _35, move _36);    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _0 = Le(move _35, move _36);     // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_36);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_35);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         StorageDead(_16);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         _12 = move _15;                  // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_22);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         _16 = move _21;                  // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
           goto -> bb8;                     // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
       }
   
       bb8: {
--         StorageDead(_21);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_15);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_17);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         _0 = move _16;                   // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
+          StorageDead(_13);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         _0 = move _12;                   // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
           goto -> bb3;                     // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
       }

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.DestinationPropagation.diff
@@ -3,128 +3,79 @@
   
   fn variant_a::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:8:25: 8:39], _2: &&(usize, usize, usize, usize)) -> bool {
       let mut _0: bool;                    // return place in scope 0 at $DIR/slice_filter.rs:+0:40: +0:40
-      let _3: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-      let _4: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-      let _5: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-      let _6: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
-      let mut _7: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:56
-      let mut _8: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:46
-      let _9: &usize;                      // in scope 0 at $DIR/slice_filter.rs:+0:45: +0:46
-      let mut _10: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:50: +0:56
-      let _11: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:55: +0:56
-      let mut _12: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:76
-      let mut _13: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:66
-      let _14: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:65: +0:66
-      let mut _15: bool;                   // in scope 0 at $DIR/slice_filter.rs:+0:70: +0:76
-      let _16: &usize;                     // in scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
-      let mut _17: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
-      let mut _18: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
-      let mut _19: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
-      let mut _20: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
+      let mut _3: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:56
+      let mut _4: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:40: +0:46
+      let mut _5: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:50: +0:56
+      let mut _6: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:76
+      let mut _7: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:60: +0:66
+      let mut _8: bool;                    // in scope 0 at $DIR/slice_filter.rs:+0:70: +0:76
+      let mut _9: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
+      let mut _10: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
+      let mut _11: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
+      let mut _12: &(usize, usize, usize, usize); // in scope 0 at $DIR/slice_filter.rs:+0:26: +0:38
       scope 1 {
--         debug a => _3;                   // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
--         debug b => _4;                   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
--         debug c => _5;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
--         debug d => _6;                   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
-+         debug a => _14;                  // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
-+         debug b => _11;                  // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
-+         debug c => _9;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
-+         debug d => _16;                  // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
+          debug a => &((*_9).0: usize);    // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
+          debug b => &((*_10).1: usize);   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
+          debug c => &((*_11).2: usize);   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
+          debug d => &((*_12).3: usize);   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
           scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
--             debug self => &_3;           // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug self => &_14;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => &_9;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _21: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _22: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug self => &&((*_9).0: usize); // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => &&((*_11).2: usize); // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _21;       // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _22;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _23: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _24: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug self => &((*_9).0: usize); // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug other => &((*_11).2: usize); // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _13: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _14: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
           scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
--             debug self => &_5;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug self => &_9;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => &_14;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _25: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _26: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug self => &&((*_11).2: usize); // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => &&((*_9).0: usize); // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _25;       // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _26;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _27: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _28: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug self => &((*_11).2: usize); // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug other => &((*_9).0: usize); // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _15: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _16: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
           scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
--             debug self => &_6;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug self => &_16;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => &_11;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _29: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _30: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug self => &&((*_12).3: usize); // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => &&((*_10).1: usize); // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 7 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _29;       // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _30;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _31: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _32: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug self => &((*_12).3: usize); // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug other => &((*_10).1: usize); // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _17: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _18: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
           scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
--             debug self => &_4;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug self => &_11;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => &_16;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _33: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              let mut _34: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug self => &&((*_10).1: usize); // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+              debug other => &&((*_12).3: usize); // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _33;       // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _34;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _35: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  let mut _36: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug self => &((*_10).1: usize); // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  debug other => &((*_12).3: usize); // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _19: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                  let mut _20: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
           }
       }
   
       bb0: {
--         StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-+         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-          _17 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
--         _3 = &((*_17).0: usize);         // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
--         StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-+         _14 = &((*_17).0: usize);        // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-+         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-          _18 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
--         _4 = &((*_18).1: usize);         // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
--         StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-+         _11 = &((*_18).1: usize);        // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-+         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-          _19 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
--         _5 = &((*_19).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
--         StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
-+         _9 = &((*_19).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-+         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
-          _20 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
--         _6 = &((*_20).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
--         StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
-+         _16 = &((*_20).3: usize);        // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
+          _9 = deref_copy (*_2);           // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
+          _10 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
+          _11 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
+          _12 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
+-         StorageLive(_3);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
-          StorageLive(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
--         StorageLive(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
--         _9 = _5;                         // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
--         _21 = deref_copy _3;             // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-+         _21 = deref_copy _14;            // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _22 = deref_copy _9;             // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_23);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _23 = (*_21);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_24);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _24 = (*_22);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _8 = Le(move _23, move _24);     // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_24);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_23);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          switchInt(move _8) -> [0: bb4, otherwise: bb5]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
+          StorageLive(_4);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
+          StorageLive(_13);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _13 = ((*_9).0: usize);          // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_14);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _14 = ((*_11).2: usize);         // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _4 = Le(move _13, move _14);     // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          switchInt(move _4) -> [0: bb4, otherwise: bb5]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
       }
   
       bb1: {
@@ -133,115 +84,80 @@
       }
   
       bb2: {
--         StorageLive(_12);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
+-         StorageLive(_6);                 // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
-          StorageLive(_13);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
--         StorageLive(_14);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
--         _14 = _3;                        // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
--         _25 = deref_copy _5;             // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-+         _25 = deref_copy _9;             // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _26 = deref_copy _14;            // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_27);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _27 = (*_25);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_28);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _28 = (*_26);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _13 = Le(move _27, move _28);    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_28);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_27);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_14);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          switchInt(move _13) -> [0: bb6, otherwise: bb7]; // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
+          StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
+          StorageLive(_15);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _15 = ((*_11).2: usize);         // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_16);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _16 = ((*_9).0: usize);          // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _7 = Le(move _15, move _16);     // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_16);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_15);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          switchInt(move _7) -> [0: bb6, otherwise: bb7]; // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
       }
   
       bb3: {
--         StorageDead(_12);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         StorageDead(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         StorageDead(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
--         StorageDead(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
--         StorageDead(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
--         StorageDead(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_6);                 // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_3);                 // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-+         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
-+         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
-+         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
-+         nop;                             // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
           return;                          // scope 0 at $DIR/slice_filter.rs:+0:76: +0:76
       }
   
       bb4: {
--         StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         StorageDead(_5);                 // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          StorageDead(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+          StorageDead(_4);                 // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           goto -> bb2;                     // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
       }
   
       bb5: {
--         StorageLive(_10);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
--         StorageLive(_11);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
--         _11 = _4;                        // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
--         _29 = deref_copy _6;             // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         StorageLive(_5);                 // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-+         _29 = deref_copy _16;            // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _30 = deref_copy _11;            // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_31);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _31 = (*_29);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_32);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _32 = (*_30);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _10 = Le(move _31, move _32);    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_32);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_31);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_11);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
--         _7 = move _10;                   // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
--         StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+          StorageLive(_17);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _17 = ((*_12).3: usize);         // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_18);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _18 = ((*_10).1: usize);         // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _5 = Le(move _17, move _18);     // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_18);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_17);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _3 = move _5;                    // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
+-         StorageDead(_5);                 // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          StorageDead(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
--         switchInt(move _7) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
-+         switchInt(move _10) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
+          StorageDead(_4);                 // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
++         switchInt(move _5) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
       }
   
       bb6: {
--         _12 = const false;               // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
+-         _6 = const false;                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
 +         _0 = const false;                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
           goto -> bb8;                     // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
       }
   
       bb7: {
--         StorageLive(_15);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
--         StorageLive(_16);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         _16 = _6;                        // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         _33 = deref_copy _4;             // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         StorageLive(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-+         _33 = deref_copy _11;            // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _34 = deref_copy _16;            // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_35);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _35 = (*_33);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageLive(_36);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _36 = (*_34);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         _15 = Le(move _35, move _36);    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _0 = Le(move _35, move _36);     // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_36);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_35);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
--         StorageDead(_16);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         _12 = move _15;                  // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
-+         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+          StorageLive(_19);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _19 = ((*_10).1: usize);         // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageLive(_20);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          _20 = ((*_12).3: usize);         // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _8 = Le(move _19, move _20);     // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _0 = Le(move _19, move _20);     // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_20);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+          StorageDead(_19);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _6 = move _8;                    // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
           goto -> bb8;                     // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
       }
   
       bb8: {
--         StorageDead(_15);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_13);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
--         _0 = move _12;                   // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
+          StorageDead(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         _0 = move _6;                    // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
 +         nop;                             // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
           goto -> bb3;                     // scope 1 at $DIR/slice_filter.rs:+0:40: +0:76
       }

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.ReferencePropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.ReferencePropagation.diff
@@ -38,20 +38,26 @@
       let mut _49: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
       let mut _50: &usize;                 // in scope 0 at $SRC_DIR/core/src/cmp.rs:LL:COL
       scope 1 {
-          debug a => _3;                   // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
-          debug b => _4;                   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
-          debug c => _5;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
-          debug d => _6;                   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
+-         debug a => _3;                   // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
+-         debug b => _4;                   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
+-         debug c => _5;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
+-         debug d => _6;                   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
++         debug a => &((*_25).0: usize);   // in scope 1 at $DIR/slice_filter.rs:+0:27: +0:28
++         debug b => &((*_26).1: usize);   // in scope 1 at $DIR/slice_filter.rs:+0:30: +0:31
++         debug c => &((*_27).2: usize);   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
++         debug d => &((*_28).3: usize);   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
           scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
 -             debug self => _9;            // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -             debug other => _10;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug self => &_3;           // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug other => &_11;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &&((*_25).0: usize); // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug other => &&((*_27).2: usize); // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _29: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _30: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _29;       // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _30;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-                 debug self => _29;       // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-                 debug other => _30;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
++                 debug self => &((*_25).0: usize); // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
++                 debug other => &((*_27).2: usize); // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
                   let mut _33: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
                   let mut _34: usize;      // in scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
@@ -59,13 +65,15 @@
           scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
 -             debug self => _18;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -             debug other => _19;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug self => &_5;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug other => &_20;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &&((*_27).2: usize); // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug other => &&((*_25).0: usize); // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _35: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _36: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _35;       // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _36;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-                 debug self => _35;       // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-                 debug other => _36;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
++                 debug self => &((*_27).2: usize); // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
++                 debug other => &((*_25).0: usize); // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
                   let mut _39: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
                   let mut _40: usize;      // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
@@ -73,13 +81,15 @@
           scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
 -             debug self => _13;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -             debug other => _14;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug self => &_6;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug other => &_15;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &&((*_28).3: usize); // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug other => &&((*_26).1: usize); // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _41: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _42: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 7 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _41;       // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _42;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-                 debug self => _41;       // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-                 debug other => _42;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
++                 debug self => &((*_28).3: usize); // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
++                 debug other => &((*_26).1: usize); // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
                   let mut _45: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
                   let mut _46: usize;      // in scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
@@ -87,13 +97,15 @@
           scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
 -             debug self => _22;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -             debug other => _23;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug self => &_4;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+             debug other => &_24;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &&((*_26).1: usize); // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug other => &&((*_28).3: usize); // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _47: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _48: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug self => _47;       // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-                  debug other => _48;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-                 debug self => _47;       // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-                 debug other => _48;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
++                 debug self => &((*_26).1: usize); // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
++                 debug other => &((*_28).3: usize); // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
                   let mut _51: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
                   let mut _52: usize;      // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
               }
@@ -101,38 +113,38 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
+-         StorageLive(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
           _25 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-          _3 = &((*_25).0: usize);         // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
-          StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
+-         _3 = &((*_25).0: usize);         // scope 0 at $DIR/slice_filter.rs:+0:27: +0:28
+-         StorageLive(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
           _26 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-          _4 = &((*_26).1: usize);         // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
-          StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
+-         _4 = &((*_26).1: usize);         // scope 0 at $DIR/slice_filter.rs:+0:30: +0:31
+-         StorageLive(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
           _27 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-          _5 = &((*_27).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
-          StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
+-         _5 = &((*_27).2: usize);         // scope 0 at $DIR/slice_filter.rs:+0:33: +0:34
+-         StorageLive(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           _28 = deref_copy (*_2);          // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
-          _6 = &((*_28).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
+-         _6 = &((*_28).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
           StorageLive(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
 -         StorageLive(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:41
 -         _9 = &_3;                        // scope 1 at $DIR/slice_filter.rs:+0:40: +0:41
 -         StorageLive(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          StorageLive(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          _11 = _5;                        // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
+-         StorageLive(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
+-         _11 = _5;                        // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
 -         _10 = &_11;                      // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
 -         _29 = deref_copy (*_9);          // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -         _30 = deref_copy (*_10);         // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _29 = deref_copy _3;             // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _30 = deref_copy _11;            // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageLive(_33);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _33 = (*_29);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _33 = (*_29);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _33 = ((*_25).0: usize);         // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageLive(_34);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _34 = (*_30);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _34 = (*_30);                    // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _34 = ((*_27).2: usize);         // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
           _8 = Le(move _33, move _34);     // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_34);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_33);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
+-         StorageDead(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
 -         StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
 -         StorageDead(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           switchInt(move _8) -> [0: bb4, otherwise: bb5]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
@@ -149,21 +161,21 @@
 -         StorageLive(_18);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:61
 -         _18 = &_5;                       // scope 1 at $DIR/slice_filter.rs:+0:60: +0:61
 -         StorageLive(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          StorageLive(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          _20 = _3;                        // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
+-         StorageLive(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
+-         _20 = _3;                        // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
 -         _19 = &_20;                      // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
 -         _35 = deref_copy (*_18);         // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -         _36 = deref_copy (*_19);         // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _35 = deref_copy _5;             // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _36 = deref_copy _20;            // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageLive(_39);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _39 = (*_35);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _39 = (*_35);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _39 = ((*_27).2: usize);         // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _40 = (*_36);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _40 = (*_36);                    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _40 = ((*_25).0: usize);         // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
           _17 = Le(move _39, move _40);    // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_40);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_39);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
+-         StorageDead(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
 -         StorageDead(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
 -         StorageDead(_18);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           switchInt(move _17) -> [0: bb6, otherwise: bb7]; // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
@@ -172,10 +184,10 @@
       bb3: {
           StorageDead(_16);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           StorageDead(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_6);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_5);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_4);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_3);                 // scope 0 at $DIR/slice_filter.rs:+0:75: +0:76
           return;                          // scope 0 at $DIR/slice_filter.rs:+0:76: +0:76
       }
   
@@ -191,21 +203,21 @@
 -         StorageLive(_13);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:51
 -         _13 = &_6;                       // scope 1 at $DIR/slice_filter.rs:+0:50: +0:51
 -         StorageLive(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          StorageLive(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          _15 = _4;                        // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         StorageLive(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         _15 = _4;                        // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 -         _14 = &_15;                      // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 -         _41 = deref_copy (*_13);         // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -         _42 = deref_copy (*_14);         // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _41 = deref_copy _6;             // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _42 = deref_copy _15;            // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageLive(_45);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _45 = (*_41);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _45 = (*_41);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _45 = ((*_28).3: usize);         // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageLive(_46);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _46 = (*_42);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _46 = (*_42);                    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _46 = ((*_26).1: usize);         // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
           _12 = Le(move _45, move _46);    // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_46);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_45);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         StorageDead(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 -         StorageDead(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 -         StorageDead(_13);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           _7 = move _12;                   // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
@@ -224,21 +236,21 @@
 -         StorageLive(_22);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:71
 -         _22 = &_4;                       // scope 1 at $DIR/slice_filter.rs:+0:70: +0:71
 -         StorageLive(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageLive(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          _24 = _6;                        // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageLive(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         _24 = _6;                        // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 -         _23 = &_24;                      // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 -         _47 = deref_copy (*_22);         // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -         _48 = deref_copy (*_23);         // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _47 = deref_copy _4;             // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-+         _48 = deref_copy _24;            // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageLive(_51);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _51 = (*_47);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _51 = (*_47);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _51 = ((*_26).1: usize);         // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageLive(_52);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          _52 = (*_48);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-         _52 = (*_48);                    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
++         _52 = ((*_28).3: usize);         // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
           _21 = Le(move _51, move _52);    // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_52);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_51);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
-          StorageDead(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 -         StorageDead(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 -         StorageDead(_22);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           _16 = move _21;                  // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76

--- a/tests/mir-opt/slice_filter.variant_a-{closure#0}.ReferencePropagation.diff
+++ b/tests/mir-opt/slice_filter.variant_a-{closure#0}.ReferencePropagation.diff
@@ -43,8 +43,10 @@
           debug c => _5;                   // in scope 1 at $DIR/slice_filter.rs:+0:33: +0:34
           debug d => _6;                   // in scope 1 at $DIR/slice_filter.rs:+0:36: +0:37
           scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:40: 8:46
-              debug self => _9;            // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _10;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug self => _9;            // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug other => _10;          // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &_3;           // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug other => &_11;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _29: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _30: &usize;         // in scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -55,8 +57,10 @@
               }
           }
           scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:60: 8:66
-              debug self => _18;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _19;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug self => _18;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug other => _19;          // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &_5;           // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug other => &_20;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _35: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _36: &usize;         // in scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -67,8 +71,10 @@
               }
           }
           scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:50: 8:56
-              debug self => _13;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _14;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug self => _13;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug other => _14;          // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &_6;           // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug other => &_15;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _41: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _42: &usize;         // in scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 7 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -79,8 +85,10 @@
               }
           }
           scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) { // at $DIR/slice_filter.rs:8:70: 8:76
-              debug self => _22;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
-              debug other => _23;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug self => _22;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+-             debug other => _23;          // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug self => &_4;           // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
++             debug other => &_24;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _47: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               let mut _48: &usize;         // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
               scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::le) { // at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -107,12 +115,12 @@
           _6 = &((*_28).3: usize);         // scope 0 at $DIR/slice_filter.rs:+0:36: +0:37
           StorageLive(_7);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
           StorageLive(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:46
-          StorageLive(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:41
-          _9 = &_3;                        // scope 1 at $DIR/slice_filter.rs:+0:40: +0:41
-          StorageLive(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
+-         StorageLive(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:40: +0:41
+-         _9 = &_3;                        // scope 1 at $DIR/slice_filter.rs:+0:40: +0:41
+-         StorageLive(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           StorageLive(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           _11 = _5;                        // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          _10 = &_11;                      // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
+-         _10 = &_11;                      // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
 -         _29 = deref_copy (*_9);          // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -         _30 = deref_copy (*_10);         // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         _29 = deref_copy _3;             // scope 2 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -125,8 +133,8 @@
           StorageDead(_34);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_33);                // scope 3 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_11);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
-          StorageDead(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
+-         StorageDead(_10);                // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
+-         StorageDead(_9);                 // scope 1 at $DIR/slice_filter.rs:+0:45: +0:46
           switchInt(move _8) -> [0: bb4, otherwise: bb5]; // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
       }
   
@@ -138,12 +146,12 @@
       bb2: {
           StorageLive(_16);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
           StorageLive(_17);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:66
-          StorageLive(_18);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:61
-          _18 = &_5;                       // scope 1 at $DIR/slice_filter.rs:+0:60: +0:61
-          StorageLive(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
+-         StorageLive(_18);                // scope 1 at $DIR/slice_filter.rs:+0:60: +0:61
+-         _18 = &_5;                       // scope 1 at $DIR/slice_filter.rs:+0:60: +0:61
+-         StorageLive(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           StorageLive(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           _20 = _3;                        // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          _19 = &_20;                      // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
+-         _19 = &_20;                      // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
 -         _35 = deref_copy (*_18);         // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -         _36 = deref_copy (*_19);         // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         _35 = deref_copy _5;             // scope 4 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -156,8 +164,8 @@
           StorageDead(_40);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_39);                // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_20);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          StorageDead(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
-          StorageDead(_18);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
+-         StorageDead(_19);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
+-         StorageDead(_18);                // scope 1 at $DIR/slice_filter.rs:+0:65: +0:66
           switchInt(move _17) -> [0: bb6, otherwise: bb7]; // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
       }
   
@@ -180,12 +188,12 @@
   
       bb5: {
           StorageLive(_12);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:56
-          StorageLive(_13);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:51
-          _13 = &_6;                       // scope 1 at $DIR/slice_filter.rs:+0:50: +0:51
-          StorageLive(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         StorageLive(_13);                // scope 1 at $DIR/slice_filter.rs:+0:50: +0:51
+-         _13 = &_6;                       // scope 1 at $DIR/slice_filter.rs:+0:50: +0:51
+-         StorageLive(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           StorageLive(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           _15 = _4;                        // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          _14 = &_15;                      // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         _14 = &_15;                      // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
 -         _41 = deref_copy (*_13);         // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -         _42 = deref_copy (*_14);         // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         _41 = deref_copy _6;             // scope 6 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -198,8 +206,8 @@
           StorageDead(_46);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_45);                // scope 7 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_15);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          StorageDead(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
-          StorageDead(_13);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         StorageDead(_14);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
+-         StorageDead(_13);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           _7 = move _12;                   // scope 1 at $DIR/slice_filter.rs:+0:40: +0:56
           StorageDead(_12);                // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
           StorageDead(_8);                 // scope 1 at $DIR/slice_filter.rs:+0:55: +0:56
@@ -213,12 +221,12 @@
   
       bb7: {
           StorageLive(_21);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:76
-          StorageLive(_22);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:71
-          _22 = &_4;                       // scope 1 at $DIR/slice_filter.rs:+0:70: +0:71
-          StorageLive(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageLive(_22);                // scope 1 at $DIR/slice_filter.rs:+0:70: +0:71
+-         _22 = &_4;                       // scope 1 at $DIR/slice_filter.rs:+0:70: +0:71
+-         StorageLive(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           StorageLive(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           _24 = _6;                        // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          _23 = &_24;                      // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         _23 = &_24;                      // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
 -         _47 = deref_copy (*_22);         // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
 -         _48 = deref_copy (*_23);         // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
 +         _47 = deref_copy _4;             // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
@@ -231,8 +239,8 @@
           StorageDead(_52);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_51);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
           StorageDead(_24);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
-          StorageDead(_22);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_23);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
+-         StorageDead(_22);                // scope 1 at $DIR/slice_filter.rs:+0:75: +0:76
           _16 = move _21;                  // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
           goto -> bb8;                     // scope 1 at $DIR/slice_filter.rs:+0:60: +0:76
       }

--- a/tests/mir-opt/uninhabited_enum.process_void.SimplifyLocals-final.after.mir
+++ b/tests/mir-opt/uninhabited_enum.process_void.SimplifyLocals-final.after.mir
@@ -3,16 +3,13 @@
 fn process_void(_1: *const Void) -> () {
     debug input => _1;                   // in scope 0 at $DIR/uninhabited_enum.rs:+0:21: +0:26
     let mut _0: ();                      // return place in scope 0 at $DIR/uninhabited_enum.rs:+0:41: +0:41
-    let _2: &Void;                       // in scope 0 at $DIR/uninhabited_enum.rs:+1:8: +1:14
     scope 1 {
-        debug _input => _2;              // in scope 1 at $DIR/uninhabited_enum.rs:+1:8: +1:14
+        debug _input => _1;              // in scope 1 at $DIR/uninhabited_enum.rs:+1:8: +1:14
     }
     scope 2 {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum.rs:+1:8: +1:14
-        StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum.rs:+4:1: +4:2
         return;                          // scope 0 at $DIR/uninhabited_enum.rs:+4:2: +4:2
     }
 }


### PR DESCRIPTION
MIR optimizations currently do not to operate on borrowed locals.

When enabling #106285, many borrows will be left as-is because they are used in debuginfo. This pass allows to replace this pattern directly in MIR debuginfo:
```rust
a => _1
_1 = &raw? mut? _2
```
becomes
```rust
a => &_2
// No statement to borrow _2.
```

This pass is implemented as a drive-by in ReferencePropagation MIR pass.

This transformation allows following following MIR opts to treat _2 as an unborrowed local, and optimize it as such, even in builds with debuginfo.

In codegen, when encountering `a => &..&_2`, we create a list of allocas:
```llvm
store ptr %_2.dbg.spill, ptr %a.ref0.dbg.spill
store ptr %a.ref0.dbg.spill, ptr %a.ref1.dbg.spill
...
call void @llvm.dbg.declare(metadata ptr %a.ref{n}.dbg.spill, /* ... */)
```

Caveat: this transformation looses the exact type, we do not differentiate `a` as a immutable, mutable reference or a raw pointer. Everything is declared to `*mut` to codegen. I'm not convinced this is a blocker.