### PR TITLE
Use proper impl self type for alias impl in rustdoc

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2414,14 +2414,15 @@ fn clean_impl<'tcx>(
     }
 
     let for_ = clean_ty(impl_.self_ty, cx);
-    let type_alias = for_.def_id(&cx.cache).and_then(|did| match tcx.def_kind(did) {
-        DefKind::TyAlias => Some(clean_middle_ty(
-            ty::Binder::dummy(tcx.type_of(did).subst_identity()),
-            cx,
-            Some(did),
-        )),
-        _ => None,
-    });
+    let type_alias =
+        for_.def_id(&cx.cache).and_then(|alias_def_id: DefId| match tcx.def_kind(alias_def_id) {
+            DefKind::TyAlias => Some(clean_middle_ty(
+                ty::Binder::dummy(tcx.type_of(def_id).subst_identity()),
+                cx,
+                Some(def_id.to_def_id()),
+            )),
+            _ => None,
+        });
     let mut make_item = |trait_: Option<Path>, for_: Type, items: Vec<Item>| {
         let kind = ImplItem(Box::new(Impl {
             unsafety: impl_.unsafety,

--- a/tests/rustdoc/impl-alias-substituted.rs
+++ b/tests/rustdoc/impl-alias-substituted.rs
@@ -1,0 +1,9 @@
+pub struct Matrix<T, const N: usize, const M: usize>([[T; N]; M]);
+
+pub type Vector<T, const N: usize> = Matrix<T, N, 1>;
+
+// @has "impl_alias_substituted/struct.Matrix.html" '//*[@class="impl"]//h3[@class="code-header"]' \
+//  "impl<T: Copy> Matrix<T, 3, 1>"
+impl<T: Copy> Vector<T, 3> {
+    pub fn test() {}
+}


### PR DESCRIPTION
We don't want to use `type_of(type_alias)`, we want to use `type_of(impl)` -- this will give us the self type of the impl *properly substituted* in the case that it's an alias.

Fixes #111420