### PR TITLE
Recover `impl<T ?Sized>` correctly

### DIFF
--- a/tests/ui/parser/impl-on-unsized-typo.rs
+++ b/tests/ui/parser/impl-on-unsized-typo.rs
@@ -1,0 +1,6 @@
+trait Tr {}
+
+impl<T ?Sized> Tr for T {}
+//~^ ERROR expected one of `,`, `:`, `=`, or `>`, found `?`
+
+fn main() {}

--- a/tests/ui/parser/impl-on-unsized-typo.stderr
+++ b/tests/ui/parser/impl-on-unsized-typo.stderr
@@ -1,0 +1,8 @@
+error: expected one of `,`, `:`, `=`, or `>`, found `?`
+  --> $DIR/impl-on-unsized-typo.rs:3:8
+   |
+LL | impl<T ?Sized> Tr for T {}
+   |        ^ expected one of `,`, `:`, `=`, or `>`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #111327

r? @Nilstrieb but you can re-roll

Alternatively, happy to close this if we're okay with just saying "sorry #111327 is just a poor side-effect of parser ambiguity" 🤷 