### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -680,7 +680,9 @@ pub type InlineAsmDiagHandlerTy = unsafe extern "C" fn(&SMDiagnostic, *const c_v
 pub mod coverageinfo {
     use super::coverage_map;
 
-    /// Aligns with [llvm::coverage::CounterMappingRegion::RegionKind](https://github.com/rust-lang/llvm-project/blob/rustc/13.0-2021-09-30/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L209-L230)
+    /// Corresponds to enum `llvm::coverage::CounterMappingRegion::RegionKind`.
+    ///
+    /// Must match the layout of `LLVMRustCounterMappingRegionKind`.
     #[derive(Copy, Clone, Debug)]
     #[repr(C)]
     pub enum RegionKind {
@@ -714,7 +716,9 @@ pub mod coverageinfo {
     /// array", encoded separately), and source location (start and end positions of the represented
     /// code region).
     ///
-    /// Matches LLVMRustCounterMappingRegion.
+    /// Corresponds to struct `llvm::coverage::CounterMappingRegion`.
+    ///
+    /// Must match the layout of `LLVMRustCounterMappingRegion`.
     #[derive(Copy, Clone, Debug)]
     #[repr(C)]
     pub struct CounterMappingRegion {

--- a/compiler/rustc_codegen_ssa/src/coverageinfo/ffi.rs
+++ b/compiler/rustc_codegen_ssa/src/coverageinfo/ffi.rs
@@ -1,6 +1,6 @@
 use rustc_middle::mir::coverage::{CounterValueReference, MappedExpressionIndex};
 
-/// Aligns with [llvm::coverage::Counter::CounterKind](https://github.com/rust-lang/llvm-project/blob/rustc/13.0-2021-09-30/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L95)
+/// Must match the layout of `LLVMRustCounterKind`.
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub enum CounterKind {
@@ -17,8 +17,10 @@ pub enum CounterKind {
 ///     `instrprof.increment()`)
 ///   * For `CounterKind::Expression`, `id` is the index into the coverage map's array of
 ///     counter expressions.
-/// Aligns with [llvm::coverage::Counter](https://github.com/rust-lang/llvm-project/blob/rustc/13.0-2021-09-30/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L102-L103)
-/// Important: The Rust struct layout (order and types of fields) must match its C++ counterpart.
+///
+/// Corresponds to struct `llvm::coverage::Counter`.
+///
+/// Must match the layout of `LLVMRustCounter`.
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct Counter {
@@ -59,7 +61,9 @@ impl Counter {
     }
 }
 
-/// Aligns with [llvm::coverage::CounterExpression::ExprKind](https://github.com/rust-lang/llvm-project/blob/rustc/13.0-2021-09-30/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L150)
+/// Corresponds to enum `llvm::coverage::CounterExpression::ExprKind`.
+///
+/// Must match the layout of `LLVMRustCounterExprKind`.
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub enum ExprKind {
@@ -67,9 +71,9 @@ pub enum ExprKind {
     Add = 1,
 }
 
-/// Aligns with [llvm::coverage::CounterExpression](https://github.com/rust-lang/llvm-project/blob/rustc/13.0-2021-09-30/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h#L151-L152)
-/// Important: The Rust struct layout (order and types of fields) must match its C++
-/// counterpart.
+/// Corresponds to struct `llvm::coverage::CounterExpression`.
+///
+/// Must match the layout of `LLVMRustCounterExpression`.
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct CounterExpression {

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -173,12 +173,21 @@ pub fn parse_check_cfg(specs: Vec<String>) -> CheckCfg {
                                         let expected_values = check_cfg
                                             .expecteds
                                             .entry(ident.name.to_string())
+                                            .and_modify(|expected_values| match expected_values {
+                                                ExpectedValues::Some(_) => {}
+                                                ExpectedValues::Any => {
+                                                    // handle the case where names(...) was done
+                                                    // before values by changing to a list
+                                                    *expected_values =
+                                                        ExpectedValues::Some(FxHashSet::default());
+                                                }
+                                            })
                                             .or_insert_with(|| {
                                                 ExpectedValues::Some(FxHashSet::default())
                                             });
 
                                         let ExpectedValues::Some(expected_values) = expected_values else {
-                                            bug!("shoudn't be possible")
+                                            bug!("`expected_values` should be a list a values")
                                         };
 
                                         for val in values {

--- a/compiler/rustc_llvm/llvm-wrapper/CoverageMappingWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/CoverageMappingWrapper.cpp
@@ -121,7 +121,7 @@ extern "C" void LLVMRustCoverageWriteMappingToBuffer(
     unsigned NumVirtualFileMappingIDs,
     const LLVMRustCounterExpression *RustExpressions,
     unsigned NumExpressions,
-    LLVMRustCounterMappingRegion *RustMappingRegions,
+    const LLVMRustCounterMappingRegion *RustMappingRegions,
     unsigned NumMappingRegions,
     RustStringRef BufferOut) {
   // Convert from FFI representation to LLVM representation.

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1022,7 +1022,7 @@ rustc_queries! {
         desc { "converting literal to mir constant" }
     }
 
-    query check_match(key: LocalDefId) {
+    query check_match(key: LocalDefId) -> Result<(), rustc_errors::ErrorGuaranteed> {
         desc { |tcx| "match-checking `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { true }
     }

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -42,7 +42,9 @@ fn mir_build(tcx: TyCtxt<'_>, def: LocalDefId) -> Body<'_> {
     // Ensure unsafeck and abstract const building is ran before we steal the THIR.
     tcx.ensure_with_value().thir_check_unsafety(def);
     tcx.ensure_with_value().thir_abstract_const(def);
-    tcx.ensure_with_value().check_match(def);
+    if let Err(e) = tcx.check_match(def) {
+        return construct_error(tcx, def, e);
+    }
 
     let body = match tcx.thir_body(def) {
         Err(error_reported) => construct_error(tcx, def, error_reported),

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -27,6 +27,7 @@
     - [armv7-unknown-linux-uclibceabihf](platform-support/armv7-unknown-linux-uclibceabihf.md)
     - [\*-android and \*-androideabi](platform-support/android.md)
     - [\*-linux-ohos](platform-support/openharmony.md)
+    - [\*-esp-espidf](platform-support/esp-idf.md)
     - [\*-unknown-fuchsia](platform-support/fuchsia.md)
     - [\*-kmc-solid_\*](platform-support/kmc-solid.md)
     - [loongarch\*-unknown-linux-\*](platform-support/loongarch-linux.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -297,7 +297,7 @@ target | std | host | notes
 `riscv32gc-unknown-linux-musl` |   |   | RISC-V Linux (kernel 5.4, musl + RISCV32 support patches)
 `riscv32im-unknown-none-elf` | * |  | Bare RISC-V (RV32IM ISA)
 [`riscv32imac-unknown-xous-elf`](platform-support/riscv32imac-unknown-xous-elf.md) | ? |  | RISC-V Xous (RV32IMAC ISA)
-`riscv32imc-esp-espidf` | ✓ |  | RISC-V ESP-IDF
+[`riscv32imc-esp-espidf`](platform-support/esp-idf.md) | ✓ |  | RISC-V ESP-IDF
 `riscv64gc-unknown-freebsd` |   |   | RISC-V FreeBSD
 `riscv64gc-unknown-fuchsia` |   |   | RISC-V Fuchsia
 `riscv64gc-unknown-linux-musl` |   |   | RISC-V Linux (kernel 4.20, musl 1.2.0)

--- a/src/doc/rustc/src/platform-support/esp-idf.md
+++ b/src/doc/rustc/src/platform-support/esp-idf.md
@@ -1,0 +1,41 @@
+# `*-esp-espidf`
+
+**Tier: 3**
+
+Targets for the [ESP-IDF](https://github.com/espressif/esp-idf) development framework running on RISC-V and Xtensa CPUs.
+
+## Target maintainers
+
+- Ivan Markov [@ivmarkov](https://github.com/ivmarkov)
+- Scott Mabin [@MabezDev](https://github.com/MabezDev)
+
+## Requirements
+
+The target names follow this format: `$ARCH-esp-espidf`, where `$ARCH` specifies the target processor architecture. The following targets are currently defined:
+
+|          Target name           | Target CPU(s)         |
+|--------------------------------|-----------------------|
+| `riscv32imc-esp-espidf`        |  [ESP32-C3](https://www.espressif.com/en/products/socs/esp32-c3)             |
+
+The minimum supported ESP-IDF version is `v4.3`, though it is recommended to use the latest stable release if possible.
+
+## Building the target
+
+The target can be built by enabling it for a `rustc` build. The `build-std` feature is required to build the standard library for ESP-IDF. `ldproxy` is also required for linking, it can be installed from crates.io.
+
+```toml
+[build]
+target = ["$ARCH-esp-espidf"]
+
+[target.$ARCH-esp-espidf]
+linker = "ldproxy"
+
+[unstable]
+build-std = ["std", "panic_abort"]
+```
+
+The `esp-idf-sys` crate will handle the compilation of ESP-IDF, including downloading the relevant toolchains for the build.
+
+## Cross-compilation toolchains and C code
+
+`esp-idf-sys` exposes the toolchain used in the compilation of ESP-IDF, see the crate [documentation for build output propagation](https://github.com/esp-rs/esp-idf-sys#conditional-compilation) for more information.

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2414,14 +2414,15 @@ fn clean_impl<'tcx>(
     }
 
     let for_ = clean_ty(impl_.self_ty, cx);
-    let type_alias = for_.def_id(&cx.cache).and_then(|did| match tcx.def_kind(did) {
-        DefKind::TyAlias => Some(clean_middle_ty(
-            ty::Binder::dummy(tcx.type_of(did).subst_identity()),
-            cx,
-            Some(did),
-        )),
-        _ => None,
-    });
+    let type_alias =
+        for_.def_id(&cx.cache).and_then(|alias_def_id: DefId| match tcx.def_kind(alias_def_id) {
+            DefKind::TyAlias => Some(clean_middle_ty(
+                ty::Binder::dummy(tcx.type_of(def_id).subst_identity()),
+                cx,
+                Some(def_id.to_def_id()),
+            )),
+            _ => None,
+        });
     let mut make_item = |trait_: Option<Path>, for_: Type, items: Vec<Item>| {
         let kind = ImplItem(Box::new(Impl {
             unsafety: impl_.unsafety,

--- a/tests/codegen/vec-shrink-panik.rs
+++ b/tests/codegen/vec-shrink-panik.rs
@@ -25,7 +25,7 @@ pub fn issue71861(vec: Vec<u32>) -> Box<[u32]> {
 
     // Call to panic_cannot_unwind in case of double-panic is expected
     // on LLVM 16 and older, but other panics are not.
-    // CHECK: filter
+    // old: filter
     // old-NEXT: ; call core::panicking::panic_cannot_unwind
     // old-NEXT: panic_cannot_unwind
 
@@ -40,7 +40,7 @@ pub fn issue75636<'a>(iter: &[&'a str]) -> Box<[&'a str]> {
 
     // Call to panic_cannot_unwind in case of double-panic is expected,
     // on LLVM 16 and older, but other panics are not.
-    // CHECK: filter
+    // old: filter
     // old-NEXT: ; call core::panicking::panic_cannot_unwind
     // old-NEXT: panic_cannot_unwind
 

--- a/tests/mir-opt/copy-prop/partial_init.main.CopyProp.diff
+++ b/tests/mir-opt/copy-prop/partial_init.main.CopyProp.diff
@@ -1,0 +1,13 @@
+- // MIR for `main` before CopyProp
++ // MIR for `main` after CopyProp
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/partial_init.rs:+0:15: +0:15
+      let mut _1: (isize,);                // in scope 0 at $SRC_DIR/core/src/intrinsics/mir.rs:LL:COL
+  
+      bb0: {
+          (_1.0: isize) = const 1_isize;   // scope 0 at $DIR/partial_init.rs:+4:13: +4:20
+          return;                          // scope 0 at $DIR/partial_init.rs:+5:13: +5:21
+      }
+  }
+  

--- a/tests/mir-opt/copy-prop/partial_init.rs
+++ b/tests/mir-opt/copy-prop/partial_init.rs
@@ -1,0 +1,18 @@
+// unit-test: CopyProp
+// Verify that we do not ICE on partial initializations.
+
+#![feature(custom_mir, core_intrinsics)]
+extern crate core;
+use core::intrinsics::mir::*;
+
+// EMIT_MIR partial_init.main.CopyProp.diff
+#[custom_mir(dialect = "runtime", phase = "post-cleanup")]
+pub fn main() {
+    mir! (
+        let x: (isize, );
+        {
+            x.0 = 1;
+            Return()
+        }
+    )
+}

--- a/tests/rustdoc/impl-alias-substituted.rs
+++ b/tests/rustdoc/impl-alias-substituted.rs
@@ -1,0 +1,9 @@
+pub struct Matrix<T, const N: usize, const M: usize>([[T; N]; M]);
+
+pub type Vector<T, const N: usize> = Matrix<T, N, 1>;
+
+// @has "impl_alias_substituted/struct.Matrix.html" '//*[@class="impl"]//h3[@class="code-header"]' \
+//  "impl<T: Copy> Matrix<T, 3, 1>"
+impl<T: Copy> Vector<T, 3> {
+    pub fn test() {}
+}

--- a/tests/ui/check-cfg/order-independant.names_after.stderr
+++ b/tests/ui/check-cfg/order-independant.names_after.stderr
@@ -1,0 +1,19 @@
+warning: unexpected `cfg` condition value
+  --> $DIR/order-independant.rs:8:7
+   |
+LL | #[cfg(a)]
+   |       ^- help: specify a config value: `= "b"`
+   |
+   = note: expected values for `a` are: `b`
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition value
+  --> $DIR/order-independant.rs:12:7
+   |
+LL | #[cfg(a = "unk")]
+   |       ^^^^^^^^^
+   |
+   = note: expected values for `a` are: `b`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/check-cfg/order-independant.names_before.stderr
+++ b/tests/ui/check-cfg/order-independant.names_before.stderr
@@ -1,0 +1,19 @@
+warning: unexpected `cfg` condition value
+  --> $DIR/order-independant.rs:8:7
+   |
+LL | #[cfg(a)]
+   |       ^- help: specify a config value: `= "b"`
+   |
+   = note: expected values for `a` are: `b`
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition value
+  --> $DIR/order-independant.rs:12:7
+   |
+LL | #[cfg(a = "unk")]
+   |       ^^^^^^^^^
+   |
+   = note: expected values for `a` are: `b`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/check-cfg/order-independant.rs
+++ b/tests/ui/check-cfg/order-independant.rs
@@ -1,0 +1,16 @@
+// check-pass
+// revisions: names_before names_after
+// compile-flags: -Z unstable-options
+// compile-flags: --check-cfg=names(names_before,names_after)
+// [names_before]compile-flags: --check-cfg=names(a) --check-cfg=values(a,"b")
+// [names_after]compile-flags: --check-cfg=values(a,"b") --check-cfg=names(a)
+
+#[cfg(a)]
+//~^ WARNING unexpected `cfg` condition value
+fn my_cfg() {}
+
+#[cfg(a = "unk")]
+//~^ WARNING unexpected `cfg` condition value
+fn my_cfg() {}
+
+fn main() {}

--- a/tests/ui/closures/2229_closure_analysis/bad-pattern.rs
+++ b/tests/ui/closures/2229_closure_analysis/bad-pattern.rs
@@ -1,0 +1,23 @@
+// regression test for #108683
+// edition:2021
+
+enum Refutable {
+    A,
+    B,
+}
+
+fn example(v1: u32, v2: [u32; 4], v3: Refutable) {
+    const PAT: u32 = 0;
+    let v4 = &v2[..];
+    || {
+        let 0 = v1; //~ ERROR refutable pattern in local binding
+        let (0 | 1) = v1; //~ ERROR refutable pattern in local binding
+        let 1.. = v1; //~ ERROR refutable pattern in local binding
+        let [0, 0, 0, 0] = v2; //~ ERROR refutable pattern in local binding
+        let [0] = v4; //~ ERROR refutable pattern in local binding
+        let Refutable::A = v3; //~ ERROR refutable pattern in local binding
+        let PAT = v1; //~ ERROR refutable pattern in local binding
+    };
+}
+
+fn main() {}

--- a/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
+++ b/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
@@ -1,0 +1,113 @@
+error[E0005]: refutable pattern in local binding
+  --> $DIR/bad-pattern.rs:13:13
+   |
+LL |         let 0 = v1;
+   |             ^ pattern `1_u32..=u32::MAX` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `u32`
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |         if let 0 = v1 { todo!() };
+   |         ++            +++++++++++
+help: alternatively, you could prepend the pattern with an underscore to define a new named variable; identifiers cannot begin with digits
+   |
+LL |         let _0 = v1;
+   |             +
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/bad-pattern.rs:14:14
+   |
+LL |         let (0 | 1) = v1;
+   |              ^^^^^ pattern `2_u32..=u32::MAX` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `u32`
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |         if let (0 | 1) = v1 { todo!() };
+   |         ++                  +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/bad-pattern.rs:15:13
+   |
+LL |         let 1.. = v1;
+   |             ^^^ pattern `0_u32` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `u32`
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |         if let 1.. = v1 { todo!() };
+   |         ++              +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/bad-pattern.rs:16:13
+   |
+LL |         let [0, 0, 0, 0] = v2;
+   |             ^^^^^^^^^^^^ pattern `[1_u32..=u32::MAX, _, _, _]` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `[u32; 4]`
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |         if let [0, 0, 0, 0] = v2 { todo!() };
+   |         ++                       +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/bad-pattern.rs:17:13
+   |
+LL |         let [0] = v4;
+   |             ^^^ patterns `&[]` and `&[_, _, ..]` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `&[u32]`
+help: you might want to use `if let` to ignore the variants that aren't matched
+   |
+LL |         if let [0] = v4 { todo!() };
+   |         ++              +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/bad-pattern.rs:18:13
+   |
+LL |         let Refutable::A = v3;
+   |             ^^^^^^^^^^^^ pattern `Refutable::B` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+note: `Refutable` defined here
+  --> $DIR/bad-pattern.rs:4:6
+   |
+LL | enum Refutable {
+   |      ^^^^^^^^^
+LL |     A,
+LL |     B,
+   |     - not covered
+   = note: the matched value is of type `Refutable`
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |         if let Refutable::A = v3 { todo!() };
+   |         ++                       +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/bad-pattern.rs:19:13
+   |
+LL |         let PAT = v1;
+   |             ^^^
+   |             |
+   |             pattern `1_u32..=u32::MAX` not covered
+   |             missing patterns are not covered because `PAT` is interpreted as a constant pattern, not a new variable
+   |             help: introduce a variable instead: `PAT_var`
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `u32`
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0005`.


### PR DESCRIPTION
Successful merges:

 - #108705 (Prevent ICE with broken borrow in closure)
 - #111292 (Fix mishandled `--check-cfg` arguments order)
 - #111382 (Isolate coverage FFI type layouts from their underlying LLVM C++ types)
 - #111385 (vec-shrink-panik: update expectations to work on LLVM 17)
 - #111389 (Add esp-idf platform-support page)
 - #111432 (Use visit_assign to detect SSA locals.)
 - #111448 (Use proper impl self type for alias impl in rustdoc)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=108705,111292,111382,111385,111389,111432,111448)
<!-- homu-ignore:end -->