### PR TITLE
Better diagnostics for `env!` where variable contains escape

### DIFF
--- a/tests/ui/extenv/extenv-escaped-var.rs
+++ b/tests/ui/extenv/extenv-escaped-var.rs
@@ -1,0 +1,3 @@
+fn main() {
+    env!("\t"); //~ERROR environment variable `\t` not defined at compile time
+}

--- a/tests/ui/extenv/extenv-escaped-var.stderr
+++ b/tests/ui/extenv/extenv-escaped-var.stderr
@@ -1,0 +1,11 @@
+error: environment variable `\t` not defined at compile time
+  --> $DIR/extenv-escaped-var.rs:2:5
+   |
+LL |     env!("\t");
+   |     ^^^^^^^^^^
+   |
+   = help: use `std::env::var("\t")` to read the variable at run time
+   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/tests/ui/extenv/issue-110547.stderr
+++ b/tests/ui/extenv/issue-110547.stderr
@@ -1,28 +1,28 @@
-error: environment variable `    ` not defined at compile time
+error: environment variable `\t` not defined at compile time
   --> $DIR/issue-110547.rs:4:5
    |
 LL |     env!{"\t"};
    |     ^^^^^^^^^^
    |
-   = help: use `std::env::var("    ")` to read the variable at run time
+   = help: use `std::env::var("\t")` to read the variable at run time
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: environment variable `    ` not defined at compile time
+error: environment variable `\t` not defined at compile time
   --> $DIR/issue-110547.rs:5:5
    |
 LL |     env!("\t");
    |     ^^^^^^^^^^
    |
-   = help: use `std::env::var("    ")` to read the variable at run time
+   = help: use `std::env::var("\t")` to read the variable at run time
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: environment variable `` not defined at compile time
+error: environment variable `\u{2069}` not defined at compile time
   --> $DIR/issue-110547.rs:6:5
    |
 LL |     env!("\u{2069}");
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: use `std::env::var("")` to read the variable at run time
+   = help: use `std::env::var("\u{2069}")` to read the variable at run time
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
Fixes #110559