### PR TITLE
Fix data race in llvm source code coverage

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -745,6 +745,9 @@ LLVMRustOptimize(
         if (InstrProfileOutput) {
           Options.InstrProfileOutput = InstrProfileOutput;
         }
+        // cargo run tests in multhreading mode by default
+        // so use atomics for coverage counters
+        Options.Atomic = true;
         MPM.addPass(InstrProfiling(Options, false));
       }
     );

--- a/tests/run-make/coverage-llvmir/filecheck.testprog.txt
+++ b/tests/run-make/coverage-llvmir/filecheck.testprog.txt
@@ -36,7 +36,7 @@ CHECK-SAME:   section "llvm.metadata"
 CHECK:        [[DEFINE_INTERNAL]] { {{.*}} } @_R{{[a-zA-Z0-9_]+}}testprog14will_be_called() unnamed_addr #{{[0-9]+}} {
 CHECK-NEXT:   start:
 CHECK-NOT:    [[DEFINE_INTERNAL]]
-CHECK:        %pgocount = load i64, {{i64\*|ptr}}
+CHECK:        atomicrmw add ptr
 CHECK-SAME:   @__profc__R{{[a-zA-Z0-9_]+}}testprog14will_be_called,
 
 CHECK:        declare void @llvm.instrprof.increment({{i8\*|ptr}}, i64, i32, i32) #[[LLVM_INSTRPROF_INCREMENT_ATTR:[0-9]+]]


### PR DESCRIPTION
Fixes #91092 .

Before this patch, increment of counters for code coverage looks like this:
```
 movq    .L__profc__RNvCsd6wgJFC5r19_3lib6bugaga+8(%rip), %rax
 addq    $1, %rax
movq    %rax, .L__profc__RNvCsd6wgJFC5r19_3lib6bugaga+8(%rip)
```

after this patch:

```
lock            incq    .L__profc__RNvCs3JgIB2SjHh2_3lib6bugaga+8(%rip)
```


