### PR TITLE
Get current target config from` --print=cfg`

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -428,7 +428,6 @@ impl TargetCfgs {
         ))
         .unwrap();
 
-        let mut current = None;
         let mut all_targets = HashSet::new();
         let mut all_archs = HashSet::new();
         let mut all_oses = HashSet::new();
@@ -449,14 +448,11 @@ impl TargetCfgs {
             }
             all_pointer_widths.insert(format!("{}bit", cfg.pointer_width));
 
-            if target == config.target {
-                current = Some(cfg);
-            }
             all_targets.insert(target.into());
         }
 
         Self {
-            current: current.expect("current target not found"),
+            current: Self::get_current_target_config(config),
             all_targets,
             all_archs,
             all_oses,
@@ -465,6 +461,89 @@ impl TargetCfgs {
             all_abis,
             all_families,
             all_pointer_widths,
+        }
+    }
+
+    fn get_current_target_config(config: &Config) -> TargetCfg {
+        let mut arch = None;
+        let mut os = None;
+        let mut env = None;
+        let mut abi = None;
+        let mut families = Vec::new();
+        let mut pointer_width = None;
+        let mut endian = None;
+        let mut panic = None;
+
+        for config in
+            rustc_output(config, &["--print=cfg", "--target", &config.target]).trim().lines()
+        {
+            let (name, value) = config
+                .split_once("=\"")
+                .map(|(name, value)| {
+                    (
+                        name,
+                        Some(
+                            value
+                                .strip_suffix("\"")
+                                .expect("key-value pair should be properly quoted"),
+                        ),
+                    )
+                })
+                .unwrap_or_else(|| (config, None));
+
+            match name {
+                "target_arch" => {
+                    arch = Some(value.expect("target_arch should be a key-value pair").to_string());
+                }
+                "target_os" => {
+                    os = Some(value.expect("target_os sould be a key-value pair").to_string());
+                }
+                "target_env" => {
+                    env = Some(value.expect("target_env should be a key-value pair").to_string());
+                }
+                "target_abi" => {
+                    abi = Some(value.expect("target_abi should be a key-value pair").to_string());
+                }
+                "target_family" => {
+                    families
+                        .push(value.expect("target_family should be a key-value pair").to_string());
+                }
+                "target_pointer_width" => {
+                    pointer_width = Some(
+                        value
+                            .expect("target_pointer_width should be a key-value pair")
+                            .parse::<u32>()
+                            .expect("target_pointer_width should be a valid u32"),
+                    );
+                }
+                "target_endian" => {
+                    endian = Some(match value.expect("target_endian should be a key-value pair") {
+                        "big" => Endian::Big,
+                        "little" => Endian::Little,
+                        _ => panic!("target_endian should be either 'big' or 'little'"),
+                    });
+                }
+                "panic" => {
+                    panic = Some(match value.expect("panic should be a key-value pair") {
+                        "abort" => PanicStrategy::Abort,
+                        "unwind" => PanicStrategy::Unwind,
+                        _ => panic!("panic should be either 'abort' or 'unwind'"),
+                    });
+                }
+                _ => (),
+            }
+        }
+
+        TargetCfg {
+            arch: arch.expect("target configuration should specify target_arch"),
+            os: os.expect("target configuration should specify target_os"),
+            env: env.expect("target configuration should specify target_env"),
+            abi: abi.expect("target configuration should specify target_abi"),
+            families,
+            pointer_width: pointer_width
+                .expect("target configuration should specify target_pointer_width"),
+            endian: endian.expect("target configuration should specify target_endian"),
+            panic: panic.expect("target configuration should specify panic"),
         }
     }
 }


### PR DESCRIPTION
Compiletest was switched to querying all targets using `--print=all-target-specs-json` and `--print=target-spec-json` in #108905. This unintentionally prevented codegen flags like `-Cpanic` from being reflected in the current target configuration. This change gets the current compiletest target config using `--print=cfg` like it was previously while still using the faster prints for getting information on all other targets.

Fixes #110850.

@jyn514 might be interested in reviewing since they commented on the issue.
cc @tmandry since this issue is affecting Fuchsia.