### PR TITLE
Use error term in projection if missing associated item in new solver

### DIFF
--- a/tests/ui/impl-trait/issue-103181-1.current.stderr
+++ b/tests/ui/impl-trait/issue-103181-1.current.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `Error`
-  --> $DIR/issue-103181-1.rs:9:5
+  --> $DIR/issue-103181-1.rs:11:5
    |
 LL |         type Error;
    |         ---------- `Error` from trait

--- a/tests/ui/impl-trait/issue-103181-1.next.stderr
+++ b/tests/ui/impl-trait/issue-103181-1.next.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `Error`
+  --> $DIR/issue-103181-1.rs:11:5
+   |
+LL |         type Error;
+   |         ---------- `Error` from trait
+LL |     }
+LL |     impl HttpBody for () {
+   |     ^^^^^^^^^^^^^^^^^^^^ missing `Error` in implementation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0046`.

--- a/tests/ui/impl-trait/issue-103181-1.rs
+++ b/tests/ui/impl-trait/issue-103181-1.rs
@@ -1,3 +1,5 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 // edition:2021
 
 mod hyper {


### PR DESCRIPTION
We were previously delaying a bug but not bailing, leading to an ICE in the `tcx.type_of(assoc_def.item.def_id)` call below.