### PR TITLE
Don't ICE in layout computation for placeholder types

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2366,13 +2366,11 @@ impl<'tcx> Ty<'tcx> {
 
             ty::Adt(def, _substs) => def.sized_constraint(tcx).0.is_empty(),
 
-            ty::Alias(..) | ty::Param(_) => false,
+            ty::Alias(..) | ty::Param(_) | ty::Placeholder(..) => false,
 
             ty::Infer(ty::TyVar(_)) => false,
 
-            ty::Bound(..)
-            | ty::Placeholder(..)
-            | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Bound(..) | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
                 bug!("`is_trivially_sized` applied to unexpected type: {:?}", self)
             }
         }

--- a/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.current.stderr
+++ b/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.current.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `&T` needs to have the same ABI as a pointer
-  --> $DIR/check-size-at-cast-polymorphic-bad.rs:11:15
+  --> $DIR/check-size-at-cast-polymorphic-bad.rs:14:15
    |
 LL |     dyn_debug(t);
    |               ^ `&T` needs to be a pointer-like type

--- a/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.next.stderr
+++ b/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.next.stderr
@@ -1,0 +1,15 @@
+error[E0277]: `&T` needs to have the same ABI as a pointer
+  --> $DIR/check-size-at-cast-polymorphic-bad.rs:14:15
+   |
+LL |     dyn_debug(t);
+   |               ^ `&T` needs to be a pointer-like type
+   |
+   = help: the trait `PointerLike` is not implemented for `&T`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | fn polymorphic<T: Debug + ?Sized>(t: &T) where &T: PointerLike {
+   |                                          +++++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.rs
+++ b/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.rs
@@ -1,3 +1,6 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+
 #![feature(dyn_star)]
 #![allow(incomplete_features)]
 


### PR DESCRIPTION
We use `layout_of` for the built-in `PointerLike` trait to check if a type can be coerced to a `dyn*`.

Since the new solver canonicalizes parameter types to placeholders, that code needs to be able to treat placeholders like params, and for the most part it does, **except** for a call to `is_trivially_sized`. This PR fixes that.