### PR TITLE
asm: loongarch64: Drop efiapi

### DIFF
--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -882,8 +882,8 @@ impl InlineAsmClobberAbi {
                 _ => Err(&["C", "system", "efiapi"]),
             },
             InlineAsmArch::LoongArch64 => match name {
-                "C" | "system" | "efiapi" => Ok(InlineAsmClobberAbi::LoongArch),
-                _ => Err(&["C", "system", "efiapi"]),
+                "C" | "system" => Ok(InlineAsmClobberAbi::LoongArch),
+                _ => Err(&["C", "system"]),
             },
             _ => Err(&[]),
         }


### PR DESCRIPTION
This PR aims to drop `efiapi` which is not a valid ABI on LoongArch.

Fixes: https://github.com/rust-lang/rust/pull/111237#discussion_r1192119809