### PR TITLE
Replace a couple of `unwrap`s in hir typeck with pattern matching

### DIFF
--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -119,7 +119,11 @@ pub(super) fn check_fn<'a, 'tcx>(
         fcx.require_type_is_sized(declared_ret_ty, decl.output.span(), traits::SizedReturnType);
     } else {
         fcx.require_type_is_sized(declared_ret_ty, decl.output.span(), traits::SizedReturnType);
-        fcx.check_return_expr(&body.value, false);
+
+        // `fcx.ret_coercion` is set to `Some` up above
+        let mut ret_coercion = fcx.ret_coercion.as_ref().unwrap().borrow_mut();
+
+        fcx.check_return_expr(&body.value, false, &mut ret_coercion);
     }
 
     // We insert the deferred_generator_interiors entry after visiting the body.


### PR DESCRIPTION
Annoying that I had to add an `unwrap` elsewhere, but at least that one is self-contained in a function, rather than being an invisible pre-condition.