### PR TITLE
Made `INVALID_DOC_ATTRIBUTES` lint deny by default

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3586,18 +3586,9 @@ declare_lint! {
     /// being validated. Usually these should be rejected as a hard error,
     /// but this lint was introduced to avoid breaking any existing
     /// crates which included them.
-    ///
-    /// This is a [future-incompatible] lint to transition this to a hard
-    /// error in the future. See [issue #82730] for more details.
-    ///
-    /// [issue #82730]: https://github.com/rust-lang/rust/issues/82730
     pub INVALID_DOC_ATTRIBUTES,
-    Warn,
+    Deny,
     "detects invalid `#[doc(...)]` attributes",
-    @future_incompatible = FutureIncompatibleInfo {
-        reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
-        reference: "issue #82730 <https://github.com/rust-lang/rust/issues/82730>",
-    };
 }
 
 declare_lint! {

--- a/tests/rustdoc-ui/doc-include-suggestion.rs
+++ b/tests/rustdoc-ui/doc-include-suggestion.rs
@@ -1,10 +1,6 @@
-//@ check-pass
-
 #[doc(include = "external-cross-doc.md")]
-//~^ WARNING unknown `doc` attribute `include`
+//~^ ERROR unknown `doc` attribute `include`
 //~| HELP use `doc = include_str!` instead
 // FIXME(#85497): make this a deny instead so it's more clear what's happening
 //~| NOTE on by default
-//~| WARNING previously accepted
-//~| NOTE see issue #82730
 pub struct NeedMoreDocs;

--- a/tests/rustdoc-ui/doc-include-suggestion.stderr
+++ b/tests/rustdoc-ui/doc-include-suggestion.stderr
@@ -1,12 +1,10 @@
-warning: unknown `doc` attribute `include`
-  --> $DIR/doc-include-suggestion.rs:3:7
+error: unknown `doc` attribute `include`
+  --> $DIR/doc-include-suggestion.rs:1:7
    |
 LL | #[doc(include = "external-cross-doc.md")]
    | ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- help: use `doc = include_str!` instead: `#[doc = include_str!("external-cross-doc.md")]`
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
-   = note: `#[warn(invalid_doc_attributes)]` on by default
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/doctest/doc-test-attr.rs
+++ b/tests/rustdoc-ui/doctest/doc-test-attr.rs
@@ -1,14 +1,10 @@
 #![crate_type = "lib"]
-#![deny(invalid_doc_attributes)]
 
 #![doc(test)]
 //~^ ERROR `#[doc(test(...)]` takes a list of attributes
-//~^^ WARN this was previously accepted by the compiler
 #![doc(test = "hello")]
 //~^ ERROR `#[doc(test(...)]` takes a list of attributes
-//~^^ WARN this was previously accepted by the compiler
 #![doc(test(a))]
 //~^ ERROR unknown `doc(test)` attribute `a`
-//~^^ WARN this was previously accepted by the compiler
 
 pub fn foo() {}

--- a/tests/rustdoc-ui/doctest/doc-test-attr.stderr
+++ b/tests/rustdoc-ui/doctest/doc-test-attr.stderr
@@ -1,34 +1,22 @@
 error: `#[doc(test(...)]` takes a list of attributes
-  --> $DIR/doc-test-attr.rs:4:8
+  --> $DIR/doc-test-attr.rs:3:8
    |
 LL | #![doc(test)]
    |        ^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
-note: the lint level is defined here
-  --> $DIR/doc-test-attr.rs:2:9
-   |
-LL | #![deny(invalid_doc_attributes)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 
 error: `#[doc(test(...)]` takes a list of attributes
-  --> $DIR/doc-test-attr.rs:7:8
+  --> $DIR/doc-test-attr.rs:5:8
    |
 LL | #![doc(test = "hello")]
    |        ^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc(test)` attribute `a`
-  --> $DIR/doc-test-attr.rs:10:13
+  --> $DIR/doc-test-attr.rs:7:13
    |
 LL | #![doc(test(a))]
    |             ^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: aborting due to 3 previous errors
 

--- a/tests/rustdoc-ui/lints/doc-attr.rs
+++ b/tests/rustdoc-ui/lints/doc-attr.rs
@@ -1,25 +1,17 @@
 #![crate_type = "lib"]
-#![deny(warnings)]
 #![doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute
-//~^^ WARN
 
 #[doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute
-//~^^ WARN
 pub fn foo() {}
 
 #[doc(123)]
 //~^ ERROR invalid `doc` attribute
-//~| WARN
 #[doc("hello", "bar")]
 //~^ ERROR invalid `doc` attribute
-//~| WARN
 //~| ERROR invalid `doc` attribute
-//~| WARN
 #[doc(foo::bar, crate::bar::baz = "bye")]
 //~^ ERROR unknown `doc` attribute
-//~| WARN
 //~| ERROR unknown `doc` attribute
-//~| WARN
 fn bar() {}

--- a/tests/rustdoc-ui/lints/doc-attr.stderr
+++ b/tests/rustdoc-ui/lints/doc-attr.stderr
@@ -1,71 +1,46 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:7:7
+  --> $DIR/doc-attr.rs:5:7
    |
 LL | #[doc(as_ptr)]
    |       ^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
-note: the lint level is defined here
-  --> $DIR/doc-attr.rs:2:9
-   |
-LL | #![deny(warnings)]
-   |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 
 error: invalid `doc` attribute
-  --> $DIR/doc-attr.rs:12:7
+  --> $DIR/doc-attr.rs:9:7
    |
 LL | #[doc(123)]
    |       ^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: invalid `doc` attribute
-  --> $DIR/doc-attr.rs:15:7
+  --> $DIR/doc-attr.rs:11:7
    |
 LL | #[doc("hello", "bar")]
    |       ^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: invalid `doc` attribute
-  --> $DIR/doc-attr.rs:15:16
+  --> $DIR/doc-attr.rs:11:16
    |
 LL | #[doc("hello", "bar")]
    |                ^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc` attribute `foo::bar`
-  --> $DIR/doc-attr.rs:20:7
+  --> $DIR/doc-attr.rs:14:7
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |       ^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc` attribute `crate::bar::baz`
-  --> $DIR/doc-attr.rs:20:17
+  --> $DIR/doc-attr.rs:14:17
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:3:8
+  --> $DIR/doc-attr.rs:2:8
    |
 LL | #![doc(as_ptr)]
    |        ^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: aborting due to 7 previous errors
 

--- a/tests/rustdoc-ui/lints/doc-spotlight.fixed
+++ b/tests/rustdoc-ui/lints/doc-spotlight.fixed
@@ -1,8 +1,6 @@
 //@ run-rustfix
-#![deny(warnings)]
 #![feature(doc_notable_trait)]
 
 #[doc(notable_trait)]
 //~^ ERROR unknown `doc` attribute `spotlight`
-//~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 trait MyTrait {}

--- a/tests/rustdoc-ui/lints/doc-spotlight.rs
+++ b/tests/rustdoc-ui/lints/doc-spotlight.rs
@@ -1,8 +1,6 @@
 //@ run-rustfix
-#![deny(warnings)]
 #![feature(doc_notable_trait)]
 
 #[doc(spotlight)]
 //~^ ERROR unknown `doc` attribute `spotlight`
-//~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 trait MyTrait {}

--- a/tests/rustdoc-ui/lints/doc-spotlight.stderr
+++ b/tests/rustdoc-ui/lints/doc-spotlight.stderr
@@ -1,19 +1,12 @@
 error: unknown `doc` attribute `spotlight`
-  --> $DIR/doc-spotlight.rs:5:7
+  --> $DIR/doc-spotlight.rs:4:7
    |
 LL | #[doc(spotlight)]
    |       ^^^^^^^^^ help: use `notable_trait` instead
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: `doc(spotlight)` was renamed to `doc(notable_trait)`
    = note: `doc(spotlight)` is now a no-op
-note: the lint level is defined here
-  --> $DIR/doc-spotlight.rs:2:9
-   |
-LL | #![deny(warnings)]
-   |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/lints/doc_cfg_hide.rs
+++ b/tests/rustdoc-ui/lints/doc_cfg_hide.rs
@@ -1,11 +1,7 @@
 #![feature(doc_cfg_hide)]
-#![deny(warnings)]
 
 #![doc(cfg_hide = "test")] //~ ERROR
-//~^ WARN
 #![doc(cfg_hide)] //~ ERROR
-//~^ WARN
 
 #[doc(cfg_hide(doc))] //~ ERROR
-//~^ WARN
 pub fn foo() {}

--- a/tests/rustdoc-ui/lints/doc_cfg_hide.stderr
+++ b/tests/rustdoc-ui/lints/doc_cfg_hide.stderr
@@ -1,40 +1,27 @@
 error: this attribute can only be applied at the crate level
-  --> $DIR/doc_cfg_hide.rs:9:7
+  --> $DIR/doc_cfg_hide.rs:6:7
    |
 LL | #[doc(cfg_hide(doc))]
    |       ^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
-note: the lint level is defined here
-  --> $DIR/doc_cfg_hide.rs:2:9
-   |
-LL | #![deny(warnings)]
-   |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 help: to apply to the crate, use an inner attribute
    |
 LL | #![doc(cfg_hide(doc))]
    |  +
 
 error: `#[doc(cfg_hide(...))]` takes a list of attributes
-  --> $DIR/doc_cfg_hide.rs:4:8
+  --> $DIR/doc_cfg_hide.rs:3:8
    |
 LL | #![doc(cfg_hide = "test")]
    |        ^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: `#[doc(cfg_hide(...))]` takes a list of attributes
-  --> $DIR/doc_cfg_hide.rs:6:8
+  --> $DIR/doc_cfg_hide.rs:4:8
    |
 LL | #![doc(cfg_hide)]
    |        ^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: aborting due to 3 previous errors
 

--- a/tests/rustdoc-ui/lints/invalid-doc-attr.rs
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr.rs
@@ -1,32 +1,25 @@
 #![crate_type = "lib"]
-#![deny(warnings)]
 #![feature(doc_masked)]
 
 #![doc(masked)]
 //~^ ERROR this attribute can only be applied to an `extern crate` item
-//~| WARN is being phased out
 
 #[doc(test(no_crate_inject))]
 //~^ ERROR can only be applied at the crate level
-//~| WARN is being phased out
 //~| HELP to apply to the crate, use an inner attribute
 //~| SUGGESTION !
 #[doc(inline)]
 //~^ ERROR can only be applied to a `use` item
-//~| WARN is being phased out
 pub fn foo() {}
 
 pub mod bar {
     #![doc(test(no_crate_inject))]
     //~^ ERROR can only be applied at the crate level
-    //~| WARN is being phased out
 
     #[doc(test(no_crate_inject))]
     //~^ ERROR can only be applied at the crate level
-    //~| WARN is being phased out
     #[doc(inline)]
     //~^ ERROR can only be applied to a `use` item
-    //~| WARN is being phased out
     pub fn baz() {}
 }
 
@@ -38,10 +31,8 @@ pub use bar::baz;
 
 #[doc(masked)]
 //~^ ERROR this attribute can only be applied to an `extern crate` item
-//~| WARN is being phased out
 pub struct Masked;
 
 #[doc(masked)]
 //~^ ERROR this attribute cannot be applied to an `extern crate self` item
-//~| WARN is being phased out
 pub extern crate self as reexport;

--- a/tests/rustdoc-ui/lints/invalid-doc-attr.stderr
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr.stderr
@@ -1,48 +1,37 @@
 error: this attribute can only be applied at the crate level
-  --> $DIR/invalid-doc-attr.rs:9:7
+  --> $DIR/invalid-doc-attr.rs:7:7
    |
 LL | #[doc(test(no_crate_inject))]
    |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
-note: the lint level is defined here
-  --> $DIR/invalid-doc-attr.rs:2:9
-   |
-LL | #![deny(warnings)]
-   |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 help: to apply to the crate, use an inner attribute
    |
 LL | #![doc(test(no_crate_inject))]
    |  +
 
 error: this attribute can only be applied to a `use` item
-  --> $DIR/invalid-doc-attr.rs:14:7
+  --> $DIR/invalid-doc-attr.rs:11:7
    |
 LL | #[doc(inline)]
    |       ^^^^^^ only applicable on `use` items
-...
+LL |
 LL | pub fn foo() {}
    | ------------ not a `use` item
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#inline-and-no_inline> for more information
 
 error: this attribute can only be applied at the crate level
-  --> $DIR/invalid-doc-attr.rs:20:12
+  --> $DIR/invalid-doc-attr.rs:16:12
    |
 LL |     #![doc(test(no_crate_inject))]
    |            ^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
 error: conflicting doc inlining attributes
-  --> $DIR/invalid-doc-attr.rs:33:7
+  --> $DIR/invalid-doc-attr.rs:26:7
    |
 LL | #[doc(inline)]
    |       ^^^^^^ this attribute...
@@ -52,61 +41,50 @@ LL | #[doc(no_inline)]
    = help: remove one of the conflicting attributes
 
 error: this attribute can only be applied to an `extern crate` item
-  --> $DIR/invalid-doc-attr.rs:39:7
+  --> $DIR/invalid-doc-attr.rs:32:7
    |
 LL | #[doc(masked)]
    |       ^^^^^^ only applicable on `extern crate` items
-...
+LL |
 LL | pub struct Masked;
    | ----------------- not an `extern crate` item
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: read <https://doc.rust-lang.org/unstable-book/language-features/doc-masked.html> for more information
 
 error: this attribute cannot be applied to an `extern crate self` item
-  --> $DIR/invalid-doc-attr.rs:44:7
+  --> $DIR/invalid-doc-attr.rs:36:7
    |
 LL | #[doc(masked)]
    |       ^^^^^^ not applicable on `extern crate self` items
-...
+LL |
 LL | pub extern crate self as reexport;
    | --------------------------------- `extern crate self` defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: this attribute can only be applied to an `extern crate` item
-  --> $DIR/invalid-doc-attr.rs:5:8
+  --> $DIR/invalid-doc-attr.rs:4:8
    |
 LL | #![doc(masked)]
    |        ^^^^^^ only applicable on `extern crate` items
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: read <https://doc.rust-lang.org/unstable-book/language-features/doc-masked.html> for more information
 
 error: this attribute can only be applied at the crate level
-  --> $DIR/invalid-doc-attr.rs:24:11
+  --> $DIR/invalid-doc-attr.rs:19:11
    |
 LL |     #[doc(test(no_crate_inject))]
    |           ^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
 error: this attribute can only be applied to a `use` item
-  --> $DIR/invalid-doc-attr.rs:27:11
+  --> $DIR/invalid-doc-attr.rs:21:11
    |
 LL |     #[doc(inline)]
    |           ^^^^^^ only applicable on `use` items
-...
+LL |
 LL |     pub fn baz() {}
    |     ------------ not a `use` item
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#inline-and-no_inline> for more information
 
 error: aborting due to 9 previous errors

--- a/tests/ui/attributes/doc-attr.rs
+++ b/tests/ui/attributes/doc-attr.rs
@@ -1,25 +1,17 @@
 #![crate_type = "lib"]
-#![deny(warnings)]
 #![doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute
-//~^^ WARN
 
 #[doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute
-//~^^ WARN
 pub fn foo() {}
 
 #[doc(123)]
 //~^ ERROR invalid `doc` attribute
-//~| WARN
 #[doc("hello", "bar")]
 //~^ ERROR invalid `doc` attribute
-//~| WARN
 //~| ERROR invalid `doc` attribute
-//~| WARN
 #[doc(foo::bar, crate::bar::baz = "bye")]
 //~^ ERROR unknown `doc` attribute
-//~| WARN
 //~| ERROR unknown `doc` attribute
-//~| WARN
 fn bar() {}

--- a/tests/ui/attributes/doc-attr.stderr
+++ b/tests/ui/attributes/doc-attr.stderr
@@ -1,71 +1,46 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:7:7
+  --> $DIR/doc-attr.rs:5:7
    |
 LL | #[doc(as_ptr)]
    |       ^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
-note: the lint level is defined here
-  --> $DIR/doc-attr.rs:2:9
-   |
-LL | #![deny(warnings)]
-   |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 
 error: invalid `doc` attribute
-  --> $DIR/doc-attr.rs:12:7
+  --> $DIR/doc-attr.rs:9:7
    |
 LL | #[doc(123)]
    |       ^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: invalid `doc` attribute
-  --> $DIR/doc-attr.rs:15:7
+  --> $DIR/doc-attr.rs:11:7
    |
 LL | #[doc("hello", "bar")]
    |       ^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: invalid `doc` attribute
-  --> $DIR/doc-attr.rs:15:16
+  --> $DIR/doc-attr.rs:11:16
    |
 LL | #[doc("hello", "bar")]
    |                ^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc` attribute `foo::bar`
-  --> $DIR/doc-attr.rs:20:7
+  --> $DIR/doc-attr.rs:14:7
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |       ^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc` attribute `crate::bar::baz`
-  --> $DIR/doc-attr.rs:20:17
+  --> $DIR/doc-attr.rs:14:17
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:3:8
+  --> $DIR/doc-attr.rs:2:8
    |
 LL | #![doc(as_ptr)]
    |        ^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/attributes/doc-test-literal.rs
+++ b/tests/ui/attributes/doc-test-literal.rs
@@ -1,7 +1,4 @@
-#![deny(warnings)]
-
 #![doc(test(""))]
 //~^ ERROR `#![doc(test(...)]` does not take a literal
-//~^^ WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() {}

--- a/tests/ui/attributes/doc-test-literal.stderr
+++ b/tests/ui/attributes/doc-test-literal.stderr
@@ -1,17 +1,10 @@
 error: `#![doc(test(...)]` does not take a literal
-  --> $DIR/doc-test-literal.rs:3:13
+  --> $DIR/doc-test-literal.rs:1:13
    |
 LL | #![doc(test(""))]
    |             ^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
-note: the lint level is defined here
-  --> $DIR/doc-test-literal.rs:1:9
-   |
-LL | #![deny(warnings)]
-   |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/future-incompatible-lint-group.rs
+++ b/tests/ui/future-incompatible-lint-group.rs
@@ -11,8 +11,7 @@ trait Tr {
 pub mod submodule {
     // Error since this is a `future_incompatible` lint
     #![doc(test(some_test))]
-        //~^ ERROR this attribute can only be applied at the crate level
-        //~| WARN this was previously accepted by the compiler
+    //~^ ERROR this attribute can only be applied at the crate level
 }
 
 fn main() {}

--- a/tests/ui/future-incompatible-lint-group.stderr
+++ b/tests/ui/future-incompatible-lint-group.stderr
@@ -14,15 +14,8 @@ error: this attribute can only be applied at the crate level
 LL |     #![doc(test(some_test))]
    |            ^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
-note: the lint level is defined here
-  --> $DIR/future-incompatible-lint-group.rs:3:9
-   |
-LL | #![deny(future_incompatible)]
-   |         ^^^^^^^^^^^^^^^^^^^
-   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(future_incompatible)]`
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/repr/invalid_repr_list_help.rs
+++ b/tests/ui/repr/invalid_repr_list_help.rs
@@ -17,6 +17,5 @@ pub enum OwO4 {
 }
 
 #[repr(uwu)] //~ERROR: unrecognized representation hint
-#[doc(owo)]  //~WARN: unknown `doc` attribute
-             //~^ WARN: this was previously
+#[doc(owo)]  //~ERROR: unknown `doc` attribute
 pub struct Owo5;

--- a/tests/ui/repr/invalid_repr_list_help.stderr
+++ b/tests/ui/repr/invalid_repr_list_help.stderr
@@ -30,15 +30,13 @@ LL | #[repr(uwu, u8)]
    |
    = help: valid reprs are `Rust` (default), `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
 
-warning: unknown `doc` attribute `owo`
+error: unknown `doc` attribute `owo`
   --> $DIR/invalid_repr_list_help.rs:20:7
    |
 LL | #[doc(owo)]
    |       ^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
-   = note: `#[warn(invalid_doc_attributes)]` on by default
+   = note: `#[deny(invalid_doc_attributes)]` on by default
 
 error[E0552]: unrecognized representation hint
   --> $DIR/invalid_repr_list_help.rs:19:8
@@ -48,6 +46,6 @@ LL | #[repr(uwu)]
    |
    = help: valid reprs are `Rust` (default), `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
 
-error: aborting due to 5 previous errors; 1 warning emitted
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0552`.

--- a/tests/ui/rustdoc/deny-invalid-doc-attrs.rs
+++ b/tests/ui/rustdoc/deny-invalid-doc-attrs.rs
@@ -2,6 +2,4 @@
 //~^ NOTE defined here
 #![doc(x)]
 //~^ ERROR unknown `doc` attribute `x`
-//~| WARNING will become a hard error
-//~| NOTE see issue #82730
 fn main() {}

--- a/tests/ui/rustdoc/deny-invalid-doc-attrs.stderr
+++ b/tests/ui/rustdoc/deny-invalid-doc-attrs.stderr
@@ -4,8 +4,6 @@ error: unknown `doc` attribute `x`
 LL | #![doc(x)]
    |        ^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 note: the lint level is defined here
   --> $DIR/deny-invalid-doc-attrs.rs:1:9
    |

--- a/tests/ui/rustdoc/doc-primitive.rs
+++ b/tests/ui/rustdoc/doc-primitive.rs
@@ -2,7 +2,6 @@
 
 #[doc(primitive = "foo")]
 //~^ ERROR unknown `doc` attribute `primitive`
-//~| WARN
 mod bar {}
 
 fn main() {}

--- a/tests/ui/rustdoc/doc-primitive.stderr
+++ b/tests/ui/rustdoc/doc-primitive.stderr
@@ -4,8 +4,6 @@ error: unknown `doc` attribute `primitive`
 LL | #[doc(primitive = "foo")]
    |       ^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 note: the lint level is defined here
   --> $DIR/doc-primitive.rs:1:9
    |

--- a/tests/ui/rustdoc/doc-test-attr.rs
+++ b/tests/ui/rustdoc/doc-test-attr.rs
@@ -3,12 +3,9 @@
 
 #![doc(test)]
 //~^ ERROR `#[doc(test(...)]` takes a list of attributes
-//~^^ WARN this was previously accepted by the compiler
 #![doc(test = "hello")]
 //~^ ERROR `#[doc(test(...)]` takes a list of attributes
-//~^^ WARN this was previously accepted by the compiler
 #![doc(test(a))]
 //~^ ERROR unknown `doc(test)` attribute `a`
-//~^^ WARN this was previously accepted by the compiler
 
 pub fn foo() {}

--- a/tests/ui/rustdoc/doc-test-attr.stderr
+++ b/tests/ui/rustdoc/doc-test-attr.stderr
@@ -4,8 +4,6 @@ error: `#[doc(test(...)]` takes a list of attributes
 LL | #![doc(test)]
    |        ^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 note: the lint level is defined here
   --> $DIR/doc-test-attr.rs:2:9
    |
@@ -13,22 +11,16 @@ LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[doc(test(...)]` takes a list of attributes
-  --> $DIR/doc-test-attr.rs:7:8
+  --> $DIR/doc-test-attr.rs:6:8
    |
 LL | #![doc(test = "hello")]
    |        ^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc(test)` attribute `a`
-  --> $DIR/doc-test-attr.rs:10:13
+  --> $DIR/doc-test-attr.rs:8:13
    |
 LL | #![doc(test(a))]
    |             ^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/82730.

# Explanations

The `INVALID_DOC_ATTRIBUTES` lint was marked as "will become a hard error into the future" for quite some time so making it `deny` by default.

<del>Waiting on https://github.com/rust-lang/backtrace-rs/pull/524 for now.</del>