### PR TITLE
Don't use `can_eq` in `derive(..)` suggestion for missing method

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2090,20 +2090,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     | sym::Hash
                     | sym::Debug => true,
                     _ => false,
-                } && match trait_pred.trait_ref.substs.as_slice() {
-                    // Only suggest deriving if lhs == rhs...
-                    [lhs, rhs] => {
-                        if let Some(lhs) = lhs.as_type()
-                            && let Some(rhs) = rhs.as_type()
-                        {
-                            self.can_eq(self.param_env, lhs, rhs)
-                        } else {
-                            false
-                        }
-                    },
-                    // Unary ops can always be derived
-                    [_] => true,
-                    _ => false,
                 };
                 if can_derive {
                     let self_name = trait_pred.self_ty().to_string();

--- a/tests/ui/issues/issue-62375.stderr
+++ b/tests/ui/issues/issue-62375.stderr
@@ -11,8 +11,11 @@ note: an implementation of `PartialEq<fn(()) -> A {A::Value}>` might be missing 
    |
 LL | enum A {
    | ^^^^^^ must implement `PartialEq<fn(()) -> A {A::Value}>`
-note: the trait `PartialEq` must be implemented
-  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+help: consider annotating `A` with `#[derive(PartialEq)]`
+   |
+LL + #[derive(PartialEq)]
+LL | enum A {
+   |
 help: use parentheses to construct this tuple variant
    |
 LL |     a == A::Value(/* () */);

--- a/tests/ui/typeck/derive-sugg-arg-arity.rs
+++ b/tests/ui/typeck/derive-sugg-arg-arity.rs
@@ -1,0 +1,8 @@
+pub struct A;
+
+fn main() {
+    match () {
+        _ => match A::partial_cmp() {},
+        //~^ ERROR the function or associated item `partial_cmp` exists for struct `A`, but its trait bounds were not satisfied
+    }
+}

--- a/tests/ui/typeck/derive-sugg-arg-arity.stderr
+++ b/tests/ui/typeck/derive-sugg-arg-arity.stderr
@@ -1,0 +1,31 @@
+error[E0599]: the function or associated item `partial_cmp` exists for struct `A`, but its trait bounds were not satisfied
+  --> $DIR/derive-sugg-arg-arity.rs:5:23
+   |
+LL | pub struct A;
+   | ------------
+   | |
+   | function or associated item `partial_cmp` not found for this struct
+   | doesn't satisfy `A: Iterator`
+   | doesn't satisfy `A: PartialOrd<_>`
+...
+LL |         _ => match A::partial_cmp() {},
+   |                       ^^^^^^^^^^^ function or associated item cannot be called on `A` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `A: PartialOrd<_>`
+           which is required by `&A: PartialOrd<&_>`
+           `A: PartialOrd<_>`
+           which is required by `&mut A: PartialOrd<&mut _>`
+           `A: Iterator`
+           which is required by `&mut A: Iterator`
+note: the trait `Iterator` must be implemented
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+help: consider annotating `A` with `#[derive(PartialEq, PartialOrd)]`
+   |
+LL + #[derive(PartialEq, PartialOrd)]
+LL | pub struct A;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Unsatisfied predicates returned from method probe may reference inference vars from that probe, so drop this extra check I added in #110877 for more accurate derive suggestions...

Fixes #111500