### PR TITLE
Don't clean bootstrap by default

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -841,7 +841,9 @@ impl<'a> Builder<'a> {
                 run::GenerateWindowsSys,
             ),
             Kind::Setup => describe!(setup::Profile, setup::Hook, setup::Link, setup::Vscode),
-            Kind::Clean => describe!(clean::CleanAll, clean::Rustc, clean::Std),
+            Kind::Clean => {
+                describe!(clean::CleanAll, clean::CleanBootstrap, clean::Rustc, clean::Std)
+            }
             // special-cased in Build::build()
             Kind::Format | Kind::Suggest => vec![],
         }


### PR DESCRIPTION
`x clean` will no longer delete bootstrap by default. This means that `x clean; x clean` won't redownload and compile bootstrap only to delete it immediately
`x clean bootstrap`/`src/bootstrap` will still clean it.

It still seems to re-extract rustc, cargo and std tarballs after cleaning bootstrap which I'm not sure how to resolve