### PR TITLE
Include better context for "already exists" error in compiletest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,6 +723,7 @@ dependencies = [
 name = "compiletest"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "build_helper",
  "colored",
  "diff",

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -20,6 +20,7 @@ once_cell = "1.16.0"
 walkdir = "2"
 glob = "0.3.0"
 lazycell = "1.3.0"
+anyhow = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -32,6 +32,7 @@ use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::str;
 use std::sync::Arc;
 
+use anyhow::Context;
 use glob::glob;
 use once_cell::sync::Lazy;
 use tracing::*;
@@ -131,7 +132,11 @@ pub fn run(config: Arc<Config>, testpaths: &TestPaths, revision: Option<&str>) {
     }
 
     let cx = TestCx { config: &config, props: &props, testpaths, revision };
-    create_dir_all(&cx.output_base_dir()).unwrap();
+    create_dir_all(&cx.output_base_dir())
+        .with_context(|| {
+            format!("failed to create output base directory {}", cx.output_base_dir().display())
+        })
+        .unwrap();
     if props.incremental {
         cx.init_incremental_test();
     }


### PR DESCRIPTION
I encountered the following error from `x.py test tests/ui` today.

```console
---- [ui] tests/ui/impl-trait/multiple-lifetimes/multiple-lifetimes.rs stdout ----
thread '[ui] tests/ui/impl-trait/multiple-lifetimes/multiple-lifetimes.rs' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 17, kind: AlreadyExists, message: "File exists" }', src/tools/compiletest/src/runtest.rs:134:43
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I found it impossible to unblock myself without knowing which directory it was stuck on.

Error message after this PR:

```console
---- [ui] tests/ui/impl-trait/multiple-lifetimes/multiple-lifetimes.rs stdout ----
thread '[ui] tests/ui/impl-trait/multiple-lifetimes/multiple-lifetimes.rs' panicked at 'called `Result::unwrap()` on an `Err` value: failed to create output base directory /git/rust/build/x86_64-unknown-linux-gnu/test/ui/impl-trait/multiple-lifetimes/multiple-lifetimes

Caused by:
    File exists (os error 17)', src/tools/compiletest/src/runtest.rs:139:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Now I was able to run `rm build/x86_64-unknown-linux-gnu/test/ui/impl-trait/multiple-lifetimes/multiple-lifetimes` and unblock myself.

Seems to be related to #109509 moving *tests/ui/impl-trait/multiple-lifetimes.rs* to *tests/ui/impl-trait/multiple-lifetimes/multiple-lifetimes.rs*.