### PR TITLE
rustdoc-json: Add tests for visibility of impls

### DIFF
--- a/tests/rustdoc-json/impls/impl_item_visibility.rs
+++ b/tests/rustdoc-json/impls/impl_item_visibility.rs
@@ -1,0 +1,26 @@
+#![feature(no_core)]
+#![no_core]
+
+pub struct Foo;
+
+/// impl Foo priv
+impl Foo {
+    fn baz() {}
+}
+// @!has '$.index[*][?(@.docs=="impl Foo priv")]'
+
+
+/// impl Foo pub
+impl Foo {
+    pub fn qux() {}
+}
+// @is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
+
+
+/// impl Foo hidden
+impl Foo {
+    #[doc(hidden)]
+    pub fn __quazl(){}
+}
+// FIXME(#111564): Is this the right behaviour?
+// @is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'

--- a/tests/rustdoc-json/impls/impl_item_visibility_show_hidden.rs
+++ b/tests/rustdoc-json/impls/impl_item_visibility_show_hidden.rs
@@ -1,0 +1,28 @@
+// compile-flags: --document-hidden-items
+#![feature(no_core)]
+#![no_core]
+
+pub struct Foo;
+
+/// impl Foo priv
+impl Foo {
+    fn baz() {}
+}
+// FIXME(#111564): Is this the right behaviour?
+// @is '$.index[*][?(@.docs=="impl Foo priv")].visibility' '"default"'
+
+
+/// impl Foo pub
+impl Foo {
+    pub fn qux() {}
+}
+// @is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
+
+
+/// impl Foo hidden
+impl Foo {
+    #[doc(hidden)]
+    pub fn __quazl(){}
+}
+// FIXME(#111564): Is this the right behaviour?
+// @is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'

--- a/tests/rustdoc-json/impls/impl_item_visibility_show_private.rs
+++ b/tests/rustdoc-json/impls/impl_item_visibility_show_private.rs
@@ -1,0 +1,27 @@
+// compile-flags: --document-private-items
+#![feature(no_core)]
+#![no_core]
+
+pub struct Foo;
+
+/// impl Foo priv
+impl Foo {
+    fn baz() {}
+}
+// @is '$.index[*][?(@.docs=="impl Foo priv")].visibility' '"default"'
+
+
+/// impl Foo pub
+impl Foo {
+    pub fn qux() {}
+}
+// @is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
+
+
+/// impl Foo hidden
+impl Foo {
+    #[doc(hidden)]
+    pub fn __quazl(){}
+}
+// FIXME(#111564): Is this the right behaviour?
+// @is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'


### PR DESCRIPTION
[Apparrently rustdoc use to give these `crate` instead of `default`](https://github.com/obi1kenobi/trustfall-rustdoc-adapter/compare/rustdoc-v24...rustdoc-v25#diff-58e57a0fc73d1353fa3a057f0fe81c6ecfd4548b429cef1aee36b1c84d8d15a4L366). CC @obi1kenobi 

The output is arguably still buggy as to weather some of these impls should be stripped, but that's a seperate issue and shouldn't block adding these tests (#111564)

r? @GuillaumeGomez 