### PR TITLE
EXPERIMENT [MIR-OPT] Add a pass that replicates simple branches into predecessors

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -90,6 +90,7 @@ mod remove_storage_markers;
 mod remove_uninit_drops;
 mod remove_unneeded_drops;
 mod remove_zsts;
+mod replicate_branches;
 mod required_consts;
 mod reveal_all;
 mod separate_const_switch;
@@ -554,7 +555,8 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &remove_unneeded_drops::RemoveUnneededDrops,
             &sroa::ScalarReplacementOfAggregates,
             &match_branches::MatchBranchSimplification,
-            // inst combine is after MatchBranchSimplification to clean up Ne(_1, false)
+            // inst simplify is after MatchBranchSimplification to clean up Ne(_1, false)
+            &replicate_branches::ReplicateBranches,
             &multiple_return_terminators::MultipleReturnTerminators,
             &instsimplify::InstSimplify,
             &separate_const_switch::SeparateConstSwitch,

--- a/compiler/rustc_mir_transform/src/replicate_branches.rs
+++ b/compiler/rustc_mir_transform/src/replicate_branches.rs
@@ -1,0 +1,104 @@
+//! Looks for basic blocks that are just a simple 2-way branch,
+//! and replicates them into their predecessors.
+//!
+//! That sounds wasteful, but it's very common that the predecessor just set
+//! whatever we're about to branch on, and this makes that easier to collapse
+//! later. And if not, well, an extra branch is no big deal.
+
+use crate::MirPass;
+
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+
+use super::simplify::simplify_cfg;
+
+pub struct ReplicateBranches;
+
+impl<'tcx> MirPass<'tcx> for ReplicateBranches {
+    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
+        sess.mir_opt_level() >= 2
+    }
+
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        debug!("Running ReplicateBranches on `{:?}`", body.source);
+
+        let mut source_and_target_blocks = vec![];
+
+        for (bb, data) in body.basic_blocks.iter_enumerated() {
+            if data.is_cleanup {
+                continue;
+            }
+
+            let TerminatorKind::SwitchInt { discr, targets } = &data.terminator().kind
+            else { continue };
+
+            let Some(place) = discr.place() else { continue };
+
+            // Only replicate simple branches. That means either:
+            // - A specific target plus a potentially-reachable otherwise, or
+            // - Two specific targets and the otherwise is unreachable.
+            if !(targets.iter().len() < 2
+                || (targets.iter().len() <= 2
+                    && body.basic_blocks[targets.otherwise()].is_empty_unreachable()))
+            {
+                continue;
+            }
+
+            // Only replicate blocks that branch on a discriminant.
+            let mut found_discriminant = false;
+            for stmt in &data.statements {
+                match &stmt.kind {
+                    StatementKind::StorageDead { .. } | StatementKind::StorageLive { .. } => {}
+                    StatementKind::Assign(place_and_rvalue)
+                        if place_and_rvalue.0 == place
+                            && matches!(place_and_rvalue.1, Rvalue::Discriminant(..)) =>
+                    {
+                        found_discriminant = true;
+                    }
+                    _ => continue,
+                }
+            }
+
+            // This currently doesn't duplicate ordinary boolean checks as that regresses
+            // various tests that seem to depend on the existing structure.
+            if !found_discriminant {
+                continue;
+            }
+
+            // Only replicate to a small number of `goto` predecessors.
+            let preds = &body.basic_blocks.predecessors()[bb];
+            if preds.len() > 2
+                || !preds.iter().copied().all(|p| {
+                    let pdata = &body.basic_blocks[p];
+                    matches!(pdata.terminator().kind, TerminatorKind::Goto { .. })
+                        && !pdata.is_cleanup
+                })
+            {
+                continue;
+            }
+
+            for p in preds {
+                source_and_target_blocks.push((*p, bb));
+            }
+        }
+
+        if source_and_target_blocks.is_empty() {
+            return;
+        }
+
+        let basic_blocks = body.basic_blocks.as_mut();
+        for (source, target) in source_and_target_blocks {
+            debug_assert_eq!(
+                basic_blocks[source].terminator().kind,
+                TerminatorKind::Goto { target },
+            );
+
+            let (source, target) = basic_blocks.pick2_mut(source, target);
+            source.statements.extend(target.statements.iter().cloned());
+            source.terminator = target.terminator.clone();
+        }
+
+        // The target blocks should be unused now, so cleanup after ourselves.
+        simplify_cfg(tcx, body);
+    }
+}

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.diff
@@ -10,9 +10,51 @@
 +     scope 1 (inlined core::num::<impl u16>::unchecked_shl) { // at $DIR/unchecked_shifts.rs:11:7: 11:23
 +         debug self => _3;                // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
 +         debug rhs => _4;                 // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-+         let mut _5: u16;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         let mut _6: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         let mut _5: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         let mut _6: u32;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
 +         scope 2 {
++             scope 3 (inlined core::num::<impl u16>::unchecked_shl::conv) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                 debug x => _6;           // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                 let mut _7: std::option::Option<u16>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                 let mut _8: std::result::Result<u16, std::num::TryFromIntError>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                 scope 4 {
++                     scope 5 (inlined <u32 as TryInto<u16>>::try_into) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                         debug self => _6; // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
++                         scope 6 (inlined convert::num::<impl TryFrom<u32> for u16>::try_from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
++                             debug u => _6; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++                             let mut _9: bool; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++                             let mut _10: u32; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++                             let mut _11: u16; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++                         }
++                     }
++                     scope 7 (inlined Result::<u16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                         debug self => _8; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
++                         let _12: u16;    // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
++                         scope 8 {
++                             debug x => _12; // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
++                         }
++                     }
++                     scope 9 (inlined #[track_caller] Option::<u16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                         debug self => _7; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
++                         let mut _13: &std::option::Option<u16>; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
++                         let _14: u16;    // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
++                         scope 10 {
++                             debug val => _14; // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
++                         }
++                         scope 11 {
++                             scope 13 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
++                                 scope 14 {
++                                     scope 15 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                                     }
++                                 }
++                             }
++                         }
++                         scope 12 (inlined Option::<u16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
++                             debug self => _13; // in scope 12 at $SRC_DIR/core/src/option.rs:LL:COL
++                         }
++                     }
++                 }
++             }
 +         }
 +     }
   
@@ -22,30 +64,61 @@
           StorageLive(_4);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
           _4 = _2;                         // scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
 -         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> bb1; // scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:23
-+         StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         _6 = (_4,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         _5 = core::num::<impl u16>::unchecked_shl::conv(move (_6.0: u32)) -> bb1; // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                                           // mir::Constant
+-                                          // mir::Constant
 -                                          // + span: $DIR/unchecked_shifts.rs:11:7: 11:20
 -                                          // + literal: Const { ty: unsafe fn(u16, u32) -> u16 {core::num::<impl u16>::unchecked_shl}, val: Value(<ZST>) }
-+                                          // + span: $SRC_DIR/core/src/num/mod.rs:LL:COL
-+                                          // + literal: Const { ty: fn(u32) -> u16 {core::num::<impl u16>::unchecked_shl::conv}, val: Value(<ZST>) }
++         StorageLive(_14);                // scope 0 at $DIR/unchecked_shifts.rs:+1:7: +1:23
++         StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _5 = (_4,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _6 = move (_5.0: u32);           // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_7);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         _10 = const 65535_u32;           // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         _9 = Gt(_6, move _10);           // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         switchInt(move _9) -> [0: bb3, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
       }
   
       bb1: {
-+         StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         _0 = unchecked_shl::<u16>(_3, move _5) -> [return: bb2, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-+                                          // mir::Constant
-+                                          // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-+                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u16, u16) -> u16 {unchecked_shl::<u16>}, val: Value(<ZST>) }
-+     }
-+ 
-+     bb2: {
-+         StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++         StorageDead(_14);                // scope 0 at $DIR/unchecked_shifts.rs:+1:7: +1:23
           StorageDead(_4);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:22: +1:23
           StorageDead(_3);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:22: +1:23
           return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
++     }
++ 
++     bb2: {
++         StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         unreachable;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb3: {
++         StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         _11 = _6 as u16 (IntToInt);      // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         _8 = Result::<u16, TryFromIntError>::Ok(move _11); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _12 = move ((_8 as Ok).0: u16);  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
++         _7 = Option::<u16>::Some(move _12); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
++         StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _14 = move ((_7 as Some).0: u16); // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
++         StorageDead(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_7);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _0 = unchecked_shl::<u16>(_3, move _14) -> [return: bb1, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                                          // mir::Constant
++                                          // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u16, u16) -> u16 {unchecked_shl::<u16>}, val: Value(<ZST>) }
       }
   }
   

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.mir
@@ -7,32 +7,104 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
     scope 1 (inlined core::num::<impl u16>::unchecked_shl) { // at $DIR/unchecked_shifts.rs:11:7: 11:23
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
         debug rhs => _2;                 // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-        let mut _3: u16;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        let mut _4: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _3: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _4: u32;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         scope 2 {
+            scope 3 (inlined core::num::<impl u16>::unchecked_shl::conv) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                debug x => _4;           // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                let mut _5: std::option::Option<u16>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                let mut _6: std::result::Result<u16, std::num::TryFromIntError>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                scope 4 {
+                    scope 5 (inlined <u32 as TryInto<u16>>::try_into) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                        debug self => _4; // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                        scope 6 (inlined convert::num::<impl TryFrom<u32> for u16>::try_from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                            debug u => _4; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _7: bool; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _8: u32; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _9: u16; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                        }
+                    }
+                    scope 7 (inlined Result::<u16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                        debug self => _6; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        let _10: u16;    // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        scope 8 {
+                            debug x => _10; // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                        }
+                    }
+                    scope 9 (inlined #[track_caller] Option::<u16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                        debug self => _5; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        let mut _11: &std::option::Option<u16>; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        let _12: u16;    // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        scope 10 {
+                            debug val => _12; // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
+                        }
+                        scope 11 {
+                            scope 13 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                                scope 14 {
+                                    scope 15 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    }
+                                }
+                            }
+                        }
+                        scope 12 (inlined Option::<u16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                            debug self => _11; // in scope 12 at $SRC_DIR/core/src/option.rs:LL:COL
+                        }
+                    }
+                }
+            }
         }
     }
 
     bb0: {
+        StorageLive(_12);                // scope 0 at $DIR/unchecked_shifts.rs:+1:7: +1:23
         StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _3 = (_2,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _4 = (_2,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _3 = core::num::<impl u16>::unchecked_shl::conv(move (_4.0: u32)) -> bb1; // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/num/mod.rs:LL:COL
-                                         // + literal: Const { ty: fn(u32) -> u16 {core::num::<impl u16>::unchecked_shl::conv}, val: Value(<ZST>) }
+        _4 = move (_3.0: u32);           // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_8);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _8 = const 65535_u32;            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _7 = Gt(_4, move _8);            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_8);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        switchInt(move _7) -> [0: bb3, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
     }
 
     bb1: {
-        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _0 = unchecked_shl::<u16>(_1, move _3) -> [return: bb2, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u16, u16) -> u16 {unchecked_shl::<u16>}, val: Value(<ZST>) }
+        StorageDead(_12);                // scope 0 at $DIR/unchecked_shifts.rs:+1:7: +1:23
+        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        unreachable;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb3: {
+        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _9 = _4 as u16 (IntToInt);       // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _6 = Result::<u16, TryFromIntError>::Ok(move _9); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _10 = move ((_6 as Ok).0: u16);  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _5 = Option::<u16>::Some(move _10); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _12 = move ((_5 as Some).0: u16); // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _0 = unchecked_shl::<u16>(_1, move _12) -> [return: bb1, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u16, u16) -> u16 {unchecked_shl::<u16>}, val: Value(<ZST>) }
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.diff
@@ -10,9 +10,51 @@
 +     scope 1 (inlined core::num::<impl i16>::unchecked_shr) { // at $DIR/unchecked_shifts.rs:17:7: 17:23
 +         debug self => _3;                // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
 +         debug rhs => _4;                 // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-+         let mut _5: i16;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         let mut _6: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         let mut _5: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         let mut _6: u32;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
 +         scope 2 {
++             scope 3 (inlined core::num::<impl i16>::unchecked_shr::conv) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                 debug x => _6;           // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                 let mut _7: std::option::Option<i16>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                 let mut _8: std::result::Result<i16, std::num::TryFromIntError>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                 scope 4 {
++                     scope 5 (inlined <u32 as TryInto<i16>>::try_into) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                         debug self => _6; // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
++                         scope 6 (inlined convert::num::<impl TryFrom<u32> for i16>::try_from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
++                             debug u => _6; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++                             let mut _9: bool; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++                             let mut _10: u32; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++                             let mut _11: i16; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++                         }
++                     }
++                     scope 7 (inlined Result::<i16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                         debug self => _8; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
++                         let _12: i16;    // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
++                         scope 8 {
++                             debug x => _12; // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
++                         }
++                     }
++                     scope 9 (inlined #[track_caller] Option::<i16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
++                         debug self => _7; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
++                         let mut _13: &std::option::Option<i16>; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
++                         let _14: i16;    // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
++                         scope 10 {
++                             debug val => _14; // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
++                         }
++                         scope 11 {
++                             scope 13 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
++                                 scope 14 {
++                                     scope 15 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                                     }
++                                 }
++                             }
++                         }
++                         scope 12 (inlined Option::<i16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
++                             debug self => _13; // in scope 12 at $SRC_DIR/core/src/option.rs:LL:COL
++                         }
++                     }
++                 }
++             }
 +         }
 +     }
   
@@ -22,30 +64,61 @@
           StorageLive(_4);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
           _4 = _2;                         // scope 0 at $DIR/unchecked_shifts.rs:+1:21: +1:22
 -         _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> bb1; // scope 0 at $DIR/unchecked_shifts.rs:+1:5: +1:23
-+         StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         _6 = (_4,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         _5 = core::num::<impl i16>::unchecked_shr::conv(move (_6.0: u32)) -> bb1; // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                                           // mir::Constant
+-                                          // mir::Constant
 -                                          // + span: $DIR/unchecked_shifts.rs:17:7: 17:20
 -                                          // + literal: Const { ty: unsafe fn(i16, u32) -> i16 {core::num::<impl i16>::unchecked_shr}, val: Value(<ZST>) }
-+                                          // + span: $SRC_DIR/core/src/num/mod.rs:LL:COL
-+                                          // + literal: Const { ty: fn(u32) -> i16 {core::num::<impl i16>::unchecked_shr::conv}, val: Value(<ZST>) }
++         StorageLive(_14);                // scope 0 at $DIR/unchecked_shifts.rs:+1:7: +1:23
++         StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _5 = (_4,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _6 = move (_5.0: u32);           // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_7);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         _10 = const 32767_u32;           // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         _9 = Gt(_6, move _10);           // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         switchInt(move _9) -> [0: bb3, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
       }
   
       bb1: {
-+         StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-+         _0 = unchecked_shr::<i16>(_3, move _5) -> [return: bb2, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-+                                          // mir::Constant
-+                                          // + span: $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-+                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(i16, i16) -> i16 {unchecked_shr::<i16>}, val: Value(<ZST>) }
-+     }
-+ 
-+     bb2: {
-+         StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++         StorageDead(_14);                // scope 0 at $DIR/unchecked_shifts.rs:+1:7: +1:23
           StorageDead(_4);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:22: +1:23
           StorageDead(_3);                 // scope 0 at $DIR/unchecked_shifts.rs:+1:22: +1:23
           return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
++     }
++ 
++     bb2: {
++         StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         unreachable;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
++     }
++ 
++     bb3: {
++         StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         _11 = _6 as i16 (IntToInt);      // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         _8 = Result::<i16, TryFromIntError>::Ok(move _11); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
++         StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _12 = move ((_8 as Ok).0: i16);  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
++         _7 = Option::<i16>::Some(move _12); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
++         StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _14 = move ((_7 as Some).0: i16); // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
++         StorageDead(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_7);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
++         _0 = unchecked_shr::<i16>(_3, move _14) -> [return: bb1, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++                                          // mir::Constant
++                                          // + span: $SRC_DIR/core/src/num/int_macros.rs:LL:COL
++                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(i16, i16) -> i16 {unchecked_shr::<i16>}, val: Value(<ZST>) }
       }
   }
   

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.mir
@@ -7,32 +7,104 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
     scope 1 (inlined core::num::<impl i16>::unchecked_shr) { // at $DIR/unchecked_shifts.rs:17:7: 17:23
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
         debug rhs => _2;                 // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        let mut _3: i16;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        let mut _4: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _3: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _4: u32;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         scope 2 {
+            scope 3 (inlined core::num::<impl i16>::unchecked_shr::conv) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                debug x => _4;           // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                let mut _5: std::option::Option<i16>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                let mut _6: std::result::Result<i16, std::num::TryFromIntError>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                scope 4 {
+                    scope 5 (inlined <u32 as TryInto<i16>>::try_into) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                        debug self => _4; // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                        scope 6 (inlined convert::num::<impl TryFrom<u32> for i16>::try_from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                            debug u => _4; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _7: bool; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _8: u32; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _9: i16; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                        }
+                    }
+                    scope 7 (inlined Result::<i16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                        debug self => _6; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        let _10: i16;    // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        scope 8 {
+                            debug x => _10; // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                        }
+                    }
+                    scope 9 (inlined #[track_caller] Option::<i16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                        debug self => _5; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        let mut _11: &std::option::Option<i16>; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        let _12: i16;    // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        scope 10 {
+                            debug val => _12; // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
+                        }
+                        scope 11 {
+                            scope 13 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                                scope 14 {
+                                    scope 15 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    }
+                                }
+                            }
+                        }
+                        scope 12 (inlined Option::<i16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                            debug self => _11; // in scope 12 at $SRC_DIR/core/src/option.rs:LL:COL
+                        }
+                    }
+                }
+            }
         }
     }
 
     bb0: {
+        StorageLive(_12);                // scope 0 at $DIR/unchecked_shifts.rs:+1:7: +1:23
         StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _3 = (_2,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _4 = (_2,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _3 = core::num::<impl i16>::unchecked_shr::conv(move (_4.0: u32)) -> bb1; // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/num/mod.rs:LL:COL
-                                         // + literal: Const { ty: fn(u32) -> i16 {core::num::<impl i16>::unchecked_shr::conv}, val: Value(<ZST>) }
+        _4 = move (_3.0: u32);           // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_8);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _8 = const 32767_u32;            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _7 = Gt(_4, move _8);            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_8);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        switchInt(move _7) -> [0: bb3, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
     }
 
     bb1: {
-        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _0 = unchecked_shr::<i16>(_1, move _3) -> [return: bb2, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(i16, i16) -> i16 {unchecked_shr::<i16>}, val: Value(<ZST>) }
+        StorageDead(_12);                // scope 0 at $DIR/unchecked_shifts.rs:+1:7: +1:23
+        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        unreachable;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb3: {
+        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _9 = _4 as i16 (IntToInt);       // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _6 = Result::<i16, TryFromIntError>::Ok(move _9); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _10 = move ((_6 as Ok).0: i16);  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _5 = Option::<i16>::Some(move _10); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _12 = move ((_5 as Some).0: i16); // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _0 = unchecked_shr::<i16>(_1, move _12) -> [return: bb1, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(i16, i16) -> i16 {unchecked_shr::<i16>}, val: Value(<ZST>) }
     }
 }

--- a/tests/mir-opt/pre-codegen/transient_enums.checked_as_u32.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/transient_enums.checked_as_u32.PreCodegen.after.mir
@@ -29,35 +29,39 @@ fn checked_as_u32(_1: u64) -> Option<u32> {
         _4 = const 4294967295_u64;       // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
         _3 = Gt(_1, move _4);            // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
         StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        switchInt(move _3) -> [0: bb3, otherwise: bb2]; // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
     }
 
     bb1: {
+        StorageDead(_7);                 // scope 0 at $DIR/transient_enums.rs:+1:18: +1:22
+        StorageDead(_2);                 // scope 0 at $DIR/transient_enums.rs:+1:21: +1:22
+        return;                          // scope 0 at $DIR/transient_enums.rs:+2:2: +2:2
+    }
+
+    bb2: {
         _2 = Result::<u32, TryFromIntError>::Err(const TryFromIntError(())); // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
                                          // mir::Constant
                                          // + span: no-location
                                          // + literal: Const { ty: TryFromIntError, val: Value(<ZST>) }
-        goto -> bb3;                     // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-    }
-
-    bb2: {
-        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _5 = _1 as u32 (IntToInt);       // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _2 = Result::<u32, TryFromIntError>::Ok(move _5); // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        goto -> bb3;                     // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-    }
-
-    bb3: {
         StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
         StorageLive(_7);                 // scope 0 at $DIR/transient_enums.rs:+1:18: +1:22
         _6 = discriminant(_2);           // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
         switchInt(move _6) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
+    bb3: {
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _5 = _1 as u32 (IntToInt);       // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _2 = Result::<u32, TryFromIntError>::Ok(move _5); // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_7);                 // scope 0 at $DIR/transient_enums.rs:+1:18: +1:22
+        goto -> bb6;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
     bb4: {
         _0 = Option::<u32>::None;        // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
-        goto -> bb7;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb1;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb5: {
@@ -67,12 +71,6 @@ fn checked_as_u32(_1: u64) -> Option<u32> {
     bb6: {
         _7 = move ((_2 as Ok).0: u32);   // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
         _0 = Option::<u32>::Some(move _7); // scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
-        goto -> bb7;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
-    }
-
-    bb7: {
-        StorageDead(_7);                 // scope 0 at $DIR/transient_enums.rs:+1:18: +1:22
-        StorageDead(_2);                 // scope 0 at $DIR/transient_enums.rs:+1:21: +1:22
-        return;                          // scope 0 at $DIR/transient_enums.rs:+2:2: +2:2
+        goto -> bb1;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 }

--- a/tests/mir-opt/pre-codegen/transient_enums.checked_as_u32.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/transient_enums.checked_as_u32.PreCodegen.after.mir
@@ -1,0 +1,78 @@
+// MIR for `checked_as_u32` after PreCodegen
+
+fn checked_as_u32(_1: u64) -> Option<u32> {
+    debug t => _1;                       // in scope 0 at $DIR/transient_enums.rs:+0:23: +0:24
+    let mut _0: std::option::Option<u32>; // return place in scope 0 at $DIR/transient_enums.rs:+0:34: +0:45
+    let mut _2: std::result::Result<u32, std::num::TryFromIntError>; // in scope 0 at $DIR/transient_enums.rs:+1:5: +1:17
+    scope 1 (inlined <u64 as TryInto<u32>>::try_into) { // at $DIR/transient_enums.rs:9:7: 9:17
+        debug self => _1;                // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        scope 2 (inlined convert::num::<impl TryFrom<u64> for u32>::try_from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+            debug u => _1;               // in scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+            let mut _3: bool;            // in scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+            let mut _4: u64;             // in scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+            let mut _5: u32;             // in scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        }
+    }
+    scope 3 (inlined Result::<u32, TryFromIntError>::ok) { // at $DIR/transient_enums.rs:9:18: 9:22
+        debug self => _2;                // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _6: isize;               // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        let _7: u32;                     // in scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        scope 4 {
+            debug x => _7;               // in scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);                 // scope 0 at $DIR/transient_enums.rs:+1:5: +1:17
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _4 = const 4294967295_u64;       // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _3 = Gt(_1, move _4);            // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+    }
+
+    bb1: {
+        _2 = Result::<u32, TryFromIntError>::Err(const TryFromIntError(())); // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: no-location
+                                         // + literal: Const { ty: TryFromIntError, val: Value(<ZST>) }
+        goto -> bb3;                     // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+    }
+
+    bb2: {
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _5 = _1 as u32 (IntToInt);       // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _2 = Result::<u32, TryFromIntError>::Ok(move _5); // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        goto -> bb3;                     // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+    }
+
+    bb3: {
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_7);                 // scope 0 at $DIR/transient_enums.rs:+1:18: +1:22
+        _6 = discriminant(_2);           // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        switchInt(move _6) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb4: {
+        _0 = Option::<u32>::None;        // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb7;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb5: {
+        unreachable;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb6: {
+        _7 = move ((_2 as Ok).0: u32);   // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+        _0 = Option::<u32>::Some(move _7); // scope 4 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb7;                     // scope 3 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb7: {
+        StorageDead(_7);                 // scope 0 at $DIR/transient_enums.rs:+1:18: +1:22
+        StorageDead(_2);                 // scope 0 at $DIR/transient_enums.rs:+1:21: +1:22
+        return;                          // scope 0 at $DIR/transient_enums.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/pre-codegen/transient_enums.rs
+++ b/tests/mir-opt/pre-codegen/transient_enums.rs
@@ -1,0 +1,10 @@
+// compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=0
+// ignore-debug
+// edition: 2021
+
+#![crate_type = "lib"]
+
+// EMIT_MIR transient_enums.checked_as_u32.PreCodegen.after.mir
+pub fn checked_as_u32(t: u64) -> Option<u32> {
+    t.try_into().ok()
+}

--- a/tests/mir-opt/pre-codegen/try_identity.new.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/try_identity.new.PreCodegen.after.mir
@@ -32,7 +32,8 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     bb1: {
         _5 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity.rs:+5:21: +5:22
         _2 = ControlFlow::<E, T>::Break(move _5); // scope 2 at $DIR/try_identity.rs:+5:27: +5:48
-        goto -> bb4;                     // scope 0 at $DIR/try_identity.rs:+5:47: +5:48
+        _6 = discriminant(_2);           // scope 0 at $DIR/try_identity.rs:+2:15: +7:10
+        switchInt(move _6) -> [0: bb5, 1: bb4, otherwise: bb2]; // scope 0 at $DIR/try_identity.rs:+2:9: +7:10
     }
 
     bb2: {
@@ -42,29 +43,25 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     bb3: {
         _4 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity.rs:+4:20: +4:21
         _2 = ControlFlow::<E, T>::Continue(move _4); // scope 1 at $DIR/try_identity.rs:+4:26: +4:50
-        goto -> bb4;                     // scope 0 at $DIR/try_identity.rs:+4:49: +4:50
+        _6 = discriminant(_2);           // scope 0 at $DIR/try_identity.rs:+2:15: +7:10
+        switchInt(move _6) -> [0: bb5, 1: bb4, otherwise: bb2]; // scope 0 at $DIR/try_identity.rs:+2:9: +7:10
     }
 
     bb4: {
-        _6 = discriminant(_2);           // scope 0 at $DIR/try_identity.rs:+2:15: +7:10
-        switchInt(move _6) -> [0: bb6, 1: bb5, otherwise: bb2]; // scope 0 at $DIR/try_identity.rs:+2:9: +7:10
-    }
-
-    bb5: {
         _8 = move ((_2 as Break).0: E);  // scope 0 at $DIR/try_identity.rs:+9:32: +9:33
         _0 = Result::<T, E>::Err(move _8); // scope 4 at $DIR/try_identity.rs:+9:45: +9:51
         StorageDead(_2);                 // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
-        goto -> bb7;                     // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
+        goto -> bb6;                     // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
     }
 
-    bb6: {
+    bb5: {
         _7 = move ((_2 as Continue).0: T); // scope 0 at $DIR/try_identity.rs:+8:35: +8:36
         _0 = Result::<T, E>::Ok(move _7); // scope 0 at $DIR/try_identity.rs:+1:5: +11:6
         StorageDead(_2);                 // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
-        goto -> bb7;                     // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
+        goto -> bb6;                     // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
     }
 
-    bb7: {
+    bb6: {
         return;                          // scope 0 at $DIR/try_identity.rs:+12:2: +12:2
     }
 }

--- a/tests/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/tests/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -55,18 +55,10 @@
           StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           StorageLive(_12);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          switchInt(move _10) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          switchInt(move _10) -> [0: bb5, 1: bb4, otherwise: bb2]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
-          StorageDead(_12);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
-          _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-          switchInt(move _5) -> [0: bb2, 1: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
-      }
-  
-      bb2: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
           _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:+1:8: +1:10
@@ -77,11 +69,11 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
       }
   
-      bb3: {
+      bb2: {
           unreachable;                     // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   
-      bb4: {
+      bb3: {
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:+1:9: +1:10
@@ -100,23 +92,27 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:+2:2: +2:2
       }
   
-      bb5: {
+      bb4: {
           _12 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           _13 = Result::<Infallible, i32>::Err(move _12); // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _13); // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_12);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          switchInt(move _5) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   
-      bb6: {
-          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-      }
-  
-      bb7: {
+      bb5: {
           _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(move _11); // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_12);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+1:9: +1:10
+          _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
+          switchInt(move _5) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+1:8: +1:10
       }
   }
   

--- a/tests/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/tests/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -41,7 +41,8 @@
           _2 = ControlFlow::<usize, i32>::Break(move _7); // scope 2 at $DIR/separate_const_switch.rs:+8:23: +8:44
           StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:+8:43: +8:44
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
-          goto -> bb4;                     // scope 0 at $DIR/separate_const_switch.rs:+8:43: +8:44
+          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+          switchInt(move _8) -> [0: bb5, 1: bb4, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
       bb2: {
@@ -56,23 +57,19 @@
           _2 = ControlFlow::<usize, i32>::Continue(move _5); // scope 1 at $DIR/separate_const_switch.rs:+7:22: +7:46
           StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:+7:45: +7:46
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
-          goto -> bb4;                     // scope 0 at $DIR/separate_const_switch.rs:+7:45: +7:46
+          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
+          switchInt(move _8) -> [0: bb5, 1: bb4, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
       }
   
       bb4: {
-          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:+5:11: +10:6
-          switchInt(move _8) -> [0: bb6, 1: bb5, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:+5:5: +10:6
-      }
-  
-      bb5: {
           StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:+12:28: +12:29
           _0 = Option::<i32>::None;        // scope 4 at $DIR/separate_const_switch.rs:+12:34: +12:38
           StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
-          goto -> bb7;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
+          goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:+12:37: +12:38
       }
   
-      bb6: {
+      bb5: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
           _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:+11:31: +11:32
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:42: +11:43
@@ -80,10 +77,10 @@
           _0 = Option::<i32>::Some(move _10); // scope 3 at $DIR/separate_const_switch.rs:+11:37: +11:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:+11:43: +11:44
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
-          goto -> bb7;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
+          goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:+11:43: +11:44
       }
   
-      bb7: {
+      bb6: {
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:+14:1: +14:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:+14:2: +14:2
       }


### PR DESCRIPTION
This means fewer blocks, so is hopefully a net win.

Draft until #105808 can simplify the discriminant checks in here.

r? @ghost