### PR TITLE
Error on hidden reexport

### DIFF
--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -34,8 +34,10 @@ pub use self::decode::{DecodeUtf16, DecodeUtf16Error};
 
 // perma-unstable re-exports
 #[unstable(feature = "char_internals", reason = "exposed only for libstd", issue = "none")]
+#[doc(hidden)]
 pub use self::methods::encode_utf16_raw;
 #[unstable(feature = "char_internals", reason = "exposed only for libstd", issue = "none")]
+#[doc(hidden)]
 pub use self::methods::encode_utf8_raw;
 
 use crate::error::Error;

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -58,9 +58,11 @@ pub use self::intersperse::{Intersperse, IntersperseWith};
 pub use self::map_while::MapWhile;
 
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[doc(hidden)]
 pub use self::zip::TrustedRandomAccess;
 
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[doc(hidden)]
 pub use self::zip::TrustedRandomAccessNoCoerce;
 
 #[stable(feature = "iter_zip", since = "1.59.0")]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -401,6 +401,7 @@ pub use self::sources::{once_with, OnceWith};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::sources::{repeat, Repeat};
 #[unstable(feature = "iter_repeat_n", issue = "104434")]
+#[doc(hidden)] // waiting on ACP#120 to decide whether to expose publicly
 pub use self::sources::{repeat_n, RepeatN};
 #[stable(feature = "iterator_repeat_with", since = "1.28.0")]
 pub use self::sources::{repeat_with, RepeatWith};
@@ -439,8 +440,10 @@ pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::adapters::StepBy;
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[doc(hidden)]
 pub use self::adapters::TrustedRandomAccess;
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[doc(hidden)]
 pub use self::adapters::TrustedRandomAccessNoCoerce;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -411,6 +411,7 @@ pub use self::sources::{successors, Successors};
 #[stable(feature = "fused", since = "1.26.0")]
 pub use self::traits::FusedIterator;
 #[unstable(issue = "none", feature = "inplace_iteration")]
+#[doc(hidden)]
 pub use self::traits::InPlaceIterable;
 #[unstable(feature = "trusted_len", issue = "37572")]
 pub use self::traits::TrustedLen;
@@ -436,6 +437,7 @@ pub use self::adapters::Flatten;
 #[stable(feature = "iter_map_while", since = "1.57.0")]
 pub use self::adapters::MapWhile;
 #[unstable(feature = "inplace_iteration", issue = "none")]
+#[doc(hidden)]
 pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::adapters::StepBy;

--- a/library/core/src/iter/sources.rs
+++ b/library/core/src/iter/sources.rs
@@ -18,6 +18,7 @@ pub use self::empty::{empty, Empty};
 pub use self::once::{once, Once};
 
 #[unstable(feature = "iter_repeat_n", issue = "104434")]
+#[doc(hidden)]
 pub use self::repeat_n::{repeat_n, RepeatN};
 
 #[stable(feature = "iterator_repeat_with", since = "1.28.0")]

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -17,6 +17,7 @@ pub use self::{
 };
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
+#[doc(hidden)]
 pub use self::marker::InPlaceIterable;
 #[unstable(feature = "trusted_step", issue = "85731")]
 pub use self::marker::TrustedStep;

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -165,6 +165,7 @@ pub use self::bit::{BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssig
 pub use self::deref::{Deref, DerefMut};
 
 #[unstable(feature = "receiver_trait", issue = "none")]
+#[doc(hidden)]
 pub use self::deref::Receiver;
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -71,6 +71,7 @@ pub use crate::concat_bytes;
 // Do not `doc(inline)` these `doc(hidden)` items.
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow(deprecated)]
+#[doc(hidden)]
 pub use crate::macros::builtin::{RustcDecodable, RustcEncodable};
 
 // Do not `doc(no_inline)` so that they become doc items on their own

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -404,6 +404,7 @@ pub use non_null::NonNull;
 
 mod unique;
 #[unstable(feature = "ptr_internals", issue = "none")]
+#[doc(hidden)]
 pub use unique::Unique;
 
 mod const_ptr;


### PR DESCRIPTION
This is not meant to be merged! It's used to actually see the impact of https://github.com/rust-lang/rust/pull/109697.

I'll cherry-pick the second commit with the changes in rust-lang libs into #109697.

So far, I only checked on `gimli` (opened a PR about it [here](https://github.com/gimli-rs/gimli/pull/656)) and `miniz_oxide` (the last version doesn't have the problem).

r? @Manishearth 