### PR TITLE
Add eholk back to compiler-contributors reviewers

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -512,6 +512,7 @@ compiler-team = [
 ]
 compiler-team-contributors = [
     "@compiler-errors",
+    "@eholk",
     "@jackh726",
     "@TaKO8Ki",
     "@WaffleLapkin",


### PR DESCRIPTION
@eholk is back from vacation so he can review things again.

r? @wesleywiser 