### PR TITLE
Fix release date of 1.58.1 in release notes.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1481,7 +1481,7 @@ and related tools.
 [is_power_of_two_usize]: https://doc.rust-lang.org/stable/core/num/struct.NonZeroUsize.html#method.is_power_of_two
 [stdarch/1266]: https://github.com/rust-lang/stdarch/pull/1266
 
-Version 1.58.1 (2022-01-19)
+Version 1.58.1 (2022-01-20)
 ===========================
 
 * Fix race condition in `std::fs::remove_dir_all` ([CVE-2022-21658])


### PR DESCRIPTION
This fixes the release notes to have the correct release date for 1.58.1. The [blog announcement](https://blog.rust-lang.org/2022/01/20/Rust-1.58.1.html) has the correct date and link (which is otherwise broken without this change).

Closes #94278