### PR TITLE
remove constant evaluation hack in `super_relate_consts`

### DIFF
--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -589,17 +589,6 @@ pub fn structurally_relate_consts<'tcx, R: TypeRelation<'tcx>>(
     debug!("{}.structurally_relate_consts(a = {:?}, b = {:?})", relation.tag(), a, b);
     let tcx = relation.tcx();
 
-    // HACK(const_generics): We still need to eagerly evaluate consts when
-    // relating them because during `normalize_param_env_or_error`,
-    // we may relate an evaluated constant in a obligation against
-    // an unnormalized (i.e. unevaluated) const in the param-env.
-    // FIXME(generic_const_exprs): Once we always lazily unify unevaluated constants
-    // these `eval` calls can be removed.
-    if !tcx.features().generic_const_exprs {
-        a = a.eval(tcx, relation.param_env());
-        b = b.eval(tcx, relation.param_env());
-    }
-
     if tcx.features().generic_const_exprs {
         a = tcx.expand_abstract_consts(a);
         b = tcx.expand_abstract_consts(b);

--- a/tests/ui/consts/unnormalized-param-env.rs
+++ b/tests/ui/consts/unnormalized-param-env.rs
@@ -1,4 +1,4 @@
-// check-pass
+// known-bug: unknown
 
 pub trait CSpace<const N: usize> {
     type Traj;

--- a/tests/ui/consts/unnormalized-param-env.stderr
+++ b/tests/ui/consts/unnormalized-param-env.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `CS: CSpace<4>` is not satisfied
+  --> $DIR/unnormalized-param-env.rs:23:5
+   |
+LL | /     fn trajectory_free<TF, S1>(&self, t: &TF)
+LL | |     where
+LL | |         CS::Traj: Sized,
+LL | |         CS: CSpace<N>,
+   | |______________________^ the trait `CSpace<4>` is not implemented for `CS`
+   |
+help: consider restricting type parameter `CS`
+   |
+LL | impl<CS: CSpace<4>> Obstacle<CS, N> for ObstacleSpace2df32 {
+   |        +++++++++++
+
+error[E0277]: the trait bound `CS: CSpace<4>` is not satisfied
+  --> $DIR/unnormalized-param-env.rs:23:8
+   |
+LL |     fn trajectory_free<TF, S1>(&self, t: &TF)
+   |        ^^^^^^^^^^^^^^^ the trait `CSpace<4>` is not implemented for `CS`
+   |
+help: consider restricting type parameter `CS`
+   |
+LL | impl<CS: CSpace<4>> Obstacle<CS, N> for ObstacleSpace2df32 {
+   |        +++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
`super_relate_consts` has as hack in it to work around the fact that `normalize_param_env_or_error` is broken. When relating two constants we attempt to evaluate them (aka normalize them). This is not an issue in any way specific to const generics, type aliases also have the same issue as demonstrated in [this code](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=84b6d3956a2c852a04b60782476b56c9). 

Opening just for a crater run

r? @compiler-errors 