### PR TITLE
move `super_relate_consts` hack to `normalize_param_env_or_error`

### DIFF
--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -589,17 +589,6 @@ pub fn structurally_relate_consts<'tcx, R: TypeRelation<'tcx>>(
     debug!("{}.structurally_relate_consts(a = {:?}, b = {:?})", relation.tag(), a, b);
     let tcx = relation.tcx();
 
-    // HACK(const_generics): We still need to eagerly evaluate consts when
-    // relating them because during `normalize_param_env_or_error`,
-    // we may relate an evaluated constant in a obligation against
-    // an unnormalized (i.e. unevaluated) const in the param-env.
-    // FIXME(generic_const_exprs): Once we always lazily unify unevaluated constants
-    // these `eval` calls can be removed.
-    if !tcx.features().generic_const_exprs {
-        a = a.eval(tcx, relation.param_env());
-        b = b.eval(tcx, relation.param_env());
-    }
-
     if tcx.features().generic_const_exprs {
         a = tcx.expand_abstract_consts(a);
         b = tcx.expand_abstract_consts(b);

--- a/tests/ui/traits/new-solver/structural-resolve-field.rs
+++ b/tests/ui/traits/new-solver/structural-resolve-field.rs
@@ -1,13 +1,35 @@
 // compile-flags: -Ztrait-solver=next
 // check-pass
 
-#[derive(Default)]
 struct Foo {
     x: i32,
 }
 
+impl MyDefault for Foo {
+    fn my_default() -> Self {
+        Self {
+            x: 0,
+        }
+    }
+}
+
+trait MyDefault {
+    fn my_default() -> Self;
+}
+
+impl MyDefault for [Foo; 0]  {
+    fn my_default() -> Self {
+        []
+    }
+}
+impl MyDefault for [Foo; 1] {
+    fn my_default() -> Self {
+        [Foo::my_default(); 1]
+    }
+}
+
 fn main() {
-    let mut xs = <[Foo; 1]>::default();
+    let mut xs = <[Foo; 1]>::my_default();
     xs[0].x = 1;
     (&mut xs[0]).x = 2;
 }


### PR DESCRIPTION
`super_relate_consts` has as hack in it to work around the fact that `normalize_param_env_or_error` is broken. When relating two constants we attempt to evaluate them (aka normalize them). This is not an issue in any way specific to const generics, type aliases also have the same issue as demonstrated in [this code](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=84b6d3956a2c852a04b60782476b56c9). 

Since the hack in `super_relate_consts` only exists to make `normalize_param_env_or_error` emit less errors move it to `normalize_param_env_or_error`. This makes `super_relate_consts` act more like the normal plain structural equality its supposed to and should help ensure that the hack doesnt accidentally affect other situations.

r? @compiler-errors 