### PR TITLE
Write to stdout if `-` is given as output file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,6 +3702,7 @@ dependencies = [
 name = "rustc_interface"
 version = "0.0.0"
 dependencies = [
+ "atty",
  "libloading",
  "rustc-rayon",
  "rustc-rayon-core",
@@ -4166,6 +4167,7 @@ dependencies = [
 name = "rustc_session"
 version = "0.0.0"
 dependencies = [
+ "atty",
  "getopts",
  "libc",
  "rustc_ast",

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -9,6 +9,8 @@ codegen_ssa_archive_build_failure =
 
 codegen_ssa_atomic_compare_exchange = Atomic compare-exchange intrinsic missing failure memory ordering
 
+codegen_ssa_binary_output_to_tty = option `-o` or `--emit` is used to write binary output type `{$shorthand}` to stdout, but stdout is a tty
+
 codegen_ssa_check_installed_visual_studio = please ensure that Visual Studio 2017 or later, or Build Tools for Visual Studio were installed with the Visual C++ option.
 
 codegen_ssa_copy_path = could not copy {$from} to {$to}: {$error}

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -83,6 +83,12 @@ impl IntoDiagnosticArg for DebugArgPath<'_> {
 }
 
 #[derive(Diagnostic)]
+#[diag(codegen_ssa_binary_output_to_tty)]
+pub struct BinaryOutputToTty {
+    pub shorthand: &'static str,
+}
+
+#[derive(Diagnostic)]
 #[diag(codegen_ssa_ignoring_emit_path)]
 pub struct IgnoringEmitPath {
     pub extension: String,

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -34,7 +34,9 @@ use rustc_interface::{interface, Queries};
 use rustc_lint::LintStore;
 use rustc_metadata::locator;
 use rustc_session::config::{nightly_options, CG_OPTIONS, Z_OPTIONS};
-use rustc_session::config::{ErrorOutputType, Input, OutputType, PrintRequest, TrimmedDefPaths};
+use rustc_session::config::{
+    ErrorOutputType, Input, OutFileName, OutputType, PrintRequest, TrimmedDefPaths,
+};
 use rustc_session::cstore::MetadataLoader;
 use rustc_session::getopts::{self, Matches};
 use rustc_session::lint::{Lint, LintId};
@@ -437,9 +439,12 @@ fn run_compiler(
 }
 
 // Extract output directory and file from matches.
-fn make_output(matches: &getopts::Matches) -> (Option<PathBuf>, Option<PathBuf>) {
+fn make_output(matches: &getopts::Matches) -> (Option<PathBuf>, Option<OutFileName>) {
     let odir = matches.opt_str("out-dir").map(|o| PathBuf::from(&o));
-    let ofile = matches.opt_str("o").map(|o| PathBuf::from(&o));
+    let ofile = matches.opt_str("o").map(|o| match o.as_str() {
+        "-" => OutFileName::Stdout,
+        path => OutFileName::Real(PathBuf::from(path)),
+    });
     (odir, ofile)
 }
 
@@ -685,7 +690,7 @@ fn print_crate_info(
                 for &style in &crate_types {
                     let fname =
                         rustc_session::output::filename_for_input(sess, style, id, &t_outputs);
-                    safe_println!("{}", fname.file_name().unwrap().to_string_lossy());
+                    safe_println!("{}", fname.as_path().file_name().unwrap().to_string_lossy());
                 }
             }
             Cfg => {

--- a/compiler/rustc_driver_impl/src/pretty.rs
+++ b/compiler/rustc_driver_impl/src/pretty.rs
@@ -9,7 +9,7 @@ use rustc_hir_pretty as pprust_hir;
 use rustc_middle::hir::map as hir_map;
 use rustc_middle::mir::{write_mir_graphviz, write_mir_pretty};
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_session::config::{PpAstTreeMode, PpHirMode, PpMode, PpSourceMode};
+use rustc_session::config::{OutFileName, PpAstTreeMode, PpHirMode, PpMode, PpSourceMode};
 use rustc_session::Session;
 use rustc_span::symbol::Ident;
 use rustc_span::FileName;
@@ -359,8 +359,8 @@ fn get_source(sess: &Session) -> (String, FileName) {
 
 fn write_or_print(out: &str, sess: &Session) {
     match &sess.io.output_file {
-        None => print!("{out}"),
-        Some(p) => {
+        None | Some(OutFileName::Stdout) => print!("{out}"),
+        Some(OutFileName::Real(p)) => {
             if let Err(e) = std::fs::write(p, out) {
                 sess.emit_fatal(UnprettyDumpFail {
                     path: p.display().to_string(),

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [lib]
 
 [dependencies]
+atty = "0.2.13"
 libloading = "0.7.1"
 tracing = "0.1"
 rustc-rayon-core = { version = "0.5.0", optional = true }

--- a/compiler/rustc_interface/messages.ftl
+++ b/compiler/rustc_interface/messages.ftl
@@ -33,6 +33,7 @@ interface_mixed_proc_macro_crate =
 interface_multiple_output_types_adaption =
     due to multiple output types requested, the explicitly specified output file name will be adapted for each output type
 
+interface_multiple_output_types_to_stdout = can't use option `-o` or `--emit` to write multiple output types to stdout
 interface_out_dir_error =
     failed to find or create the directory specified by `--out-dir`
 

--- a/compiler/rustc_interface/src/errors.rs
+++ b/compiler/rustc_interface/src/errors.rs
@@ -108,3 +108,7 @@ pub struct IgnoringExtraFilename;
 #[derive(Diagnostic)]
 #[diag(interface_ignoring_out_dir)]
 pub struct IgnoringOutDir;
+
+#[derive(Diagnostic)]
+#[diag(interface_multiple_output_types_to_stdout)]
+pub struct MultipleOutputTypesToStdout;

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -14,7 +14,7 @@ use rustc_middle::{bug, ty};
 use rustc_parse::maybe_new_parser_from_source_str;
 use rustc_query_impl::QueryCtxt;
 use rustc_query_system::query::print_query_stack;
-use rustc_session::config::{self, ErrorOutputType, Input, OutputFilenames};
+use rustc_session::config::{self, ErrorOutputType, Input, OutFileName, OutputFilenames};
 use rustc_session::config::{CheckCfg, ExpectedValues};
 use rustc_session::lint;
 use rustc_session::parse::{CrateConfig, ParseSess};
@@ -252,7 +252,7 @@ pub struct Config {
 
     pub input: Input,
     pub output_dir: Option<PathBuf>,
-    pub output_file: Option<PathBuf>,
+    pub output_file: Option<OutFileName>,
     pub file_loader: Option<Box<dyn FileLoader + Send + Sync>>,
     pub locale_resources: &'static [&'static str],
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -11,7 +11,7 @@ use rustc_session::config::InstrumentXRay;
 use rustc_session::config::TraitSolver;
 use rustc_session::config::{build_configuration, build_session_options, to_crate_config};
 use rustc_session::config::{
-    BranchProtection, Externs, OomStrategy, OutputType, OutputTypes, PAuthKey, PacRet,
+    BranchProtection, Externs, OomStrategy, OutFileName, OutputType, OutputTypes, PAuthKey, PacRet,
     ProcMacroExecutionStrategy, SymbolManglingVersion, WasiExecModel,
 };
 use rustc_session::config::{CFGuard, ExternEntry, LinkerPluginLto, LtoCli, SwitchWithOptPath};
@@ -167,8 +167,14 @@ fn test_output_types_tracking_hash_different_paths() {
     let mut v2 = Options::default();
     let mut v3 = Options::default();
 
-    v1.output_types = OutputTypes::new(&[(OutputType::Exe, Some(PathBuf::from("./some/thing")))]);
-    v2.output_types = OutputTypes::new(&[(OutputType::Exe, Some(PathBuf::from("/some/thing")))]);
+    v1.output_types = OutputTypes::new(&[(
+        OutputType::Exe,
+        Some(OutFileName::Real(PathBuf::from("./some/thing"))),
+    )]);
+    v2.output_types = OutputTypes::new(&[(
+        OutputType::Exe,
+        Some(OutFileName::Real(PathBuf::from("/some/thing"))),
+    )]);
     v3.output_types = OutputTypes::new(&[(OutputType::Exe, None)]);
 
     assert_non_crate_hash_different(&v1, &v2);
@@ -182,13 +188,13 @@ fn test_output_types_tracking_hash_different_construction_order() {
     let mut v2 = Options::default();
 
     v1.output_types = OutputTypes::new(&[
-        (OutputType::Exe, Some(PathBuf::from("./some/thing"))),
-        (OutputType::Bitcode, Some(PathBuf::from("./some/thing.bc"))),
+        (OutputType::Exe, Some(OutFileName::Real(PathBuf::from("./some/thing")))),
+        (OutputType::Bitcode, Some(OutFileName::Real(PathBuf::from("./some/thing.bc")))),
     ]);
 
     v2.output_types = OutputTypes::new(&[
-        (OutputType::Bitcode, Some(PathBuf::from("./some/thing.bc"))),
-        (OutputType::Exe, Some(PathBuf::from("./some/thing"))),
+        (OutputType::Bitcode, Some(OutFileName::Real(PathBuf::from("./some/thing.bc")))),
+        (OutputType::Exe, Some(OutFileName::Real(PathBuf::from("./some/thing")))),
     ]);
 
     assert_same_hash(&v1, &v2);

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -4,6 +4,9 @@ metadata_as_needed_compatibility =
 metadata_bad_panic_strategy =
     the linked panic runtime `{$runtime}` is not compiled with this crate's panic strategy `{$strategy}`
 
+metadata_binary_output_to_tty =
+    option `-o` or `--emit` is used to write binary output type `metadata` to stdout, but stdout is a tty
+
 metadata_bundle_needs_static =
     linking modifier `bundle` is only compatible with `static` linking kind
 
@@ -63,6 +66,9 @@ metadata_fail_seek_file =
 metadata_fail_write_file =
     failed to write to the file: {$err}
 
+metadata_failed_copy_to_stdout =
+    failed to copy {$filename} to stdout: {$err}
+
 metadata_failed_create_encoded_metadata =
     failed to create encoded metadata from file: {$err}
 
@@ -71,6 +77,9 @@ metadata_failed_create_file =
 
 metadata_failed_create_tempdir =
     couldn't create a temp dir: {$err}
+
+metadata_failed_remove =
+    failed to remove {$filename}: {$err}
 
 metadata_failed_write_error =
     failed to write {$filename}: {$err}

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -78,9 +78,6 @@ metadata_failed_create_file =
 metadata_failed_create_tempdir =
     couldn't create a temp dir: {$err}
 
-metadata_failed_remove =
-    failed to remove {$filename}: {$err}
-
 metadata_failed_write_error =
     failed to write {$filename}: {$err}
 

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -396,6 +396,24 @@ pub struct FailedWriteError {
 }
 
 #[derive(Diagnostic)]
+#[diag(metadata_failed_copy_to_stdout)]
+pub struct FailedCopyToStdout {
+    pub filename: PathBuf,
+    pub err: Error,
+}
+
+#[derive(Diagnostic)]
+#[diag(metadata_failed_remove)]
+pub struct FailedRemove {
+    pub filename: PathBuf,
+    pub err: Error,
+}
+
+#[derive(Diagnostic)]
+#[diag(metadata_binary_output_to_tty)]
+pub struct BinaryOutputToTty;
+
+#[derive(Diagnostic)]
 #[diag(metadata_missing_native_library)]
 pub struct MissingNativeLibrary<'a> {
     libname: &'a str,

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -403,13 +403,6 @@ pub struct FailedCopyToStdout {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata_failed_remove)]
-pub struct FailedRemove {
-    pub filename: PathBuf,
-    pub err: Error,
-}
-
-#[derive(Diagnostic)]
 #[diag(metadata_binary_output_to_tty)]
 pub struct BinaryOutputToTty;
 

--- a/compiler/rustc_metadata/src/fs.rs
+++ b/compiler/rustc_metadata/src/fs.rs
@@ -1,6 +1,6 @@
 use crate::errors::{
     BinaryOutputToTty, FailedCopyToStdout, FailedCreateEncodedMetadata, FailedCreateFile,
-    FailedCreateTempdir, FailedRemove, FailedWriteError,
+    FailedCreateTempdir, FailedWriteError,
 };
 use crate::{encode_metadata, EncodedMetadata};
 
@@ -108,13 +108,6 @@ pub fn encode_and_write_metadata(tcx: TyCtxt<'_>) -> (EncodedMetadata, bool) {
         .unwrap_or_else(|err| {
             tcx.sess.emit_fatal(FailedCreateEncodedMetadata { err });
         });
-
-    // Delete the temporary metadata file if output is stdout
-    if need_metadata_file && out_filename.is_stdout() {
-        if let Err(err) = fs::remove_file(&metadata_filename) {
-            tcx.sess.emit_err(FailedRemove { filename: metadata_filename, err });
-        }
-    }
 
     let need_metadata_module = metadata_kind == MetadataKind::Compressed;
 

--- a/compiler/rustc_metadata/src/fs.rs
+++ b/compiler/rustc_metadata/src/fs.rs
@@ -1,18 +1,19 @@
 use crate::errors::{
-    FailedCreateEncodedMetadata, FailedCreateFile, FailedCreateTempdir, FailedWriteError,
+    BinaryOutputToTty, FailedCopyToStdout, FailedCreateEncodedMetadata, FailedCreateFile,
+    FailedCreateTempdir, FailedRemove, FailedWriteError,
 };
 use crate::{encode_metadata, EncodedMetadata};
 
 use rustc_data_structures::temp_dir::MaybeTempDir;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::ty::TyCtxt;
-use rustc_session::config::OutputType;
+use rustc_session::config::{OutFileName, OutputType};
 use rustc_session::output::filename_for_metadata;
 use rustc_session::{MetadataKind, Session};
 use tempfile::Builder as TempFileBuilder;
 
-use std::fs;
 use std::path::{Path, PathBuf};
+use std::{fs, io};
 
 // FIXME(eddyb) maybe include the crate name in this?
 pub const METADATA_FILENAME: &str = "lib.rmeta";
@@ -74,25 +75,46 @@ pub fn encode_and_write_metadata(tcx: TyCtxt<'_>) -> (EncodedMetadata, bool) {
     // this file always exists.
     let need_metadata_file = tcx.sess.opts.output_types.contains_key(&OutputType::Metadata);
     let (metadata_filename, metadata_tmpdir) = if need_metadata_file {
-        if let Err(err) = non_durable_rename(&metadata_filename, &out_filename) {
-            tcx.sess.emit_fatal(FailedWriteError { filename: out_filename, err });
-        }
+        let filename = match out_filename {
+            OutFileName::Real(ref path) => {
+                if let Err(err) = non_durable_rename(&metadata_filename, path) {
+                    tcx.sess.emit_fatal(FailedWriteError { filename: path.to_path_buf(), err });
+                }
+                path.clone()
+            }
+            OutFileName::Stdout => {
+                if out_filename.is_tty() {
+                    tcx.sess.emit_err(BinaryOutputToTty);
+                } else if let Err(err) = copy_to_stdout(&metadata_filename) {
+                    tcx.sess
+                        .emit_err(FailedCopyToStdout { filename: metadata_filename.clone(), err });
+                }
+                metadata_filename
+            }
+        };
         if tcx.sess.opts.json_artifact_notifications {
             tcx.sess
                 .parse_sess
                 .span_diagnostic
-                .emit_artifact_notification(&out_filename, "metadata");
+                .emit_artifact_notification(&out_filename.as_path(), "metadata");
         }
-        (out_filename, None)
+        (filename, None)
     } else {
         (metadata_filename, Some(metadata_tmpdir))
     };
 
     // Load metadata back to memory: codegen may need to include it in object files.
-    let metadata =
-        EncodedMetadata::from_path(metadata_filename, metadata_tmpdir).unwrap_or_else(|err| {
+    let metadata = EncodedMetadata::from_path(metadata_filename.clone(), metadata_tmpdir)
+        .unwrap_or_else(|err| {
             tcx.sess.emit_fatal(FailedCreateEncodedMetadata { err });
         });
+
+    // Delete the temporary metadata file if output is stdout
+    if need_metadata_file && out_filename.is_stdout() {
+        if let Err(err) = fs::remove_file(&metadata_filename) {
+            tcx.sess.emit_err(FailedRemove { filename: metadata_filename, err });
+        }
+    }
 
     let need_metadata_module = metadata_kind == MetadataKind::Compressed;
 
@@ -115,4 +137,12 @@ pub fn non_durable_rename(src: &Path, dst: &Path) -> std::io::Result<()> {
 pub fn non_durable_rename(src: &Path, dst: &Path) -> std::io::Result<()> {
     let _ = std::fs::remove_file(dst);
     std::fs::rename(src, dst)
+}
+
+pub fn copy_to_stdout(from: &Path) -> io::Result<()> {
+    let file = fs::File::open(from)?;
+    let mut reader = io::BufReader::new(file);
+    let mut stdout = io::stdout();
+    io::copy(&mut reader, &mut stdout)?;
+    Ok(())
 }

--- a/compiler/rustc_session/Cargo.toml
+++ b/compiler/rustc_session/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+atty = "0.2.13"
 getopts = "0.2"
 rustc_macros = { path = "../rustc_macros" }
 tracing = "0.1"

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -30,6 +30,7 @@ use std::collections::btree_map::{
     Iter as BTreeMapIter, Keys as BTreeMapKeysIter, Values as BTreeMapValuesIter,
 };
 use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
 use std::fmt;
 use std::hash::Hash;
 use std::iter;
@@ -333,7 +334,7 @@ impl OutputType {
         }
     }
 
-    fn shorthand(&self) -> &'static str {
+    pub fn shorthand(&self) -> &'static str {
         match *self {
             OutputType::Bitcode => "llvm-bc",
             OutputType::Assembly => "asm",
@@ -384,6 +385,18 @@ impl OutputType {
             OutputType::Metadata => "rmeta",
             OutputType::DepInfo => "d",
             OutputType::Exe => "",
+        }
+    }
+
+    pub fn is_text_output(&self) -> bool {
+        match *self {
+            OutputType::Assembly
+            | OutputType::LlvmAssembly
+            | OutputType::Mir
+            | OutputType::DepInfo => true,
+            OutputType::Bitcode | OutputType::Object | OutputType::Metadata | OutputType::Exe => {
+                false
+            }
         }
     }
 }
@@ -438,14 +451,14 @@ pub enum ResolveDocLinks {
 /// dependency tracking for command-line arguments. Also only hash keys, since tracking
 /// should only depend on the output types, not the paths they're written to.
 #[derive(Clone, Debug, Hash, HashStable_Generic)]
-pub struct OutputTypes(BTreeMap<OutputType, Option<PathBuf>>);
+pub struct OutputTypes(BTreeMap<OutputType, Option<OutFileName>>);
 
 impl OutputTypes {
-    pub fn new(entries: &[(OutputType, Option<PathBuf>)]) -> OutputTypes {
+    pub fn new(entries: &[(OutputType, Option<OutFileName>)]) -> OutputTypes {
         OutputTypes(BTreeMap::from_iter(entries.iter().map(|&(k, ref v)| (k, v.clone()))))
     }
 
-    pub fn get(&self, key: &OutputType) -> Option<&Option<PathBuf>> {
+    pub fn get(&self, key: &OutputType) -> Option<&Option<OutFileName>> {
         self.0.get(key)
     }
 
@@ -453,11 +466,15 @@ impl OutputTypes {
         self.0.contains_key(key)
     }
 
-    pub fn keys(&self) -> BTreeMapKeysIter<'_, OutputType, Option<PathBuf>> {
+    pub fn iter(&self) -> BTreeMapIter<'_, OutputType, Option<OutFileName>> {
+        self.0.iter()
+    }
+
+    pub fn keys(&self) -> BTreeMapKeysIter<'_, OutputType, Option<OutFileName>> {
         self.0.keys()
     }
 
-    pub fn values(&self) -> BTreeMapValuesIter<'_, OutputType, Option<PathBuf>> {
+    pub fn values(&self) -> BTreeMapValuesIter<'_, OutputType, Option<OutFileName>> {
         self.0.values()
     }
 
@@ -658,11 +675,71 @@ impl Input {
     }
 }
 
+#[derive(Clone, Hash, Debug, HashStable_Generic, PartialEq)]
+pub enum OutFileName {
+    Real(PathBuf),
+    Stdout,
+}
+
+impl OutFileName {
+    pub fn parent(&self) -> Option<&Path> {
+        match *self {
+            OutFileName::Real(ref path) => path.parent(),
+            OutFileName::Stdout => None,
+        }
+    }
+
+    pub fn filestem(&self) -> Option<&OsStr> {
+        match *self {
+            OutFileName::Real(ref path) => path.file_stem(),
+            OutFileName::Stdout => Some(OsStr::new("stdout")),
+        }
+    }
+
+    pub fn is_stdout(&self) -> bool {
+        match *self {
+            OutFileName::Real(_) => false,
+            OutFileName::Stdout => true,
+        }
+    }
+
+    pub fn is_tty(&self) -> bool {
+        match *self {
+            OutFileName::Real(_) => false,
+            OutFileName::Stdout => atty::is(atty::Stream::Stdout),
+        }
+    }
+
+    pub fn as_path(&self) -> &Path {
+        match *self {
+            OutFileName::Real(ref path) => path.as_ref(),
+            OutFileName::Stdout => &Path::new("stdout"),
+        }
+    }
+
+    /// For a given output filename, return the actual name of the file that
+    /// can be used to write codegen data of type `flavor`. For real-path
+    /// output filenames, this would be trivial as we can just use the path.
+    /// Otherwise for stdout, return a temporary path so that the codegen data
+    /// may be later copied to stdout.
+    pub fn file_for_writing(
+        &self,
+        outputs: &OutputFilenames,
+        flavor: OutputType,
+        codegen_unit_name: Option<&str>,
+    ) -> PathBuf {
+        match *self {
+            OutFileName::Real(ref path) => path.clone(),
+            OutFileName::Stdout => outputs.temp_path(flavor, codegen_unit_name),
+        }
+    }
+}
+
 #[derive(Clone, Hash, Debug, HashStable_Generic)]
 pub struct OutputFilenames {
     pub out_directory: PathBuf,
     filestem: String,
-    pub single_output_file: Option<PathBuf>,
+    pub single_output_file: Option<OutFileName>,
     pub temps_directory: Option<PathBuf>,
     pub outputs: OutputTypes,
 }
@@ -675,7 +752,7 @@ impl OutputFilenames {
     pub fn new(
         out_directory: PathBuf,
         out_filestem: String,
-        single_output_file: Option<PathBuf>,
+        single_output_file: Option<OutFileName>,
         temps_directory: Option<PathBuf>,
         extra: String,
         outputs: OutputTypes,
@@ -689,12 +766,12 @@ impl OutputFilenames {
         }
     }
 
-    pub fn path(&self, flavor: OutputType) -> PathBuf {
+    pub fn path(&self, flavor: OutputType) -> OutFileName {
         self.outputs
             .get(&flavor)
             .and_then(|p| p.to_owned())
             .or_else(|| self.single_output_file.clone())
-            .unwrap_or_else(|| self.output_path(flavor))
+            .unwrap_or_else(|| OutFileName::Real(self.output_path(flavor)))
     }
 
     /// Gets the output path where a compilation artifact of the given type
@@ -1821,7 +1898,10 @@ fn parse_output_types(
             for output_type in list.split(',') {
                 let (shorthand, path) = match output_type.split_once('=') {
                     None => (output_type, None),
-                    Some((shorthand, path)) => (shorthand, Some(PathBuf::from(path))),
+                    Some((shorthand, "-")) => (shorthand, Some(OutFileName::Stdout)),
+                    Some((shorthand, path)) => {
+                        (shorthand, Some(OutFileName::Real(PathBuf::from(path))))
+                    }
                 };
                 let output_type = OutputType::from_shorthand(shorthand).unwrap_or_else(|| {
                     early_error(
@@ -2892,7 +2972,7 @@ pub(crate) mod dep_tracking {
     use super::{
         BranchProtection, CFGuard, CFProtection, CrateType, DebugInfo, ErrorOutputType,
         InstrumentCoverage, InstrumentXRay, LdImpl, LinkerPluginLto, LocationDetail, LtoCli,
-        OomStrategy, OptLevel, OutputType, OutputTypes, Passes, ResolveDocLinks,
+        OomStrategy, OptLevel, OutFileName, OutputType, OutputTypes, Passes, ResolveDocLinks,
         SourceFileHashAlgorithm, SplitDwarfKind, SwitchWithOptPath, SymbolManglingVersion,
         TraitSolver, TrimmedDefPaths,
     };
@@ -2990,6 +3070,7 @@ pub(crate) mod dep_tracking {
         SourceFileHashAlgorithm,
         TrimmedDefPaths,
         Option<LdImpl>,
+        OutFileName,
         OutputType,
         RealFileName,
         LocationDetail,

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -2,7 +2,9 @@ use crate::cgu_reuse_tracker::CguReuseTracker;
 use crate::code_stats::CodeStats;
 pub use crate::code_stats::{DataTypeKind, FieldInfo, FieldKind, SizeKind, VariantInfo};
 use crate::config::Input;
-use crate::config::{self, CrateType, InstrumentCoverage, OptLevel, OutputType, SwitchWithOptPath};
+use crate::config::{
+    self, CrateType, InstrumentCoverage, OptLevel, OutFileName, OutputType, SwitchWithOptPath,
+};
 use crate::errors;
 use crate::parse::{add_feature_diagnostics, ParseSess};
 use crate::search_paths::{PathKind, SearchPath};
@@ -135,7 +137,7 @@ pub struct Limits {
 pub struct CompilerIO {
     pub input: Input,
     pub output_dir: Option<PathBuf>,
-    pub output_file: Option<PathBuf>,
+    pub output_file: Option<OutFileName>,
     pub temps_dir: Option<PathBuf>,
 }
 

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -202,6 +202,12 @@ flag](codegen-options/index.md#extra-filename). The files are written to the
 current directory unless the [`--out-dir` flag](#option-out-dir) is used. Each
 emission type may also specify the output filename with the form `KIND=PATH`,
 which takes precedence over the `-o` flag.
+Specifying `-o -` or `--emit KIND=-` asks rustc to emit to stdout.
+Text output types (`asm`, `dep-info`, `llvm-ir` and `mir`) can be written to
+stdout despite it being a tty or not. This will result in an error if any
+binary output type is written to stdout that is a tty.
+This will also result in an error if multiple output types
+would be written to stdout, because they would be all mixed together.
 
 [LLVM bitcode]: https://llvm.org/docs/BitCodeFormat.html
 [LLVM IR]: https://llvm.org/docs/LangRef.html

--- a/tests/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
+++ b/tests/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
@@ -62,7 +62,7 @@ impl CodegenBackend for TheBackend {
         codegen_results: CodegenResults,
         outputs: &OutputFilenames,
     ) -> Result<(), ErrorGuaranteed> {
-        use rustc_session::{config::CrateType, output::out_filename};
+        use rustc_session::{config::{CrateType, OutFileName}, output::out_filename};
         use std::io::Write;
         let crate_name = codegen_results.crate_info.local_crate_name;
         for &crate_type in sess.opts.crate_types.iter() {
@@ -70,8 +70,16 @@ impl CodegenBackend for TheBackend {
                 sess.fatal(format!("Crate type is {:?}", crate_type));
             }
             let output_name = out_filename(sess, crate_type, &outputs, crate_name);
-            let mut out_file = ::std::fs::File::create(output_name).unwrap();
-            write!(out_file, "This has been \"compiled\" successfully.").unwrap();
+            match output_name {
+                OutFileName::Real(ref path) => {
+                    let mut out_file = ::std::fs::File::create(path).unwrap();
+                    write!(out_file, "This has been \"compiled\" successfully.").unwrap();
+                }
+                OutFileName::Stdout => {
+                    let mut stdout = std::io::stdout();
+                    write!(stdout, "This has been \"compiled\" successfully.").unwrap();
+                }
+            }
         }
         Ok(())
     }

--- a/tests/run-make-fulldeps/issue-19371/foo.rs
+++ b/tests/run-make-fulldeps/issue-19371/foo.rs
@@ -6,7 +6,7 @@ extern crate rustc_session;
 extern crate rustc_span;
 
 use rustc_interface::interface;
-use rustc_session::config::{Input, Options, OutputType, OutputTypes};
+use rustc_session::config::{Input, Options, OutFileName, OutputType, OutputTypes};
 use rustc_span::source_map::FileName;
 
 use std::path::PathBuf;
@@ -50,7 +50,7 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
         crate_cfg: Default::default(),
         crate_check_cfg: Default::default(),
         input,
-        output_file: Some(output),
+        output_file: Some(OutFileName::Real(output)),
         output_dir: None,
         file_loader: None,
         locale_resources: &[],

--- a/tests/run-make/emit-to-stdout/Makefile
+++ b/tests/run-make/emit-to-stdout/Makefile
@@ -32,7 +32,7 @@ obj: $(OUT)
 # it there.
 metadata: $(OUT)
 	cp $(SRC) $(OUT)
-	(cd $(OUT); pwd; ls -d; $(RUSTC) --emit metadata=- $(SRC) 1>/dev/ptmx 2>$(OUT)/$@ || true)
+	(cd $(OUT); $(RUSTC) --emit metadata=- $(SRC) 1>/dev/ptmx 2>$(OUT)/$@ || true)
 	diff $(OUT)/$@ emit-metadata.stderr
 
 link: $(OUT)

--- a/tests/run-make/emit-to-stdout/Makefile
+++ b/tests/run-make/emit-to-stdout/Makefile
@@ -1,0 +1,51 @@
+include ../tools.mk
+
+SRC=test.rs
+OUT=$(TMPDIR)/out
+
+all: asm llvm-ir dep-info mir llvm-bc obj metadata link multiple-types multiple-types-option-o
+
+asm: $(OUT)
+	$(RUSTC) --emit asm=$(OUT)/$@ $(SRC)
+	$(RUSTC) --emit asm=- $(SRC) | diff - $(OUT)/$@
+llvm-ir: $(OUT)
+	$(RUSTC) --emit llvm-ir=$(OUT)/$@ $(SRC)
+	$(RUSTC) --emit llvm-ir=- $(SRC) | diff - $(OUT)/$@
+dep-info: $(OUT)
+	$(RUSTC) -Z dep-info-omit-d-target=yes --emit dep-info=$(OUT)/$@ $(SRC)
+	$(RUSTC) --emit dep-info=- $(SRC) | diff - $(OUT)/$@
+mir: $(OUT)
+	$(RUSTC) --emit mir=$(OUT)/$@ $(SRC)
+	$(RUSTC) --emit mir=- $(SRC) | diff - $(OUT)/$@
+
+llvm-bc: $(OUT)
+	$(RUSTC) --emit llvm-bc=- $(SRC) 1>/dev/ptmx 2>$(OUT)/$@ || true
+	diff $(OUT)/$@ emit-llvm-bc.stderr
+obj: $(OUT)
+	$(RUSTC) --emit obj=- $(SRC) 1>/dev/ptmx 2>$(OUT)/$@ || true
+	diff $(OUT)/$@ emit-obj.stderr
+
+# For metadata output, a temporary directory will be created to hold the temporary
+# metadata file. But when output is stdout, the temporary directory will be located
+# in the same place as $(SRC), which is mounted as read-only in the tests. Thus as
+# a workaround, $(SRC) is copied to the test output directory $(OUT) and we compile
+# it there.
+metadata: $(OUT)
+	cp $(SRC) $(OUT)
+	(cd $(OUT); pwd; ls -d; $(RUSTC) --emit metadata=- $(SRC) 1>/dev/ptmx 2>$(OUT)/$@ || true)
+	diff $(OUT)/$@ emit-metadata.stderr
+
+link: $(OUT)
+	$(RUSTC) --emit link=- $(SRC) 1>/dev/ptmx 2>$(OUT)/$@ || true
+	diff $(OUT)/$@ emit-link.stderr
+
+multiple-types: $(OUT)
+	$(RUSTC) --emit asm=- --emit llvm-ir=- --emit dep-info=- --emit mir=- $(SRC) 2>$(OUT)/$@ || true
+	diff $(OUT)/$@ emit-multiple-types.stderr
+
+multiple-types-option-o: $(OUT)
+	$(RUSTC) -o - --emit asm,llvm-ir,dep-info,mir $(SRC) 2>$(OUT)/$@ || true
+	diff $(OUT)/$@ emit-multiple-types.stderr
+
+$(OUT):
+	mkdir -p $(OUT)

--- a/tests/run-make/emit-to-stdout/emit-link.stderr
+++ b/tests/run-make/emit-to-stdout/emit-link.stderr
@@ -1,0 +1,4 @@
+error: option `-o` or `--emit` is used to write binary output type `link` to stdout, but stdout is a tty
+
+error: aborting due to previous error
+

--- a/tests/run-make/emit-to-stdout/emit-llvm-bc.stderr
+++ b/tests/run-make/emit-to-stdout/emit-llvm-bc.stderr
@@ -1,0 +1,4 @@
+error: option `-o` or `--emit` is used to write binary output type `llvm-bc` to stdout, but stdout is a tty
+
+error: aborting due to previous error
+

--- a/tests/run-make/emit-to-stdout/emit-metadata.stderr
+++ b/tests/run-make/emit-to-stdout/emit-metadata.stderr
@@ -1,0 +1,4 @@
+error: option `-o` or `--emit` is used to write binary output type `metadata` to stdout, but stdout is a tty
+
+error: aborting due to previous error
+

--- a/tests/run-make/emit-to-stdout/emit-multiple-types.stderr
+++ b/tests/run-make/emit-to-stdout/emit-multiple-types.stderr
@@ -1,0 +1,4 @@
+error: can't use option `-o` or `--emit` to write multiple output types to stdout
+
+error: aborting due to previous error
+

--- a/tests/run-make/emit-to-stdout/emit-obj.stderr
+++ b/tests/run-make/emit-to-stdout/emit-obj.stderr
@@ -1,0 +1,4 @@
+error: option `-o` or `--emit` is used to write binary output type `obj` to stdout, but stdout is a tty
+
+error: aborting due to previous error
+

--- a/tests/run-make/emit-to-stdout/test.rs
+++ b/tests/run-make/emit-to-stdout/test.rs
@@ -1,0 +1,1 @@
+#![crate_type = "rlib"]


### PR DESCRIPTION
With this PR, if `-o -` or `--emit KIND=-` is provided, output will be written to stdout instead. Binary output (those of type `obj`, `llvm-bc`, `link` and `metadata`) being written this way will result in an error unless stdout is not a tty. Multiple output types going to stdout will trigger an error too, as they will all be mixded together.

This implements https://github.com/rust-lang/compiler-team/issues/431

The idea behind the changes is to introduce an `OutFileName` enum that represents the output - be it a real path or stdout - and to use this enum along the code paths that handle different output types.