### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1481,7 +1481,7 @@ and related tools.
 [is_power_of_two_usize]: https://doc.rust-lang.org/stable/core/num/struct.NonZeroUsize.html#method.is_power_of_two
 [stdarch/1266]: https://github.com/rust-lang/stdarch/pull/1266
 
-Version 1.58.1 (2022-01-19)
+Version 1.58.1 (2022-01-20)
 ===========================
 
 * Fix race condition in `std::fs::remove_dir_all` ([CVE-2022-21658])

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -169,14 +169,14 @@ impl<'tcx> ConstEvalErr<'tcx> {
                 // See <https://github.com/rust-lang/rust/pull/63152>.
                 let mut err = struct_error(tcx, &self.error.to_string());
                 self.decorate(&mut err, decorate);
-                ErrorHandled::Reported(err.emit())
+                ErrorHandled::Reported(err.emit().into())
             }
             _ => {
                 // Report as hard error.
                 let mut err = struct_error(tcx, message);
                 err.span_label(self.span, self.error.to_string());
                 self.decorate(&mut err, decorate);
-                ErrorHandled::Reported(err.emit())
+                ErrorHandled::Reported(err.emit().into())
             }
         }
     }

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -382,7 +382,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
                         rustc_span::DUMMY_SP,
                         "This is likely a const item that is missing from its impl",
                     );
-                    throw_inval!(AlreadyReported(guar));
+                    throw_inval!(AlreadyReported(guar.into()));
                 } else {
                     // `find_mir_or_eval_fn` checks that this is a const fn before even calling us,
                     // so this should be unreachable.

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -595,7 +595,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // FIXME(generic_const_exprs): `ConstKind::Expr` should be able to be evaluated
             ty::ConstKind::Expr(_) => throw_inval!(TooGeneric),
             ty::ConstKind::Error(reported) => {
-                throw_inval!(AlreadyReported(reported))
+                throw_inval!(AlreadyReported(reported.into()))
             }
             ty::ConstKind::Unevaluated(uv) => {
                 let instance = self.resolve(uv.def, uv.substs)?;

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -338,7 +338,7 @@ declare_features! (
     /// Allow conditional compilation depending on rust version
     (active, cfg_version, "1.45.0", Some(64796), None),
     /// Allows to use the `#[cfi_encoding = ""]` attribute.
-    (active, cfi_encoding, "1.69.0", Some(89653), None),
+    (active, cfi_encoding, "CURRENT_RUSTC_VERSION", Some(89653), None),
     /// Allows `for<...>` on closures and generators.
     (active, closure_lifetime_binder, "1.64.0", Some(97362), None),
     /// Allows `#[track_caller]` on closures and generators.

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1533,7 +1533,7 @@ impl<'tcx> InferCtxt<'tcx> {
             if let Some(ct) = tcx.thir_abstract_const(unevaluated.def)? {
                 let ct = tcx.expand_abstract_consts(ct.subst(tcx, substs));
                 if let Err(e) = ct.error_reported() {
-                    return Err(ErrorHandled::Reported(e));
+                    return Err(ErrorHandled::Reported(e.into()));
                 } else if ct.has_non_region_infer() || ct.has_non_region_param() {
                     return Err(ErrorHandled::TooGeneric);
                 } else {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -611,7 +611,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
 
 declare_lint! {
     /// The `missing_copy_implementations` lint detects potentially-forgotten
-    /// implementations of [`Copy`].
+    /// implementations of [`Copy`] for public types.
     ///
     /// [`Copy`]: https://doc.rust-lang.org/std/marker/trait.Copy.html
     ///
@@ -729,7 +729,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingCopyImplementations {
 
 declare_lint! {
     /// The `missing_debug_implementations` lint detects missing
-    /// implementations of [`fmt::Debug`].
+    /// implementations of [`fmt::Debug`] for public types.
     ///
     /// [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
     ///

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -120,8 +120,8 @@ use crate::ty::{self, Instance, Ty, TyCtxt};
 pub use self::error::{
     struct_error, CheckInAllocMsg, ErrorHandled, EvalToAllocationRawResult, EvalToConstValueResult,
     EvalToValTreeResult, InterpError, InterpErrorInfo, InterpResult, InvalidProgramInfo,
-    MachineStopType, ResourceExhaustionInfo, ScalarSizeMismatch, UndefinedBehaviorInfo,
-    UninitBytesAccess, UnsupportedOpInfo,
+    MachineStopType, ReportedErrorInfo, ResourceExhaustionInfo, ScalarSizeMismatch,
+    UndefinedBehaviorInfo, UninitBytesAccess, UnsupportedOpInfo,
 };
 
 pub use self::value::{get_slice_bytes, ConstAlloc, ConstValue, Scalar};

--- a/compiler/rustc_middle/src/mir/interpret/queries.rs
+++ b/compiler/rustc_middle/src/mir/interpret/queries.rs
@@ -61,7 +61,7 @@ impl<'tcx> TyCtxt<'tcx> {
                 self.const_eval_global_id(param_env, cid, span)
             }
             Ok(None) => Err(ErrorHandled::TooGeneric),
-            Err(error_reported) => Err(ErrorHandled::Reported(error_reported)),
+            Err(err) => Err(ErrorHandled::Reported(err.into())),
         }
     }
 
@@ -110,7 +110,7 @@ impl<'tcx> TyCtxt<'tcx> {
                 })
             }
             Ok(None) => Err(ErrorHandled::TooGeneric),
-            Err(error_reported) => Err(ErrorHandled::Reported(error_reported)),
+            Err(err) => Err(ErrorHandled::Reported(err.into())),
         }
     }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2342,7 +2342,7 @@ impl<'tcx> ConstantKind<'tcx> {
                 match tcx.const_eval_resolve(param_env, uneval, None) {
                     Ok(val) => Self::Val(val, ty),
                     Err(ErrorHandled::TooGeneric) => self,
-                    Err(ErrorHandled::Reported(guar)) => Self::Ty(tcx.const_error(ty, guar)),
+                    Err(ErrorHandled::Reported(guar)) => Self::Ty(tcx.const_error(ty, guar.into())),
                 }
             }
         }

--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -245,7 +245,7 @@ impl<'tcx> ConstKind<'tcx> {
                         // can leak through `val` into the const we return.
                         Ok(val) => Some(Ok(EvalResult::ValTree(val?))),
                         Err(ErrorHandled::TooGeneric) => None,
-                        Err(ErrorHandled::Reported(e)) => Some(Err(e)),
+                        Err(ErrorHandled::Reported(e)) => Some(Err(e.into())),
                     }
                 }
                 EvalMode::Mir => {
@@ -256,7 +256,7 @@ impl<'tcx> ConstKind<'tcx> {
                         // can leak through `val` into the const we return.
                         Ok(val) => Some(Ok(EvalResult::ConstVal(val))),
                         Err(ErrorHandled::TooGeneric) => None,
-                        Err(ErrorHandled::Reported(e)) => Some(Err(e)),
+                        Err(ErrorHandled::Reported(e)) => Some(Err(e.into())),
                     }
                 }
             }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3528,10 +3528,6 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
         //
         // Similar thing, for types, happens in `report_errors` above.
         let report_errors_for_call = |this: &mut Self, parent_err: Spanned<ResolutionError<'a>>| {
-            if !source.is_call() {
-                return Some(parent_err);
-            }
-
             // Before we start looking for candidates, we have to get our hands
             // on the type user is trying to perform invocation on; basically:
             // we're transforming `HashMap::new` into just `HashMap`.

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -801,7 +801,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                                             span: tcx.def_span(unevaluated.def),
                                             unevaluated: unevaluated,
                                         });
-                                    Err(ErrorHandled::Reported(reported))
+                                    Err(ErrorHandled::Reported(reported.into()))
                                 }
                                 Err(err) => Err(err),
                             }

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -79,7 +79,7 @@ pub fn is_const_evaluatable<'tcx>(
                             "Missing value for constant, but no error reported?",
                         )))
                     }
-                    Err(ErrorHandled::Reported(e)) => Err(NotConstEvaluatable::Error(e)),
+                    Err(ErrorHandled::Reported(e)) => Err(NotConstEvaluatable::Error(e.into())),
                     Ok(_) => Ok(()),
                 }
             }
@@ -147,7 +147,7 @@ pub fn is_const_evaluatable<'tcx>(
 
                 Err(err)
             }
-            Err(ErrorHandled::Reported(e)) => Err(NotConstEvaluatable::Error(e)),
+            Err(ErrorHandled::Reported(e)) => Err(NotConstEvaluatable::Error(e.into())),
             Ok(_) => Ok(()),
         }
     }

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -615,7 +615,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                         (Err(ErrorHandled::Reported(reported)), _)
                         | (_, Err(ErrorHandled::Reported(reported))) => ProcessResult::Error(
                             CodeSelectionError(SelectionError::NotConstEvaluatable(
-                                NotConstEvaluatable::Error(reported),
+                                NotConstEvaluatable::Error(reported.into()),
                             )),
                         ),
                         (Err(ErrorHandled::TooGeneric), _) | (_, Err(ErrorHandled::TooGeneric)) => {

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -3021,7 +3021,7 @@ impl<'a, K, V, A> CursorMut<'a, K, V, A> {
         })
     }
 
-    /// Returns a mutable reference to the of the element that the cursor is
+    /// Returns a mutable reference to the key of the element that the cursor is
     /// currently pointing to.
     ///
     /// This returns `None` if the cursor is currently pointing to the

--- a/src/tools/miri/src/diagnostics.rs
+++ b/src/tools/miri/src/diagnostics.rs
@@ -289,7 +289,7 @@ pub fn report_error<'tcx, 'mir>(
                     (None, format!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information")),
                 ],
             InvalidProgram(
-                InvalidProgramInfo::AlreadyReported(rustc_errors::ErrorGuaranteed { .. })
+                InvalidProgramInfo::AlreadyReported(_)
             ) => {
                 // This got already reported. No point in reporting it again.
                 return None;

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -47,7 +47,6 @@ extern crate rustc_ast;
 extern crate rustc_middle;
 extern crate rustc_const_eval;
 extern crate rustc_data_structures;
-extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_index;
 extern crate rustc_session;

--- a/tests/ui/consts/const-eval/format.stderr
+++ b/tests/ui/consts/const-eval/format.stderr
@@ -43,62 +43,6 @@ LL |     println!("{:?}", 0);
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-note: erroneous constant used
-  --> $DIR/format.rs:2:12
-   |
-LL |     panic!("{:?}", 0);
-   |            ^^^^^^
-
-note: erroneous constant used
-  --> $DIR/format.rs:2:12
-   |
-LL |     panic!("{:?}", 0);
-   |            ^^^^^^
-
-note: erroneous constant used
-  --> $DIR/format.rs:2:20
-   |
-LL |     panic!("{:?}", 0);
-   |                    ^
-   |
-   = note: this note originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-note: erroneous constant used
-  --> $DIR/format.rs:2:20
-   |
-LL |     panic!("{:?}", 0);
-   |                    ^
-   |
-   = note: this note originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-note: erroneous constant used
-  --> $DIR/format.rs:8:14
-   |
-LL |     println!("{:?}", 0);
-   |              ^^^^^^
-
-note: erroneous constant used
-  --> $DIR/format.rs:8:14
-   |
-LL |     println!("{:?}", 0);
-   |              ^^^^^^
-
-note: erroneous constant used
-  --> $DIR/format.rs:8:22
-   |
-LL |     println!("{:?}", 0);
-   |                      ^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-note: erroneous constant used
-  --> $DIR/format.rs:8:22
-   |
-LL |     println!("{:?}", 0);
-   |                      ^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/consts/const-integer-bool-ops.rs
+++ b/tests/ui/consts/const-integer-bool-ops.rs
@@ -6,7 +6,6 @@ const X: usize = 42 && 39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR: [i32; X] = [99; 34];
-//~^ constant
 
 const X1: usize = 42 || 39;
 //~^ ERROR mismatched types
@@ -16,7 +15,6 @@ const X1: usize = 42 || 39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR1: [i32; X1] = [99; 47];
-//~^ constant
 
 const X2: usize = -42 || -39;
 //~^ ERROR mismatched types
@@ -26,7 +24,6 @@ const X2: usize = -42 || -39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR2: [i32; X2] = [99; 18446744073709551607];
-//~^ constant
 
 const X3: usize = -42 && -39;
 //~^ ERROR mismatched types
@@ -36,43 +33,36 @@ const X3: usize = -42 && -39;
 //~| ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARR3: [i32; X3] = [99; 6];
-//~^ constant
 
 const Y: usize = 42.0 == 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR: [i32; Y] = [99; 1];
-//~^ constant
 
 const Y1: usize = 42.0 >= 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR1: [i32; Y1] = [99; 1];
-//~^ constant
 
 const Y2: usize = 42.0 <= 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR2: [i32; Y2] = [99; 1];
-//~^ constant
 
 const Y3: usize = 42.0 > 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR3: [i32; Y3] = [99; 0];
-//~^ constant
 
 const Y4: usize = 42.0 < 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR4: [i32; Y4] = [99; 0];
-//~^ constant
 
 const Y5: usize = 42.0 != 42.0;
 //~^ ERROR mismatched types
 //~| expected `usize`, found `bool`
 const ARRR5: [i32; Y5] = [99; 0];
-//~^ constant
 
 fn main() {
     let _ = ARR;

--- a/tests/ui/consts/const-integer-bool-ops.stderr
+++ b/tests/ui/consts/const-integer-bool-ops.stderr
@@ -16,155 +16,95 @@ error[E0308]: mismatched types
 LL | const X: usize = 42 && 39;
    |                  ^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:8:18
-   |
-LL | const ARR: [i32; X] = [99; 34];
-   |                  ^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:11:19
+  --> $DIR/const-integer-bool-ops.rs:10:19
    |
 LL | const X1: usize = 42 || 39;
    |                   ^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:11:25
+  --> $DIR/const-integer-bool-ops.rs:10:25
    |
 LL | const X1: usize = 42 || 39;
    |                         ^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:11:19
+  --> $DIR/const-integer-bool-ops.rs:10:19
    |
 LL | const X1: usize = 42 || 39;
    |                   ^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:18:19
-   |
-LL | const ARR1: [i32; X1] = [99; 47];
-   |                   ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:21:19
+  --> $DIR/const-integer-bool-ops.rs:19:19
    |
 LL | const X2: usize = -42 || -39;
    |                   ^^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:21:26
+  --> $DIR/const-integer-bool-ops.rs:19:26
    |
 LL | const X2: usize = -42 || -39;
    |                          ^^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:21:19
+  --> $DIR/const-integer-bool-ops.rs:19:19
    |
 LL | const X2: usize = -42 || -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
+error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:28:19
    |
-LL | const ARR2: [i32; X2] = [99; 18446744073709551607];
-   |                   ^^
-
-error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:31:19
-   |
 LL | const X3: usize = -42 && -39;
    |                   ^^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:31:26
+  --> $DIR/const-integer-bool-ops.rs:28:26
    |
 LL | const X3: usize = -42 && -39;
    |                          ^^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:31:19
+  --> $DIR/const-integer-bool-ops.rs:28:19
    |
 LL | const X3: usize = -42 && -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:38:19
-   |
-LL | const ARR3: [i32; X3] = [99; 6];
-   |                   ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:41:18
+  --> $DIR/const-integer-bool-ops.rs:37:18
    |
 LL | const Y: usize = 42.0 == 42.0;
    |                  ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:44:19
-   |
-LL | const ARRR: [i32; Y] = [99; 1];
-   |                   ^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:47:19
+  --> $DIR/const-integer-bool-ops.rs:42:19
    |
 LL | const Y1: usize = 42.0 >= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:50:20
-   |
-LL | const ARRR1: [i32; Y1] = [99; 1];
-   |                    ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:53:19
+  --> $DIR/const-integer-bool-ops.rs:47:19
    |
 LL | const Y2: usize = 42.0 <= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:56:20
-   |
-LL | const ARRR2: [i32; Y2] = [99; 1];
-   |                    ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:59:19
+  --> $DIR/const-integer-bool-ops.rs:52:19
    |
 LL | const Y3: usize = 42.0 > 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:62:20
-   |
-LL | const ARRR3: [i32; Y3] = [99; 0];
-   |                    ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:65:19
+  --> $DIR/const-integer-bool-ops.rs:57:19
    |
 LL | const Y4: usize = 42.0 < 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:68:20
-   |
-LL | const ARRR4: [i32; Y4] = [99; 0];
-   |                    ^^
-
 error[E0308]: mismatched types
-  --> $DIR/const-integer-bool-ops.rs:71:19
+  --> $DIR/const-integer-bool-ops.rs:62:19
    |
 LL | const Y5: usize = 42.0 != 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
-
-note: erroneous constant used
-  --> $DIR/const-integer-bool-ops.rs:74:20
-   |
-LL | const ARRR5: [i32; Y5] = [99; 0];
-   |                    ^^
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/consts/const-mut-refs/issue-76510.32bit.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.32bit.stderr
@@ -19,12 +19,6 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL | const S: &'static mut str = &mut " hello ";
    |                             ^^^^^^^^^^^^^^ cannot borrow as mutable
 
-note: erroneous constant used
-  --> $DIR/issue-76510.rs:11:70
-   |
-LL |         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));
-   |                                                                      ^
-
 error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0596, E0658, E0764.

--- a/tests/ui/consts/const-mut-refs/issue-76510.64bit.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.64bit.stderr
@@ -19,12 +19,6 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL | const S: &'static mut str = &mut " hello ";
    |                             ^^^^^^^^^^^^^^ cannot borrow as mutable
 
-note: erroneous constant used
-  --> $DIR/issue-76510.rs:11:70
-   |
-LL |         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));
-   |                                                                      ^
-
 error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0596, E0658, E0764.

--- a/tests/ui/consts/const-mut-refs/issue-76510.rs
+++ b/tests/ui/consts/const-mut-refs/issue-76510.rs
@@ -9,7 +9,6 @@ const S: &'static mut str = &mut " hello ";
 
 const fn trigger() -> [(); unsafe {
         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));
-        //~^ constant
         0
     }] {
     [(); 0]

--- a/tests/ui/consts/const-tup-index-span.rs
+++ b/tests/ui/consts/const-tup-index-span.rs
@@ -4,7 +4,6 @@ const TUP: (usize,) = 5usize << 64;
 //~^ ERROR mismatched types
 //~| expected `(usize,)`, found `usize`
 const ARR: [i32; TUP.0] = [];
-//~^ constant
 
 fn main() {
 }

--- a/tests/ui/consts/const-tup-index-span.stderr
+++ b/tests/ui/consts/const-tup-index-span.stderr
@@ -11,12 +11,6 @@ help: use a trailing comma to create a tuple with one element
 LL | const TUP: (usize,) = (5usize << 64,);
    |                       +            ++
 
-note: erroneous constant used
-  --> $DIR/const-tup-index-span.rs:6:18
-   |
-LL | const ARR: [i32; TUP.0] = [];
-   |                  ^^^
-
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/issue-54954.rs
+++ b/tests/ui/consts/issue-54954.rs
@@ -9,8 +9,6 @@ trait Tt {
 }
 
 fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-  //~^ constant
-  //~| constant
     z
 }
 

--- a/tests/ui/consts/issue-54954.stderr
+++ b/tests/ui/consts/issue-54954.stderr
@@ -16,18 +16,6 @@ LL | |         core::mem::size_of::<T>()
 LL | |     }
    | |_____- `Tt::const_val` defined here
 
-note: erroneous constant used
-  --> $DIR/issue-54954.rs:11:15
-   |
-LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-   |               ^^^^^^^
-
-note: erroneous constant used
-  --> $DIR/issue-54954.rs:11:34
-   |
-LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-   |                                  ^^^^^^^
-
 error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0379, E0790.

--- a/tests/ui/consts/issue-56164.stderr
+++ b/tests/ui/consts/issue-56164.stderr
@@ -28,18 +28,6 @@ error: function pointer calls are not allowed in constant functions
 LL |     input()
    |     ^^^^^^^
 
-note: erroneous constant used
-  --> $DIR/issue-56164.rs:1:18
-   |
-LL | const fn foo() { (||{})() }
-   |                  ^^^^^^
-
-note: erroneous constant used
-  --> $DIR/issue-56164.rs:1:18
-   |
-LL | const fn foo() { (||{})() }
-   |                  ^^^^^^
-
 error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0015, E0277.

--- a/tests/ui/consts/issue-66693.stderr
+++ b/tests/ui/consts/issue-66693.stderr
@@ -22,17 +22,5 @@ LL |     panic!(&1);
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-note: erroneous constant used
-  --> $DIR/issue-66693.rs:11:12
-   |
-LL |     panic!(&1);
-   |            ^^
-
-note: erroneous constant used
-  --> $DIR/issue-66693.rs:11:12
-   |
-LL |     panic!(&1);
-   |            ^^
-
 error: aborting due to 3 previous errors
 

--- a/tests/ui/enum-discriminant/issue-41394.rs
+++ b/tests/ui/enum-discriminant/issue-41394.rs
@@ -5,7 +5,6 @@ enum Foo {
 
 enum Bar {
     A = Foo::A as isize
-    //~^ const
 }
 
 fn main() {}

--- a/tests/ui/enum-discriminant/issue-41394.stderr
+++ b/tests/ui/enum-discriminant/issue-41394.stderr
@@ -6,12 +6,6 @@ LL |     A = "" + 1
    |         |
    |         &str
 
-note: erroneous constant used
-  --> $DIR/issue-41394.rs:7:9
-   |
-LL |     A = Foo::A as isize
-   |         ^^^^^^^^^^^^^^^
-
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/generic-associated-types/equality-bound.stderr
+++ b/tests/ui/generic-associated-types/equality-bound.stderr
@@ -36,7 +36,10 @@ error[E0433]: failed to resolve: use of undeclared type `I`
   --> $DIR/equality-bound.rs:9:41
    |
 LL | fn sum3<J: Iterator>(i: J) -> i32 where I::Item = i32 {
-   |                                         ^ use of undeclared type `I`
+   |                                         ^
+   |                                         |
+   |                                         use of undeclared type `I`
+   |                                         help: a type parameter with a similar name exists: `J`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/builtin-prelude-no-accidents.stderr
+++ b/tests/ui/macros/builtin-prelude-no-accidents.stderr
@@ -4,17 +4,20 @@ error[E0433]: failed to resolve: use of undeclared crate or module `env`
 LL |     env::current_dir;
    |     ^^^ use of undeclared crate or module `env`
 
+error[E0433]: failed to resolve: use of undeclared crate or module `vec`
+  --> $DIR/builtin-prelude-no-accidents.rs:7:14
+   |
+LL |     type B = vec::Vec<u8>;
+   |              ^^^
+   |              |
+   |              use of undeclared crate or module `vec`
+   |              help: a struct with a similar name exists (notice the capitalization): `Vec`
+
 error[E0433]: failed to resolve: use of undeclared crate or module `panic`
   --> $DIR/builtin-prelude-no-accidents.rs:6:14
    |
 LL |     type A = panic::PanicInfo;
    |              ^^^^^ use of undeclared crate or module `panic`
-
-error[E0433]: failed to resolve: use of undeclared crate or module `vec`
-  --> $DIR/builtin-prelude-no-accidents.rs:7:14
-   |
-LL |     type B = vec::Vec<u8>;
-   |              ^^^ use of undeclared crate or module `vec`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -1,9 +1,3 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `dyn`
-  --> $DIR/dyn-trait-compatibility.rs:3:11
-   |
-LL | type A1 = dyn::dyn;
-   |           ^^^ use of undeclared crate or module `dyn`
-
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:1:11
    |
@@ -45,6 +39,12 @@ error[E0412]: cannot find type `dyn` in this scope
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                ^^^ not found in this scope
+
+error[E0433]: failed to resolve: use of undeclared crate or module `dyn`
+  --> $DIR/dyn-trait-compatibility.rs:3:11
+   |
+LL | type A1 = dyn::dyn;
+   |           ^^^ use of undeclared crate or module `dyn`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/parser/impl-on-unsized-typo.rs
+++ b/tests/ui/parser/impl-on-unsized-typo.rs
@@ -1,0 +1,6 @@
+trait Tr {}
+
+impl<T ?Sized> Tr for T {}
+//~^ ERROR expected one of `,`, `:`, `=`, or `>`, found `?`
+
+fn main() {}

--- a/tests/ui/parser/impl-on-unsized-typo.stderr
+++ b/tests/ui/parser/impl-on-unsized-typo.stderr
@@ -1,0 +1,8 @@
+error: expected one of `,`, `:`, `=`, or `>`, found `?`
+  --> $DIR/impl-on-unsized-typo.rs:3:8
+   |
+LL | impl<T ?Sized> Tr for T {}
+   |        ^ expected one of `,`, `:`, `=`, or `>`
+
+error: aborting due to previous error
+

--- a/tests/ui/pattern/pattern-error-continue.stderr
+++ b/tests/ui/pattern/pattern-error-continue.stderr
@@ -1,9 +1,3 @@
-error[E0433]: failed to resolve: use of undeclared type `E`
-  --> $DIR/pattern-error-continue.rs:33:9
-   |
-LL |         E::V => {}
-   |         ^ use of undeclared type `E`
-
 error[E0532]: expected tuple struct or tuple variant, found unit variant `A::D`
   --> $DIR/pattern-error-continue.rs:18:9
    |
@@ -55,6 +49,15 @@ note: function defined here
    |
 LL | fn f(_c: char) {}
    |    ^ --------
+
+error[E0433]: failed to resolve: use of undeclared type `E`
+  --> $DIR/pattern-error-continue.rs:33:9
+   |
+LL |         E::V => {}
+   |         ^
+   |         |
+   |         use of undeclared type `E`
+   |         help: an enum with a similar name exists: `A`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/resolve/issue-109250.rs
+++ b/tests/ui/resolve/issue-109250.rs
@@ -1,0 +1,3 @@
+fn main() {       //~ HELP consider importing
+    HashMap::new; //~ ERROR failed to resolve: use of undeclared type `HashMap`
+}

--- a/tests/ui/resolve/issue-109250.stderr
+++ b/tests/ui/resolve/issue-109250.stderr
@@ -1,0 +1,14 @@
+error[E0433]: failed to resolve: use of undeclared type `HashMap`
+  --> $DIR/issue-109250.rs:2:5
+   |
+LL |     HashMap::new;
+   |     ^^^^^^^ use of undeclared type `HashMap`
+   |
+help: consider importing this struct
+   |
+LL + use std::collections::HashMap;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/resolve/issue-50599.rs
+++ b/tests/ui/resolve/issue-50599.rs
@@ -2,5 +2,4 @@ fn main() {
     const N: u32 = 1_000;
     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize; //~ ERROR cannot find value
     let mut digits = [0u32; M];
-    //~^ constant
 }

--- a/tests/ui/resolve/issue-50599.stderr
+++ b/tests/ui/resolve/issue-50599.stderr
@@ -16,12 +16,6 @@ LL -     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
 LL +     const M: usize = (f64::from(N) * LOG10_2) as usize;
    |
 
-note: erroneous constant used
-  --> $DIR/issue-50599.rs:4:29
-   |
-LL |     let mut digits = [0u32; M];
-   |                             ^
-
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/resolve-variant-assoc-item.stderr
+++ b/tests/ui/resolve/resolve-variant-assoc-item.stderr
@@ -3,12 +3,26 @@ error[E0433]: failed to resolve: `V` is a variant, not a module
    |
 LL |     E::V::associated_item;
    |        ^ `V` is a variant, not a module
+   |
+help: there is an enum variant `E::V`; try using the variant's enum
+   |
+LL |     E;
+   |     ~
 
 error[E0433]: failed to resolve: `V` is a variant, not a module
   --> $DIR/resolve-variant-assoc-item.rs:6:5
    |
 LL |     V::associated_item;
    |     ^ `V` is a variant, not a module
+   |
+help: there is an enum variant `E::V`; try using the variant's enum
+   |
+LL |     E;
+   |     ~
+help: an enum with a similar name exists
+   |
+LL |     E::associated_item;
+   |     ~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type/type-dependent-def-issue-49241.rs
+++ b/tests/ui/type/type-dependent-def-issue-49241.rs
@@ -2,5 +2,4 @@ fn main() {
     let v = vec![0];
     const l: usize = v.count(); //~ ERROR attempt to use a non-constant value in a constant
     let s: [u32; l] = v.into_iter().collect();
-    //~^ constant
 }

--- a/tests/ui/type/type-dependent-def-issue-49241.stderr
+++ b/tests/ui/type/type-dependent-def-issue-49241.stderr
@@ -6,12 +6,6 @@ LL |     const l: usize = v.count();
    |     |
    |     help: consider using `let` instead of `const`: `let l`
 
-note: erroneous constant used
-  --> $DIR/type-dependent-def-issue-49241.rs:4:18
-   |
-LL |     let s: [u32; l] = v.into_iter().collect();
-   |                  ^
-
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0435`.

--- a/tests/ui/type/type-path-err-node-types.stderr
+++ b/tests/ui/type/type-path-err-node-types.stderr
@@ -1,9 +1,3 @@
-error[E0433]: failed to resolve: use of undeclared type `NonExistent`
-  --> $DIR/type-path-err-node-types.rs:15:5
-   |
-LL |     NonExistent::Assoc::<u8>;
-   |     ^^^^^^^^^^^ use of undeclared type `NonExistent`
-
 error[E0412]: cannot find type `Nonexistent` in this scope
   --> $DIR/type-path-err-node-types.rs:7:12
    |
@@ -21,6 +15,12 @@ error[E0425]: cannot find value `nonexistent` in this scope
    |
 LL |     nonexistent.nonexistent::<u8>();
    |     ^^^^^^^^^^^ not found in this scope
+
+error[E0433]: failed to resolve: use of undeclared type `NonExistent`
+  --> $DIR/type-path-err-node-types.rs:15:5
+   |
+LL |     NonExistent::Assoc::<u8>;
+   |     ^^^^^^^^^^^ use of undeclared type `NonExistent`
 
 error[E0282]: type annotations needed
   --> $DIR/type-path-err-node-types.rs:23:14

--- a/tests/ui/weird-exprs.rs
+++ b/tests/ui/weird-exprs.rs
@@ -5,13 +5,16 @@
 
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
+#![allow(redundant_semicolons)]
 #![allow(unreachable_code)]
 #![allow(unused_braces, unused_must_use, unused_parens)]
 #![allow(uncommon_codepoints, confusable_idents)]
+#![allow(unused_imports)]
 #![allow(unreachable_patterns)]
 
 #![recursion_limit = "256"]
 
+extern crate core;
 use std::cell::Cell;
 use std::mem::swap;
 
@@ -204,6 +207,30 @@ fn closure_matching() {
     assert!(matches!(x(..), |_| Some(4)));
 }
 
+fn semisemisemisemisemi() {
+    ;;;;;;; ;;;;;;; ;;;    ;;; ;;
+    ;;      ;;      ;;;;  ;;;; ;;
+    ;;;;;;; ;;;;;   ;; ;;;; ;; ;;
+         ;; ;;      ;;  ;;  ;; ;;
+    ;;;;;;; ;;;;;;; ;;      ;; ;;
+}
+
+fn useful_syntax() {
+    use {{std::{{collections::{{HashMap}}}}}};
+    use ::{{{{core}, {std}}}};
+    use {{::{{core as core2}}}};
+}
+
+fn infcx() {
+    pub mod cx {
+        pub mod cx {
+            pub use super::cx;
+            pub struct Cx;
+        }
+    }
+    let _cx: cx::cx::Cx = cx::cx::cx::cx::cx::Cx;
+}
+
 pub fn main() {
     strange();
     funny();
@@ -227,4 +254,7 @@ pub fn main() {
     function();
     bathroom_stall();
     closure_matching();
+    semisemisemisemisemi();
+    useful_syntax();
+    infcx();
 }

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -512,6 +512,7 @@ compiler-team = [
 ]
 compiler-team-contributors = [
     "@compiler-errors",
+    "@eholk",
     "@jackh726",
     "@TaKO8Ki",
     "@WaffleLapkin",

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -532,6 +532,7 @@ bootstrap = [
     "@Mark-Simulacrum",
     "@albertlarsan68",
     "@ozkanonur",
+    "@clubby789",
 ]
 infra-ci = [
     "@Mark-Simulacrum",


### PR DESCRIPTION
Successful merges:

 - #111428 (refactor(resolve): clean up the early error return caused by non-call)
 - #111449 (Recover `impl<T ?Sized>` correctly)
 - #111572 (Document that `missing_copy_implementations` and `missing_debug_implementations` only apply to public items.)
 - #111602 (Suppress "erroneous constant used" for constants tainted by errors)
 - #111605 (fixup version placeholder for `cfi_encoding` feature)
 - #111607 (Add clubby789 to the bootstrap review rotation)
 - #111614 (Add more interesting nonsense to weird-exprs.rs)
 - #111617 (Fixed typo)
 - #111620 (Add eholk back to compiler-contributors reviewers)
 - #111621 (Fix release date of 1.58.1 in release notes.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=111428,111449,111572,111602,111605,111607,111614,111617,111620,111621)
<!-- homu-ignore:end -->