### PR TITLE
optimizing Use expressions inside if condition

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -76,6 +76,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     )
                 })
             }
+            ExprKind::Use { source } => this.then_else_break(
+                block,
+                &this.thir[source],
+                temp_scope_override,
+                break_scope,
+                variable_source_info,
+            ),
             ExprKind::Let { expr, ref pat } => this.lower_let_expr(
                 block,
                 &this.thir[expr],

--- a/tests/mir-opt/bool_compare.opt1.InstSimplify.diff
+++ b/tests/mir-opt/bool_compare.opt1.InstSimplify.diff
@@ -13,16 +13,17 @@
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
 -         _2 = Ne(move _3, const true);    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
 +         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
-          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
           switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
       }
   
       bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
           _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:+1:20: +1:21
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:34
       }
   
       bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
           _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:+1:31: +1:32
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:34
       }

--- a/tests/mir-opt/bool_compare.opt2.InstSimplify.diff
+++ b/tests/mir-opt/bool_compare.opt2.InstSimplify.diff
@@ -13,16 +13,17 @@
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
 -         _2 = Ne(const true, move _3);    // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
 +         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
-          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
           switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:17
       }
   
       bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
           _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:+1:20: +1:21
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:34
       }
   
       bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:16: +1:17
           _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:+1:31: +1:32
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:34
       }

--- a/tests/mir-opt/bool_compare.opt3.InstSimplify.diff
+++ b/tests/mir-opt/bool_compare.opt3.InstSimplify.diff
@@ -13,16 +13,17 @@
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:8: +1:9
 -         _2 = Eq(move _3, const false);   // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
 +         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
-          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
           switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
       }
   
       bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
           _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:+1:21: +1:22
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:35
       }
   
       bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
           _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:+1:32: +1:33
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:35
       }

--- a/tests/mir-opt/bool_compare.opt4.InstSimplify.diff
+++ b/tests/mir-opt/bool_compare.opt4.InstSimplify.diff
@@ -13,16 +13,17 @@
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
 -         _2 = Eq(const false, move _3);   // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
 +         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
-          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
           switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:+1:8: +1:18
       }
   
       bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
           _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:+1:21: +1:22
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:35
       }
   
       bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:+1:17: +1:18
           _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:+1:32: +1:33
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:+1:5: +1:35
       }

--- a/tests/mir-opt/building/logical_and_in_conditional.function_from_issue_111583.built.after.mir
+++ b/tests/mir-opt/building/logical_and_in_conditional.function_from_issue_111583.built.after.mir
@@ -40,7 +40,7 @@ fn function_from_issue_111583(_1: f64) -> () {
         _9 = _1;                         // scope 2 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
         _8 = core::f64::<impl f64>::to_bits(move _9) -> [return: bb1, unwind: bb10]; // scope 2 at $DIR/logical_and_in_conditional.rs:+3:9: +3:20
                                          // mir::Constant
-                                         // + span: $DIR/logical_and_in_conditional.rs:28:11: 28:18
+                                         // + span: $DIR/logical_and_in_conditional.rs:19:11: 19:18
                                          // + literal: Const { ty: fn(f64) -> u64 {core::f64::<impl f64>::to_bits}, val: Value(<ZST>) }
     }
 

--- a/tests/mir-opt/building/logical_and_in_conditional.function_from_issue_111583.built.after.mir
+++ b/tests/mir-opt/building/logical_and_in_conditional.function_from_issue_111583.built.after.mir
@@ -1,0 +1,113 @@
+// MIR for `function_from_issue_111583` after built
+
+fn function_from_issue_111583(_1: f64) -> () {
+    debug z => _1;                       // in scope 0 at $DIR/logical_and_in_conditional.rs:+0:31: +0:32
+    let mut _0: ();                      // return place in scope 0 at $DIR/logical_and_in_conditional.rs:+0:39: +0:39
+    let _2: u64;                         // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:9: +1:13
+    let mut _3: u64;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:16: +1:25
+    let mut _5: bool;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:8: +3:38
+    let mut _6: u64;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:8: +3:33
+    let mut _7: u64;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:8: +3:26
+    let mut _8: u64;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:9: +3:20
+    let mut _9: f64;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
+    let mut _10: u64;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:29: +3:33
+    let mut _11: bool;                   // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:42: +3:60
+    let mut _12: f64;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:42: +3:52
+    let mut _13: f64;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:42: +3:43
+    scope 1 {
+        debug mask => _2;                // in scope 1 at $DIR/logical_and_in_conditional.rs:+1:9: +1:13
+        let mut _4: i32;                 // in scope 1 at $DIR/logical_and_in_conditional.rs:+2:9: +2:16
+        scope 2 {
+            debug ret => _4;             // in scope 2 at $DIR/logical_and_in_conditional.rs:+2:9: +2:16
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:9: +1:13
+        StorageLive(_3);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:16: +1:25
+        _3 = Shl(const 1_u64, const 38_i32); // scope 0 at $DIR/logical_and_in_conditional.rs:+1:16: +1:25
+        _2 = Sub(move _3, const 1_u64);  // scope 0 at $DIR/logical_and_in_conditional.rs:+1:16: +1:29
+        StorageDead(_3);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:28: +1:29
+        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/logical_and_in_conditional.rs:+1:9: +1:13
+        StorageLive(_4);                 // scope 1 at $DIR/logical_and_in_conditional.rs:+2:9: +2:16
+        _4 = const 0_i32;                // scope 1 at $DIR/logical_and_in_conditional.rs:+2:19: +2:20
+        FakeRead(ForLet(None), _4);      // scope 1 at $DIR/logical_and_in_conditional.rs:+2:9: +2:16
+        StorageLive(_5);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:8: +3:38
+        StorageLive(_6);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:8: +3:33
+        StorageLive(_7);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:8: +3:26
+        StorageLive(_8);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:9: +3:20
+        StorageLive(_9);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
+        _9 = _1;                         // scope 2 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
+        _8 = core::f64::<impl f64>::to_bits(move _9) -> [return: bb1, unwind: bb10]; // scope 2 at $DIR/logical_and_in_conditional.rs:+3:9: +3:20
+                                         // mir::Constant
+                                         // + span: $DIR/logical_and_in_conditional.rs:28:11: 28:18
+                                         // + literal: Const { ty: fn(f64) -> u64 {core::f64::<impl f64>::to_bits}, val: Value(<ZST>) }
+    }
+
+    bb1: {
+        StorageDead(_9);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:19: +3:20
+        _7 = Shr(move _8, const 8_i32);  // scope 2 at $DIR/logical_and_in_conditional.rs:+3:8: +3:26
+        StorageDead(_8);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:25: +3:26
+        StorageLive(_10);                // scope 2 at $DIR/logical_and_in_conditional.rs:+3:29: +3:33
+        _10 = _2;                        // scope 2 at $DIR/logical_and_in_conditional.rs:+3:29: +3:33
+        _6 = BitAnd(move _7, move _10);  // scope 2 at $DIR/logical_and_in_conditional.rs:+3:8: +3:33
+        StorageDead(_10);                // scope 2 at $DIR/logical_and_in_conditional.rs:+3:32: +3:33
+        StorageDead(_7);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:32: +3:33
+        _5 = Eq(move _6, const 0_u64);   // scope 2 at $DIR/logical_and_in_conditional.rs:+3:8: +3:38
+        switchInt(move _5) -> [0: bb3, otherwise: bb2]; // scope 2 at $DIR/logical_and_in_conditional.rs:+3:8: +3:38
+    }
+
+    bb2: {
+        StorageDead(_6);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:37: +3:38
+        StorageLive(_11);                // scope 2 at $DIR/logical_and_in_conditional.rs:+3:42: +3:60
+        StorageLive(_12);                // scope 2 at $DIR/logical_and_in_conditional.rs:+3:42: +3:52
+        StorageLive(_13);                // scope 2 at $DIR/logical_and_in_conditional.rs:+3:42: +3:43
+        _13 = _1;                        // scope 2 at $DIR/logical_and_in_conditional.rs:+3:42: +3:43
+        _12 = Rem(move _13, const 0.0625f64); // scope 2 at $DIR/logical_and_in_conditional.rs:+3:42: +3:52
+        StorageDead(_13);                // scope 2 at $DIR/logical_and_in_conditional.rs:+3:51: +3:52
+        _11 = Lt(move _12, const 1.0E-13f64); // scope 2 at $DIR/logical_and_in_conditional.rs:+3:42: +3:60
+        switchInt(move _11) -> [0: bb5, otherwise: bb4]; // scope 2 at $DIR/logical_and_in_conditional.rs:+3:42: +3:60
+    }
+
+    bb3: {
+        goto -> bb7;                     // scope 2 at $DIR/logical_and_in_conditional.rs:+3:8: +3:38
+    }
+
+    bb4: {
+        StorageDead(_12);                // scope 2 at $DIR/logical_and_in_conditional.rs:+3:59: +3:60
+        _4 = Add(_4, const 1_i32);       // scope 2 at $DIR/logical_and_in_conditional.rs:+4:9: +4:17
+        _0 = const ();                   // scope 2 at $DIR/logical_and_in_conditional.rs:+3:61: +5:6
+        goto -> bb9;                     // scope 2 at $DIR/logical_and_in_conditional.rs:+3:5: +5:6
+    }
+
+    bb5: {
+        goto -> bb6;                     // scope 2 at $DIR/logical_and_in_conditional.rs:+3:42: +3:60
+    }
+
+    bb6: {
+        StorageDead(_12);                // scope 2 at $DIR/logical_and_in_conditional.rs:+3:59: +3:60
+        goto -> bb8;                     // scope 2 at no-location
+    }
+
+    bb7: {
+        StorageDead(_6);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+3:37: +3:38
+        goto -> bb8;                     // scope 2 at no-location
+    }
+
+    bb8: {
+        _0 = const ();                   // scope 2 at $DIR/logical_and_in_conditional.rs:+5:6: +5:6
+        goto -> bb9;                     // scope 2 at $DIR/logical_and_in_conditional.rs:+3:5: +5:6
+    }
+
+    bb9: {
+        StorageDead(_11);                // scope 2 at $DIR/logical_and_in_conditional.rs:+5:5: +5:6
+        StorageDead(_5);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+5:5: +5:6
+        StorageDead(_4);                 // scope 1 at $DIR/logical_and_in_conditional.rs:+6:1: +6:2
+        StorageDead(_2);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+6:1: +6:2
+        return;                          // scope 0 at $DIR/logical_and_in_conditional.rs:+6:2: +6:2
+    }
+
+    bb10 (cleanup): {
+        resume;                          // scope 0 at $DIR/logical_and_in_conditional.rs:+0:1: +6:2
+    }
+}

--- a/tests/mir-opt/building/logical_and_in_conditional.rs
+++ b/tests/mir-opt/building/logical_and_in_conditional.rs
@@ -20,7 +20,18 @@ fn test_and(a: i32, b: i32, c: i32) {
     } {}
 }
 
+// https://github.com/rust-lang/rust/issues/111583
+// EMIT_MIR logical_and_in_conditional.function_from_issue_111583.built.after.mir
+fn function_from_issue_111583(z: f64) {
+    let mask = (1 << 38) - 1;
+    let mut ret = 0;
+    if (z.to_bits() >> 8) & mask == 0 && z % 0.0625 < 1e-13 {
+        ret += 1;
+    }
+}
+
 fn main() {
+    function_from_issue_111583(0.0);
     for a in 0..1 {
         for b in 0..1 {
             for c in 0..1 {

--- a/tests/mir-opt/building/logical_and_in_conditional.rs
+++ b/tests/mir-opt/building/logical_and_in_conditional.rs
@@ -1,0 +1,31 @@
+struct Droppy;
+
+impl Drop for Droppy {
+    fn drop(&mut self) {
+        println!("drop");
+    }
+}
+
+// EMIT_MIR logical_and_in_conditional.test_and.built.after.mir
+fn test_and(a: i32, b: i32, c: i32) {
+    if {
+        let _t = Droppy;
+        a == 0
+    } && {
+        let _t = Droppy;
+        b == 0
+    } && {
+        let _t = Droppy;
+        c == 0
+    } {}
+}
+
+fn main() {
+    for a in 0..1 {
+        for b in 0..1 {
+            for c in 0..1 {
+                test_and(a, b, c);
+            }
+        }
+    }
+}

--- a/tests/mir-opt/building/logical_and_in_conditional.rs
+++ b/tests/mir-opt/building/logical_and_in_conditional.rs
@@ -1,4 +1,4 @@
-struct Droppy;
+struct Droppy(bool);
 
 impl Drop for Droppy {
     fn drop(&mut self) {
@@ -8,16 +8,7 @@ impl Drop for Droppy {
 
 // EMIT_MIR logical_and_in_conditional.test_and.built.after.mir
 fn test_and(a: i32, b: i32, c: i32) {
-    if {
-        let _t = Droppy;
-        a == 0
-    } && {
-        let _t = Droppy;
-        b == 0
-    } && {
-        let _t = Droppy;
-        c == 0
-    } {}
+    if Droppy(a == 0).0 && Droppy(b == 0).0 && Droppy(c == 0).0 {}
 }
 
 // https://github.com/rust-lang/rust/issues/111583

--- a/tests/mir-opt/building/logical_and_in_conditional.test_and.built.after.mir
+++ b/tests/mir-opt/building/logical_and_in_conditional.test_and.built.after.mir
@@ -1,0 +1,110 @@
+// MIR for `test_and` after built
+
+fn test_and(_1: i32, _2: i32, _3: i32) -> () {
+    debug a => _1;                       // in scope 0 at $DIR/logical_and_in_conditional.rs:+0:13: +0:14
+    debug b => _2;                       // in scope 0 at $DIR/logical_and_in_conditional.rs:+0:21: +0:22
+    debug c => _3;                       // in scope 0 at $DIR/logical_and_in_conditional.rs:+0:29: +0:30
+    let mut _0: ();                      // return place in scope 0 at $DIR/logical_and_in_conditional.rs:+0:37: +0:37
+    let mut _4: bool;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +4:6
+    let _5: Droppy;                      // in scope 0 at $DIR/logical_and_in_conditional.rs:+2:13: +2:15
+    let mut _6: i32;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
+    let mut _7: bool;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+4:10: +7:6
+    let _8: Droppy;                      // in scope 0 at $DIR/logical_and_in_conditional.rs:+5:13: +5:15
+    let mut _9: i32;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+6:9: +6:10
+    let mut _10: bool;                   // in scope 0 at $DIR/logical_and_in_conditional.rs:+7:10: +10:6
+    let _11: Droppy;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+8:13: +8:15
+    let mut _12: i32;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+9:9: +9:10
+    scope 1 {
+        debug _t => _5;                  // in scope 1 at $DIR/logical_and_in_conditional.rs:+2:13: +2:15
+    }
+    scope 2 {
+        debug _t => _8;                  // in scope 2 at $DIR/logical_and_in_conditional.rs:+5:13: +5:15
+    }
+    scope 3 {
+        debug _t => _11;                 // in scope 3 at $DIR/logical_and_in_conditional.rs:+8:13: +8:15
+    }
+
+    bb0: {
+        StorageLive(_4);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +4:6
+        StorageLive(_5);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+2:13: +2:15
+        _5 = Droppy;                     // scope 0 at $DIR/logical_and_in_conditional.rs:+2:18: +2:24
+        FakeRead(ForLet(None), _5);      // scope 0 at $DIR/logical_and_in_conditional.rs:+2:13: +2:15
+        StorageLive(_6);                 // scope 1 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
+        _6 = _1;                         // scope 1 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
+        _4 = Eq(move _6, const 0_i32);   // scope 1 at $DIR/logical_and_in_conditional.rs:+3:9: +3:15
+        StorageDead(_6);                 // scope 1 at $DIR/logical_and_in_conditional.rs:+3:14: +3:15
+        drop(_5) -> [return: bb1, unwind: bb12]; // scope 0 at $DIR/logical_and_in_conditional.rs:+4:5: +4:6
+    }
+
+    bb1: {
+        StorageDead(_5);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+4:5: +4:6
+        switchInt(move _4) -> [0: bb3, otherwise: bb2]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +4:6
+    }
+
+    bb2: {
+        StorageLive(_7);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+4:10: +7:6
+        StorageLive(_8);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+5:13: +5:15
+        _8 = Droppy;                     // scope 0 at $DIR/logical_and_in_conditional.rs:+5:18: +5:24
+        FakeRead(ForLet(None), _8);      // scope 0 at $DIR/logical_and_in_conditional.rs:+5:13: +5:15
+        StorageLive(_9);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+6:9: +6:10
+        _9 = _2;                         // scope 2 at $DIR/logical_and_in_conditional.rs:+6:9: +6:10
+        _7 = Eq(move _9, const 0_i32);   // scope 2 at $DIR/logical_and_in_conditional.rs:+6:9: +6:15
+        StorageDead(_9);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+6:14: +6:15
+        drop(_8) -> [return: bb4, unwind: bb12]; // scope 0 at $DIR/logical_and_in_conditional.rs:+7:5: +7:6
+    }
+
+    bb3: {
+        goto -> bb10;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +4:6
+    }
+
+    bb4: {
+        StorageDead(_8);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+7:5: +7:6
+        switchInt(move _7) -> [0: bb6, otherwise: bb5]; // scope 0 at $DIR/logical_and_in_conditional.rs:+4:10: +7:6
+    }
+
+    bb5: {
+        StorageLive(_10);                // scope 0 at $DIR/logical_and_in_conditional.rs:+7:10: +10:6
+        StorageLive(_11);                // scope 0 at $DIR/logical_and_in_conditional.rs:+8:13: +8:15
+        _11 = Droppy;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+8:18: +8:24
+        FakeRead(ForLet(None), _11);     // scope 0 at $DIR/logical_and_in_conditional.rs:+8:13: +8:15
+        StorageLive(_12);                // scope 3 at $DIR/logical_and_in_conditional.rs:+9:9: +9:10
+        _12 = _3;                        // scope 3 at $DIR/logical_and_in_conditional.rs:+9:9: +9:10
+        _10 = Eq(move _12, const 0_i32); // scope 3 at $DIR/logical_and_in_conditional.rs:+9:9: +9:15
+        StorageDead(_12);                // scope 3 at $DIR/logical_and_in_conditional.rs:+9:14: +9:15
+        drop(_11) -> [return: bb7, unwind: bb12]; // scope 0 at $DIR/logical_and_in_conditional.rs:+10:5: +10:6
+    }
+
+    bb6: {
+        goto -> bb10;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+4:10: +7:6
+    }
+
+    bb7: {
+        StorageDead(_11);                // scope 0 at $DIR/logical_and_in_conditional.rs:+10:5: +10:6
+        switchInt(move _10) -> [0: bb9, otherwise: bb8]; // scope 0 at $DIR/logical_and_in_conditional.rs:+7:10: +10:6
+    }
+
+    bb8: {
+        _0 = const ();                   // scope 0 at $DIR/logical_and_in_conditional.rs:+10:7: +10:9
+        goto -> bb11;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:5: +10:9
+    }
+
+    bb9: {
+        goto -> bb10;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+7:10: +10:6
+    }
+
+    bb10: {
+        _0 = const ();                   // scope 0 at $DIR/logical_and_in_conditional.rs:+10:9: +10:9
+        goto -> bb11;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:5: +10:9
+    }
+
+    bb11: {
+        StorageDead(_10);                // scope 0 at $DIR/logical_and_in_conditional.rs:+10:8: +10:9
+        StorageDead(_7);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+10:8: +10:9
+        StorageDead(_4);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+10:8: +10:9
+        return;                          // scope 0 at $DIR/logical_and_in_conditional.rs:+11:2: +11:2
+    }
+
+    bb12 (cleanup): {
+        resume;                          // scope 0 at $DIR/logical_and_in_conditional.rs:+0:1: +11:2
+    }
+}

--- a/tests/mir-opt/building/logical_and_in_conditional.test_and.built.after.mir
+++ b/tests/mir-opt/building/logical_and_in_conditional.test_and.built.after.mir
@@ -5,106 +5,133 @@ fn test_and(_1: i32, _2: i32, _3: i32) -> () {
     debug b => _2;                       // in scope 0 at $DIR/logical_and_in_conditional.rs:+0:21: +0:22
     debug c => _3;                       // in scope 0 at $DIR/logical_and_in_conditional.rs:+0:29: +0:30
     let mut _0: ();                      // return place in scope 0 at $DIR/logical_and_in_conditional.rs:+0:37: +0:37
-    let mut _4: bool;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +4:6
-    let _5: Droppy;                      // in scope 0 at $DIR/logical_and_in_conditional.rs:+2:13: +2:15
-    let mut _6: i32;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
-    let mut _7: bool;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+4:10: +7:6
-    let _8: Droppy;                      // in scope 0 at $DIR/logical_and_in_conditional.rs:+5:13: +5:15
-    let mut _9: i32;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+6:9: +6:10
-    let mut _10: bool;                   // in scope 0 at $DIR/logical_and_in_conditional.rs:+7:10: +10:6
-    let _11: Droppy;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+8:13: +8:15
-    let mut _12: i32;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+9:9: +9:10
-    scope 1 {
-        debug _t => _5;                  // in scope 1 at $DIR/logical_and_in_conditional.rs:+2:13: +2:15
-    }
-    scope 2 {
-        debug _t => _8;                  // in scope 2 at $DIR/logical_and_in_conditional.rs:+5:13: +5:15
-    }
-    scope 3 {
-        debug _t => _11;                 // in scope 3 at $DIR/logical_and_in_conditional.rs:+8:13: +8:15
-    }
+    let mut _4: bool;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +1:24
+    let mut _5: Droppy;                  // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +1:22
+    let mut _6: bool;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:15: +1:21
+    let mut _7: i32;                     // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:15: +1:16
+    let mut _8: bool;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:28: +1:44
+    let mut _9: Droppy;                  // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:28: +1:42
+    let mut _10: bool;                   // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:35: +1:41
+    let mut _11: i32;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:35: +1:36
+    let mut _12: bool;                   // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:48: +1:64
+    let mut _13: Droppy;                 // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:48: +1:62
+    let mut _14: bool;                   // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:55: +1:61
+    let mut _15: i32;                    // in scope 0 at $DIR/logical_and_in_conditional.rs:+1:55: +1:56
 
     bb0: {
-        StorageLive(_4);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +4:6
-        StorageLive(_5);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+2:13: +2:15
-        _5 = Droppy;                     // scope 0 at $DIR/logical_and_in_conditional.rs:+2:18: +2:24
-        FakeRead(ForLet(None), _5);      // scope 0 at $DIR/logical_and_in_conditional.rs:+2:13: +2:15
-        StorageLive(_6);                 // scope 1 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
-        _6 = _1;                         // scope 1 at $DIR/logical_and_in_conditional.rs:+3:9: +3:10
-        _4 = Eq(move _6, const 0_i32);   // scope 1 at $DIR/logical_and_in_conditional.rs:+3:9: +3:15
-        StorageDead(_6);                 // scope 1 at $DIR/logical_and_in_conditional.rs:+3:14: +3:15
-        drop(_5) -> [return: bb1, unwind: bb12]; // scope 0 at $DIR/logical_and_in_conditional.rs:+4:5: +4:6
+        StorageLive(_4);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +1:24
+        StorageLive(_5);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +1:22
+        StorageLive(_6);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:15: +1:21
+        StorageLive(_7);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:15: +1:16
+        _7 = _1;                         // scope 0 at $DIR/logical_and_in_conditional.rs:+1:15: +1:16
+        _6 = Eq(move _7, const 0_i32);   // scope 0 at $DIR/logical_and_in_conditional.rs:+1:15: +1:21
+        StorageDead(_7);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:20: +1:21
+        _5 = Droppy(move _6);            // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +1:22
+        StorageDead(_6);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:21: +1:22
+        _4 = (_5.0: bool);               // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +1:24
+        switchInt(move _4) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +1:24
     }
 
     bb1: {
-        StorageDead(_5);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+4:5: +4:6
-        switchInt(move _4) -> [0: bb3, otherwise: bb2]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +4:6
+        drop(_5) -> [return: bb3, unwind: bb18]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:23: +1:24
     }
 
     bb2: {
-        StorageLive(_7);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+4:10: +7:6
-        StorageLive(_8);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+5:13: +5:15
-        _8 = Droppy;                     // scope 0 at $DIR/logical_and_in_conditional.rs:+5:18: +5:24
-        FakeRead(ForLet(None), _8);      // scope 0 at $DIR/logical_and_in_conditional.rs:+5:13: +5:15
-        StorageLive(_9);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+6:9: +6:10
-        _9 = _2;                         // scope 2 at $DIR/logical_and_in_conditional.rs:+6:9: +6:10
-        _7 = Eq(move _9, const 0_i32);   // scope 2 at $DIR/logical_and_in_conditional.rs:+6:9: +6:15
-        StorageDead(_9);                 // scope 2 at $DIR/logical_and_in_conditional.rs:+6:14: +6:15
-        drop(_8) -> [return: bb4, unwind: bb12]; // scope 0 at $DIR/logical_and_in_conditional.rs:+7:5: +7:6
+        goto -> bb14;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +1:24
     }
 
     bb3: {
-        goto -> bb10;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:8: +4:6
+        StorageDead(_5);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:23: +1:24
+        StorageLive(_8);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:28: +1:44
+        StorageLive(_9);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:28: +1:42
+        StorageLive(_10);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:35: +1:41
+        StorageLive(_11);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:35: +1:36
+        _11 = _2;                        // scope 0 at $DIR/logical_and_in_conditional.rs:+1:35: +1:36
+        _10 = Eq(move _11, const 0_i32); // scope 0 at $DIR/logical_and_in_conditional.rs:+1:35: +1:41
+        StorageDead(_11);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:40: +1:41
+        _9 = Droppy(move _10);           // scope 0 at $DIR/logical_and_in_conditional.rs:+1:28: +1:42
+        StorageDead(_10);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:41: +1:42
+        _8 = (_9.0: bool);               // scope 0 at $DIR/logical_and_in_conditional.rs:+1:28: +1:44
+        switchInt(move _8) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:28: +1:44
     }
 
     bb4: {
-        StorageDead(_8);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+7:5: +7:6
-        switchInt(move _7) -> [0: bb6, otherwise: bb5]; // scope 0 at $DIR/logical_and_in_conditional.rs:+4:10: +7:6
+        drop(_9) -> [return: bb6, unwind: bb18]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:43: +1:44
     }
 
     bb5: {
-        StorageLive(_10);                // scope 0 at $DIR/logical_and_in_conditional.rs:+7:10: +10:6
-        StorageLive(_11);                // scope 0 at $DIR/logical_and_in_conditional.rs:+8:13: +8:15
-        _11 = Droppy;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+8:18: +8:24
-        FakeRead(ForLet(None), _11);     // scope 0 at $DIR/logical_and_in_conditional.rs:+8:13: +8:15
-        StorageLive(_12);                // scope 3 at $DIR/logical_and_in_conditional.rs:+9:9: +9:10
-        _12 = _3;                        // scope 3 at $DIR/logical_and_in_conditional.rs:+9:9: +9:10
-        _10 = Eq(move _12, const 0_i32); // scope 3 at $DIR/logical_and_in_conditional.rs:+9:9: +9:15
-        StorageDead(_12);                // scope 3 at $DIR/logical_and_in_conditional.rs:+9:14: +9:15
-        drop(_11) -> [return: bb7, unwind: bb12]; // scope 0 at $DIR/logical_and_in_conditional.rs:+10:5: +10:6
+        goto -> bb12;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:28: +1:44
     }
 
     bb6: {
-        goto -> bb10;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+4:10: +7:6
+        StorageDead(_9);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:43: +1:44
+        StorageLive(_12);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:48: +1:64
+        StorageLive(_13);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:48: +1:62
+        StorageLive(_14);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:55: +1:61
+        StorageLive(_15);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:55: +1:56
+        _15 = _3;                        // scope 0 at $DIR/logical_and_in_conditional.rs:+1:55: +1:56
+        _14 = Eq(move _15, const 0_i32); // scope 0 at $DIR/logical_and_in_conditional.rs:+1:55: +1:61
+        StorageDead(_15);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:60: +1:61
+        _13 = Droppy(move _14);          // scope 0 at $DIR/logical_and_in_conditional.rs:+1:48: +1:62
+        StorageDead(_14);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:61: +1:62
+        _12 = (_13.0: bool);             // scope 0 at $DIR/logical_and_in_conditional.rs:+1:48: +1:64
+        switchInt(move _12) -> [0: bb8, otherwise: bb7]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:48: +1:64
     }
 
     bb7: {
-        StorageDead(_11);                // scope 0 at $DIR/logical_and_in_conditional.rs:+10:5: +10:6
-        switchInt(move _10) -> [0: bb9, otherwise: bb8]; // scope 0 at $DIR/logical_and_in_conditional.rs:+7:10: +10:6
+        drop(_13) -> [return: bb9, unwind: bb18]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:63: +1:64
     }
 
     bb8: {
-        _0 = const ();                   // scope 0 at $DIR/logical_and_in_conditional.rs:+10:7: +10:9
-        goto -> bb11;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:5: +10:9
+        goto -> bb10;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:48: +1:64
     }
 
     bb9: {
-        goto -> bb10;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+7:10: +10:6
+        StorageDead(_13);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:63: +1:64
+        _0 = const ();                   // scope 0 at $DIR/logical_and_in_conditional.rs:+1:65: +1:67
+        goto -> bb17;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:5: +1:67
     }
 
     bb10: {
-        _0 = const ();                   // scope 0 at $DIR/logical_and_in_conditional.rs:+10:9: +10:9
-        goto -> bb11;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:5: +10:9
+        drop(_13) -> [return: bb11, unwind: bb18]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:63: +1:64
     }
 
     bb11: {
-        StorageDead(_10);                // scope 0 at $DIR/logical_and_in_conditional.rs:+10:8: +10:9
-        StorageDead(_7);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+10:8: +10:9
-        StorageDead(_4);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+10:8: +10:9
-        return;                          // scope 0 at $DIR/logical_and_in_conditional.rs:+11:2: +11:2
+        StorageDead(_13);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:63: +1:64
+        goto -> bb16;                    // scope 0 at no-location
     }
 
-    bb12 (cleanup): {
-        resume;                          // scope 0 at $DIR/logical_and_in_conditional.rs:+0:1: +11:2
+    bb12: {
+        drop(_9) -> [return: bb13, unwind: bb18]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:43: +1:44
+    }
+
+    bb13: {
+        StorageDead(_9);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:43: +1:44
+        goto -> bb16;                    // scope 0 at no-location
+    }
+
+    bb14: {
+        drop(_5) -> [return: bb15, unwind: bb18]; // scope 0 at $DIR/logical_and_in_conditional.rs:+1:23: +1:24
+    }
+
+    bb15: {
+        StorageDead(_5);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:23: +1:24
+        goto -> bb16;                    // scope 0 at no-location
+    }
+
+    bb16: {
+        _0 = const ();                   // scope 0 at $DIR/logical_and_in_conditional.rs:+1:67: +1:67
+        goto -> bb17;                    // scope 0 at $DIR/logical_and_in_conditional.rs:+1:5: +1:67
+    }
+
+    bb17: {
+        StorageDead(_12);                // scope 0 at $DIR/logical_and_in_conditional.rs:+1:66: +1:67
+        StorageDead(_8);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:66: +1:67
+        StorageDead(_4);                 // scope 0 at $DIR/logical_and_in_conditional.rs:+1:66: +1:67
+        return;                          // scope 0 at $DIR/logical_and_in_conditional.rs:+2:2: +2:2
+    }
+
+    bb18 (cleanup): {
+        resume;                          // scope 0 at $DIR/logical_and_in_conditional.rs:+0:1: +2:2
     }
 }

--- a/tests/mir-opt/const_goto_storage.match_nested_if.ConstGoto.diff
+++ b/tests/mir-opt/const_goto_storage.match_nested_if.ConstGoto.diff
@@ -40,31 +40,33 @@
 -     }
 - 
 -     bb3: {
--         StorageDead(_6);                 // scope 0 at $DIR/const_goto_storage.rs:+2:51: +2:52
 -         switchInt(move _5) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_storage.rs:+2:21: +2:52
 -     }
 - 
 -     bb4: {
+-         StorageDead(_6);                 // scope 0 at $DIR/const_goto_storage.rs:+2:51: +2:52
 -         _4 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+2:55: +2:59
 -         goto -> bb6;                     // scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
 -     }
 - 
 -     bb5: {
+-         StorageDead(_6);                 // scope 0 at $DIR/const_goto_storage.rs:+2:51: +2:52
 -         _4 = const false;                // scope 0 at $DIR/const_goto_storage.rs:+2:69: +2:74
 -         goto -> bb6;                     // scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
 -     }
 - 
 -     bb6: {
--         StorageDead(_5);                 // scope 0 at $DIR/const_goto_storage.rs:+2:75: +2:76
 -         switchInt(move _4) -> [0: bb8, otherwise: bb7]; // scope 0 at $DIR/const_goto_storage.rs:+2:18: +2:76
 -     }
 - 
 -     bb7: {
+-         StorageDead(_5);                 // scope 0 at $DIR/const_goto_storage.rs:+2:75: +2:76
 -         _3 = const true;                 // scope 0 at $DIR/const_goto_storage.rs:+3:13: +3:17
 -         goto -> bb9;                     // scope 0 at $DIR/const_goto_storage.rs:+2:15: +6:10
 -     }
 - 
 -     bb8: {
+-         StorageDead(_5);                 // scope 0 at $DIR/const_goto_storage.rs:+2:75: +2:76
 -         _3 = const false;                // scope 0 at $DIR/const_goto_storage.rs:+5:13: +5:18
 -         goto -> bb9;                     // scope 0 at $DIR/const_goto_storage.rs:+2:15: +6:10
 -     }

--- a/tests/mir-opt/dataflow-const-prop/if.main.DataflowConstProp.diff
+++ b/tests/mir-opt/dataflow-const-prop/if.main.DataflowConstProp.diff
@@ -39,19 +39,20 @@
           StorageLive(_4);                 // scope 1 at $DIR/if.rs:+2:16: +2:17
 -         _4 = _1;                         // scope 1 at $DIR/if.rs:+2:16: +2:17
 -         _3 = Eq(move _4, const 1_i32);   // scope 1 at $DIR/if.rs:+2:16: +2:22
+-         switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/if.rs:+2:16: +2:22
 +         _4 = const 1_i32;                // scope 1 at $DIR/if.rs:+2:16: +2:17
 +         _3 = const true;                 // scope 1 at $DIR/if.rs:+2:16: +2:22
-          StorageDead(_4);                 // scope 1 at $DIR/if.rs:+2:21: +2:22
--         switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/if.rs:+2:16: +2:22
 +         switchInt(const true) -> [0: bb2, otherwise: bb1]; // scope 1 at $DIR/if.rs:+2:16: +2:22
       }
   
       bb1: {
+          StorageDead(_4);                 // scope 1 at $DIR/if.rs:+2:21: +2:22
           _2 = const 2_i32;                // scope 1 at $DIR/if.rs:+2:25: +2:26
           goto -> bb3;                     // scope 1 at $DIR/if.rs:+2:13: +2:39
       }
   
       bb2: {
+          StorageDead(_4);                 // scope 1 at $DIR/if.rs:+2:21: +2:22
           _2 = const 3_i32;                // scope 1 at $DIR/if.rs:+2:36: +2:37
           goto -> bb3;                     // scope 1 at $DIR/if.rs:+2:13: +2:39
       }
@@ -70,20 +71,21 @@
           StorageLive(_9);                 // scope 3 at $DIR/if.rs:+5:16: +5:17
 -         _9 = _1;                         // scope 3 at $DIR/if.rs:+5:16: +5:17
 -         _8 = Eq(move _9, const 1_i32);   // scope 3 at $DIR/if.rs:+5:16: +5:22
+-         switchInt(move _8) -> [0: bb5, otherwise: bb4]; // scope 3 at $DIR/if.rs:+5:16: +5:22
 +         _9 = const 1_i32;                // scope 3 at $DIR/if.rs:+5:16: +5:17
 +         _8 = const true;                 // scope 3 at $DIR/if.rs:+5:16: +5:22
-          StorageDead(_9);                 // scope 3 at $DIR/if.rs:+5:21: +5:22
--         switchInt(move _8) -> [0: bb5, otherwise: bb4]; // scope 3 at $DIR/if.rs:+5:16: +5:22
 +         switchInt(const true) -> [0: bb5, otherwise: bb4]; // scope 3 at $DIR/if.rs:+5:16: +5:22
       }
   
       bb4: {
+          StorageDead(_9);                 // scope 3 at $DIR/if.rs:+5:21: +5:22
 -         _7 = _1;                         // scope 3 at $DIR/if.rs:+5:25: +5:26
 +         _7 = const 1_i32;                // scope 3 at $DIR/if.rs:+5:25: +5:26
           goto -> bb6;                     // scope 3 at $DIR/if.rs:+5:13: +5:43
       }
   
       bb5: {
+          StorageDead(_9);                 // scope 3 at $DIR/if.rs:+5:21: +5:22
           StorageLive(_10);                // scope 3 at $DIR/if.rs:+5:36: +5:37
           _10 = _1;                        // scope 3 at $DIR/if.rs:+5:36: +5:37
           _7 = Add(move _10, const 1_i32); // scope 3 at $DIR/if.rs:+5:36: +5:41

--- a/tests/mir-opt/equal_true.opt.InstSimplify.diff
+++ b/tests/mir-opt/equal_true.opt.InstSimplify.diff
@@ -13,16 +13,17 @@
           _3 = _1;                         // scope 0 at $DIR/equal_true.rs:+1:8: +1:9
 -         _2 = Eq(move _3, const true);    // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
 +         _2 = move _3;                    // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
-          StorageDead(_3);                 // scope 0 at $DIR/equal_true.rs:+1:16: +1:17
           switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/equal_true.rs:+1:8: +1:17
       }
   
       bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/equal_true.rs:+1:16: +1:17
           _0 = const 0_i32;                // scope 0 at $DIR/equal_true.rs:+1:20: +1:21
           goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:+1:5: +1:34
       }
   
       bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/equal_true.rs:+1:16: +1:17
           _0 = const 1_i32;                // scope 0 at $DIR/equal_true.rs:+1:31: +1:32
           goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:+1:5: +1:34
       }

--- a/tests/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
@@ -12,16 +12,17 @@
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _2 = Eq(move _3, const -42f32);  // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:18
-          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:17: +1:18
           switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:18
       }
   
       bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:17: +1:18
           _0 = const 0_i32;                // scope 0 at $DIR/if_condition_int.rs:+1:21: +1:22
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:35
       }
   
       bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:17: +1:18
           _0 = const 1_i32;                // scope 0 at $DIR/if_condition_int.rs:+1:32: +1:33
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:35
       }

--- a/tests/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
@@ -12,21 +12,19 @@
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
 -         _2 = Eq(move _3, const 'x');     // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
--         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
 -         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
 +         switchInt(move _3) -> [120: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
           _0 = const 0_u32;                // scope 0 at $DIR/if_condition_int.rs:+1:19: +1:20
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:33
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
           _0 = const 1_u32;                // scope 0 at $DIR/if_condition_int.rs:+1:30: +1:31
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:33
       }

--- a/tests/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
@@ -12,21 +12,19 @@
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
 -         _2 = Eq(move _3, const 42_i8);   // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
--         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
 -         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
 +         switchInt(move _3) -> [42: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
           _0 = const 0_u32;                // scope 0 at $DIR/if_condition_int.rs:+1:18: +1:19
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:32
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
           _0 = const 1_u32;                // scope 0 at $DIR/if_condition_int.rs:+1:29: +1:30
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:32
       }

--- a/tests/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
@@ -14,40 +14,36 @@
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
 -         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
--         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
 -         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
 +         switchInt(move _3) -> [42: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
           _0 = const 0_u32;                // scope 0 at $DIR/if_condition_int.rs:+2:9: +2:10
           goto -> bb6;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +7:6
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
           StorageLive(_4);                 // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
           StorageLive(_5);                 // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:16
           _5 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:16
 -         _4 = Ne(move _5, const 21_u32);  // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
--         StorageDead(_5);                 // scope 0 at $DIR/if_condition_int.rs:+3:21: +3:22
 -         switchInt(move _4) -> [0: bb4, otherwise: bb3]; // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+3:21: +3:22
 +         switchInt(move _5) -> [21: bb4, otherwise: bb3]; // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
       }
   
       bb3: {
-+         StorageDead(_5);                 // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
+          StorageDead(_5);                 // scope 0 at $DIR/if_condition_int.rs:+3:21: +3:22
           _0 = const 1_u32;                // scope 0 at $DIR/if_condition_int.rs:+4:9: +4:10
           goto -> bb5;                     // scope 0 at $DIR/if_condition_int.rs:+3:12: +7:6
       }
   
       bb4: {
-+         StorageDead(_5);                 // scope 0 at $DIR/if_condition_int.rs:+3:15: +3:22
+          StorageDead(_5);                 // scope 0 at $DIR/if_condition_int.rs:+3:21: +3:22
           _0 = const 2_u32;                // scope 0 at $DIR/if_condition_int.rs:+6:9: +6:10
           goto -> bb5;                     // scope 0 at $DIR/if_condition_int.rs:+3:12: +7:6
       }

--- a/tests/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
@@ -12,21 +12,19 @@
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
 -         _2 = Eq(move _3, const -42_i32); // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
--         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
 -         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
 +         switchInt(move _3) -> [4294967254: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
           _0 = const 0_u32;                // scope 0 at $DIR/if_condition_int.rs:+1:19: +1:20
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:33
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:16
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:15: +1:16
           _0 = const 1_u32;                // scope 0 at $DIR/if_condition_int.rs:+1:30: +1:31
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:33
       }

--- a/tests/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
+++ b/tests/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
@@ -12,21 +12,19 @@
           StorageLive(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:9
 -         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
--         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
 -         switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
 +         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
-+         nop;                             // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
 +         switchInt(move _3) -> [42: bb1, otherwise: bb2]; // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
           _0 = const 0_u32;                // scope 0 at $DIR/if_condition_int.rs:+1:18: +1:19
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:32
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:8: +1:15
+          StorageDead(_3);                 // scope 0 at $DIR/if_condition_int.rs:+1:14: +1:15
           _0 = const 1_u32;                // scope 0 at $DIR/if_condition_int.rs:+1:29: +1:30
           goto -> bb3;                     // scope 0 at $DIR/if_condition_int.rs:+1:5: +1:32
       }

--- a/tests/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/tests/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -18,11 +18,11 @@
           StorageLive(_3);                 // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:9
           _3 = _1;                         // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:9
           _2 = Gt(move _3, const 0_i32);   // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:13
-          StorageDead(_3);                 // scope 0 at $DIR/inline_diverging.rs:+1:12: +1:13
           switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/inline_diverging.rs:+1:8: +1:13
       }
   
       bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/inline_diverging.rs:+1:12: +1:13
           StorageLive(_4);                 // scope 0 at $DIR/inline_diverging.rs:+2:9: +2:10
           _4 = _1;                         // scope 0 at $DIR/inline_diverging.rs:+2:9: +2:10
           _0 = move _4 as u32 (IntToInt);  // scope 0 at $DIR/inline_diverging.rs:+2:9: +2:17
@@ -32,6 +32,7 @@
       }
   
       bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/inline_diverging.rs:+1:12: +1:13
           StorageLive(_6);                 // scope 0 at $DIR/inline_diverging.rs:+4:9: +4:16
 -         _6 = panic();                    // scope 0 at $DIR/inline_diverging.rs:+4:9: +4:16
 +         StorageLive(_7);                 // scope 0 at $DIR/inline_diverging.rs:+4:9: +4:16

--- a/tests/mir-opt/issue_99325.main.built.after.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.mir
@@ -108,11 +108,11 @@ fn main() -> () {
         StorageDead(_13);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_12);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _10 = Not(move _11);             // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_11);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         switchInt(move _10) -> [0: bb4, otherwise: bb3]; // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb3: {
+        StorageDead(_11);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_15);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _15 = core::panicking::AssertKind::Eq; // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         FakeRead(ForLet(None), _15);     // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -156,6 +156,7 @@ fn main() -> () {
     }
 
     bb7: {
+        StorageDead(_11);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _1 = const ();                   // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         goto -> bb8;                     // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
@@ -217,11 +218,11 @@ fn main() -> () {
         StorageDead(_34);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_33);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _31 = Not(move _32);             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         switchInt(move _31) -> [0: bb13, otherwise: bb12]; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb12: {
+        StorageDead(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_36);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _36 = core::panicking::AssertKind::Eq; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         FakeRead(ForLet(None), _36);     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -265,6 +266,7 @@ fn main() -> () {
     }
 
     bb16: {
+        StorageDead(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _23 = const ();                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         goto -> bb17;                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }

--- a/tests/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.diff
+++ b/tests/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.diff
@@ -32,12 +32,12 @@
       bb1: {
           StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
           switchInt(move _3) -> [0: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
       }
   
       bb2: {
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
           StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
           _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
           _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
@@ -52,6 +52,8 @@
       }
   
       bb4: {
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
           _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:11
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:+1:5: +5:6
       }

--- a/tests/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.diff
+++ b/tests/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.diff
@@ -35,12 +35,12 @@
       bb1: {
           StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
           switchInt(move _3) -> [0: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:+1:8: +1:27
       }
   
       bb2: {
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
           StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
           _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:+2:15: +2:20
           _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:+2:9: +2:21
@@ -55,6 +55,8 @@
       }
   
       bb4: {
+          StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:+1:26: +1:27
           StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
           _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:+4:15: +4:16
           _12 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:+4:9: +4:17

--- a/tests/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
+++ b/tests/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
@@ -31,12 +31,12 @@
       bb1: {
           StorageDead(_6);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_slice_len.rs:+1:8: +1:27
-          StorageDead(_5);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
-          StorageDead(_4);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
           switchInt(move _3) -> [0: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_slice_len.rs:+1:8: +1:27
       }
   
       bb2: {
+          StorageDead(_5);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
           StorageLive(_7);                 // scope 0 at $DIR/lower_slice_len.rs:+2:15: +2:20
           _7 = _1;                         // scope 0 at $DIR/lower_slice_len.rs:+2:15: +2:20
           _8 = Len((*_2));                 // scope 0 at $DIR/lower_slice_len.rs:+2:9: +2:21
@@ -51,6 +51,8 @@
       }
   
       bb4: {
+          StorageDead(_5);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
+          StorageDead(_4);                 // scope 0 at $DIR/lower_slice_len.rs:+1:26: +1:27
           _0 = const 42_u8;                // scope 0 at $DIR/lower_slice_len.rs:+4:9: +4:11
           goto -> bb5;                     // scope 0 at $DIR/lower_slice_len.rs:+1:5: +5:6
       }

--- a/tests/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.diff
@@ -40,39 +40,43 @@
 -     }
 - 
 -     bb3: {
-+         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
-+         _7 = move _6;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
-+         _5 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+2:45: +2:50
-+         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
-          StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:51: +2:52
 -         switchInt(move _5) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
 -     }
 - 
 -     bb4: {
++         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
++         _7 = move _6;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
++         _5 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+2:45: +2:50
++         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:24: +2:28
++         StorageLive(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
++         _8 = move _5;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
+          StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:51: +2:52
 -         _4 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:55: +2:59
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
 -     }
 - 
 -     bb5: {
+-         StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:51: +2:52
 -         _4 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:+2:69: +2:74
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
 -     }
 - 
 -     bb6: {
-+         StorageLive(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
-+         _8 = move _5;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
-+         _4 = Ne(_8, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+2:69: +2:74
-+         StorageDead(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
-          StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:75: +2:76
 -         switchInt(move _4) -> [0: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
 -     }
 - 
 -     bb7: {
++         _4 = Ne(_8, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+2:69: +2:74
++         StorageDead(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:21: +2:52
++         StorageLive(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
++         _9 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
+          StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:75: +2:76
 -         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:+3:13: +3:17
 -         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:+2:15: +6:10
 -     }
 - 
 -     bb8: {
+-         StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:75: +2:76
 -         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:+5:13: +5:18
 -         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:+2:15: +6:10
 -     }
@@ -82,8 +86,6 @@
 -     }
 - 
 -     bb10: {
-+         StorageLive(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
-+         _9 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
 +         _3 = Ne(_9, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:+5:13: +5:18
 +         StorageDead(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:+2:18: +2:76
 +         StorageLive(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:+2:15: +6:10

--- a/tests/mir-opt/not_equal_false.opt.InstSimplify.diff
+++ b/tests/mir-opt/not_equal_false.opt.InstSimplify.diff
@@ -13,16 +13,17 @@
           _3 = _1;                         // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:9
 -         _2 = Ne(move _3, const false);   // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
 +         _2 = move _3;                    // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
-          StorageDead(_3);                 // scope 0 at $DIR/not_equal_false.rs:+1:17: +1:18
           switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:+1:8: +1:18
       }
   
       bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/not_equal_false.rs:+1:17: +1:18
           _0 = const 0_u32;                // scope 0 at $DIR/not_equal_false.rs:+1:21: +1:22
           goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:+1:5: +1:35
       }
   
       bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/not_equal_false.rs:+1:17: +1:18
           _0 = const 1_u32;                // scope 0 at $DIR/not_equal_false.rs:+1:32: +1:33
           goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:+1:5: +1:35
       }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.mir
@@ -64,11 +64,11 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
         _4 = Len((*_5));                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         _3 = Lt(_2, move _4);            // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
     }
 
     bb1: {
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageLive(_7);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         _8 = &raw mut (*_1);             // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
@@ -90,6 +90,7 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
     }
 
     bb2: {
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         _0 = const Option::<&mut u32>::None; // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
                                          // mir::Constant
                                          // + span: no-location

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -142,11 +142,11 @@ fn array_casts() -> () {
         StorageDead(_25);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_24);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _22 = Not(move _23);             // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageDead(_23);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         switchInt(move _22) -> [0: bb4, otherwise: bb3]; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
     bb3: {
+        StorageDead(_23);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_27);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _27 = core::panicking::AssertKind::Eq; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_28);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -170,6 +170,7 @@ fn array_casts() -> () {
     }
 
     bb4: {
+        StorageDead(_23);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _12 = const ();                  // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_22);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/tests/ui/rfc-2497-if-let-chains/chains-without-let.rs
+++ b/tests/ui/rfc-2497-if-let-chains/chains-without-let.rs
@@ -1,7 +1,7 @@
 fn and_chain() {
     let z;
     if true && { z = 3; true} && z == 3 {}
-    //~^ ERROR E0381
+    // no longer ERROR E0381
 }
 
 fn and_chain_2() {

--- a/tests/ui/rfc-2497-if-let-chains/chains-without-let.stderr
+++ b/tests/ui/rfc-2497-if-let-chains/chains-without-let.stderr
@@ -1,14 +1,4 @@
 error[E0381]: used binding `z` is possibly-uninitialized
-  --> $DIR/chains-without-let.rs:3:34
-   |
-LL |     let z;
-   |         - binding declared here but left uninitialized
-LL |     if true && { z = 3; true} && z == 3 {}
-   |                  -----           ^ `z` used here but it is possibly-uninitialized
-   |                  |
-   |                  binding initialized here in some conditions
-
-error[E0381]: used binding `z` is possibly-uninitialized
   --> $DIR/chains-without-let.rs:9:31
    |
 LL |     let z;
@@ -28,6 +18,6 @@ LL |     if false || { z = 3; false} || z == 3 {}
    |                   |
    |                   binding initialized here in some conditions
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0381`.


### PR DESCRIPTION
First time contributor here.

While debugging the issue, I noticed that the HIR tree for the "slow" part contained `Use` expressions that were not handled in any special way during lowering to MIR, and thus introduced  a temporary variable and lead to the performance degradation reported.

The change of course affects how MIR is generated, and thus affects a number of tests.  In particular, it makes one (ui) test pass when it used to compile with error.  The other tests affected, according to my (shallow) analysis, look correct.

Feedback appreciated.

Fixes #111583