### PR TITLE
suggest `Option::as_deref(_mut)` on type mismatch in option combinator if it passes typeck

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -27,7 +27,6 @@ use rustc_infer::infer::error_reporting::TypeErrCtxt;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::{DefineOpaqueTypes, InferOk, LateBoundRegionConversionTime};
 use rustc_middle::hir::map;
-use rustc_middle::query::Key;
 use rustc_middle::ty::error::TypeError::{self, Sorts};
 use rustc_middle::ty::{
     self, suggest_arbitrary_trait_bound, suggest_constraining_type_param, AdtKind,
@@ -3701,8 +3700,8 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         let Some(typeck_results) = self.typeck_results.as_ref() else { return };
 
         // Make sure we're dealing with the `Option` type.
-        let Some(ty_adt_did) = typeck_results.expr_ty_adjusted(expr).ty_adt_id() else { return };
-        if !tcx.is_diagnostic_item(sym::Option, ty_adt_did) {
+        let Some(option_ty_adt) = typeck_results.expr_ty_adjusted(expr).ty_adt_def() else { return };
+        if !tcx.is_diagnostic_item(sym::Option, option_ty_adt.did()) {
             return;
         }
 

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
@@ -1,0 +1,40 @@
+fn produces_string() -> Option<String> {
+    Some("my cool string".to_owned())
+}
+
+fn takes_str_but_too_many_refs(_: &&str) -> Option<()> {
+    Some(())
+}
+
+fn no_args() -> Option<()> {
+    Some(())
+}
+
+fn generic_ref<T>(_: &T) -> Option<()> {
+    Some(())
+}
+
+extern "C" fn takes_str_but_wrong_abi(_: &str) -> Option<()> {
+    Some(())
+}
+
+unsafe fn takes_str_but_unsafe(_: &str) -> Option<()> {
+    Some(())
+}
+
+struct TypeWithoutDeref;
+
+fn main() {
+    let _ = produces_string().and_then(takes_str_but_too_many_refs);
+    //~^ ERROR type mismatch in function arguments
+    let _ = produces_string().and_then(takes_str_but_wrong_abi);
+    //~^ ERROR expected a `FnOnce<(String,)>` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+    let _ = produces_string().and_then(takes_str_but_unsafe);
+    //~^ ERROR expected a `FnOnce<(String,)>` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+    let _ = produces_string().and_then(no_args);
+    //~^ ERROR function is expected to take 1 argument, but it takes 0 arguments
+    let _ = produces_string().and_then(generic_ref);
+    //~^ ERROR type mismatch in function arguments
+    let _ = Some(TypeWithoutDeref).and_then(takes_str_but_too_many_refs);
+    //~^ ERROR type mismatch in function arguments
+}

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
@@ -1,0 +1,96 @@
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef-unfixable.rs:28:40
+   |
+LL | fn takes_str_but_too_many_refs(_: &&str) -> Option<()> {
+   | ------------------------------------------------------ found signature defined here
+...
+LL |     let _ = produces_string().and_then(takes_str_but_too_many_refs);
+   |                               -------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected due to this
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a, 'b> fn(&'a &'b str) -> _`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error[E0277]: expected a `FnOnce<(String,)>` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+  --> $DIR/suggest-option-asderef-unfixable.rs:30:40
+   |
+LL |     let _ = produces_string().and_then(takes_str_but_wrong_abi);
+   |                               -------- ^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce<(String,)>` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error[E0277]: expected a `FnOnce<(String,)>` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+  --> $DIR/suggest-option-asderef-unfixable.rs:32:40
+   |
+LL |     let _ = produces_string().and_then(takes_str_but_unsafe);
+   |                               -------- ^^^^^^^^^^^^^^^^^^^^ call the function in a closure: `|| unsafe { /* code */ }`
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+   = note: unsafe function cannot be called generically without an unsafe block
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error[E0593]: function is expected to take 1 argument, but it takes 0 arguments
+  --> $DIR/suggest-option-asderef-unfixable.rs:34:40
+   |
+LL | fn no_args() -> Option<()> {
+   | -------------------------- takes 0 arguments
+...
+LL |     let _ = produces_string().and_then(no_args);
+   |                               -------- ^^^^^^^ expected function that takes 1 argument
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef-unfixable.rs:36:40
+   |
+LL | fn generic_ref<T>(_: &T) -> Option<()> {
+   | -------------------------------------- found signature defined here
+...
+LL |     let _ = produces_string().and_then(generic_ref);
+   |                               -------- ^^^^^^^^^^^ expected due to this
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a> fn(&'a _) -> _`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+help: do not borrow the argument
+   |
+LL - fn generic_ref<T>(_: &T) -> Option<()> {
+LL + fn generic_ref<T>(_: T) -> Option<()> {
+   |
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef-unfixable.rs:38:45
+   |
+LL | fn takes_str_but_too_many_refs(_: &&str) -> Option<()> {
+   | ------------------------------------------------------ found signature defined here
+...
+LL |     let _ = Some(TypeWithoutDeref).and_then(takes_str_but_too_many_refs);
+   |                                    -------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected due to this
+   |                                    |
+   |                                    required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(TypeWithoutDeref) -> _`
+              found function signature `for<'a, 'b> fn(&'a &'b str) -> _`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0593, E0631.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/mismatched_types/suggest-option-asderef.fixed
+++ b/tests/ui/mismatched_types/suggest-option-asderef.fixed
@@ -1,0 +1,30 @@
+// run-rustfix
+
+fn produces_string() -> Option<String> {
+    Some("my cool string".to_owned())
+}
+
+fn takes_str(_: &str) -> Option<()> {
+    Some(())
+}
+
+fn takes_str_mut(_: &mut str) -> Option<()> {
+    Some(())
+}
+
+fn generic<T>(_: T) -> Option<()> {
+    Some(())
+}
+
+fn main() {
+    let _: Option<()> = produces_string().as_deref().and_then(takes_str);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref()` first
+    let _: Option<Option<()>> = produces_string().as_deref().map(takes_str);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref()` first
+    let _: Option<Option<()>> = produces_string().as_deref_mut().map(takes_str_mut);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref_mut()` first
+    let _ = produces_string().and_then(generic);
+}

--- a/tests/ui/mismatched_types/suggest-option-asderef.rs
+++ b/tests/ui/mismatched_types/suggest-option-asderef.rs
@@ -1,0 +1,30 @@
+// run-rustfix
+
+fn produces_string() -> Option<String> {
+    Some("my cool string".to_owned())
+}
+
+fn takes_str(_: &str) -> Option<()> {
+    Some(())
+}
+
+fn takes_str_mut(_: &mut str) -> Option<()> {
+    Some(())
+}
+
+fn generic<T>(_: T) -> Option<()> {
+    Some(())
+}
+
+fn main() {
+    let _: Option<()> = produces_string().and_then(takes_str);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref()` first
+    let _: Option<Option<()>> = produces_string().map(takes_str);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref()` first
+    let _: Option<Option<()>> = produces_string().map(takes_str_mut);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref_mut()` first
+    let _ = produces_string().and_then(generic);
+}

--- a/tests/ui/mismatched_types/suggest-option-asderef.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef.stderr
@@ -1,0 +1,63 @@
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef.rs:20:52
+   |
+LL | fn takes_str(_: &str) -> Option<()> {
+   | ----------------------------------- found signature defined here
+...
+LL |     let _: Option<()> = produces_string().and_then(takes_str);
+   |                                           -------- ^^^^^^^^^ expected due to this
+   |                                           |
+   |                                           required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a> fn(&'a str) -> _`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+help: call `Option::as_deref()` first
+   |
+LL |     let _: Option<()> = produces_string().as_deref().and_then(takes_str);
+   |                                          +++++++++++
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef.rs:23:55
+   |
+LL | fn takes_str(_: &str) -> Option<()> {
+   | ----------------------------------- found signature defined here
+...
+LL |     let _: Option<Option<()>> = produces_string().map(takes_str);
+   |                                                   --- ^^^^^^^^^ expected due to this
+   |                                                   |
+   |                                                   required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a> fn(&'a str) -> _`
+note: required by a bound in `Option::<T>::map`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+help: call `Option::as_deref()` first
+   |
+LL |     let _: Option<Option<()>> = produces_string().as_deref().map(takes_str);
+   |                                                  +++++++++++
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef.rs:26:55
+   |
+LL | fn takes_str_mut(_: &mut str) -> Option<()> {
+   | ------------------------------------------- found signature defined here
+...
+LL |     let _: Option<Option<()>> = produces_string().map(takes_str_mut);
+   |                                                   --- ^^^^^^^^^^^^^ expected due to this
+   |                                                   |
+   |                                                   required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a> fn(&'a mut str) -> _`
+note: required by a bound in `Option::<T>::map`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+help: call `Option::as_deref_mut()` first
+   |
+LL |     let _: Option<Option<()>> = produces_string().as_deref_mut().map(takes_str_mut);
+   |                                                  +++++++++++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0631`.


### PR DESCRIPTION
Fixes #106342.
This adds a suggestion to call `.as_deref()` (or `.as_deref_mut()` resp.) if typeck fails due to a type mismatch in the function passed to an `Option` combinator such as `.map()` or `.and_then()`.
For example:
```rs
fn foo(_: &str) {}
Some(String::new()).map(foo);
```
The `.map()` method requires its argument to satisfy `F: FnOnce(String)`, but it received `fn(&str)`, which won't pass. However, placing a `.as_deref()` before the `.map()` call fixes this since `&str == &<String as Deref>::Target`