### PR TITLE
Do not build docs in try builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,6 +578,7 @@ jobs:
       actions: write
     name: "try - ${{ matrix.name }}"
     env:
+      DIST_TRY_BUILD: 1
       CI_JOB_NAME: "${{ matrix.name }}"
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       SCCACHE_BUCKET: rust-lang-ci-sccache2

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -264,6 +264,7 @@ docker \
   --env RUST_CI_OVERRIDE_RELEASE_CHANNEL \
   --env CI_JOB_NAME="${CI_JOB_NAME-$IMAGE}" \
   --env BASE_COMMIT="$BASE_COMMIT" \
+  --env DIST_TRY_BUILD \
   --init \
   --rm \
   rust-ci \

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -757,6 +757,7 @@ jobs:
     <<: *base-ci-job
     name: try - ${{ matrix.name }}
     env:
+      DIST_TRY_BUILD: 1
       <<: [*shared-ci-variables, *prod-variables]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf') && github.repository == 'rust-lang-ci/rust'
     strategy:


### PR DESCRIPTION
This PR adds a new environment variable to the optimized build Python script, which causes it to ignore certain parts of the final `dist` build (mainly docs) in try builds. This reduces the duration of try builds by ~10 minutes.