### PR TITLE
Reduce the default number of CGUs for incremental.

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1229,7 +1229,7 @@ impl Session {
         // codegen units in order to reduce the "collateral damage" small
         // changes cause.
         if self.opts.incremental.is_some() {
-            return 256;
+            return 64;
         }
 
         // Why is 16 codegen units the default all the time?

--- a/config.example.toml
+++ b/config.example.toml
@@ -434,7 +434,7 @@ changelog-seen = 2
 # compiler.
 #
 # Uses the rustc defaults: https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
-#codegen-units = if incremental { 256 } else { 16 }
+#codegen-units = if incremental { 64 } else { 16 }
 
 # Sets the number of codegen units to build the standard library with,
 # regardless of what the codegen-unit setting for the rest of the compiler is.

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -40,7 +40,7 @@ also produce slower code. Setting this to 1 may improve the performance of
 generated code, but may be slower to compile.
 
 The default value, if not specified, is 16 for non-incremental builds. For
-incremental builds the default is 256 which allows caching to be more granular.
+incremental builds the default is 64 which allows caching to be more granular.
 
 ## control-flow-guard
 


### PR DESCRIPTION
Because it gives better performance.

r? @ghost