### PR TITLE
Fix local libs not included when printing native static libs

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -574,6 +574,8 @@ fn link_staticlib<'a>(
         }
     }
 
+    all_native_libs.extend_from_slice(&codegen_results.crate_info.used_libraries);
+
     if sess.opts.prints.contains(&PrintRequest::NativeStaticLibs) {
         print_native_static_libs(sess, &all_native_libs, &all_rust_dylibs);
     }

--- a/tests/run-make/print-native-static-libs/Makefile
+++ b/tests/run-make/print-native-static-libs/Makefile
@@ -1,0 +1,15 @@
+include ../tools.mk
+
+# ignore-cross-compile
+# ignore-wasm
+
+all:
+	$(RUSTC) --crate-type rlib -lbar_cli bar.rs
+	$(RUSTC) foo.rs -lfoo_cli --crate-type staticlib --print native-static-libs 2>&1 \
+		| grep 'note: native-static-libs: ' \
+		| sed 's/note: native-static-libs: \(.*\)/\1/' > $(TMPDIR)/libs.txt
+
+	cat $(TMPDIR)/libs.txt | grep -F "glib-2.0" # in bar.rs
+	cat $(TMPDIR)/libs.txt | grep -F "systemd" # in foo.rs
+	cat $(TMPDIR)/libs.txt | grep -F "bar_cli"
+	cat $(TMPDIR)/libs.txt | grep -F "foo_cli"

--- a/tests/run-make/print-native-static-libs/bar.rs
+++ b/tests/run-make/print-native-static-libs/bar.rs
@@ -1,0 +1,13 @@
+#[no_mangle]
+pub extern "C" fn my_bar_add(left: i32, right: i32) -> i32 {
+    // Obviously makes no sense but...
+    unsafe {
+        g_free(std::ptr::null_mut());
+    }
+    left + right
+}
+
+#[link(name = "glib-2.0")]
+extern "C" {
+    fn g_free(p: *mut ());
+}

--- a/tests/run-make/print-native-static-libs/foo.rs
+++ b/tests/run-make/print-native-static-libs/foo.rs
@@ -1,0 +1,15 @@
+extern crate bar;
+
+#[no_mangle]
+pub extern "C" fn my_foo_add(left: i32, right: i32) -> i32 {
+    // Obviously makes no sense but...
+    unsafe {
+        init(std::ptr::null_mut());
+    }
+    bar::my_bar_add(left, right)
+}
+
+#[link(name = "systemd")]
+extern "C" {
+    fn init(p: *mut ());
+}


### PR DESCRIPTION
This PR fixes https://github.com/rust-lang/rust/issues/111643 by adding the local used libs to the printed `--print=native-static-libs` output.

It seems that `--print=native-static-libs` doesn't have any test, so I added one. It's very simple and doesn't even tries to compile the result to a binary as I don't know how to handle external library linking in CI. (Note that https://github.com/rust-lang/rust/blob/master/tests/run-make/staticlib-dylib-linkage/Makefile does compile to a binary)

r? @bjorn3