### PR TITLE
rustc_span/symbol.rs Code Quality Impr.

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1994,13 +1994,14 @@ impl Interner {
         // is no `inner.arena.alloc_str()` method. This is clearly safe.
         let string: &str =
             unsafe { str::from_utf8_unchecked(inner.arena.alloc_slice(string.as_bytes())) };
-
-        inner.strings.push(string as *const str);
+        let sp = string as *const str;
+        
+        inner.strings.push(sp);
 
         // This second hash table lookup can be avoided by using `RawEntryMut`,
         // but this code path isn't hot enough for it to be worth it. See
         // #91445 for details.
-        inner.names.insert(string as *const str, name);
+        inner.names.insert(sp, name);
         name
     }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1983,7 +1983,7 @@ impl Interner {
     #[inline]
     fn intern(&self, string: &str) -> Symbol {
         let mut inner = self.0.lock();
-        if let Some(&name) = inner.names.get(string) {
+        if let Some(&name) = inner.names.get(&(string as *const str)) {
             return name;
         }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1995,7 +1995,7 @@ impl Interner {
         let string: &str =
             unsafe { str::from_utf8_unchecked(inner.arena.alloc_slice(string.as_bytes())) };
         let sp = string as *const str;
-        
+
         inner.strings.push(sp);
 
         // This second hash table lookup can be avoided by using `RawEntryMut`,


### PR DESCRIPTION
The struct ‘InternerInner’ should not be holding static references to strings, as this will mislead future contributors. This will obstruct future progress, albeit working out right now.

The idiomatic implementation to represent a low-level struct ‘owning’ some sort of untyped data is to use raw-pointer-fields (see example for ‘PhantomData’ in std) and only convert them into references inside methods of the struct. This better reflects that references to the data can only be safely obtained via the struct’s carefully crafted methods. The current implementation suggests otherwise; namely that the '’InternerInner’'s references can be freely assumed to be soundly used as ‘'static’, if one overlooks the provided comment. This increases the chance for accidental unsound implementations and hinders effectivity the more the code’s requirements become complex.

For example, disregarding the use-case-plausibility of the following scenario, an implementor could create a method on ‘InternerInner’ to replace its ‘DroplessArena’ from whatever reason. As of now, he would do this without second thoughts. My suggestions applied, the struct’s raw pointers would highlight and connote that certain safety requirements are.