### PR TITLE
Retune statement costs used in MIR inlining heuristics

### DIFF
--- a/tests/codegen/iter-repeat-n-trivial-drop.rs
+++ b/tests/codegen/iter-repeat-n-trivial-drop.rs
@@ -9,6 +9,7 @@
 pub struct NotCopy(u16);
 
 impl Drop for NotCopy {
+    #[inline]
     fn drop(&mut self) {}
 }
 
@@ -33,7 +34,7 @@ pub fn iter_repeat_n_next(it: &mut std::iter::RepeatN<NotCopy>) -> Option<NotCop
 
     // CHECK: [[EMPTY]]:
     // CHECK-NOT: br
-    // CHECK: phi i16 [ undef, %start ], [ %[[VAL]], %[[NOT_EMPTY]] ]
+    // CHECK: phi i16 [ %[[VAL]], %[[NOT_EMPTY]] ], [ undef, %start ]
     // CHECK-NOT: br
     // CHECK: ret
 

--- a/tests/codegen/slice-as_chunks.rs
+++ b/tests/codegen/slice-as_chunks.rs
@@ -23,8 +23,8 @@ pub fn chunks4(x: &[u8]) -> &[[u8; 4]] {
 #[no_mangle]
 pub fn chunks4_with_remainder(x: &[u8]) -> (&[[u8; 4]], &[u8]) {
     // CHECK: and i64 %x.1, -4
+    // CHECK: lshr
     // CHECK: and i64 %x.1, 3
-    // CHECK: lshr exact
     // CHECK-NOT: mul
     // CHECK-NOT: udiv
     // CHECK-NOT: urem

--- a/tests/mir-opt/inline/inline_into_box_place.main.Inline.diff
+++ b/tests/mir-opt/inline/inline_into_box_place.main.Inline.diff
@@ -18,6 +18,101 @@
 +         let mut _6: *mut u8;             // in scope 3 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
 +         let mut _7: *const std::vec::Vec<u32>; // in scope 3 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
 +         scope 4 {
++             scope 5 (inlined alloc::alloc::exchange_malloc) { // at $SRC_DIR/alloc/src/boxed.rs:LL:COL
++                 debug size => _4;        // in scope 5 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                 debug align => _5;       // in scope 5 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                 let _8: std::alloc::Layout; // in scope 5 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                 let mut _9: std::result::Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError>; // in scope 5 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                 let mut _10: isize;      // in scope 5 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                 let mut _12: !;          // in scope 5 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                 scope 6 {
++                     debug layout => _8;  // in scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                     let _11: std::ptr::NonNull<[u8]>; // in scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                     let mut _13: &std::alloc::Global; // in scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                     scope 8 {
++                         debug ptr => _11; // in scope 8 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                         scope 18 (inlined NonNull::<[u8]>::as_mut_ptr) { // at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                             debug self => _11; // in scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                             let mut _16: std::ptr::NonNull<u8>; // in scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                             scope 19 (inlined NonNull::<[u8]>::as_non_null_ptr) { // at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                 debug self => _11; // in scope 19 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                 let mut _17: *mut u8; // in scope 19 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                 let mut _18: *mut [u8]; // in scope 19 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                 scope 20 {
++                                     scope 21 (inlined NonNull::<[u8]>::as_ptr) { // at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                         debug self => _11; // in scope 21 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                         let mut _19: *const [u8]; // in scope 21 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                     }
++                                     scope 22 (inlined ptr::mut_ptr::<impl *mut [u8]>::as_mut_ptr) { // at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                         debug self => _18; // in scope 22 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++                                     }
++                                     scope 23 (inlined NonNull::<u8>::new_unchecked) { // at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                         debug ptr => _17; // in scope 23 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                         let mut _20: *const u8; // in scope 23 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                         let mut _21: *mut u8; // in scope 23 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                                         scope 24 {
++                                             scope 25 (inlined NonNull::<T>::new_unchecked::runtime::<u8>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                                                 debug ptr => _21; // in scope 25 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                                                 scope 26 (inlined ptr::mut_ptr::<impl *mut u8>::is_null) { // at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                                     debug self => _21; // in scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++                                                     let mut _22: *mut u8; // in scope 26 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++                                                     scope 27 {
++                                                         scope 28 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++                                                             debug ptr => _22; // in scope 28 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++                                                             scope 29 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++                                                                 debug self => _22; // in scope 29 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++                                                                 scope 30 {
++                                                                     scope 31 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++                                                                         debug self => _22; // in scope 31 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++                                                                     }
++                                                                 }
++                                                             }
++                                                         }
++                                                     }
++                                                 }
++                                             }
++                                         }
++                                     }
++                                 }
++                             }
++                             scope 32 (inlined NonNull::<u8>::as_ptr) { // at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                 debug self => _16; // in scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                                 let mut _23: *const u8; // in scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++                             }
++                         }
++                     }
++                     scope 17 (inlined <std::alloc::Global as Allocator>::allocate) { // at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                         debug self => const _; // in scope 17 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                         debug layout => _8; // in scope 17 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                     }
++                 }
++                 scope 7 {
++                     scope 9 (inlined Layout::from_size_align_unchecked) { // at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                         debug size => _4; // in scope 9 at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
++                         debug align => _5; // in scope 9 at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
++                         let mut _14: std::ptr::Alignment; // in scope 9 at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
++                         scope 10 {
++                             scope 11 (inlined std::ptr::Alignment::new_unchecked) { // at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
++                                 debug align => _5; // in scope 11 at $SRC_DIR/core/src/ptr/alignment.rs:LL:COL
++                                 let mut _15: usize; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                                 scope 12 {
++                                     scope 14 (inlined std::ptr::Alignment::new_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                                         debug align => _15; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
++                                         scope 15 (inlined core::num::<impl usize>::is_power_of_two) { // at $SRC_DIR/core/src/ptr/alignment.rs:LL:COL
++                                             debug self => _15; // in scope 15 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                                             scope 16 (inlined core::num::<impl usize>::count_ones) { // at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                                                 debug self => _15; // in scope 16 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
++                                             }
++                                         }
++                                     }
++                                 }
++                                 scope 13 {
++                                 }
++                             }
++                         }
++                     }
++                 }
++             }
 +         }
 +     }
   
@@ -36,46 +131,107 @@
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Unevaluated(alloc::raw_vec::RawVec::<T>::NEW, [u32], None) }
 +         _2 = Vec::<u32> { buf: move _3, len: const 0_usize }; // scope 2 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         StorageDead(_3);                 // scope 2 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
++         StorageLive(_12);                // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:49
 +         _4 = SizeOf(std::vec::Vec<u32>); // scope 4 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
 +         _5 = AlignOf(std::vec::Vec<u32>); // scope 4 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-+         _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> [return: bb3, unwind: bb4]; // scope 4 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
++         StorageLive(_8);                 // scope 4 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
++         StorageLive(_11);                // scope 4 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
++         StorageLive(_13);                // scope 4 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
++         StorageLive(_14);                // scope 10 at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
++         StorageLive(_15);                // scope 10 at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
++         _14 = _5 as std::ptr::Alignment (Transmute); // scope 13 at $SRC_DIR/core/src/ptr/alignment.rs:LL:COL
++         StorageDead(_15);                // scope 10 at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
++         _8 = Layout { size: _4, align: move _14 }; // scope 10 at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
++         StorageDead(_14);                // scope 10 at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
++         StorageLive(_9);                 // scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++         _13 = const _;                   // scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
 +                                          // mir::Constant
-+                                          // + span: $SRC_DIR/alloc/src/boxed.rs:LL:COL
-+                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
++                                          // + span: $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                                          // + literal: Const { ty: &std::alloc::Global, val: Unevaluated(alloc::alloc::exchange_malloc, [], Some(promoted[0])) }
++         _9 = std::alloc::Global::alloc_impl(_13, _8, const false) -> [return: bb7, unwind: bb3]; // scope 17 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                                          // mir::Constant
++                                          // + span: $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                                          // + literal: Const { ty: for<'a> fn(&'a std::alloc::Global, Layout, bool) -> Result<NonNull<[u8]>, std::alloc::AllocError> {std::alloc::Global::alloc_impl}, val: Value(<ZST>) }
       }
   
       bb1: {
 -         _1 = Box::<Vec<u32>>::new(move _2) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:49
--                                          // mir::Constant
++         StorageDead(_1);                 // scope 0 at $DIR/inline_into_box_place.rs:+2:1: +2:2
++         return;                          // scope 0 at $DIR/inline_into_box_place.rs:+2:2: +2:2
++     }
++ 
++     bb2 (cleanup): {
++         resume;                          // scope 0 at $DIR/inline_into_box_place.rs:+0:1: +2:2
++     }
++ 
++     bb3 (cleanup): {
++         drop(_2) -> [return: bb2, unwind terminate]; // scope 3 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
++     }
++ 
++     bb4: {
++         _12 = handle_alloc_error(_8) -> bb3; // scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
+                                           // mir::Constant
 -                                          // + span: $DIR/inline_into_box_place.rs:8:29: 8:37
 -                                          // + user_ty: UserType(1)
 -                                          // + literal: Const { ty: fn(Vec<u32>) -> Box<Vec<u32>> {Box::<Vec<u32>>::new}, val: Value(<ZST>) }
-+         StorageDead(_1);                 // scope 0 at $DIR/inline_into_box_place.rs:+2:1: +2:2
-+         return;                          // scope 0 at $DIR/inline_into_box_place.rs:+2:2: +2:2
++                                          // + span: $SRC_DIR/alloc/src/alloc.rs:LL:COL
++                                          // + literal: Const { ty: fn(Layout) -> ! {handle_alloc_error}, val: Value(<ZST>) }
       }
   
 -     bb2: {
--         StorageDead(_2);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:48: +1:49
--         _0 = const ();                   // scope 0 at $DIR/inline_into_box_place.rs:+0:11: +2:2
--         drop(_1) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline_into_box_place.rs:+2:1: +2:2
-+     bb2 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline_into_box_place.rs:+0:1: +2:2
-      }
-  
-      bb3: {
--         StorageDead(_1);                 // scope 0 at $DIR/inline_into_box_place.rs:+2:1: +2:2
--         return;                          // scope 0 at $DIR/inline_into_box_place.rs:+2:2: +2:2
++     bb5: {
++         unreachable;                     // scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++     }
++ 
++     bb6: {
++         _11 = ((_9 as Ok).0: std::ptr::NonNull<[u8]>); // scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++         StorageLive(_16);                // scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageLive(_17);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageLive(_18);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageLive(_19);                // scope 21 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         _19 = (_11.0: *const [u8]);      // scope 21 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         _18 = move _19 as *mut [u8] (PtrToPtr); // scope 21 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageDead(_19);                // scope 21 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         _17 = _18 as *mut u8 (PtrToPtr); // scope 22 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
++         StorageDead(_18);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageLive(_20);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageLive(_21);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageLive(_22);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         _20 = _17 as *const u8 (Pointer(MutToConstPointer)); // scope 24 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         _16 = NonNull::<u8> { pointer: _20 }; // scope 24 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageDead(_22);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageDead(_21);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageDead(_20);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageDead(_17);                // scope 20 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageLive(_23);                // scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         _23 = (_16.0: *const u8);        // scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         _6 = move _23 as *mut u8 (PtrToPtr); // scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageDead(_23);                // scope 32 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageDead(_16);                // scope 18 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
++         StorageDead(_9);                 // scope 5 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++         StorageDead(_13);                // scope 4 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
++         StorageDead(_11);                // scope 4 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
++         StorageDead(_8);                 // scope 4 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
 +         _1 = ShallowInitBox(move _6, std::vec::Vec<u32>); // scope 3 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
 +         _7 = (((_1.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>); // scope 3 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
 +         (*_7) = move _2;                 // scope 3 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-+         StorageDead(_2);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:48: +1:49
-+         _0 = const ();                   // scope 0 at $DIR/inline_into_box_place.rs:+0:11: +2:2
++         StorageDead(_12);                // scope 0 at $DIR/inline_into_box_place.rs:+1:29: +1:49
+          StorageDead(_2);                 // scope 0 at $DIR/inline_into_box_place.rs:+1:48: +1:49
+          _0 = const ();                   // scope 0 at $DIR/inline_into_box_place.rs:+0:11: +2:2
+-         drop(_1) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline_into_box_place.rs:+2:1: +2:2
 +         drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/inline_into_box_place.rs:+2:1: +2:2
       }
   
-      bb4 (cleanup): {
+-     bb3: {
+-         StorageDead(_1);                 // scope 0 at $DIR/inline_into_box_place.rs:+2:1: +2:2
+-         return;                          // scope 0 at $DIR/inline_into_box_place.rs:+2:2: +2:2
+-     }
+- 
+-     bb4 (cleanup): {
 -         resume;                          // scope 0 at $DIR/inline_into_box_place.rs:+0:1: +2:2
-+         drop(_2) -> [return: bb2, unwind terminate]; // scope 3 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
++     bb7: {
++         _10 = discriminant(_9);          // scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
++         switchInt(move _10) -> [0: bb6, 1: bb4, otherwise: bb5]; // scope 6 at $SRC_DIR/alloc/src/alloc.rs:LL:COL
       }
   }
   

--- a/tests/mir-opt/pre-codegen/mem_swap.mem_swap_complex.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.mem_swap_complex.PreCodegen.after.mir
@@ -4,15 +4,89 @@ fn mem_swap_complex(_1: &mut [u16; 13], _2: &mut [u16; 13]) -> () {
     debug a => _1;                       // in scope 0 at $DIR/mem_swap.rs:+0:25: +0:26
     debug b => _2;                       // in scope 0 at $DIR/mem_swap.rs:+0:44: +0:45
     let mut _0: ();                      // return place in scope 0 at $DIR/mem_swap.rs:+0:63: +0:63
+    scope 1 (inlined std::mem::swap::<[u16; 13]>) { // at $DIR/mem_swap.rs:19:5: 19:25
+        debug x => _1;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        debug y => _2;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _3: *mut [u16; 13];      // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _4: *mut [u16; 13];      // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        scope 2 {
+        }
+        scope 3 (inlined std::mem::size_of::<[u16; 13]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 4 (inlined align_of::<[u16; 13]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 5 (inlined mem::swap_simple::<[u16; 13]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug x => _1;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug y => _2;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _6: *const [u16; 13]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _8: *const [u16; 13]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _9: *mut [u16; 13];  // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _10: *mut [u16; 13]; // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            scope 6 {
+                let _5: [u16; 13];       // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                scope 7 {
+                    debug a => _5;       // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    let _7: [u16; 13];   // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 8 {
+                        debug b => _7;   // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        scope 15 (inlined std::ptr::write::<[u16; 13]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _9; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _7; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _13: *mut [u16; 13]; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 16 {
+                                scope 17 (inlined std::ptr::write::runtime::<[u16; 13]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _13; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                        scope 18 (inlined std::ptr::write::<[u16; 13]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _10; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _5; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _14: *mut [u16; 13]; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 19 {
+                                scope 20 (inlined std::ptr::write::runtime::<[u16; 13]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _14; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                    scope 12 (inlined std::ptr::read::<[u16; 13]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        debug src => _8; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        let mut _12: *const [u16; 13]; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 13 {
+                            scope 14 (inlined std::ptr::read::runtime::<[u16; 13]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug src => _12; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            }
+                        }
+                    }
+                }
+                scope 9 (inlined std::ptr::read::<[u16; 13]>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    debug src => _6;     // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                    let mut _11: *const [u16; 13]; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    scope 10 {
+                        scope 11 (inlined std::ptr::read::runtime::<[u16; 13]>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug src => _11; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     bb0: {
-        _0 = std::mem::swap::<[u16; 13]>(_1, _2) -> bb1; // scope 0 at $DIR/mem_swap.rs:+1:5: +1:25
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _3 = &raw mut (*_1);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _4 = &raw mut (*_2);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _0 = swap_nonoverlapping::<[u16; 13]>(move _3, move _4, const 1_usize) -> bb1; // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
                                          // mir::Constant
-                                         // + span: $DIR/mem_swap.rs:19:5: 19:19
-                                         // + literal: Const { ty: for<'a, 'b> fn(&'a mut [u16; 13], &'b mut [u16; 13]) {std::mem::swap::<[u16; 13]>}, val: Value(<ZST>) }
+                                         // + span: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                         // + literal: Const { ty: unsafe fn(*mut [u16; 13], *mut [u16; 13], usize) {swap_nonoverlapping::<[u16; 13]>}, val: Value(<ZST>) }
     }
 
     bb1: {
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
     }
 }

--- a/tests/mir-opt/pre-codegen/mem_swap.mem_swap_complex.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.mem_swap_complex.PreCodegen.after.mir
@@ -1,0 +1,18 @@
+// MIR for `mem_swap_complex` after PreCodegen
+
+fn mem_swap_complex(_1: &mut [u16; 13], _2: &mut [u16; 13]) -> () {
+    debug a => _1;                       // in scope 0 at $DIR/mem_swap.rs:+0:25: +0:26
+    debug b => _2;                       // in scope 0 at $DIR/mem_swap.rs:+0:44: +0:45
+    let mut _0: ();                      // return place in scope 0 at $DIR/mem_swap.rs:+0:63: +0:63
+
+    bb0: {
+        _0 = std::mem::swap::<[u16; 13]>(_1, _2) -> bb1; // scope 0 at $DIR/mem_swap.rs:+1:5: +1:25
+                                         // mir::Constant
+                                         // + span: $DIR/mem_swap.rs:19:5: 19:19
+                                         // + literal: Const { ty: for<'a, 'b> fn(&'a mut [u16; 13], &'b mut [u16; 13]) {std::mem::swap::<[u16; 13]>}, val: Value(<ZST>) }
+    }
+
+    bb1: {
+        return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/pre-codegen/mem_swap.mem_swap_generic.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.mem_swap_generic.PreCodegen.after.mir
@@ -4,15 +4,152 @@ fn mem_swap_generic(_1: &mut T, _2: &mut T) -> () {
     debug a => _1;                       // in scope 0 at $DIR/mem_swap.rs:+0:28: +0:29
     debug b => _2;                       // in scope 0 at $DIR/mem_swap.rs:+0:39: +0:40
     let mut _0: ();                      // return place in scope 0 at $DIR/mem_swap.rs:+0:50: +0:50
+    scope 1 (inlined std::mem::swap::<T>) { // at $DIR/mem_swap.rs:9:5: 9:25
+        debug x => _1;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        debug y => _2;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _3: bool;                // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _4: usize;               // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _5: usize;               // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _6: usize;               // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _7: bool;                // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _8: *mut T;              // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        let mut _9: *mut T;              // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        scope 2 {
+        }
+        scope 3 (inlined std::mem::size_of::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 4 (inlined align_of::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 5 (inlined mem::swap_simple::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug x => _1;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug y => _2;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _11: *const T;       // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _13: *const T;       // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _14: *mut T;         // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _15: *mut T;         // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            scope 6 {
+                let _10: T;              // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                scope 7 {
+                    debug a => _10;      // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    let _12: T;          // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 8 {
+                        debug b => _12;  // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        scope 15 (inlined std::ptr::write::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _14; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _12; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _18: *mut T; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 16 {
+                                scope 17 (inlined std::ptr::write::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _18; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                        scope 18 (inlined std::ptr::write::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _15; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _10; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _19: *mut T; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 19 {
+                                scope 20 (inlined std::ptr::write::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _19; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                    scope 12 (inlined std::ptr::read::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        debug src => _13; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        let mut _17: *const T; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 13 {
+                            scope 14 (inlined std::ptr::read::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug src => _17; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            }
+                        }
+                    }
+                }
+                scope 9 (inlined std::ptr::read::<T>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    debug src => _11;    // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                    let mut _16: *const T; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    scope 10 {
+                        scope 11 (inlined std::ptr::read::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug src => _16; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     bb0: {
-        _0 = std::mem::swap::<T>(_1, _2) -> bb1; // scope 0 at $DIR/mem_swap.rs:+1:5: +1:25
-                                         // mir::Constant
-                                         // + span: $DIR/mem_swap.rs:9:5: 9:19
-                                         // + literal: Const { ty: for<'a, 'b> fn(&'a mut T, &'b mut T) {std::mem::swap::<T>}, val: Value(<ZST>) }
+        StorageLive(_3);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _5 = SizeOf(T);                  // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _6 = AlignOf(T);                 // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _7 = Eq(_6, const 0_usize);      // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        assert(!move _7, "attempt to divide `{}` by zero", _5) -> bb2; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
     }
 
     bb1: {
         return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
+    }
+
+    bb2: {
+        _4 = Div(move _5, move _6);      // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _3 = Gt(move _4, const 4_usize); // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        switchInt(move _3) -> [0: bb5, otherwise: bb3]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+    }
+
+    bb3: {
+        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _8 = &raw mut (*_1);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _9 = &raw mut (*_2);             // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _0 = swap_nonoverlapping::<T>(move _8, move _9, const 1_usize) -> bb4; // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                                         // + literal: Const { ty: unsafe fn(*mut T, *mut T, usize) {swap_nonoverlapping::<T>}, val: Value(<ZST>) }
+    }
+
+    bb4: {
+        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+    }
+
+    bb5: {
+        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_10);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_12);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _11 = &raw const (*_1);          // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_16);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _10 = (*_11);                    // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_16);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_13);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _13 = &raw const (*_2);          // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_17);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _12 = (*_13);                    // scope 13 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_17);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_13);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_14);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _14 = &raw mut (*_1);            // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_18);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_14) = move _12;               // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_18);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_14);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_15);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _15 = &raw mut (*_2);            // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_19);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_15) = move _10;               // scope 19 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_19);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_15);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_12);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_10);                // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
     }
 }

--- a/tests/mir-opt/pre-codegen/mem_swap.mem_swap_generic.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.mem_swap_generic.PreCodegen.after.mir
@@ -1,0 +1,18 @@
+// MIR for `mem_swap_generic` after PreCodegen
+
+fn mem_swap_generic(_1: &mut T, _2: &mut T) -> () {
+    debug a => _1;                       // in scope 0 at $DIR/mem_swap.rs:+0:28: +0:29
+    debug b => _2;                       // in scope 0 at $DIR/mem_swap.rs:+0:39: +0:40
+    let mut _0: ();                      // return place in scope 0 at $DIR/mem_swap.rs:+0:50: +0:50
+
+    bb0: {
+        _0 = std::mem::swap::<T>(_1, _2) -> bb1; // scope 0 at $DIR/mem_swap.rs:+1:5: +1:25
+                                         // mir::Constant
+                                         // + span: $DIR/mem_swap.rs:9:5: 9:19
+                                         // + literal: Const { ty: for<'a, 'b> fn(&'a mut T, &'b mut T) {std::mem::swap::<T>}, val: Value(<ZST>) }
+    }
+
+    bb1: {
+        return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/pre-codegen/mem_swap.mem_swap_simple.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.mem_swap_simple.PreCodegen.after.mir
@@ -4,15 +4,102 @@ fn mem_swap_simple(_1: &mut u32, _2: &mut u32) -> () {
     debug a => _1;                       // in scope 0 at $DIR/mem_swap.rs:+0:24: +0:25
     debug b => _2;                       // in scope 0 at $DIR/mem_swap.rs:+0:37: +0:38
     let mut _0: ();                      // return place in scope 0 at $DIR/mem_swap.rs:+0:50: +0:50
-
-    bb0: {
-        _0 = std::mem::swap::<u32>(_1, _2) -> bb1; // scope 0 at $DIR/mem_swap.rs:+1:5: +1:25
-                                         // mir::Constant
-                                         // + span: $DIR/mem_swap.rs:14:5: 14:19
-                                         // + literal: Const { ty: for<'a, 'b> fn(&'a mut u32, &'b mut u32) {std::mem::swap::<u32>}, val: Value(<ZST>) }
+    scope 1 (inlined std::mem::swap::<u32>) { // at $DIR/mem_swap.rs:14:5: 14:25
+        debug x => _1;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        debug y => _2;                   // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        scope 2 {
+        }
+        scope 3 (inlined std::mem::size_of::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 4 (inlined align_of::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        }
+        scope 5 (inlined mem::swap_simple::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug x => _1;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            debug y => _2;               // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _4: *const u32;      // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _6: *const u32;      // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _7: *mut u32;        // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            let mut _8: *mut u32;        // in scope 5 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+            scope 6 {
+                let _3: u32;             // in scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                scope 7 {
+                    debug a => _3;       // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    let _5: u32;         // in scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    scope 8 {
+                        debug b => _5;   // in scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        scope 15 (inlined std::ptr::write::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _7; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _5; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _11: *mut u32; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 16 {
+                                scope 17 (inlined std::ptr::write::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _11; // in scope 17 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                        scope 18 (inlined std::ptr::write::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                            debug dst => _8; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            debug src => _3; // in scope 18 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                            let mut _12: *mut u32; // in scope 18 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            scope 19 {
+                                scope 20 (inlined std::ptr::write::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug dst => _12; // in scope 20 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                }
+                            }
+                        }
+                    }
+                    scope 12 (inlined std::ptr::read::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                        debug src => _6; // in scope 12 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        let mut _10: *const u32; // in scope 12 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        scope 13 {
+                            scope 14 (inlined std::ptr::read::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug src => _10; // in scope 14 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            }
+                        }
+                    }
+                }
+                scope 9 (inlined std::ptr::read::<u32>) { // at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                    debug src => _4;     // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                    let mut _9: *const u32; // in scope 9 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    scope 10 {
+                        scope 11 (inlined std::ptr::read::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug src => _9; // in scope 11 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                        }
+                    }
+                }
+            }
+        }
     }
 
-    bb1: {
+    bb0: {
+        StorageLive(_3);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_4);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _4 = &raw const (*_1);           // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _3 = (*_4);                      // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_4);                 // scope 6 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _6 = &raw const (*_2);           // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_10);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _5 = (*_6);                      // scope 13 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_10);                // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_6);                 // scope 7 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_7);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _7 = &raw mut (*_1);             // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_11);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_7) = move _5;                 // scope 16 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_11);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_7);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_8);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        _8 = &raw mut (*_2);             // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageLive(_12);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        (*_8) = move _3;                 // scope 19 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_12);                // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 8 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
         return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
     }
 }

--- a/tests/mir-opt/pre-codegen/mem_swap.mem_swap_simple.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_swap.mem_swap_simple.PreCodegen.after.mir
@@ -1,0 +1,18 @@
+// MIR for `mem_swap_simple` after PreCodegen
+
+fn mem_swap_simple(_1: &mut u32, _2: &mut u32) -> () {
+    debug a => _1;                       // in scope 0 at $DIR/mem_swap.rs:+0:24: +0:25
+    debug b => _2;                       // in scope 0 at $DIR/mem_swap.rs:+0:37: +0:38
+    let mut _0: ();                      // return place in scope 0 at $DIR/mem_swap.rs:+0:50: +0:50
+
+    bb0: {
+        _0 = std::mem::swap::<u32>(_1, _2) -> bb1; // scope 0 at $DIR/mem_swap.rs:+1:5: +1:25
+                                         // mir::Constant
+                                         // + span: $DIR/mem_swap.rs:14:5: 14:19
+                                         // + literal: Const { ty: for<'a, 'b> fn(&'a mut u32, &'b mut u32) {std::mem::swap::<u32>}, val: Value(<ZST>) }
+    }
+
+    bb1: {
+        return;                          // scope 0 at $DIR/mem_swap.rs:+2:2: +2:2
+    }
+}

--- a/tests/mir-opt/pre-codegen/mem_swap.rs
+++ b/tests/mir-opt/pre-codegen/mem_swap.rs
@@ -1,0 +1,20 @@
+// compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
+// only-64bit
+// ignore-debug
+
+#![crate_type = "lib"]
+
+// EMIT_MIR mem_swap.mem_swap_generic.PreCodegen.after.mir
+pub fn mem_swap_generic<T>(a: &mut T, b: &mut T) {
+    std::mem::swap(a, b)
+}
+
+// EMIT_MIR mem_swap.mem_swap_simple.PreCodegen.after.mir
+pub fn mem_swap_simple(a: &mut u32, b: &mut u32) {
+    std::mem::swap(a, b)
+}
+
+// EMIT_MIR mem_swap.mem_swap_complex.PreCodegen.after.mir
+pub fn mem_swap_complex(a: &mut [u16; 13], b: &mut [u16; 13]) {
+    std::mem::swap(a, b)
+}

--- a/tests/mir-opt/pre-codegen/slice_index.slice_index_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_index_range.PreCodegen.after.mir
@@ -7,20 +7,185 @@ fn slice_index_range(_1: &[u32], _2: std::ops::Range<usize>) -> &[u32] {
     scope 1 (inlined #[track_caller] core::slice::index::<impl Index<std::ops::Range<usize>> for [u32]>::index) { // at $DIR/slice_index.rs:21:6: 21:18
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         debug index => _2;               // in scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        let _3: &[u32];                  // in scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        scope 2 (inlined #[track_caller] <std::ops::Range<usize> as SliceIndex<[u32]>>::index) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            debug self => _2;            // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            debug slice => _1;           // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _3: bool;            // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _4: usize;           // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _5: usize;           // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let _6: !;                   // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _7: usize;           // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _8: usize;           // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _9: bool;            // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _10: usize;          // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _11: usize;          // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let _12: !;                  // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _13: usize;          // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _14: usize;          // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let _15: *const [u32];       // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _16: *const [u32];   // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            scope 3 {
+                scope 4 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    debug self => _2;    // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    debug slice => _16;  // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let _17: std::ops::Range<usize>; // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _19: usize;  // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _20: usize;  // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _21: *const u32; // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _22: *const u32; // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _23: usize;  // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _24: usize;  // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _25: std::ops::Range<usize>; // in scope 4 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    let mut _26: *const [u32]; // in scope 4 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                    scope 5 {
+                        debug this => _17; // in scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                        scope 6 {
+                            let _18: usize; // in scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                            scope 7 {
+                                debug new_len => _18; // in scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                scope 12 (inlined ptr::const_ptr::<impl *const [u32]>::as_ptr) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                    debug self => _16; // in scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                }
+                                scope 13 (inlined ptr::const_ptr::<impl *const u32>::add) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                    debug self => _22; // in scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    debug count => _23; // in scope 13 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    scope 14 {
+                                    }
+                                }
+                                scope 15 (inlined slice_from_raw_parts::<u32>) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                    debug data => _21; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    debug len => _24; // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    let mut _27: *const (); // in scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                    scope 16 (inlined ptr::const_ptr::<impl *const u32>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                        debug self => _21; // in scope 16 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    }
+                                    scope 17 (inlined std::ptr::from_raw_parts::<[u32]>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                        debug data_address => _27; // in scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                        debug metadata => _24; // in scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                        let mut _28: std::ptr::metadata::PtrRepr<[u32]>; // in scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                        let mut _29: std::ptr::metadata::PtrComponents<[u32]>; // in scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                        scope 18 {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 8 (inlined <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug this => _25; // in scope 8 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                debug slice => _26; // in scope 8 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                scope 9 (inlined ptr::const_ptr::<impl *const [u32]>::len) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                    debug self => _26; // in scope 9 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                    scope 10 (inlined std::ptr::metadata::<[u32]>) { // at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                                        debug ptr => _26; // in scope 10 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                        scope 11 {
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _3 = <std::ops::Range<usize> as SliceIndex<[u32]>>::index(move _2, _1) -> bb1; // scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/slice/index.rs:LL:COL
-                                         // + literal: Const { ty: for<'a> fn(std::ops::Range<usize>, &'a [u32]) -> &'a <std::ops::Range<usize> as SliceIndex<[u32]>>::Output {<std::ops::Range<usize> as SliceIndex<[u32]>>::index}, val: Value(<ZST>) }
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _4 = (_2.0: usize);              // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _5 = (_2.1: usize);              // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _3 = Gt(move _4, move _5);       // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
     }
 
     bb1: {
-        _0 = _3;                         // scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_7);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _7 = (_2.0: usize);              // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _8 = (_2.1: usize);              // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _6 = core::slice::index::slice_index_order_fail(move _7, move _8); // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // + literal: Const { ty: fn(usize, usize) -> ! {core::slice::index::slice_index_order_fail}, val: Value(<ZST>) }
+    }
+
+    bb2: {
+        StorageLive(_9);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_10);                // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _10 = (_2.1: usize);             // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_11);                // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _11 = Len((*_1));                // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _9 = Gt(move _10, move _11);     // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_11);                // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_10);                // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        switchInt(move _9) -> [0: bb4, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+    }
+
+    bb3: {
+        StorageLive(_13);                // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _13 = (_2.1: usize);             // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_14);                // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _14 = Len((*_1));                // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _12 = core::slice::index::slice_end_index_len_fail(move _13, move _14); // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // + literal: Const { ty: fn(usize, usize) -> ! {core::slice::index::slice_end_index_len_fail}, val: Value(<ZST>) }
+    }
+
+    bb4: {
+        StorageDead(_9);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_15);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_16);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _16 = &raw const (*_1);          // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_17);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_25);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_26);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_18);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_19);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _19 = (_2.1: usize);             // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_20);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _20 = (_2.0: usize);             // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _18 = unchecked_sub::<usize>(move _19, move _20) -> [return: bb5, unwind unreachable]; // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/slice/index.rs:LL:COL
+                                         // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(usize, usize) -> usize {unchecked_sub::<usize>}, val: Value(<ZST>) }
+    }
+
+    bb5: {
+        StorageDead(_20);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_19);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_21);                // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_22);                // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _22 = _16 as *const u32 (PtrToPtr); // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_23);                // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _23 = (_2.0: usize);             // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _21 = Offset(_22, _23);          // scope 14 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_23);                // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_22);                // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_24);                // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _24 = _18;                       // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_27);                // scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _27 = _21 as *const () (PtrToPtr); // scope 16 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageLive(_28);                // scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_29);                // scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _29 = ptr::metadata::PtrComponents::<[u32]> { data_address: _27, metadata: _24 }; // scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _28 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _29 }; // scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_29);                // scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _15 = (_28.0: *const [u32]);     // scope 18 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_28);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_27);                // scope 15 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_24);                // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_21);                // scope 7 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_18);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_26);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_25);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_17);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_16);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _0 = &(*_15);                    // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_15);                // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         return;                          // scope 0 at $DIR/slice_index.rs:+2:2: +2:2
     }
 }


### PR DESCRIPTION
Like how `StorageDead`/`StorageLive` were already considered "zero cost" when considering inlining, this attempts to better assign costs reflecting what work will actually need to be done, making some things more expensive and some things cheaper.

For example,
```rust
*_1 = (*_2) * (*_3)
```
is now 4 times ***more*** expensive than it used to be, to account for the derefs.

However
```rust
_4 = _2
_5 = _3
_6 = _4 * _5
_0 = _6
```
becomes 4 times ***less*** expensive than it used to be, since those copies are likely going to be uninteresting at codegen time.

Roughly, instead of the previous approach of attributing costs to `Statement`s, this change attributes costs to `Deref` projections and `Rvalue`s instead.  (Since the cost visitor was already walking all the way through the MIR down to the projection elements, I'm hoping that this won't actually be materially more expensive.)

That way it can know that things like `*mut T` to `*const T` casts should be considered free, since they're not going to actually *do* anything.

As an example of the impact, this adds a MIR pre-codegen test for `mem::swap`, as that previously wasn't inlined even for simple types like `u32` because it has a bunch of reference-to-pointer conversions and makes sizeof/alignof calls, all of which added up to a cost too high to inline despite them actually being trivial.

Draft while I see if perf says this is terrible,
r? @ghost 