### PR TITLE
Create definitions for promoted constants.

### DIFF
--- a/compiler/rustc_borrowck/src/consumers.rs
+++ b/compiler/rustc_borrowck/src/consumers.rs
@@ -3,7 +3,6 @@
 //! This file provides API for compiler consumers.
 
 use rustc_hir::def_id::LocalDefId;
-use rustc_index::IndexSlice;
 use rustc_infer::infer::{DefiningAnchor, TyCtxtInferExt};
 use rustc_middle::mir::Body;
 use rustc_middle::ty::TyCtxt;
@@ -29,9 +28,8 @@ pub use super::{
 ///
 /// *   Polonius is highly unstable, so expect regular changes in its signature or other details.
 pub fn get_body_with_borrowck_facts(tcx: TyCtxt<'_>, def: LocalDefId) -> BodyWithBorrowckFacts<'_> {
-    let (input_body, promoted) = tcx.mir_promoted(def);
+    let (input_body, _) = tcx.mir_promoted(def);
     let infcx = tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bind(def)).build();
     let input_body: &Body<'_> = &input_body.borrow();
-    let promoted: &IndexSlice<_, _> = &promoted.borrow();
-    *super::do_mir_borrowck(&infcx, input_body, promoted, true).1.unwrap()
+    *super::do_mir_borrowck(&infcx, input_body, true).1.unwrap()
 }

--- a/compiler/rustc_borrowck/src/invalidation.rs
+++ b/compiler/rustc_borrowck/src/invalidation.rs
@@ -351,7 +351,6 @@ impl<'cx, 'tcx> InvalidationGenerator<'cx, 'tcx> {
         let tcx = self.tcx;
         let body = self.body;
         let borrow_set = self.borrow_set;
-        let indices = self.borrow_set.indices();
         each_borrow_involving_path(
             self,
             tcx,
@@ -359,7 +358,7 @@ impl<'cx, 'tcx> InvalidationGenerator<'cx, 'tcx> {
             location,
             (sd, place),
             borrow_set,
-            indices,
+            |_| true,
             |this, borrow_index, borrow| {
                 match (rw, borrow.kind) {
                     // Obviously an activation is compatible with its own

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -118,7 +118,7 @@ pub fn provide(providers: &mut Providers) {
 
 fn mir_borrowck(tcx: TyCtxt<'_>, def: LocalDefId) -> &BorrowCheckResult<'_> {
     let (input_body, _) = tcx.mir_promoted(def);
-    debug!("run query mir_borrowck: {}", tcx.def_path_str(def));
+    debug!("run query mir_borrowck: {def:?}");
 
     if input_body.borrow().should_skip() {
         debug!("Skipping borrowck because of injected body");
@@ -137,7 +137,7 @@ fn mir_borrowck(tcx: TyCtxt<'_>, def: LocalDefId) -> &BorrowCheckResult<'_> {
         tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bind(typeck_root)).build();
     let input_body: &Body<'_> = &input_body.borrow();
     let opt_closure_req = do_mir_borrowck(&infcx, input_body, false).0;
-    debug!("mir_borrowck done");
+    debug!("mir_borrowck done: {def:?}");
 
     tcx.arena.alloc(opt_closure_req)
 }

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -23,7 +23,7 @@ use rustc_errors::{Diagnostic, DiagnosticBuilder, DiagnosticMessage, Subdiagnost
 use rustc_fluent_macro::fluent_messages;
 use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
-use rustc_index::bit_set::ChunkedBitSet;
+use rustc_index::bit_set::{BitSet, ChunkedBitSet};
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_infer::infer::{
     DefiningAnchor, InferCtxt, NllRegionVariableOrigin, RegionVariableOrigin, TyCtxtInferExt,
@@ -41,7 +41,6 @@ use rustc_session::lint::builtin::UNUSED_MUT;
 use rustc_span::{Span, Symbol};
 use rustc_target::abi::FieldIdx;
 
-use either::Either;
 use smallvec::SmallVec;
 use std::cell::OnceCell;
 use std::cell::RefCell;
@@ -1049,12 +1048,16 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let borrow_set = self.borrow_set.clone();
 
         // Use polonius output if it has been enabled.
-        let polonius_output = self.polonius_output.clone();
-        let borrows_in_scope = if let Some(polonius) = &polonius_output {
+        let mut polonius_output;
+        let borrows_in_scope = if let Some(polonius) = &self.polonius_output {
             let location = self.location_table.start_index(location);
-            Either::Left(polonius.errors_at(location).iter().copied())
+            polonius_output = BitSet::new_empty(borrow_set.len());
+            for &idx in polonius.errors_at(location) {
+                polonius_output.insert(idx);
+            }
+            &polonius_output
         } else {
-            Either::Right(flow_state.borrows.iter())
+            &flow_state.borrows
         };
 
         each_borrow_involving_path(
@@ -1064,7 +1067,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             location,
             (sd, place_span.0),
             &borrow_set,
-            borrows_in_scope,
+            |borrow_index| borrows_in_scope.contains(borrow_index),
             |this, borrow_index, borrow| match (rw, borrow.kind) {
                 // Obviously an activation is compatible with its own
                 // reservation (or even prior activating uses of same

--- a/compiler/rustc_borrowck/src/places_conflict.rs
+++ b/compiler/rustc_borrowck/src/places_conflict.rs
@@ -1,3 +1,45 @@
+//! The borrowck rules for proving disjointness are applied from the "root" of the
+//! borrow forwards, iterating over "similar" projections in lockstep until
+//! we can prove overlap one way or another. Essentially, we treat `Overlap` as
+//! a monoid and report a conflict if the product ends up not being `Disjoint`.
+//!
+//! At each step, if we didn't run out of borrow or place, we know that our elements
+//! have the same type, and that they only overlap if they are the identical.
+//!
+//! For example, if we are comparing these:
+//! BORROW:  (*x1[2].y).z.a
+//! ACCESS:  (*x1[i].y).w.b
+//!
+//! Then our steps are:
+//!       x1         |   x1          -- places are the same
+//!       x1[2]      |   x1[i]       -- equal or disjoint (disjoint if indexes differ)
+//!       x1[2].y    |   x1[i].y     -- equal or disjoint
+//!      *x1[2].y    |  *x1[i].y     -- equal or disjoint
+//!     (*x1[2].y).z | (*x1[i].y).w  -- we are disjoint and don't need to check more!
+//!
+//! Because `zip` does potentially bad things to the iterator inside, this loop
+//! also handles the case where the access might be a *prefix* of the borrow, e.g.
+//!
+//! BORROW:  (*x1[2].y).z.a
+//! ACCESS:  x1[i].y
+//!
+//! Then our steps are:
+//!       x1         |   x1          -- places are the same
+//!       x1[2]      |   x1[i]       -- equal or disjoint (disjoint if indexes differ)
+//!       x1[2].y    |   x1[i].y     -- equal or disjoint
+//!
+//! -- here we run out of access - the borrow can access a part of it. If this
+//! is a full deep access, then we *know* the borrow conflicts with it. However,
+//! if the access is shallow, then we can proceed:
+//!
+//!       x1[2].y    | (*x1[i].y)    -- a deref! the access can't get past this, so we
+//!                                     are disjoint
+//!
+//! Our invariant is, that at each step of the iteration:
+//!  - If we didn't run out of access to match, our borrow and access are comparable
+//!    and either equal or disjoint.
+//!  - If we did run out of access, the borrow can access a part of it.
+
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
 use crate::ArtificialField;
@@ -46,7 +88,7 @@ pub(crate) fn places_conflict<'tcx>(
 /// access depth. The `bias` parameter is used to determine how the unknowable (comparing runtime
 /// array indices, for example) should be interpreted - this depends on what the caller wants in
 /// order to make the conservative choice and preserve soundness.
-#[instrument(level = "debug", skip(tcx, body))]
+#[inline]
 pub(super) fn borrow_conflicts_with_place<'tcx>(
     tcx: TyCtxt<'tcx>,
     body: &Body<'tcx>,
@@ -56,15 +98,24 @@ pub(super) fn borrow_conflicts_with_place<'tcx>(
     access: AccessDepth,
     bias: PlaceConflictBias,
 ) -> bool {
+    let borrow_local = borrow_place.local;
+    let access_local = access_place.local;
+
+    if borrow_local != access_local {
+        // We have proven the borrow disjoint - further projections will remain disjoint.
+        return false;
+    }
+
     // This Local/Local case is handled by the more general code below, but
     // it's so common that it's a speed win to check for it first.
-    if let Some(l1) = borrow_place.as_local() && let Some(l2) = access_place.as_local() {
-        return l1 == l2;
+    if borrow_place.projection.is_empty() && access_place.projection.is_empty() {
+        return true;
     }
 
     place_components_conflict(tcx, body, borrow_place, borrow_kind, access_place, access, bias)
 }
 
+#[instrument(level = "debug", skip(tcx, body))]
 fn place_components_conflict<'tcx>(
     tcx: TyCtxt<'tcx>,
     body: &Body<'tcx>,
@@ -74,65 +125,10 @@ fn place_components_conflict<'tcx>(
     access: AccessDepth,
     bias: PlaceConflictBias,
 ) -> bool {
-    // The borrowck rules for proving disjointness are applied from the "root" of the
-    // borrow forwards, iterating over "similar" projections in lockstep until
-    // we can prove overlap one way or another. Essentially, we treat `Overlap` as
-    // a monoid and report a conflict if the product ends up not being `Disjoint`.
-    //
-    // At each step, if we didn't run out of borrow or place, we know that our elements
-    // have the same type, and that they only overlap if they are the identical.
-    //
-    // For example, if we are comparing these:
-    // BORROW:  (*x1[2].y).z.a
-    // ACCESS:  (*x1[i].y).w.b
-    //
-    // Then our steps are:
-    //       x1         |   x1          -- places are the same
-    //       x1[2]      |   x1[i]       -- equal or disjoint (disjoint if indexes differ)
-    //       x1[2].y    |   x1[i].y     -- equal or disjoint
-    //      *x1[2].y    |  *x1[i].y     -- equal or disjoint
-    //     (*x1[2].y).z | (*x1[i].y).w  -- we are disjoint and don't need to check more!
-    //
-    // Because `zip` does potentially bad things to the iterator inside, this loop
-    // also handles the case where the access might be a *prefix* of the borrow, e.g.
-    //
-    // BORROW:  (*x1[2].y).z.a
-    // ACCESS:  x1[i].y
-    //
-    // Then our steps are:
-    //       x1         |   x1          -- places are the same
-    //       x1[2]      |   x1[i]       -- equal or disjoint (disjoint if indexes differ)
-    //       x1[2].y    |   x1[i].y     -- equal or disjoint
-    //
-    // -- here we run out of access - the borrow can access a part of it. If this
-    // is a full deep access, then we *know* the borrow conflicts with it. However,
-    // if the access is shallow, then we can proceed:
-    //
-    //       x1[2].y    | (*x1[i].y)    -- a deref! the access can't get past this, so we
-    //                                     are disjoint
-    //
-    // Our invariant is, that at each step of the iteration:
-    //  - If we didn't run out of access to match, our borrow and access are comparable
-    //    and either equal or disjoint.
-    //  - If we did run out of access, the borrow can access a part of it.
-
     let borrow_local = borrow_place.local;
     let access_local = access_place.local;
-
-    match place_base_conflict(borrow_local, access_local) {
-        Overlap::Arbitrary => {
-            bug!("Two base can't return Arbitrary");
-        }
-        Overlap::EqualOrDisjoint => {
-            // This is the recursive case - proceed to the next element.
-        }
-        Overlap::Disjoint => {
-            // We have proven the borrow disjoint - further
-            // projections will remain disjoint.
-            debug!("borrow_conflicts_with_place: disjoint");
-            return false;
-        }
-    }
+    // borrow_conflicts_with_place should have checked that.
+    assert_eq!(borrow_local, access_local);
 
     // loop invariant: borrow_c is always either equal to access_c or disjoint from it.
     for (i, (borrow_c, &access_c)) in
@@ -284,21 +280,6 @@ fn place_components_conflict<'tcx>(
     } else {
         debug!("borrow_conflicts_with_place: full borrow, CONFLICT");
         true
-    }
-}
-
-// Given that the bases of `elem1` and `elem2` are always either equal
-// or disjoint (and have the same type!), return the overlap situation
-// between `elem1` and `elem2`.
-fn place_base_conflict(l1: Local, l2: Local) -> Overlap {
-    if l1 == l2 {
-        // the same local - base case, equal
-        debug!("place_element_conflict: DISJOINT-OR-EQ-LOCAL");
-        Overlap::EqualOrDisjoint
-    } else {
-        // different locals - base case, disjoint
-        debug!("place_element_conflict: DISJOINT-LOCAL");
-        Overlap::Disjoint
     }
 }
 

--- a/compiler/rustc_borrowck/src/places_conflict.rs
+++ b/compiler/rustc_borrowck/src/places_conflict.rs
@@ -7,33 +7,43 @@
 //! have the same type, and that they only overlap if they are the identical.
 //!
 //! For example, if we are comparing these:
+//! ```text
 //! BORROW:  (*x1[2].y).z.a
 //! ACCESS:  (*x1[i].y).w.b
+//! ```
 //!
 //! Then our steps are:
+//! ```text
 //!       x1         |   x1          -- places are the same
 //!       x1[2]      |   x1[i]       -- equal or disjoint (disjoint if indexes differ)
 //!       x1[2].y    |   x1[i].y     -- equal or disjoint
 //!      *x1[2].y    |  *x1[i].y     -- equal or disjoint
 //!     (*x1[2].y).z | (*x1[i].y).w  -- we are disjoint and don't need to check more!
+//! ```
 //!
 //! Because `zip` does potentially bad things to the iterator inside, this loop
 //! also handles the case where the access might be a *prefix* of the borrow, e.g.
 //!
+//! ```text
 //! BORROW:  (*x1[2].y).z.a
 //! ACCESS:  x1[i].y
+//! ```
 //!
 //! Then our steps are:
+//! ```text
 //!       x1         |   x1          -- places are the same
 //!       x1[2]      |   x1[i]       -- equal or disjoint (disjoint if indexes differ)
 //!       x1[2].y    |   x1[i].y     -- equal or disjoint
+//! ```
 //!
 //! -- here we run out of access - the borrow can access a part of it. If this
 //! is a full deep access, then we *know* the borrow conflicts with it. However,
 //! if the access is shallow, then we can proceed:
 //!
+//! ```text
 //!       x1[2].y    | (*x1[i].y)    -- a deref! the access can't get past this, so we
 //!                                     are disjoint
+//! ```
 //!
 //! Our invariant is, that at each step of the iteration:
 //!  - If we didn't run out of access to match, our borrow and access are comparable

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -246,9 +246,10 @@ pub enum ExtraConstraintInfo {
 }
 
 #[instrument(skip(infcx, sccs), level = "debug")]
+#[inline(never)] // This is a debugging tool, we need to discard it from profiles.
 fn sccs_info<'cx, 'tcx>(
     infcx: &'cx BorrowckInferCtxt<'cx, 'tcx>,
-    sccs: Rc<Sccs<RegionVid, ConstraintSccIndex>>,
+    sccs: &Sccs<RegionVid, ConstraintSccIndex>,
 ) {
     use crate::renumber::RegionCtxt;
 
@@ -348,7 +349,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let constraint_sccs = Rc::new(constraints.compute_sccs(&constraint_graph, fr_static));
 
         if cfg!(debug_assertions) {
-            sccs_info(_infcx, constraint_sccs.clone());
+            sccs_info(_infcx, &*constraint_sccs);
         }
 
         let mut scc_values =

--- a/compiler/rustc_borrowck/src/renumber.rs
+++ b/compiler/rustc_borrowck/src/renumber.rs
@@ -1,32 +1,21 @@
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
+
 use crate::BorrowckInferCtxt;
-use rustc_index::IndexSlice;
 use rustc_infer::infer::NllRegionVariableOrigin;
 use rustc_middle::mir::visit::{MutVisitor, TyContext};
 use rustc_middle::mir::Constant;
-use rustc_middle::mir::{Body, Location, Promoted};
+use rustc_middle::mir::{Body, Location};
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable};
 use rustc_span::{Span, Symbol};
 
 /// Replaces all free regions appearing in the MIR with fresh
 /// inference variables, returning the number of variables created.
-#[instrument(skip(infcx, body, promoted), level = "debug")]
-pub fn renumber_mir<'tcx>(
-    infcx: &BorrowckInferCtxt<'_, 'tcx>,
-    body: &mut Body<'tcx>,
-    promoted: &mut IndexSlice<Promoted, Body<'tcx>>,
-) {
+#[instrument(skip(infcx, body), level = "debug")]
+pub fn renumber_mir<'tcx>(infcx: &BorrowckInferCtxt<'_, 'tcx>, body: &mut Body<'tcx>) {
     debug!(?body.arg_count);
-
-    let mut renumberer = RegionRenumberer { infcx };
-
-    for body in promoted.iter_mut() {
-        renumberer.visit_body(body);
-    }
-
-    renumberer.visit_body(body);
+    RegionRenumberer { infcx }.visit_body(body);
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -948,6 +948,16 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
     /// Equate the inferred type and the annotated type for user type annotations
     #[instrument(skip(self), level = "debug")]
     fn check_user_type_annotations(&mut self) {
+        // Promoted clone the `user_type_annotations` from their original body, because some
+        // statements may refer to them. However, we don't want to apply the other type annotations
+        // while checking the promoted: that would create spurious constraints that we won't be
+        // able to verify. Instead, the annotations are checked on-demand before relating to the
+        // actual type in MIR.
+        if let DefKind::Promoted = self.tcx().def_kind(self.body.source.def_id()) {
+            debug!("promoted: skipping user type annotations");
+            return;
+        }
+
         debug!(?self.user_type_annotations);
         for user_annotation in self.user_type_annotations {
             let CanonicalUserTypeAnnotation { span, ref user_ty, inferred_ty } = *user_annotation;
@@ -1012,12 +1022,23 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         locations: Locations,
         category: ConstraintCategory<'tcx>,
     ) -> Fallible<()> {
-        let annotated_type = self.user_type_annotations[user_ty.base].inferred_ty;
+        let CanonicalUserTypeAnnotation {
+            span,
+            user_ty: ref canonical_user_ty,
+            inferred_ty: annotated_type,
+        } = self.user_type_annotations[user_ty.base];
         trace!(?annotated_type);
-        let mut curr_projected_ty = PlaceTy::from_ty(annotated_type);
+
+        // We may have skipped checking the canonical annotation earlier, so do it now.
+        if let DefKind::Promoted = self.tcx().def_kind(self.body.source.def_id()) {
+            let annotation =
+                self.instantiate_canonical_with_fresh_inference_vars(span, canonical_user_ty);
+            self.ascribe_user_type(annotated_type, annotation, span);
+        }
 
         let tcx = self.infcx.tcx;
 
+        let mut curr_projected_ty = PlaceTy::from_ty(annotated_type);
         for proj in &user_ty.projs {
             if let ty::Alias(ty::Opaque, ..) = curr_projected_ty.ty.kind() {
                 // There is nothing that we can compare here if we go through an opaque type.

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -441,7 +441,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         }
 
         // This is a const fn. Call it.
-        Ok(Some((ecx.load_mir(instance.def, None)?, instance)))
+        Ok(Some((ecx.load_mir(instance.def)?, instance)))
     }
 
     fn call_intrinsic(

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -458,15 +458,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     pub fn load_mir(
         &self,
         instance: ty::InstanceDef<'tcx>,
-        promoted: Option<mir::Promoted>,
     ) -> InterpResult<'tcx, &'tcx mir::Body<'tcx>> {
-        trace!("load mir(instance={:?}, promoted={:?})", instance, promoted);
-        let body = if let Some(promoted) = promoted {
-            let def = instance.def_id();
-            &self.tcx.promoted_mir(def)[promoted]
-        } else {
-            M::load_mir(self, instance)?
-        };
+        let body = M::load_mir(self, instance)?;
         // do not continue if typeck errors occurred (can only occur in local crate)
         if let Some(err) = body.tainted_by_errors {
             throw_inval!(AlreadyReported(ReportedErrorInfo::tainted_by_errors(err)));

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -5,9 +5,7 @@
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{
     self,
-    interpret::{
-        Allocation, ConstAllocation, ConstValue, GlobalId, InterpResult, PointerArithmetic, Scalar,
-    },
+    interpret::{Allocation, ConstAllocation, ConstValue, InterpResult, PointerArithmetic, Scalar},
     BinOp, NonDivergingIntrinsic,
 };
 use rustc_middle::ty;
@@ -163,7 +161,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | sym::type_id
             | sym::type_name
             | sym::variant_count => {
-                let gid = GlobalId { instance };
                 let ty = match intrinsic_name {
                     sym::pref_align_of | sym::variant_count => self.tcx.types.usize,
                     sym::needs_drop => self.tcx.types.bool,
@@ -172,7 +169,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     _ => bug!(),
                 };
                 let val = self.ctfe_query(None, |tcx| {
-                    tcx.const_eval_global_id(self.param_env, gid, Some(tcx.span))
+                    tcx.const_eval_global_id(self.param_env, instance, Some(tcx.span))
                 })?;
                 let val = self.const_val_to_op(val, ty, Some(dest.layout))?;
                 self.copy_op(&val, dest, /*allow_transmute*/ false)?;

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -163,7 +163,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | sym::type_id
             | sym::type_name
             | sym::variant_count => {
-                let gid = GlobalId { instance, promoted: None };
+                let gid = GlobalId { instance };
                 let ty = match intrinsic_name {
                     sym::pref_align_of | sym::variant_count => self.tcx.types.usize,
                     sym::needs_drop => self.tcx.types.bool,

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -12,9 +12,9 @@ use rustc_span::Span;
 use rustc_target::abi::{self, Abi, Align, HasDataLayout, Size};
 
 use super::{
-    alloc_range, from_known_layout, mir_assign_valid_types, AllocId, ConstValue, Frame, GlobalId,
-    InterpCx, InterpResult, MPlaceTy, Machine, MemPlace, MemPlaceMeta, Place, PlaceTy, Pointer,
-    Provenance, Scalar,
+    alloc_range, from_known_layout, mir_assign_valid_types, AllocId, ConstValue, Frame, InterpCx,
+    InterpResult, MPlaceTy, Machine, MemPlace, MemPlaceMeta, Place, PlaceTy, Pointer, Provenance,
+    Scalar,
 };
 
 /// An `Immediate` represents a single immediate self-contained Rust value.
@@ -599,9 +599,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
             ty::ConstKind::Unevaluated(uv) => {
                 let instance = self.resolve(uv.def, uv.substs)?;
-                let cid = GlobalId { instance };
                 self.ctfe_query(span, |tcx| {
-                    tcx.eval_to_valtree(self.param_env.with_const().and(cid))
+                    tcx.eval_to_valtree(self.param_env.with_const().and(instance))
                 })?
                 .unwrap_or_else(|| bug!("unable to create ValTree for {uv:?}"))
             }
@@ -628,7 +627,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             mir::ConstantKind::Val(val, ty) => self.const_val_to_op(val, ty, layout),
             mir::ConstantKind::Unevaluated(uv, _) => {
                 let instance = self.resolve(uv.def, uv.substs)?;
-                Ok(self.eval_global(GlobalId { instance }, span)?.into())
+                Ok(self.eval_global(instance, span)?.into())
             }
         }
     }

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -599,7 +599,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
             ty::ConstKind::Unevaluated(uv) => {
                 let instance = self.resolve(uv.def, uv.substs)?;
-                let cid = GlobalId { instance, promoted: None };
+                let cid = GlobalId { instance };
                 self.ctfe_query(span, |tcx| {
                     tcx.eval_to_valtree(self.param_env.with_const().and(cid))
                 })?
@@ -628,7 +628,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             mir::ConstantKind::Val(val, ty) => self.const_val_to_op(val, ty, layout),
             mir::ConstantKind::Unevaluated(uv, _) => {
                 let instance = self.resolve(uv.def, uv.substs)?;
-                Ok(self.eval_global(GlobalId { instance, promoted: uv.promoted }, span)?.into())
+                Ok(self.eval_global(GlobalId { instance }, span)?.into())
             }
         }
     }

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -905,7 +905,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
         feeder.opt_local_def_id_to_hir_id(None);
 
         let def_id = feeder.def_id();
-        self.promoted.source = MirSource::item(def_id.to_def_id());
+        self.promoted.source = ty::InstanceDef::Item(def_id.to_def_id());
         let parent_substs = tcx.erase_regions(InternalSubsts::identity_for_item(
             tcx,
             tcx.typeck_root_def_id(source_def_id.to_def_id()),

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -42,7 +42,7 @@ impl<'tcx> MirPass<'tcx> for Validator {
         // terribly important that they pass the validator. However, I think other passes might
         // still see them, in which case they might be surprised. It would probably be better if we
         // didn't put this through the MIR pipeline at all.
-        if matches!(body.source.instance, InstanceDef::Intrinsic(..) | InstanceDef::Virtual(..)) {
+        if matches!(body.source, InstanceDef::Intrinsic(..) | InstanceDef::Virtual(..)) {
             return;
         }
         let def_id = body.source.def_id();
@@ -74,7 +74,7 @@ impl<'tcx> MirPass<'tcx> for Validator {
         checker.check_cleanup_control_flow();
 
         if let MirPhase::Runtime(_) = body.phase {
-            if let ty::InstanceDef::Item(_) = body.source.instance {
+            if let ty::InstanceDef::Item(_) = body.source {
                 if body.has_free_regions() {
                     checker.fail(
                         Location::START,
@@ -109,7 +109,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             span,
             format!(
                 "broken MIR in {:?} ({}) at {:?}:\n{}",
-                self.body.source.instance,
+                self.body.source,
                 self.when,
                 location,
                 msg.as_ref()
@@ -1104,7 +1104,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 self.body.span,
                 format!(
                     "broken MIR in {:?} ({}):\ninvalid source scope {:?}",
-                    self.body.source.instance, self.when, scope,
+                    self.body.source, self.when, scope,
                 ),
             );
         }

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -121,6 +121,9 @@ pub enum DefKind {
     },
     Closure,
     Generator,
+
+    /// Promoted constant from a MIR body.
+    Promoted,
 }
 
 impl DefKind {
@@ -167,6 +170,7 @@ impl DefKind {
             DefKind::Generator => "generator",
             DefKind::ExternCrate => "extern crate",
             DefKind::GlobalAsm => "global assembly block",
+            DefKind::Promoted => "promoted constant",
         }
     }
 
@@ -227,6 +231,7 @@ impl DefKind {
             | DefKind::Use
             | DefKind::ForeignMod
             | DefKind::GlobalAsm
+            | DefKind::Promoted
             | DefKind::Impl { .. }
             | DefKind::ImplTraitPlaceholder => None,
         }
@@ -271,6 +276,7 @@ impl DefKind {
             | DefKind::AnonConst
             | DefKind::InlineConst
             | DefKind::GlobalAsm
+            | DefKind::Promoted
             | DefKind::ExternCrate => false,
         }
     }

--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -278,6 +278,8 @@ pub enum DefPathData {
     Ctor,
     /// A constant expression (see `{ast,hir}::AnonConst`).
     AnonConst,
+    /// A constant promoted from a MIR body.
+    Promoted,
     /// An `impl Trait` type node.
     ImplTrait,
     /// `impl Trait` generated associated type node.
@@ -405,7 +407,7 @@ impl DefPathData {
             TypeNs(name) | ValueNs(name) | MacroNs(name) | LifetimeNs(name) => Some(name),
 
             Impl | ForeignMod | CrateRoot | Use | GlobalAsm | ClosureExpr | Ctor | AnonConst
-            | ImplTrait | ImplTraitAssocTy => None,
+            | ImplTrait | ImplTraitAssocTy | Promoted => None,
         }
     }
 
@@ -425,6 +427,7 @@ impl DefPathData {
             Ctor => DefPathDataName::Anon { namespace: sym::constructor },
             AnonConst => DefPathDataName::Anon { namespace: sym::constant },
             ImplTrait | ImplTraitAssocTy => DefPathDataName::Anon { namespace: sym::opaque },
+            Promoted => DefPathDataName::Anon { namespace: sym::promoted },
         }
     }
 }

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -62,7 +62,13 @@ pub(super) fn predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredic
 fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::GenericPredicates<'_> {
     use rustc_hir::*;
 
-    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
+    let generics = tcx.generics_of(def_id);
+    let Some(hir_id) = tcx.opt_local_def_id_to_hir_id(def_id) else {
+        return ty::GenericPredicates {
+            parent: generics.parent,
+            predicates: &[],
+        };
+    };
     let node = tcx.hir().get(hir_id);
 
     let mut is_trait = None;
@@ -114,7 +120,6 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
         _ => NO_GENERICS,
     };
 
-    let generics = tcx.generics_of(def_id);
     let parent_count = generics.parent_count as u32;
     let has_own_self = generics.has_self && parent_count == 0;
 

--- a/compiler/rustc_hir_analysis/src/outlives/mod.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/mod.rs
@@ -18,7 +18,9 @@ pub fn provide(providers: &mut Providers) {
 }
 
 fn inferred_outlives_of(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[(ty::Clause<'_>, Span)] {
-    let id = tcx.hir().local_def_id_to_hir_id(item_def_id);
+    let Some(id) = tcx.opt_local_def_id_to_hir_id(item_def_id) else {
+        return &[];
+    };
 
     if matches!(tcx.def_kind(item_def_id), hir::def::DefKind::AnonConst) && tcx.lazy_normalization()
     {

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -219,7 +219,6 @@ provide! { tcx, def_id, other, cdata,
     optimized_mir => { table }
     mir_for_ctfe => { table }
     mir_generator_witnesses => { table }
-    promoted_mir => { table }
     def_span => { table }
     def_ident_span => { table }
     lookup_stability => { table }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -829,6 +829,7 @@ fn should_encode_span(def_kind: DefKind) -> bool {
         | DefKind::AssocConst
         | DefKind::Macro(_)
         | DefKind::ExternCrate
+        | DefKind::Promoted
         | DefKind::Use
         | DefKind::AnonConst
         | DefKind::InlineConst
@@ -876,6 +877,7 @@ fn should_encode_attrs(def_kind: DefKind) -> bool {
         | DefKind::AnonConst
         | DefKind::InlineConst
         | DefKind::OpaqueTy
+        | DefKind::Promoted
         | DefKind::ImplTraitPlaceholder
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
@@ -914,6 +916,7 @@ fn should_encode_expn_that_defined(def_kind: DefKind) -> bool {
         | DefKind::ImplTraitPlaceholder
         | DefKind::Field
         | DefKind::LifetimeParam
+        | DefKind::Promoted
         | DefKind::GlobalAsm
         | DefKind::Closure
         | DefKind::Generator => false,
@@ -953,6 +956,7 @@ fn should_encode_visibility(def_kind: DefKind) -> bool {
         | DefKind::Impl { .. }
         | DefKind::Closure
         | DefKind::Generator
+        | DefKind::Promoted
         | DefKind::ExternCrate => false,
     }
 }
@@ -990,6 +994,7 @@ fn should_encode_stability(def_kind: DefKind) -> bool {
         | DefKind::GlobalAsm
         | DefKind::Closure
         | DefKind::Generator
+        | DefKind::Promoted
         | DefKind::ExternCrate => false,
     }
 }
@@ -1015,6 +1020,7 @@ fn should_encode_mir(tcx: TyCtxt<'_>, def_id: LocalDefId) -> (bool, bool) {
         | DefKind::InlineConst
         | DefKind::AssocConst
         | DefKind::Static(..)
+        | DefKind::Promoted
         | DefKind::Const => (true, false),
         // Full-fledged functions + closures
         DefKind::AssocFn | DefKind::Fn | DefKind::Closure => {
@@ -1068,6 +1074,7 @@ fn should_encode_variances(def_kind: DefKind) -> bool {
         | DefKind::GlobalAsm
         | DefKind::Closure
         | DefKind::Generator
+        | DefKind::Promoted
         | DefKind::ExternCrate => false,
     }
 }
@@ -1097,6 +1104,7 @@ fn should_encode_generics(def_kind: DefKind) -> bool {
         | DefKind::Field
         | DefKind::TyParam
         | DefKind::Closure
+        | DefKind::Promoted
         | DefKind::Generator => true,
         DefKind::Mod
         | DefKind::ForeignMod
@@ -1129,6 +1137,7 @@ fn should_encode_type(tcx: TyCtxt<'_>, def_id: LocalDefId, def_kind: DefKind) ->
         | DefKind::Generator
         | DefKind::ConstParam
         | DefKind::AnonConst
+        | DefKind::Promoted
         | DefKind::InlineConst => true,
 
         DefKind::OpaqueTy => {
@@ -1219,6 +1228,7 @@ fn should_encode_const(def_kind: DefKind) -> bool {
         | DefKind::Use
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
+        | DefKind::Promoted
         | DefKind::ExternCrate => false,
     }
 }
@@ -1542,7 +1552,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     }
                 }
             }
-            record!(self.tables.promoted_mir[def_id.to_def_id()] <- tcx.promoted_mir(def_id));
+
+            for &def_id in tcx.promoted_mir(def_id) {
+                record!(self.tables.mir_for_ctfe[def_id.to_def_id()] <- tcx.mir_for_ctfe(def_id));
+            }
 
             let instance = ty::InstanceDef::Item(def_id.to_def_id());
             let unused = tcx.unused_generic_params(instance);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -393,7 +393,6 @@ define_tables! {
     optimized_mir: Table<DefIndex, LazyValue<mir::Body<'static>>>,
     mir_for_ctfe: Table<DefIndex, LazyValue<mir::Body<'static>>>,
     mir_generator_witnesses: Table<DefIndex, LazyValue<mir::GeneratorLayout<'static>>>,
-    promoted_mir: Table<DefIndex, LazyValue<IndexVec<mir::Promoted, mir::Body<'static>>>>,
     thir_abstract_const: Table<DefIndex, LazyValue<ty::EarlyBinder<ty::Const<'static>>>>,
     impl_parent: Table<DefIndex, RawDefId>,
     impl_polarity: Table<DefIndex, ty::ImplPolarity>,

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -150,6 +150,7 @@ fixed_size_enum! {
         ( Impl { of_trait: true }                  )
         ( Closure                                  )
         ( Generator                                )
+        ( Promoted                                 )
         ( Static(ast::Mutability::Not)             )
         ( Static(ast::Mutability::Mut)             )
         ( Ctor(CtorOf::Struct, CtorKind::Fn)       )

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -19,14 +19,13 @@ macro_rules! arena_types {
                 rustc_data_structures::steal::Steal<
                     rustc_index::IndexVec<
                         rustc_middle::mir::Promoted,
-                        rustc_middle::mir::Body<'tcx>
+                        rustc_span::def_id::LocalDefId,
                     >
                 >,
-            [decode] promoted:
-                rustc_index::IndexVec<
-                    rustc_middle::mir::Promoted,
-                    rustc_middle::mir::Body<'tcx>
-                >,
+            [decode] promoted: rustc_index::IndexVec<
+                rustc_middle::mir::Promoted,
+                rustc_span::def_id::LocalDefId,
+            >,
             [decode] typeck_results: rustc_middle::ty::TypeckResults<'tcx>,
             [decode] borrowck_result:
                 rustc_middle::mir::BorrowCheckResult<'tcx>,

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -451,9 +451,11 @@ impl<'hir> Map<'hir> {
     /// Panics if `LocalDefId` does not have an associated body.
     pub fn body_owner_kind(self, def_id: LocalDefId) -> BodyOwnerKind {
         match self.tcx.def_kind(def_id) {
-            DefKind::Const | DefKind::AssocConst | DefKind::InlineConst | DefKind::AnonConst => {
-                BodyOwnerKind::Const
-            }
+            DefKind::Const
+            | DefKind::AssocConst
+            | DefKind::InlineConst
+            | DefKind::AnonConst
+            | DefKind::Promoted => BodyOwnerKind::Const,
             DefKind::Ctor(..) | DefKind::Fn | DefKind::AssocFn => BodyOwnerKind::Fn,
             DefKind::Closure | DefKind::Generator => BodyOwnerKind::Closure,
             DefKind::Static(mt) => BodyOwnerKind::Static(mt),

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -160,7 +160,7 @@ pub fn provide(providers: &mut Providers) {
     };
     providers.def_ident_span = |tcx, def_id| {
         let def_id = def_id;
-        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
+        let hir_id = tcx.opt_local_def_id_to_hir_id(def_id)?;
         tcx.hir().opt_ident_span(hir_id)
     };
     providers.fn_arg_names = |tcx, id| {

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -112,7 +112,6 @@ use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_serialize::{Decodable, Encodable};
 use rustc_target::abi::{AddressSpace, Endian, HasDataLayout};
 
-use crate::mir;
 use crate::ty::codec::{TyDecoder, TyEncoder};
 use crate::ty::subst::GenericArgKind;
 use crate::ty::{self, Instance, Ty, TyCtxt};
@@ -142,19 +141,11 @@ pub struct GlobalId<'tcx> {
     /// For a constant or static, the `Instance` of the item itself.
     /// For a promoted global, the `Instance` of the function they belong to.
     pub instance: ty::Instance<'tcx>,
-
-    /// The index for promoted globals within their function's `mir::Body`.
-    pub promoted: Option<mir::Promoted>,
 }
 
 impl<'tcx> GlobalId<'tcx> {
     pub fn display(self, tcx: TyCtxt<'tcx>) -> String {
-        let instance_name = with_no_trimmed_paths!(tcx.def_path_str(self.instance.def.def_id()));
-        if let Some(promoted) = self.promoted {
-            format!("{}::{:?}", instance_name, promoted)
-        } else {
-            instance_name
-        }
+        with_no_trimmed_paths!(tcx.def_path_str(self.instance.def.def_id()))
     }
 }
 

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -108,7 +108,6 @@ use rustc_data_structures::tiny_list::TinyList;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::DefId;
 use rustc_macros::HashStable;
-use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_serialize::{Decodable, Encodable};
 use rustc_target::abi::{AddressSpace, Endian, HasDataLayout};
 
@@ -131,23 +130,6 @@ pub use self::allocation::{
 };
 
 pub use self::pointer::{Pointer, PointerArithmetic, Provenance};
-
-/// Uniquely identifies one of the following:
-/// - A constant
-/// - A static
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, TyEncodable, TyDecodable)]
-#[derive(HashStable, Lift, TypeFoldable, TypeVisitable)]
-pub struct GlobalId<'tcx> {
-    /// For a constant or static, the `Instance` of the item itself.
-    /// For a promoted global, the `Instance` of the function they belong to.
-    pub instance: ty::Instance<'tcx>,
-}
-
-impl<'tcx> GlobalId<'tcx> {
-    pub fn display(self, tcx: TyCtxt<'tcx>) -> String {
-        with_no_trimmed_paths!(tcx.def_path_str(self.instance.def.def_id()))
-    }
-}
 
 /// Input argument for `tcx.lit_to_const`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, HashStable)]

--- a/compiler/rustc_middle/src/mir/interpret/queries.rs
+++ b/compiler/rustc_middle/src/mir/interpret/queries.rs
@@ -22,7 +22,7 @@ impl<'tcx> TyCtxt<'tcx> {
         // encountered.
         let substs = InternalSubsts::identity_for_item(self, def_id);
         let instance = ty::Instance::new(def_id, substs);
-        let cid = GlobalId { instance, promoted: None };
+        let cid = GlobalId { instance };
         let param_env = self.param_env(def_id).with_reveal_all_normalized(self);
         self.const_eval_global_id(param_env, cid, None)
     }
@@ -58,7 +58,7 @@ impl<'tcx> TyCtxt<'tcx> {
             ct.def, ct.substs,
         ) {
             Ok(Some(instance)) => {
-                let cid = GlobalId { instance, promoted: ct.promoted };
+                let cid = GlobalId { instance };
                 self.const_eval_global_id(param_env, cid, span)
             }
             Ok(None) => Err(ErrorHandled::TooGeneric),
@@ -85,7 +85,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
         match ty::Instance::resolve(self, param_env, ct.def, ct.substs) {
             Ok(Some(instance)) => {
-                let cid = GlobalId { instance, promoted: None };
+                let cid = GlobalId { instance };
                 self.const_eval_global_id_for_typeck(param_env, cid, span).inspect(|_| {
                     // We are emitting the lint here instead of in `is_const_evaluatable`
                     // as we normalize obligations before checking them, and normalization
@@ -121,7 +121,7 @@ impl<'tcx> TyCtxt<'tcx> {
         instance: ty::Instance<'tcx>,
         span: Option<Span>,
     ) -> EvalToConstValueResult<'tcx> {
-        self.const_eval_global_id(param_env, GlobalId { instance, promoted: None }, span)
+        self.const_eval_global_id(param_env, GlobalId { instance }, span)
     }
 
     /// Evaluate a constant to a `ConstValue`.
@@ -185,7 +185,7 @@ impl<'tcx> TyCtxtAt<'tcx> {
         trace!("eval_static_initializer: Need to compute {:?}", def_id);
         assert!(self.is_static(def_id));
         let instance = ty::Instance::mono(*self, def_id);
-        let gid = GlobalId { instance, promoted: None };
+        let gid = GlobalId { instance };
         self.eval_to_allocation(gid, ty::ParamEnv::reveal_all())
     }
 
@@ -216,7 +216,7 @@ impl<'tcx> TyCtxtEnsure<'tcx> {
         // encountered.
         let substs = InternalSubsts::identity_for_item(self.tcx, def_id);
         let instance = ty::Instance::new(def_id, substs);
-        let cid = GlobalId { instance, promoted: None };
+        let cid = GlobalId { instance };
         let param_env =
             self.tcx.param_env(def_id).with_reveal_all_normalized(self.tcx).with_const();
         // Const-eval shouldn't depend on lifetimes at all, so we can erase them, which should
@@ -230,7 +230,7 @@ impl<'tcx> TyCtxtEnsure<'tcx> {
         trace!("eval_static_initializer: Need to compute {:?}", def_id);
         assert!(self.tcx.is_static(def_id));
         let instance = ty::Instance::mono(self.tcx, def_id);
-        let gid = GlobalId { instance, promoted: None };
+        let gid = GlobalId { instance };
         let param_env = ty::ParamEnv::reveal_all().with_const();
         trace!("eval_to_allocation: Need to compute {:?}", gid);
         self.eval_to_allocation_raw(param_env.and(gid))

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -179,28 +179,6 @@ impl RuntimePhase {
     }
 }
 
-/// Where a specific `mir::Body` comes from.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[derive(HashStable, TyEncodable, TyDecodable, TypeFoldable, TypeVisitable)]
-pub struct MirSource<'tcx> {
-    pub instance: InstanceDef<'tcx>,
-}
-
-impl<'tcx> MirSource<'tcx> {
-    pub fn item(def_id: DefId) -> Self {
-        MirSource { instance: InstanceDef::Item(def_id) }
-    }
-
-    pub fn from_instance(instance: InstanceDef<'tcx>) -> Self {
-        MirSource { instance }
-    }
-
-    #[inline]
-    pub fn def_id(&self) -> DefId {
-        self.instance.def_id()
-    }
-}
-
 #[derive(Clone, TyEncodable, TyDecodable, Debug, HashStable, TypeFoldable, TypeVisitable)]
 pub struct GeneratorInfo<'tcx> {
     /// The yield type of the function, if it is a generator.
@@ -234,7 +212,7 @@ pub struct Body<'tcx> {
     /// How many passses we have executed since starting the current phase. Used for debug output.
     pub pass_count: usize,
 
-    pub source: MirSource<'tcx>,
+    pub source: InstanceDef<'tcx>,
 
     /// A list of source scopes; these are referenced by statements
     /// and used for debuginfo. Indexed by a `SourceScope`.
@@ -305,7 +283,7 @@ pub struct Body<'tcx> {
 
 impl<'tcx> Body<'tcx> {
     pub fn new(
-        source: MirSource<'tcx>,
+        source: InstanceDef<'tcx>,
         basic_blocks: IndexVec<BasicBlock, BasicBlockData<'tcx>>,
         source_scopes: IndexVec<SourceScope, SourceScopeData<'tcx>>,
         local_decls: IndexVec<Local, LocalDecl<'tcx>>,
@@ -362,7 +340,7 @@ impl<'tcx> Body<'tcx> {
         let mut body = Body {
             phase: MirPhase::Built,
             pass_count: 0,
-            source: MirSource::item(CRATE_DEF_ID.to_def_id()),
+            source: InstanceDef::Item(CRATE_DEF_ID.to_def_id()),
             basic_blocks: BasicBlocks::new(basic_blocks),
             source_scopes: IndexVec::new(),
             generator: None,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -184,18 +184,15 @@ impl RuntimePhase {
 #[derive(HashStable, TyEncodable, TyDecodable, TypeFoldable, TypeVisitable)]
 pub struct MirSource<'tcx> {
     pub instance: InstanceDef<'tcx>,
-
-    /// If `Some`, this is a promoted rvalue within the parent function.
-    pub promoted: Option<Promoted>,
 }
 
 impl<'tcx> MirSource<'tcx> {
     pub fn item(def_id: DefId) -> Self {
-        MirSource { instance: InstanceDef::Item(def_id), promoted: None }
+        MirSource { instance: InstanceDef::Item(def_id) }
     }
 
     pub fn from_instance(instance: InstanceDef<'tcx>) -> Self {
-        MirSource { instance, promoted: None }
+        MirSource { instance }
     }
 
     #[inline]
@@ -2500,7 +2497,7 @@ impl<'tcx> ConstantKind<'tcx> {
             ty::InlineConstSubsts::new(tcx, ty::InlineConstSubstsParts { parent_substs, ty })
                 .substs;
 
-        let uneval = UnevaluatedConst { def: def_id.to_def_id(), substs, promoted: None };
+        let uneval = UnevaluatedConst { def: def_id.to_def_id(), substs };
         debug_assert!(!uneval.has_free_regions());
 
         Self::Unevaluated(uneval, ty)
@@ -2594,7 +2591,6 @@ impl<'tcx> ConstantKind<'tcx> {
                     UnevaluatedConst {
                         def: did,
                         substs: InternalSubsts::identity_for_item(tcx, did),
-                        promoted: None,
                     },
                     ty,
                 )
@@ -2620,7 +2616,6 @@ impl<'tcx> ConstantKind<'tcx> {
 pub struct UnevaluatedConst<'tcx> {
     pub def: DefId,
     pub substs: SubstsRef<'tcx>,
-    pub promoted: Option<Promoted>,
 }
 
 impl<'tcx> UnevaluatedConst<'tcx> {
@@ -2635,7 +2630,7 @@ impl<'tcx> UnevaluatedConst<'tcx> {
 impl<'tcx> UnevaluatedConst<'tcx> {
     #[inline]
     pub fn new(def: DefId, substs: SubstsRef<'tcx>) -> UnevaluatedConst<'tcx> {
-        UnevaluatedConst { def, substs, promoted: Default::default() }
+        UnevaluatedConst { def, substs }
     }
 }
 

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -176,7 +176,7 @@ fn dump_file_basename<'tcx>(
     let item_name = tcx.def_path(source.def_id()).to_filename_friendly_no_crate();
     // All drop shims have the same DefId, so we have to add the type
     // to get unique file names.
-    let shim_disambiguator = match source.instance {
+    let shim_disambiguator = match source {
         ty::InstanceDef::DropGlue(_, Some(ty)) => {
             // Unfortunately, pretty-printed typed are not very filename-friendly.
             // We dome some filtering.
@@ -976,7 +976,7 @@ fn write_allocation_bytes<'tcx, Prov: Provenance, Extra, Bytes: AllocBytes>(
 fn write_mir_sig(tcx: TyCtxt<'_>, body: &Body<'_>, w: &mut dyn Write) -> io::Result<()> {
     use rustc_hir::def::DefKind;
 
-    trace!("write_mir_sig: {:?}", body.source.instance);
+    trace!("write_mir_sig: {:?}", body.source);
     let def_id = body.source.def_id();
     let kind = tcx.def_kind(def_id);
     let is_function = match kind {

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -307,7 +307,6 @@ tcx_lifetime! {
     rustc_middle::mir::DestructuredConstant,
     rustc_middle::mir::interpret::ConstAlloc,
     rustc_middle::mir::interpret::ConstValue,
-    rustc_middle::mir::interpret::GlobalId,
     rustc_middle::mir::interpret::LitToConstInput,
     rustc_middle::traits::ChalkEnvironmentAndGoal,
     rustc_middle::traits::query::MethodAutoderefStepsResult,

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -87,14 +87,6 @@ impl<'tcx> Key for ty::Instance<'tcx> {
     }
 }
 
-impl<'tcx> Key for mir::interpret::GlobalId<'tcx> {
-    type CacheSelector = DefaultCacheSelector<Self>;
-
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
-        self.instance.default_span(tcx)
-    }
-}
-
 impl<'tcx> Key for (Ty<'tcx>, Option<ty::PolyExistentialTraitRef<'tcx>>) {
     type CacheSelector = DefaultCacheSelector<Self>;
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -18,7 +18,6 @@ use crate::middle::privacy::EffectiveVisibilities;
 use crate::middle::resolve_bound_vars::{ObjectLifetimeDefault, ResolveBoundVars, ResolvedArg};
 use crate::middle::stability::{self, DeprecationEntry};
 use crate::mir;
-use crate::mir::interpret::GlobalId;
 use crate::mir::interpret::{
     ConstValue, EvalToAllocationRawResult, EvalToConstValueResult, EvalToValTreeResult,
 };
@@ -1028,11 +1027,11 @@ rustc_queries! {
     /// Evaluates a constant and returns the computed allocation.
     ///
     /// **Do not use this** directly, use the `tcx.eval_static_initializer` wrapper.
-    query eval_to_allocation_raw(key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>)
+    query eval_to_allocation_raw(key: ty::ParamEnvAnd<'tcx, ty::Instance<'tcx>>)
         -> EvalToAllocationRawResult<'tcx> {
         desc { |tcx|
             "const-evaluating + checking `{}`",
-            key.value.display(tcx)
+            tcx.def_path_str(key.value.def_id()),
         }
         cache_on_disk_if { true }
     }
@@ -1043,11 +1042,11 @@ rustc_queries! {
     ///
     /// **Do not use this** directly, use one of the following wrappers: `tcx.const_eval_poly`,
     /// `tcx.const_eval_resolve`, `tcx.const_eval_instance`, or `tcx.const_eval_global_id`.
-    query eval_to_const_value_raw(key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>)
+    query eval_to_const_value_raw(key: ty::ParamEnvAnd<'tcx, ty::Instance<'tcx>>)
         -> EvalToConstValueResult<'tcx> {
         desc { |tcx|
             "simplifying constant for the type system `{}`",
-            key.value.display(tcx)
+            tcx.def_path_str(key.value.def_id()),
         }
         cache_on_disk_if { true }
     }
@@ -1055,7 +1054,7 @@ rustc_queries! {
     /// Evaluate a constant and convert it to a type level constant or
     /// return `None` if that is not possible.
     query eval_to_valtree(
-        key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>
+        key: ty::ParamEnvAnd<'tcx, ty::Instance<'tcx>>
     ) -> EvalToValTreeResult<'tcx> {
         desc { "evaluating type-level constant" }
     }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -518,7 +518,6 @@ rustc_queries! {
         &'tcx Steal<mir::Body<'tcx>>,
         &'tcx IndexVec<mir::Promoted, LocalDefId>,
     ) {
-        no_hash
         desc { |tcx| "promoting constants in MIR for `{}`", tcx.def_path_str(key) }
     }
 

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -782,10 +782,7 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>>
     }
 }
 
-impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>>
-    for &'tcx IndexVec<mir::Promoted, mir::Body<'tcx>>
-{
-    #[inline]
+impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for &'tcx IndexVec<mir::Promoted, LocalDefId> {
     fn decode(d: &mut CacheDecoder<'a, 'tcx>) -> Self {
         RefDecodable::decode(d)
     }

--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -30,7 +30,7 @@ impl rustc_errors::IntoDiagnosticArg for UnevaluatedConst<'_> {
 impl<'tcx> UnevaluatedConst<'tcx> {
     #[inline]
     pub fn expand(self) -> mir::UnevaluatedConst<'tcx> {
-        mir::UnevaluatedConst { def: self.def, substs: self.substs, promoted: None }
+        mir::UnevaluatedConst { def: self.def, substs: self.substs }
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -13,7 +13,7 @@ use crate::middle::codegen_fn_attrs::CodegenFnAttrs;
 use crate::middle::resolve_bound_vars;
 use crate::middle::stability;
 use crate::mir::interpret::{self, Allocation, ConstAllocation};
-use crate::mir::{Body, Local, Place, PlaceElem, ProjectionKind, Promoted};
+use crate::mir::{Body, Local, Place, PlaceElem, ProjectionKind};
 use crate::query::plumbing::QuerySystem;
 use crate::query::LocalCrate;
 use crate::query::Providers;
@@ -559,7 +559,11 @@ impl<'tcx> TyCtxt<'tcx> {
             self.codegen_fn_attrs(def_id)
         } else if matches!(
             def_kind,
-            DefKind::AnonConst | DefKind::AssocConst | DefKind::Const | DefKind::InlineConst
+            DefKind::AnonConst
+                | DefKind::AssocConst
+                | DefKind::Const
+                | DefKind::InlineConst
+                | DefKind::Promoted
         ) {
             CodegenFnAttrs::EMPTY
         } else {
@@ -577,13 +581,6 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn alloc_steal_mir(self, mir: Body<'tcx>) -> &'tcx Steal<Body<'tcx>> {
         self.arena.alloc(Steal::new(mir))
-    }
-
-    pub fn alloc_steal_promoted(
-        self,
-        promoted: IndexVec<Promoted, Body<'tcx>>,
-    ) -> &'tcx Steal<IndexVec<Promoted, Body<'tcx>>> {
-        self.arena.alloc(Steal::new(promoted))
     }
 
     pub fn mk_adt_def(
@@ -2393,6 +2390,7 @@ impl<'tcx> TyCtxt<'tcx> {
         )
     }
 
+    #[track_caller]
     pub fn local_def_id_to_hir_id(self, local_def_id: LocalDefId) -> HirId {
         self.opt_local_def_id_to_hir_id(local_def_id).unwrap()
     }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2304,7 +2304,13 @@ impl<'tcx> TyCtxt<'tcx> {
         let did: DefId = did.into();
         let filter_fn = move |a: &&ast::Attribute| a.has_name(attr);
         if let Some(did) = did.as_local() {
-            self.hir().attrs(self.hir().local_def_id_to_hir_id(did)).iter().filter(filter_fn)
+            if let Some(hir_id) = self.opt_local_def_id_to_hir_id(did) {
+                self.hir().attrs(hir_id)
+            } else {
+                &[]
+            }
+            .iter()
+            .filter(filter_fn)
         } else if cfg!(debug_assertions) && rustc_feature::is_builtin_only_local(attr) {
             bug!("tried to access the `only_local` attribute `{}` from an extern crate", attr);
         } else {

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -144,6 +144,8 @@ pub trait Printer<'tcx>: Sized {
                         // Anon consts doesn't have their own generics, and inline consts' own
                         // generics are their inferred types, so don't print them.
                         DefPathData::AnonConst => {}
+                        // Promoted do not have their own generics, so we don't print them.
+                        DefPathData::Promoted => {}
 
                         // If we have any generic arguments to print, we do that
                         // on top of the same path, but without its own generics.

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1324,7 +1324,7 @@ pub trait PrettyPrinter<'tcx>:
                     DefKind::Const | DefKind::AssocConst => {
                         p!(print_value_path(def, substs))
                     }
-                    DefKind::AnonConst => {
+                    DefKind::AnonConst | DefKind::Promoted => {
                         if def.is_local()
                             && let span = self.tcx().def_span(def)
                             && let Ok(snip) = self.tcx().sess.source_map().span_to_snippet(span)

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -533,7 +533,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn is_typeck_child(self, def_id: DefId) -> bool {
         matches!(
             self.def_kind(def_id),
-            DefKind::Closure | DefKind::Generator | DefKind::InlineConst
+            DefKind::Closure | DefKind::Generator | DefKind::InlineConst | DefKind::Promoted
         )
     }
 

--- a/compiler/rustc_mir_build/src/build/custom/mod.rs
+++ b/compiler/rustc_mir_build/src/build/custom/mod.rs
@@ -25,7 +25,7 @@ use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::{
     mir::*,
     thir::*,
-    ty::{ParamEnv, Ty, TyCtxt},
+    ty::{InstanceDef, ParamEnv, Ty, TyCtxt},
 };
 use rustc_span::Span;
 
@@ -45,7 +45,7 @@ pub(super) fn build_custom_mir<'tcx>(
 ) -> Body<'tcx> {
     let mut body = Body {
         basic_blocks: BasicBlocks::new(IndexVec::new()),
-        source: MirSource::item(did),
+        source: InstanceDef::Item(did),
         phase: MirPhase::Built,
         source_scopes: IndexVec::new(),
         generator: None,

--- a/compiler/rustc_mir_build/src/build/expr/as_constant.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_constant.rs
@@ -2,7 +2,6 @@
 
 use crate::build::{parse_float_into_constval, Builder};
 use rustc_ast as ast;
-use rustc_middle::mir;
 use rustc_middle::mir::interpret::{
     Allocation, ConstValue, LitToConstError, LitToConstInput, Scalar,
 };
@@ -78,7 +77,7 @@ pub fn as_constant_inner<'tcx>(
         ExprKind::NamedConst { def_id, substs, ref user_ty } => {
             let user_ty = user_ty.as_ref().and_then(push_cuta);
 
-            let uneval = mir::UnevaluatedConst::new(def_id, substs);
+            let uneval = UnevaluatedConst::new(def_id, substs);
             let literal = ConstantKind::Unevaluated(uneval, ty);
 
             Constant { user_ty, span, literal }
@@ -90,7 +89,7 @@ pub fn as_constant_inner<'tcx>(
             Constant { user_ty: None, span, literal }
         }
         ExprKind::ConstBlock { did: def_id, substs } => {
-            let uneval = mir::UnevaluatedConst::new(def_id, substs);
+            let uneval = UnevaluatedConst::new(def_id, substs);
             let literal = ConstantKind::Unevaluated(uneval, ty);
 
             Constant { user_ty: None, span, literal }

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -640,7 +640,7 @@ fn construct_error(tcx: TyCtxt<'_>, def: LocalDefId, err: ErrorGuaranteed) -> Bo
     cfg.terminate(START_BLOCK, source_info, TerminatorKind::Unreachable);
 
     let mut body = Body::new(
-        MirSource::item(def.to_def_id()),
+        ty::InstanceDef::Item(def.to_def_id()),
         cfg.basic_blocks,
         source_scopes,
         local_decls,
@@ -730,7 +730,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
 
         Body::new(
-            MirSource::item(self.def_id.to_def_id()),
+            ty::InstanceDef::Item(self.def_id.to_def_id()),
             self.cfg.basic_blocks,
             self.source_scopes,
             self.local_decls,

--- a/compiler/rustc_mir_transform/src/check_packed_ref.rs
+++ b/compiler/rustc_mir_transform/src/check_packed_ref.rs
@@ -39,7 +39,7 @@ impl<'tcx> Visitor<'tcx> for PackedRefChecker<'_, 'tcx> {
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, _location: Location) {
         if context.is_borrow() {
             if util::is_disaligned(self.tcx, self.body, self.param_env, *place) {
-                let def_id = self.body.source.instance.def_id();
+                let def_id = self.body.source.def_id();
                 if let Some(impl_def_id) = self.tcx.impl_of_method(def_id)
                     && self.tcx.is_builtin_derived(impl_def_id)
                 {

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -148,14 +148,11 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
             };
 
             if let Some(uv) = maybe_uneval {
-                if uv.promoted.is_none() {
-                    let def_id = uv.def;
-                    if self.tcx.def_kind(def_id) == DefKind::InlineConst {
-                        let local_def_id = def_id.expect_local();
-                        let UnsafetyCheckResult { violations, used_unsafe_blocks, .. } =
-                            self.tcx.unsafety_check_result(local_def_id);
-                        self.register_violations(violations, used_unsafe_blocks.items().copied());
-                    }
+                if self.tcx.def_kind(uv.def) == DefKind::InlineConst {
+                    let local_def_id = uv.def.expect_local();
+                    let UnsafetyCheckResult { violations, used_unsafe_blocks, .. } =
+                        self.tcx.unsafety_check_result(local_def_id);
+                    self.register_violations(violations, used_unsafe_blocks.items().copied());
                 }
             }
         }

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -58,11 +58,6 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
 
     #[instrument(skip(self, tcx), level = "debug")]
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        // will be evaluated by miri and produce its errors there
-        if body.source.promoted.is_some() {
-            return;
-        }
-
         let def_id = body.source.def_id().expect_local();
         let def_kind = tcx.def_kind(def_id);
         let is_fn_like = def_kind.is_fn_like();

--- a/compiler/rustc_mir_transform/src/const_prop_lint.rs
+++ b/compiler/rustc_mir_transform/src/const_prop_lint.rs
@@ -38,11 +38,6 @@ pub struct ConstProp;
 
 impl<'tcx> MirLint<'tcx> for ConstProp {
     fn run_lint(&self, tcx: TyCtxt<'tcx>, body: &Body<'tcx>) {
-        // will be evaluated by miri and produce its errors there
-        if body.source.promoted.is_some() {
-            return;
-        }
-
         let def_id = body.source.def_id().expect_local();
         let is_fn_like = tcx.def_kind(def_id).is_fn_like();
         let is_assoc_const = tcx.def_kind(def_id) == DefKind::AssocConst;

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -16,6 +16,7 @@ use crate::MirPass;
 
 use rustc_data_structures::graph::WithNumNodes;
 use rustc_data_structures::sync::Lrc;
+use rustc_hir::def::DefKind;
 use rustc_index::IndexVec;
 use rustc_middle::hir;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
@@ -57,7 +58,7 @@ impl<'tcx> MirPass<'tcx> for InstrumentCoverage {
 
         // If the InstrumentCoverage pass is called on promoted MIRs, skip them.
         // See: https://github.com/rust-lang/rust/pull/73011#discussion_r438317601
-        if mir_source.promoted.is_some() {
+        if let DefKind::Promoted = tcx.def_kind(mir_source.def_id()) {
             trace!(
                 "InstrumentCoverage skipped for {:?} (already promoted for Miri evaluation)",
                 mir_source.def_id()

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -76,9 +76,7 @@ fn inline<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) -> bool {
     if !tcx.hir().body_owner_kind(def_id).is_fn_or_closure() {
         return false;
     }
-    if body.source.promoted.is_some() {
-        return false;
-    }
+
     // Avoid inlining into generators, since their `optimized_mir` is used for layout computation,
     // which can create a cycle, even when no attempt is made to inline the function in the other
     // direction.

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -692,6 +692,7 @@ impl<'tcx> EmbargoVisitor<'tcx> {
             | DefKind::InlineConst
             | DefKind::Field
             | DefKind::GlobalAsm
+            | DefKind::Promoted
             | DefKind::Impl { .. }
             | DefKind::Closure
             | DefKind::Generator => (),

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -979,6 +979,7 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
                 | DefKind::LifetimeParam
                 | DefKind::GlobalAsm
                 | DefKind::Closure
+                | DefKind::Promoted
                 | DefKind::Impl { .. }
                 | DefKind::Generator,
                 _,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1145,6 +1145,7 @@ symbols! {
         proc_macro_path_invoc,
         profiler_builtins,
         profiler_runtime,
+        promoted,
         ptr,
         ptr_guaranteed_cmp,
         ptr_mask,

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -372,6 +372,7 @@ fn encode_ty_name(tcx: TyCtxt<'_>, def_id: DefId) -> String {
             hir::definitions::DefPathData::ClosureExpr => "C",
             hir::definitions::DefPathData::Ctor => "c",
             hir::definitions::DefPathData::AnonConst => "k",
+            hir::definitions::DefPathData::Promoted => "p",
             hir::definitions::DefPathData::ImplTrait => "i",
             hir::definitions::DefPathData::CrateRoot
             | hir::definitions::DefPathData::Use

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -777,6 +777,7 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
             DefPathData::ClosureExpr => 'C',
             DefPathData::Ctor => 'c',
             DefPathData::AnonConst => 'k',
+            DefPathData::Promoted => 'p',
             DefPathData::ImplTrait => 'i',
 
             // These should never show up as `path_append` arguments.

--- a/compiler/rustc_ty_utils/src/implied_bounds.rs
+++ b/compiler/rustc_ty_utils/src/implied_bounds.rs
@@ -68,6 +68,7 @@ fn assumed_wf_types(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::List<Ty<'_>> {
         | DefKind::Field
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
+        | DefKind::Promoted
         | DefKind::Closure
         | DefKind::Generator => ty::List::empty(),
     }

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -183,6 +183,7 @@ fn opaque_types_defined_by<'tcx>(tcx: TyCtxt<'tcx>, item: LocalDefId) -> &'tcx [
         | DefKind::AnonConst
         | DefKind::InlineConst
         | DefKind::OpaqueTy
+        | DefKind::Promoted
         | DefKind::ImplTraitPlaceholder
         | DefKind::Field
         | DefKind::LifetimeParam

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -118,6 +118,10 @@ fn adt_sized_constraint(tcx: TyCtxt<'_>, def_id: DefId) -> &[Ty<'_>] {
 
 /// See `ParamEnv` struct definition for details.
 fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
+    if let DefKind::Promoted = tcx.def_kind(def_id) {
+        return tcx.param_env(tcx.parent(def_id));
+    }
+
     // Compute the bounds on Self and the type parameters.
     let ty::InstantiatedPredicates { mut predicates, .. } =
         tcx.predicates_of(def_id).instantiate_identity(tcx);

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -135,6 +135,7 @@ impl From<DefKind> for ItemType {
             | DefKind::ForeignMod
             | DefKind::AnonConst
             | DefKind::InlineConst
+            | DefKind::Promoted
             | DefKind::OpaqueTy
             | DefKind::ImplTraitPlaceholder
             | DefKind::Field

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1810,6 +1810,7 @@ fn resolution_failure(
                             | LifetimeParam
                             | Ctor(_, _)
                             | AnonConst
+                            | Promoted
                             | InlineConst => {
                                 let note = assoc_item_not_allowed(res);
                                 if let Some(span) = sp {

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -160,7 +160,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     fn eval_path_scalar(&self, path: &[&str]) -> Scalar<Provenance> {
         let this = self.eval_context_ref();
         let instance = this.resolve_path(path, Namespace::ValueNS);
-        let cid = GlobalId { instance, promoted: None };
+        let cid = GlobalId { instance };
         // We don't give a span -- this isn't actually used directly by the program anyway.
         let const_val = this
             .eval_global(cid, None)
@@ -358,7 +358,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         }
 
         // Push frame.
-        let mir = this.load_mir(f.def, None)?;
+        let mir = this.load_mir(f.def)?;
         let dest = match dest {
             Some(dest) => dest.clone(),
             None => MPlaceTy::fake_alloc_zst(this.layout_of(mir.return_ty())?).into(),

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -160,10 +160,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     fn eval_path_scalar(&self, path: &[&str]) -> Scalar<Provenance> {
         let this = self.eval_context_ref();
         let instance = this.resolve_path(path, Namespace::ValueNS);
-        let cid = GlobalId { instance };
         // We don't give a span -- this isn't actually used directly by the program anyway.
         let const_val = this
-            .eval_global(cid, None)
+            .eval_global(instance, None)
             .unwrap_or_else(|err| panic!("failed to evaluate required Rust item: {path:?}\n{err}"));
         this.read_scalar(&const_val.into())
             .unwrap_or_else(|err| panic!("failed to read required Rust item: {path:?}\n{err}"))

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -228,7 +228,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         };
         match instance {
             None => Ok(None), // no symbol with this name
-            Some(instance) => Ok(Some((this.load_mir(instance.def, None)?, instance))),
+            Some(instance) => Ok(Some((this.load_mir(instance.def)?, instance))),
         }
     }
 
@@ -283,7 +283,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                         let panic_impl_id = tcx.lang_items().panic_impl().unwrap();
                         let panic_impl_instance = ty::Instance::mono(tcx, panic_impl_id);
                         return Ok(Some((
-                            this.load_mir(panic_impl_instance.def, None)?,
+                            this.load_mir(panic_impl_instance.def)?,
                             panic_impl_instance,
                         )));
                     }

--- a/src/tools/miri/src/shims/mod.rs
+++ b/src/tools/miri/src/shims/mod.rs
@@ -59,7 +59,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         }
 
         // Otherwise, load the MIR.
-        Ok(Some((this.load_mir(instance.def, None)?, instance)))
+        Ok(Some((this.load_mir(instance.def)?, instance)))
     }
 
     /// Returns `true` if the computation was performed, and `false` if we should just evaluate

--- a/tests/mir-opt/combine_transmutes.adt_transmutes.InstSimplify.diff
+++ b/tests/mir-opt/combine_transmutes.adt_transmutes.InstSimplify.diff
@@ -40,7 +40,7 @@
           _2 = Option::<NonZeroU8>::Some(const _); // scope 0 at $DIR/combine_transmutes.rs:+1:28: +1:58
                                            // mir::Constant
                                            // + span: $DIR/combine_transmutes.rs:35:33: 35:57
-                                           // + literal: Const { ty: NonZeroU8, val: Unevaluated(NonZeroU8::MAX, [], None) }
+                                           // + literal: Const { ty: NonZeroU8, val: Unevaluated(NonZeroU8::MAX, []) }
           _1 = move _2 as u8 (Transmute);  // scope 0 at $DIR/combine_transmutes.rs:+1:18: +1:59
           StorageDead(_2);                 // scope 0 at $DIR/combine_transmutes.rs:+1:58: +1:59
           StorageLive(_3);                 // scope 1 at $DIR/combine_transmutes.rs:+2:9: +2:11

--- a/tests/mir-opt/const_promotion_extern_static.BAR-{promoted#0}.SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.BAR-{promoted#0}.SimplifyCfg-elaborate-drops.after.mir
@@ -1,6 +1,6 @@
-// MIR for `BAR::promoted[0]` after SimplifyCfg-elaborate-drops
+// MIR for `BAR::{promoted#0}` after SimplifyCfg-elaborate-drops
 
-promoted[0] in BAR: &[&i32; 1] = {
+BAR::{promoted#0}: &[&i32; 1] = {
     let mut _0: &[&i32; 1];              // return place in scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:44
     let mut _1: [&i32; 1];               // in scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:35
     let mut _2: &i32;                    // in scope 0 at $DIR/const_promotion_extern_static.rs:+0:32: +0:34

--- a/tests/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/tests/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -25,7 +25,7 @@
 -         _3 = [move _4];                  // scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:35
 -         _2 = &_3;                        // scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:44
 +                                          // + span: $DIR/const_promotion_extern_static.rs:9:31: 9:44
-+                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(BAR, [], Some(promoted[0])) }
++                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(BAR::{promoted#0}, [&[&i32; 1]]) }
 +         _2 = &(*_6);                     // scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:44
           _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:44
 -         StorageDead(_4);                 // scope 0 at $DIR/const_promotion_extern_static.rs:+0:34: +0:35

--- a/tests/mir-opt/const_promotion_extern_static.FOO-{promoted#0}.SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.FOO-{promoted#0}.SimplifyCfg-elaborate-drops.after.mir
@@ -1,6 +1,6 @@
-// MIR for `FOO::promoted[0]` after SimplifyCfg-elaborate-drops
+// MIR for `FOO::{promoted#0}` after SimplifyCfg-elaborate-drops
 
-promoted[0] in FOO: &[&i32; 1] = {
+FOO::{promoted#0}: &[&i32; 1] = {
     let mut _0: &[&i32; 1];              // return place in scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:55
     let mut _1: [&i32; 1];               // in scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:46
     let mut _2: &i32;                    // in scope 0 at $DIR/const_promotion_extern_static.rs:+0:32: +0:45

--- a/tests/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/tests/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -27,7 +27,7 @@
 -         _3 = [move _4];                  // scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:46
 -         _2 = &_3;                        // scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:55
 +                                          // + span: $DIR/const_promotion_extern_static.rs:13:31: 13:55
-+                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(FOO, [], Some(promoted[0])) }
++                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(FOO::{promoted#0}, [&[&i32; 1]]) }
 +         _2 = &(*_6);                     // scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:55
           _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const_promotion_extern_static.rs:+0:31: +0:55
 -         StorageDead(_4);                 // scope 0 at $DIR/const_promotion_extern_static.rs:+0:45: +0:46

--- a/tests/mir-opt/const_promotion_extern_static.rs
+++ b/tests/mir-opt/const_promotion_extern_static.rs
@@ -5,11 +5,11 @@ extern "C" {
 static Y: i32 = 42;
 
 // EMIT_MIR const_promotion_extern_static.BAR.PromoteTemps.diff
-// EMIT_MIR const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR const_promotion_extern_static.BAR-{promoted#0}.SimplifyCfg-elaborate-drops.after.mir
 static mut BAR: *const &i32 = [&Y].as_ptr();
 
 // EMIT_MIR const_promotion_extern_static.FOO.PromoteTemps.diff
-// EMIT_MIR const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR const_promotion_extern_static.FOO-{promoted#0}.SimplifyCfg-elaborate-drops.after.mir
 static mut FOO: *const &i32 = [unsafe { &X }].as_ptr();
 
 // EMIT_MIR const_promotion_extern_static.BOP.built.after.mir

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
@@ -28,7 +28,7 @@
           _9 = const _;                    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
                                            // mir::Constant
                                            // + span: $DIR/bad_op_unsafe_oob_for_slices.rs:9:25: 9:35
-                                           // + literal: Const { ty: &[i32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
+                                           // + literal: Const { ty: &[i32; 3], val: Unevaluated(main::{promoted#0}, [&[i32; 3]]) }
           _3 = &(*_9);                     // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
@@ -28,7 +28,7 @@
           _9 = const _;                    // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
                                            // mir::Constant
                                            // + span: $DIR/bad_op_unsafe_oob_for_slices.rs:9:25: 9:35
-                                           // + literal: Const { ty: &[i32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
+                                           // + literal: Const { ty: &[i32; 3], val: Unevaluated(main::{promoted#0}, [&[i32; 3]]) }
           _3 = &(*_9);                     // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _2 = &raw const (*_3);           // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35
           _1 = move _2 as *const [i32] (Pointer(Unsize)); // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:+1:25: +1:35

--- a/tests/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
@@ -19,7 +19,7 @@
           _3 = const _;                    // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:16
                                            // mir::Constant
                                            // + span: $DIR/const_prop_fails_gracefully.rs:9:13: 9:16
-                                           // + literal: Const { ty: &i32, val: Unevaluated(FOO, [], None) }
+                                           // + literal: Const { ty: &i32, val: Unevaluated(FOO, []) }
           _2 = &raw const (*_3);           // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:16
           _1 = move _2 as usize (PointerExposeAddress); // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:13: +2:39
           StorageDead(_2);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:+2:38: +2:39

--- a/tests/mir-opt/const_prop/ref_deref.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/ref_deref.main.ConstProp.diff
@@ -14,7 +14,7 @@
           _4 = const _;                    // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
                                            // mir::Constant
                                            // + span: $DIR/ref_deref.rs:5:6: 5:10
-                                           // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
+                                           // + literal: Const { ty: &i32, val: Unevaluated(main::{promoted#0}, [&i32]) }
           _2 = &(*_4);                     // scope 0 at $DIR/ref_deref.rs:+1:6: +1:10
           _1 = (*_2);                      // scope 0 at $DIR/ref_deref.rs:+1:5: +1:10
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref.rs:+1:10: +1:11

--- a/tests/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
@@ -14,7 +14,7 @@
           _4 = const _;                    // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
                                            // mir::Constant
                                            // + span: $DIR/ref_deref_project.rs:5:6: 5:17
-                                           // + literal: Const { ty: &(i32, i32), val: Unevaluated(main, [], Some(promoted[0])) }
+                                           // + literal: Const { ty: &(i32, i32), val: Unevaluated(main::{promoted#0}, [&(i32, i32)]) }
           _2 = &((*_4).1: i32);            // scope 0 at $DIR/ref_deref_project.rs:+1:6: +1:17
           _1 = (*_2);                      // scope 0 at $DIR/ref_deref_project.rs:+1:5: +1:17
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:+1:17: +1:18

--- a/tests/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
@@ -21,7 +21,7 @@
           _9 = const _;                    // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
                                            // mir::Constant
                                            // + span: $DIR/slice_len.rs:8:6: 8:19
-                                           // + literal: Const { ty: &[u32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
+                                           // + literal: Const { ty: &[u32; 3], val: Unevaluated(main::{promoted#0}, [&[u32; 3]]) }
           _4 = _9;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _3 = _4;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:+1:6: +1:19

--- a/tests/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
@@ -21,7 +21,7 @@
           _9 = const _;                    // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
                                            // mir::Constant
                                            // + span: $DIR/slice_len.rs:8:6: 8:19
-                                           // + literal: Const { ty: &[u32; 3], val: Unevaluated(main, [], Some(promoted[0])) }
+                                           // + literal: Const { ty: &[u32; 3], val: Unevaluated(main::{promoted#0}, [&[u32; 3]]) }
           _4 = _9;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _3 = _4;                         // scope 0 at $DIR/slice_len.rs:+1:6: +1:19
           _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:+1:6: +1:19

--- a/tests/mir-opt/derefer_complex_case.main.Derefer.diff
+++ b/tests/mir-opt/derefer_complex_case.main.Derefer.diff
@@ -31,7 +31,7 @@
           _14 = const _;                   // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
                                            // mir::Constant
                                            // + span: $DIR/derefer_complex_case.rs:6:17: 6:26
-                                           // + literal: Const { ty: &[i32; 2], val: Unevaluated(main, [], Some(promoted[0])) }
+                                           // + literal: Const { ty: &[i32; 2], val: Unevaluated(main::{promoted#0}, [&[i32; 2]]) }
           _2 = &(*_14);                    // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
           _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> bb1; // scope 0 at $DIR/derefer_complex_case.rs:+1:17: +1:26
                                            // mir::Constant

--- a/tests/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/tests/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -35,7 +35,7 @@ fn bar() -> bool {
         _10 = const _;                   // scope 1 at $DIR/inline_retag.rs:+2:7: +2:9
                                          // mir::Constant
                                          // + span: $DIR/inline_retag.rs:12:7: 12:9
-                                         // + literal: Const { ty: &i32, val: Unevaluated(bar, [], Some(promoted[1])) }
+                                         // + literal: Const { ty: &i32, val: Unevaluated(bar::{promoted#1}, [&i32]) }
         Retag(_10);                      // scope 1 at $DIR/inline_retag.rs:+2:7: +2:9
         _4 = &(*_10);                    // scope 1 at $DIR/inline_retag.rs:+2:7: +2:9
         _3 = &(*_4);                     // scope 1 at $DIR/inline_retag.rs:+2:7: +2:9
@@ -44,7 +44,7 @@ fn bar() -> bool {
         _9 = const _;                    // scope 1 at $DIR/inline_retag.rs:+2:11: +2:14
                                          // mir::Constant
                                          // + span: $DIR/inline_retag.rs:12:11: 12:14
-                                         // + literal: Const { ty: &i32, val: Unevaluated(bar, [], Some(promoted[0])) }
+                                         // + literal: Const { ty: &i32, val: Unevaluated(bar::{promoted#0}, [&i32]) }
         Retag(_9);                       // scope 1 at $DIR/inline_retag.rs:+2:11: +2:14
         _7 = &(*_9);                     // scope 1 at $DIR/inline_retag.rs:+2:11: +2:14
         _6 = &(*_7);                     // scope 1 at $DIR/inline_retag.rs:+2:11: +2:14

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.diff
@@ -23,7 +23,7 @@
 -                                          // + span: $DIR/issue_106141.rs:3:5: 3:10
 -                                          // + literal: Const { ty: fn() -> usize {inner}, val: Value(<ZST>) }
 +                                          // + span: $DIR/issue_106141.rs:12:18: 12:25
-+                                          // + literal: Const { ty: &[bool; 1], val: Unevaluated(inner, [], Some(promoted[0])) }
++                                          // + literal: Const { ty: &[bool; 1], val: Unevaluated(inner::{promoted#0}, [&[bool; 1]]) }
 +         _0 = index() -> bb1;             // scope 2 at $DIR/issue_106141.rs:13:17: 13:24
 +                                          // mir::Constant
 +                                          // + span: $DIR/issue_106141.rs:13:17: 13:22

--- a/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
+++ b/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
@@ -47,7 +47,7 @@
           _19 = const _;                   // scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
                                            // mir::Constant
                                            // + span: $DIR/lower_intrinsics.rs:83:42: 83:44
-                                           // + literal: Const { ty: &i32, val: Unevaluated(discriminant, [T], Some(promoted[2])) }
+                                           // + literal: Const { ty: &i32, val: Unevaluated(discriminant::{promoted#2}, [T, &i32]) }
           _7 = &(*_19);                    // scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
           _6 = &(*_7);                     // scope 0 at $DIR/lower_intrinsics.rs:+2:42: +2:44
 -         _5 = discriminant_value::<i32>(move _6) -> [return: bb2, unwind unreachable]; // scope 0 at $DIR/lower_intrinsics.rs:+2:5: +2:45
@@ -68,7 +68,7 @@
           _18 = const _;                   // scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
                                            // mir::Constant
                                            // + span: $DIR/lower_intrinsics.rs:84:42: 84:45
-                                           // + literal: Const { ty: &(), val: Unevaluated(discriminant, [T], Some(promoted[1])) }
+                                           // + literal: Const { ty: &(), val: Unevaluated(discriminant::{promoted#1}, [T, &()]) }
           _11 = &(*_18);                   // scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
           _10 = &(*_11);                   // scope 0 at $DIR/lower_intrinsics.rs:+3:42: +3:45
 -         _9 = discriminant_value::<()>(move _10) -> [return: bb3, unwind unreachable]; // scope 0 at $DIR/lower_intrinsics.rs:+3:5: +3:46
@@ -89,7 +89,7 @@
           _17 = const _;                   // scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
                                            // mir::Constant
                                            // + span: $DIR/lower_intrinsics.rs:85:42: 85:47
-                                           // + literal: Const { ty: &E, val: Unevaluated(discriminant, [T], Some(promoted[0])) }
+                                           // + literal: Const { ty: &E, val: Unevaluated(discriminant::{promoted#0}, [T, &E]) }
           _15 = &(*_17);                   // scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
           _14 = &(*_15);                   // scope 0 at $DIR/lower_intrinsics.rs:+4:42: +4:47
 -         _13 = discriminant_value::<E>(move _14) -> [return: bb4, unwind unreachable]; // scope 0 at $DIR/lower_intrinsics.rs:+4:5: +4:48

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -67,7 +67,7 @@
           _28 = const _;                   // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:535:17: 535:24
-                                           // + literal: Const { ty: &T, val: Unevaluated(debuginfo, [], Some(promoted[2])) }
+                                           // + literal: Const { ty: &T, val: Unevaluated(debuginfo::{promoted#2}, [&debuginfo::T]) }
 -         _3 = &((*_28).0: u8);            // scope 1 at $DIR/reference_prop.rs:+4:17: +4:24
 -         StorageLive(_5);                 // scope 2 at $DIR/reference_prop.rs:+7:9: +7:17
 -         _5 = &(*_1);                     // scope 2 at $DIR/reference_prop.rs:+7:20: +7:32
@@ -83,7 +83,7 @@
           _27 = const _;                   // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:542:14: 542:31
-                                           // + literal: Const { ty: &Option<i32>, val: Unevaluated(debuginfo, [], Some(promoted[1])) }
+                                           // + literal: Const { ty: &Option<i32>, val: Unevaluated(debuginfo::{promoted#1}, [&std::option::Option<i32>]) }
 -         _9 = &(((*_27) as Some).0: i32); // scope 3 at $DIR/reference_prop.rs:+11:14: +11:31
 -         _6 = const ();                   // scope 4 at $DIR/reference_prop.rs:+11:36: +11:38
 -         StorageDead(_9);                 // scope 3 at $DIR/reference_prop.rs:+11:37: +11:38
@@ -109,7 +109,7 @@
           _26 = const _;                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
                                            // mir::Constant
                                            // + span: $DIR/reference_prop.rs:547:83: 547:90
-                                           // + literal: Const { ty: &[i32; 10], val: Unevaluated(debuginfo, [], Some(promoted[0])) }
+                                           // + literal: Const { ty: &[i32; 10], val: Unevaluated(debuginfo::{promoted#0}, [&[i32; 10]]) }
           _13 = &(*_26);                   // scope 5 at $DIR/reference_prop.rs:+16:83: +16:90
           StorageLive(_15);                // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93
           _15 = RangeFull;                 // scope 5 at $DIR/reference_prop.rs:+16:91: +16:93

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -119,7 +119,7 @@ fn array_casts() -> () {
         _35 = const _;                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: &usize, val: Unevaluated(array_casts, [], Some(promoted[0])) }
+                                         // + literal: Const { ty: &usize, val: Unevaluated(array_casts::{promoted#0}, [&usize]) }
         Retag(_35);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _18 = &(*_35);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _13 = (move _14, move _18);      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -142,7 +142,7 @@ fn main() -> () {
         _28 = const _;                   // scope 7 at $DIR/retag.rs:+18:21: +18:23
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:48:21: 48:23
-                                         // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
+                                         // + literal: Const { ty: &i32, val: Unevaluated(main::{promoted#0}, [&i32]) }
         Retag(_28);                      // scope 7 at $DIR/retag.rs:+18:21: +18:23
         _23 = &(*_28);                   // scope 7 at $DIR/retag.rs:+18:21: +18:23
         _22 = &(*_23);                   // scope 7 at $DIR/retag.rs:+18:21: +18:23

--- a/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
@@ -99,7 +99,7 @@
           _26 = const _;                   // scope 4 at $DIR/lifetimes.rs:+10:19: +10:28
                                            // mir::Constant
                                            // + span: $DIR/lifetimes.rs:27:19: 27:28
-                                           // + literal: Const { ty: &[&str; 3], val: Unevaluated(foo, [T], Some(promoted[0])) }
+                                           // + literal: Const { ty: &[&str; 3], val: Unevaluated(foo::{promoted#0}, [T, &[&str; 3]]) }
           _14 = &(*_26);                   // scope 4 at $DIR/lifetimes.rs:+10:19: +10:28
           _13 = &(*_14);                   // scope 4 at $DIR/lifetimes.rs:+10:19: +10:28
           _12 = move _13 as &[&str] (Pointer(Unsize)); // scope 4 at $DIR/lifetimes.rs:+10:19: +10:28

--- a/tests/ui/associated-consts/defaults-cyclic-fail.stderr
+++ b/tests/ui/associated-consts/defaults-cyclic-fail.stderr
@@ -10,7 +10,7 @@ note: ...which requires const-evaluating + checking `Tr::B`...
 LL |     const B: u8 = Self::A;
    |                   ^^^^^^^
    = note: ...which again requires const-evaluating + checking `Tr::A`, completing the cycle
-note: cycle used when const-evaluating + checking `main::promoted[1]`
+note: cycle used when const-evaluating + checking `main::{promoted#1}`
   --> $DIR/defaults-cyclic-fail.rs:16:16
    |
 LL |     assert_eq!(<() as Tr>::A, 0);

--- a/tests/ui/borrowck/issue-81899.rs
+++ b/tests/ui/borrowck/issue-81899.rs
@@ -8,7 +8,7 @@ const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
+    panic!() //~ ERROR evaluation of `_CONST::{promoted#0}` failed
     //~^ panic
 }
 

--- a/tests/ui/borrowck/issue-81899.stderr
+++ b/tests/ui/borrowck/issue-81899.stderr
@@ -1,4 +1,4 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation of `_CONST::{promoted#0}` failed
   --> $DIR/issue-81899.rs:11:5
    |
 LL |     panic!()
@@ -9,7 +9,7 @@ note: inside `f::<[closure@$DIR/issue-81899.rs:4:31: 4:34]>`
    |
 LL |     panic!()
    |     ^^^^^^^^
-note: inside `_CONST`
+note: inside `_CONST::{promoted#0}`
   --> $DIR/issue-81899.rs:4:24
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});

--- a/tests/ui/borrowck/issue-88434-minimal-example.rs
+++ b/tests/ui/borrowck/issue-88434-minimal-example.rs
@@ -7,7 +7,7 @@ const fn f<F>(_: &F)
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
+    panic!() //~ ERROR evaluation of `_CONST::{promoted#0}` failed
     //~^ panic
 }
 

--- a/tests/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/tests/ui/borrowck/issue-88434-minimal-example.stderr
@@ -1,4 +1,4 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation of `_CONST::{promoted#0}` failed
   --> $DIR/issue-88434-minimal-example.rs:10:5
    |
 LL |     panic!()
@@ -9,7 +9,7 @@ note: inside `f::<[closure@$DIR/issue-88434-minimal-example.rs:3:25: 3:28]>`
    |
 LL |     panic!()
    |     ^^^^^^^^
-note: inside `_CONST`
+note: inside `_CONST::{promoted#0}`
   --> $DIR/issue-88434-minimal-example.rs:3:22
    |
 LL | const _CONST: &() = &f(&|_| {});

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
@@ -7,7 +7,7 @@ const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
+    panic!() //~ ERROR evaluation of `_CONST::{promoted#0}` failed
     //~^ panic
 }
 

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -1,4 +1,4 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation of `_CONST::{promoted#0}` failed
   --> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
    |
 LL |     panic!()
@@ -9,7 +9,7 @@ note: inside `f::<[closure@$DIR/issue-88434-removal-index-should-be-less.rs:3:31
    |
 LL |     panic!()
    |     ^^^^^^^^
-note: inside `_CONST`
+note: inside `_CONST::{promoted#0}`
   --> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});

--- a/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
@@ -330,10 +330,10 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:160:1
+  --> $DIR/raw-bytes.rs:160:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
@@ -347,10 +347,10 @@ LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:166:1
+  --> $DIR/raw-bytes.rs:166:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
@@ -364,10 +364,10 @@ LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:170:1
+  --> $DIR/raw-bytes.rs:170:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -330,10 +330,10 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:160:1
+  --> $DIR/raw-bytes.rs:160:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
@@ -347,10 +347,10 @@ LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:166:1
+  --> $DIR/raw-bytes.rs:166:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
@@ -364,10 +364,10 @@ LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:170:1
+  --> $DIR/raw-bytes.rs:170:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -34,10 +34,10 @@ const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
 //~^ ERROR evaluation of constant value failed
 
 const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-//~^ ERROR evaluation of constant value failed
+//~^ ERROR evaluation of `REF_AS_USIZE_SLICE::{promoted#0}` failed
 
 const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
-//~^ ERROR evaluation of constant value failed
+//~^ ERROR evaluation of `REF_AS_USIZE_BOX_SLICE::{promoted#0}` failed
 
 const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
 //~^ ERROR it is undefined behavior to use this value

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -51,7 +51,7 @@ LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation of `REF_AS_USIZE_SLICE::{promoted#0}` failed
   --> $DIR/ub-ref-ptr.rs:36:39
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
@@ -66,7 +66,7 @@ note: erroneous constant used
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
+error[E0080]: evaluation of `REF_AS_USIZE_BOX_SLICE::{promoted#0}` failed
   --> $DIR/ub-ref-ptr.rs:39:86
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };

--- a/tests/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -129,10 +129,10 @@ LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:85:1
+  --> $DIR/ub-wide-ptr.rs:85:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
@@ -146,10 +146,10 @@ LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:92:1
+  --> $DIR/ub-wide-ptr.rs:92:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
@@ -163,10 +163,10 @@ LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:96:1
+  --> $DIR/ub-wide-ptr.rs:96:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {

--- a/tests/ui/consts/invalid-union.32bit.stderr
+++ b/tests/ui/consts/invalid-union.32bit.stderr
@@ -1,8 +1,8 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-union.rs:41:1
+  --> $DIR/invalid-union.rs:42:25
    |
-LL | fn main() {
-   | ^^^^^^^^^ constructing invalid value at .<deref>.y.<enum-variant(B)>.0: encountered `UnsafeCell` in a `const`
+LL |     let _: &'static _ = &C;
+   |                         ^^ constructing invalid value at .<deref>.y.<enum-variant(B)>.0: encountered `UnsafeCell` in a `const`
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
@@ -10,13 +10,13 @@ LL | fn main() {
            }
 
 note: erroneous constant used
-  --> $DIR/invalid-union.rs:43:25
+  --> $DIR/invalid-union.rs:42:25
    |
 LL |     let _: &'static _ = &C;
    |                         ^^
 
 note: erroneous constant used
-  --> $DIR/invalid-union.rs:43:25
+  --> $DIR/invalid-union.rs:42:25
    |
 LL |     let _: &'static _ = &C;
    |                         ^^

--- a/tests/ui/consts/invalid-union.64bit.stderr
+++ b/tests/ui/consts/invalid-union.64bit.stderr
@@ -1,8 +1,8 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-union.rs:41:1
+  --> $DIR/invalid-union.rs:42:25
    |
-LL | fn main() {
-   | ^^^^^^^^^ constructing invalid value at .<deref>.y.<enum-variant(B)>.0: encountered `UnsafeCell` in a `const`
+LL |     let _: &'static _ = &C;
+   |                         ^^ constructing invalid value at .<deref>.y.<enum-variant(B)>.0: encountered `UnsafeCell` in a `const`
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
@@ -10,13 +10,13 @@ LL | fn main() {
            }
 
 note: erroneous constant used
-  --> $DIR/invalid-union.rs:43:25
+  --> $DIR/invalid-union.rs:42:25
    |
 LL |     let _: &'static _ = &C;
    |                         ^^
 
 note: erroneous constant used
-  --> $DIR/invalid-union.rs:43:25
+  --> $DIR/invalid-union.rs:42:25
    |
 LL |     let _: &'static _ = &C;
    |                         ^^

--- a/tests/ui/consts/invalid-union.rs
+++ b/tests/ui/consts/invalid-union.rs
@@ -38,7 +38,7 @@ const C: S = {
     s
 };
 
-fn main() { //~ ERROR it is undefined behavior to use this value
-    // FIXME the span here is wrong, sould be pointing at the line below, not above.
+fn main() {
     let _: &'static _ = &C;
+    //~^ ERROR it is undefined behavior to use this value
 }

--- a/tests/ui/limits/issue-55878.stderr
+++ b/tests/ui/limits/issue-55878.stderr
@@ -3,7 +3,7 @@ error[E0080]: values of the type `[u8; usize::MAX]` are too big for the current 
    |
 note: inside `std::mem::size_of::<[u8; usize::MAX]>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `main`
+note: inside `main::{promoted#0}`
   --> $DIR/issue-55878.rs:7:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());

--- a/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -1,3 +1,11 @@
+note: no external requirements
+  --> $DIR/ty-param-closure-approximate-lower-bound.rs:23:26
+   |
+LL |     let cell = Cell::new(&());
+   |                          ^^^
+   |
+   = note: defining inline constant type: generic<T>::{promoted#0}
+
 note: external requirements
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:24:24
    |

--- a/tests/ui/nll/user-annotations/promoted-annotation.stderr
+++ b/tests/ui/nll/user-annotations/promoted-annotation.stderr
@@ -6,7 +6,7 @@ LL | fn foo<'a>() {
 LL |     let x = 0;
    |         - binding `x` declared here
 LL |     let f = &drop::<&'a i32>;
-   |             ---------------- assignment requires that `x` is borrowed for `'a`
+   |             ---------------- using this value as a constant requires that `x` is borrowed for `'a`
 LL |     f(&x);
    |       ^^ borrowed value does not live long enough
 LL |

--- a/tests/ui/polymorphization/promoted-function-1.rs
+++ b/tests/ui/polymorphization/promoted-function-1.rs
@@ -9,4 +9,5 @@ fn foo<'a>(_: &'a ()) {}
 pub fn test<T>() {
     //~^ ERROR item has unused generic parameters
     foo(&());
+    //~^ ERROR item has unused generic parameters
 }

--- a/tests/ui/polymorphization/promoted-function-1.stderr
+++ b/tests/ui/polymorphization/promoted-function-1.stderr
@@ -1,8 +1,17 @@
 error: item has unused generic parameters
+  --> $DIR/promoted-function-1.rs:11:9
+   |
+LL | pub fn test<T>() {
+   |             - generic parameter `T` is unused
+LL |
+LL |     foo(&());
+   |         ^^^
+
+error: item has unused generic parameters
   --> $DIR/promoted-function-1.rs:9:8
    |
 LL | pub fn test<T>() {
    |        ^^^^ - generic parameter `T` is unused
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 

--- a/tests/ui/polymorphization/unsized_cast.rs
+++ b/tests/ui/polymorphization/unsized_cast.rs
@@ -10,7 +10,8 @@ fn foo<T: Default>() {
     let _: T = Default::default();
     (|| Box::new(|| {}) as Box<dyn Fn()>)();
     //~^ ERROR item has unused generic parameters
-    //~^^ ERROR item has unused generic parameters
+    //~| ERROR item has unused generic parameters
+    //~| ERROR item has unused generic parameters
 }
 
 #[rustc_polymorphize_error]
@@ -18,9 +19,11 @@ fn foo2<T: Default>() {
     let _: T = Default::default();
     (|| {
         //~^ ERROR item has unused generic parameters
+        //~| ERROR item has unused generic parameters
         let call: extern "rust-call" fn(_, _) = Fn::call;
         call(&|| {}, ());
         //~^ ERROR item has unused generic parameters
+        //~| ERROR item has unused generic parameters
     })();
 }
 

--- a/tests/ui/polymorphization/unsized_cast.stderr
+++ b/tests/ui/polymorphization/unsized_cast.stderr
@@ -17,7 +17,16 @@ LL |     (|| Box::new(|| {}) as Box<dyn Fn()>)();
    |      ^^
 
 error: item has unused generic parameters
-  --> $DIR/unsized_cast.rs:22:15
+  --> $DIR/unsized_cast.rs:11:5
+   |
+LL | fn foo<T: Default>() {
+   |        - generic parameter `T` is unused
+LL |     let _: T = Default::default();
+LL |     (|| Box::new(|| {}) as Box<dyn Fn()>)();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: item has unused generic parameters
+  --> $DIR/unsized_cast.rs:24:15
    |
 LL | fn foo2<T: Default>() {
    |         - generic parameter `T` is unused
@@ -26,7 +35,16 @@ LL |         call(&|| {}, ());
    |               ^^
 
 error: item has unused generic parameters
-  --> $DIR/unsized_cast.rs:19:6
+  --> $DIR/unsized_cast.rs:24:14
+   |
+LL | fn foo2<T: Default>() {
+   |         - generic parameter `T` is unused
+...
+LL |         call(&|| {}, ());
+   |              ^^^^^^
+
+error: item has unused generic parameters
+  --> $DIR/unsized_cast.rs:20:6
    |
 LL | fn foo2<T: Default>() {
    |         - generic parameter `T` is unused
@@ -34,5 +52,20 @@ LL |     let _: T = Default::default();
 LL |     (|| {
    |      ^^
 
-error: aborting due to 4 previous errors
+error: item has unused generic parameters
+  --> $DIR/unsized_cast.rs:20:5
+   |
+LL |   fn foo2<T: Default>() {
+   |           - generic parameter `T` is unused
+LL |       let _: T = Default::default();
+LL | /     (|| {
+LL | |
+LL | |
+LL | |         let call: extern "rust-call" fn(_, _) = Fn::call;
+...  |
+LL | |
+LL | |     })();
+   | |______^
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/query-system/query_depth.rs
+++ b/tests/ui/query-system/query_depth.rs
@@ -26,6 +26,6 @@ type Byte = Option<Option<Option<Option< Option<Option<Option<Option<
 >>>> >>>>;
 
 fn main() {
-//~^ ERROR: queries overflow the depth limit!
     println!("{}", std::mem::size_of::<Byte>());
+    //~^ ERROR: queries overflow the depth limit!
 }

--- a/tests/ui/query-system/query_depth.stderr
+++ b/tests/ui/query-system/query_depth.stderr
@@ -1,11 +1,12 @@
 error: queries overflow the depth limit!
-  --> $DIR/query_depth.rs:28:1
+  --> $DIR/query_depth.rs:29:20
    |
-LL | fn main() {
-   | ^^^^^^^^^
+LL |     println!("{}", std::mem::size_of::<Byte>());
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "128"]` attribute to your crate (`query_depth`)
    = note: query depth increased by 66 when computing layout of `core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<core::option::Option<alloc::boxed::Box<alloc::string::String>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/tests/ui/rfcs/rfc1623-2.rs
+++ b/tests/ui/rfcs/rfc1623-2.rs
@@ -50,9 +50,9 @@ static STATIC_SIMPLE_FN: &'static fn(&[u8]) -> &[u8] = &(id_u8_slice as fn(&[u8]
 const CONST_SIMPLE_FN: &'static fn(&[u8]) -> &[u8] = &(id_u8_slice as fn(&[u8]) -> &[u8]);
 
 // this should be the same as without elision
-static STATIC_NON_ELIDED_fN: &'static for<'a> fn(&'a [u8]) -> &'a [u8] =
+static STATIC_NON_ELIDED_FN: &'static for<'a> fn(&'a [u8]) -> &'a [u8] =
     &(id_u8_slice as for<'a> fn(&'a [u8]) -> &'a [u8]);
-const CONST_NON_ELIDED_fN: &'static for<'a> fn(&'a [u8]) -> &'a [u8] =
+const CONST_NON_ELIDED_FN: &'static for<'a> fn(&'a [u8]) -> &'a [u8] =
     &(id_u8_slice as for<'a> fn(&'a [u8]) -> &'a [u8]);
 
 // another function that elides, each to a different unbound lifetime


### PR DESCRIPTION
The current handling of promoted carries an `Option<Promoted>` everywhere to disambiguate the normal item from the constant.

This PR replaces the promoted constants by new definitions with new `DefKind::Promoted`.
This method allows to unify borrow-checking with the code path for inline consts.

The main caveat is creating even more definitions that do not have any HIR associated, triggering new corner cases where `local_def_id_to_hir_id` panics.