### PR TITLE
don't skip inference for type in `offset_of!`

### DIFF
--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -692,15 +692,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             fcx_typeck_results.offset_of_data().items_in_stable_order()
         {
             let hir_id = hir::HirId { owner: common_hir_owner, local_id };
-
-            if cfg!(debug_assertions) && container.has_infer() {
-                span_bug!(
-                    hir_id.to_span(self.fcx.tcx),
-                    "writeback: `{:?}` has inference variables",
-                    container
-                );
-            };
-
+            let container = self.resolve(container, &hir_id);
             self.typeck_results.offset_of_data_mut().insert(hir_id, (container, indices.clone()));
         }
     }

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -481,10 +481,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }))))
             }
 
-            ExprKind::OffsetOf { container, fields } => block.and(Rvalue::NullaryOp(
-                NullOp::OffsetOf(fields),
-                this.tcx.erase_regions(container),
-            )),
+            ExprKind::OffsetOf { container, fields } => {
+                block.and(Rvalue::NullaryOp(NullOp::OffsetOf(fields), container))
+            }
 
             ExprKind::Literal { .. }
             | ExprKind::NamedConst { .. }

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -394,6 +394,8 @@ fn offset_of() {
         z: T
     }
 
+    trait Trait {}
+
     // Ensure that this type of generics works
     fn offs_of_z<T>() -> usize {
         offset_of!(Generic<T>, z)
@@ -401,6 +403,9 @@ fn offset_of() {
 
     assert_eq!(offset_of!(Generic<u8>, z), 8);
     assert_eq!(offs_of_z::<u8>(), 8);
+
+    // Ensure that it works with the implicit lifetime in `Box<dyn Trait + '_>`.
+    assert_eq!(offset_of!(Generic<Box<dyn Trait>>, z), 8);
 }
 
 #[test]

--- a/tests/ui/offset-of/offset-of-arg-count.rs
+++ b/tests/ui/offset-of/offset-of-arg-count.rs
@@ -13,7 +13,7 @@ fn main() {
     offset_of!(S, f..); //~ ERROR no rules expected the token
     offset_of!(S, f..,); //~ ERROR no rules expected the token
     offset_of!(Lt<'static>, bar); // issue #111657
-
+    offset_of!(Lt<'_>, bar); // issue #111678
 }
 
 struct S { f: u8, }

--- a/tests/ui/offset-of/offset-of-dst-field.rs
+++ b/tests/ui/offset-of/offset-of-dst-field.rs
@@ -41,6 +41,7 @@ fn main() {
 fn delta() {
     offset_of!(Delta<Alpha>, z); //~ ERROR the size for values of type
     offset_of!(Delta<Extern>, z); //~ ERROR the size for values of type
+    offset_of!(Delta<dyn Trait>, z); //~ ERROR the size for values of type
 }
 
 fn generic_with_maybe_sized<T: ?Sized>() -> usize {

--- a/tests/ui/offset-of/offset-of-dst-field.stderr
+++ b/tests/ui/offset-of/offset-of-dst-field.stderr
@@ -34,6 +34,15 @@ LL |     offset_of!(Delta<Extern>, z);
    = help: the trait `Sized` is not implemented for `Extern`
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
+  --> $DIR/offset-of-dst-field.rs:44:5
+   |
+LL |     offset_of!(Delta<dyn Trait>, z);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn Trait`
+   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:42:5
    |
@@ -49,7 +58,7 @@ LL | struct Alpha {
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/offset-of-dst-field.rs:47:5
+  --> $DIR/offset-of-dst-field.rs:48:5
    |
 LL | fn generic_with_maybe_sized<T: ?Sized>() -> usize {
    |                             - this type parameter needs to be `std::marker::Sized`
@@ -63,6 +72,6 @@ LL - fn generic_with_maybe_sized<T: ?Sized>() -> usize {
 LL + fn generic_with_maybe_sized<T>() -> usize {
    |
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/offset-of/offset-of-inference.rs
+++ b/tests/ui/offset-of/offset-of-inference.rs
@@ -1,0 +1,11 @@
+// Test that inference types in `offset_of!` don't ICE.
+
+#![feature(offset_of)]
+
+struct Foo<T> {
+    x: T,
+}
+
+fn main() {
+    let _ = core::mem::offset_of!(Foo<_>, x); //~ ERROR: type annotations needed
+}

--- a/tests/ui/offset-of/offset-of-inference.stderr
+++ b/tests/ui/offset-of/offset-of-inference.stderr
@@ -1,0 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/offset-of-inference.rs:10:35
+   |
+LL |     let _ = core::mem::offset_of!(Foo<_>, x);
+   |                                   ^^^^^^ cannot infer type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/111678 by no longer skipping inference on the type in `offset_of!`. Simply erasing the regions the during writeback isn't enough and can cause ICEs. A test case for this is included.

This reverts https://github.com/rust-lang/rust/pull/111661, because it becomes redundant, since inference already erases the regions.