### PR TITLE
Bump `cc` for `bootstrap`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,17 @@ jobs:
           - name: x86_64-gnu-tools
             os: ubuntu-20.04-16core-64gb
             env: {}
+          - name: dist-apple-various
+            env:
+              SCRIPT: "./x.py dist bootstrap --include-default-paths --host='' --target=aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim"
+              RUST_CONFIGURE_ARGS: "--enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false"
+              RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+              MACOSX_DEPLOYMENT_TARGET: 10.7
+              SELECT_XCODE: /Applications/Xcode_13.4.1.app
+              NO_LLVM_ASSERTIONS: 1
+              NO_DEBUG_ASSERTIONS: 1
+              NO_OVERFLOW_CHECKS: 1
+            os: macos-latest
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -89,9 +89,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 
 [[package]]
 name = "cfg-if"

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -89,9 +89,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 
 [[package]]
 name = "cfg-if"

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -89,8 +89,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
-source = "git+https://github.com/rust-lang/cc-rs?rev=57853c4bf8a89a0f4c9137eb367ac580305c6919#57853c4bf8a89a0f4c9137eb367ac580305c6919"
+version = "1.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 
 [[package]]
 name = "cfg-if"

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -89,9 +89,8 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+version = "1.0.73"
+source = "git+https://github.com/rust-lang/cc-rs?rev=53fb72c87e5769a299f1886ead831901b9c775d6#53fb72c87e5769a299f1886ead831901b9c775d6"
 
 [[package]]
 name = "cfg-if"

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -89,8 +89,8 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
-source = "git+https://github.com/rust-lang/cc-rs?rev=53fb72c87e5769a299f1886ead831901b9c775d6#53fb72c87e5769a299f1886ead831901b9c775d6"
+version = "1.0.79"
+source = "git+https://github.com/rust-lang/cc-rs?rev=57853c4bf8a89a0f4c9137eb367ac580305c6919#57853c4bf8a89a0f4c9137eb367ac580305c6919"
 
 [[package]]
 name = "cfg-if"

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -92,3 +92,6 @@ debug = 0
 [profile.dev.package]
 # Only use debuginfo=1 to further reduce compile times.
 bootstrap.debug = 1
+
+[patch.crates-io]
+cc = { git = 'https://github.com/rust-lang/cc-rs', rev = '53fb72c87e5769a299f1886ead831901b9c775d6' }

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -92,6 +92,3 @@ debug = 0
 [profile.dev.package]
 # Only use debuginfo=1 to further reduce compile times.
 bootstrap.debug = 1
-
-[patch.crates-io]
-cc = { git = 'https://github.com/rust-lang/cc-rs', rev = '57853c4bf8a89a0f4c9137eb367ac580305c6919' }

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -94,4 +94,4 @@ debug = 0
 bootstrap.debug = 1
 
 [patch.crates-io]
-cc = { git = 'https://github.com/rust-lang/cc-rs', rev = '53fb72c87e5769a299f1886ead831901b9c775d6' }
+cc = { git = 'https://github.com/rust-lang/cc-rs', rev = '57853c4bf8a89a0f4c9137eb367ac580305c6919' }

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -314,6 +314,19 @@ jobs:
           - name: x86_64-gnu-tools
             <<: *job-linux-16c
 
+          - name: dist-apple-various
+            env:
+              SCRIPT: ./x.py dist bootstrap --include-default-paths --host='' --target=aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim
+              RUST_CONFIGURE_ARGS: --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false
+              RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+              MACOSX_DEPLOYMENT_TARGET: 10.7
+              SELECT_XCODE: /Applications/Xcode_13.4.1.app
+              NO_LLVM_ASSERTIONS: 1
+              NO_DEBUG_ASSERTIONS: 1
+              NO_OVERFLOW_CHECKS: 1
+            <<: *job-macos-xl
+
+
   auto:
     permissions:
       actions: write # for rust-lang/simpleinfra/github-actions/cancel-outdated-builds

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -27,13 +27,6 @@ if isMacOS; then
     ciCommandSetEnv CC "${bindir}/clang"
     ciCommandSetEnv CXX "${bindir}/clang++"
 
-    # macOS 10.15 onwards doesn't have libraries in /usr/include anymore: those
-    # are now located deep into the filesystem, under Xcode's own files. The
-    # native clang is configured to use the correct path, but our custom one
-    # doesn't. This sets the SDKROOT environment variable to the SDK so that
-    # our own clang can figure out the correct include path on its own.
-    ciCommandSetEnv SDKROOT "$(xcrun --sdk macosx --show-sdk-path)"
-
     # Configure `AR` specifically so rustbuild doesn't try to infer it as
     # `clang-ar` by accident.
     ciCommandSetEnv AR "ar"


### PR DESCRIPTION
Bump the version of dependency `cc` to `1.0.77` for `bootstrap`, syncing with `rust/Cargo.lock`

Resolves #111700