### PR TITLE
Give a more useful location for where a span_bug was delayed

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1740,7 +1740,7 @@ impl DelayedDiagnostic {
     }
 
     fn decorate(mut self) -> Diagnostic {
-        self.inner.note(format!("delayed at {}", self.note));
+        self.inner.note(format!("delayed at {}\n{}", self.inner.emitted_at, self.note));
         self.inner
     }
 }

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -238,6 +238,7 @@ impl<'a> DerefMut for SnapshotParser<'a> {
 
 impl<'a> Parser<'a> {
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_err<S: Into<MultiSpan>>(
         &self,
         sp: S,


### PR DESCRIPTION
Before:
```
   = note: delayed at    0: <rustc_errors::HandlerInner>::emit_diagnostic
                        at ./compiler/rustc_errors/src/lib.rs:1335:29
              1: <rustc_errors::Handler>::emit_diagnostic
                        at ./compiler/rustc_errors/src/lib.rs:1124:9
...
```

After:
```
   = note: delayed at compiler/rustc_parse/src/parser/diagnostics.rs:2158:28
              0: <rustc_errors::HandlerInner>::emit_diagnostic
                        at ./compiler/rustc_errors/src/lib.rs:1335:29
              1: <rustc_errors::Handler>::emit_diagnostic
                        at ./compiler/rustc_errors/src/lib.rs:1124:9
...
```

This both makes the relevant frame easier to find without having to dig through diagnostic internals, and avoids the weird-looking formatting for the first frame.

Found while working on https://github.com/rust-lang/rust/issues/111529.