### PR TITLE
Document `Pin` memory layout

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -393,6 +393,8 @@ use crate::ops::{CoerceUnsized, Deref, DerefMut, DispatchFromDyn, Receiver};
 /// value in place, preventing the value referenced by that pointer from being moved
 /// unless it implements [`Unpin`].
 ///
+/// `Pin<P>` is guaranteed to have the same memory layout and ABI as `P`.
+///
 /// *See the [`pin` module] documentation for an explanation of pinning.*
 ///
 /// [`pin` module]: self


### PR DESCRIPTION
The fact that `Pin` is `#[repr(transparent)]` technically isn't documented anywhere currently. I don't see any reason why `Pin`'s layout would ever change, so this PR codifies it.

@rustbot label +T-libs-api -T-libs +A-docs +A-layout +A-pin