### PR TITLE
Stop confusing specification levels when computing expectations.

### DIFF
--- a/tests/ui/lint/rfc-2383-lint-reason/root-attribute-confusion.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/root-attribute-confusion.rs
@@ -1,0 +1,7 @@
+// check-pass
+// compile-flags: -Dunused_attributes
+
+#![deny(unused_crate_dependencies)]
+#![feature(lint_reasons)]
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/111682