### PR TITLE
use git ls-tree --format instead of manually carving hashes

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -547,19 +547,17 @@ impl Build {
         let checked_out_hash =
             output(Command::new("git").args(&["rev-parse", "HEAD"]).current_dir(&absolute_path));
         // update_submodules
-        let recorded = output(
+        let actual_hash = output(
             Command::new("git")
                 .args(&["ls-tree", "HEAD"])
                 .arg(relative_path)
+                // FIXME: replace --format with --object-only when git >= 2.36
+                .arg("--format=%(objectname)")
                 .current_dir(&self.config.src),
         );
-        let actual_hash = recorded
-            .split_whitespace()
-            .nth(2)
-            .unwrap_or_else(|| panic!("unexpected output `{}`", recorded));
 
         // update_submodule
-        if actual_hash == checked_out_hash.trim_end() {
+        if actual_hash == checked_out_hash {
             // already checked out
             return;
         }

--- a/src/ci/scripts/checkout-submodules.sh
+++ b/src/ci/scripts/checkout-submodules.sh
@@ -47,7 +47,8 @@ urls=($urls)
 for i in ${!modules[@]}; do
     module=${modules[$i]}
     if [[ " $included " = *" $module "* ]]; then
-        commit="$(git ls-tree HEAD $module | awk '{print $3}')"
+        # FIXME: replace --format with --object-only when git >= 2.36
+        commit="$(git ls-tree HEAD $module --format='%(objectname)')"
         git rm $module
         url=${urls[$i]}
         url=${url/\.git/}


### PR DESCRIPTION
https://git-scm.com/docs/git-ls-tree#Documentation/git-ls-tree.txt---formatltformatgt
--object-only can be used only from git 2.36 version.