### PR TITLE
Use replacen instead of strip_prefix to skip prefix chars

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -329,11 +329,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span = item_name.span;
 
         // Don't show generic arguments when the method can't be found in any implementation (#81576).
-        let mut ty_str_reported = if trait_missing_method {
-            ty_str.strip_prefix("dyn ").expect("Failed to remove the prefix dyn").to_owned()
-        } else {
-            ty_str.clone()
-        };
+        let mut ty_str_reported =
+            if trait_missing_method { ty_str.replacen("dyn ", "", 1) } else { ty_str.clone() };
 
         if let ty::Adt(_, generics) = rcvr_ty.kind() {
             if generics.len() > 0 {
@@ -389,8 +386,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty_str
         };
         if trait_missing_method {
-            ty_str =
-                ty_str.strip_prefix("dyn ").expect("Failed to remove the prefix dyn").to_owned();
+            ty_str = ty_str.replacen("dyn ", "", 1);
         }
 
         if let Some(file) = ty_file {

--- a/tests/ui/resolve/issue-111727.rs
+++ b/tests/ui/resolve/issue-111727.rs
@@ -1,0 +1,5 @@
+// edition: 2021
+
+fn main() {
+    std::any::Any::create(); //~ ERROR
+}

--- a/tests/ui/resolve/issue-111727.stderr
+++ b/tests/ui/resolve/issue-111727.stderr
@@ -1,0 +1,9 @@
+error[E0599]: no function or associated item named `create` found for trait `(Any + 'static)`
+  --> $DIR/issue-111727.rs:4:20
+   |
+LL |     std::any::Any::create();
+   |                    ^^^^^^ function or associated item not found in `Any`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fixes #111727 