### PR TITLE
Keep only the trait when emitting the error for `MyTrait + 'a`

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -288,8 +288,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mode = no_match_data.mode;
         let tcx = self.tcx;
         let rcvr_ty = self.resolve_vars_if_possible(rcvr_ty);
-        let (ty_str, ty_file) = tcx.short_ty_string(rcvr_ty);
-        let short_ty_str = with_forced_trimmed_paths!(rcvr_ty.to_string());
+        let (mut ty_str, ty_file) = tcx.short_ty_string(rcvr_ty);
+        let mut short_ty_str = with_forced_trimmed_paths!(rcvr_ty.to_string());
         let is_method = mode == Mode::MethodCall;
         let unsatisfied_predicates = &no_match_data.unsatisfied_predicates;
         let similar_candidate = no_match_data.similar_candidate;
@@ -328,13 +328,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
         span = item_name.span;
 
-        // Don't show generic arguments when the method can't be found in any implementation (#81576).
-        let mut ty_str_reported = if trait_missing_method {
-            ty_str.strip_prefix("dyn ").expect("Failed to remove the prefix dyn").to_owned()
-        } else {
-            ty_str.clone()
-        };
+        if trait_missing_method && let ty::Dynamic(predicates, _, _) = rcvr_ty.kind() {
+            ty_str = predicates.to_string();
+            short_ty_str = with_forced_trimmed_paths!(predicates.to_string());
+        }
 
+        // Don't show generic arguments when the method can't be found in any implementation (#81576).
+        let mut ty_str_reported = ty_str.clone();
         if let ty::Adt(_, generics) = rcvr_ty.kind() {
             if generics.len() > 0 {
                 let mut autoderef = self.autoderef(span, rcvr_ty);
@@ -383,14 +383,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if tcx.sess.source_map().is_multiline(sugg_span) {
             err.span_label(sugg_span.with_hi(span.lo()), "");
         }
-        let mut ty_str = if short_ty_str.len() < ty_str.len() && ty_str.len() > 10 {
-            short_ty_str
-        } else {
-            ty_str
-        };
-        if trait_missing_method {
-            ty_str =
-                ty_str.strip_prefix("dyn ").expect("Failed to remove the prefix dyn").to_owned();
+
+        if short_ty_str.len() < ty_str.len() && ty_str.len() > 10 {
+            ty_str = short_ty_str;
         }
 
         if let Some(file) = ty_file {

--- a/tests/ui/resolve/issue-111727.rs
+++ b/tests/ui/resolve/issue-111727.rs
@@ -1,0 +1,5 @@
+// edition: 2021
+
+fn main() {
+    std::any::Any::create(); //~ ERROR
+}

--- a/tests/ui/resolve/issue-111727.stderr
+++ b/tests/ui/resolve/issue-111727.stderr
@@ -1,0 +1,9 @@
+error[E0599]: no function or associated item named `create` found for trait `Any`
+  --> $DIR/issue-111727.rs:4:20
+   |
+LL |     std::any::Any::create();
+   |                    ^^^^^^ function or associated item not found in `Any`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fixes #111727 