### PR TITLE
bootstrap: (half) merge cp_r and cp_filtered

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1564,7 +1564,6 @@ impl Build {
                     self.create_dir(&dst);
                     self.recurse_(&path, &dst, &relative, filter);
                 } else {
-                    let _ = fs::remove_file(&dst);
                     self.copy(&path, &dst);
                 }
             }


### PR DESCRIPTION
Half-way merges cp_r and cp_filtered functions, as there some different points:

`cp_r` and `cp_filtered` difference:
skip running if dry_run => `cp_r`: yes, `cp_filtered`: no
removes target dir if it exist (i.e. can't be used to copy files into dst dir from multiple sources, (or no?)) => `cp_r`: no,  `cp_filtered`: yes

Currently this two places didn't changed.