### PR TITLE
Implement intrinsic for swapping values

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/driver/jit.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/jit.rs
@@ -325,7 +325,7 @@ fn dep_symbol_lookup_fn(
             Linkage::NotLinked | Linkage::IncludedFromDylib => {}
             Linkage::Static => {
                 let name = crate_info.crate_name[&cnum];
-                let mut err = sess.struct_err(&format!("Can't load static lib {}", name));
+                let mut err = sess.struct_err(format!("Can't load static lib {}", name));
                 err.note("rustc_codegen_cranelift can only load dylibs in JIT mode.");
                 err.emit();
             }

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -7,6 +7,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(extern_types)]
 #![feature(hash_raw_entry)]
+#![feature(inline_const)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(never_type)]

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -9,12 +9,12 @@ use crate::meth;
 use crate::traits::*;
 use crate::MemFlags;
 
-use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::{sym, Span};
-use rustc_target::abi::{
-    call::{FnAbi, PassMode},
-    WrappingRange,
-};
+use rustc_middle::ty;
+use rustc_middle::ty::{Ty, TyCtxt};
+use rustc_span::sym;
+use rustc_span::Span;
+use rustc_target::abi::call::{FnAbi, PassMode};
+use rustc_target::abi::WrappingRange;
 
 fn copy_intrinsic<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     bx: &mut Bx,
@@ -34,6 +34,442 @@ fn copy_intrinsic<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         bx.memmove(dst, align, src, align, size, flags);
     } else {
         bx.memcpy(dst, align, src, align, size, flags);
+    }
+}
+
+mod swap_intrinsic {
+    use crate::traits::*;
+    use crate::MemFlags;
+
+    use rustc_middle::mir::interpret::PointerArithmetic;
+    use rustc_middle::ty::Ty;
+    use rustc_span::Span;
+    use rustc_target::abi::{Align, Size};
+    use rustc_target::spec::HasTargetSpec;
+
+    // Note: We deliberately interpret our values as some ranges of bytes
+    // for performance like did earlier in the old `core::mem::swap` implementation
+    // and use immediate values instead of PlaceRefs.
+    pub(super) fn single<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+        bx: &mut Bx,
+        x_ptr: Bx::Value,
+        y_ptr: Bx::Value,
+        ty: Ty<'tcx>,
+        span: Span,
+    ) {
+        let layout = bx.layout_of(ty);
+        if layout.is_unsized() {
+            span_bug!(span, "swap_nonoverlapping_single must be called only for sized types");
+        }
+        if layout.is_zst() {
+            // no-op
+            return;
+        }
+        let should_use_2_temp_vals = {
+            // Primitive integer or something equal to it by size.
+            (layout.size <= bx.cx().pointer_size() && layout.size.bytes().is_power_of_two())
+            // SPIR-V doesn't allow reinterpretation of values as chunks of arbitrary ints
+            // so we need to read and copy them full.
+            // For small values we use double read-double write.
+            || (layout.size <= bx.cx().pointer_size() && bx.cx().target_spec().arch == "spirv")
+        };
+        if should_use_2_temp_vals {
+            let ty = bx.backend_type(layout);
+            let align = layout.align.abi;
+            swap_using_2_temps(bx, x_ptr, y_ptr, ty, align);
+            return;
+        }
+
+        // If need to swap large value,
+        // it probably better to do single memcpy from one elem
+        // to another after saving the old value.
+        let should_use_single_temp_val = {
+            // Most likely some `Simd<X, N>` type from portable simd or manual simd.
+            // There is no difference with double read in release build
+            // but it reduces amount of code generated in debug build.
+            (layout.align.abi.bytes() == layout.size.bytes() && layout.size > bx.cx().pointer_size())
+            // Probably aggregate with some SIMD type field.
+            // E.g. `Option<f32x4>`.
+            // Need to think how to do it better.
+            || layout.align.abi > bx.data_layout().pointer_align.abi
+            // SPIRV doesn't allow partial reads/writes and value reinterpretations
+            // so our best chance to reduce stack usage is to use single alloca.
+            || bx.cx().target_spec().arch == "spirv"
+        };
+        if should_use_single_temp_val {
+            let ty = bx.backend_type(layout);
+            swap_using_single_temp(bx, x_ptr, y_ptr, ty, layout.size, layout.align.abi);
+            return;
+        }
+
+        // Both LLVM and GCC seem to benefit from same splitting loops
+        // so place this code here to prevent duplication.
+        // https://godbolt.org/z/arzvePb8T
+
+        if bx.cx().target_spec().arch == "x86_64" {
+            swap_unaligned_x86_64_single(bx, layout, x_ptr, y_ptr);
+            return;
+        }
+
+        // Swap using aligned integers as chunks.
+        assert!(layout.align.abi.bytes() <= bx.pointer_size().bytes());
+        assert_eq!(bx.data_layout().pointer_align.abi.bytes(), bx.pointer_size().bytes());
+        let chunk_size = std::cmp::min(layout.align.abi.bytes(), bx.pointer_size().bytes());
+        let chunk_size = Size::from_bytes(chunk_size);
+        make_swaps_loop(
+            bx,
+            x_ptr,
+            y_ptr,
+            ToSwap::Bytes(layout.size),
+            ChunkInfo::IntChunk(chunk_size),
+            NumOfTemps::Two,
+            Align::from_bytes(chunk_size.bytes()).unwrap(),
+        );
+    }
+
+    // `x86_64` allows optimization using unaligned accesses
+    // because unaligned reads/writes are fast on x86_64.
+    // https://lemire.me/blog/2012/05/31/data-alignment-for-speed-myth-or-reality/
+    // We manually swap last `x % ZMM_BYTES` bytes in a way that would always vectorize
+    // them AVX and/or SSE because both GCC and LLVM generate fails to use smaller SIMD registers
+    // if they had used larger ones.
+    fn swap_unaligned_x86_64_single<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+        bx: &mut Bx,
+        layout: Bx::LayoutOfResult,
+        x_ptr: Bx::Value,
+        y_ptr: Bx::Value,
+    ) {
+        const ZMM_BYTES: u64 = 512 / 8;
+        const YMM_BYTES: u64 = 256 / 8;
+        const XMM_BYTES: u64 = 128 / 8;
+
+        let min_align = Align::from_bytes(1).expect("One is always valid align.");
+        let ptr_size = bx.cx().pointer_size();
+        // Need to do pointercasts because `rustc_codegen_gcc` ignores passed type
+        // in `inbounds_gep`.
+        let x_ptr = bx.pointercast(x_ptr, bx.type_i8p());
+        let y_ptr = bx.pointercast(y_ptr, bx.type_i8p());
+
+        let mut total_offset = Size::ZERO;
+        // Make a loop that is vectorized using largest vectors.
+        // It would use largest available vectors, not necessary ZMM.
+        if layout.size.bytes() >= ZMM_BYTES {
+            let to_swap = Size::from_bytes(layout.size.bytes() / ZMM_BYTES * ZMM_BYTES);
+            make_swaps_loop(
+                bx,
+                x_ptr,
+                y_ptr,
+                ToSwap::Bytes(to_swap),
+                ChunkInfo::IntChunk(ptr_size),
+                NumOfTemps::Two,
+                min_align,
+            );
+            total_offset += to_swap;
+        }
+        // This loop contents are based on knowledge from this: https://godbolt.org/z/Mr4rWfoad
+        // And this: https://godbolt.org/z/YzcWofG5Y
+        // Both LLVM and GCC fail to use SIMD registers for swapping tails without this.
+        for (num_temps, chunk_size) in [(4, YMM_BYTES), (2, XMM_BYTES)] {
+            let chunk_size = Size::from_bytes(chunk_size);
+            assert_eq!(
+                ptr_size * num_temps,
+                chunk_size,
+                "Invalid assumption about pointer size or register size",
+            );
+            if layout.size < total_offset + chunk_size {
+                continue;
+            }
+
+            let x_tmps_and_offsets: Vec<_> = (0..num_temps)
+                .map(|i| {
+                    let curr_off = total_offset + i * ptr_size;
+                    let curr_off = bx.const_usize(curr_off.bytes());
+                    let x_gep = bx.inbounds_gep(bx.type_i8(), x_ptr, &[curr_off]);
+                    // FIXME: Remove pointercast after stopping support of LLVM 14.
+                    let x_gep = bx.pointercast(x_gep, bx.type_ptr_to(bx.type_isize()));
+                    (bx.load(bx.type_isize(), x_gep, min_align), curr_off)
+                })
+                .collect();
+
+            let chunk_size_val = bx.const_usize(chunk_size.bytes());
+            let chunk_offset = bx.const_usize(total_offset.bytes());
+            let x_chunk_gep = bx.inbounds_gep(bx.type_i8(), x_ptr, &[chunk_offset]);
+            let y_chunk_gep = bx.inbounds_gep(bx.type_i8(), y_ptr, &[chunk_offset]);
+            // FIXME(AngelicosPhosphoros): Use memcpy.inline here.
+            bx.memcpy(
+                x_chunk_gep,
+                min_align,
+                y_chunk_gep,
+                min_align,
+                chunk_size_val,
+                MemFlags::UNALIGNED,
+            );
+            for (x_tmp, curr_off) in x_tmps_and_offsets {
+                let y_gep = bx.inbounds_gep(bx.type_i8(), y_ptr, &[curr_off]);
+                // FIXME: Remove pointercast after stopping support of LLVM 14.
+                let y_gep = bx.pointercast(y_gep, bx.type_ptr_to(bx.type_isize()));
+                bx.store(x_tmp, y_gep, min_align);
+            }
+
+            total_offset += chunk_size;
+        }
+
+        // I decided to use swaps by pow2 ints here based
+        // on this codegen example: https://godbolt.org/z/rWYqMGnWh
+        // This loops implements it using minimal amount of instructions
+        // and registers involved.
+        let mut current_size = bx.pointer_size();
+        while total_offset < layout.size {
+            // In each loop iteration, remaining amount of unswapped bytes
+            // is less than in previous iteration.
+
+            assert_ne!(current_size, Size::ZERO, "We must had finished swapping when it was 1");
+
+            let next_size = Size::from_bytes(current_size.bytes() / 2);
+            if total_offset + current_size > layout.size {
+                current_size = next_size;
+                continue;
+            }
+
+            let tail_offset = bx.const_usize(total_offset.bytes());
+            let x_tail_ptr = bx.inbounds_gep(bx.type_i8(), x_ptr, &[tail_offset]);
+            let y_tail_ptr = bx.inbounds_gep(bx.type_i8(), y_ptr, &[tail_offset]);
+
+            let chunt_ty = choose_int_by_size(bx, current_size);
+            swap_using_2_temps(bx, x_tail_ptr, y_tail_ptr, chunt_ty, min_align);
+
+            total_offset += current_size;
+            current_size = next_size;
+        }
+    }
+
+    // We cannot use some of optimizations available for [`single`]
+    // because we don't know how many bytes exactly we need to swap.
+    pub(super) fn many<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+        bx: &mut Bx,
+        x_ptr: Bx::Value,
+        y_ptr: Bx::Value,
+        count: Bx::Value,
+        ty: Ty<'tcx>,
+        span: Span,
+    ) {
+        let layout = bx.layout_of(ty);
+        if layout.is_unsized() {
+            span_bug!(span, "swap_nonoverlapping_many must be called only for sized types");
+        }
+        if layout.is_zst() {
+            // no-op
+            return;
+        }
+
+        let must_not_split_values = {
+            // Unusual type, maybe some manual SIMD optimization.
+            layout.align.abi > bx.data_layout().pointer_align.abi && layout.align.abi.bytes() == layout.size.bytes()
+            // Probably aggregate with some SIMD type field.
+            // E.g. `Option<f32x4>`.
+            // Need to think how to do it better.
+            || layout.align.abi > bx.data_layout().pointer_align.abi
+            // SPIR-V doesn't allow reinterpretation of values as chunks of arbitrary ints
+            // so we need to read and copy them by element full.
+            || bx.cx().target_spec().arch == "spirv"
+        };
+
+        if must_not_split_values {
+            let back_ty = bx.backend_type(layout);
+            let num_of_temps =
+                if layout.size > bx.pointer_size() { NumOfTemps::Single } else { NumOfTemps::Two };
+            make_swaps_loop(
+                bx,
+                x_ptr,
+                y_ptr,
+                ToSwap::Iterations(count),
+                ChunkInfo::RealTyChunk(back_ty, layout.size),
+                num_of_temps,
+                layout.align.abi,
+            );
+            return;
+        }
+
+        let chunk_size = if bx.cx().target_spec().arch == "x86_64" {
+            // x86_64 allows unaligned reads/writes
+            // and it is relatively fast
+            // so try largest chunk available.
+            const INT_SIZES: [u64; 4] = [1, 2, 4, 8];
+            INT_SIZES
+                .into_iter()
+                .map(Size::from_bytes)
+                .take_while(|x| *x <= layout.size)
+                .filter(|x| layout.size.bytes() % x.bytes() == 0)
+                .last()
+                .unwrap()
+        } else {
+            // Fallback to integer with size equal to alignment
+            Size::from_bytes(layout.align.abi.bytes())
+        };
+
+        let chunks_per_elem = layout.size.bytes() / chunk_size.bytes();
+        assert_ne!(chunks_per_elem, 0);
+        let iterations = if chunks_per_elem == 1 {
+            count
+        } else {
+            let chunks_per_elem = bx.const_usize(chunks_per_elem);
+            bx.unchecked_umul(count, chunks_per_elem)
+        };
+
+        make_swaps_loop(
+            bx,
+            x_ptr,
+            y_ptr,
+            ToSwap::Iterations(iterations),
+            ChunkInfo::IntChunk(chunk_size),
+            NumOfTemps::Two,
+            // It iterates either by chunks equal to alignment
+            // or multiply of alignment so it would always be correct.
+            layout.align.abi,
+        );
+    }
+
+    fn choose_int_by_size<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+        bx: &mut Bx,
+        size: Size,
+    ) -> Bx::Type {
+        match size.bits() {
+            8 => bx.type_i8(),
+            16 => bx.type_i16(),
+            32 => bx.type_i32(),
+            64 => bx.type_i64(),
+            128 => bx.type_i128(),
+            _ => unreachable!("Unexpected target int {:?}.", size),
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum ToSwap<BxValue> {
+        /// Size of region to swap. Useful when we know exact value.
+        Bytes(Size),
+        /// Number of chunks to swap. For runtime value.
+        Iterations(BxValue),
+    }
+
+    #[derive(Clone, Copy)]
+    enum ChunkInfo<BxType> {
+        /// When we want to use it directly
+        RealTyChunk(BxType, Size),
+        /// When we want to split value by integer chunk.
+        IntChunk(Size),
+    }
+
+    #[derive(Copy, Clone, Eq, PartialEq)]
+    enum NumOfTemps {
+        Single,
+        Two,
+    }
+
+    fn make_swaps_loop<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+        bx: &mut Bx,
+        x_ptr: Bx::Value,
+        y_ptr: Bx::Value,
+        to_swap: ToSwap<Bx::Value>,
+        chunk_info: ChunkInfo<Bx::Type>,
+        num_of_temps: NumOfTemps,
+        access_align: Align,
+    ) {
+        let (ChunkInfo::IntChunk(chunk_size) | ChunkInfo::RealTyChunk(_, chunk_size)) = chunk_info;
+
+        assert_ne!(chunk_size, Size::ZERO);
+
+        if let ToSwap::Bytes(total_bytes) = to_swap {
+            assert!(
+                total_bytes > chunk_size,
+                "No need to generate loop when simple swap is enough."
+            );
+            assert_eq!(
+                total_bytes.bytes() % chunk_size.bytes(),
+                0,
+                "Cannot split size of swap into chunks."
+            );
+        }
+
+        assert_eq!(
+            chunk_size.bytes() % access_align.bytes(),
+            0,
+            "Ensure that access align doesn't shift",
+        );
+
+        let chunk_ty = match chunk_info {
+            ChunkInfo::RealTyChunk(ty, _) => ty,
+            ChunkInfo::IntChunk(size) => choose_int_by_size(bx, size),
+        };
+
+        let iterations = match to_swap {
+            ToSwap::Bytes(s) => {
+                let iterations_val = s.bytes() / chunk_size.bytes();
+                bx.const_usize(iterations_val)
+            }
+            ToSwap::Iterations(it) => it,
+        };
+
+        // Need to do pointercasts because `rustc_codegen_gcc` ignores passed type
+        // in `inbounds_gep`.
+        let x_ptr = bx.pointercast(x_ptr, bx.type_i8p());
+        let y_ptr = bx.pointercast(y_ptr, bx.type_i8p());
+        bx.make_memory_loop(
+            "swap_loop",
+            [x_ptr, y_ptr],
+            [chunk_size; 2],
+            iterations,
+            |body_bx, &[curr_x_ptr, curr_y_ptr]| match num_of_temps {
+                NumOfTemps::Single => swap_using_single_temp(
+                    body_bx,
+                    curr_x_ptr,
+                    curr_y_ptr,
+                    chunk_ty,
+                    chunk_size,
+                    access_align,
+                ),
+                NumOfTemps::Two => {
+                    swap_using_2_temps(body_bx, curr_x_ptr, curr_y_ptr, chunk_ty, access_align)
+                }
+            },
+        );
+    }
+
+    fn swap_using_2_temps<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+        bx: &mut Bx,
+        x_ptr: Bx::Value,
+        y_ptr: Bx::Value,
+        tmp_ty: Bx::Type,
+        access_align: Align,
+    ) {
+        // FIXME: Remove pointercast when stop support of LLVM 14.
+        let tmp_ptr_ty = bx.type_ptr_to(tmp_ty);
+        let x_ptr = bx.pointercast(x_ptr, tmp_ptr_ty);
+        let y_ptr = bx.pointercast(y_ptr, tmp_ptr_ty);
+
+        let tmp_x = bx.load(tmp_ty, x_ptr, access_align);
+        let tmp_y = bx.load(tmp_ty, y_ptr, access_align);
+        bx.store(tmp_y, x_ptr, access_align);
+        bx.store(tmp_x, y_ptr, access_align);
+    }
+
+    fn swap_using_single_temp<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
+        bx: &mut Bx,
+        x_ptr: Bx::Value,
+        y_ptr: Bx::Value,
+        tmp_ty: Bx::Type,
+        tmp_size: Size,
+        access_align: Align,
+    ) {
+        // FIXME: Remove pointercast when stop support of LLVM 14.
+        let tmp_ptr_ty = bx.type_ptr_to(tmp_ty);
+        let x_ptr = bx.pointercast(x_ptr, tmp_ptr_ty);
+        let y_ptr = bx.pointercast(y_ptr, tmp_ptr_ty);
+
+        let num_bytes = bx.const_usize(tmp_size.bytes());
+        let tmp_x = bx.load(tmp_ty, x_ptr, access_align);
+        // FIXME(AngelicosPhosphoros): Use memcpy.inline here.
+        bx.memcpy(x_ptr, access_align, y_ptr, access_align, num_bytes, MemFlags::empty());
+        bx.store(tmp_x, y_ptr, access_align);
     }
 }
 
@@ -151,6 +587,27 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     args[1].immediate(),
                     args[0].immediate(),
                     args[2].immediate(),
+                );
+                return;
+            }
+            sym::swap_nonoverlapping_single => {
+                swap_intrinsic::single(
+                    bx,
+                    args[0].immediate(),
+                    args[1].immediate(),
+                    substs.type_at(0),
+                    span,
+                );
+                return;
+            }
+            sym::swap_nonoverlapping_many => {
+                swap_intrinsic::many(
+                    bx,
+                    args[0].immediate(),
+                    args[1].immediate(),
+                    args[2].immediate(),
+                    substs.type_at(0),
+                    span,
                 );
                 return;
             }

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -257,6 +257,21 @@ pub trait BuilderMethods<'a, 'tcx>:
         flags: MemFlags,
     );
 
+    /// Loop that iterates over some memory using offsets steps.
+    /// Interprets pointers as u8 pointers.
+    /// `BodyPtrsVisitor` allow access to body and current iteration pointers.
+    /// Steps MUST not be zeros.
+    /// `steps[i]*iterations` MUST not overflow targets `usize`.
+    fn make_memory_loop<BodyPtrsVisitor, const VAR_COUNT: usize>(
+        &mut self,
+        loop_name: &str,
+        start_ptrs: [Self::Value; VAR_COUNT],
+        steps: [Size; VAR_COUNT],
+        iterations: Self::Value,
+        visitor: BodyPtrsVisitor,
+    ) where
+        BodyPtrsVisitor: FnOnce(&mut Self, &[Self::Value; VAR_COUNT]);
+
     fn select(
         &mut self,
         cond: Self::Value,

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -291,6 +291,24 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             sym::write_bytes => {
                 self.write_bytes_intrinsic(&args[0], &args[1], &args[2])?;
             }
+            sym::swap_nonoverlapping_single => {
+                let layout = self.layout_of(substs.type_at(0))?;
+                self.mem_swap_nonoverlapping(
+                    self.read_pointer(&args[0])?,
+                    self.read_pointer(&args[1])?,
+                    1,
+                    layout,
+                )?;
+            }
+            sym::swap_nonoverlapping_many => {
+                let layout = self.layout_of(substs.type_at(0))?;
+                self.mem_swap_nonoverlapping(
+                    self.read_pointer(&args[0])?,
+                    self.read_pointer(&args[1])?,
+                    self.read_target_usize(&args[2])?,
+                    layout,
+                )?;
+            }
             sym::arith_offset => {
                 let ptr = self.read_pointer(&args[0])?;
                 let offset_count = self.read_target_isize(&args[1])?;

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -278,6 +278,23 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
                 ],
                 tcx.mk_unit(),
             ),
+            sym::swap_nonoverlapping_single => (
+                1,
+                vec![
+                    tcx.mk_ptr(ty::TypeAndMut { ty: param(0), mutbl: hir::Mutability::Mut }),
+                    tcx.mk_ptr(ty::TypeAndMut { ty: param(0), mutbl: hir::Mutability::Mut }),
+                ],
+                tcx.mk_unit(),
+            ),
+            sym::swap_nonoverlapping_many => (
+                1,
+                vec![
+                    tcx.mk_ptr(ty::TypeAndMut { ty: param(0), mutbl: hir::Mutability::Mut }),
+                    tcx.mk_ptr(ty::TypeAndMut { ty: param(0), mutbl: hir::Mutability::Mut }),
+                    tcx.types.usize,
+                ],
+                tcx.mk_unit(),
+            ),
             sym::sqrtf32 => (0, vec![tcx.types.f32], tcx.types.f32),
             sym::sqrtf64 => (0, vec![tcx.types.f64], tcx.types.f64),
             sym::powif32 => (0, vec![tcx.types.f32, tcx.types.i32], tcx.types.f32),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1480,6 +1480,8 @@ symbols! {
         sub_assign,
         sub_with_overflow,
         suggestion,
+        swap_nonoverlapping_many,
+        swap_nonoverlapping_single,
         sym,
         sync,
         t32,

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2768,6 +2768,67 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     }
 }
 
+#[cfg(not(bootstrap))]
+extern "rust-intrinsic" {
+    /// This is an implementation detail of [`crate::mem::swap`] and should
+    /// not be used anywhere else.
+    ///
+    /// Swaps 2 values using minimal extra memory depending on target.
+    /// Created to remove target/backend specific optimizations from library code to
+    /// make MIR-level optimizations simpler to implement.
+    ///
+    /// The operation is "untyped" in the sense that data may be uninitialized or otherwise violate the
+    /// requirements of `T`. The initialization state is preserved exactly.
+    ///
+    /// # Safety
+    ///
+    /// Behavior is undefined if any of the following conditions are violated:
+    ///
+    /// * Both `x` and `y` must be valid for both reads and writes of `size_of::<T>()` bytes.
+    ///
+    /// * Both `x` and `y` must be properly aligned.
+    ///
+    /// * The region of memory beginning at `x` with a size of `size_of::<T>()`
+    ///   bytes must *not* overlap with the region of memory beginning at `y`
+    ///   with the same size.
+    ///
+    /// Note that even if the effectively copied size (`size_of::<T>()`) is `0`,
+    /// the pointers must be non-null and properly aligned.
+    #[rustc_nounwind]
+    #[rustc_const_unstable(feature = "const_swap", issue = "83163")]
+    pub fn swap_nonoverlapping_single<T: Sized>(x: *mut T, y: *mut T);
+
+    /// This is an implementation detail of [`crate::ptr::swap_nonoverlapping`] and should
+    /// not be used anywhere else.
+    ///
+    /// Swaps 2 ranges of values starting from `x` and `y` using minimal extra memory depending on target.
+    /// Created to remove target/backend specific optimizations from library code to
+    /// make MIR-level optimizations simpler to implement.
+    ///
+    /// The operation is "untyped" in the sense that data may be uninitialized or otherwise violate the
+    /// requirements of `T`. The initialization state is preserved exactly.
+    ///
+    /// # Safety
+    ///
+    /// Behavior is undefined if any of the following conditions are violated:
+    ///
+    /// * Both `x` and `y` must be valid for both reads and writes of `count *
+    ///   size_of::<T>()` bytes.
+    ///
+    /// * Both `x` and `y` must be properly aligned.
+    ///
+    /// * The region of memory beginning at `x` with a size of `count *
+    ///   size_of::<T>()` bytes must *not* overlap with the region of memory
+    ///   beginning at `y` with the same size.
+    ///
+    /// Note that even if the effectively copied size (`count * size_of::<T>()`) is `0`,
+    /// the pointers must be non-null and properly aligned.
+    ///
+    #[rustc_nounwind]
+    #[rustc_const_unstable(feature = "const_swap", issue = "83163")]
+    pub fn swap_nonoverlapping_many<T: Sized>(x: *mut T, y: *mut T, count: usize);
+}
+
 /// Sets `count * size_of::<T>()` bytes of memory starting at `dst` to
 /// `val`.
 ///

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -724,40 +724,52 @@ pub unsafe fn uninitialized<T>() -> T {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_swap", issue = "83163")]
 pub const fn swap<T>(x: &mut T, y: &mut T) {
-    // NOTE(eddyb) SPIR-V's Logical addressing model doesn't allow for arbitrary
-    // reinterpretation of values as (chunkable) byte arrays, and the loop in the
-    // block optimization in `swap_slice` is hard to rewrite back
-    // into the (unoptimized) direct swapping implementation, so we disable it.
-    // FIXME(eddyb) the block optimization also prevents MIR optimizations from
-    // understanding `mem::replace`, `Option::take`, etc. - a better overall
-    // solution might be to make `ptr::swap_nonoverlapping` into an intrinsic, which
-    // a backend can choose to implement using the block optimization, or not.
-    #[cfg(not(any(target_arch = "spirv")))]
+    #[cfg(bootstrap)]
     {
-        // For types that are larger multiples of their alignment, the simple way
-        // tends to copy the whole thing to stack rather than doing it one part
-        // at a time, so instead treat them as one-element slices and piggy-back
-        // the slice optimizations that will split up the swaps.
-        if size_of::<T>() / align_of::<T>() > 4 {
-            // SAFETY: exclusive references always point to one non-overlapping
-            // element and are non-null and properly aligned.
-            return unsafe { ptr::swap_nonoverlapping(x, y, 1) };
+        // NOTE(eddyb) SPIR-V's Logical addressing model doesn't allow for arbitrary
+        // reinterpretation of values as (chunkable) byte arrays, and the loop in the
+        // block optimization in `swap_slice` is hard to rewrite back
+        // into the (unoptimized) direct swapping implementation, so we disable it.
+        // FIXME(eddyb) the block optimization also prevents MIR optimizations from
+        // understanding `mem::replace`, `Option::take`, etc. - a better overall
+        // solution might be to make `ptr::swap_nonoverlapping` into an intrinsic, which
+        // a backend can choose to implement using the block optimization, or not.
+        #[cfg(not(any(target_arch = "spirv")))]
+        {
+            // For types that are larger multiples of their alignment, the simple way
+            // tends to copy the whole thing to stack rather than doing it one part
+            // at a time, so instead treat them as one-element slices and piggy-back
+            // the slice optimizations that will split up the swaps.
+            if size_of::<T>() / align_of::<T>() > 4 {
+                // SAFETY: exclusive references always point to one non-overlapping
+                // element and are non-null and properly aligned.
+                return unsafe { ptr::swap_nonoverlapping(x, y, 1) };
+            }
         }
-    }
 
-    // If a scalar consists of just a small number of alignment units, let
-    // the codegen just swap those pieces directly, as it's likely just a
-    // few instructions and anything else is probably overcomplicated.
-    //
-    // Most importantly, this covers primitives and simd types that tend to
-    // have size=align where doing anything else can be a pessimization.
-    // (This will also be used for ZSTs, though any solution works for them.)
-    swap_simple(x, y);
+        // If a scalar consists of just a small number of alignment units, let
+        // the codegen just swap those pieces directly, as it's likely just a
+        // few instructions and anything else is probably overcomplicated.
+        //
+        // Most importantly, this covers primitives and simd types that tend to
+        // have size=align where doing anything else can be a pessimization.
+        // (This will also be used for ZSTs, though any solution works for them.)
+        swap_simple(x, y);
+    }
+    #[cfg(not(bootstrap))]
+    // SAFETY: since `x` and `y` are mutable references,
+    // 1. `x` and `y` are initialized.
+    // 2. `x` and `y` cannot overlap.
+    // 3. `x` and `y` are aligned.
+    unsafe {
+        core::intrinsics::swap_nonoverlapping_single(x, y);
+    }
 }
 
 /// Same as [`swap`] semantically, but always uses the simple implementation.
 ///
 /// Used elsewhere in `mem` and `ptr` at the bottom layer of calls.
+#[cfg(bootstrap)]
 #[rustc_const_unstable(feature = "const_swap", issue = "83163")]
 #[inline]
 pub(crate) const fn swap_simple<T>(x: &mut T, y: &mut T) {

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -104,6 +104,92 @@ fn test_swap() {
 }
 
 #[test]
+fn test_many() {
+    // This tests if chunking works properly
+    fn swap_sized<T: Copy + Eq + core::fmt::Debug, const SIZE: usize>(a: T, b: T) {
+        let mut x: [T; SIZE] = [a; SIZE];
+        let mut y: [T; SIZE] = [b; SIZE];
+        swap::<[T; SIZE]>(&mut x, &mut y);
+        assert_eq!(x, [b; SIZE]);
+        assert_eq!(y, [a; SIZE]);
+    }
+
+    fn swap_t<T: Copy + Eq + core::fmt::Debug>(a: T, b: T) {
+        swap_sized::<T, 0>(a, b);
+        swap_sized::<T, 1>(a, b);
+        swap_sized::<T, 2>(a, b);
+        swap_sized::<T, 3>(a, b);
+        swap_sized::<T, 4>(a, b);
+        swap_sized::<T, 5>(a, b);
+        swap_sized::<T, 6>(a, b);
+        swap_sized::<T, 7>(a, b);
+        swap_sized::<T, 8>(a, b);
+        swap_sized::<T, 9>(a, b);
+        swap_sized::<T, 10>(a, b);
+        swap_sized::<T, 11>(a, b);
+        swap_sized::<T, 12>(a, b);
+        swap_sized::<T, 13>(a, b);
+        swap_sized::<T, 14>(a, b);
+        swap_sized::<T, 15>(a, b);
+        swap_sized::<T, 16>(a, b);
+        swap_sized::<T, 17>(a, b);
+        swap_sized::<T, 18>(a, b);
+        swap_sized::<T, 19>(a, b);
+        swap_sized::<T, 20>(a, b);
+        swap_sized::<T, 21>(a, b);
+        swap_sized::<T, 22>(a, b);
+        swap_sized::<T, 23>(a, b);
+        swap_sized::<T, 24>(a, b);
+        swap_sized::<T, 25>(a, b);
+        swap_sized::<T, 26>(a, b);
+        swap_sized::<T, 27>(a, b);
+        swap_sized::<T, 28>(a, b);
+        swap_sized::<T, 29>(a, b);
+        swap_sized::<T, 30>(a, b);
+        swap_sized::<T, 31>(a, b);
+        swap_sized::<T, 32>(a, b);
+        swap_sized::<T, 33>(a, b);
+    }
+
+    swap_t::<u8>(7, 0xFF);
+    swap_t::<u16>(0xFAFA, 0x9898);
+    swap_t::<u32>(0xF0F0_F0F0, 0x0E0E_0E0E);
+    swap_t::<u64>(7, 8);
+
+    #[derive(Eq, PartialEq, Debug)]
+    #[repr(align(32))]
+    struct LargeAlign([u8; 32]);
+
+    let mut x = LargeAlign([9; 32]);
+    let mut y = LargeAlign([20; 32]);
+    swap(&mut x, &mut y);
+    assert_eq!(x, LargeAlign([20; 32]));
+    assert_eq!(y, LargeAlign([9; 32]));
+
+    #[derive(Eq, PartialEq, Debug)]
+    #[repr(align(32))]
+    struct LargeAlignAndSize([u8; 96]);
+
+    let mut x = LargeAlignAndSize([9; 96]);
+    let mut y = LargeAlignAndSize([20; 96]);
+    swap(&mut x, &mut y);
+    assert_eq!(x, LargeAlignAndSize([20; 96]));
+    assert_eq!(y, LargeAlignAndSize([9; 96]));
+
+    #[derive(Eq, PartialEq, Debug)]
+    struct WithPadding {
+        a: u16,
+        b: u64,
+    }
+
+    let mut x = WithPadding { a: 7, b: 27 };
+    let mut y = WithPadding { a: 77, b: u64::MAX };
+    swap(&mut x, &mut y);
+    assert_eq!(x, WithPadding { a: 77, b: u64::MAX });
+    assert_eq!(y, WithPadding { a: 7, b: 27 });
+}
+
+#[test]
 fn test_replace() {
     let mut x = Some("test".to_string());
     let y = replace(&mut x, None);

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -1089,6 +1089,28 @@ fn swap_copy_untyped() {
 }
 
 #[test]
+fn test_swap_unaligned_on_x86_64() {
+    #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+    struct AlignedTo2([u16; 4]);
+
+    assert!(
+        mem::size_of::<AlignedTo2>() >= mem::size_of::<usize>()
+            && mem::align_of::<AlignedTo2>() == 2
+            && mem::align_of::<AlignedTo2>() < mem::align_of::<usize>()
+    );
+
+    let buff0: &mut [_] = &mut [AlignedTo2([1, 2, 3, 4]); 20];
+    let buff1: &mut [_] = &mut [AlignedTo2([5, 6, 7, 8]); 20];
+    let len = 20;
+
+    unsafe {
+        swap_nonoverlapping(buff0.as_mut_ptr(), buff1.as_mut_ptr(), read_volatile(&len));
+    }
+    assert_eq!(buff0, &[AlignedTo2([5, 6, 7, 8]); 20]);
+    assert_eq!(buff1, &[AlignedTo2([1, 2, 3, 4]); 20]);
+}
+
+#[test]
 fn test_const_copy() {
     const {
         let ptr1 = &1;

--- a/tests/codegen/swap-simd-types.rs
+++ b/tests/codegen/swap-simd-types.rs
@@ -1,4 +1,4 @@
-// compile-flags: -O -C target-feature=+avx
+// compile-flags: -Copt-level=3 -C target-feature=+avx
 // only-x86_64
 // ignore-debug: the debug assertions get in the way
 
@@ -35,7 +35,7 @@ pub fn swap_m256_slice(x: &mut [__m256], y: &mut [__m256]) {
 #[no_mangle]
 pub fn swap_bytes32(x: &mut [u8; 32], y: &mut [u8; 32]) {
 // CHECK-NOT: alloca
-// CHECK: load <32 x i8>{{.+}}align 1
-// CHECK: store <32 x i8>{{.+}}align 1
+// CHECK: load <4 x i64>{{.+}}align 1
+// CHECK: store <4 x i64>{{.+}}align 1
     swap(x, y)
 }

--- a/tests/codegen/swap-small-types.rs
+++ b/tests/codegen/swap-small-types.rs
@@ -1,8 +1,9 @@
-// compile-flags: -O -Z merge-functions=disabled
+// compile-flags: -Copt-level=3 -Z merge-functions=disabled
 // only-x86_64
 // ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
+#![feature(portable_simd)]
 
 use std::mem::swap;
 
@@ -26,10 +27,61 @@ pub fn swap_rgb48_manually(x: &mut RGB48, y: &mut RGB48) {
 #[no_mangle]
 pub fn swap_rgb48(x: &mut RGB48, y: &mut RGB48) {
     // CHECK-NOT: alloca
-    // CHECK: load <3 x i16>
-    // CHECK: load <3 x i16>
-    // CHECK: store <3 x i16>
-    // CHECK: store <3 x i16>
+    // CHECK-NOT: br
+    // CHECK: load i32
+
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+    // CHECK: store i32
+
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+    // CHECK: load i16
+
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+    // CHECK: store i16
+
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+    // CHECK: ret void
+    swap(x, y)
+}
+
+// CHECK-LABEL: @swap_vecs
+#[no_mangle]
+pub fn swap_vecs(x: &mut Vec<u32>, y: &mut Vec<u32>) {
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+
+    // CHECK: load <{{[0-9]+}} x i64>
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+
+    // CHECK: store <{{[0-9]+}} x i64>
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+
+    // CHECK: load i64
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+
+    // CHECK: store i64
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+
+    // CHECK: ret void
+    swap(x, y)
+}
+
+// CHECK-LABEL: @swap_slices
+#[no_mangle]
+pub fn swap_slices<'a>(x: &mut &'a [u32], y: &mut &'a [u32]) {
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+    // CHECK: load <{{[0-9]+}} x i64>
+    // CHECK: store <{{[0-9]+}} x i64>
+    // CHECK: ret void
     swap(x, y)
 }
 
@@ -40,23 +92,23 @@ type RGB24 = [u8; 3];
 // CHECK-LABEL: @swap_rgb24_slices
 #[no_mangle]
 pub fn swap_rgb24_slices(x: &mut [RGB24], y: &mut [RGB24]) {
-// CHECK-NOT: alloca
-// CHECK: load <{{[0-9]+}} x i8>
-// CHECK: store <{{[0-9]+}} x i8>
+    // CHECK-NOT: alloca
+    // CHECK: load <{{[0-9]+}} x i8>
+    // CHECK: store <{{[0-9]+}} x i8>
     if x.len() == y.len() {
         x.swap_with_slice(y);
     }
 }
 
-// This one has a power-of-two size, so we iterate over it directly
+// This one has a power-of-two size, so we iterate over it using ints.
 type RGBA32 = [u8; 4];
 
 // CHECK-LABEL: @swap_rgba32_slices
 #[no_mangle]
 pub fn swap_rgba32_slices(x: &mut [RGBA32], y: &mut [RGBA32]) {
-// CHECK-NOT: alloca
-// CHECK: load <{{[0-9]+}} x i32>
-// CHECK: store <{{[0-9]+}} x i32>
+    // CHECK-NOT: alloca
+    // CHECK: load <{{[0-9]+}} x i32>
+    // CHECK: store <{{[0-9]+}} x i32>
     if x.len() == y.len() {
         x.swap_with_slice(y);
     }
@@ -69,10 +121,38 @@ const _: () = assert!(!std::mem::size_of::<String>().is_power_of_two());
 // CHECK-LABEL: @swap_string_slices
 #[no_mangle]
 pub fn swap_string_slices(x: &mut [String], y: &mut [String]) {
-// CHECK-NOT: alloca
-// CHECK: load <{{[0-9]+}} x i64>
-// CHECK: store <{{[0-9]+}} x i64>
+    // CHECK-NOT: alloca
+    // CHECK: load <{{[0-9]+}} x i64>
+    // CHECK: store <{{[0-9]+}} x i64>
     if x.len() == y.len() {
         x.swap_with_slice(y);
     }
+}
+
+#[repr(C, packed)]
+pub struct Packed {
+    pub first: bool,
+    pub second: u64,
+}
+
+// CHECK-LABEL: @swap_packed_structs
+#[no_mangle]
+pub fn swap_packed_structs(x: &mut Packed, y: &mut Packed) {
+    // CHECK-NOT: alloca
+    // CHECK: ret void
+    swap(x, y)
+}
+
+// CHECK-LABEL: @swap_simd_type
+#[no_mangle]
+pub fn swap_simd_type(x: &mut std::simd::f32x4, y: &mut std::simd::f32x4){
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+    // CHECK: load <4 x float>
+
+    // CHECK-NOT: alloca
+    // CHECK-NOT: br
+    // CHECK: store <4 x float>
+    // CHECK: ret void
+    swap(x, y)
 }

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -3,12 +3,6 @@ error[E0080]: evaluation of constant value failed
    |
    = note: unable to copy parts of a pointer from memory at ALLOC_ID
    |
-note: inside `std::ptr::read::<MaybeUninit<MaybeUninit<u8>>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `mem::swap_simple::<MaybeUninit<MaybeUninit<u8>>>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `ptr::swap_nonoverlapping_simple_untyped::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `swap_nonoverlapping::<MaybeUninit<u8>>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `X`

--- a/tests/ui/intrinsics/swap_nonoverlapping_single.rs
+++ b/tests/ui/intrinsics/swap_nonoverlapping_single.rs
@@ -1,0 +1,132 @@
+#![feature(core_intrinsics, const_mut_refs, const_swap)]
+#![crate_type = "rlib"]
+
+//! This module tests if `swap_nonoverlapping_single` works properly in const contexts.
+
+use std::intrinsics::swap_nonoverlapping_single;
+
+pub const OK_A: () = {
+    let mut a = 0i32;
+    let mut b = 5i32;
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+    assert!(a == 5, "Must NOT fail.");
+    assert!(b == 0, "Must NOT fail.");
+};
+
+pub const ERR_A0: () = {
+    let mut a = 0i32;
+    let mut b = 5i32;
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+
+    assert!(a != 5, "Must fail."); //~ ERROR evaluation of constant value failed
+};
+
+pub const ERR_A1: () = {
+    let mut a = 0i32;
+    let mut b = 5i32;
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+
+    assert!(b != 0, "Must fail."); //~ ERROR evaluation of constant value failed
+};
+
+// This must NOT fail.
+pub const B: () = {
+    let mut a = 0i32;
+    let mut b = 5i32;
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+    assert!(a == 0, "Must NOT fail.");
+    assert!(b == 5, "Must NOT fail.");
+};
+
+pub const ERR_B0: () = {
+    let mut a = 0i32;
+    let mut b = 5i32;
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+
+    assert!(a != 0, "Must fail."); //~ ERROR evaluation of constant value failed
+};
+
+pub const ERR_B1: () = {
+    let mut a = 0i32;
+    let mut b = 5i32;
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+
+    assert!(b != 5, "Must fail."); //~ ERROR evaluation of constant value failed
+};
+
+// This must NOT fail.
+pub const NON_OVERLAPPING_PTRS: () = {
+    let mut chunk = [0_i32, 1, 2, 3];
+
+    let ptr = chunk.as_mut_ptr();
+    let ptr2 = unsafe { ptr.add(2) };
+    let x: &mut [i32; 2] = unsafe { &mut *ptr.cast() };
+    let y: &mut [i32; 2] = unsafe { &mut *ptr2.cast() };
+    unsafe {
+        swap_nonoverlapping_single(x, y);
+    }
+
+    assert!(matches!(chunk, [2, 3, 0, 1]), "Must NOT fail.");
+};
+
+pub const OVERLAPPING_PTRS_0: () = {
+    let mut chunk = [0_i32, 1, 2, 3];
+
+    let ptr = chunk.as_mut_ptr();
+    let ptr2 = unsafe { ptr.add(1) };
+    let x: &mut [i32; 2] = unsafe { &mut *ptr.cast() };
+    let y: &mut [i32; 2] = unsafe { &mut *ptr2.cast() };
+
+    unsafe {
+        swap_nonoverlapping_single(x, y); //~ ERROR evaluation of constant value failed
+    }
+};
+
+pub const OVERLAPPING_PTRS_1: () = {
+    let mut val = 7;
+
+    let ptr: *mut _ = &mut val;
+    let x: &mut i32 = unsafe { &mut *ptr };
+    let y: &mut i32 = unsafe { &mut *ptr };
+
+    unsafe {
+        swap_nonoverlapping_single(x, y); //~ ERROR evaluation of constant value failed
+    }
+};
+
+pub const OK_STRUCT: () = {
+    struct Adt {
+        fl: bool,
+        val: usize,
+    }
+    let mut a = Adt { fl: false, val: 10 };
+    let mut b = Adt { fl: true, val: 77 };
+
+    unsafe {
+        swap_nonoverlapping_single(&mut a, &mut b);
+    }
+
+    assert!(matches!(a, Adt { fl: true, val: 77 }), "Must NOT fail.");
+    assert!(matches!(b, Adt { fl: false, val: 10 }), "Must NOT fail.");
+};

--- a/tests/ui/intrinsics/swap_nonoverlapping_single.stderr
+++ b/tests/ui/intrinsics/swap_nonoverlapping_single.stderr
@@ -1,0 +1,47 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/swap_nonoverlapping_single.rs:25:5
+   |
+LL |     assert!(a != 5, "Must fail.");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Must fail.', $DIR/swap_nonoverlapping_single.rs:25:5
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/swap_nonoverlapping_single.rs:35:5
+   |
+LL |     assert!(b != 0, "Must fail.");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Must fail.', $DIR/swap_nonoverlapping_single.rs:35:5
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/swap_nonoverlapping_single.rs:62:5
+   |
+LL |     assert!(a != 0, "Must fail.");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Must fail.', $DIR/swap_nonoverlapping_single.rs:62:5
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/swap_nonoverlapping_single.rs:75:5
+   |
+LL |     assert!(b != 5, "Must fail.");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Must fail.', $DIR/swap_nonoverlapping_single.rs:75:5
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/swap_nonoverlapping_single.rs:102:9
+   |
+LL |         swap_nonoverlapping_single(x, y);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ swap was called on overlapping memory.
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/swap_nonoverlapping_single.rs:114:9
+   |
+LL |         swap_nonoverlapping_single(x, y);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ swap was called on overlapping memory.
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
This allows move target- and backend-specific optmization from library code to codegen.
Also, this should make MIR-optimization simpler.

Main optimization implemented in this PR makes backend generate swap without using allocas
removing unneccessary memory writes and reads and reducing stack usage.

One of the main optimizations is using larger integer chunks for swapping in x86_64 by utilizing unaligned reads/writes. It reduces code size (especially for debug builds) and prevent cases of ineffective vectorizations like `load <4 x i8>` (LLVM doesn't vectorize it further despite vectorizing `load i32`).

Also added more tests.

`rustc_codegen_cranelift` implementation is naive because **bjorn3** promised to rewrite it later.

`rustc_codegen_gcc` uses same implementation via `rustc_codegen_ssa`.

Previous try: https://github.com/rust-lang/rust/pull/98892