### PR TITLE
Don't structurally resolve during method ambiguity in probe

### DIFF
--- a/tests/ui/autoref-autoderef/deref-ambiguity-becomes-nonambiguous.rs
+++ b/tests/ui/autoref-autoderef/deref-ambiguity-becomes-nonambiguous.rs
@@ -1,0 +1,40 @@
+use std::ops::Deref;
+use std::rc::Rc;
+
+struct Value<T>(T);
+
+pub trait Wrap<T> {
+    fn wrap() -> Self;
+}
+
+impl<R, A1, A2> Wrap<fn(A1, A2) -> R> for Value<fn(A1, A2) -> R> {
+    fn wrap() -> Self {
+        todo!()
+    }
+}
+
+impl<F, R, A1, A2> Wrap<F> for Value<Rc<dyn Fn(A1, A2) -> R>> {
+    fn wrap() -> Self {
+        todo!()
+    }
+}
+
+impl<F> Deref for Value<Rc<F>> {
+    type Target = F;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+fn main() {
+    let var_fn = Value::wrap();
+    //~^ ERROR type annotations needed for `Value<Rc<_>>`
+
+    // The combination of `Value: Wrap` obligation plus the autoderef steps
+    // (caused by the `Deref` impl above) actually means that the self type
+    // of the method fn below is constrained to be `Value<Rc<dyn Fn(?0, ?1) -> ?2>>`.
+    // However, that's only known to us on the error path -- we still need
+    // to emit an ambiguity error, though.
+    let _ = var_fn.clone();
+}

--- a/tests/ui/autoref-autoderef/deref-ambiguity-becomes-nonambiguous.stderr
+++ b/tests/ui/autoref-autoderef/deref-ambiguity-becomes-nonambiguous.stderr
@@ -1,0 +1,17 @@
+error[E0282]: type annotations needed for `Value<Rc<_>>`
+  --> $DIR/deref-ambiguity-becomes-nonambiguous.rs:31:9
+   |
+LL |     let var_fn = Value::wrap();
+   |         ^^^^^^
+...
+LL |     let _ = var_fn.clone();
+   |                    ----- type must be known at this point
+   |
+help: consider giving `var_fn` an explicit type, where the placeholders `_` are specified
+   |
+LL |     let var_fn: Value<Rc<_>> = Value::wrap();
+   |               ++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
See comment in UI test for reason for the failure. This is all on the error path anyways, not really sure what the assertion is there to achieve anyways...

Fixes #111739