### PR TITLE
Perform autoref/autoderef on `.await`

### DIFF
--- a/tests/ui/async-await/await-into-future-autoref.rs
+++ b/tests/ui/async-await/await-into-future-autoref.rs
@@ -1,0 +1,44 @@
+//@ run-pass
+//@ aux-build: issue-72470-lib.rs
+//@ edition:2021
+extern crate issue_72470_lib;
+use std::{future::{Future, IntoFuture}, pin::Pin};
+
+struct AwaitMe;
+
+impl IntoFuture for &AwaitMe {
+    type Output = i32;
+    type IntoFuture = Pin<Box<dyn Future<Output = i32>>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(me())
+    }
+}
+
+async fn me() -> i32 {
+    41
+}
+
+async fn run() {
+    assert_eq!(AwaitMe.await, 41);
+}
+
+struct AwaitMeToo;
+
+impl IntoFuture for &mut AwaitMeToo {
+    type Output = i32;
+    type IntoFuture = Pin<Box<dyn Future<Output = i32>>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(me())
+    }
+}
+
+async fn run_too() {
+    assert_eq!(AwaitMeToo.await, 41);
+}
+
+fn main() {
+    issue_72470_lib::run(run());
+    issue_72470_lib::run(run_too());
+}


### PR DESCRIPTION
This PR adds support for autoref/autoderef of the receiver of an `.await` (before calling `IntoFuture::into_future()`).

This PR is not ready to merge yet—the feature works, but diagnostics are regressed. I would like to get some feedback on my current approach, before investing more effort into it.

Fixes #111546.