### PR TITLE
Make `x test --dry-run` less verbose

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1796,6 +1796,14 @@ impl Step for BookTest {
     ///
     /// This uses the `rustdoc` that sits next to `compiler`.
     fn run(self, builder: &Builder<'_>) {
+        let host = self.compiler.host;
+        let _guard = builder.msg(
+            Kind::Test,
+            self.compiler.stage,
+            &format!("book {}", self.name),
+            host,
+            host,
+        );
         // External docs are different from local because:
         // - Some books need pre-processing by mdbook before being tested.
         // - They need to save their state to toolstate.
@@ -1987,7 +1995,7 @@ fn markdown_test(builder: &Builder<'_>, compiler: Compiler, markdown: &Path) -> 
         }
     }
 
-    builder.info(&format!("doc tests for: {}", markdown.display()));
+    builder.verbose(&format!("doc tests for: {}", markdown.display()));
     let mut cmd = builder.rustdoc_cmd(compiler);
     builder.add_rust_test_threads(&mut cmd);
     // allow for unstable options such as new editions


### PR DESCRIPTION
The new output looks like `Testing stage2 book rustc (x86_64-unknown-linux-gnu)`.

Previously, this would print a message for each doctest, which was quite verbose:
```
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/exploit-mitigations.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/instrument-coverage.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/json.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/linker-plugin-lto.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/lints/groups.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/lints/index.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/lints/levels.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/aarch64-apple-ios-sim.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/aarch64-nintendo-switch-freestanding.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/apple-watchos.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/armeb-unknown-linux-gnueabi.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/armv4t-none-eabi.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/armv5te-none-eabi.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/armv6k-nintendo-3ds.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/armv7-sony-vita-newlibeabihf.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabi.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabihf.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/esp-idf.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/fuchsia.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/kmc-solid.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/loongarch-linux.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/m68k-unknown-linux-gnu.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/mipsel-sony-psx.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/nto-qnx.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/openbsd.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/openharmony.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/riscv32imac-unknown-xous-elf.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/unknown-uefi.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/wasm64-unknown-unknown.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/x86_64-fortanix-unknown-sgx.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/platform-support/x86_64-unknown-none.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/profile-guided-optimization.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/target-tier-policy.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/targets/custom.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/targets/index.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/tests/index.md
doc tests for: /home/jyn/src/rust/src/doc/rustc/src/what-is-rustc.md
```