### PR TITLE
[rustc_ty_utils] Treat `drop_in_place`'s *mut argument like &mut when adding LLVM attributes

### DIFF
--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -238,6 +238,7 @@ fn adjust_for_rust_scalar<'tcx>(
     layout: TyAndLayout<'tcx>,
     offset: Size,
     is_return: bool,
+    is_drop_target: bool,
 ) {
     // Booleans are always a noundef i1 that needs to be zero-extended.
     if scalar.is_bool() {
@@ -307,6 +308,25 @@ fn adjust_for_rust_scalar<'tcx>(
             }
         }
     }
+
+    // If this is the argument to `drop_in_place`, the contents of which we fully control as the
+    // compiler, then we may be able to mark that argument `noalias`. Currently, we're conservative
+    // and do so only if `drop_in_place` results in a direct call to the programmer's `drop` method.
+    // The `drop` method requires `&mut self`, so we're effectively just propagating the `noalias`
+    // guarantee from `drop` upward to `drop_in_place` in this case.
+    if is_drop_target {
+        match *layout.ty.kind() {
+            ty::RawPtr(inner) => {
+                if let ty::Adt(adt_def, _) = inner.ty.kind() {
+                    if adt_def.destructor(cx.tcx()).is_some() {
+                        debug!("marking drop_in_place argument as noalias");
+                        attrs.set(ArgAttribute::NoAlias);
+                    }
+                }
+            }
+            _ => bug!("drop target isn't a raw pointer"),
+        }
+    }
 }
 
 // FIXME(eddyb) perhaps group the signature/type-containing (or all of them?)
@@ -362,10 +382,16 @@ fn fn_abi_new_uncached<'tcx>(
     use SpecAbi::*;
     let rust_abi = matches!(sig.abi, RustIntrinsic | PlatformIntrinsic | Rust | RustCall);
 
+    let is_drop_in_place = match (cx.tcx.lang_items().drop_in_place_fn(), fn_def_id) {
+        (Some(drop_in_place_fn), Some(fn_def_id)) => drop_in_place_fn == fn_def_id,
+        _ => false,
+    };
+
     let arg_of = |ty: Ty<'tcx>, arg_idx: Option<usize>| -> Result<_, FnAbiError<'tcx>> {
         let span = tracing::debug_span!("arg_of");
         let _entered = span.enter();
         let is_return = arg_idx.is_none();
+        let is_drop_target = is_drop_in_place && arg_idx == Some(0);
 
         let layout = cx.layout_of(ty)?;
         let layout = if force_thin_self_ptr && arg_idx == Some(0) {
@@ -379,7 +405,15 @@ fn fn_abi_new_uncached<'tcx>(
 
         let mut arg = ArgAbi::new(cx, layout, |layout, scalar, offset| {
             let mut attrs = ArgAttributes::new();
-            adjust_for_rust_scalar(*cx, &mut attrs, scalar, *layout, offset, is_return);
+            adjust_for_rust_scalar(
+                *cx,
+                &mut attrs,
+                scalar,
+                *layout,
+                offset,
+                is_return,
+                is_drop_target,
+            );
             attrs
         });
 

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -307,24 +307,17 @@ fn adjust_for_rust_scalar<'tcx>(
                 attrs.set(ArgAttribute::ReadOnly);
             }
         }
-    }
 
-    // If this is the argument to `drop_in_place`, the contents of which we fully control as the
-    // compiler, then we may be able to mark that argument `noalias`. Currently, we're conservative
-    // and do so only if `drop_in_place` results in a direct call to the programmer's `drop` method.
-    // The `drop` method requires `&mut self`, so we're effectively just propagating the `noalias`
-    // guarantee from `drop` upward to `drop_in_place` in this case.
-    if is_drop_target {
-        match *layout.ty.kind() {
-            ty::RawPtr(inner) => {
-                if let ty::Adt(adt_def, _) = inner.ty.kind() {
-                    if adt_def.destructor(cx.tcx()).is_some() {
-                        debug!("marking drop_in_place argument as noalias");
-                        attrs.set(ArgAttribute::NoAlias);
-                    }
-                }
-            }
-            _ => bug!("drop target isn't a raw pointer"),
+        // If this is the argument to `drop_in_place`, the contents of which we fully control as the
+        // compiler, then we mark this argument as `noalias`, aligned, and dereferenceable. (The
+        // standard library documents the necessary requirements to uphold these attributes for code
+        // that calls this method directly.) This can enable better optimizations, such as argument
+        // promotion.
+        if is_drop_target {
+            attrs.set(ArgAttribute::NoAlias);
+            attrs.set(ArgAttribute::NonNull);
+            attrs.pointee_size = pointee.size;
+            attrs.pointee_align = Some(pointee.align);
         }
     }
 }

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -375,10 +375,8 @@ fn fn_abi_new_uncached<'tcx>(
     use SpecAbi::*;
     let rust_abi = matches!(sig.abi, RustIntrinsic | PlatformIntrinsic | Rust | RustCall);
 
-    let is_drop_in_place = match (cx.tcx.lang_items().drop_in_place_fn(), fn_def_id) {
-        (Some(drop_in_place_fn), Some(fn_def_id)) => drop_in_place_fn == fn_def_id,
-        _ => false,
-    };
+    let is_drop_in_place =
+        fn_def_id.is_some() && fn_def_id == cx.tcx.lang_items().drop_in_place_fn();
 
     let arg_of = |ty: Ty<'tcx>, arg_idx: Option<usize>| -> Result<_, FnAbiError<'tcx>> {
         let span = tracing::debug_span!("arg_of");

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -437,22 +437,40 @@ mod mut_ptr;
 ///
 /// # Safety
 ///
-/// Behavior is undefined if any of the following conditions are violated:
+/// Immediately upon executing, `drop_in_place` takes out a mutable borrow on the
+/// pointed-to-value. Effectively, this function is implemented like so:
+///
+/// ```
+/// # struct Foo { x: i32 }
+/// fn drop_in_place(to_drop: *mut Foo) {
+///     let mut value = &mut *to_drop;
+///     // ... drop the fields of `value` ...
+/// }
+/// ```
+///
+/// This implies that the behavior is undefined if any of the following
+/// conditions are violated:
 ///
 /// * `to_drop` must be [valid] for both reads and writes.
 ///
-/// * `to_drop` must be properly aligned.
+/// * `to_drop` must be properly aligned, even if T has size 0.
 ///
-/// * The value `to_drop` points to must be valid for dropping, which may mean it must uphold
-///   additional invariants - this is type-dependent.
+/// * `to_drop` must be nonnull, even if T has size 0.
+///
+/// * The value `to_drop` points to must be valid for dropping, which may mean
+///   it must uphold additional invariants. These invariants depend on the type
+///   of the value being dropped. For instance, when dropping a Box, the box's
+///   pointer to the heap must be valid.
+///
+/// * While `drop_in_place` is executing, the only way to access parts of
+///   `to_drop` is through the `&mut self` references supplied to the
+///   `Drop::drop` methods that `drop_in_place` invokes.
 ///
 /// Additionally, if `T` is not [`Copy`], using the pointed-to value after
 /// calling `drop_in_place` can cause undefined behavior. Note that `*to_drop =
 /// foo` counts as a use because it will cause the value to be dropped
 /// again. [`write()`] can be used to overwrite data without causing it to be
 /// dropped.
-///
-/// Note that even if `T` has size `0`, the pointer must be non-null and properly aligned.
 ///
 /// [valid]: self#safety
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -442,7 +442,7 @@ mod mut_ptr;
 ///
 /// ```
 /// # struct Foo { x: i32 }
-/// fn drop_in_place(to_drop: *mut Foo) {
+/// unsafe fn drop_in_place(to_drop: *mut Foo) {
 ///     let mut value = &mut *to_drop;
 ///     // ... drop the fields of `value` ...
 /// }

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -443,8 +443,10 @@ mod mut_ptr;
 /// ```
 /// # struct Foo { x: i32 }
 /// unsafe fn drop_in_place(to_drop: *mut Foo) {
-///     let mut value = &mut *to_drop;
-///     // ... drop the fields of `value` ...
+///     drop_in_place_inner(&mut *to_drop);
+///     unsafe fn drop_in_place_inner(to_drop: &mut Foo) {
+///         // ... drop the fields of `value` ...
+///     }
 /// }
 /// ```
 ///
@@ -453,9 +455,9 @@ mod mut_ptr;
 ///
 /// * `to_drop` must be [valid] for both reads and writes.
 ///
-/// * `to_drop` must be properly aligned, even if T has size 0.
+/// * `to_drop` must be properly aligned, even if `T` has size 0.
 ///
-/// * `to_drop` must be nonnull, even if T has size 0.
+/// * `to_drop` must be nonnull, even if `T` has size 0.
 ///
 /// * The value `to_drop` points to must be valid for dropping, which may mean
 ///   it must uphold additional invariants. These invariants depend on the type

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -437,21 +437,7 @@ mod mut_ptr;
 ///
 /// # Safety
 ///
-/// Immediately upon executing, `drop_in_place` takes out a mutable borrow on the
-/// pointed-to-value. Effectively, this function is implemented like so:
-///
-/// ```
-/// # struct Foo { x: i32 }
-/// unsafe fn drop_in_place(to_drop: *mut Foo) {
-///     drop_in_place_inner(&mut *to_drop);
-///     unsafe fn drop_in_place_inner(to_drop: &mut Foo) {
-///         // ... drop the fields of `value` ...
-///     }
-/// }
-/// ```
-///
-/// This implies that the behavior is undefined if any of the following
-/// conditions are violated:
+/// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `to_drop` must be [valid] for both reads and writes.
 ///

--- a/tests/codegen/drop-in-place-noalias.rs
+++ b/tests/codegen/drop-in-place-noalias.rs
@@ -1,0 +1,34 @@
+// Tests that the compiler can mark `drop_in_place` as `noalias` when safe to do so.
+
+#![crate_type="lib"]
+
+use std::hint::black_box;
+
+// CHECK: define{{.*}}drop_in_place{{.*}}Foo{{.*}}({{.*}}noalias{{.*}})
+
+#[repr(C)]
+pub struct Foo {
+    a: i32,
+    b: i32,
+    c: i32,
+}
+
+impl Drop for Foo {
+    #[inline(never)]
+    fn drop(&mut self) {
+        black_box(self.a);
+    }
+}
+
+extern {
+    fn bar();
+    fn baz(foo: Foo);
+}
+
+pub fn haha() {
+    let foo = Foo { a: 1, b: 2, c: 3 };
+    unsafe {
+        bar();
+        baz(foo);
+    }
+}

--- a/tests/codegen/drop-in-place-noalias.rs
+++ b/tests/codegen/drop-in-place-noalias.rs
@@ -4,7 +4,7 @@
 
 use std::hint::black_box;
 
-// CHECK: define{{.*}}drop_in_place{{.*}}Foo{{.*}}({{.*}}noalias{{.*}})
+// CHECK: define{{.*}}core{{.*}}ptr{{.*}}drop_in_place{{.*}}Foo{{.*}}({{.*}}noalias {{.*}} align 4 dereferenceable(12){{.*}})
 
 #[repr(C)]
 pub struct Foo {

--- a/tests/codegen/drop-in-place-noalias.rs
+++ b/tests/codegen/drop-in-place-noalias.rs
@@ -1,4 +1,4 @@
-// compile-flags: -C no-prepopulate-passes
+// compile-flags: -O -C no-prepopulate-passes
 
 // Tests that the compiler can apply `noalias` and other &mut attributes to `drop_in_place`.
 // Note that non-Unpin types should not get `noalias`, matching &mut behavior.

--- a/tests/codegen/noalias-box-off.rs
+++ b/tests/codegen/noalias-box-off.rs
@@ -3,6 +3,6 @@
 #![crate_type = "lib"]
 
 // CHECK-LABEL: @box_should_not_have_noalias_if_disabled(
-// CHECK-NOT: noalias
+// CHECK-NOT: noalias{{.*}}%
 #[no_mangle]
 pub fn box_should_not_have_noalias_if_disabled(_b: Box<u8>) {}

--- a/tests/codegen/noalias-box-off.rs
+++ b/tests/codegen/noalias-box-off.rs
@@ -3,6 +3,9 @@
 #![crate_type = "lib"]
 
 // CHECK-LABEL: @box_should_not_have_noalias_if_disabled(
-// CHECK-NOT: noalias{{.*}}%
+// CHECK-NOT: noalias
+// CHECK-SAME: %foo)
 #[no_mangle]
-pub fn box_should_not_have_noalias_if_disabled(_b: Box<u8>) {}
+pub fn box_should_not_have_noalias_if_disabled(foo: Box<u8>) {
+    drop(foo);
+}


### PR DESCRIPTION
This resurrects PR #103614, which has sat idle for a while.

This could probably use a new perf run, since we're on a new LLVM version now.

r? @oli-obk
cc @RalfJung

---

LLVM can make use of the `noalias` parameter attribute on the parameter to `drop_in_place` in areas like argument promotion. Because the Rust compiler fully controls the code for `drop_in_place`, it can soundly deduce parameter attributes on it.

In #103957, Miri was changed to retag `drop_in_place`'s argument as if it was `&mut`, matching this change.