### PR TITLE
Unset MIRI_BLESS for mir-opt-level 4 miri tests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -620,6 +620,8 @@ impl Step for Miri {
             cargo.env("MIRIFLAGS", "-O -Zmir-opt-level=4 -Cdebug-assertions=yes");
             // Optimizations can change backtraces
             cargo.env("MIRI_SKIP_UI_CHECKS", "1");
+            // `MIRI_SKIP_UI_CHECKS` and `MIRI_BLESS` are incompatible
+            cargo.env_remove("MIRI_BLESS");
             // Optimizations can change error locations and remove UB so don't run `fail` tests.
             cargo.args(&["tests/pass", "tests/panic"]);
 


### PR DESCRIPTION
When running `x.py test src/tools/miri --bless`, the 2nd test run (with mir-opt-level 4) crashes because it disables ui checking, which is incompatible with blessing. This PR fixes that by not trying to bless that run.