### PR TITLE
MIR: opt-in normalization of `BasicBlock` and `Local` numbering

### DIFF
--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -105,7 +105,7 @@ pub struct Terminator<'tcx> {
     pub kind: TerminatorKind<'tcx>,
 }
 
-pub type Successors<'a> = impl Iterator<Item = BasicBlock> + 'a;
+pub type Successors<'a> = impl DoubleEndedIterator<Item = BasicBlock> + 'a;
 pub type SuccessorsMut<'a> =
     iter::Chain<std::option::IntoIter<&'a mut BasicBlock>, slice::IterMut<'a, BasicBlock>>;
 

--- a/compiler/rustc_middle/src/mir/traversal.rs
+++ b/compiler/rustc_middle/src/mir/traversal.rs
@@ -149,7 +149,7 @@ impl<'a, 'tcx> Postorder<'a, 'tcx> {
         //      B     C
         //      |     |
         //      |     |
-        //      D     |
+        //      |     D
         //       \   /
         //        \ /
         //         E
@@ -159,26 +159,26 @@ impl<'a, 'tcx> Postorder<'a, 'tcx> {
         //
         // When the first call to `traverse_successor` happens, the following happens:
         //
-        //     [(B, [D]),  // `B` taken from the successors of `A`, pushed to the
-        //                 // top of the stack along with the successors of `B`
-        //      (A, [C])]
+        //     [(C, [D]),  // `C` taken from the successors of `A`, pushed to the
+        //                 // top of the stack along with the successors of `C`
+        //      (A, [B])]
         //
-        //     [(D, [E]),  // `D` taken from successors of `B`, pushed to stack
-        //      (B, []),
-        //      (A, [C])]
+        //     [(D, [E]),  // `D` taken from successors of `C`, pushed to stack
+        //      (C, []),
+        //      (A, [B])]
         //
         //     [(E, []),   // `E` taken from successors of `D`, pushed to stack
         //      (D, []),
-        //      (B, []),
-        //      (A, [C])]
+        //      (C, []),
+        //      (A, [B])]
         //
         // Now that the top of the stack has no successors we can traverse, each item will
-        // be popped off during iteration until we get back to `A`. This yields [E, D, B].
+        // be popped off during iteration until we get back to `A`. This yields [E, D, C].
         //
-        // When we yield `B` and call `traverse_successor`, we push `C` to the stack, but
+        // When we yield `C` and call `traverse_successor`, we push `B` to the stack, but
         // since we've already visited `E`, that child isn't added to the stack. The last
-        // two iterations yield `C` and finally `A` for a final traversal of [E, D, B, C, A]
-        while let Some(&mut (_, ref mut iter)) = self.visit_stack.last_mut() && let Some(bb) = iter.next() {
+        // two iterations yield `B` and finally `A` for a final traversal of [E, D, C, B, A]
+        while let Some(&mut (_, ref mut iter)) = self.visit_stack.last_mut() && let Some(bb) = iter.next_back() {
             if self.visited.insert(bb) {
                 if let Some(term) = &self.basic_blocks[bb].terminator {
                     self.visit_stack.push((bb, term.successors()));

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(rustc::diagnostic_outside_of_impl)]
 #![feature(box_patterns)]
 #![feature(drain_filter)]
+#![feature(is_sorted)]
 #![feature(let_chains)]
 #![feature(map_try_insert)]
 #![feature(min_specialization)]
@@ -84,6 +85,7 @@ mod match_branches;
 mod multiple_return_terminators;
 mod normalize_array_len;
 mod nrvo;
+mod prettify;
 mod ref_prop;
 mod remove_noop_landing_pads;
 mod remove_storage_markers;
@@ -581,6 +583,9 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &large_enums::EnumSizeOpt { discrepancy: 128 },
             // Some cleanup necessary at least for LLVM and potentially other codegen backends.
             &add_call_guards::CriticalCallEdges,
+            // Cleanup for human readability, off by default.
+            &prettify::ReorderBasicBlocks,
+            &prettify::ReorderLocals,
             // Dump the end result for testing and debugging purposes.
             &dump_mir::Marker("PreCodegen"),
         ],

--- a/compiler/rustc_mir_transform/src/prettify.rs
+++ b/compiler/rustc_mir_transform/src/prettify.rs
@@ -1,0 +1,134 @@
+//! These two passes provide no value to the compiler, so are off at every level.
+//!
+//! However, they can be enabled on the command line
+//! (`-Zmir-enable-passes=+ReorderBasicBlocks,+ReorderLocals`)
+//! to make the MIR easier to read for humans.
+
+use crate::MirPass;
+use rustc_index::{bit_set::BitSet, IndexSlice, IndexVec};
+use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+use rustc_session::Session;
+
+pub struct ReorderBasicBlocks;
+
+impl<'tcx> MirPass<'tcx> for ReorderBasicBlocks {
+    fn is_enabled(&self, _session: &Session) -> bool {
+        false
+    }
+
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let rpo: IndexVec<BasicBlock, BasicBlock> =
+            body.basic_blocks.postorder().iter().copied().rev().collect();
+        if rpo.iter().is_sorted() {
+            return;
+        }
+
+        let mut updater = BasicBlockUpdater { map: rpo.invert_bijective_mapping(), tcx };
+        debug_assert_eq!(updater.map[START_BLOCK], START_BLOCK);
+        updater.visit_body(body);
+
+        permute(body.basic_blocks.as_mut(), &updater.map);
+    }
+}
+
+pub struct ReorderLocals;
+
+impl<'tcx> MirPass<'tcx> for ReorderLocals {
+    fn is_enabled(&self, _session: &Session) -> bool {
+        false
+    }
+
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let mut finder =
+            LocalFinder { map: IndexVec::new(), seen: BitSet::new_empty(body.local_decls.len()) };
+
+        // We can't reorder the return place or the arguments
+        for i in 0..=body.arg_count {
+            finder.track(Local::from_usize(i));
+        }
+
+        for (bb, bbd) in body.basic_blocks.iter_enumerated() {
+            finder.visit_basic_block_data(bb, bbd);
+        }
+
+        // track everything in case there are some locals that we never saw,
+        // such as in non-block things like debug info or in non-uses.
+        for local in body.local_decls.indices() {
+            finder.track(local);
+        }
+
+        if finder.map.iter().is_sorted() {
+            return;
+        }
+
+        let mut updater = LocalUpdater { map: finder.map.invert_bijective_mapping(), tcx };
+        debug_assert_eq!(updater.map[RETURN_PLACE], RETURN_PLACE);
+        updater.visit_body_preserves_cfg(body);
+
+        permute(&mut body.local_decls, &updater.map);
+    }
+}
+
+fn permute<I: rustc_index::Idx + Ord, T>(data: &mut IndexVec<I, T>, map: &IndexSlice<I, I>) {
+    // FIXME: It would be nice to have a less-awkward way to apply permutations,
+    // but I don't know one that exists.  `sort_by_cached_key` has logic for it
+    // internally, but not in a way that we're allowed to use here.
+    let mut enumerated: Vec<_> = std::mem::take(data).into_iter_enumerated().collect();
+    enumerated.sort_by_key(|p| map[p.0]);
+    *data = enumerated.into_iter().map(|p| p.1).collect();
+}
+
+struct BasicBlockUpdater<'tcx> {
+    map: IndexVec<BasicBlock, BasicBlock>,
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> MutVisitor<'tcx> for BasicBlockUpdater<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    fn visit_terminator(&mut self, terminator: &mut Terminator<'tcx>, _location: Location) {
+        for succ in terminator.successors_mut() {
+            *succ = self.map[*succ];
+        }
+    }
+}
+
+struct LocalFinder {
+    map: IndexVec<Local, Local>,
+    seen: BitSet<Local>,
+}
+
+impl LocalFinder {
+    fn track(&mut self, l: Local) {
+        if self.seen.insert(l) {
+            self.map.push(l);
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for LocalFinder {
+    fn visit_local(&mut self, l: Local, context: PlaceContext, _location: Location) {
+        if context.is_use() {
+            self.track(l);
+        }
+    }
+}
+
+struct LocalUpdater<'tcx> {
+    pub map: IndexVec<Local, Local>,
+    pub tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> MutVisitor<'tcx> for LocalUpdater<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    fn visit_local(&mut self, l: &mut Local, _: PlaceContext, _: Location) {
+        *l = self.map[*l];
+    }
+}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2045,7 +2045,10 @@ impl<'test> TestCx<'test> {
                 if let Some(pass) = &self.props.mir_unit_test {
                     rustc.args(&["-Zmir-opt-level=0", &format!("-Zmir-enable-passes=+{}", pass)]);
                 } else {
-                    rustc.arg("-Zmir-opt-level=4");
+                    rustc.args(&[
+                        "-Zmir-opt-level=4",
+                        "-Zmir-enable-passes=+ReorderBasicBlocks,+ReorderLocals",
+                    ]);
                 }
 
                 let mir_dump_dir = self.get_mir_dump_dir();

--- a/tests/mir-opt/deref-patterns/string.foo.PreCodegen.after.mir
+++ b/tests/mir-opt/deref-patterns/string.foo.PreCodegen.after.mir
@@ -3,41 +3,33 @@
 fn foo(_1: Option<String>) -> i32 {
     debug s => _1;                       // in scope 0 at $DIR/string.rs:+0:12: +0:13
     let mut _0: i32;                     // return place in scope 0 at $DIR/string.rs:+0:34: +0:37
-    let mut _2: &std::string::String;    // in scope 0 at $DIR/string.rs:+2:14: +2:17
-    let mut _3: &str;                    // in scope 0 at $DIR/string.rs:+2:14: +2:17
-    let mut _4: bool;                    // in scope 0 at $DIR/string.rs:+2:14: +2:17
-    let mut _5: isize;                   // in scope 0 at $DIR/string.rs:+2:9: +2:18
-    let _6: std::option::Option<std::string::String>; // in scope 0 at $DIR/string.rs:+3:9: +3:10
-    let mut _7: bool;                    // in scope 0 at $DIR/string.rs:+5:1: +5:2
+    let mut _2: bool;                    // in scope 0 at $DIR/string.rs:+5:1: +5:2
+    let mut _3: isize;                   // in scope 0 at $DIR/string.rs:+2:9: +2:18
+    let mut _4: &std::string::String;    // in scope 0 at $DIR/string.rs:+2:14: +2:17
+    let mut _5: &str;                    // in scope 0 at $DIR/string.rs:+2:14: +2:17
+    let mut _6: bool;                    // in scope 0 at $DIR/string.rs:+2:14: +2:17
+    let _7: std::option::Option<std::string::String>; // in scope 0 at $DIR/string.rs:+3:9: +3:10
     scope 1 {
-        debug s => _6;                   // in scope 1 at $DIR/string.rs:+3:9: +3:10
+        debug s => _7;                   // in scope 1 at $DIR/string.rs:+3:9: +3:10
     }
 
     bb0: {
-        _7 = const false;                // scope 0 at $DIR/string.rs:+1:11: +1:12
-        _7 = const true;                 // scope 0 at $DIR/string.rs:+1:11: +1:12
-        _5 = discriminant(_1);           // scope 0 at $DIR/string.rs:+1:11: +1:12
-        switchInt(move _5) -> [1: bb2, otherwise: bb1]; // scope 0 at $DIR/string.rs:+1:5: +1:12
+        _2 = const false;                // scope 0 at $DIR/string.rs:+1:11: +1:12
+        _2 = const true;                 // scope 0 at $DIR/string.rs:+1:11: +1:12
+        _3 = discriminant(_1);           // scope 0 at $DIR/string.rs:+1:11: +1:12
+        switchInt(move _3) -> [1: bb1, otherwise: bb5]; // scope 0 at $DIR/string.rs:+1:5: +1:12
     }
 
     bb1: {
-        StorageLive(_6);                 // scope 0 at $DIR/string.rs:+3:9: +3:10
-        _7 = const false;                // scope 0 at $DIR/string.rs:+3:9: +3:10
-        _6 = move _1;                    // scope 0 at $DIR/string.rs:+3:9: +3:10
-        _0 = const 4321_i32;             // scope 1 at $DIR/string.rs:+3:14: +3:18
-        drop(_6) -> [return: bb6, unwind unreachable]; // scope 0 at $DIR/string.rs:+3:17: +3:18
-    }
-
-    bb2: {
-        _2 = &((_1 as Some).0: std::string::String); // scope 0 at $DIR/string.rs:+2:14: +2:17
-        _3 = <String as Deref>::deref(move _2) -> [return: bb3, unwind unreachable]; // scope 0 at $DIR/string.rs:+2:14: +2:17
+        _4 = &((_1 as Some).0: std::string::String); // scope 0 at $DIR/string.rs:+2:14: +2:17
+        _5 = <String as Deref>::deref(move _4) -> [return: bb2, unwind unreachable]; // scope 0 at $DIR/string.rs:+2:14: +2:17
                                          // mir::Constant
                                          // + span: $DIR/string.rs:9:14: 9:17
                                          // + literal: Const { ty: for<'a> fn(&'a String) -> &'a <String as Deref>::Target {<String as Deref>::deref}, val: Value(<ZST>) }
     }
 
-    bb3: {
-        _4 = <str as PartialEq>::eq(_3, const "a") -> [return: bb4, unwind unreachable]; // scope 0 at $DIR/string.rs:+2:14: +2:17
+    bb2: {
+        _6 = <str as PartialEq>::eq(_5, const "a") -> [return: bb3, unwind unreachable]; // scope 0 at $DIR/string.rs:+2:14: +2:17
                                          // mir::Constant
                                          // + span: $DIR/string.rs:9:14: 9:17
                                          // + literal: Const { ty: for<'a, 'b> fn(&'a str, &'b str) -> bool {<str as PartialEq>::eq}, val: Value(<ZST>) }
@@ -46,29 +38,37 @@ fn foo(_1: Option<String>) -> i32 {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
     }
 
+    bb3: {
+        switchInt(move _6) -> [0: bb5, otherwise: bb4]; // scope 0 at $DIR/string.rs:+2:14: +2:17
+    }
+
     bb4: {
-        switchInt(move _4) -> [0: bb1, otherwise: bb5]; // scope 0 at $DIR/string.rs:+2:14: +2:17
+        _0 = const 1234_i32;             // scope 0 at $DIR/string.rs:+2:22: +2:26
+        goto -> bb7;                     // scope 0 at $DIR/string.rs:+2:22: +2:26
     }
 
     bb5: {
-        _0 = const 1234_i32;             // scope 0 at $DIR/string.rs:+2:22: +2:26
-        goto -> bb9;                     // scope 0 at $DIR/string.rs:+2:22: +2:26
+        StorageLive(_7);                 // scope 0 at $DIR/string.rs:+3:9: +3:10
+        _2 = const false;                // scope 0 at $DIR/string.rs:+3:9: +3:10
+        _7 = move _1;                    // scope 0 at $DIR/string.rs:+3:9: +3:10
+        _0 = const 4321_i32;             // scope 1 at $DIR/string.rs:+3:14: +3:18
+        drop(_7) -> [return: bb6, unwind unreachable]; // scope 0 at $DIR/string.rs:+3:17: +3:18
     }
 
     bb6: {
-        StorageDead(_6);                 // scope 0 at $DIR/string.rs:+3:17: +3:18
-        goto -> bb9;                     // scope 0 at $DIR/string.rs:+3:17: +3:18
+        StorageDead(_7);                 // scope 0 at $DIR/string.rs:+3:17: +3:18
+        goto -> bb7;                     // scope 0 at $DIR/string.rs:+3:17: +3:18
     }
 
     bb7: {
-        return;                          // scope 0 at $DIR/string.rs:+5:2: +5:2
+        switchInt(_2) -> [0: bb9, otherwise: bb8]; // scope 0 at $DIR/string.rs:+5:1: +5:2
     }
 
     bb8: {
-        drop(_1) -> [return: bb7, unwind unreachable]; // scope 0 at $DIR/string.rs:+5:1: +5:2
+        drop(_1) -> [return: bb9, unwind unreachable]; // scope 0 at $DIR/string.rs:+5:1: +5:2
     }
 
     bb9: {
-        switchInt(_7) -> [0: bb7, otherwise: bb8]; // scope 0 at $DIR/string.rs:+5:1: +5:2
+        return;                          // scope 0 at $DIR/string.rs:+5:2: +5:2
     }
 }

--- a/tests/mir-opt/inline/cycle.g.Inline.diff
+++ b/tests/mir-opt/inline/cycle.g.Inline.diff
@@ -8,8 +8,8 @@
 +     let mut _5: ();                      // in scope 0 at $DIR/cycle.rs:6:5: 6:8
 +     scope 1 (inlined f::<fn() {main}>) { // at $DIR/cycle.rs:12:5: 12:12
 +         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:5:6: 5:7
-+         let _3: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         let mut _4: &fn() {main};        // in scope 1 at $DIR/cycle.rs:6:5: 6:6
++         let mut _3: &fn() {main};        // in scope 1 at $DIR/cycle.rs:6:5: 6:6
++         let _4: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         scope 2 (inlined <fn() {main} as Fn<()>>::call - shim(fn() {main})) { // at $DIR/cycle.rs:6:5: 6:8
 +         }
 +     }
@@ -25,16 +25,16 @@
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:12:7: 12:11
                                            // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
-+         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
++         StorageLive(_4);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
++         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
++         _3 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         _5 = const ();                   // scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         _3 = move (*_4)() -> [return: bb4, unwind: bb2]; // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++         _4 = move (*_3)() -> [return: bb4, unwind: bb2]; // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
++         StorageDead(_4);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
 +         StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:12
           StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:+1:12: +1:13
           _0 = const ();                   // scope 0 at $DIR/cycle.rs:+0:8: +2:2
@@ -51,7 +51,7 @@
 + 
 +     bb4: {
 +         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
++         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
 +         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
       }
   }

--- a/tests/mir-opt/inline/cycle.main.Inline.diff
+++ b/tests/mir-opt/inline/cycle.main.Inline.diff
@@ -8,8 +8,8 @@
 +     let mut _5: ();                      // in scope 0 at $DIR/cycle.rs:6:5: 6:8
 +     scope 1 (inlined f::<fn() {g}>) {    // at $DIR/cycle.rs:17:5: 17:9
 +         debug g => _2;                   // in scope 1 at $DIR/cycle.rs:5:6: 5:7
-+         let _3: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         let mut _4: &fn() {g};           // in scope 1 at $DIR/cycle.rs:6:5: 6:6
++         let mut _3: &fn() {g};           // in scope 1 at $DIR/cycle.rs:6:5: 6:6
++         let _4: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         scope 2 (inlined <fn() {g} as Fn<()>>::call - shim(fn() {g})) { // at $DIR/cycle.rs:6:5: 6:8
 +         }
 +     }
@@ -25,16 +25,16 @@
 -                                          // mir::Constant
                                            // + span: $DIR/cycle.rs:17:7: 17:8
                                            // + literal: Const { ty: fn() {g}, val: Value(<ZST>) }
-+         StorageLive(_3);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
-+         StorageLive(_4);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
-+         _4 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
++         StorageLive(_4);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
++         StorageLive(_3);                 // scope 1 at $DIR/cycle.rs:6:5: 6:6
++         _3 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         _5 = const ();                   // scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         _3 = move (*_4)() -> [return: bb4, unwind: bb2]; // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++         _4 = move (*_3)() -> [return: bb4, unwind: bb2]; // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
++         StorageDead(_4);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
 +         StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:+1:5: +1:9
           StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:+1:9: +1:10
           _0 = const ();                   // scope 0 at $DIR/cycle.rs:+0:11: +2:2
@@ -51,7 +51,7 @@
 + 
 +     bb4: {
 +         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         StorageDead(_4);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
++         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
 +         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2
       }
   }

--- a/tests/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/tests/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -17,10 +17,10 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
             debug _q => _9;              // in scope 2 at $DIR/inline_closure_captures.rs:+1:14: +1:16
             debug q => (*((*_6).0: &i32)); // in scope 2 at $DIR/inline_closure_captures.rs:+0:23: +0:24
             debug t => (*((*_6).1: &T)); // in scope 2 at $DIR/inline_closure_captures.rs:+0:17: +0:18
-            let mut _10: i32;            // in scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
-            let mut _11: T;              // in scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
-            let mut _12: &i32;           // in scope 2 at $DIR/inline_closure_captures.rs:+1:13: +1:24
-            let mut _13: &T;             // in scope 2 at $DIR/inline_closure_captures.rs:+1:13: +1:24
+            let mut _10: &i32;           // in scope 2 at $DIR/inline_closure_captures.rs:+1:13: +1:24
+            let mut _11: i32;            // in scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
+            let mut _12: &T;             // in scope 2 at $DIR/inline_closure_captures.rs:+1:13: +1:24
+            let mut _13: T;              // in scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
         }
     }
 
@@ -49,15 +49,15 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         _7 = (move _8,);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
         StorageLive(_9);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
         _9 = move (_7.0: i32);           // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
-        StorageLive(_10);                // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
-        _12 = deref_copy ((*_6).0: &i32); // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
-        _10 = (*_12);                    // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
-        StorageLive(_11);                // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
-        _13 = deref_copy ((*_6).1: &T);  // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
-        _11 = (*_13);                    // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
-        _0 = (move _10, move _11);       // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
+        StorageLive(_11);                // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
+        _10 = deref_copy ((*_6).0: &i32); // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
+        _11 = (*_10);                    // scope 2 at $DIR/inline_closure_captures.rs:+1:19: +1:20
+        StorageLive(_13);                // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
+        _12 = deref_copy ((*_6).1: &T);  // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
+        _13 = (*_12);                    // scope 2 at $DIR/inline_closure_captures.rs:+1:22: +1:23
+        _0 = (move _11, move _13);       // scope 2 at $DIR/inline_closure_captures.rs:+1:18: +1:24
+        StorageDead(_13);                // scope 2 at $DIR/inline_closure_captures.rs:+1:23: +1:24
         StorageDead(_11);                // scope 2 at $DIR/inline_closure_captures.rs:+1:23: +1:24
-        StorageDead(_10);                // scope 2 at $DIR/inline_closure_captures.rs:+1:23: +1:24
         StorageDead(_9);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:5: +2:9
         StorageDead(_8);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:8: +2:9
         StorageDead(_7);                 // scope 1 at $DIR/inline_closure_captures.rs:+2:8: +2:9

--- a/tests/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/tests/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -8,15 +8,15 @@
 +     let mut _8: ();                      // in scope 0 at $DIR/inline_diverging.rs:27:13: 27:16
 +     scope 1 (inlined call_twice::<!, fn() -> ! {sleep}>) { // at $DIR/inline_diverging.rs:22:5: 22:22
 +         debug f => _2;                   // in scope 1 at $DIR/inline_diverging.rs:26:36: 26:37
-+         let _3: !;                       // in scope 1 at $DIR/inline_diverging.rs:27:9: 27:10
-+         let mut _4: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
++         let mut _3: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
++         let _4: !;                       // in scope 1 at $DIR/inline_diverging.rs:27:9: 27:10
 +         let mut _5: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline_diverging.rs:28:13: 28:14
-+         let mut _6: !;                   // in scope 1 at $DIR/inline_diverging.rs:29:6: 29:7
-+         let mut _7: !;                   // in scope 1 at $DIR/inline_diverging.rs:29:9: 29:10
++         let mut _6: !;                   // in scope 1 at $DIR/inline_diverging.rs:29:9: 29:10
++         let mut _7: !;                   // in scope 1 at $DIR/inline_diverging.rs:29:6: 29:7
 +         scope 2 {
-+             debug a => _3;               // in scope 2 at $DIR/inline_diverging.rs:27:9: 27:10
++             debug a => _4;               // in scope 2 at $DIR/inline_diverging.rs:27:9: 27:10
 +             scope 3 {
-+                 debug b => _7;           // in scope 3 at $DIR/inline_diverging.rs:28:9: 28:10
++                 debug b => _6;           // in scope 3 at $DIR/inline_diverging.rs:28:9: 28:10
 +             }
 +         }
 +         scope 4 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline_diverging.rs:27:13: 27:16
@@ -34,22 +34,22 @@
 -                                          // mir::Constant
                                            // + span: $DIR/inline_diverging.rs:22:16: 22:21
                                            // + literal: Const { ty: fn() -> ! {sleep}, val: Value(<ZST>) }
-+         StorageLive(_7);                 // scope 0 at $DIR/inline_diverging.rs:+1:5: +1:22
-+         StorageLive(_3);                 // scope 1 at $DIR/inline_diverging.rs:27:9: 27:10
-+         StorageLive(_4);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
-+         _4 = &_2;                        // scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
++         StorageLive(_6);                 // scope 0 at $DIR/inline_diverging.rs:+1:5: +1:22
++         StorageLive(_4);                 // scope 1 at $DIR/inline_diverging.rs:27:9: 27:10
++         StorageLive(_3);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
++         _3 = &_2;                        // scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
 +         StorageLive(_8);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
 +         _8 = const ();                   // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
-+         _3 = move (*_4)() -> [return: bb6, unwind: bb4]; // scope 4 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++         _4 = move (*_3)() -> [return: bb6, unwind: bb4]; // scope 4 at $SRC_DIR/core/src/ops/function.rs:LL:COL
 +     }
 + 
 +     bb1: {
 +         StorageDead(_5);                 // scope 2 at $DIR/inline_diverging.rs:28:15: 28:16
-+         StorageLive(_6);                 // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
-+         _6 = move _3;                    // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
-+         _1 = (move _6, move _7);         // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
-+         StorageDead(_6);                 // scope 3 at $DIR/inline_diverging.rs:29:10: 29:11
-+         StorageDead(_3);                 // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
++         StorageLive(_7);                 // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
++         _7 = move _4;                    // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
++         _1 = (move _7, move _6);         // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
++         StorageDead(_7);                 // scope 3 at $DIR/inline_diverging.rs:29:10: 29:11
++         StorageDead(_4);                 // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
 +         drop(_2) -> bb2;                 // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
 +     }
 + 
@@ -58,7 +58,7 @@
 +     }
 + 
 +     bb3 (cleanup): {
-+         drop(_3) -> [return: bb4, unwind terminate]; // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
++         drop(_4) -> [return: bb4, unwind terminate]; // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
 +     }
 + 
 +     bb4 (cleanup): {
@@ -71,10 +71,10 @@
 + 
 +     bb6: {
 +         StorageDead(_8);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
-+         StorageDead(_4);                 // scope 1 at $DIR/inline_diverging.rs:27:15: 27:16
++         StorageDead(_3);                 // scope 1 at $DIR/inline_diverging.rs:27:15: 27:16
 +         StorageLive(_5);                 // scope 2 at $DIR/inline_diverging.rs:28:13: 28:14
 +         _5 = &_2;                        // scope 2 at $DIR/inline_diverging.rs:28:13: 28:14
-+         _7 = <fn() -> ! {sleep} as Fn<()>>::call(move _5, const ()) -> [return: bb1, unwind: bb3]; // scope 2 at $DIR/inline_diverging.rs:28:13: 28:16
++         _6 = <fn() -> ! {sleep} as Fn<()>>::call(move _5, const ()) -> [return: bb1, unwind: bb3]; // scope 2 at $DIR/inline_diverging.rs:28:13: 28:16
 +                                          // mir::Constant
 +                                          // + span: $DIR/inline_diverging.rs:28:13: 28:14
 +                                          // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a fn() -> ! {sleep}, ()) -> <fn() -> ! {sleep} as FnOnce<()>>::Output {<fn() -> ! {sleep} as Fn<()>>::call}, val: Value(<ZST>) }

--- a/tests/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/tests/mir-opt/inline/inline_generator.main.Inline.diff
@@ -23,9 +23,9 @@
 +     }
 +     scope 6 (inlined g::{closure#0}) {   // at $DIR/inline_generator.rs:9:33: 9:46
 +         debug a => _5;                   // in scope 6 at $DIR/inline_generator.rs:15:6: 15:7
-+         let mut _6: i32;                 // in scope 6 at $DIR/inline_generator.rs:15:17: 15:39
++         let mut _6: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline_generator.rs:15:5: 15:41
 +         let mut _7: u32;                 // in scope 6 at $DIR/inline_generator.rs:15:5: 15:41
-+         let mut _8: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline_generator.rs:15:5: 15:41
++         let mut _8: i32;                 // in scope 6 at $DIR/inline_generator.rs:15:17: 15:39
 +         let mut _9: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline_generator.rs:15:5: 15:41
 +         let mut _10: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]; // in scope 6 at $DIR/inline_generator.rs:15:5: 15:41
 +     }
@@ -70,9 +70,9 @@
 -                                          // + literal: Const { ty: for<'a> fn(Pin<&'a mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>, bool) -> GeneratorState<<[generator@$DIR/inline_generator.rs:15:5: 15:8] as Generator<bool>>::Yield, <[generator@$DIR/inline_generator.rs:15:5: 15:8] as Generator<bool>>::Return> {<[generator@$DIR/inline_generator.rs:15:5: 15:8] as Generator<bool>>::resume}, val: Value(<ZST>) }
 +         StorageLive(_5);                 // scope 0 at $DIR/inline_generator.rs:+1:33: +1:46
 +         _5 = const false;                // scope 0 at $DIR/inline_generator.rs:+1:33: +1:46
-+         _8 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
-+         _7 = discriminant((*_8));        // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
-+         switchInt(move _7) -> [0: bb3, 1: bb8, 3: bb7, otherwise: bb9]; // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
++         _6 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
++         _7 = discriminant((*_6));        // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
++         switchInt(move _7) -> [0: bb3, 1: bb7, 3: bb8, otherwise: bb9]; // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
       }
   
 -     bb3: {
@@ -91,38 +91,38 @@
 +     }
 + 
 +     bb3: {
-+         StorageLive(_6);                 // scope 6 at $DIR/inline_generator.rs:15:17: 15:39
-+         switchInt(_5) -> [0: bb5, otherwise: bb4]; // scope 6 at $DIR/inline_generator.rs:15:20: 15:21
++         StorageLive(_8);                 // scope 6 at $DIR/inline_generator.rs:15:17: 15:39
++         switchInt(_5) -> [0: bb4, otherwise: bb5]; // scope 6 at $DIR/inline_generator.rs:15:20: 15:21
 +     }
 + 
 +     bb4: {
-+         _6 = const 7_i32;                // scope 6 at $DIR/inline_generator.rs:15:24: 15:25
++         _8 = const 13_i32;               // scope 6 at $DIR/inline_generator.rs:15:35: 15:37
 +         goto -> bb6;                     // scope 6 at $DIR/inline_generator.rs:15:17: 15:39
 +     }
 + 
 +     bb5: {
-+         _6 = const 13_i32;               // scope 6 at $DIR/inline_generator.rs:15:35: 15:37
++         _8 = const 7_i32;                // scope 6 at $DIR/inline_generator.rs:15:24: 15:25
 +         goto -> bb6;                     // scope 6 at $DIR/inline_generator.rs:15:17: 15:39
 +     }
 + 
 +     bb6: {
-+         _1 = GeneratorState::<i32, bool>::Yielded(move _6); // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
++         _1 = GeneratorState::<i32, bool>::Yielded(move _8); // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
 +         _9 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
 +         discriminant((*_9)) = 3;         // scope 6 at $DIR/inline_generator.rs:15:11: 15:39
 +         goto -> bb1;                     // scope 0 at $DIR/inline_generator.rs:15:11: 15:39
 +     }
 + 
 +     bb7: {
-+         StorageLive(_6);                 // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
-+         StorageDead(_6);                 // scope 6 at $DIR/inline_generator.rs:15:38: 15:39
++         assert(const false, "generator resumed after completion") -> [success: bb7, unwind: bb2]; // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
++     }
++ 
++     bb8: {
++         StorageLive(_8);                 // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
++         StorageDead(_8);                 // scope 6 at $DIR/inline_generator.rs:15:38: 15:39
 +         _1 = GeneratorState::<i32, bool>::Complete(_5); // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
 +         _10 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]); // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
 +         discriminant((*_10)) = 1;        // scope 6 at $DIR/inline_generator.rs:15:41: 15:41
 +         goto -> bb1;                     // scope 0 at $DIR/inline_generator.rs:15:41: 15:41
-+     }
-+ 
-+     bb8: {
-+         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline_generator.rs:15:5: 15:41
 +     }
 + 
 +     bb9: {

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.diff
@@ -4,9 +4,9 @@
   fn outer() -> usize {
       let mut _0: usize;                   // return place in scope 0 at $DIR/issue_106141.rs:+0:19: +0:24
 +     scope 1 (inlined inner) {            // at $DIR/issue_106141.rs:3:5: 3:12
-+         let mut _1: bool;                // in scope 1 at $DIR/issue_106141.rs:14:8: 14:21
++         let mut _1: &[bool; 1];          // in scope 1 at $DIR/issue_106141.rs:12:18: 12:25
 +         let mut _2: bool;                // in scope 1 at $DIR/issue_106141.rs:14:8: 14:21
-+         let mut _3: &[bool; 1];          // in scope 1 at $DIR/issue_106141.rs:12:18: 12:25
++         let mut _3: bool;                // in scope 1 at $DIR/issue_106141.rs:14:8: 14:21
 +         scope 2 {
 +             debug buffer => const _;     // in scope 2 at $DIR/issue_106141.rs:12:9: 12:15
 +             scope 3 {
@@ -17,8 +17,8 @@
   
       bb0: {
 -         _0 = inner() -> bb1;             // scope 0 at $DIR/issue_106141.rs:+1:5: +1:12
-+         StorageLive(_3);                 // scope 0 at $DIR/issue_106141.rs:+1:5: +1:12
-+         _3 = const _;                    // scope 1 at $DIR/issue_106141.rs:12:18: 12:25
++         StorageLive(_1);                 // scope 0 at $DIR/issue_106141.rs:+1:5: +1:12
++         _1 = const _;                    // scope 1 at $DIR/issue_106141.rs:12:18: 12:25
                                            // mir::Constant
 -                                          // + span: $DIR/issue_106141.rs:3:5: 3:10
 -                                          // + literal: Const { ty: fn() -> usize {inner}, val: Value(<ZST>) }
@@ -31,14 +31,14 @@
       }
   
       bb1: {
-+         StorageLive(_1);                 // scope 3 at $DIR/issue_106141.rs:14:8: 14:21
++         StorageLive(_3);                 // scope 3 at $DIR/issue_106141.rs:14:8: 14:21
 +         _2 = Lt(_0, const 1_usize);      // scope 3 at $DIR/issue_106141.rs:14:8: 14:21
 +         assert(move _2, "index out of bounds: the length is {} but the index is {}", const 1_usize, _0) -> bb2; // scope 3 at $DIR/issue_106141.rs:14:8: 14:21
 +     }
 + 
 +     bb2: {
-+         _1 = (*_3)[_0];                  // scope 3 at $DIR/issue_106141.rs:14:8: 14:21
-+         switchInt(move _1) -> [0: bb3, otherwise: bb4]; // scope 3 at $DIR/issue_106141.rs:14:8: 14:21
++         _3 = (*_1)[_0];                  // scope 3 at $DIR/issue_106141.rs:14:8: 14:21
++         switchInt(move _3) -> [0: bb3, otherwise: bb4]; // scope 3 at $DIR/issue_106141.rs:14:8: 14:21
 +     }
 + 
 +     bb3: {
@@ -47,8 +47,8 @@
 +     }
 + 
 +     bb4: {
-+         StorageDead(_1);                 // scope 3 at $DIR/issue_106141.rs:18:5: 18:6
-+         StorageDead(_3);                 // scope 0 at $DIR/issue_106141.rs:+1:5: +1:12
++         StorageDead(_3);                 // scope 3 at $DIR/issue_106141.rs:18:5: 18:6
++         StorageDead(_1);                 // scope 0 at $DIR/issue_106141.rs:+1:5: +1:12
           return;                          // scope 0 at $DIR/issue_106141.rs:+2:2: +2:2
       }
   }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.mir
@@ -7,38 +7,38 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
     scope 1 (inlined core::num::<impl u16>::unchecked_shl) { // at $DIR/unchecked_shifts.rs:11:7: 11:23
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
         debug rhs => _2;                 // in scope 1 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-        let mut _3: u16;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        let mut _4: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        let mut _5: u32;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _3: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _4: u32;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _13: u16;                // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         scope 2 {
             scope 3 (inlined core::num::<impl u16>::unchecked_shl::conv) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                debug x => _5;           // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                let mut _6: std::option::Option<u16>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                let mut _7: std::result::Result<u16, std::num::TryFromIntError>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                debug x => _4;           // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                let mut _8: std::result::Result<u16, std::num::TryFromIntError>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                let mut _11: std::option::Option<u16>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
                 scope 4 {
                     scope 5 (inlined <u32 as TryInto<u16>>::try_into) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                        debug self => _5; // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                        debug self => _4; // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                         scope 6 (inlined convert::num::<impl TryFrom<u32> for u16>::try_from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-                            debug u => _5; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-                            let mut _8: bool; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-                            let mut _9: u32; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-                            let mut _10: u16; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            debug u => _4; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _5: u32; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _6: bool; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _7: u16; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
                         }
                     }
                     scope 7 (inlined Result::<u16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                        debug self => _7; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-                        let mut _11: isize; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-                        let _12: u16;    // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        debug self => _8; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        let mut _9: isize; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        let _10: u16;    // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
                         scope 8 {
-                            debug x => _12; // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                            debug x => _10; // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                         }
                     }
                     scope 9 (inlined #[track_caller] Option::<u16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                        debug self => _6; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-                        let mut _13: &std::option::Option<u16>; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-                        let mut _14: isize; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        debug self => _11; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        let mut _12: isize; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        let mut _14: &std::option::Option<u16>; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
                         scope 10 {
-                            debug val => _3; // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
+                            debug val => _13; // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
                         }
                         scope 11 {
                             scope 13 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
@@ -49,7 +49,7 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
                             }
                         }
                         scope 12 (inlined Option::<u16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
-                            debug self => _13; // in scope 12 at $SRC_DIR/core/src/option.rs:LL:COL
+                            debug self => _14; // in scope 12 at $SRC_DIR/core/src/option.rs:LL:COL
                         }
                     }
                 }
@@ -58,81 +58,81 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
     }
 
     bb0: {
+        StorageLive(_13);                // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _3 = (_2,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _4 = (_2,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _5 = move (_4.0: u32);           // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_7);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_8);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _9 = const 65535_u32;            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _8 = Gt(_5, move _9);            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        switchInt(move _8) -> [0: bb3, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _4 = move (_3.0: u32);           // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_5);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _5 = const 65535_u32;            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _6 = Gt(_4, move _5);            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_5);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        switchInt(move _6) -> [0: bb1, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
+        StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _7 = _4 as u16 (IntToInt);       // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _8 = Result::<u16, TryFromIntError>::Ok(move _7); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        goto -> bb3;                     // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
     }
 
     bb2: {
-        _7 = Result::<u16, TryFromIntError>::Err(const TryFromIntError(())); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _8 = Result::<u16, TryFromIntError>::Err(const TryFromIntError(())); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
                                          // mir::Constant
                                          // + span: no-location
                                          // + literal: Const { ty: TryFromIntError, val: Value(<ZST>) }
-        goto -> bb4;                     // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        goto -> bb3;                     // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
     }
 
     bb3: {
-        StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _10 = _5 as u16 (IntToInt);      // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _7 = Result::<u16, TryFromIntError>::Ok(move _10); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        goto -> bb4;                     // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_6);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _9 = discriminant(_8);           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        switchInt(move _9) -> [0: bb4, 1: bb5, otherwise: bb9]; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb4: {
-        StorageDead(_8);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _11 = discriminant(_7);          // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        switchInt(move _11) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _10 = move ((_8 as Ok).0: u16);  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _11 = Option::<u16>::Some(move _10); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb6;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb5: {
-        _6 = Option::<u16>::None;        // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        goto -> bb8;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _11 = Option::<u16>::None;       // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb6;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb6: {
-        unreachable;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _12 = discriminant(_11);         // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _12) -> [1: bb7, otherwise: bb9]; // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb7: {
-        _12 = move ((_7 as Ok).0: u16);  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        _6 = Option::<u16>::Some(move _12); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-        goto -> bb8;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-    }
-
-    bb8: {
-        StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageDead(_7);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _14 = discriminant(_6);          // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-        switchInt(move _14) -> [1: bb9, otherwise: bb6]; // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-    }
-
-    bb9: {
-        _3 = move ((_6 as Some).0: u16); // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-        StorageDead(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageDead(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _13 = move ((_11 as Some).0: u16); // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_14);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _0 = unchecked_shl::<u16>(_1, move _3) -> [return: bb1, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _0 = unchecked_shl::<u16>(_1, move _13) -> [return: bb8, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u16, u16) -> u16 {unchecked_shl::<u16>}, val: Value(<ZST>) }
+    }
+
+    bb8: {
+        StorageDead(_13);                // scope 2 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
+    }
+
+    bb9: {
+        unreachable;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.mir
@@ -7,38 +7,38 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
     scope 1 (inlined core::num::<impl i16>::unchecked_shr) { // at $DIR/unchecked_shifts.rs:17:7: 17:23
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
         debug rhs => _2;                 // in scope 1 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        let mut _3: i16;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        let mut _4: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        let mut _5: u32;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _3: (u32,);              // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _4: u32;                 // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        let mut _13: i16;                // in scope 1 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         scope 2 {
             scope 3 (inlined core::num::<impl i16>::unchecked_shr::conv) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                debug x => _5;           // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                let mut _6: std::option::Option<i16>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                let mut _7: std::result::Result<i16, std::num::TryFromIntError>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                debug x => _4;           // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                let mut _8: std::result::Result<i16, std::num::TryFromIntError>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                let mut _11: std::option::Option<i16>; // in scope 3 at $SRC_DIR/core/src/num/mod.rs:LL:COL
                 scope 4 {
                     scope 5 (inlined <u32 as TryInto<i16>>::try_into) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                        debug self => _5; // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                        debug self => _4; // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                         scope 6 (inlined convert::num::<impl TryFrom<u32> for i16>::try_from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-                            debug u => _5; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-                            let mut _8: bool; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-                            let mut _9: u32; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-                            let mut _10: i16; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            debug u => _4; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _5: u32; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _6: bool; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+                            let mut _7: i16; // in scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
                         }
                     }
                     scope 7 (inlined Result::<i16, TryFromIntError>::ok) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                        debug self => _7; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-                        let mut _11: isize; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-                        let _12: i16;    // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        debug self => _8; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        let mut _9: isize; // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+                        let _10: i16;    // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
                         scope 8 {
-                            debug x => _12; // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                            debug x => _10; // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                         }
                     }
                     scope 9 (inlined #[track_caller] Option::<i16>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                        debug self => _6; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-                        let mut _13: &std::option::Option<i16>; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-                        let mut _14: isize; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        debug self => _11; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        let mut _12: isize; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+                        let mut _14: &std::option::Option<i16>; // in scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
                         scope 10 {
-                            debug val => _3; // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
+                            debug val => _13; // in scope 10 at $SRC_DIR/core/src/option.rs:LL:COL
                         }
                         scope 11 {
                             scope 13 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
@@ -49,7 +49,7 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
                             }
                         }
                         scope 12 (inlined Option::<i16>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
-                            debug self => _13; // in scope 12 at $SRC_DIR/core/src/option.rs:LL:COL
+                            debug self => _14; // in scope 12 at $SRC_DIR/core/src/option.rs:LL:COL
                         }
                     }
                 }
@@ -58,81 +58,81 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
     }
 
     bb0: {
+        StorageLive(_13);                // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _3 = (_2,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _4 = (_2,);                      // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _5 = move (_4.0: u32);           // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_7);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_8);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _9 = const 32767_u32;            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _8 = Gt(_5, move _9);            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        switchInt(move _8) -> [0: bb3, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _4 = move (_3.0: u32);           // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_6);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_5);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _5 = const 32767_u32;            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _6 = Gt(_4, move _5);            // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_5);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        switchInt(move _6) -> [0: bb1, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
-        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
+        StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _7 = _4 as i16 (IntToInt);       // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _8 = Result::<i16, TryFromIntError>::Ok(move _7); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        goto -> bb3;                     // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
     }
 
     bb2: {
-        _7 = Result::<i16, TryFromIntError>::Err(const TryFromIntError(())); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        _8 = Result::<i16, TryFromIntError>::Err(const TryFromIntError(())); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
                                          // mir::Constant
                                          // + span: no-location
                                          // + literal: Const { ty: TryFromIntError, val: Value(<ZST>) }
-        goto -> bb4;                     // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        goto -> bb3;                     // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
     }
 
     bb3: {
-        StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _10 = _5 as i16 (IntToInt);      // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        _7 = Result::<i16, TryFromIntError>::Ok(move _10); // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        goto -> bb4;                     // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageDead(_6);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
+        StorageLive(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _9 = discriminant(_8);           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        switchInt(move _9) -> [0: bb4, 1: bb5, otherwise: bb9]; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb4: {
-        StorageDead(_8);                 // scope 6 at $SRC_DIR/core/src/convert/num.rs:LL:COL
-        StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _11 = discriminant(_7);          // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        switchInt(move _11) -> [0: bb7, 1: bb5, otherwise: bb6]; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _10 = move ((_8 as Ok).0: i16);  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _11 = Option::<i16>::Some(move _10); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb6;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb5: {
-        _6 = Option::<i16>::None;        // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        goto -> bb8;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _11 = Option::<i16>::None;       // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        goto -> bb6;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb6: {
-        unreachable;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_10);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _12 = discriminant(_11);         // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _12) -> [1: bb7, otherwise: bb9]; // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb7: {
-        _12 = move ((_7 as Ok).0: i16);  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        _6 = Option::<i16>::Some(move _12); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-        goto -> bb8;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-    }
-
-    bb8: {
-        StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageDead(_7);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _14 = discriminant(_6);          // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-        switchInt(move _14) -> [1: bb9, otherwise: bb6]; // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-    }
-
-    bb9: {
-        _3 = move ((_6 as Some).0: i16); // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
-        StorageDead(_13);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageDead(_6);                 // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _13 = move ((_11 as Some).0: i16); // scope 9 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_14);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _0 = unchecked_shr::<i16>(_1, move _3) -> [return: bb1, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/num/mod.rs:LL:COL
+        _0 = unchecked_shr::<i16>(_1, move _13) -> [return: bb8, unwind unreachable]; // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/num/int_macros.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(i16, i16) -> i16 {unchecked_shr::<i16>}, val: Value(<ZST>) }
+    }
+
+    bb8: {
+        StorageDead(_13);                // scope 2 at $SRC_DIR/core/src/num/int_macros.rs:LL:COL
+        return;                          // scope 0 at $DIR/unchecked_shifts.rs:+2:2: +2:2
+    }
+
+    bb9: {
+        unreachable;                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.mir
@@ -5,8 +5,8 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
     let mut _0: T;                       // return place in scope 0 at $DIR/unwrap_unchecked.rs:+0:54: +0:55
     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) { // at $DIR/unwrap_unchecked.rs:10:9: 10:27
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
-        let mut _2: &std::option::Option<T>; // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
-        let mut _3: isize;               // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _2: isize;               // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _3: &std::option::Option<T>; // in scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
         scope 2 {
             debug val => _0;             // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
         }
@@ -19,23 +19,23 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
             }
         }
         scope 4 (inlined Option::<T>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
-            debug self => _2;            // in scope 4 at $SRC_DIR/core/src/option.rs:LL:COL
+            debug self => _3;            // in scope 4 at $SRC_DIR/core/src/option.rs:LL:COL
         }
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
-        _3 = discriminant(_1);           // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
-        switchInt(move _3) -> [1: bb2, otherwise: bb1]; // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageLive(_3);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
+        _2 = discriminant(_1);           // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _2) -> [1: bb1, otherwise: bb2]; // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb1: {
-        unreachable;                     // scope 6 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+        _0 = move ((_1 as Some).0: T);   // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_3);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
+        return;                          // scope 0 at $DIR/unwrap_unchecked.rs:+2:2: +2:2
     }
 
     bb2: {
-        _0 = move ((_1 as Some).0: T);   // scope 1 at $SRC_DIR/core/src/option.rs:LL:COL
-        StorageDead(_2);                 // scope 0 at $DIR/unwrap_unchecked.rs:+1:9: +1:27
-        return;                          // scope 0 at $DIR/unwrap_unchecked.rs:+2:2: +2:2
+        unreachable;                     // scope 6 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
     }
 }

--- a/tests/mir-opt/issue_101973.inner.ConstProp.diff
+++ b/tests/mir-opt/issue_101973.inner.ConstProp.diff
@@ -18,8 +18,8 @@
       let mut _13: bool;                   // in scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
       scope 1 (inlined imm8) {             // at $DIR/issue_101973.rs:15:5: 15:17
           debug x => _1;                   // in scope 1 at $DIR/issue_101973.rs:6:13: 6:14
-          let mut _14: u32;                // in scope 1 at $DIR/issue_101973.rs:8:12: 8:27
-          let mut _15: u32;                // in scope 1 at $DIR/issue_101973.rs:8:12: 8:20
+          let mut _14: u32;                // in scope 1 at $DIR/issue_101973.rs:8:12: 8:20
+          let mut _15: u32;                // in scope 1 at $DIR/issue_101973.rs:8:12: 8:27
           scope 2 {
               debug out => _4;             // in scope 2 at $DIR/issue_101973.rs:7:9: 7:16
           }
@@ -33,13 +33,13 @@
           StorageLive(_2);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:65
           StorageLive(_3);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:58
           StorageLive(_4);                 // scope 0 at $DIR/issue_101973.rs:+1:5: +1:17
-          StorageLive(_14);                // scope 2 at $DIR/issue_101973.rs:8:12: 8:27
-          StorageLive(_15);                // scope 2 at $DIR/issue_101973.rs:8:12: 8:20
-          _15 = Shr(_1, const 0_i32);      // scope 2 at $DIR/issue_101973.rs:8:12: 8:20
-          _14 = BitAnd(move _15, const 255_u32); // scope 2 at $DIR/issue_101973.rs:8:12: 8:27
-          StorageDead(_15);                // scope 2 at $DIR/issue_101973.rs:8:26: 8:27
-          _4 = BitOr(const 0_u32, move _14); // scope 2 at $DIR/issue_101973.rs:8:5: 8:27
+          StorageLive(_15);                // scope 2 at $DIR/issue_101973.rs:8:12: 8:27
+          StorageLive(_14);                // scope 2 at $DIR/issue_101973.rs:8:12: 8:20
+          _14 = Shr(_1, const 0_i32);      // scope 2 at $DIR/issue_101973.rs:8:12: 8:20
+          _15 = BitAnd(move _14, const 255_u32); // scope 2 at $DIR/issue_101973.rs:8:12: 8:27
           StorageDead(_14);                // scope 2 at $DIR/issue_101973.rs:8:26: 8:27
+          _4 = BitOr(const 0_u32, move _15); // scope 2 at $DIR/issue_101973.rs:8:5: 8:27
+          StorageDead(_15);                // scope 2 at $DIR/issue_101973.rs:8:26: 8:27
           StorageLive(_6);                 // scope 0 at $DIR/issue_101973.rs:+1:31: +1:57
           StorageLive(_7);                 // scope 0 at $DIR/issue_101973.rs:+1:31: +1:52
           StorageLive(_8);                 // scope 0 at $DIR/issue_101973.rs:+1:32: +1:45

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -3,19 +3,19 @@
 fn num_to_digit(_1: char) -> u32 {
     debug num => _1;                     // in scope 0 at $DIR/issue_59352.rs:+0:21: +0:24
     let mut _0: u32;                     // return place in scope 0 at $DIR/issue_59352.rs:+0:35: +0:38
-    let mut _2: std::option::Option<u32>; // in scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
+    let mut _5: std::option::Option<u32>; // in scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
     scope 1 (inlined char::methods::<impl char>::is_digit) { // at $DIR/issue_59352.rs:15:12: 15:23
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         debug radix => const 8_u32;      // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        let _2: std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         let mut _3: &std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        let _4: std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         scope 2 (inlined Option::<u32>::is_some) { // at $SRC_DIR/core/src/char/methods.rs:LL:COL
             debug self => _3;            // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
-            let mut _5: isize;           // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+            let mut _4: isize;           // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
         }
     }
     scope 3 (inlined #[track_caller] Option::<u32>::unwrap) { // at $DIR/issue_59352.rs:15:42: 15:50
-        debug self => _2;                // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        debug self => _5;                // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         let mut _6: isize;               // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         let mut _7: !;                   // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         scope 4 {
@@ -25,44 +25,35 @@ fn num_to_digit(_1: char) -> u32 {
 
     bb0: {
         StorageLive(_3);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _4 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        StorageLive(_2);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _2 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb1; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageLive(_2);                 // scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
-        _2 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb2; // scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
+        _3 = &_2;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _4 = discriminant((*_3));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        StorageDead(_2);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        switchInt(move _4) -> [1: bb2, otherwise: bb7]; // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
+    }
+
+    bb2: {
+        StorageLive(_5);                 // scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
+        _5 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb3; // scope 0 at $DIR/issue_59352.rs:+2:26: +2:41
                                          // mir::Constant
                                          // + span: $DIR/issue_59352.rs:15:30: 15:38
                                          // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(<ZST>) }
     }
 
-    bb2: {
-        _6 = discriminant(_2);           // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        switchInt(move _6) -> [0: bb6, 1: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-    }
-
     bb3: {
-        _0 = const 0_u32;                // scope 0 at $DIR/issue_59352.rs:+2:60: +2:61
-        goto -> bb4;                     // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
+        _6 = discriminant(_5);           // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _6) -> [0: bb4, 1: bb5, otherwise: bb6]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb4: {
-        return;                          // scope 0 at $DIR/issue_59352.rs:+3:2: +3:2
-    }
-
-    bb5: {
-        _3 = &_4;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        _5 = discriminant((*_3));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
-        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
-        switchInt(move _5) -> [1: bb1, otherwise: bb3]; // scope 0 at $DIR/issue_59352.rs:+2:8: +2:23
-    }
-
-    bb6: {
         _7 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/option.rs:LL:COL
@@ -72,13 +63,22 @@ fn num_to_digit(_1: char) -> u32 {
                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
     }
 
-    bb7: {
+    bb5: {
+        _0 = move ((_5 as Some).0: u32); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageDead(_5);                 // scope 0 at $DIR/issue_59352.rs:+2:49: +2:50
+        goto -> bb8;                     // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
+    }
+
+    bb6: {
         unreachable;                     // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
+    bb7: {
+        _0 = const 0_u32;                // scope 0 at $DIR/issue_59352.rs:+2:60: +2:61
+        goto -> bb8;                     // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
+    }
+
     bb8: {
-        _0 = move ((_2 as Some).0: u32); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
-        StorageDead(_2);                 // scope 0 at $DIR/issue_59352.rs:+2:49: +2:50
-        goto -> bb4;                     // scope 0 at $DIR/issue_59352.rs:+2:5: +2:63
+        return;                          // scope 0 at $DIR/issue_59352.rs:+3:2: +3:2
     }
 }

--- a/tests/mir-opt/pre-codegen/duplicate_switch_targets.ub_if_b.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/duplicate_switch_targets.ub_if_b.PreCodegen.after.mir
@@ -13,15 +13,15 @@ fn ub_if_b(_1: Thing) -> Thing {
 
     bb0: {
         _2 = discriminant(_1);           // scope 0 at $DIR/duplicate_switch_targets.rs:+1:11: +1:12
-        switchInt(move _2) -> [0: bb2, otherwise: bb1]; // scope 0 at $DIR/duplicate_switch_targets.rs:+1:5: +1:12
+        switchInt(move _2) -> [0: bb1, otherwise: bb2]; // scope 0 at $DIR/duplicate_switch_targets.rs:+1:5: +1:12
     }
 
     bb1: {
-        unreachable;                     // scope 2 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+        _0 = move _1;                    // scope 0 at $DIR/duplicate_switch_targets.rs:+2:21: +2:22
+        return;                          // scope 0 at $DIR/duplicate_switch_targets.rs:+5:2: +5:2
     }
 
     bb2: {
-        _0 = move _1;                    // scope 0 at $DIR/duplicate_switch_targets.rs:+2:21: +2:22
-        return;                          // scope 0 at $DIR/duplicate_switch_targets.rs:+5:2: +5:2
+        unreachable;                     // scope 2 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
     }
 }

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.mir
@@ -7,20 +7,20 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/range_iter.rs:+0:60: +0:60
     let mut _4: std::ops::Range<u32>;    // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
     let mut _5: std::ops::Range<u32>;    // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
-    let _6: ();                          // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
+    let mut _6: &mut std::ops::Range<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
     let mut _7: std::option::Option<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
-    let mut _8: &mut std::ops::Range<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
-    let mut _9: isize;                   // in scope 0 at $DIR/range_iter.rs:+1:5: +3:6
-    let mut _11: &impl Fn(u32);          // in scope 0 at $DIR/range_iter.rs:+2:9: +2:10
-    let mut _12: (u32,);                 // in scope 0 at $DIR/range_iter.rs:+2:9: +2:13
+    let mut _8: isize;                   // in scope 0 at $DIR/range_iter.rs:+1:5: +3:6
+    let mut _10: &impl Fn(u32);          // in scope 0 at $DIR/range_iter.rs:+2:9: +2:10
+    let mut _11: (u32,);                 // in scope 0 at $DIR/range_iter.rs:+2:9: +2:13
+    let _12: ();                         // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
     scope 1 {
         debug iter => _5;                // in scope 1 at $DIR/range_iter.rs:+1:14: +1:24
-        let _10: u32;                    // in scope 1 at $DIR/range_iter.rs:+1:9: +1:10
+        let _9: u32;                     // in scope 1 at $DIR/range_iter.rs:+1:9: +1:10
         scope 2 {
-            debug x => _10;              // in scope 2 at $DIR/range_iter.rs:+1:9: +1:10
+            debug x => _9;               // in scope 2 at $DIR/range_iter.rs:+1:9: +1:10
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) { // at $DIR/range_iter.rs:21:14: 21:24
-            debug self => _8;            // in scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+            debug self => _6;            // in scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         }
     }
     scope 3 (inlined <std::ops::Range<u32> as IntoIterator>::into_iter) { // at $DIR/range_iter.rs:21:14: 21:24
@@ -36,56 +36,56 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb1: {
         StorageLive(_7);                 // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
-        _8 = &mut _5;                    // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
-        _7 = <std::ops::Range<u32> as iter::range::RangeIteratorImpl>::spec_next(_8) -> [return: bb9, unwind: bb7]; // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _6 = &mut _5;                    // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
+        _7 = <std::ops::Range<u32> as iter::range::RangeIteratorImpl>::spec_next(_6) -> [return: bb2, unwind: bb8]; // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // + literal: Const { ty: for<'a> fn(&'a mut std::ops::Range<u32>) -> Option<<std::ops::Range<u32> as iter::range::RangeIteratorImpl>::Item> {<std::ops::Range<u32> as iter::range::RangeIteratorImpl>::spec_next}, val: Value(<ZST>) }
     }
 
     bb2: {
-        _10 = ((_7 as Some).0: u32);     // scope 1 at $DIR/range_iter.rs:+1:9: +1:10
-        StorageLive(_11);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
-        _11 = &_3;                       // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
-        StorageLive(_12);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
-        _12 = (_10,);                    // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
-        _6 = <impl Fn(u32) as Fn<(u32,)>>::call(move _11, move _12) -> [return: bb5, unwind: bb7]; // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
+        _8 = discriminant(_7);           // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
+        switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb7]; // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
+    }
+
+    bb3: {
+        StorageDead(_7);                 // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
+        StorageDead(_5);                 // scope 0 at $DIR/range_iter.rs:+3:5: +3:6
+        drop(_3) -> bb4;                 // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
+    }
+
+    bb4: {
+        return;                          // scope 0 at $DIR/range_iter.rs:+4:2: +4:2
+    }
+
+    bb5: {
+        _9 = ((_7 as Some).0: u32);      // scope 1 at $DIR/range_iter.rs:+1:9: +1:10
+        StorageLive(_10);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
+        _10 = &_3;                       // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
+        StorageLive(_11);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
+        _11 = (_9,);                     // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
+        _12 = <impl Fn(u32) as Fn<(u32,)>>::call(move _10, move _11) -> [return: bb6, unwind: bb8]; // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
                                          // mir::Constant
                                          // + span: $DIR/range_iter.rs:22:9: 22:10
                                          // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a impl Fn(u32), (u32,)) -> <impl Fn(u32) as FnOnce<(u32,)>>::Output {<impl Fn(u32) as Fn<(u32,)>>::call}, val: Value(<ZST>) }
     }
 
-    bb3: {
-        unreachable;                     // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
-    }
-
-    bb4: {
-        StorageDead(_7);                 // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
-        StorageDead(_5);                 // scope 0 at $DIR/range_iter.rs:+3:5: +3:6
-        drop(_3) -> bb6;                 // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
-    }
-
-    bb5: {
-        StorageDead(_12);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
+    bb6: {
         StorageDead(_11);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
+        StorageDead(_10);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
         StorageDead(_7);                 // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
         goto -> bb1;                     // scope 1 at $DIR/range_iter.rs:+1:5: +3:6
     }
 
-    bb6: {
-        return;                          // scope 0 at $DIR/range_iter.rs:+4:2: +4:2
-    }
-
-    bb7 (cleanup): {
-        drop(_3) -> [return: bb8, unwind terminate]; // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
+    bb7: {
+        unreachable;                     // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
     }
 
     bb8 (cleanup): {
-        resume;                          // scope 0 at $DIR/range_iter.rs:+0:1: +4:2
+        drop(_3) -> [return: bb9, unwind terminate]; // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
     }
 
-    bb9: {
-        _9 = discriminant(_7);           // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
-        switchInt(move _9) -> [0: bb4, 1: bb2, otherwise: bb3]; // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
+    bb9 (cleanup): {
+        resume;                          // scope 0 at $DIR/range_iter.rs:+0:1: +4:2
     }
 }

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.mir
@@ -7,20 +7,20 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/range_iter.rs:+0:62: +0:62
     let mut _4: std::ops::RangeInclusive<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:25
     let mut _5: std::ops::RangeInclusive<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:25
-    let _6: ();                          // in scope 0 at $DIR/range_iter.rs:+1:14: +1:25
+    let mut _6: &mut std::ops::RangeInclusive<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:25
     let mut _7: std::option::Option<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:25
-    let mut _8: &mut std::ops::RangeInclusive<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:25
-    let mut _9: isize;                   // in scope 0 at $DIR/range_iter.rs:+1:5: +3:6
-    let mut _11: &impl Fn(u32);          // in scope 0 at $DIR/range_iter.rs:+2:9: +2:10
-    let mut _12: (u32,);                 // in scope 0 at $DIR/range_iter.rs:+2:9: +2:13
+    let mut _8: isize;                   // in scope 0 at $DIR/range_iter.rs:+1:5: +3:6
+    let mut _10: &impl Fn(u32);          // in scope 0 at $DIR/range_iter.rs:+2:9: +2:10
+    let mut _11: (u32,);                 // in scope 0 at $DIR/range_iter.rs:+2:9: +2:13
+    let _12: ();                         // in scope 0 at $DIR/range_iter.rs:+1:14: +1:25
     scope 1 {
         debug iter => _5;                // in scope 1 at $DIR/range_iter.rs:+1:14: +1:25
-        let _10: u32;                    // in scope 1 at $DIR/range_iter.rs:+1:9: +1:10
+        let _9: u32;                     // in scope 1 at $DIR/range_iter.rs:+1:9: +1:10
         scope 2 {
-            debug x => _10;              // in scope 2 at $DIR/range_iter.rs:+1:9: +1:10
+            debug x => _9;               // in scope 2 at $DIR/range_iter.rs:+1:9: +1:10
         }
         scope 5 (inlined iter::range::<impl Iterator for RangeInclusive<u32>>::next) { // at $DIR/range_iter.rs:28:14: 28:25
-            debug self => _8;            // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+            debug self => _6;            // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         }
     }
     scope 3 (inlined RangeInclusive::<u32>::new) { // at $DIR/range_iter.rs:28:14: 28:25
@@ -40,56 +40,56 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb1: {
         StorageLive(_7);                 // scope 1 at $DIR/range_iter.rs:+1:14: +1:25
-        _8 = &mut _5;                    // scope 1 at $DIR/range_iter.rs:+1:14: +1:25
-        _7 = <RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(_8) -> [return: bb9, unwind: bb7]; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _6 = &mut _5;                    // scope 1 at $DIR/range_iter.rs:+1:14: +1:25
+        _7 = <RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(_6) -> [return: bb2, unwind: bb8]; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // + literal: Const { ty: for<'a> fn(&'a mut RangeInclusive<u32>) -> Option<<RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::Item> {<RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next}, val: Value(<ZST>) }
     }
 
     bb2: {
-        _10 = ((_7 as Some).0: u32);     // scope 1 at $DIR/range_iter.rs:+1:9: +1:10
-        StorageLive(_11);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
-        _11 = &_3;                       // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
-        StorageLive(_12);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
-        _12 = (_10,);                    // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
-        _6 = <impl Fn(u32) as Fn<(u32,)>>::call(move _11, move _12) -> [return: bb5, unwind: bb7]; // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
+        _8 = discriminant(_7);           // scope 1 at $DIR/range_iter.rs:+1:14: +1:25
+        switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb7]; // scope 1 at $DIR/range_iter.rs:+1:14: +1:25
+    }
+
+    bb3: {
+        StorageDead(_7);                 // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
+        StorageDead(_5);                 // scope 0 at $DIR/range_iter.rs:+3:5: +3:6
+        drop(_3) -> bb4;                 // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
+    }
+
+    bb4: {
+        return;                          // scope 0 at $DIR/range_iter.rs:+4:2: +4:2
+    }
+
+    bb5: {
+        _9 = ((_7 as Some).0: u32);      // scope 1 at $DIR/range_iter.rs:+1:9: +1:10
+        StorageLive(_10);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
+        _10 = &_3;                       // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
+        StorageLive(_11);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
+        _11 = (_9,);                     // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
+        _12 = <impl Fn(u32) as Fn<(u32,)>>::call(move _10, move _11) -> [return: bb6, unwind: bb8]; // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
                                          // mir::Constant
                                          // + span: $DIR/range_iter.rs:29:9: 29:10
                                          // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a impl Fn(u32), (u32,)) -> <impl Fn(u32) as FnOnce<(u32,)>>::Output {<impl Fn(u32) as Fn<(u32,)>>::call}, val: Value(<ZST>) }
     }
 
-    bb3: {
-        unreachable;                     // scope 1 at $DIR/range_iter.rs:+1:14: +1:25
-    }
-
-    bb4: {
-        StorageDead(_7);                 // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
-        StorageDead(_5);                 // scope 0 at $DIR/range_iter.rs:+3:5: +3:6
-        drop(_3) -> bb6;                 // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
-    }
-
-    bb5: {
-        StorageDead(_12);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
+    bb6: {
         StorageDead(_11);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
+        StorageDead(_10);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
         StorageDead(_7);                 // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
         goto -> bb1;                     // scope 1 at $DIR/range_iter.rs:+1:5: +3:6
     }
 
-    bb6: {
-        return;                          // scope 0 at $DIR/range_iter.rs:+4:2: +4:2
-    }
-
-    bb7 (cleanup): {
-        drop(_3) -> [return: bb8, unwind terminate]; // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
+    bb7: {
+        unreachable;                     // scope 1 at $DIR/range_iter.rs:+1:14: +1:25
     }
 
     bb8 (cleanup): {
-        resume;                          // scope 0 at $DIR/range_iter.rs:+0:1: +4:2
+        drop(_3) -> [return: bb9, unwind terminate]; // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
     }
 
-    bb9: {
-        _9 = discriminant(_7);           // scope 1 at $DIR/range_iter.rs:+1:14: +1:25
-        switchInt(move _9) -> [0: bb4, 1: bb2, otherwise: bb3]; // scope 1 at $DIR/range_iter.rs:+1:14: +1:25
+    bb9 (cleanup): {
+        resume;                          // scope 0 at $DIR/range_iter.rs:+0:1: +4:2
     }
 }

--- a/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
@@ -3,18 +3,18 @@
 fn ezmap(_1: Option<i32>) -> Option<i32> {
     debug x => _1;                       // in scope 0 at $DIR/simple_option_map.rs:+0:14: +0:15
     let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/simple_option_map.rs:+0:33: +0:44
-    let mut _6: i32;                     // in scope 0 at $DIR/simple_option_map.rs:11:25: 11:29
+    let mut _5: i32;                     // in scope 0 at $DIR/simple_option_map.rs:11:25: 11:29
     scope 1 (inlined map::<i32, i32, [closure@$DIR/simple_option_map.rs:18:12: 18:15]>) { // at $DIR/simple_option_map.rs:18:5: 18:22
         debug slf => _1;                 // in scope 1 at $DIR/simple_option_map.rs:6:17: 6:20
         debug f => const ZeroSized: [closure@$DIR/simple_option_map.rs:18:12: 18:15]; // in scope 1 at $DIR/simple_option_map.rs:6:33: 6:34
         let mut _2: isize;               // in scope 1 at $DIR/simple_option_map.rs:11:9: 11:16
         let _3: i32;                     // in scope 1 at $DIR/simple_option_map.rs:11:14: 11:15
-        let mut _4: i32;                 // in scope 1 at $DIR/simple_option_map.rs:11:25: 11:29
-        let mut _5: (i32,);              // in scope 1 at $DIR/simple_option_map.rs:11:25: 11:29
+        let mut _4: (i32,);              // in scope 1 at $DIR/simple_option_map.rs:11:25: 11:29
+        let mut _6: i32;                 // in scope 1 at $DIR/simple_option_map.rs:11:25: 11:29
         scope 2 {
             debug x => _3;               // in scope 2 at $DIR/simple_option_map.rs:11:14: 11:15
             scope 3 (inlined ezmap::{closure#0}) { // at $DIR/simple_option_map.rs:11:25: 11:29
-                debug n => _6;           // in scope 3 at $DIR/simple_option_map.rs:+1:13: +1:14
+                debug n => _5;           // in scope 3 at $DIR/simple_option_map.rs:+1:13: +1:14
             }
         }
     }
@@ -22,35 +22,35 @@ fn ezmap(_1: Option<i32>) -> Option<i32> {
     bb0: {
         StorageLive(_3);                 // scope 0 at $DIR/simple_option_map.rs:+1:5: +1:22
         _2 = discriminant(_1);           // scope 1 at $DIR/simple_option_map.rs:10:11: 10:14
-        switchInt(move _2) -> [0: bb1, 1: bb3, otherwise: bb2]; // scope 1 at $DIR/simple_option_map.rs:10:5: 10:14
+        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4]; // scope 1 at $DIR/simple_option_map.rs:10:5: 10:14
     }
 
     bb1: {
         _0 = Option::<i32>::None;        // scope 1 at $DIR/simple_option_map.rs:12:17: 12:21
-        goto -> bb4;                     // scope 1 at $DIR/simple_option_map.rs:12:17: 12:21
+        goto -> bb3;                     // scope 1 at $DIR/simple_option_map.rs:12:17: 12:21
     }
 
     bb2: {
-        unreachable;                     // scope 1 at $DIR/simple_option_map.rs:10:11: 10:14
+        _3 = ((_1 as Some).0: i32);      // scope 1 at $DIR/simple_option_map.rs:11:14: 11:15
+        StorageLive(_6);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
+        StorageLive(_4);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
+        _4 = (move _3,);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
+        StorageLive(_5);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
+        _5 = move (_4.0: i32);           // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
+        _6 = Add(_5, const 1_i32);       // scope 3 at $DIR/simple_option_map.rs:+1:16: +1:21
+        StorageDead(_5);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
+        StorageDead(_4);                 // scope 2 at $DIR/simple_option_map.rs:11:28: 11:29
+        _0 = Option::<i32>::Some(move _6); // scope 2 at $DIR/simple_option_map.rs:11:20: 11:30
+        StorageDead(_6);                 // scope 2 at $DIR/simple_option_map.rs:11:29: 11:30
+        goto -> bb3;                     // scope 1 at $DIR/simple_option_map.rs:14:1: 14:2
     }
 
     bb3: {
-        _3 = ((_1 as Some).0: i32);      // scope 1 at $DIR/simple_option_map.rs:11:14: 11:15
-        StorageLive(_4);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
-        StorageLive(_5);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
-        _5 = (move _3,);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
-        StorageLive(_6);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
-        _6 = move (_5.0: i32);           // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
-        _4 = Add(_6, const 1_i32);       // scope 3 at $DIR/simple_option_map.rs:+1:16: +1:21
-        StorageDead(_6);                 // scope 2 at $DIR/simple_option_map.rs:11:25: 11:29
-        StorageDead(_5);                 // scope 2 at $DIR/simple_option_map.rs:11:28: 11:29
-        _0 = Option::<i32>::Some(move _4); // scope 2 at $DIR/simple_option_map.rs:11:20: 11:30
-        StorageDead(_4);                 // scope 2 at $DIR/simple_option_map.rs:11:29: 11:30
-        goto -> bb4;                     // scope 1 at $DIR/simple_option_map.rs:14:1: 14:2
+        StorageDead(_3);                 // scope 0 at $DIR/simple_option_map.rs:+1:5: +1:22
+        return;                          // scope 0 at $DIR/simple_option_map.rs:+2:2: +2:2
     }
 
     bb4: {
-        StorageDead(_3);                 // scope 0 at $DIR/simple_option_map.rs:+1:5: +1:22
-        return;                          // scope 0 at $DIR/simple_option_map.rs:+2:2: +2:2
+        unreachable;                     // scope 1 at $DIR/simple_option_map.rs:10:11: 10:14
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.mir
@@ -10,17 +10,17 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
         scope 2 (inlined <usize as SliceIndex<[u32]>>::get_mut) { // at $SRC_DIR/core/src/slice/mod.rs:LL:COL
             debug self => _2;            // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
             debug slice => _1;           // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-            let mut _3: bool;            // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _3: &[u32];          // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
             let mut _4: usize;           // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-            let mut _5: &[u32];          // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-            let mut _6: &mut u32;        // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-            let mut _7: *mut u32;        // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-            let mut _8: *mut [u32];      // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _5: bool;            // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _6: *mut [u32];      // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _8: *mut u32;        // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+            let mut _9: &mut u32;        // in scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
             scope 3 {
                 scope 4 (inlined <usize as SliceIndex<[u32]>>::get_unchecked_mut) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
                     debug self => _2;    // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                    debug slice => _8;   // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                    let mut _9: *mut u32; // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    debug slice => _6;   // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    let mut _7: *mut u32; // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
                     let mut _10: usize;  // in scope 4 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                     let mut _11: *mut [u32]; // in scope 4 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                     scope 5 {
@@ -40,10 +40,10 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
                                 }
                             }
                             scope 11 (inlined ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                                debug self => _8; // in scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _6; // in scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                             }
                             scope 12 (inlined ptr::mut_ptr::<impl *mut u32>::add) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                                debug self => _9; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _7; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 debug count => _2; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 scope 13 {
                                 }
@@ -56,40 +56,19 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
     }
 
     bb0: {
-        StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_9);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _5 = &(*_1);                     // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _4 = Len((*_5));                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _3 = Lt(_2, move _4);            // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _3 = &(*_1);                     // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _4 = Len((*_3));                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _5 = Lt(_2, move _4);            // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        switchInt(move _3) -> [0: bb2, otherwise: bb1]; // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        switchInt(move _5) -> [0: bb1, otherwise: bb2]; // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
     }
 
     bb1: {
-        StorageLive(_7);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _8 = &raw mut (*_1);             // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _9 = _8 as *mut u32 (PtrToPtr);  // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        _7 = Offset(_9, _2);             // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _6 = &mut (*_7);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _0 = Option::<&mut u32>::Some(_6); // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_7);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        goto -> bb3;                     // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-    }
-
-    bb2: {
         _0 = const Option::<&mut u32>::None; // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
                                          // mir::Constant
                                          // + span: no-location
@@ -97,9 +76,30 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
         goto -> bb3;                     // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
     }
 
+    bb2: {
+        StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_6);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _6 = &raw mut (*_1);             // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _7 = _6 as *mut u32 (PtrToPtr);  // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        _8 = Offset(_7, _2);             // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_12);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_6);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _9 = &mut (*_8);                 // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _0 = Option::<&mut u32>::Some(_9); // scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        goto -> bb3;                     // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+    }
+
     bb3: {
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_9);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         return;                          // scope 0 at $DIR/slice_index.rs:+2:2: +2:2
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.mir
@@ -8,61 +8,61 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
         debug self => _1;                // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         debug index => _2;               // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         let mut _3: *mut [u32];          // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        let mut _4: *mut [u32];          // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        let mut _15: *mut [u32];         // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         scope 2 {
             scope 3 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) { // at $SRC_DIR/core/src/slice/mod.rs:LL:COL
                 debug self => _2;        // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                debug slice => _4;       // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                let _5: std::ops::Range<usize>; // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                let mut _7: usize;       // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                debug slice => _3;       // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _4: usize;       // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _5: usize;       // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _7: *mut u32;    // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
                 let mut _8: usize;       // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
                 let mut _9: *mut u32;    // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                let mut _10: *mut u32;   // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                let mut _11: usize;      // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                let mut _12: usize;      // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                let mut _13: std::ops::Range<usize>; // in scope 3 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                let mut _14: *mut [u32]; // in scope 3 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                let mut _10: usize;      // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let _16: std::ops::Range<usize>; // in scope 3 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                let mut _17: std::ops::Range<usize>; // in scope 3 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                let mut _18: *mut [u32]; // in scope 3 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                 scope 4 {
-                    debug this => _5;    // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+                    debug this => _16;   // in scope 4 at $SRC_DIR/core/src/slice/index.rs:LL:COL
                     scope 5 {
                         let _6: usize;   // in scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
                         scope 6 {
                             debug new_len => _6; // in scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
                             scope 11 (inlined ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                                debug self => _4; // in scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _3; // in scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                             }
                             scope 12 (inlined ptr::mut_ptr::<impl *mut u32>::add) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                                debug self => _10; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                debug count => _11; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _7; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug count => _8; // in scope 12 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 scope 13 {
                                 }
                             }
                             scope 14 (inlined slice_from_raw_parts_mut::<u32>) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
                                 debug data => _9; // in scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                debug len => _12; // in scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                let mut _16: *mut (); // in scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                debug len => _10; // in scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                                let mut _11: *mut (); // in scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                 scope 15 (inlined ptr::mut_ptr::<impl *mut u32>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                     debug self => _9; // in scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 }
                                 scope 16 (inlined std::ptr::from_raw_parts_mut::<[u32]>) { // at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                    debug data_address => _16; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                                    debug metadata => _12; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                                    let mut _17: std::ptr::metadata::PtrRepr<[u32]>; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                                    let mut _18: std::ptr::metadata::PtrComponents<[u32]>; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-                                    let mut _19: *const (); // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    debug data_address => _11; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    debug metadata => _10; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    let mut _12: *const (); // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    let mut _13: std::ptr::metadata::PtrComponents<[u32]>; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    let mut _14: std::ptr::metadata::PtrRepr<[u32]>; // in scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
                                     scope 17 {
                                     }
                                 }
                             }
                         }
                         scope 7 (inlined <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked_mut::runtime::<u32>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            debug this => _13; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                            debug slice => _14; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug this => _17; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug slice => _18; // in scope 7 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                             scope 8 (inlined ptr::mut_ptr::<impl *mut [u32]>::len) { // at $SRC_DIR/core/src/slice/index.rs:LL:COL
-                                debug self => _14; // in scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                let mut _15: *const [u32]; // in scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                debug self => _18; // in scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                let mut _19: *const [u32]; // in scope 8 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                 scope 9 (inlined std::ptr::metadata::<[u32]>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                    debug ptr => _15; // in scope 9 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+                                    debug ptr => _19; // in scope 9 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
                                     scope 10 {
                                     }
                                 }
@@ -75,60 +75,60 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     }
 
     bb0: {
-        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        _4 = &raw mut (*_1);             // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_13);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_14);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         StorageLive(_15);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        _3 = &raw mut (*_1);             // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_16);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_17);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_18);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_19);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         StorageLive(_6);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_7);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _7 = (_2.1: usize);              // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_8);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _8 = (_2.0: usize);              // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _6 = unchecked_sub::<usize>(move _7, move _8) -> [return: bb1, unwind unreachable]; // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_4);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _4 = (_2.1: usize);              // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_5);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _5 = (_2.0: usize);              // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _6 = unchecked_sub::<usize>(move _4, move _5) -> [return: bb1, unwind unreachable]; // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/slice/index.rs:LL:COL
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(usize, usize) -> usize {unchecked_sub::<usize>}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_8);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_7);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_5);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_4);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _7 = _3 as *mut u32 (PtrToPtr);  // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_8);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _8 = (_2.0: usize);              // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _9 = Offset(_7, _8);             // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageDead(_8);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _10 = _4 as *mut u32 (PtrToPtr); // scope 11 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _11 = (_2.0: usize);             // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _9 = Offset(_10, _11);           // scope 13 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        _10 = _6;                        // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
+        StorageLive(_11);                // scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _11 = _9 as *mut () (PtrToPtr);  // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+        StorageLive(_14);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_13);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageLive(_12);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _12 = _11 as *const () (Pointer(MutToConstPointer)); // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _13 = ptr::metadata::PtrComponents::<[u32]> { data_address: move _12, metadata: _10 }; // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_12);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _14 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _13 }; // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_13);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        _15 = (_14.1: *mut [u32]);       // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_14);                // scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
+        StorageDead(_11);                // scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        _12 = _6;                        // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageLive(_16);                // scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _16 = _9 as *mut () (PtrToPtr);  // scope 15 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-        StorageLive(_17);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageLive(_18);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageLive(_19);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _19 = _16 as *const () (Pointer(MutToConstPointer)); // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _18 = ptr::metadata::PtrComponents::<[u32]> { data_address: move _19, metadata: _12 }; // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_19);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _17 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _18 }; // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_18);                // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        _3 = (_17.1: *mut [u32]);        // scope 17 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_17);                // scope 16 at $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
-        StorageDead(_16);                // scope 14 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/slice/index.rs:LL:COL
         StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/slice/index.rs:LL:COL
-        StorageDead(_15);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageDead(_14);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageDead(_13);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        _0 = &mut (*_3);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageDead(_3);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_19);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_18);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_17);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_16);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        _0 = &mut (*_15);                // scope 2 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_15);                // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         return;                          // scope 0 at $DIR/slice_index.rs:+2:2: +2:2
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.mir
@@ -4,41 +4,41 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     debug slice => _1;                   // in scope 0 at $DIR/slice_iter.rs:+0:28: +0:33
     debug f => _2;                       // in scope 0 at $DIR/slice_iter.rs:+0:44: +0:45
     let mut _0: ();                      // return place in scope 0 at $DIR/slice_iter.rs:+0:60: +0:60
-    let mut _3: std::slice::Iter<'_, T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
-    let mut _4: std::slice::Iter<'_, T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
-    let _5: ();                          // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
-    let mut _6: std::option::Option<&T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
-    let mut _7: &mut std::slice::Iter<'_, T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
-    let mut _8: isize;                   // in scope 0 at $DIR/slice_iter.rs:+1:5: +3:6
-    let mut _10: &impl Fn(&T);           // in scope 0 at $DIR/slice_iter.rs:+2:9: +2:10
-    let mut _11: (&T,);                  // in scope 0 at $DIR/slice_iter.rs:+2:9: +2:13
+    let mut _13: std::slice::Iter<'_, T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
+    let mut _14: std::slice::Iter<'_, T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
+    let mut _15: &mut std::slice::Iter<'_, T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
+    let mut _16: std::option::Option<&T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
+    let mut _17: isize;                  // in scope 0 at $DIR/slice_iter.rs:+1:5: +3:6
+    let mut _19: &impl Fn(&T);           // in scope 0 at $DIR/slice_iter.rs:+2:9: +2:10
+    let mut _20: (&T,);                  // in scope 0 at $DIR/slice_iter.rs:+2:9: +2:13
+    let _21: ();                         // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
     scope 1 {
-        debug iter => _4;                // in scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
-        let _9: &T;                      // in scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
+        debug iter => _14;               // in scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
+        let _18: &T;                     // in scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
         scope 2 {
-            debug x => _9;               // in scope 2 at $DIR/slice_iter.rs:+1:9: +1:10
+            debug x => _18;              // in scope 2 at $DIR/slice_iter.rs:+1:9: +1:10
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) { // at $DIR/slice_iter.rs:28:20: 28:26
         debug self => _1;                // in scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         scope 4 (inlined std::slice::Iter::<'_, T>::new) { // at $SRC_DIR/core/src/slice/mod.rs:LL:COL
             debug slice => _1;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let _12: *const T;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _14: bool;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _15: usize;          // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _16: usize;          // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _17: std::ptr::NonNull<T>; // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _18: *mut T;         // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _19: *const T;       // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let _4: *const T;            // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _5: bool;            // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _6: usize;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _8: usize;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _9: *mut T;          // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _11: std::ptr::NonNull<T>; // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _12: *const T;       // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
             scope 5 {
-                debug ptr => _12;        // in scope 5 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+                debug ptr => _4;         // in scope 5 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
                 scope 6 {
-                    let _13: *const T;   // in scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+                    let _7: *const T;    // in scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
                     scope 7 {
-                        debug end => _13; // in scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+                        debug end => _7; // in scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
                         scope 13 (inlined NonNull::<T>::new_unchecked) { // at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-                            debug ptr => _18; // in scope 13 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-                            let mut _21: *const T; // in scope 13 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                            debug ptr => _9; // in scope 13 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                            let mut _10: *const T; // in scope 13 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
                             let mut _22: *mut T; // in scope 13 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                             scope 14 {
                                 scope 15 (inlined NonNull::<T>::new_unchecked::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
@@ -65,13 +65,13 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         }
                     }
                     scope 9 (inlined invalid::<T>) { // at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-                        debug addr => _15; // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        debug addr => _8; // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                         scope 10 {
                         }
                     }
                     scope 11 (inlined ptr::const_ptr::<impl *const T>::add) { // at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-                        debug self => _12; // in scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        debug count => _16; // in scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug self => _4; // in scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug count => _6; // in scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                         scope 12 {
                         }
                     }
@@ -79,125 +79,125 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             }
             scope 8 (inlined core::slice::<impl [T]>::as_ptr) { // at $SRC_DIR/core/src/slice/iter.rs:LL:COL
                 debug self => _1;        // in scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-                let mut _20: *const [T]; // in scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+                let mut _3: *const [T];  // in scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
             }
         }
     }
     scope 22 (inlined <std::slice::Iter<'_, T> as IntoIterator>::into_iter) { // at $DIR/slice_iter.rs:28:14: 28:26
-        debug self => _3;                // in scope 22 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+        debug self => _13;               // in scope 22 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
     }
 
     bb0: {
-        StorageLive(_12);                // scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_20);                // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        _20 = &raw const (*_1);          // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        _12 = move _20 as *const T (PtrToPtr); // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageDead(_20);                // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_13);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_14);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _14 = const _;                   // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        switchInt(move _14) -> [0: bb11, otherwise: bb10]; // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_4);                 // scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_3);                 // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        _3 = &raw const (*_1);           // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        _4 = move _3 as *const T (PtrToPtr); // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_5);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _5 = const _;                    // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        switchInt(move _5) -> [0: bb1, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
     }
 
     bb1: {
-        StorageLive(_6);                 // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
-        _7 = &mut _4;                    // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
-        _6 = <std::slice::Iter<'_, T> as Iterator>::next(_7) -> [return: bb2, unwind: bb8]; // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
+        StorageLive(_6);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _6 = Len((*_1));                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _7 = Offset(_4, _6);             // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_6);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        goto -> bb3;                     // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+    }
+
+    bb2: {
+        StorageLive(_8);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _8 = Len((*_1));                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _7 = _8 as *const T (Transmute); // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        goto -> bb3;                     // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+    }
+
+    bb3: {
+        StorageDead(_5);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_11);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_9);                 // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _9 = _4 as *mut T (PtrToPtr);    // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_10);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_22);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_23);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _10 = _9 as *const T (Pointer(MutToConstPointer)); // scope 14 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _11 = NonNull::<T> { pointer: _10 }; // scope 14 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_23);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_22);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_10);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_9);                 // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_12);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _12 = _7;                        // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _13 = std::slice::Iter::<'_, T> { ptr: move _11, end: move _12, _marker: const ZeroSized: PhantomData<&T> }; // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: no-location
+                                         // + literal: Const { ty: PhantomData<&T>, val: Value(<ZST>) }
+                                         // adt
+                                         // + user_ty: UserType(1)
+        StorageDead(_12);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_11);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_4);                 // scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_14);                // scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
+        _14 = move _13;                  // scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
+        goto -> bb4;                     // scope 1 at $DIR/slice_iter.rs:+1:5: +3:6
+    }
+
+    bb4: {
+        StorageLive(_16);                // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
+        _15 = &mut _14;                  // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
+        _16 = <std::slice::Iter<'_, T> as Iterator>::next(_15) -> [return: bb5, unwind: bb11]; // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
                                          // mir::Constant
                                          // + span: $DIR/slice_iter.rs:28:14: 28:26
                                          // + literal: Const { ty: for<'a> fn(&'a mut std::slice::Iter<'_, T>) -> Option<<std::slice::Iter<'_, T> as Iterator>::Item> {<std::slice::Iter<'_, T> as Iterator>::next}, val: Value(<ZST>) }
     }
 
-    bb2: {
-        _8 = discriminant(_6);           // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
-        switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4]; // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
-    }
-
-    bb3: {
-        _9 = ((_6 as Some).0: &T);       // scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
-        StorageLive(_10);                // scope 2 at $DIR/slice_iter.rs:+2:9: +2:10
-        _10 = &_2;                       // scope 2 at $DIR/slice_iter.rs:+2:9: +2:10
-        StorageLive(_11);                // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
-        _11 = (_9,);                     // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
-        _5 = <impl Fn(&T) as Fn<(&T,)>>::call(move _10, move _11) -> [return: bb6, unwind: bb8]; // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
-                                         // mir::Constant
-                                         // + span: $DIR/slice_iter.rs:29:9: 29:10
-                                         // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a impl Fn(&T), (&T,)) -> <impl Fn(&T) as FnOnce<(&T,)>>::Output {<impl Fn(&T) as Fn<(&T,)>>::call}, val: Value(<ZST>) }
-    }
-
-    bb4: {
-        unreachable;                     // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
-    }
-
     bb5: {
-        StorageDead(_6);                 // scope 1 at $DIR/slice_iter.rs:+3:5: +3:6
-        StorageDead(_4);                 // scope 0 at $DIR/slice_iter.rs:+3:5: +3:6
-        drop(_2) -> bb7;                 // scope 0 at $DIR/slice_iter.rs:+4:1: +4:2
+        _17 = discriminant(_16);         // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
+        switchInt(move _17) -> [0: bb6, 1: bb8, otherwise: bb10]; // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
     }
 
     bb6: {
-        StorageDead(_11);                // scope 2 at $DIR/slice_iter.rs:+2:12: +2:13
-        StorageDead(_10);                // scope 2 at $DIR/slice_iter.rs:+2:12: +2:13
-        StorageDead(_6);                 // scope 1 at $DIR/slice_iter.rs:+3:5: +3:6
-        goto -> bb1;                     // scope 1 at $DIR/slice_iter.rs:+1:5: +3:6
+        StorageDead(_16);                // scope 1 at $DIR/slice_iter.rs:+3:5: +3:6
+        StorageDead(_14);                // scope 0 at $DIR/slice_iter.rs:+3:5: +3:6
+        drop(_2) -> bb7;                 // scope 0 at $DIR/slice_iter.rs:+4:1: +4:2
     }
 
     bb7: {
         return;                          // scope 0 at $DIR/slice_iter.rs:+4:2: +4:2
     }
 
-    bb8 (cleanup): {
-        drop(_2) -> [return: bb9, unwind terminate]; // scope 0 at $DIR/slice_iter.rs:+4:1: +4:2
+    bb8: {
+        _18 = ((_16 as Some).0: &T);     // scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
+        StorageLive(_19);                // scope 2 at $DIR/slice_iter.rs:+2:9: +2:10
+        _19 = &_2;                       // scope 2 at $DIR/slice_iter.rs:+2:9: +2:10
+        StorageLive(_20);                // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
+        _20 = (_18,);                    // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
+        _21 = <impl Fn(&T) as Fn<(&T,)>>::call(move _19, move _20) -> [return: bb9, unwind: bb11]; // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
+                                         // mir::Constant
+                                         // + span: $DIR/slice_iter.rs:29:9: 29:10
+                                         // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a impl Fn(&T), (&T,)) -> <impl Fn(&T) as FnOnce<(&T,)>>::Output {<impl Fn(&T) as Fn<(&T,)>>::call}, val: Value(<ZST>) }
     }
 
-    bb9 (cleanup): {
-        resume;                          // scope 0 at $DIR/slice_iter.rs:+0:1: +4:2
+    bb9: {
+        StorageDead(_20);                // scope 2 at $DIR/slice_iter.rs:+2:12: +2:13
+        StorageDead(_19);                // scope 2 at $DIR/slice_iter.rs:+2:12: +2:13
+        StorageDead(_16);                // scope 1 at $DIR/slice_iter.rs:+3:5: +3:6
+        goto -> bb4;                     // scope 1 at $DIR/slice_iter.rs:+1:5: +3:6
     }
 
     bb10: {
-        StorageLive(_15);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _15 = Len((*_1));                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _13 = _15 as *const T (Transmute); // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_15);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        goto -> bb12;                    // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        unreachable;                     // scope 1 at $DIR/slice_iter.rs:+1:14: +1:26
     }
 
-    bb11: {
-        StorageLive(_16);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _16 = Len((*_1));                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _13 = Offset(_12, _16);          // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_16);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        goto -> bb12;                    // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+    bb11 (cleanup): {
+        drop(_2) -> [return: bb12, unwind terminate]; // scope 0 at $DIR/slice_iter.rs:+4:1: +4:2
     }
 
-    bb12: {
-        StorageDead(_14);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_17);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_18);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _18 = _12 as *mut T (PtrToPtr);  // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_21);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_22);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_23);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _21 = _18 as *const T (Pointer(MutToConstPointer)); // scope 14 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        _17 = NonNull::<T> { pointer: _21 }; // scope 14 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        StorageDead(_23);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_22);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_21);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_18);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_19);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _19 = _13;                       // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _3 = std::slice::Iter::<'_, T> { ptr: move _17, end: move _19, _marker: const ZeroSized: PhantomData<&T> }; // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: no-location
-                                         // + literal: Const { ty: PhantomData<&T>, val: Value(<ZST>) }
-                                         // adt
-                                         // + user_ty: UserType(1)
-        StorageDead(_19);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_17);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_13);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_12);                // scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_4);                 // scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
-        _4 = move _3;                    // scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
-        goto -> bb1;                     // scope 1 at $DIR/slice_iter.rs:+1:5: +3:6
+    bb12 (cleanup): {
+        resume;                          // scope 0 at $DIR/slice_iter.rs:+0:1: +4:2
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.mir
@@ -4,61 +4,61 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     debug slice => _1;                   // in scope 0 at $DIR/slice_iter.rs:+0:28: +0:33
     debug f => _2;                       // in scope 0 at $DIR/slice_iter.rs:+0:44: +0:45
     let mut _0: ();                      // return place in scope 0 at $DIR/slice_iter.rs:+0:60: +0:60
-    let mut _3: std::iter::Rev<std::slice::Iter<'_, T>>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
-    let mut _4: std::slice::Iter<'_, T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
-    let mut _5: std::iter::Rev<std::slice::Iter<'_, T>>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
-    let _6: ();                          // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
-    let mut _7: std::option::Option<&T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
-    let mut _8: &mut std::iter::Rev<std::slice::Iter<'_, T>>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
-    let mut _9: isize;                   // in scope 0 at $DIR/slice_iter.rs:+1:5: +3:6
-    let mut _11: &impl Fn(&T);           // in scope 0 at $DIR/slice_iter.rs:+2:9: +2:10
-    let mut _12: (&T,);                  // in scope 0 at $DIR/slice_iter.rs:+2:9: +2:13
+    let mut _13: std::slice::Iter<'_, T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
+    let mut _14: std::iter::Rev<std::slice::Iter<'_, T>>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
+    let mut _15: std::iter::Rev<std::slice::Iter<'_, T>>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
+    let mut _16: &mut std::iter::Rev<std::slice::Iter<'_, T>>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
+    let mut _18: std::option::Option<&T>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
+    let mut _19: isize;                  // in scope 0 at $DIR/slice_iter.rs:+1:5: +3:6
+    let mut _21: &impl Fn(&T);           // in scope 0 at $DIR/slice_iter.rs:+2:9: +2:10
+    let mut _22: (&T,);                  // in scope 0 at $DIR/slice_iter.rs:+2:9: +2:13
+    let _23: ();                         // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
     scope 1 {
-        debug iter => _5;                // in scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
-        let _10: &T;                     // in scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
+        debug iter => _15;               // in scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
+        let _20: &T;                     // in scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
         scope 2 {
-            debug x => _10;              // in scope 2 at $DIR/slice_iter.rs:+1:9: +1:10
+            debug x => _20;              // in scope 2 at $DIR/slice_iter.rs:+1:9: +1:10
         }
         scope 25 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) { // at $DIR/slice_iter.rs:35:14: 35:32
-            debug self => _8;            // in scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
-            let mut _25: &mut std::slice::Iter<'_, T>; // in scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
+            debug self => _16;           // in scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
+            let mut _17: &mut std::slice::Iter<'_, T>; // in scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) { // at $DIR/slice_iter.rs:35:20: 35:26
         debug self => _1;                // in scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
         scope 4 (inlined std::slice::Iter::<'_, T>::new) { // at $SRC_DIR/core/src/slice/mod.rs:LL:COL
             debug slice => _1;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let _13: *const T;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _15: bool;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _16: usize;          // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _17: usize;          // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _18: std::ptr::NonNull<T>; // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _19: *mut T;         // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-            let mut _20: *const T;       // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let _4: *const T;            // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _5: bool;            // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _6: usize;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _8: usize;           // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _9: *mut T;          // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _11: std::ptr::NonNull<T>; // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+            let mut _12: *const T;       // in scope 4 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
             scope 5 {
-                debug ptr => _13;        // in scope 5 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+                debug ptr => _4;         // in scope 5 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
                 scope 6 {
-                    let _14: *const T;   // in scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+                    let _7: *const T;    // in scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
                     scope 7 {
-                        debug end => _14; // in scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+                        debug end => _7; // in scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
                         scope 13 (inlined NonNull::<T>::new_unchecked) { // at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-                            debug ptr => _19; // in scope 13 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-                            let mut _22: *const T; // in scope 13 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-                            let mut _23: *mut T; // in scope 13 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                            debug ptr => _9; // in scope 13 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                            let mut _10: *const T; // in scope 13 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+                            let mut _24: *mut T; // in scope 13 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                             scope 14 {
                                 scope 15 (inlined NonNull::<T>::new_unchecked::runtime::<T>) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-                                    debug ptr => _23; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                    debug ptr => _24; // in scope 15 at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) { // at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-                                        debug self => _23; // in scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                        let mut _24: *mut u8; // in scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        debug self => _24; // in scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                        let mut _25: *mut u8; // in scope 16 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                                debug ptr => _24; // in scope 18 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                                debug ptr => _25; // in scope 18 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                                    debug self => _24; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                                    debug self => _25; // in scope 19 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) { // at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-                                                            debug self => _24; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+                                                            debug self => _25; // in scope 21 at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
                                                         }
                                                     }
                                                 }
@@ -70,13 +70,13 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         }
                     }
                     scope 9 (inlined invalid::<T>) { // at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-                        debug addr => _16; // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+                        debug addr => _8; // in scope 9 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                         scope 10 {
                         }
                     }
                     scope 11 (inlined ptr::const_ptr::<impl *const T>::add) { // at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-                        debug self => _13; // in scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-                        debug count => _17; // in scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug self => _4; // in scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+                        debug count => _6; // in scope 11 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
                         scope 12 {
                         }
                     }
@@ -84,137 +84,137 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             }
             scope 8 (inlined core::slice::<impl [T]>::as_ptr) { // at $SRC_DIR/core/src/slice/iter.rs:LL:COL
                 debug self => _1;        // in scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-                let mut _21: *const [T]; // in scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+                let mut _3: *const [T];  // in scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
             }
         }
     }
     scope 22 (inlined <std::slice::Iter<'_, T> as Iterator>::rev) { // at $DIR/slice_iter.rs:35:27: 35:32
-        debug self => _4;                // in scope 22 at $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+        debug self => _13;               // in scope 22 at $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
         scope 23 (inlined Rev::<std::slice::Iter<'_, T>>::new) { // at $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
-            debug iter => _4;            // in scope 23 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
+            debug iter => _13;           // in scope 23 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
         }
     }
     scope 24 (inlined <Rev<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) { // at $DIR/slice_iter.rs:35:14: 35:32
-        debug self => _3;                // in scope 24 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+        debug self => _14;               // in scope 24 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
     }
 
     bb0: {
-        StorageLive(_4);                 // scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
-        StorageLive(_13);                // scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_21);                // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        _21 = &raw const (*_1);          // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        _13 = move _21 as *const T (PtrToPtr); // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageDead(_21);                // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        StorageLive(_14);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_15);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _15 = const _;                   // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        switchInt(move _15) -> [0: bb10, otherwise: bb9]; // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_13);                // scope 0 at $DIR/slice_iter.rs:+1:14: +1:26
+        StorageLive(_4);                 // scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_3);                 // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        _3 = &raw const (*_1);           // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        _4 = move _3 as *const T (PtrToPtr); // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageDead(_3);                 // scope 8 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_5);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _5 = const _;                    // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        switchInt(move _5) -> [0: bb1, otherwise: bb2]; // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
     }
 
     bb1: {
-        StorageLive(_7);                 // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
-        _8 = &mut _5;                    // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
-        StorageLive(_25);                // scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
-        _25 = &mut ((*_8).0: std::slice::Iter<'_, T>); // scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
-        _7 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _25) -> [return: bb12, unwind: bb7]; // scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
-                                         // + literal: Const { ty: for<'a> fn(&'a mut std::slice::Iter<'_, T>) -> Option<<std::slice::Iter<'_, T> as Iterator>::Item> {<std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back}, val: Value(<ZST>) }
+        StorageLive(_6);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _6 = Len((*_1));                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _7 = Offset(_4, _6);             // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+        StorageDead(_6);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        goto -> bb3;                     // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
     }
 
     bb2: {
-        _10 = ((_7 as Some).0: &T);      // scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
-        StorageLive(_11);                // scope 2 at $DIR/slice_iter.rs:+2:9: +2:10
-        _11 = &_2;                       // scope 2 at $DIR/slice_iter.rs:+2:9: +2:10
-        StorageLive(_12);                // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
-        _12 = (_10,);                    // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
-        _6 = <impl Fn(&T) as Fn<(&T,)>>::call(move _11, move _12) -> [return: bb5, unwind: bb7]; // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
-                                         // mir::Constant
-                                         // + span: $DIR/slice_iter.rs:36:9: 36:10
-                                         // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a impl Fn(&T), (&T,)) -> <impl Fn(&T) as FnOnce<(&T,)>>::Output {<impl Fn(&T) as Fn<(&T,)>>::call}, val: Value(<ZST>) }
+        StorageLive(_8);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _8 = Len((*_1));                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _7 = _8 as *const T (Transmute); // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        StorageDead(_8);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        goto -> bb3;                     // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
     }
 
     bb3: {
-        unreachable;                     // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
-    }
-
-    bb4: {
-        StorageDead(_7);                 // scope 1 at $DIR/slice_iter.rs:+3:5: +3:6
-        StorageDead(_5);                 // scope 0 at $DIR/slice_iter.rs:+3:5: +3:6
-        drop(_2) -> bb6;                 // scope 0 at $DIR/slice_iter.rs:+4:1: +4:2
-    }
-
-    bb5: {
-        StorageDead(_12);                // scope 2 at $DIR/slice_iter.rs:+2:12: +2:13
-        StorageDead(_11);                // scope 2 at $DIR/slice_iter.rs:+2:12: +2:13
-        StorageDead(_7);                 // scope 1 at $DIR/slice_iter.rs:+3:5: +3:6
-        goto -> bb1;                     // scope 1 at $DIR/slice_iter.rs:+1:5: +3:6
-    }
-
-    bb6: {
-        return;                          // scope 0 at $DIR/slice_iter.rs:+4:2: +4:2
-    }
-
-    bb7 (cleanup): {
-        drop(_2) -> [return: bb8, unwind terminate]; // scope 0 at $DIR/slice_iter.rs:+4:1: +4:2
-    }
-
-    bb8 (cleanup): {
-        resume;                          // scope 0 at $DIR/slice_iter.rs:+0:1: +4:2
-    }
-
-    bb9: {
-        StorageLive(_16);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _16 = Len((*_1));                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _14 = _16 as *const T (Transmute); // scope 10 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        StorageDead(_16);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        goto -> bb11;                    // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-    }
-
-    bb10: {
-        StorageLive(_17);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _17 = Len((*_1));                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _14 = Offset(_13, _17);          // scope 12 at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-        StorageDead(_17);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        goto -> bb11;                    // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-    }
-
-    bb11: {
-        StorageDead(_15);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_18);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_19);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _19 = _13 as *mut T (PtrToPtr);  // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_22);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_23);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_5);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_11);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_9);                 // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _9 = _4 as *mut T (PtrToPtr);    // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_10);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
         StorageLive(_24);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _22 = _19 as *const T (Pointer(MutToConstPointer)); // scope 14 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
-        _18 = NonNull::<T> { pointer: _22 }; // scope 14 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageLive(_25);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _10 = _9 as *const T (Pointer(MutToConstPointer)); // scope 14 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        _11 = NonNull::<T> { pointer: _10 }; // scope 14 at $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+        StorageDead(_25);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
         StorageDead(_24);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_23);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_22);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_19);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageLive(_20);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _20 = _14;                       // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        _4 = std::slice::Iter::<'_, T> { ptr: move _18, end: move _20, _marker: const ZeroSized: PhantomData<&T> }; // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_10);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_9);                 // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageLive(_12);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _12 = _7;                        // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        _13 = std::slice::Iter::<'_, T> { ptr: move _11, end: move _12, _marker: const ZeroSized: PhantomData<&T> }; // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
                                          // mir::Constant
                                          // + span: no-location
                                          // + literal: Const { ty: PhantomData<&T>, val: Value(<ZST>) }
                                          // adt
                                          // + user_ty: UserType(1)
-        StorageDead(_20);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_18);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_14);                // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
-        StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-        _3 = Rev::<std::slice::Iter<'_, T>> { iter: move _4 }; // scope 23 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
-        StorageDead(_4);                 // scope 0 at $DIR/slice_iter.rs:+1:31: +1:32
-        StorageLive(_5);                 // scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
-        _5 = move _3;                    // scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
-        goto -> bb1;                     // scope 1 at $DIR/slice_iter.rs:+1:5: +3:6
+        StorageDead(_12);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_11);                // scope 7 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/slice/iter.rs:LL:COL
+        StorageDead(_4);                 // scope 3 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+        _14 = Rev::<std::slice::Iter<'_, T>> { iter: move _13 }; // scope 23 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
+        StorageDead(_13);                // scope 0 at $DIR/slice_iter.rs:+1:31: +1:32
+        StorageLive(_15);                // scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
+        _15 = move _14;                  // scope 0 at $DIR/slice_iter.rs:+1:14: +1:32
+        goto -> bb4;                     // scope 1 at $DIR/slice_iter.rs:+1:5: +3:6
     }
 
-    bb12: {
-        StorageDead(_25);                // scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
-        _9 = discriminant(_7);           // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
-        switchInt(move _9) -> [0: bb4, 1: bb2, otherwise: bb3]; // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
+    bb4: {
+        StorageLive(_18);                // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
+        _16 = &mut _15;                  // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
+        StorageLive(_17);                // scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
+        _17 = &mut ((*_16).0: std::slice::Iter<'_, T>); // scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
+        _18 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _17) -> [return: bb5, unwind: bb11]; // scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
+                                         // + literal: Const { ty: for<'a> fn(&'a mut std::slice::Iter<'_, T>) -> Option<<std::slice::Iter<'_, T> as Iterator>::Item> {<std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back}, val: Value(<ZST>) }
+    }
+
+    bb5: {
+        StorageDead(_17);                // scope 25 at $SRC_DIR/core/src/iter/adapters/rev.rs:LL:COL
+        _19 = discriminant(_18);         // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
+        switchInt(move _19) -> [0: bb6, 1: bb8, otherwise: bb10]; // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
+    }
+
+    bb6: {
+        StorageDead(_18);                // scope 1 at $DIR/slice_iter.rs:+3:5: +3:6
+        StorageDead(_15);                // scope 0 at $DIR/slice_iter.rs:+3:5: +3:6
+        drop(_2) -> bb7;                 // scope 0 at $DIR/slice_iter.rs:+4:1: +4:2
+    }
+
+    bb7: {
+        return;                          // scope 0 at $DIR/slice_iter.rs:+4:2: +4:2
+    }
+
+    bb8: {
+        _20 = ((_18 as Some).0: &T);     // scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
+        StorageLive(_21);                // scope 2 at $DIR/slice_iter.rs:+2:9: +2:10
+        _21 = &_2;                       // scope 2 at $DIR/slice_iter.rs:+2:9: +2:10
+        StorageLive(_22);                // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
+        _22 = (_20,);                    // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
+        _23 = <impl Fn(&T) as Fn<(&T,)>>::call(move _21, move _22) -> [return: bb9, unwind: bb11]; // scope 2 at $DIR/slice_iter.rs:+2:9: +2:13
+                                         // mir::Constant
+                                         // + span: $DIR/slice_iter.rs:36:9: 36:10
+                                         // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a impl Fn(&T), (&T,)) -> <impl Fn(&T) as FnOnce<(&T,)>>::Output {<impl Fn(&T) as Fn<(&T,)>>::call}, val: Value(<ZST>) }
+    }
+
+    bb9: {
+        StorageDead(_22);                // scope 2 at $DIR/slice_iter.rs:+2:12: +2:13
+        StorageDead(_21);                // scope 2 at $DIR/slice_iter.rs:+2:12: +2:13
+        StorageDead(_18);                // scope 1 at $DIR/slice_iter.rs:+3:5: +3:6
+        goto -> bb4;                     // scope 1 at $DIR/slice_iter.rs:+1:5: +3:6
+    }
+
+    bb10: {
+        unreachable;                     // scope 1 at $DIR/slice_iter.rs:+1:14: +1:32
+    }
+
+    bb11 (cleanup): {
+        drop(_2) -> [return: bb12, unwind terminate]; // scope 0 at $DIR/slice_iter.rs:+4:1: +4:2
+    }
+
+    bb12 (cleanup): {
+        resume;                          // scope 0 at $DIR/slice_iter.rs:+0:1: +4:2
     }
 }

--- a/tests/mir-opt/pre-codegen/try_identity.new.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/try_identity.new.PreCodegen.after.mir
@@ -3,15 +3,15 @@
 fn new(_1: Result<T, E>) -> Result<T, E> {
     debug x => _1;                       // in scope 0 at $DIR/try_identity.rs:+0:14: +0:15
     let mut _0: std::result::Result<T, E>; // return place in scope 0 at $DIR/try_identity.rs:+0:34: +0:46
-    let mut _2: std::ops::ControlFlow<E, T>; // in scope 0 at $DIR/try_identity.rs:+2:15: +7:10
-    let mut _3: isize;                   // in scope 0 at $DIR/try_identity.rs:+4:17: +4:22
-    let _4: T;                           // in scope 0 at $DIR/try_identity.rs:+4:20: +4:21
+    let mut _2: isize;                   // in scope 0 at $DIR/try_identity.rs:+4:17: +4:22
+    let _3: T;                           // in scope 0 at $DIR/try_identity.rs:+4:20: +4:21
+    let mut _4: std::ops::ControlFlow<E, T>; // in scope 0 at $DIR/try_identity.rs:+2:15: +7:10
     let _5: E;                           // in scope 0 at $DIR/try_identity.rs:+5:21: +5:22
     let mut _6: isize;                   // in scope 0 at $DIR/try_identity.rs:+8:13: +8:37
     let _7: T;                           // in scope 0 at $DIR/try_identity.rs:+8:35: +8:36
     let _8: E;                           // in scope 0 at $DIR/try_identity.rs:+9:32: +9:33
     scope 1 {
-        debug v => _4;                   // in scope 1 at $DIR/try_identity.rs:+4:20: +4:21
+        debug v => _3;                   // in scope 1 at $DIR/try_identity.rs:+4:20: +4:21
     }
     scope 2 {
         debug e => _5;                   // in scope 2 at $DIR/try_identity.rs:+5:21: +5:22
@@ -24,47 +24,47 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/try_identity.rs:+2:15: +7:10
-        _3 = discriminant(_1);           // scope 0 at $DIR/try_identity.rs:+3:19: +3:20
-        switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/try_identity.rs:+3:13: +3:20
+        StorageLive(_4);                 // scope 0 at $DIR/try_identity.rs:+2:15: +7:10
+        _2 = discriminant(_1);           // scope 0 at $DIR/try_identity.rs:+3:19: +3:20
+        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb7]; // scope 0 at $DIR/try_identity.rs:+3:13: +3:20
     }
 
     bb1: {
-        _5 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity.rs:+5:21: +5:22
-        _2 = ControlFlow::<E, T>::Break(move _5); // scope 2 at $DIR/try_identity.rs:+5:27: +5:48
-        goto -> bb4;                     // scope 0 at $DIR/try_identity.rs:+5:47: +5:48
+        _3 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity.rs:+4:20: +4:21
+        _4 = ControlFlow::<E, T>::Continue(move _3); // scope 1 at $DIR/try_identity.rs:+4:26: +4:50
+        goto -> bb3;                     // scope 0 at $DIR/try_identity.rs:+4:49: +4:50
     }
 
     bb2: {
-        unreachable;                     // scope 0 at $DIR/try_identity.rs:+3:19: +3:20
+        _5 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity.rs:+5:21: +5:22
+        _4 = ControlFlow::<E, T>::Break(move _5); // scope 2 at $DIR/try_identity.rs:+5:27: +5:48
+        goto -> bb3;                     // scope 0 at $DIR/try_identity.rs:+5:47: +5:48
     }
 
     bb3: {
-        _4 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity.rs:+4:20: +4:21
-        _2 = ControlFlow::<E, T>::Continue(move _4); // scope 1 at $DIR/try_identity.rs:+4:26: +4:50
-        goto -> bb4;                     // scope 0 at $DIR/try_identity.rs:+4:49: +4:50
+        _6 = discriminant(_4);           // scope 0 at $DIR/try_identity.rs:+2:15: +7:10
+        switchInt(move _6) -> [0: bb4, 1: bb5, otherwise: bb7]; // scope 0 at $DIR/try_identity.rs:+2:9: +7:10
     }
 
     bb4: {
-        _6 = discriminant(_2);           // scope 0 at $DIR/try_identity.rs:+2:15: +7:10
-        switchInt(move _6) -> [0: bb6, 1: bb5, otherwise: bb2]; // scope 0 at $DIR/try_identity.rs:+2:9: +7:10
+        _7 = move ((_4 as Continue).0: T); // scope 0 at $DIR/try_identity.rs:+8:35: +8:36
+        _0 = Result::<T, E>::Ok(move _7); // scope 0 at $DIR/try_identity.rs:+1:5: +11:6
+        StorageDead(_4);                 // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
+        goto -> bb6;                     // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
     }
 
     bb5: {
-        _8 = move ((_2 as Break).0: E);  // scope 0 at $DIR/try_identity.rs:+9:32: +9:33
+        _8 = move ((_4 as Break).0: E);  // scope 0 at $DIR/try_identity.rs:+9:32: +9:33
         _0 = Result::<T, E>::Err(move _8); // scope 4 at $DIR/try_identity.rs:+9:45: +9:51
-        StorageDead(_2);                 // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
-        goto -> bb7;                     // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
+        StorageDead(_4);                 // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
+        goto -> bb6;                     // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
     }
 
     bb6: {
-        _7 = move ((_2 as Continue).0: T); // scope 0 at $DIR/try_identity.rs:+8:35: +8:36
-        _0 = Result::<T, E>::Ok(move _7); // scope 0 at $DIR/try_identity.rs:+1:5: +11:6
-        StorageDead(_2);                 // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
-        goto -> bb7;                     // scope 0 at $DIR/try_identity.rs:+12:1: +12:2
+        return;                          // scope 0 at $DIR/try_identity.rs:+12:2: +12:2
     }
 
     bb7: {
-        return;                          // scope 0 at $DIR/try_identity.rs:+12:2: +12:2
+        unreachable;                     // scope 0 at $DIR/try_identity.rs:+3:19: +3:20
     }
 }

--- a/tests/mir-opt/pre-codegen/try_identity.old.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/try_identity.old.PreCodegen.after.mir
@@ -15,26 +15,26 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
 
     bb0: {
         _2 = discriminant(_1);           // scope 0 at $DIR/try_identity.rs:+2:15: +2:16
-        switchInt(move _2) -> [0: bb3, 1: bb1, otherwise: bb2]; // scope 0 at $DIR/try_identity.rs:+2:9: +2:16
+        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4]; // scope 0 at $DIR/try_identity.rs:+2:9: +2:16
     }
 
     bb1: {
-        _4 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity.rs:+4:17: +4:18
-        _0 = Result::<T, E>::Err(move _4); // scope 2 at $DIR/try_identity.rs:+4:30: +4:36
-        goto -> bb4;                     // scope 0 at $DIR/try_identity.rs:+7:1: +7:2
+        _3 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity.rs:+3:16: +3:17
+        _0 = Result::<T, E>::Ok(move _3); // scope 0 at $DIR/try_identity.rs:+1:5: +6:6
+        goto -> bb3;                     // scope 0 at $DIR/try_identity.rs:+7:1: +7:2
     }
 
     bb2: {
-        unreachable;                     // scope 0 at $DIR/try_identity.rs:+2:15: +2:16
+        _4 = move ((_1 as Err).0: E);    // scope 0 at $DIR/try_identity.rs:+4:17: +4:18
+        _0 = Result::<T, E>::Err(move _4); // scope 2 at $DIR/try_identity.rs:+4:30: +4:36
+        goto -> bb3;                     // scope 0 at $DIR/try_identity.rs:+7:1: +7:2
     }
 
     bb3: {
-        _3 = move ((_1 as Ok).0: T);     // scope 0 at $DIR/try_identity.rs:+3:16: +3:17
-        _0 = Result::<T, E>::Ok(move _3); // scope 0 at $DIR/try_identity.rs:+1:5: +6:6
-        goto -> bb4;                     // scope 0 at $DIR/try_identity.rs:+7:1: +7:2
+        return;                          // scope 0 at $DIR/try_identity.rs:+7:2: +7:2
     }
 
     bb4: {
-        return;                          // scope 0 at $DIR/try_identity.rs:+7:2: +7:2
+        unreachable;                     // scope 0 at $DIR/try_identity.rs:+2:15: +2:16
     }
 }

--- a/tests/mir-opt/tls_access.main.PreCodegen.after.mir
+++ b/tests/mir-opt/tls_access.main.PreCodegen.after.mir
@@ -2,27 +2,27 @@
 
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/tls_access.rs:+0:11: +0:11
-    let _2: *mut u8;                     // in scope 0 at $DIR/tls_access.rs:+2:18: +2:21
+    let _1: *mut u8;                     // in scope 0 at $DIR/tls_access.rs:+2:18: +2:21
     let mut _3: *mut u8;                 // in scope 0 at $DIR/tls_access.rs:+3:9: +3:12
     scope 1 {
-        let _1: &u8;                     // in scope 1 at $DIR/tls_access.rs:+2:13: +2:14
+        let _2: &u8;                     // in scope 1 at $DIR/tls_access.rs:+2:13: +2:14
         scope 2 {
-            debug a => _1;               // in scope 2 at $DIR/tls_access.rs:+2:13: +2:14
+            debug a => _2;               // in scope 2 at $DIR/tls_access.rs:+2:13: +2:14
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 1 at $DIR/tls_access.rs:+2:13: +2:14
-        StorageLive(_2);                 // scope 1 at $DIR/tls_access.rs:+2:18: +2:21
-        _2 = &/*tls*/ mut FOO;           // scope 1 at $DIR/tls_access.rs:+2:18: +2:21
-        _1 = &(*_2);                     // scope 1 at $DIR/tls_access.rs:+2:17: +2:21
+        StorageLive(_2);                 // scope 1 at $DIR/tls_access.rs:+2:13: +2:14
+        StorageLive(_1);                 // scope 1 at $DIR/tls_access.rs:+2:18: +2:21
+        _1 = &/*tls*/ mut FOO;           // scope 1 at $DIR/tls_access.rs:+2:18: +2:21
+        _2 = &(*_1);                     // scope 1 at $DIR/tls_access.rs:+2:17: +2:21
         StorageLive(_3);                 // scope 2 at $DIR/tls_access.rs:+3:9: +3:12
         _3 = &/*tls*/ mut FOO;           // scope 2 at $DIR/tls_access.rs:+3:9: +3:12
         (*_3) = const 42_u8;             // scope 2 at $DIR/tls_access.rs:+3:9: +3:17
         StorageDead(_3);                 // scope 2 at $DIR/tls_access.rs:+3:17: +3:18
         _0 = const ();                   // scope 1 at $DIR/tls_access.rs:+1:5: +4:6
-        StorageDead(_2);                 // scope 1 at $DIR/tls_access.rs:+4:5: +4:6
         StorageDead(_1);                 // scope 1 at $DIR/tls_access.rs:+4:5: +4:6
+        StorageDead(_2);                 // scope 1 at $DIR/tls_access.rs:+4:5: +4:6
         return;                          // scope 0 at $DIR/tls_access.rs:+5:2: +5:2
     }
 }

--- a/tests/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/tests/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -31,18 +31,18 @@ fn while_loop(_1: bool) -> () {
     }
 
     bb4: {
-        switchInt(move _3) -> [0: bb6, otherwise: bb5]; // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
+        switchInt(move _3) -> [0: bb5, otherwise: bb6]; // scope 0 at $DIR/while_storage.rs:+2:12: +2:23
     }
 
     bb5: {
         StorageDead(_3);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
-        goto -> bb7;                     // scope 0 at no-location
+        StorageDead(_2);                 // scope 0 at $DIR/while_storage.rs:+5:5: +5:6
+        goto -> bb1;                     // scope 0 at $DIR/while_storage.rs:+1:5: +5:6
     }
 
     bb6: {
         StorageDead(_3);                 // scope 0 at $DIR/while_storage.rs:+4:9: +4:10
-        StorageDead(_2);                 // scope 0 at $DIR/while_storage.rs:+5:5: +5:6
-        goto -> bb1;                     // scope 0 at $DIR/while_storage.rs:+1:5: +5:6
+        goto -> bb7;                     // scope 0 at no-location
     }
 
     bb7: {

--- a/tests/ui/borrowck/borrowck-thread-local-static-borrow-outlives-fn.stderr
+++ b/tests/ui/borrowck/borrowck-thread-local-static-borrow-outlives-fn.stderr
@@ -4,7 +4,7 @@ error[E0712]: thread-local variable borrowed past end of function
 LL |      assert_static(&FOO);
    |                    ^^^^ thread-local variables cannot be borrowed beyond the end of the function
 LL | }
-   | - end of enclosing function is here
+   |  - end of enclosing function is here
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-17954.stderr
+++ b/tests/ui/issues/issue-17954.stderr
@@ -5,7 +5,7 @@ LL |     let a = &FOO;
    |             ^^^^ thread-local variables cannot be borrowed beyond the end of the function
 ...
 LL | }
-   | - end of enclosing function is here
+   |  - end of enclosing function is here
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-52049.stderr
+++ b/tests/ui/issues/issue-52049.stderr
@@ -2,12 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-52049.rs:6:10
    |
 LL |     foo(&unpromotable(5u32));
-   |     -----^^^^^^^^^^^^^^^^^^-
+   |     -----^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
    |     |    |
    |     |    creates a temporary value which is freed while still in use
    |     argument requires that borrow lasts for `'static`
-LL | }
-   | - temporary value is freed at the end of this statement
 
 error: aborting due to previous error
 

--- a/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.stderr
+++ b/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.stderr
@@ -10,7 +10,7 @@ LL |     let read = &refcell as &RefCell<dyn Read>;
    |                -------- cast requires that `foo` is borrowed for `'static`
 ...
 LL | }
-   | - `foo` dropped here while still borrowed
+   |  - `foo` dropped here while still borrowed
 
 error: lifetime may not live long enough
   --> $DIR/issue-90600-expected-return-static-indirect.rs:9:16


### PR DESCRIPTION
This doesn't matter at all for actual codegen, but after spending some time reading pre-codegen MIR, I was wishing I didn't have to jump around so much in reading post-inlining code.

So this add two passes that are off by default for every mir level, but can be enabled (`-Zmir-enable-passes=+ReorderBasicBlocks,+ReorderLocals`) for humans.