### PR TITLE
Disambiguate expansions relative to the creating DepNode

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1071,7 +1071,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     }
                 };
 
-                let desugared_span = this.mark_span_with_reason(DesugaringKind::Async, span, None);
+                let desugared_span =
+                    this.tcx.mark_span_with_reason(DesugaringKind::Async, span, None);
 
                 // Construct a parameter representing `__argN: <ty>` to replace the parameter of the
                 // async function.
@@ -1160,7 +1161,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                     // Transform into `drop-temps { <user-body> }`, an expression:
                     let desugared_span =
-                        this.mark_span_with_reason(DesugaringKind::Async, user_body.span, None);
+                        this.tcx.mark_span_with_reason(DesugaringKind::Async, user_body.span, None);
                     let user_body =
                         this.expr_drop_temps(desugared_span, this.arena.alloc(user_body));
 

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -762,19 +762,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         self.tcx.sess.diagnostic()
     }
 
-    /// Reuses the span but adds information like the kind of the desugaring and features that are
-    /// allowed inside this span.
-    fn mark_span_with_reason(
-        &self,
-        reason: DesugaringKind,
-        span: Span,
-        allow_internal_unstable: Option<Lrc<[Symbol]>>,
-    ) -> Span {
-        self.tcx.with_stable_hashing_context(|hcx| {
-            span.mark_with_reason(allow_internal_unstable, reason, self.tcx.sess.edition(), hcx)
-        })
-    }
-
     /// Intercept all spans entering HIR.
     /// Mark a span as relative to the current owning item.
     fn lower_span(&self, span: Span) -> Span {
@@ -1529,7 +1516,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         // desugaring that explicitly states that we don't want to track that.
         // Not tracking it makes lints in rustc and clippy very fragile, as
         // frequently opened issues show.
-        let opaque_ty_span = self.mark_span_with_reason(DesugaringKind::OpaqueTy, span, None);
+        let opaque_ty_span = self.tcx.mark_span_with_reason(DesugaringKind::OpaqueTy, span, None);
 
         let opaque_ty_def_id = self.create_def(
             self.current_hir_id_owner.def_id,
@@ -1893,7 +1880,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     ) -> hir::FnRetTy<'hir> {
         let span = output.span();
 
-        let opaque_ty_span = self.mark_span_with_reason(DesugaringKind::Async, span, None);
+        let opaque_ty_span = self.tcx.mark_span_with_reason(DesugaringKind::Async, span, None);
 
         let fn_def_id = self.local_def_id(fn_node_id);
 

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -196,6 +196,10 @@ impl<D: Decoder> Decodable<D> for Fingerprint {
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Hash)]
 pub struct PackedFingerprint(Fingerprint);
 
+impl PackedFingerprint {
+    pub const ZERO: PackedFingerprint = PackedFingerprint(Fingerprint::ZERO);
+}
+
 impl std::fmt::Display for PackedFingerprint {
     #[inline]
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -486,7 +486,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                                 .map(|(path, item, _exts, is_const)| {
                                     // FIXME: Consider using the derive resolutions (`_exts`)
                                     // instead of enqueuing the derives to be resolved again later.
-                                    let expn_id = LocalExpnId::fresh_empty();
+                                    let expn_id = LocalExpnId::reserve_expansion_id();
                                     derive_invocations.push((
                                         Invocation {
                                             kind: InvocationKind::Derive { path, item, is_const },
@@ -1548,7 +1548,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
     }
 
     fn collect(&mut self, fragment_kind: AstFragmentKind, kind: InvocationKind) -> AstFragment {
-        let expn_id = LocalExpnId::fresh_empty();
+        let expn_id = LocalExpnId::reserve_expansion_id();
         let vis = kind.placeholder_visibility();
         self.invocations.push((
             Invocation {

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -486,7 +486,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                                 .map(|(path, item, _exts, is_const)| {
                                     // FIXME: Consider using the derive resolutions (`_exts`)
                                     // instead of enqueuing the derives to be resolved again later.
-                                    let expn_id = LocalExpnId::reserve_expansion_id();
+                                    let expn_id = LocalExpnId::reserve_expn_id();
                                     derive_invocations.push((
                                         Invocation {
                                             kind: InvocationKind::Derive { path, item, is_const },
@@ -1548,7 +1548,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
     }
 
     fn collect(&mut self, fragment_kind: AstFragmentKind, kind: InvocationKind) -> AstFragment {
-        let expn_id = LocalExpnId::reserve_expansion_id();
+        let expn_id = LocalExpnId::reserve_expn_id();
         let vis = kind.placeholder_visibility();
         self.invocations.push((
             Invocation {

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -54,7 +54,8 @@ impl rustc_query_system::dep_graph::DepKind for DepKind {
         OP: FnOnce() -> R,
     {
         ty::tls::with_context(|icx| {
-            let icx = ty::tls::ImplicitCtxt { current_node, task_deps, ..icx.clone() };
+            let icx =
+                ty::tls::ImplicitCtxt { current_node: &current_node, task_deps, ..icx.clone() };
 
             ty::tls::enter_context(&icx, op)
         })

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -16,6 +16,7 @@ pub(crate) use dep_node::{make_compile_codegen_unit, make_compile_mono_item};
 
 pub type DepGraph = rustc_query_system::dep_graph::DepGraph<DepKind>;
 
+pub type CurrentDepNode = rustc_query_system::dep_graph::CurrentDepNode<DepKind>;
 pub type TaskDeps = rustc_query_system::dep_graph::TaskDeps<DepKind>;
 pub type TaskDepsRef<'a> = rustc_query_system::dep_graph::TaskDepsRef<'a, DepKind>;
 pub type DepGraphQuery = rustc_query_system::dep_graph::DepGraphQuery<DepKind>;
@@ -48,12 +49,12 @@ impl rustc_query_system::dep_graph::DepKind for DepKind {
         write!(f, ")")
     }
 
-    fn with_deps<OP, R>(task_deps: TaskDepsRef<'_>, op: OP) -> R
+    fn with_deps<OP, R>(current_node: CurrentDepNode, task_deps: TaskDepsRef<'_>, op: OP) -> R
     where
         OP: FnOnce() -> R,
     {
         ty::tls::with_context(|icx| {
-            let icx = ty::tls::ImplicitCtxt { task_deps, ..icx.clone() };
+            let icx = ty::tls::ImplicitCtxt { current_node, task_deps, ..icx.clone() };
 
             ty::tls::enter_context(&icx, op)
         })

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -630,20 +630,7 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for ExpnId {
 
             let data: ExpnData = decoder
                 .with_position(pos.to_usize(), |decoder| decode_tagged(decoder, TAG_EXPN_DATA));
-            let expn_id = rustc_span::hygiene::register_local_expn_id(data, hash);
-
-            #[cfg(debug_assertions)]
-            {
-                use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-                let local_hash = decoder.tcx.with_stable_hashing_context(|mut hcx| {
-                    let mut hasher = StableHasher::new();
-                    expn_id.expn_data().hash_stable(&mut hcx, &mut hasher);
-                    hasher.finish()
-                });
-                debug_assert_eq!(hash.local_hash(), local_hash);
-            }
-
-            expn_id
+            rustc_span::hygiene::register_local_expn_id(data, hash)
         } else {
             let index_guess = decoder.foreign_expn_data[&hash];
             decoder.tcx.cstore_untracked().expn_hash_to_expn_id(

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -909,18 +909,13 @@ impl<'tcx> TyCtxt<'tcx> {
 
 impl<'tcx> TyCtxt<'tcx> {
     #[instrument(level = "trace", skip(self), ret)]
-    pub fn create_expansion(self, expn_data: ExpnData) -> LocalExpnId {
+    pub fn create_expn(self, expn_data: ExpnData) -> LocalExpnId {
         tls::with_related_context(self, |icx| {
             let CurrentDepNode::Regular { dep_node, expn_disambiguators } = icx.current_node else {
                 bug!("creating an expansion outside of a query")
             };
             self.with_stable_hashing_context(|ctx| {
-                LocalExpnId::create_untracked_expansion(
-                    expn_data,
-                    dep_node,
-                    ctx,
-                    &expn_disambiguators,
-                )
+                LocalExpnId::create_untracked_expn(expn_data, dep_node, ctx, &expn_disambiguators)
             })
         })
     }
@@ -928,7 +923,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Fill an empty expansion. This method must not be used outside of the resolver.
     #[inline]
     #[instrument(level = "trace", skip(self))]
-    pub fn finalize_expansion(self, expn_id: LocalExpnId, expn_data: ExpnData) {
+    pub fn finalize_expn(self, expn_id: LocalExpnId, expn_data: ExpnData) {
         tls::with_related_context(self, |icx| {
             let CurrentDepNode::Regular { dep_node, expn_disambiguators } = icx.current_node else {
                 bug!("creating an expansion outside of a query")
@@ -951,7 +946,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let mut expn_data =
             ExpnData::default(ExpnKind::Desugaring(reason), span, edition, None, None);
         expn_data.allow_internal_unstable = allow_internal_unstable;
-        let expn_id = self.create_expansion(expn_data);
+        let expn_id = self.create_expn(expn_data);
         span.fresh_expansion(expn_id)
     }
 }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -5,7 +5,7 @@
 pub mod tls;
 
 use crate::arena::Arena;
-use crate::dep_graph::{CurrentDepNode, DepGraph, DepKindStruct, DepNode};
+use crate::dep_graph::{CurrentDepNode, DepGraph, DepKindStruct};
 use crate::infer::canonical::CanonicalVarInfo;
 use crate::lint::struct_lint_level;
 use crate::metadata::ModChild;
@@ -902,25 +902,15 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 }
 
-const ENSURE_FAKE_DEP_NODE_SYNC: () = if std::mem::size_of::<rustc_span::hygiene::FakeDepNode>()
-    != std::mem::size_of::<DepNode>()
-{
-    panic!(
-        "rustc_span::hygiene::FakeDepNode has come out of sync with DepNode and should be updated."
-    )
-};
-
 impl<'tcx> TyCtxt<'tcx> {
     #[instrument(level = "trace", skip(self), ret)]
     pub fn create_expansion(self, expn_data: ExpnData) -> LocalExpnId {
-        let current_node = tls::with_related_context(self, |icx| icx.current_node);
-        let CurrentDepNode::Regular(DepNode { kind, hash }) = current_node else {
+        let current_node = tls::with_related_context(self, |icx| icx.current_node.clone());
+        let CurrentDepNode::Regular { dep_node, expn_disambiguators } = current_node else {
             bug!("creating an expansion outside of a query")
         };
-        let _ = ENSURE_FAKE_DEP_NODE_SYNC;
-        let fake_dep_node = rustc_span::hygiene::FakeDepNode { kind: kind as _, hash };
         self.with_stable_hashing_context(|ctx| {
-            LocalExpnId::create_untracked_expansion(expn_data, fake_dep_node, ctx)
+            LocalExpnId::create_untracked_expansion(expn_data, dep_node, ctx, &expn_disambiguators)
         })
     }
 
@@ -928,14 +918,12 @@ impl<'tcx> TyCtxt<'tcx> {
     #[inline]
     #[instrument(level = "trace", skip(self))]
     pub fn finalize_expansion(self, expn_id: LocalExpnId, expn_data: ExpnData) {
-        let current_node = tls::with_related_context(self, |icx| icx.current_node);
-        let CurrentDepNode::Regular(DepNode { kind, hash }) = current_node else {
+        let current_node = tls::with_related_context(self, |icx| icx.current_node.clone());
+        let CurrentDepNode::Regular { dep_node, expn_disambiguators } = current_node else {
             bug!("creating an expansion outside of a query")
         };
-        let _ = ENSURE_FAKE_DEP_NODE_SYNC;
-        let fake_dep_node = rustc_span::hygiene::FakeDepNode { kind: kind as _, hash };
         self.with_stable_hashing_context(|ctx| {
-            expn_id.set_untracked_expn_data(expn_data, fake_dep_node, ctx)
+            expn_id.set_untracked_expn_data(expn_data, dep_node, ctx, &expn_disambiguators)
         });
     }
 

--- a/compiler/rustc_middle/src/ty/context/tls.rs
+++ b/compiler/rustc_middle/src/ty/context/tls.rs
@@ -1,6 +1,6 @@
 use super::{GlobalCtxt, TyCtxt};
 
-use crate::dep_graph::{CurrentDepNode, DepNode, TaskDepsRef};
+use crate::dep_graph::{CurrentDepNode, TaskDepsRef};
 use crate::query::plumbing::QueryJobId;
 use rustc_data_structures::sync::{self, Lock};
 use rustc_errors::Diagnostic;
@@ -33,7 +33,7 @@ pub struct ImplicitCtxt<'a, 'tcx> {
 
     /// The DepNode of the query being executed. This is updated by the dep-graph. This is used to
     /// know which query created an expansion.
-    pub current_node: CurrentDepNode,
+    pub current_node: &'a CurrentDepNode,
 
     /// The current dep graph task. This is used to add dependencies to queries
     /// when executing them.
@@ -41,13 +41,8 @@ pub struct ImplicitCtxt<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> ImplicitCtxt<'a, 'tcx> {
-    pub fn new(gcx: &'tcx GlobalCtxt<'tcx>) -> Self {
+    pub fn new(gcx: &'tcx GlobalCtxt<'tcx>, current_node: &'a CurrentDepNode) -> Self {
         let tcx = TyCtxt { gcx };
-        let current_node = if tcx.dep_graph.is_fully_enabled() {
-            CurrentDepNode::Untracked
-        } else {
-            CurrentDepNode::regular(DepNode::NULL)
-        };
         ImplicitCtxt {
             tcx,
             query: None,

--- a/compiler/rustc_middle/src/ty/context/tls.rs
+++ b/compiler/rustc_middle/src/ty/context/tls.rs
@@ -31,7 +31,7 @@ pub struct ImplicitCtxt<'a, 'tcx> {
     /// Used to prevent queries from calling too deeply.
     pub query_depth: usize,
 
-    /// The DepNode of the query being executed. This is updated by the dep-graph. Thisis used to
+    /// The DepNode of the query being executed. This is updated by the dep-graph. This is used to
     /// know which query created an expansion.
     pub current_node: CurrentDepNode,
 
@@ -46,7 +46,7 @@ impl<'a, 'tcx> ImplicitCtxt<'a, 'tcx> {
         let current_node = if tcx.dep_graph.is_fully_enabled() {
             CurrentDepNode::Untracked
         } else {
-            CurrentDepNode::Regular(DepNode::NULL)
+            CurrentDepNode::regular(DepNode::NULL)
         };
         ImplicitCtxt {
             tcx,

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -142,7 +142,7 @@ impl QueryContext for QueryCtxt<'_> {
                 query: Some(token),
                 diagnostics,
                 query_depth: current_icx.query_depth + depth_limit as usize,
-                current_node: current_icx.current_node.clone(),
+                current_node: current_icx.current_node,
                 task_deps: current_icx.task_deps,
             };
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -142,7 +142,7 @@ impl QueryContext for QueryCtxt<'_> {
                 query: Some(token),
                 diagnostics,
                 query_depth: current_icx.query_depth + depth_limit as usize,
-                current_node: current_icx.current_node,
+                current_node: current_icx.current_node.clone(),
                 task_deps: current_icx.task_deps,
             };
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -142,6 +142,7 @@ impl QueryContext for QueryCtxt<'_> {
                 query: Some(token),
                 diagnostics,
                 query_depth: current_icx.query_depth + depth_limit as usize,
+                current_node: current_icx.current_node,
                 task_deps: current_icx.task_deps,
             };
 

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -58,6 +58,8 @@ pub struct DepNode<K> {
 }
 
 impl<K: DepKind> DepNode<K> {
+    pub const NULL: DepNode<K> = DepNode { kind: K::NULL, hash: PackedFingerprint::ZERO };
+
     /// Creates a new, parameterless DepNode. This method will assert
     /// that the DepNode corresponding to the given DepKind actually
     /// does not require any parameters.

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -355,7 +355,7 @@ impl<K: DepKind> DepGraphData<K> {
         );
 
         let with_deps =
-            |task_deps| K::with_deps(CurrentDepNode::Regular(key), task_deps, || task(cx, arg));
+            |task_deps| K::with_deps(CurrentDepNode::regular(key), task_deps, || task(cx, arg));
         let (result, edges) = if cx.dep_context().is_eval_always(key.kind) {
             (with_deps(TaskDepsRef::EvalAlways), smallvec![])
         } else {

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -153,7 +153,7 @@ pub enum CurrentDepNode<K> {
 
 impl<K> CurrentDepNode<K> {
     pub fn regular(dep_node: DepNode<K>) -> CurrentDepNode<K> {
-        CurrentDepNode::Regular { dep_node, expn_disambiguators: Lock::new(UnhashMap::default()) }
+        CurrentDepNode::Regular { dep_node, expn_disambiguators: Default::default() }
     }
 }
 

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -15,7 +15,7 @@ pub use serialized::{SerializedDepGraph, SerializedDepNodeIndex};
 use crate::ich::StableHashingContext;
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::stable_hasher::Hash64;
-use rustc_data_structures::sync::{Lock, Lrc};
+use rustc_data_structures::sync::Lock;
 use rustc_data_structures::unhash::UnhashMap;
 use rustc_serialize::{opaque::FileEncoder, Encodable};
 use rustc_session::Session;
@@ -140,13 +140,12 @@ impl FingerprintStyle {
     }
 }
 
-#[derive(Clone)]
 pub enum CurrentDepNode<K> {
     Regular {
         dep_node: DepNode<K>,
         /// Disambiguation map for expansions created while executing
         /// the query with this `DepNode`.
-        expn_disambiguators: Lrc<Lock<UnhashMap<Hash64, u32>>>,
+        expn_disambiguators: Lock<UnhashMap<Hash64, u32>>,
     },
     Anonymous,
     Untracked,
@@ -154,10 +153,7 @@ pub enum CurrentDepNode<K> {
 
 impl<K> CurrentDepNode<K> {
     pub fn regular(dep_node: DepNode<K>) -> CurrentDepNode<K> {
-        CurrentDepNode::Regular {
-            dep_node,
-            expn_disambiguators: Lrc::new(Lock::new(UnhashMap::default())),
-        }
+        CurrentDepNode::Regular { dep_node, expn_disambiguators: Lock::new(UnhashMap::default()) }
     }
 }
 

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -137,6 +137,13 @@ impl FingerprintStyle {
     }
 }
 
+#[derive(Copy, Clone, Hash)]
+pub enum CurrentDepNode<K> {
+    Regular(DepNode<K>),
+    Anonymous,
+    Untracked,
+}
+
 /// Describe the different families of dependency nodes.
 pub trait DepKind: Copy + fmt::Debug + Eq + Hash + Send + Encodable<FileEncoder> + 'static {
     /// DepKind to use when incr. comp. is turned off.
@@ -149,7 +156,7 @@ pub trait DepKind: Copy + fmt::Debug + Eq + Hash + Send + Encodable<FileEncoder>
     fn debug_node(node: &DepNode<Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 
     /// Execute the operation with provided dependencies.
-    fn with_deps<OP, R>(deps: TaskDepsRef<'_, Self>, op: OP) -> R
+    fn with_deps<OP, R>(node: CurrentDepNode<Self>, deps: TaskDepsRef<'_, Self>, op: OP) -> R
     where
         OP: FnOnce() -> R;
 

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -632,7 +632,7 @@ where
     // The dep-graph for this computation is already in-place, but any side effect due to this
     // query needs to know our DepNode.
     let result =
-        Qcx::DepKind::with_deps(CurrentDepNode::Regular(*dep_node), TaskDepsRef::Ignore, || {
+        Qcx::DepKind::with_deps(CurrentDepNode::regular(*dep_node), TaskDepsRef::Ignore, || {
             query.compute(qcx, *key)
         });
 

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -676,6 +676,10 @@ pub(crate) fn incremental_verify_ich<Tcx, V>(
     });
 
     let old_hash = dep_graph_data.prev_fingerprint_of(prev_index);
+    debug!(
+        dep_node = ?tcx.dep_graph().data().unwrap().prev_node_of(prev_index),
+        ?new_hash, ?old_hash,
+    );
 
     if new_hash != old_hash {
         incremental_verify_ich_failed(tcx, prev_index, &|| format_value(&result));

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -680,11 +680,6 @@ pub(crate) fn incremental_verify_ich<Tcx, V>(
     });
 
     let old_hash = dep_graph_data.prev_fingerprint_of(prev_index);
-    debug!(
-        dep_node = ?tcx.dep_graph().data().unwrap().prev_node_of(prev_index),
-        ?new_hash, ?old_hash,
-    );
-
     if new_hash != old_hash {
         incremental_verify_ich_failed(tcx, prev_index, &|| format_value(&result));
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -51,7 +51,6 @@ use rustc_middle::query::Providers;
 use rustc_middle::span_bug;
 use rustc_middle::ty::{self, MainDefinition, RegisteredTools, TyCtxt};
 use rustc_middle::ty::{ResolverGlobalCtxt, ResolverOutputs};
-use rustc_query_system::ich::StableHashingContext;
 use rustc_session::lint::LintBuffer;
 use rustc_span::hygiene::{ExpnId, LocalExpnId, MacroKind, SyntaxContext, Transparency};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
@@ -1443,10 +1442,6 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             lint_buffer: Steal::new(self.lint_buffer),
         };
         ResolverOutputs { global_ctxt, ast_lowering }
-    }
-
-    fn create_stable_hashing_context(&self) -> StableHashingContext<'_> {
-        StableHashingContext::new(self.tcx.sess, self.tcx.untracked())
     }
 
     fn crate_loader<T>(&mut self, f: impl FnOnce(&mut CrateLoader<'_, '_>) -> T) -> T {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -217,7 +217,7 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
     ) -> LocalExpnId {
         let parent_module =
             parent_module_id.map(|module_id| self.local_def_id(module_id).to_def_id());
-        let expn_id = self.tcx.create_expansion(ExpnData::allow_unstable(
+        let expn_id = self.tcx.create_expn(ExpnData::allow_unstable(
             ExpnKind::AstPass(pass),
             call_site,
             self.tcx.sess.edition(),
@@ -287,7 +287,7 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
 
         let span = invoc.span();
         let def_id = res.opt_def_id();
-        self.tcx.finalize_expansion(
+        self.tcx.finalize_expn(
             invoc_id,
             ext.expn_data(
                 parent_scope.expansion,

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -182,7 +182,7 @@ impl LocalExpnId {
 
     /// Create a new expansions without any information. This method must not be used outside of
     /// the resolver.
-    pub fn reserve_expansion_id() -> LocalExpnId {
+    pub fn reserve_expn_id() -> LocalExpnId {
         HygieneData::with(|data| {
             let expn_id = data.local_expn_data.push(None);
             let _eid = data.local_expn_hashes.push(ExpnHash(Fingerprint::ZERO));
@@ -191,9 +191,9 @@ impl LocalExpnId {
         })
     }
 
-    /// This method is an implementation detail of `TyCtxt::create_expansion`.
+    /// This method is an implementation detail of `TyCtxt::create_expn`.
     #[instrument(level = "trace", skip(ctx), ret)]
-    pub fn create_untracked_expansion(
+    pub fn create_untracked_expn(
         mut expn_data: ExpnData,
         hash_extra: impl Hash + Copy + fmt::Debug,
         ctx: impl HashStableContext,
@@ -213,7 +213,7 @@ impl LocalExpnId {
         })
     }
 
-    /// Implementation detail of `TyCtxt::finalize_expansion`.
+    /// Implementation detail of `TyCtxt::finalize_expn`.
     #[inline]
     #[instrument(level = "trace", skip(ctx))]
     pub fn set_untracked_expn_data(

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -192,10 +192,9 @@ impl LocalExpnId {
     }
 
     /// This method is an implementation detail of `TyCtxt::create_expn`.
-    #[instrument(level = "trace", skip(ctx), ret)]
     pub fn create_untracked_expn(
         mut expn_data: ExpnData,
-        hash_extra: impl Hash + Copy + fmt::Debug,
+        hash_extra: impl Hash + Copy,
         ctx: impl HashStableContext,
         disambiguation_map: &Lock<UnhashMap<Hash64, u32>>,
     ) -> LocalExpnId {
@@ -215,11 +214,10 @@ impl LocalExpnId {
 
     /// Implementation detail of `TyCtxt::finalize_expn`.
     #[inline]
-    #[instrument(level = "trace", skip(ctx))]
     pub fn set_untracked_expn_data(
         self,
         mut expn_data: ExpnData,
-        hash_extra: impl Hash + Copy + fmt::Debug,
+        hash_extra: impl Hash + Copy,
         ctx: impl HashStableContext,
         disambiguation_map: &Lock<UnhashMap<Hash64, u32>>,
     ) {
@@ -1462,10 +1460,9 @@ impl<D: Decoder> Decodable<D> for SyntaxContext {
 /// `set_expn_data`). It is *not* called for foreign `ExpnId`s deserialized
 /// from another crate's metadata - since `ExpnHash` includes the stable crate id,
 /// collisions are only possible between `ExpnId`s within the same crate.
-#[instrument(level = "trace", skip(ctx), ret)]
 fn update_disambiguator(
     expn_data: &mut ExpnData,
-    hash_extra: impl Hash + Copy + fmt::Debug,
+    hash_extra: impl Hash + Copy,
     mut ctx: impl HashStableContext,
     disambiguation_map: &Lock<UnhashMap<Hash64, u32>>,
 ) -> ExpnHash {

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -204,8 +204,8 @@ impl LocalExpnId {
             let expn_id = data.local_expn_data.push(Some(expn_data));
             let _eid = data.local_expn_hashes.push(expn_hash);
             debug_assert_eq!(expn_id, _eid);
-            let _old_id = data.expn_hash_to_expn_id.insert(expn_hash, expn_id.to_expn_id());
-            if !_old_id.is_none() {
+            let old_id = data.expn_hash_to_expn_id.insert(expn_hash, expn_id.to_expn_id());
+            if old_id.is_some() {
                 panic!("Hash collision while creating expansion. Cannot continue.");
             }
             expn_id
@@ -229,8 +229,8 @@ impl LocalExpnId {
             *old_expn_data = Some(expn_data);
             debug_assert_eq!(data.local_expn_hashes[self].0, Fingerprint::ZERO);
             data.local_expn_hashes[self] = expn_hash;
-            let _old_id = data.expn_hash_to_expn_id.insert(expn_hash, self.to_expn_id());
-            if !_old_id.is_none() {
+            let old_id = data.expn_hash_to_expn_id.insert(expn_hash, self.to_expn_id());
+            if old_id.is_some() {
                 panic!("Hash collision while creating expansion. Cannot continue.");
             }
         });
@@ -1266,8 +1266,8 @@ pub fn register_local_expn_id(data: ExpnData, hash: ExpnHash) -> ExpnId {
 
         let expn_id = expn_id.to_expn_id();
 
-        let _old_id = hygiene_data.expn_hash_to_expn_id.insert(hash, expn_id);
-        if !_old_id.is_none() {
+        let old_id = hygiene_data.expn_hash_to_expn_id.insert(hash, expn_id);
+        if old_id.is_some() {
             panic!("Hash collision while creating expansion. Cannot continue.");
         }
         expn_id
@@ -1288,8 +1288,8 @@ pub fn register_expn_id(
         debug_assert!(_old_data.is_none());
         let _old_hash = hygiene_data.foreign_expn_hashes.insert(expn_id, hash);
         debug_assert!(_old_hash.is_none());
-        let _old_id = hygiene_data.expn_hash_to_expn_id.insert(hash, expn_id);
-        if !_old_id.is_none() {
+        let old_id = hygiene_data.expn_hash_to_expn_id.insert(hash, expn_id);
+        if old_id.is_some() {
             panic!("Hash collision while creating expansion. Cannot continue.");
         }
     });

--- a/src/librustdoc/passes/lint/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/lint/check_code_block_syntax.rs
@@ -7,7 +7,7 @@ use rustc_errors::{
 };
 use rustc_parse::parse_stream_from_source_str;
 use rustc_session::parse::ParseSess;
-use rustc_span::hygiene::{AstPass, ExpnData, ExpnKind, LocalExpnId};
+use rustc_span::hygiene::{AstPass, ExpnData, ExpnKind};
 use rustc_span::source_map::{FilePathMapping, SourceMap};
 use rustc_span::{FileName, InnerSpan, DUMMY_SP};
 
@@ -47,7 +47,7 @@ fn check_rust_syntax(
     let edition = code_block.lang_string.edition.unwrap_or_else(|| cx.tcx.sess.edition());
     let expn_data =
         ExpnData::default(ExpnKind::AstPass(AstPass::TestHarness), DUMMY_SP, edition, None, None);
-    let expn_id = cx.tcx.with_stable_hashing_context(|hcx| LocalExpnId::fresh(expn_data, hcx));
+    let expn_id = cx.tcx.create_expansion(expn_data);
     let span = DUMMY_SP.fresh_expansion(expn_id);
 
     let is_empty = rustc_driver::catch_fatal_errors(|| {

--- a/src/librustdoc/passes/lint/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/lint/check_code_block_syntax.rs
@@ -47,7 +47,7 @@ fn check_rust_syntax(
     let edition = code_block.lang_string.edition.unwrap_or_else(|| cx.tcx.sess.edition());
     let expn_data =
         ExpnData::default(ExpnKind::AstPass(AstPass::TestHarness), DUMMY_SP, edition, None, None);
-    let expn_id = cx.tcx.create_expansion(expn_data);
+    let expn_id = cx.tcx.create_expn(expn_data);
     let span = DUMMY_SP.fresh_expansion(expn_id);
 
     let is_empty = rustc_driver::catch_fatal_errors(|| {


### PR DESCRIPTION
Expansion data requires to be disambiguated in case of colliding spans. The current disambiguation mechanism was merely looking at hash collisions using a global disambiguation counter.

This global counter created an untracked data dependency between unrelated queries. For instance here: https://github.com/rust-lang/rust/issues/110457#issuecomment-1555008573

This PR replaces the global disambiguation map by a per-DepNode map. This requires threading the currently evaluated DepNode through the implicit context. We use a dummy in the non-incremental case to simplify the logic.