### PR TITLE
rustdoc: include strikethrough in item summary

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -551,7 +551,15 @@ impl<'a, I: Iterator<Item = Event<'a>>> SummaryLine<'a, I> {
 }
 
 fn check_if_allowed_tag(t: &Tag<'_>) -> bool {
-    matches!(t, Tag::Paragraph | Tag::Emphasis | Tag::Strong | Tag::Link(..) | Tag::BlockQuote)
+    matches!(
+        t,
+        Tag::Paragraph
+            | Tag::Emphasis
+            | Tag::Strong
+            | Tag::Strikethrough
+            | Tag::Link(..)
+            | Tag::BlockQuote
+    )
 }
 
 fn is_forbidden_tag(t: &Tag<'_>) -> bool {

--- a/tests/rustdoc/strikethrough-in-summary.rs
+++ b/tests/rustdoc/strikethrough-in-summary.rs
@@ -1,0 +1,6 @@
+#![crate_name = "foo"]
+
+// @has foo/index.html '//del' 'strike'
+
+/// ~~strike~~
+pub fn strike() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/111822. Since **bold** and *italic* are included, I don't see why ~~strikethrough~~ shouldn't be.