### PR TITLE
Render test messages from bootstrap

### DIFF
--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -168,9 +168,14 @@ impl<'a> Renderer<'a> {
         if !self.failures.is_empty() {
             println!("\nfailures:\n");
             for failure in &self.failures {
-                if let Some(stdout) = &failure.stdout {
+                if failure.stdout.is_some() || failure.message.is_some() {
                     println!("---- {} stdout ----", failure.name);
-                    println!("{stdout}");
+                    if let Some(stdout) = &failure.stdout {
+                        println!("{stdout}");
+                    }
+                    if let Some(message) = &failure.message {
+                        println!("note: {message}");
+                    }
                 }
             }
 


### PR DESCRIPTION
Bootstrap was not rendering messages from the test harness when a test failed. This can include messages like "test did not panic as expected". This fixes it by making sure those messages are printed on failure.

Fixes #111825