### PR TITLE
array::split_array*(): return arrays instead of slices

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -639,9 +639,9 @@ impl<T, const N: usize> [T; N] {
     /// let v = [1, 2, 3, 4, 5, 6];
     ///
     /// {
-    ///    let (left, right) = v.split_array_ref::<0>();
-    ///    assert_eq!(left, &[]);
-    ///    assert_eq!(right, &[1, 2, 3, 4, 5, 6]);
+    ///     let (left, right) = v.split_array_ref::<0>();
+    ///     assert_eq!(left, &[]);
+    ///     assert_eq!(right, &[1, 2, 3, 4, 5, 6]);
     /// }
     ///
     /// {
@@ -713,9 +713,9 @@ impl<T, const N: usize> [T; N] {
     /// let v = [1, 2, 3, 4, 5, 6];
     ///
     /// {
-    ///    let (left, right) = v.rsplit_array_ref::<0>();
-    ///    assert_eq!(left, &[1, 2, 3, 4, 5, 6]);
-    ///    assert_eq!(right, &[]);
+    ///     let (left, right) = v.rsplit_array_ref::<0>();
+    ///     assert_eq!(left, &[1, 2, 3, 4, 5, 6]);
+    ///     assert_eq!(right, &[]);
     /// }
     ///
     /// {

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -656,16 +656,16 @@ impl<T, const N: usize> [T; N] {
     ///     assert_eq!(right, &[]);
     /// }
     /// ```
-    #[unstable(
-        feature = "split_array",
-        reason = "return type should have array as 2nd element",
-        issue = "90091"
-    )]
+    #[unstable(feature = "split_array", reason = "new API", issue = "90091")]
     #[inline]
-    pub const fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T]) {
-        // FIXME: remove once constraint is encoded in return type
-        const { assert!(M <= N) }
-        self.as_slice().split_array_ref::<M>().unwrap()
+    pub const fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T; N - M]) {
+        // SAFETY: 0 <= M <= len (N)
+        let (left, right) = unsafe { self.split_at_unchecked(M) };
+
+        // SAFETY: `split_at_unchecked()` guarantees that:
+        // - `left` is a slice of `M` elements,
+        // - `right` is a slice of `N - M` elements.
+        unsafe { (from_slice_unchecked(left), from_slice_unchecked(right)) }
     }
 
     /// Divides one mutable array reference into two at an index.
@@ -687,16 +687,16 @@ impl<T, const N: usize> [T; N] {
     /// right[1] = 4;
     /// assert_eq!(v, [1, 2, 3, 4, 5, 6]);
     /// ```
-    #[unstable(
-        feature = "split_array",
-        reason = "return type should have array as 2nd element",
-        issue = "90091"
-    )]
+    #[unstable(feature = "split_array", reason = "new API", issue = "90091")]
     #[inline]
-    pub const fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T]) {
-        // FIXME: remove once constraint is encoded in return type
-        const { assert!(M <= N) }
-        (self as &mut [T]).split_array_mut::<M>().unwrap()
+    pub const fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T; N - M]) {
+        // SAFETY: 0 <= M <= len (N)
+        let (left, right) = unsafe { self.split_at_mut_unchecked(M) };
+
+        // SAFETY: `split_at_mut_unchecked()` guarantees that:
+        // - `left` is a slice of `M` elements,
+        // - `right` is a slice of `N - M` elements.
+        unsafe { (from_mut_slice_unchecked(left), from_mut_slice_unchecked(right)) }
     }
 
     /// Divides one array reference into two at an index from the end.
@@ -730,16 +730,16 @@ impl<T, const N: usize> [T; N] {
     ///     assert_eq!(right, &[1, 2, 3, 4, 5, 6]);
     /// }
     /// ```
-    #[unstable(
-        feature = "split_array",
-        reason = "return type should have array as 2nd element",
-        issue = "90091"
-    )]
+    #[unstable(feature = "split_array", reason = "new API", issue = "90091")]
     #[inline]
-    pub const fn rsplit_array_ref<const M: usize>(&self) -> (&[T], &[T; M]) {
-        // FIXME: remove once constraint is encoded in return type
-        const { assert!(M <= N) }
-        self.as_slice().rsplit_array_ref::<M>().unwrap()
+    pub const fn rsplit_array_ref<const M: usize>(&self) -> (&[T; N - M], &[T; M]) {
+        // SAFETY: 0 <= (N-M) <= len (N)
+        let (left, right) = unsafe { self.split_at_unchecked(N - M) };
+
+        // SAFETY: `split_at_unchecked()` guarantees that:
+        // - `left` is a slice of `N-M` elements,
+        // - `right` is a slice of `N - (N-M) == M` elements.
+        unsafe { (from_slice_unchecked(left), from_slice_unchecked(right)) }
     }
 
     /// Divides one mutable array reference into two at an index from the end.
@@ -761,16 +761,16 @@ impl<T, const N: usize> [T; N] {
     /// right[1] = 4;
     /// assert_eq!(v, [1, 2, 3, 4, 5, 6]);
     /// ```
-    #[unstable(
-        feature = "split_array",
-        reason = "return type should have array as 2nd element",
-        issue = "90091"
-    )]
+    #[unstable(feature = "split_array", reason = "new API", issue = "90091")]
     #[inline]
-    pub const fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T], &mut [T; M]) {
-        // FIXME: remove once constraint is encoded in return type
-        const { assert!(M <= N) }
-        (self as &mut [T]).rsplit_array_mut::<M>().unwrap()
+    pub const fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T; N - M], &mut [T; M]) {
+        // SAFETY: 0 <= (N-M) <= len (N)
+        let (left, right) = unsafe { self.split_at_mut_unchecked(N - M) };
+
+        // SAFETY: `split_at_mut_unchecked()` guarantees that:
+        // - `left` is a slice of `N-M` elements,
+        // - `right` is a slice of `N - (N-M) == M` elements.
+        unsafe { (from_mut_slice_unchecked(left), from_mut_slice_unchecked(right)) }
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -667,7 +667,7 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T]) {
-        (&self[..]).split_array_ref::<M>()
+        (&self[..]).split_array_ref::<M>().unwrap()
     }
 
     /// Divides one mutable array reference into two at an index.
@@ -700,7 +700,7 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T]) {
-        (&mut self[..]).split_array_mut::<M>()
+        (&mut self[..]).split_array_mut::<M>().unwrap()
     }
 
     /// Divides one array reference into two at an index from the end.
@@ -745,7 +745,7 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn rsplit_array_ref<const M: usize>(&self) -> (&[T], &[T; M]) {
-        (&self[..]).rsplit_array_ref::<M>()
+        (&self[..]).rsplit_array_ref::<M>().unwrap()
     }
 
     /// Divides one mutable array reference into two at an index from the end.
@@ -778,7 +778,7 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T], &mut [T; M]) {
-        (&mut self[..]).rsplit_array_mut::<M>()
+        (&mut self[..]).rsplit_array_mut::<M>().unwrap()
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -631,10 +631,6 @@ impl<T, const N: usize> [T; N] {
     /// the index `M` itself) and the second will contain all
     /// indices from `[M, N)` (excluding the index `N` itself).
     ///
-    /// # Panics
-    ///
-    /// Panics if `M > N`.
-    ///
     /// # Examples
     ///
     /// ```
@@ -667,6 +663,8 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T]) {
+        // FIXME: remove once constraint is encoded in return type
+        const { assert!(M <= N) }
         (&self[..]).split_array_ref::<M>().unwrap()
     }
 
@@ -675,10 +673,6 @@ impl<T, const N: usize> [T; N] {
     /// The first will contain all indices from `[0, M)` (excluding
     /// the index `M` itself) and the second will contain all
     /// indices from `[M, N)` (excluding the index `N` itself).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `M > N`.
     ///
     /// # Examples
     ///
@@ -700,6 +694,8 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T]) {
+        // FIXME: remove once constraint is encoded in return type
+        const { assert!(M <= N) }
         (&mut self[..]).split_array_mut::<M>().unwrap()
     }
 
@@ -708,10 +704,6 @@ impl<T, const N: usize> [T; N] {
     /// The first will contain all indices from `[0, N - M)` (excluding
     /// the index `N - M` itself) and the second will contain all
     /// indices from `[N - M, N)` (excluding the index `N` itself).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `M > N`.
     ///
     /// # Examples
     ///
@@ -745,6 +737,8 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn rsplit_array_ref<const M: usize>(&self) -> (&[T], &[T; M]) {
+        // FIXME: remove once constraint is encoded in return type
+        const { assert!(M <= N) }
         (&self[..]).rsplit_array_ref::<M>().unwrap()
     }
 
@@ -753,10 +747,6 @@ impl<T, const N: usize> [T; N] {
     /// The first will contain all indices from `[0, N - M)` (excluding
     /// the index `N - M` itself) and the second will contain all
     /// indices from `[N - M, N)` (excluding the index `N` itself).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `M > N`.
     ///
     /// # Examples
     ///
@@ -778,6 +768,8 @@ impl<T, const N: usize> [T; N] {
     )]
     #[inline]
     pub fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T], &mut [T; M]) {
+        // FIXME: remove once constraint is encoded in return type
+        const { assert!(M <= N) }
         (&mut self[..]).rsplit_array_mut::<M>().unwrap()
     }
 }

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -774,6 +774,57 @@ impl<T, const N: usize> [T; N] {
     }
 }
 
+/// Unsafely converts a slice of `N` elements to an array reference of `N` elements.
+///
+/// # Safety
+///
+/// The caller must ensure that the slice has at least `N` elements. Violating this constraint
+/// causes Undefined Behaviour.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(array_from_slice)]
+///
+/// let v = [1, 0, 3, 0, 5, 6];
+/// // SAFETY: `&v[2..5]` is a slice of 3 elements.
+/// let r = unsafe { <&[i32; 3]>::from_slice_unchecked(&v[2..5]) };
+/// assert_eq!(r, &[3, 0, 5]);
+/// ```
+#[inline]
+#[must_use]
+const unsafe fn from_slice_unchecked<T, const N: usize>(s: &[T]) -> &[T; N] {
+    // SAFETY: caller guarantees that `s` is a slice of at least `N` elements.
+    unsafe { &*(s.as_ptr() as *const [T; N]) }
+}
+
+/// Unsafely converts a mutable slice of `N` elements to a mutable array reference of `N` elements.
+///
+/// # Safety
+///
+/// The caller must ensure that the slice has at least `N` elements. Violating this constraint
+/// causes Undefined Behaviour.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(array_from_slice)]
+///
+/// let mut v = [1, 0, 3, 0, 5, 6];
+/// // SAFETY: `&mut v[2..5]` is a slice of 3 elements.
+/// let r = unsafe { <&mut [i32; 3]>::from_mut_slice_unchecked(&mut v[2..5]) };
+/// assert_eq!(r, &[3, 0, 5]);
+/// r[1] = 9;
+/// assert_eq!(r, &[3, 9, 5]);
+/// assert_eq!(v, [1, 0, 3, 9, 5, 6]);
+/// ```
+#[inline]
+#[must_use]
+const unsafe fn from_mut_slice_unchecked<T, const N: usize>(s: &mut [T]) -> &mut [T; N] {
+    // SAFETY: caller guarantees that `s` is a slice of at least `N` elements.
+    unsafe { &mut *(s.as_ptr() as *mut [T; N]) }
+}
+
 /// Populate an array from the first `N` elements of `iter`
 ///
 /// # Panics

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -662,10 +662,10 @@ impl<T, const N: usize> [T; N] {
         issue = "90091"
     )]
     #[inline]
-    pub fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T]) {
+    pub const fn split_array_ref<const M: usize>(&self) -> (&[T; M], &[T]) {
         // FIXME: remove once constraint is encoded in return type
         const { assert!(M <= N) }
-        (&self[..]).split_array_ref::<M>().unwrap()
+        self.as_slice().split_array_ref::<M>().unwrap()
     }
 
     /// Divides one mutable array reference into two at an index.
@@ -693,10 +693,10 @@ impl<T, const N: usize> [T; N] {
         issue = "90091"
     )]
     #[inline]
-    pub fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T]) {
+    pub const fn split_array_mut<const M: usize>(&mut self) -> (&mut [T; M], &mut [T]) {
         // FIXME: remove once constraint is encoded in return type
         const { assert!(M <= N) }
-        (&mut self[..]).split_array_mut::<M>().unwrap()
+        (self as &mut [T]).split_array_mut::<M>().unwrap()
     }
 
     /// Divides one array reference into two at an index from the end.
@@ -736,10 +736,10 @@ impl<T, const N: usize> [T; N] {
         issue = "90091"
     )]
     #[inline]
-    pub fn rsplit_array_ref<const M: usize>(&self) -> (&[T], &[T; M]) {
+    pub const fn rsplit_array_ref<const M: usize>(&self) -> (&[T], &[T; M]) {
         // FIXME: remove once constraint is encoded in return type
         const { assert!(M <= N) }
-        (&self[..]).rsplit_array_ref::<M>().unwrap()
+        self.as_slice().rsplit_array_ref::<M>().unwrap()
     }
 
     /// Divides one mutable array reference into two at an index from the end.
@@ -767,10 +767,10 @@ impl<T, const N: usize> [T; N] {
         issue = "90091"
     )]
     #[inline]
-    pub fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T], &mut [T; M]) {
+    pub const fn rsplit_array_mut<const M: usize>(&mut self) -> (&mut [T], &mut [T; M]) {
         // FIXME: remove once constraint is encoded in return type
         const { assert!(M <= N) }
-        (&mut self[..]).rsplit_array_mut::<M>().unwrap()
+        (self as &mut [T]).rsplit_array_mut::<M>().unwrap()
     }
 }
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2538,14 +2538,15 @@ pub(crate) fn is_aligned_and_not_null<T>(ptr: *const T) -> bool {
     !ptr.is_null() && ptr.is_aligned()
 }
 
+const fn max_len<T>() -> usize {
+    let size = crate::mem::size_of::<T>();
+    if size == 0 { usize::MAX } else { isize::MAX as usize / size }
+}
+
 /// Checks whether an allocation of `len` instances of `T` exceeds
 /// the maximum allowed allocation size.
 pub(crate) fn is_valid_allocation_size<T>(len: usize) -> bool {
-    let max_len = const {
-        let size = crate::mem::size_of::<T>();
-        if size == 0 { usize::MAX } else { isize::MAX as usize / size }
-    };
-    len <= max_len
+    len <= max_len::<T>()
 }
 
 /// Checks whether the regions of memory starting at `src` and `dst` of size

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -164,6 +164,7 @@
 #![feature(const_waker)]
 #![feature(core_panic)]
 #![feature(duration_consts_float)]
+#![feature(generic_const_exprs)]
 #![feature(internal_impls_macro)]
 #![feature(ip)]
 #![feature(is_ascii_octdigit)]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1774,9 +1774,9 @@ impl<T> [T] {
     /// let v = &[1, 2, 3, 4, 5, 6][..];
     ///
     /// {
-    ///    let (left, right) = v.split_array_ref::<0>().unwrap();
-    ///    assert_eq!(left, &[]);
-    ///    assert_eq!(right, [1, 2, 3, 4, 5, 6]);
+    ///     let (left, right) = v.split_array_ref::<0>().unwrap();
+    ///     assert_eq!(left, &[]);
+    ///     assert_eq!(right, [1, 2, 3, 4, 5, 6]);
     /// }
     ///
     /// {
@@ -1863,9 +1863,9 @@ impl<T> [T] {
     /// let v = &[1, 2, 3, 4, 5, 6][..];
     ///
     /// {
-    ///    let (left, right) = v.rsplit_array_ref::<0>().unwrap();
-    ///    assert_eq!(left, [1, 2, 3, 4, 5, 6]);
-    ///    assert_eq!(right, &[]);
+    ///     let (left, right) = v.rsplit_array_ref::<0>().unwrap();
+    ///     assert_eq!(left, [1, 2, 3, 4, 5, 6]);
+    ///     assert_eq!(right, &[]);
     /// }
     ///
     /// {

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1797,7 +1797,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
-    pub fn split_array_ref<const N: usize>(&self) -> Option<(&[T; N], &[T])> {
+    pub const fn split_array_ref<const N: usize>(&self) -> Option<(&[T; N], &[T])> {
         if N > self.len() {
             None
         } else {
@@ -1835,7 +1835,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
-    pub fn split_array_mut<const N: usize>(&mut self) -> Option<(&mut [T; N], &mut [T])> {
+    pub const fn split_array_mut<const N: usize>(&mut self) -> Option<(&mut [T; N], &mut [T])> {
         if N > self.len() {
             None
         } else {
@@ -1885,7 +1885,7 @@ impl<T> [T] {
     #[unstable(feature = "split_array", reason = "new API", issue = "90091")]
     #[inline]
     #[must_use]
-    pub fn rsplit_array_ref<const N: usize>(&self) -> Option<(&[T], &[T; N])> {
+    pub const fn rsplit_array_ref<const N: usize>(&self) -> Option<(&[T], &[T; N])> {
         if N > self.len() {
             None
         } else {
@@ -1923,7 +1923,7 @@ impl<T> [T] {
     #[unstable(feature = "split_array", reason = "new API", issue = "90091")]
     #[inline]
     #[must_use]
-    pub fn rsplit_array_mut<const N: usize>(&mut self) -> Option<(&mut [T], &mut [T; N])> {
+    pub const fn rsplit_array_mut<const N: usize>(&mut self) -> Option<(&mut [T], &mut [T; N])> {
         if N > self.len() {
             None
         } else {

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -488,38 +488,6 @@ fn array_rsplit_array_mut() {
     }
 }
 
-#[should_panic]
-#[test]
-fn array_split_array_ref_out_of_bounds() {
-    let v = [1, 2, 3, 4, 5, 6];
-
-    v.split_array_ref::<7>();
-}
-
-#[should_panic]
-#[test]
-fn array_split_array_mut_out_of_bounds() {
-    let mut v = [1, 2, 3, 4, 5, 6];
-
-    v.split_array_mut::<7>();
-}
-
-#[should_panic]
-#[test]
-fn array_rsplit_array_ref_out_of_bounds() {
-    let v = [1, 2, 3, 4, 5, 6];
-
-    v.rsplit_array_ref::<7>();
-}
-
-#[should_panic]
-#[test]
-fn array_rsplit_array_mut_out_of_bounds() {
-    let mut v = [1, 2, 3, 4, 5, 6];
-
-    v.rsplit_array_mut::<7>();
-}
-
 #[test]
 fn array_intoiter_advance_by() {
     use std::cell::Cell;

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2375,13 +2375,13 @@ fn slice_split_array_mut() {
     let v = &mut [1, 2, 3, 4, 5, 6][..];
 
     {
-        let (left, right) = v.split_array_mut::<0>();
+        let (left, right) = v.split_array_mut::<0>().unwrap();
         assert_eq!(left, &mut []);
         assert_eq!(right, [1, 2, 3, 4, 5, 6]);
     }
 
     {
-        let (left, right) = v.split_array_mut::<6>();
+        let (left, right) = v.split_array_mut::<6>().unwrap();
         assert_eq!(left, &mut [1, 2, 3, 4, 5, 6]);
         assert_eq!(right, []);
     }
@@ -2392,13 +2392,13 @@ fn slice_rsplit_array_mut() {
     let v = &mut [1, 2, 3, 4, 5, 6][..];
 
     {
-        let (left, right) = v.rsplit_array_mut::<0>();
+        let (left, right) = v.rsplit_array_mut::<0>().unwrap();
         assert_eq!(left, [1, 2, 3, 4, 5, 6]);
         assert_eq!(right, &mut []);
     }
 
     {
-        let (left, right) = v.rsplit_array_mut::<6>();
+        let (left, right) = v.rsplit_array_mut::<6>().unwrap();
         assert_eq!(left, []);
         assert_eq!(right, &mut [1, 2, 3, 4, 5, 6]);
     }
@@ -2416,36 +2416,32 @@ fn split_as_slice() {
     assert_eq!(split.as_slice(), &[]);
 }
 
-#[should_panic]
 #[test]
 fn slice_split_array_ref_out_of_bounds() {
     let v = &[1, 2, 3, 4, 5, 6][..];
 
-    let _ = v.split_array_ref::<7>();
+    assert!(v.split_array_ref::<7>().is_none());
 }
 
-#[should_panic]
 #[test]
 fn slice_split_array_mut_out_of_bounds() {
     let v = &mut [1, 2, 3, 4, 5, 6][..];
 
-    let _ = v.split_array_mut::<7>();
+    assert!(v.split_array_mut::<7>().is_none());
 }
 
-#[should_panic]
 #[test]
 fn slice_rsplit_array_ref_out_of_bounds() {
     let v = &[1, 2, 3, 4, 5, 6][..];
 
-    let _ = v.rsplit_array_ref::<7>();
+    assert!(v.rsplit_array_ref::<7>().is_none());
 }
 
-#[should_panic]
 #[test]
 fn slice_rsplit_array_mut_out_of_bounds() {
     let v = &mut [1, 2, 3, 4, 5, 6][..];
 
-    let _ = v.rsplit_array_mut::<7>();
+    assert!(v.rsplit_array_mut::<7>().is_none());
 }
 
 macro_rules! take_tests {


### PR DESCRIPTION
This is an update to #90091, spun out of #109049, which
1. makes the `split_array_*()` methods on `array` return arrays instead of slices
3. adds `array::split_array()`.

It is [blocked on](https://github.com/rust-lang/rust/pull/109049#issuecomment-1465179193) support for `#![feature(generic_const_exprs)]`.

The first four commits are from #109049.

@rustbot label +S-blocked