### PR TITLE
fix: dedup `static_candidates` before report

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -473,6 +473,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut custom_span_label = false;
 
         let static_candidates = &mut no_match_data.static_candidates;
+
+        // `static_candidates` may have same candidates appended by
+        // inherent and extension, which may result in incorrect
+        // diagnostic.
+        static_candidates.dedup();
+
         if !static_candidates.is_empty() {
             err.note(
                 "found the following associated functions; to be used as methods, \

--- a/tests/ui/suggestions/issue-103646.rs
+++ b/tests/ui/suggestions/issue-103646.rs
@@ -1,0 +1,11 @@
+trait Cat {
+    fn nya() {}
+}
+
+fn uwu<T: Cat>(c: T) {
+    c.nya();
+    //~^ ERROR no method named `nya` found for type parameter `T` in the current scope
+    //~| Suggestion T::nya()
+}
+
+fn main() {}

--- a/tests/ui/suggestions/issue-103646.stderr
+++ b/tests/ui/suggestions/issue-103646.stderr
@@ -1,0 +1,21 @@
+error[E0599]: no method named `nya` found for type parameter `T` in the current scope
+  --> $DIR/issue-103646.rs:6:7
+   |
+LL | fn uwu<T: Cat>(c: T) {
+   |        - method `nya` not found for this type parameter
+LL |     c.nya();
+   |     --^^^--
+   |     | |
+   |     | this is an associated function, not a method
+   |     help: use associated function syntax instead: `T::nya()`
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: the candidate is defined in the trait `Cat`
+  --> $DIR/issue-103646.rs:2:5
+   |
+LL |     fn nya() {}
+   |     ^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/103646

`record_static_candidate` had been executed twice, resulting in the presence of two identical `CandidateSource::Trait(Cat)`  in static_candidates. This PR aims to deduplication the `static_candidates` list, allowing it to execute `suggest_associated_call_syntax` properly.