### PR TITLE
Clarify intended use case for From/TryFrom/Into/TryInto

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -22,6 +22,15 @@
 //! may be necessary to implement [`Into`] or [`TryInto`] directly when converting to a type
 //! outside the current crate.
 //!
+//! # When to implement these traits
+//!
+//! Generally, the conversion traits in this module are intended to convert between types that
+//! are semantically equivalent and differ only in representation.
+//! 
+//! For example, [`From`]/[`TryFrom`] implementations exist for string to string, list to list,
+//! number to number, or error to error conversions. However, implementing `From<i32>` for
+//! `String` or `TryFrom<&str>` for `i32` would not be appropriate.
+    
 //! # Generic Implementations
 //!
 //! - [`AsRef`] and [`AsMut`] auto-dereference if the inner type is a reference

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -26,7 +26,7 @@
 //!
 //! Generally, the conversion traits in this module are intended to convert between types that
 //! are semantically equivalent and differ only in representation.
-//! 
+//!
 //! For example, [`From`]/[`TryFrom`] implementations exist for string to string, list to list,
 //! number to number, or error to error conversions. However, implementing `From<i32>` for
 //! `String` or `TryFrom<&str>` for `i32` would not be appropriate.

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -30,7 +30,7 @@
 //! For example, [`From`]/[`TryFrom`] implementations exist for string to string, list to list,
 //! number to number, or error to error conversions. However, implementing `From<i32>` for
 //! `String` or `TryFrom<&str>` for `i32` would not be appropriate.
-    
+//!
 //! # Generic Implementations
 //!
 //! - [`AsRef`] and [`AsMut`] auto-dereference if the inner type is a reference


### PR DESCRIPTION
Many people seem to believe these traits should be implemented for transformations between any two types.

I decided to put the new text into std::convert itself instead of any particular trait because it applies to all four conversion traits.