### PR TITLE
[RFC-3086] Restrict the parsing of `count`

### DIFF
--- a/compiler/rustc_expand/src/mbe/metavar_expr.rs
+++ b/compiler/rustc_expand/src/mbe/metavar_expr.rs
@@ -93,7 +93,17 @@ fn parse_count<'sess>(
     span: Span,
 ) -> PResult<'sess, MetaVarExpr> {
     let ident = parse_ident(iter, sess, span)?;
-    let depth = if try_eat_comma(iter) { Some(parse_depth(iter, sess, span)?) } else { None };
+    let depth = if try_eat_comma(iter) {
+        if iter.look_ahead(0).is_none() {
+            return Err(sess.span_diagnostic.struct_span_err(
+                span,
+                "`count` followed by a comma must have an associated index indicating its depth",
+            ));
+        }
+        Some(parse_depth(iter, sess, span)?)
+    } else {
+        None
+    };
     Ok(MetaVarExpr::Count(ident, depth))
 }
 

--- a/tests/ui/macros/rfc-3086-metavar-expr/issue-111904.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/issue-111904.rs
@@ -1,0 +1,14 @@
+#![feature(macro_metavar_expr)]
+
+macro_rules! foo {
+    ( $( $($t:ident),* );* ) => { ${count(t,)} }
+    //~^ ERROR `count` followed by a comma must have an associated
+    //~| ERROR expected expression, found `$`
+}
+
+fn test() {
+    foo!(a, a; b, b);
+}
+
+fn main() {
+}

--- a/tests/ui/macros/rfc-3086-metavar-expr/issue-111904.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/issue-111904.stderr
@@ -1,0 +1,19 @@
+error: `count` followed by a comma must have an associated index indicating its depth
+  --> $DIR/issue-111904.rs:4:37
+   |
+LL |     ( $( $($t:ident),* );* ) => { ${count(t,)} }
+   |                                     ^^^^^
+
+error: expected expression, found `$`
+  --> $DIR/issue-111904.rs:4:35
+   |
+LL |     ( $( $($t:ident),* );* ) => { ${count(t,)} }
+   |                                   ^ expected expression
+...
+LL |     foo!(a, a; b, b);
+   |     ---------------- in this macro invocation
+   |
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fix #111904

The original RFC didn't mention the possibility of using `${count(t,)}` and such thing isn't very semantically accurate which can lead to confusion.