### PR TITLE
Add a feature to remove the static initializer on Linux/GNU

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -75,6 +75,10 @@ std_detect_file_io = ["std_detect/std_detect_file_io"]
 std_detect_dlsym_getauxval = ["std_detect/std_detect_dlsym_getauxval"]
 std_detect_env_override = ["std_detect/std_detect_env_override"]
 
+# Removes the static initializer on Linux with glibc. This will break
+# std::env::args in a cdylib as a result, causing it to always be empty.
+explicit-init-args-with-glibc = []
+
 [package.metadata.fortanix-sgx]
 # Maximum possible number of threads when testing
 threads = 125


### PR DESCRIPTION
The `explicit-init-args-with-glibc` feature will disable the static initializer that is used on Linux with glibc to initialize `std::env::args`. The result is that the args will be empty in a cdylib on this platform.

The feature is off by default, so there is no change to any Rust users unless they build stdlib themselves and turn the feature on explicitly.