### PR TITLE
[RFC-3086] Consider out-of-bound depths of `count`

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -80,6 +80,9 @@ expand_meta_var_dif_seq_matchers = {$msg}
 expand_meta_var_expr_unrecognized_var =
     variable `{$key}` is not recognized in meta-variable expression
 
+expand_missing_count_fragment =
+    related fragment that refers the `count` meta-variable expression was not found
+
 expand_module_circular =
     circular modules: {$modules}
 

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -408,3 +408,10 @@ pub struct DuplicateMatcherBinding {
     #[label(expand_label2)]
     pub prev: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(expand_missing_count_fragment)]
+pub(crate) struct MissingCountFragment {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_expand/src/mbe/metavar_expr.rs
+++ b/compiler/rustc_expand/src/mbe/metavar_expr.rs
@@ -11,7 +11,7 @@ use rustc_span::Span;
 #[derive(Debug, Clone, PartialEq, Encodable, Decodable)]
 pub(crate) enum MetaVarExpr {
     /// The number of repetitions of an identifier, optionally limited to a number
-    /// of outer-most repetition depths. If the depth limit is `None` then the depth is unlimited.
+    /// of outer-most repetition depths.
     Count(Ident, Option<usize>),
 
     /// Ignore a meta-variable for repetition without expansion.

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -1,7 +1,7 @@
 use crate::base::ExtCtxt;
 use crate::errors::{
-    CountRepetitionMisplaced, MetaVarExprUnrecognizedVar, MetaVarsDifSeqMatchers, MustRepeatOnce,
-    NoSyntaxVarsExprRepeat, VarStillRepeating,
+    CountRepetitionMisplaced, MetaVarExprUnrecognizedVar, MetaVarsDifSeqMatchers,
+    MissingCountFragment, MustRepeatOnce, NoSyntaxVarsExprRepeat, VarStillRepeating,
 };
 use crate::mbe::macro_parser::{MatchedNonterminal, MatchedSeq, MatchedTokenTree, NamedMatch};
 use crate::mbe::{self, MetaVarExpr};
@@ -447,6 +447,9 @@ fn count_repetitions<'a>(
                 }
             }
             MatchedSeq(named_matches) => {
+                if named_matches.is_empty() {
+                    return Err(cx.create_err(MissingCountFragment { span: sp.entire() }));
+                }
                 let new_declared_lhs_depth = declared_lhs_depth + 1;
                 match depth_opt {
                     None => named_matches
@@ -505,7 +508,7 @@ fn out_of_bounds_err<'a>(
         )
     } else {
         format!(
-            "depth parameter on meta-variable expression `{ty}` \
+            "depth parameter of meta-variable expression `{ty}` \
              must be less than {max}"
         )
     };

--- a/tests/ui/macros/rfc-3086-metavar-expr/issue-111905.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/issue-111905.rs
@@ -1,0 +1,19 @@
+#![feature(macro_metavar_expr)]
+
+macro_rules! foo {
+    ($($t:ident)*) => { ${count(t, 4294967296)} };
+    //~^ ERROR related fragment that refers the `count` meta-variable expression was not found
+}
+
+macro_rules! bar {
+    ( $( { $( [ $( ( $( $t:ident )* ) )* ] )* } )* ) => { ${count(t, 4294967296)} }
+    //~^ ERROR related fragment that refers the `count` meta-variable expression was not found
+}
+
+fn test() {
+    foo!();
+    bar!( { [] [] } );
+}
+
+fn main() {
+}

--- a/tests/ui/macros/rfc-3086-metavar-expr/issue-111905.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/issue-111905.stderr
@@ -1,0 +1,14 @@
+error: related fragment that refers the `count` meta-variable expression was not found
+  --> $DIR/issue-111905.rs:4:26
+   |
+LL |     ($($t:ident)*) => { ${count(t, 4294967296)} };
+   |                          ^^^^^^^^^^^^^^^^^^^^^^
+
+error: related fragment that refers the `count` meta-variable expression was not found
+  --> $DIR/issue-111905.rs:9:60
+   |
+LL |     ( $( { $( [ $( ( $( $t:ident )* ) )* ] )* } )* ) => { ${count(t, 4294967296)} }
+   |                                                            ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.rs
@@ -5,7 +5,7 @@ macro_rules! a {
         (
             ${count(foo, 0)},
             ${count(foo, 10)},
-            //~^ ERROR depth parameter on meta-variable expression `count` must be less than 4
+            //~^ ERROR depth parameter of meta-variable expression `count` must be less than 4
         )
     };
 }
@@ -17,7 +17,7 @@ macro_rules! b {
                 ${ignore(foo)}
                 ${index(0)},
                 ${index(10)},
-                //~^ ERROR depth parameter on meta-variable expression `index` must be less than 3
+                //~^ ERROR depth parameter of meta-variable expression `index` must be less than 3
             )* )* )*
         )
     };
@@ -30,7 +30,7 @@ macro_rules! c {
                 ${ignore(foo)}
                 ${length(0)}
                 ${length(10)}
-                //~^ ERROR depth parameter on meta-variable expression `length` must be less than 2
+                //~^ ERROR depth parameter of meta-variable expression `length` must be less than 2
             )* )*
         )
     };

--- a/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.stderr
@@ -1,16 +1,16 @@
-error: depth parameter on meta-variable expression `count` must be less than 4
+error: depth parameter of meta-variable expression `count` must be less than 4
   --> $DIR/out-of-bounds-arguments.rs:7:14
    |
 LL |             ${count(foo, 10)},
    |              ^^^^^^^^^^^^^^^^
 
-error: depth parameter on meta-variable expression `index` must be less than 3
+error: depth parameter of meta-variable expression `index` must be less than 3
   --> $DIR/out-of-bounds-arguments.rs:19:18
    |
 LL |                 ${index(10)},
    |                  ^^^^^^^^^^^
 
-error: depth parameter on meta-variable expression `length` must be less than 2
+error: depth parameter of meta-variable expression `length` must be less than 2
   --> $DIR/out-of-bounds-arguments.rs:32:18
    |
 LL |                 ${length(10)}


### PR DESCRIPTION
Fix #111905

In the matching of macro calls and their respective declarations (transcribe), a warning is issued if `count` has a depth greater than the number of nested `NamedMatch`s through be verification of `MatchedSeq` with empty elements.

Doesn't affect `( $( { $( [ $( ( $( $t:ident )* ) )* ] )* } )* ) => { ${count(t, 1)} }` called with `bar!( { [] [] } )` which will still continue to output `2`.