### PR TITLE
Don't print newlines in APITs

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1425,7 +1425,16 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             DefPathData::ImplTrait,
                             span,
                         );
-                        let ident = Ident::from_str_and_span(&pprust::ty_to_string(t), span);
+
+                        // HACK: pprust breaks strings with newlines when the type
+                        // gets too long. We don't want these to show up in compiler
+                        // output or built artifacts, so replace them here...
+                        // Perhaps we should instead format APITs more robustly.
+                        let ident = Ident::from_str_and_span(
+                            &pprust::ty_to_string(t).replace('\n', " "),
+                            span,
+                        );
+
                         let (param, bounds, path) = self.lower_universal_param_and_bounds(
                             *def_node_id,
                             span,

--- a/tests/ui/impl-trait/arg-position-impl-trait-too-long.rs
+++ b/tests/ui/impl-trait/arg-position-impl-trait-too-long.rs
@@ -1,0 +1,22 @@
+struct Header;
+struct EntryMetadata;
+struct Entry<A, B>(A, B);
+
+trait Tr {
+    type EncodedKey;
+    type EncodedValue;
+}
+
+fn test<C: Tr, R>(
+    // This APIT is long, however we shouldn't render the type name with a newline in it.
+    y: impl FnOnce(
+        &mut Header,
+        &mut [EntryMetadata],
+        &mut [Entry<C::EncodedKey, C::EncodedValue>]
+    ) -> R,
+) {
+    let () = y;
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/arg-position-impl-trait-too-long.stderr
+++ b/tests/ui/impl-trait/arg-position-impl-trait-too-long.stderr
@@ -1,0 +1,22 @@
+error[E0308]: mismatched types
+  --> $DIR/arg-position-impl-trait-too-long.rs:18:9
+   |
+LL |       y: impl FnOnce(
+   |  ________-
+LL | |         &mut Header,
+LL | |         &mut [EntryMetadata],
+LL | |         &mut [Entry<C::EncodedKey, C::EncodedValue>]
+LL | |     ) -> R,
+   | |__________- this type parameter
+LL |   ) {
+LL |       let () = y;
+   |           ^^   - this expression has type `impl FnOnce(&mut Header, &mut [EntryMetadata], &mut [Entry<C::EncodedKey, C::EncodedValue>]) -> R`
+   |           |
+   |           expected type parameter `impl FnOnce(&mut Header, &mut [EntryMetadata], &mut [Entry<C::EncodedKey, C::EncodedValue>]) -> R`, found `()`
+   |
+   = note: expected type parameter `impl FnOnce(&mut Header, &mut [EntryMetadata], &mut [Entry<C::EncodedKey, C::EncodedValue>]) -> R`
+                   found unit type `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This is kind of a hack, but it gets the job done because the only "special" formatting that (afaict) `rustc_ast_pretty` does is break with newlines sometimes.

Fixes rust-lang/measureme#207