### PR TITLE
[RFC-3086] Add a new `concat` metavar expr

### DIFF
--- a/tests/ui/macros/rfc-3086-metavar-expr/concat.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/concat.rs
@@ -1,0 +1,39 @@
+// run-pass
+
+#![allow(dead_code, non_camel_case_types)]
+#![feature(macro_metavar_expr)]
+
+macro_rules! simple_ident {
+    ( $lhs:ident, $rhs:ident ) => { ${concat(lhs, rhs)} };
+}
+
+macro_rules! create_things {
+    ( $lhs:ident ) => {
+        struct ${concat(lhs, _separated_idents_in_a_struct)} {
+            foo: i32,
+            ${concat(lhs, _separated_idents_in_a_field)}: i32,
+        }
+
+        mod ${concat(lhs, _separated_idents_in_a_module)} {
+            pub const FOO: () = ();
+        }
+
+        fn ${concat(lhs, _separated_idents_in_a_fn)}() {}
+    };
+}
+
+create_things!(look_ma);
+
+fn main() {
+    let abcdef = 1;
+    let _another = simple_ident!(abc, def);
+
+    look_ma_separated_idents_in_a_fn();
+
+    let _ = look_ma_separated_idents_in_a_module::FOO;
+
+    let _ = look_ma_separated_idents_in_a_struct {
+        foo: 1,
+        look_ma_separated_idents_in_a_field: 2,
+    };
+}


### PR DESCRIPTION
While investigating the blockers for the stabilization of #83527, I figured it would probably be nice to have a way to concatenate identifiers as well as literals without having to use third-parties or `concat_idents!`.

```rust
macro_rules! create_things {
    ( $lhs:ident ) => {
        struct ${concat(lhs, _separated_idents_in_a_struct)} {
            foo: i32,
            ${concat(lhs, _separated_idents_in_a_field)}: i32,
        }

        mod ${concat(lhs, _separated_idents_in_a_module)} {
            pub const FOO: () = ();
        }

        fn ${concat(lhs, _separated_idents_in_a_fn)}() {}
    };
}

create_things!(look_ma);

fn main() {
    look_ma_separated_idents_in_a_fn();

    let _ = look_ma_separated_idents_in_a_module::FOO;

    let _ = look_ma_separated_idents_in_a_struct {
        foo: 1,
        look_ma_separated_idents_in_a_field: 2,
    };
}
```

The intention here is to allow further experimentation of a nightly feature to gather more feedback. If such thing is not desired, needs a RFC or anything else, feel free to close this PR.

Implementation-wise, there are some things that still need to be tweaked.

* https://internals.rust-lang.org/t/macro-meta-functions/16743?u=cad97
* https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/macros.20in.20ident.20position
* https://github.com/rust-lang/rust/issues/29599
* https://github.com/rust-lang/rust/issues/13294
* https://github.com/rust-lang/rust/issues/50408