### PR TITLE
Include test suite metadata in the build metrics

### DIFF
--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -16,9 +16,21 @@ use sysinfo::{CpuExt, System, SystemExt};
 
 // Update this number whenever a breaking change is made to the build metrics.
 //
-// Versions:
-// 0: initial version
-// 1: replaced JsonNode::Test with JsonNode::TestSuite
+// The output format is versioned for two reasons:
+//
+// - The metadata is intended to be consumed by external tooling, and exposing a format version
+//   helps the tools determine whether they're compatible with a metrics file.
+//
+// - If a developer enables build metrics in their local checkout, making a breaking change to the
+//   metrics format would result in a hard-to-diagnose error message when an existing metrics file
+//   is not compatible with the new changes. With a format version number, bootstrap can discard
+//   incompatible metrics files instead of appending metrics to them.
+//
+// Version changelog:
+//
+// - v0: initial version
+// - v1: replaced JsonNode::Test with JsonNode::TestSuite
+//
 const CURRENT_FORMAT_VERSION: usize = 1;
 
 pub(crate) struct BuildMetrics {

--- a/src/bootstrap/metrics.rs
+++ b/src/bootstrap/metrics.rs
@@ -114,9 +114,7 @@ impl BuildMetrics {
         if let Some(test_suite) = step.test_suites.last_mut() {
             test_suite.tests.push(Test { name: name.to_string(), outcome });
         } else {
-            panic!(
-                "metrics.record_test() called without calling metrics.record_test_suite() first"
-            );
+            panic!("metrics.record_test() called without calling metrics.begin_test_suite() first");
         }
     }
 
@@ -194,7 +192,7 @@ impl BuildMetrics {
     fn prepare_json_step(&self, step: StepMetrics) -> JsonNode {
         let mut children = Vec::new();
         children.extend(step.children.into_iter().map(|child| self.prepare_json_step(child)));
-        children.extend(step.test_suites.into_iter().map(|suite| JsonNode::TestSuite(suite)));
+        children.extend(step.test_suites.into_iter().map(JsonNode::TestSuite));
 
         JsonNode::RustbuildStep {
             type_: step.type_,
@@ -277,7 +275,7 @@ struct TestSuite {
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub(crate) enum TestSuiteMetadata {
-    Crate {
+    CargoPackage {
         crates: Vec<String>,
         target: String,
         host: String,

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -317,6 +317,17 @@ impl Step for Cargo {
         cargo.env("CARGO_TEST_DISABLE_NIGHTLY", "1");
         cargo.env("PATH", &path_for_cargo(builder, compiler));
 
+        #[cfg(feature = "build-metrics")]
+        builder.metrics.begin_test_suite(
+            crate::metrics::TestSuiteMetadata::Crate {
+                crates: vec!["cargo".into()],
+                target: self.host.triple.to_string(),
+                host: self.host.triple.to_string(),
+                stage: self.stage,
+            },
+            builder,
+        );
+
         let _time = util::timeit(&builder);
         add_flags_and_try_run_tests(builder, &mut cargo);
     }
@@ -1759,6 +1770,19 @@ note: if you're sure you want to do this, please open an issue as to why. In the
 
         builder.ci_env.force_coloring_in_ci(&mut cmd);
 
+        #[cfg(feature = "build-metrics")]
+        builder.metrics.begin_test_suite(
+            crate::metrics::TestSuiteMetadata::Compiletest {
+                suite: suite.into(),
+                mode: mode.into(),
+                compare_mode: None,
+                target: self.target.triple.to_string(),
+                host: self.compiler.host.triple.to_string(),
+                stage: self.compiler.stage,
+            },
+            builder,
+        );
+
         builder.info(&format!(
             "Check compiletest suite={} mode={} ({} -> {})",
             suite, mode, &compiler.host, target
@@ -1768,6 +1792,20 @@ note: if you're sure you want to do this, please open an issue as to why. In the
 
         if let Some(compare_mode) = compare_mode {
             cmd.arg("--compare-mode").arg(compare_mode);
+
+            #[cfg(feature = "build-metrics")]
+            builder.metrics.begin_test_suite(
+                crate::metrics::TestSuiteMetadata::Compiletest {
+                    suite: suite.into(),
+                    mode: mode.into(),
+                    compare_mode: Some(compare_mode.into()),
+                    target: self.target.triple.to_string(),
+                    host: self.compiler.host.triple.to_string(),
+                    stage: self.compiler.stage,
+                },
+                builder,
+            );
+
             builder.info(&format!(
                 "Check compiletest suite={} mode={} compare_mode={} ({} -> {})",
                 suite, mode, compare_mode, &compiler.host, target
@@ -2094,6 +2132,17 @@ fn run_cargo_test(
     let mut cargo =
         prepare_cargo_test(cargo, libtest_args, crates, primary_crate, compiler, target, builder);
     let _time = util::timeit(&builder);
+
+    #[cfg(feature = "build-metrics")]
+    builder.metrics.begin_test_suite(
+        crate::metrics::TestSuiteMetadata::Crate {
+            crates: crates.iter().map(|c| c.to_string()).collect(),
+            target: target.triple.to_string(),
+            host: compiler.host.triple.to_string(),
+            stage: compiler.stage,
+        },
+        builder,
+    );
     add_flags_and_try_run_tests(builder, &mut cargo)
 }
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -319,7 +319,7 @@ impl Step for Cargo {
 
         #[cfg(feature = "build-metrics")]
         builder.metrics.begin_test_suite(
-            crate::metrics::TestSuiteMetadata::Crate {
+            crate::metrics::TestSuiteMetadata::CargoPackage {
                 crates: vec!["cargo".into()],
                 target: self.host.triple.to_string(),
                 host: self.host.triple.to_string(),
@@ -2135,7 +2135,7 @@ fn run_cargo_test(
 
     #[cfg(feature = "build-metrics")]
     builder.metrics.begin_test_suite(
-        crate::metrics::TestSuiteMetadata::Crate {
+        crate::metrics::TestSuiteMetadata::CargoPackage {
             crates: crates.iter().map(|c| c.to_string()).collect(),
             target: target.triple.to_string(),
             host: compiler.host.triple.to_string(),


### PR DESCRIPTION
This PR enhances the build metadata to include structured information about the test suites being executed, allowing external tools consuming the metadata to understand what was being tested.

The included metadata is:

* Target triple
* Host triple
* Stage number
* For compiletest tests:
  * Suite name
  * Mode
  * Comparing mode
* For crate tests:
  * List of crate names

This is implemented by replacing the `test` JSON node with a new `test_suite` node, which contains the metadata and the list of tests. This change also improves the handling of multiple test suites executed in the same step (for example in compiletest tests with a compare mode), as the multiple test suite executions will now be tracked in separate `test_suite` nodes.

This included a breaking change in the build metrics metadata format. To better handle this, in the second commit this PR introduces the `metadata_version` top-level field. The old version is considered to be `0`, while the new one `1`. Bootstrap will also gracefully handle existing metadata of a different version.

r? @jyn514 