### PR TITLE
improve error message for calling a method on a raw pointer with an unknown pointee

### DIFF
--- a/compiler/rustc_hir_typeck/messages.ftl
+++ b/compiler/rustc_hir_typeck/messages.ftl
@@ -59,8 +59,8 @@ hir_typeck_lang_start_incorrect_param = parameter {$param_num} of the `start` la
 hir_typeck_lang_start_incorrect_ret_ty = the return type of the `start` lang item is incorrect
     .suggestion = change the type from `{$found_ty}` to `{$expected_ty}`
 
-hir_typeck_method_call_on_unknown_type =
-    the type of this value must be known to call a method on a raw pointer on it
+hir_typeck_method_call_on_unknown_raw_pointee =
+    cannot call a method on a raw pointer with an unknown pointee type
 
 hir_typeck_missing_parentheses_in_range = can't call method `{$method_name}` on type `{$ty_str}`
 

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -49,8 +49,8 @@ pub struct StructExprNonExhaustive {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_typeck_method_call_on_unknown_type, code = "E0699")]
-pub struct MethodCallOnUnknownType {
+#[diag(hir_typeck_method_call_on_unknown_raw_pointee, code = "E0699")]
+pub struct MethodCallOnUnknownRawPointee {
     #[primary_span]
     pub span: Span,
 }

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -3,7 +3,7 @@ use super::CandidateSource;
 use super::MethodError;
 use super::NoMatchData;
 
-use crate::errors::MethodCallOnUnknownType;
+use crate::errors::MethodCallOnUnknownRawPointee;
 use crate::FnCtxt;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
@@ -438,7 +438,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // so we do a future-compat lint here for the 2015 edition
                 // (see https://github.com/rust-lang/rust/issues/46906)
                 if self.tcx.sess.rust_2018() {
-                    self.tcx.sess.emit_err(MethodCallOnUnknownType { span });
+                    self.tcx.sess.emit_err(MethodCallOnUnknownRawPointee { span });
                 } else {
                     self.tcx.struct_span_lint_hir(
                         lint::builtin::TYVAR_BEHIND_RAW_POINTER,

--- a/tests/ui/editions/edition-raw-pointer-method-2018.rs
+++ b/tests/ui/editions/edition-raw-pointer-method-2018.rs
@@ -7,5 +7,5 @@ fn main() {
     let x = 0;
     let y = &x as *const _;
     let _ = y.is_null();
-    //~^ error: the type of this value must be known to call a method on a raw pointer on it [E0699]
+    //~^ error: cannot call a method on a raw pointer with an unknown pointee type [E0699]
 }

--- a/tests/ui/editions/edition-raw-pointer-method-2018.stderr
+++ b/tests/ui/editions/edition-raw-pointer-method-2018.stderr
@@ -1,4 +1,4 @@
-error[E0699]: the type of this value must be known to call a method on a raw pointer on it
+error[E0699]: cannot call a method on a raw pointer with an unknown pointee type
   --> $DIR/edition-raw-pointer-method-2018.rs:9:15
    |
 LL |     let _ = y.is_null();

--- a/tests/ui/methods/call_method_unknown_pointee.rs
+++ b/tests/ui/methods/call_method_unknown_pointee.rs
@@ -1,0 +1,28 @@
+// edition: 2018
+
+// tests that the pointee type of a raw pointer must be known to call methods on it
+// see also: `tests/ui/editions/edition-raw-pointer-method-2018.rs`
+
+fn main() {
+    let val = 1_u32;
+    let ptr = &val as *const u32;
+    unsafe {
+        let _a: i32 = (ptr as *const _).read();
+        //~^ ERROR cannot call a method on a raw pointer with an unknown pointee type [E0699]
+        let b = ptr as *const _;
+        let _b: u8 = b.read();
+        //~^ ERROR cannot call a method on a raw pointer with an unknown pointee type [E0699]
+        let _c = (ptr as *const u8).read(); // we know the type here
+    }
+
+    let mut val = 2_u32;
+    let ptr = &mut val as *mut u32;
+    unsafe {
+        let _a: i32 = (ptr as *mut _).read();
+        //~^ ERROR cannot call a method on a raw pointer with an unknown pointee type [E0699]
+        let b = ptr as *mut _;
+        b.write(10);
+        //~^ ERROR cannot call a method on a raw pointer with an unknown pointee type [E0699]
+        (ptr as *mut i32).write(1000); // we know the type here
+    }
+}

--- a/tests/ui/methods/call_method_unknown_pointee.stderr
+++ b/tests/ui/methods/call_method_unknown_pointee.stderr
@@ -1,0 +1,27 @@
+error[E0699]: cannot call a method on a raw pointer with an unknown pointee type
+  --> $DIR/call_method_unknown_pointee.rs:10:41
+   |
+LL |         let _a: i32 = (ptr as *const _).read();
+   |                                         ^^^^
+
+error[E0699]: cannot call a method on a raw pointer with an unknown pointee type
+  --> $DIR/call_method_unknown_pointee.rs:13:24
+   |
+LL |         let _b: u8 = b.read();
+   |                        ^^^^
+
+error[E0699]: cannot call a method on a raw pointer with an unknown pointee type
+  --> $DIR/call_method_unknown_pointee.rs:21:39
+   |
+LL |         let _a: i32 = (ptr as *mut _).read();
+   |                                       ^^^^
+
+error[E0699]: cannot call a method on a raw pointer with an unknown pointee type
+  --> $DIR/call_method_unknown_pointee.rs:24:11
+   |
+LL |         b.write(10);
+   |           ^^^^^
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0699`.


### PR DESCRIPTION
The old error message had very confusing wording.
Also added some more test cases besides the single edition test.

r? @compiler-errors 