### PR TITLE
Make GDB Python Pretty Printers loadable after spawning GDB, avoiding required `rust-gdb`

### DIFF
--- a/src/etc/gdb_load_rust_pretty_printers.py
+++ b/src/etc/gdb_load_rust_pretty_printers.py
@@ -1,3 +1,14 @@
+# Add this folder to the python sys path; GDB Python-interpreter will now find modules in this path
+import sys
+from os import path
+self_dir = path.dirname(path.realpath(__file__))
+sys.path.append(self_dir)
+
 import gdb
 import gdb_lookup
-gdb_lookup.register_printers(gdb.current_objfile())
+
+# current_objfile can be none; even with `gdb foo-app`; sourcing this file after gdb init now works
+try:
+    gdb_lookup.register_printers(gdb.current_objfile())
+except Exception:
+    gdb_lookup.register_printers(gdb.selected_inferior().progspace)


### PR DESCRIPTION
Fixes #111961

Makes the Python pretty printer library source'able from within GDB after spawn, making the wrapper script `rust-gdb` become not the required approach to use the pretty printer library.

Allows for integration into GUI:s that wrap GDB extremely easy. The previous design complicates this feature.