### PR TITLE
Check that negative impls are always applicable

### DIFF
--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -23,15 +23,11 @@ pub trait AstDeref {
     fn ast_deref_mut(&mut self) -> &mut Self::Target;
 }
 
-macro_rules! impl_not_ast_deref {
-    ($($T:ty),+ $(,)?) => {
-        $(
-            impl !AstDeref for $T {}
-        )+
-    };
-}
-
-impl_not_ast_deref!(AssocItem, Expr, ForeignItem, Item, Stmt);
+impl !AstDeref for AssocItem {}
+impl !AstDeref for Expr {}
+impl !AstDeref for ForeignItem {}
+impl !AstDeref for Item {}
+impl !AstDeref for Stmt {}
 
 impl<T> AstDeref for P<T> {
     type Target = T;

--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -23,10 +23,10 @@ pub trait AstDeref {
     fn ast_deref_mut(&mut self) -> &mut Self::Target;
 }
 
-impl !AstDeref for AssocItem {}
 impl !AstDeref for Expr {}
-impl !AstDeref for ForeignItem {}
-impl !AstDeref for Item {}
+impl<K> !AstDeref for Item<K> {}
+// AssocItem = Item<AssocItemKind> so it's already !AstDeref above.
+// ForeignItem = Item<ForeignItemKind> so it's already !AstDeref above.
 impl !AstDeref for Stmt {}
 
 impl<T> AstDeref for P<T> {

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -612,7 +612,7 @@ where
 // It is not safe to implement HashStable for HashSet or any other collection type
 // with unstable but observable iteration order.
 // See https://github.com/rust-lang/compiler-team/issues/533 for further information.
-impl<V, HCX> !HashStable<HCX> for std::collections::HashSet<V> {}
+impl<K, V, HCX: ?Sized> !HashStable<HCX> for std::collections::HashSet<K, V> {}
 
 impl<K, V, HCX> HashStable<HCX> for ::std::collections::BTreeMap<K, V>
 where

--- a/compiler/rustc_hir_analysis/src/check/always_applicable.rs
+++ b/compiler/rustc_hir_analysis/src/check/always_applicable.rs
@@ -1,0 +1,195 @@
+use rustc_data_structures::fx::FxHashSet;
+use rustc_errors::{struct_span_err, ErrorGuaranteed};
+use rustc_infer::infer::outlives::env::OutlivesEnvironment;
+use rustc_infer::infer::{RegionResolutionError, TyCtxtInferExt};
+use rustc_middle::ty::subst::SubstsRef;
+use rustc_middle::ty::util::CheckRegions;
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_trait_selection::traits::{self, ObligationCtxt};
+
+use crate::hir::def_id::DefId;
+
+/// This function confirms that the trait implementation identified by
+/// `trait_impl_def_id` is not any more specialized than the type it is
+/// attached to (Issue #8142).
+///
+/// This means:
+///
+/// 1. The generic region/type parameters of the impl's self type must
+///    all be parameters of the Trait impl itself (i.e., no
+///    specialization like `impl Trait for Foo<i32>`), and,
+///
+/// 2. Any bounds on the generic parameters must be reflected in the
+///    struct/enum definition for the nominal type itself (i.e.
+///    cannot do `struct S<T>; impl<T:Clone> Trait for S<T> { ... }`).
+///
+pub fn check_trait_impl(tcx: TyCtxt<'_>, trait_impl_def_id: DefId) -> Result<(), ErrorGuaranteed> {
+    let self_type = tcx.type_of(trait_impl_def_id).subst_identity();
+    check_trait_impl_given_ty(tcx, trait_impl_def_id, self_type)
+}
+
+fn check_trait_impl_given_ty<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    trait_impl_def_id: DefId,
+    ty: Ty<'tcx>,
+) -> Result<(), ErrorGuaranteed> {
+    match ty.kind() {
+        ty::Adt(adt_def, adt_to_impl_substs) => {
+            ensure_trait_params_and_item_params_correspond(
+                tcx,
+                trait_impl_def_id,
+                adt_def.did(),
+                adt_to_impl_substs,
+            )?;
+
+            ensure_trait_predicates_are_implied_by_item_defn(
+                tcx,
+                trait_impl_def_id,
+                adt_def.did(),
+                adt_to_impl_substs,
+            )
+        }
+
+        ty::Ref(_, ty, _) | ty::Array(ty, _) | ty::Slice(ty) => {
+            check_trait_impl_given_ty(tcx, trait_impl_def_id, *ty)
+        }
+
+        ty::Tuple(tys) => {
+            for ty in tys.iter() {
+                check_trait_impl_given_ty(tcx, trait_impl_def_id, ty)?
+            }
+
+            Ok(())
+        }
+
+        _ => Ok(()),
+    }
+}
+
+fn ensure_trait_params_and_item_params_correspond<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    trait_impl_def_id: DefId,
+    self_type_did: DefId,
+    adt_to_impl_substs: SubstsRef<'tcx>,
+) -> Result<(), ErrorGuaranteed> {
+    let Err(arg) = tcx.uses_unique_generic_params(adt_to_impl_substs, CheckRegions::OnlyEarlyBound) else {
+        return Ok(())
+    };
+
+    let trait_impl_span = tcx.def_span(trait_impl_def_id);
+    let item_span = tcx.def_span(self_type_did);
+    let self_descr = tcx.def_descr(self_type_did);
+    let mut err =
+        struct_span_err!(tcx.sess, trait_impl_span, E0366, "negative impls cannot be specialized");
+    match arg {
+        ty::util::NotUniqueParam::DuplicateParam(arg) => {
+            err.note(format!("`{arg}` is mentioned multiple times"))
+        }
+        ty::util::NotUniqueParam::NotParam(arg) => {
+            err.note(format!("`{arg}` is not a generic parameter"))
+        }
+    };
+    err.span_note(
+        item_span,
+        format!(
+            "use the same sequence of generic lifetime, type and const parameters \
+                     as the {self_descr} definition",
+        ),
+    );
+    Err(err.emit())
+}
+
+/// Confirms that every predicate imposed by predicates is
+/// implied by assuming the predicates attached to self_type_did.
+fn ensure_trait_predicates_are_implied_by_item_defn<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    trait_impl_def_id: DefId,
+    adt_def_id: DefId,
+    adt_to_impl_substs: SubstsRef<'tcx>,
+) -> Result<(), ErrorGuaranteed> {
+    let infcx = tcx.infer_ctxt().build();
+    let ocx = ObligationCtxt::new(&infcx);
+
+    // Take the param-env of the adt and substitute the substs that show up in
+    // the implementation's self type. This gives us the assumptions that the
+    // self ty of the implementation is allowed to know just from it being a
+    // well-formed adt, since that's all we're allowed to assume while proving
+    // the Drop implementation is not specialized.
+    //
+    // We don't need to normalize this param-env or anything, since we're only
+    // substituting it with free params, so no additional param-env normalization
+    // can occur on top of what has been done in the param_env query itself.
+    let param_env = ty::EarlyBinder::bind(tcx.param_env(adt_def_id))
+        .subst(tcx, adt_to_impl_substs)
+        .with_constness(tcx.constness(trait_impl_def_id));
+
+    for (pred, span) in tcx.predicates_of(trait_impl_def_id).instantiate_identity(tcx) {
+        let cause = traits::ObligationCause::dummy_with_span(span);
+        let pred = ocx.normalize(&cause, param_env, pred);
+        ocx.register_obligation(traits::Obligation::new(tcx, cause, param_env, pred));
+    }
+
+    // All of the custom error reporting logic is to preserve parity with the old
+    // error messages.
+    //
+    // They can probably get removed with better treatment of the new `DropImpl`
+    // obligation cause code, and perhaps some custom logic in `report_region_errors`.
+
+    let errors = ocx.select_all_or_error();
+    if !errors.is_empty() {
+        let mut guar = None;
+        let mut root_predicates = FxHashSet::default();
+        for error in errors {
+            let root_predicate = error.root_obligation.predicate;
+            if root_predicates.insert(root_predicate) {
+                let item_span = tcx.def_span(adt_def_id);
+                let self_descr = tcx.def_descr(adt_def_id);
+                guar = Some(
+                    struct_span_err!(
+                        tcx.sess,
+                        error.root_obligation.cause.span,
+                        E0367,
+                        "negative impl requires `{root_predicate}` \
+                        but the {self_descr} it is implemented for does not",
+                    )
+                    .span_note(item_span, "the implementor must specify the same requirement")
+                    .emit(),
+                );
+            }
+        }
+        return Err(guar.unwrap());
+    }
+
+    let errors = ocx.infcx.resolve_regions(&OutlivesEnvironment::new(param_env));
+    if !errors.is_empty() {
+        let mut guar = None;
+        for error in errors {
+            let item_span = tcx.def_span(adt_def_id);
+            let self_descr = tcx.def_descr(adt_def_id);
+            let outlives = match error {
+                RegionResolutionError::ConcreteFailure(_, a, b) => format!("{b}: {a}"),
+                RegionResolutionError::GenericBoundFailure(_, generic, r) => {
+                    format!("{generic}: {r}")
+                }
+                RegionResolutionError::SubSupConflict(_, _, _, a, _, b, _) => format!("{b}: {a}"),
+                RegionResolutionError::UpperBoundUniverseConflict(a, _, _, _, b) => {
+                    format!("{b}: {a}", a = ty::Region::new_var(tcx, a))
+                }
+            };
+            guar = Some(
+                struct_span_err!(
+                    tcx.sess,
+                    error.origin().span(),
+                    E0367,
+                    "negative impl requires `{outlives}` \
+                    but the {self_descr} it is implemented for does not",
+                )
+                .span_note(item_span, "the implementor must specify the same requirement")
+                .emit(),
+            );
+        }
+        return Err(guar.unwrap());
+    }
+
+    Ok(())
+}

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -62,6 +62,7 @@ a type parameter).
 
 */
 
+pub mod always_applicable;
 mod check;
 mod compare_impl_item;
 pub mod dropck;

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1,3 +1,4 @@
+use super::always_applicable;
 use crate::autoderef::Autoderef;
 use crate::constrained_generic_params::{identify_constrained_generic_params, Parameter};
 
@@ -177,6 +178,10 @@ fn check_item<'tcx>(tcx: TyCtxt<'tcx>, item: &'tcx hir::Item<'tcx>) {
         // won't be allowed unless there's an *explicit* implementation of `Send`
         // for `T`
         hir::ItemKind::Impl(impl_) => {
+            if matches!(impl_.polarity, ast::ImplPolarity::Negative(_)) && impl_.of_trait.is_some()
+            {
+                let _ = always_applicable::check_trait_impl(tcx, def_id.to_def_id());
+            }
             let is_auto = tcx
                 .impl_trait_ref(def_id)
                 .is_some_and(|trait_ref| tcx.trait_is_auto(trait_ref.skip_binder().def_id));

--- a/tests/ui/auto-traits/suspicious-negative-impls-lint.rs
+++ b/tests/ui/auto-traits/suspicious-negative-impls-lint.rs
@@ -7,15 +7,18 @@ struct ContainsVec<T>(Vec<T>);
 impl !Send for ContainsVec<u32> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
+//~| ERROR negative impls cannot be specialized [E0366]
 
 pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
 impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
+//~| ERROR negative impls cannot be specialized [E0366]
 
 pub struct WithLifetime<'a, T>(&'a (), T);
 impl<T> !Sync for WithLifetime<'static, Option<T>> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
+//~| ERROR negative impls cannot be specialized [E0366]
 
 fn main() {}

--- a/tests/ui/auto-traits/suspicious-negative-impls-lint.stderr
+++ b/tests/ui/auto-traits/suspicious-negative-impls-lint.stderr
@@ -19,7 +19,7 @@ LL | #![deny(suspicious_auto_trait_impls)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/suspicious-negative-impls-lint.rs:12:1
+  --> $DIR/suspicious-negative-impls-lint.rs:13:1
    |
 LL | impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,13 +28,13 @@ LL | impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `*const T` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-negative-impls-lint.rs:11:1
+  --> $DIR/suspicious-negative-impls-lint.rs:12:1
    |
 LL | pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cross-crate traits with a default impl, like `Sync`, should not be specialized
-  --> $DIR/suspicious-negative-impls-lint.rs:17:1
+  --> $DIR/suspicious-negative-impls-lint.rs:19:1
    |
 LL | impl<T> !Sync for WithLifetime<'static, Option<T>> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,10 +43,50 @@ LL | impl<T> !Sync for WithLifetime<'static, Option<T>> {}
    = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
    = note: `Option<T>` is not a generic parameter
 note: try using the same sequence of generic parameters as the struct definition
-  --> $DIR/suspicious-negative-impls-lint.rs:16:1
+  --> $DIR/suspicious-negative-impls-lint.rs:18:1
    |
 LL | pub struct WithLifetime<'a, T>(&'a (), T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0366]: negative impls cannot be specialized
+  --> $DIR/suspicious-negative-impls-lint.rs:7:1
+   |
+LL | impl !Send for ContainsVec<u32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `u32` is not a generic parameter
+note: use the same sequence of generic lifetime, type and const parameters as the struct definition
+  --> $DIR/suspicious-negative-impls-lint.rs:6:1
+   |
+LL | struct ContainsVec<T>(Vec<T>);
+   | ^^^^^^^^^^^^^^^^^^^^^
 
+error[E0366]: negative impls cannot be specialized
+  --> $DIR/suspicious-negative-impls-lint.rs:13:1
+   |
+LL | impl<T> !Send for WithPhantomDataSend<*const T, u8> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `*const T` is not a generic parameter
+note: use the same sequence of generic lifetime, type and const parameters as the struct definition
+  --> $DIR/suspicious-negative-impls-lint.rs:12:1
+   |
+LL | pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0366]: negative impls cannot be specialized
+  --> $DIR/suspicious-negative-impls-lint.rs:19:1
+   |
+LL | impl<T> !Sync for WithLifetime<'static, Option<T>> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `'static` is not a generic parameter
+note: use the same sequence of generic lifetime, type and const parameters as the struct definition
+  --> $DIR/suspicious-negative-impls-lint.rs:18:1
+   |
+LL | pub struct WithLifetime<'a, T>(&'a (), T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0366`.

--- a/tests/ui/coherence/coherence-overlap-negative-impls.rs
+++ b/tests/ui/coherence/coherence-overlap-negative-impls.rs
@@ -1,4 +1,3 @@
-// check-pass
 // known-bug: #74629
 
 // Should fail. The `0` and `1` impls overlap, violating coherence. Eg, with
@@ -15,16 +14,20 @@ struct Test;
 
 trait Fold<F> {}
 
-impl<T, F> Fold<F> for Cons<T> // 0
+impl<T, F> Fold<F> for Cons<T>
+// 0
 where
     T: Fold<Nil>,
-{}
+{
+}
 
-impl<T, F> Fold<F> for Cons<T> // 1
+impl<T, F> Fold<F> for Cons<T>
+// 1
 where
     T: Fold<F>,
     private::Is<T>: private::NotNil,
-{}
+{
+}
 
 impl<F> Fold<F> for Test {} // 2
 

--- a/tests/ui/coherence/coherence-overlap-negative-impls.stderr
+++ b/tests/ui/coherence/coherence-overlap-negative-impls.stderr
@@ -1,0 +1,16 @@
+error[E0366]: negative impls cannot be specialized
+  --> $DIR/coherence-overlap-negative-impls.rs:41:5
+   |
+LL |     impl !NotNil for Is<Nil> {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Nil` is not a generic parameter
+note: use the same sequence of generic lifetime, type and const parameters as the struct definition
+  --> $DIR/coherence-overlap-negative-impls.rs:37:5
+   |
+LL |     pub struct Is<T>(T);
+   |     ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0366`.

--- a/tests/ui/specialization/defaultimpl/validation.rs
+++ b/tests/ui/specialization/defaultimpl/validation.rs
@@ -1,16 +1,24 @@
 #![feature(negative_impls)]
-#![feature(specialization)] //~ WARN the feature `specialization` is incomplete
+#![feature(specialization)]
+//~^ WARN the feature `specialization` is incomplete
 
 struct S;
 struct Z;
 
-default impl S {} //~ ERROR inherent impls cannot be `default`
+default impl S {}
+//~^ ERROR inherent impls cannot be `default`
 
-default unsafe impl Send for S {} //~ ERROR impls of auto traits cannot be default
-default impl !Send for Z {} //~ ERROR impls of auto traits cannot be default
-                            //~^ ERROR negative impls cannot be default impls
+default unsafe impl Send for S {}
+//~^ ERROR impls of auto traits cannot be default
+
+default impl !Send for Z {}
+//~^ ERROR impls of auto traits cannot be default
+//~| ERROR negative impl requires `Z: Send` but the struct it is implemented for does not [E0367]
+//~| ERROR negative impls cannot be default impls [E0750]
 
 trait Tr {}
-default impl !Tr for S {} //~ ERROR negative impls cannot be default impls
+default impl !Tr for S {}
+//~^ ERROR negative impls cannot be default impls
+//~| ERROR negative impl requires `S: Tr` but the struct it is implemented for does not [E0367]
 
 fn main() {}

--- a/tests/ui/specialization/defaultimpl/validation.stderr
+++ b/tests/ui/specialization/defaultimpl/validation.stderr
@@ -1,5 +1,5 @@
 error: inherent impls cannot be `default`
-  --> $DIR/validation.rs:7:14
+  --> $DIR/validation.rs:8:14
    |
 LL | default impl S {}
    | -------      ^ inherent impl for this type
@@ -19,15 +19,27 @@ LL | #![feature(specialization)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: impls of auto traits cannot be default
-  --> $DIR/validation.rs:9:21
+  --> $DIR/validation.rs:11:21
    |
 LL | default unsafe impl Send for S {}
    | -------             ^^^^ auto trait
    | |
    | default because of this
 
+error[E0367]: negative impl requires `Z: Send` but the struct it is implemented for does not
+  --> $DIR/validation.rs:14:1
+   |
+LL | default impl !Send for Z {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the implementor must specify the same requirement
+  --> $DIR/validation.rs:6:1
+   |
+LL | struct Z;
+   | ^^^^^^^^
+
 error: impls of auto traits cannot be default
-  --> $DIR/validation.rs:10:15
+  --> $DIR/validation.rs:14:15
    |
 LL | default impl !Send for Z {}
    | -------       ^^^^ auto trait
@@ -35,17 +47,30 @@ LL | default impl !Send for Z {}
    | default because of this
 
 error[E0750]: negative impls cannot be default impls
-  --> $DIR/validation.rs:10:1
+  --> $DIR/validation.rs:14:1
    |
 LL | default impl !Send for Z {}
    | ^^^^^^^      ^
 
+error[E0367]: negative impl requires `S: Tr` but the struct it is implemented for does not
+  --> $DIR/validation.rs:20:1
+   |
+LL | default impl !Tr for S {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the implementor must specify the same requirement
+  --> $DIR/validation.rs:5:1
+   |
+LL | struct S;
+   | ^^^^^^^^
+
 error[E0750]: negative impls cannot be default impls
-  --> $DIR/validation.rs:14:1
+  --> $DIR/validation.rs:20:1
    |
 LL | default impl !Tr for S {}
    | ^^^^^^^      ^
 
-error: aborting due to 5 previous errors; 1 warning emitted
+error: aborting due to 7 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0750`.
+Some errors have detailed explanations: E0367, E0750.
+For more information about an error, try `rustc --explain E0367`.


### PR DESCRIPTION
This code is very similar to the code we have in `compiler/rustc_hir_analysis/src/check/dropck.rs` but given that there are some differences and that we have to handle error messages differently, I'm not sure how much is worth reusing things.

We may want to adjust some of the changes tests but I leave that up to be discussed in reviews.

r? @nikomatsakis 

cc @compiler-errors 