### PR TITLE
bootstrap: Make `clean` respect `dry-run`

### DIFF
--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -85,6 +85,10 @@ clean_crate_tree! {
 }
 
 fn clean_default(build: &Build, all: bool) {
+    if build.config.dry_run() {
+        return;
+    }
+
     rm_rf("tmp".as_ref());
 
     if all {


### PR DESCRIPTION
I noticed `clean_default` was getting run twice as the `DryRun::SelfCheck` flag is ignored