### PR TITLE
Fix several occurences of the `improper_ctypes` lint in tests where that was not the intent

### DIFF
--- a/tests/codegen/riscv-abi/riscv64-lp64-lp64f-lp64d-abi.rs
+++ b/tests/codegen/riscv-abi/riscv64-lp64-lp64f-lp64d-abi.rs
@@ -4,7 +4,6 @@
 #![crate_type = "lib"]
 #![no_core]
 #![feature(no_core, lang_items)]
-#![allow(improper_ctypes)]
 
 #[lang = "sized"]
 trait Sized {}
@@ -83,8 +82,7 @@ pub struct Tiny {
 
 // CHECK: define void @f_agg_tiny(i64 %0)
 #[no_mangle]
-pub extern "C" fn f_agg_tiny(mut e: Tiny) {
-}
+pub extern "C" fn f_agg_tiny(mut e: Tiny) {}
 
 // CHECK: define i64 @f_agg_tiny_ret()
 #[no_mangle]
@@ -100,8 +98,7 @@ pub struct Small {
 
 // CHECK: define void @f_agg_small([2 x i64] %0)
 #[no_mangle]
-pub extern "C" fn f_agg_small(mut x: Small) {
-}
+pub extern "C" fn f_agg_small(mut x: Small) {}
 
 // CHECK: define [2 x i64] @f_agg_small_ret()
 #[no_mangle]
@@ -116,8 +113,7 @@ pub struct SmallAligned {
 
 // CHECK: define void @f_agg_small_aligned(i128 %0)
 #[no_mangle]
-pub extern "C" fn f_agg_small_aligned(mut x: SmallAligned) {
-}
+pub extern "C" fn f_agg_small_aligned(mut x: SmallAligned) {}
 
 #[repr(C)]
 pub struct Large {
@@ -129,8 +125,7 @@ pub struct Large {
 
 // CHECK: define void @f_agg_large({{%Large\*|ptr}} {{.*}}%x)
 #[no_mangle]
-pub extern "C" fn f_agg_large(mut x: Large) {
-}
+pub extern "C" fn f_agg_large(mut x: Large) {}
 
 // CHECK: define void @f_agg_large_ret({{%Large\*|ptr}} {{.*}}sret{{.*}}, i32 noundef signext %i, i8 noundef signext %j)
 #[no_mangle]

--- a/tests/debuginfo/type-names.rs
+++ b/tests/debuginfo/type-names.rs
@@ -355,7 +355,6 @@ fn generic_function<T>(x: T) -> T {
     x
 }
 
-#[allow(improper_ctypes)]
 extern "C" {
     fn printf(_: *const u8, ...) -> isize;
 }

--- a/tests/ui/abi/abi-sysv64-arg-passing.rs
+++ b/tests/ui/abi/abi-sysv64-arg-passing.rs
@@ -32,32 +32,35 @@
 // note: windows is ignored as rust_test_helpers does not have the sysv64 abi on windows
 
 #[allow(dead_code)]
-#[allow(improper_ctypes)]
-
+// #[allow(improper_ctypes)]
 #[cfg(target_arch = "x86_64")]
 mod tests {
     #[repr(C)]
     #[derive(Copy, Clone, PartialEq, Debug)]
     pub struct TwoU8s {
-        one: u8, two: u8
+        one: u8,
+        two: u8,
     }
 
     #[repr(C)]
     #[derive(Copy, Clone, PartialEq, Debug)]
     pub struct TwoU16s {
-        one: u16, two: u16
+        one: u16,
+        two: u16,
     }
 
     #[repr(C)]
     #[derive(Copy, Clone, PartialEq, Debug)]
     pub struct TwoU32s {
-        one: u32, two: u32
+        one: u32,
+        two: u32,
     }
 
     #[repr(C)]
     #[derive(Copy, Clone, PartialEq, Debug)]
     pub struct TwoU64s {
-        one: u64, two: u64
+        one: u64,
+        two: u64,
     }
 
     #[repr(C)]
@@ -83,19 +86,34 @@ mod tests {
 
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct Quad { a: u64, b: u64, c: u64, d: u64 }
-
-    #[derive(Copy, Clone)]
-    pub struct QuadFloats { a: f32, b: f32, c: f32, d: f32 }
+    pub struct Quad {
+        a: u64,
+        b: u64,
+        c: u64,
+        d: u64,
+    }
 
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct Floats { a: f64, b: u8, c: f64 }
+    pub struct QuadFloats {
+        a: f32,
+        b: f32,
+        c: f32,
+        d: f32,
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct Floats {
+        a: f64,
+        b: u8,
+        c: f64,
+    }
 
     #[repr(C, u8)]
     pub enum U8TaggedEnumOptionU64U64 {
         None,
-        Some(u64,u64),
+        Some(u64, u64),
     }
 
     #[repr(C, u8)]
@@ -111,6 +129,7 @@ mod tests {
         pub fn rust_dbg_extern_identity_u32(v: u32) -> u32;
         pub fn rust_dbg_extern_identity_u64(v: u64) -> u64;
         pub fn rust_dbg_extern_identity_double(v: f64) -> f64;
+        #[allow(improper_ctypes)] // intentional for test
         pub fn rust_dbg_extern_empty_struct(v1: ManyInts, e: Empty, v2: ManyInts);
         pub fn rust_dbg_extern_identity_TwoU8s(v: TwoU8s) -> TwoU8s;
         pub fn rust_dbg_extern_identity_TwoU16s(v: TwoU16s) -> TwoU16s;
@@ -123,8 +142,13 @@ mod tests {
         pub fn get_x(x: S) -> u64;
         pub fn get_y(x: S) -> u64;
         pub fn get_z(x: S) -> u64;
-        pub fn get_c_many_params(_: *const (), _: *const (),
-                                 _: *const (), _: *const (), f: Quad) -> u64;
+        pub fn get_c_many_params(
+            _: *const (),
+            _: *const (),
+            _: *const (),
+            _: *const (),
+            f: Quad,
+        ) -> u64;
         pub fn get_c_exhaust_sysv64_ints(
             _: *const (),
             _: *const (),
@@ -150,9 +174,7 @@ mod tests {
     }
 
     pub fn cabi_int_widening() {
-        let x = unsafe {
-            rust_int8_to_int32(-1)
-        };
+        let x = unsafe { rust_int8_to_int32(-1) };
 
         assert!(x == -1);
     }
@@ -189,7 +211,7 @@ mod tests {
                 arg3: 4,
                 arg4: 5,
                 arg5: 6,
-                arg6: TwoU8s { one: 7, two: 8, }
+                arg6: TwoU8s { one: 7, two: 8 },
             };
             let y = ManyInts {
                 arg1: 1,
@@ -197,7 +219,7 @@ mod tests {
                 arg3: 3,
                 arg4: 4,
                 arg5: 5,
-                arg6: TwoU8s { one: 6, two: 7, }
+                arg6: TwoU8s { one: 6, two: 7 },
             };
             let empty = Empty;
             rust_dbg_extern_empty_struct(x, empty, y);
@@ -206,7 +228,7 @@ mod tests {
 
     pub fn extern_pass_twou8s() {
         unsafe {
-            let x = TwoU8s {one: 22, two: 23};
+            let x = TwoU8s { one: 22, two: 23 };
             let y = rust_dbg_extern_identity_TwoU8s(x);
             assert_eq!(x, y);
         }
@@ -214,7 +236,7 @@ mod tests {
 
     pub fn extern_pass_twou16s() {
         unsafe {
-            let x = TwoU16s {one: 22, two: 23};
+            let x = TwoU16s { one: 22, two: 23 };
             let y = rust_dbg_extern_identity_TwoU16s(x);
             assert_eq!(x, y);
         }
@@ -222,7 +244,7 @@ mod tests {
 
     pub fn extern_pass_twou32s() {
         unsafe {
-            let x = TwoU32s {one: 22, two: 23};
+            let x = TwoU32s { one: 22, two: 23 };
             let y = rust_dbg_extern_identity_TwoU32s(x);
             assert_eq!(x, y);
         }
@@ -230,7 +252,7 @@ mod tests {
 
     pub fn extern_pass_twou64s() {
         unsafe {
-            let x = TwoU64s {one: 22, two: 23};
+            let x = TwoU64s { one: 22, two: 23 };
             let y = rust_dbg_extern_identity_TwoU64s(x);
             assert_eq!(x, y);
         }
@@ -270,9 +292,7 @@ mod tests {
 
     #[inline(never)]
     fn indirect_call(func: unsafe extern "sysv64" fn(s: S) -> u64, s: S) -> u64 {
-        unsafe {
-            func(s)
-        }
+        unsafe { func(s) }
     }
 
     pub fn foreign_fn_with_byval() {
@@ -286,12 +306,7 @@ mod tests {
         use std::ptr;
         unsafe {
             let null = ptr::null();
-            let q = Quad {
-                a: 1,
-                b: 2,
-                c: 3,
-                d: 4
-            };
+            let q = Quad { a: 1, b: 2, c: 3, d: 4 };
             assert_eq!(get_c_many_params(null, null, null, null, q), q.c);
         }
     }
@@ -304,16 +319,8 @@ mod tests {
         use std::ptr;
         unsafe {
             let null = ptr::null();
-            let q = QuadFloats {
-                a: 10.2,
-                b: 20.3,
-                c: 30.4,
-                d: 40.5
-            };
-            assert_eq!(
-                get_c_exhaust_sysv64_ints(null, null, null, null, null, null, null, q),
-                q.c,
-            );
+            let q = QuadFloats { a: 10.2, b: 20.3, c: 30.4, d: 40.5 };
+            assert_eq!(get_c_exhaust_sysv64_ints(null, null, null, null, null, null, null, q), q.c,);
         }
     }
 
@@ -323,10 +330,12 @@ mod tests {
 
     fn test1() {
         unsafe {
-            let q = Quad { a: 0xaaaa_aaaa_aaaa_aaaa,
-                     b: 0xbbbb_bbbb_bbbb_bbbb,
-                     c: 0xcccc_cccc_cccc_cccc,
-                     d: 0xdddd_dddd_dddd_dddd };
+            let q = Quad {
+                a: 0xaaaa_aaaa_aaaa_aaaa,
+                b: 0xbbbb_bbbb_bbbb_bbbb,
+                c: 0xcccc_cccc_cccc_cccc,
+                d: 0xdddd_dddd_dddd_dddd,
+            };
             let qq = rust_dbg_abi_1(q);
             println!("a: {:x}", qq.a as usize);
             println!("b: {:x}", qq.b as usize);
@@ -341,9 +350,7 @@ mod tests {
 
     fn test2() {
         unsafe {
-            let f = Floats { a: 1.234567890e-15_f64,
-                     b: 0b_1010_1010,
-                     c: 1.0987654321e-15_f64 };
+            let f = Floats { a: 1.234567890e-15_f64, b: 0b_1010_1010, c: 1.0987654321e-15_f64 };
             let ff = rust_dbg_abi_2(f);
             println!("a: {}", ff.a as f64);
             println!("b: {}", ff.b as usize);
@@ -369,7 +376,7 @@ mod tests {
         }
 
         let none_u64u64 = unsafe { rust_dbg_new_none_u64u64() };
-        if let U8TaggedEnumOptionU64U64::Some(_,_) = none_u64u64 {
+        if let U8TaggedEnumOptionU64U64::Some(_, _) = none_u64u64 {
             panic!("unexpected some");
         }
 
@@ -443,6 +450,4 @@ fn main() {
 }
 
 #[cfg(not(target_arch = "x86_64"))]
-fn main() {
-
-}
+fn main() {}

--- a/tests/ui/abi/abi-sysv64-arg-passing.rs
+++ b/tests/ui/abi/abi-sysv64-arg-passing.rs
@@ -320,7 +320,7 @@ mod tests {
         unsafe {
             let null = ptr::null();
             let q = QuadFloats { a: 10.2, b: 20.3, c: 30.4, d: 40.5 };
-            assert_eq!(get_c_exhaust_sysv64_ints(null, null, null, null, null, null, null, q), q.c,);
+            assert_eq!(get_c_exhaust_sysv64_ints(null, null, null, null, null, null, null, q), q.c);
         }
     }
 

--- a/tests/ui/abi/abi-sysv64-register-usage.rs
+++ b/tests/ui/abi/abi-sysv64-register-usage.rs
@@ -44,11 +44,11 @@ pub extern "sysv64" fn all_the_registers(
 // this struct contains 8 i64's, while only 6 can be passed in registers.
 #[cfg(target_arch = "x86_64")]
 #[derive(PartialEq, Eq, Debug)]
+#[repr(C)]
 pub struct LargeStruct(i64, i64, i64, i64, i64, i64, i64, i64);
 
 #[cfg(target_arch = "x86_64")]
 #[inline(never)]
-#[allow(improper_ctypes_definitions)]
 pub extern "sysv64" fn large_struct_by_val(mut foo: LargeStruct) -> LargeStruct {
     foo.0 *= 1;
     foo.1 *= 2;

--- a/tests/ui/abi/extern/extern-pass-TwoU16s.rs
+++ b/tests/ui/abi/extern/extern-pass-TwoU16s.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc for ffi testing
 
@@ -7,6 +6,7 @@
 // by value.
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(C)]
 pub struct TwoU16s {
     one: u16,
     two: u16,

--- a/tests/ui/abi/extern/extern-pass-TwoU32s.rs
+++ b/tests/ui/abi/extern/extern-pass-TwoU32s.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc for ffi testing
 
@@ -7,6 +6,7 @@
 // by value.
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(C)]
 pub struct TwoU32s {
     one: u32,
     two: u32,

--- a/tests/ui/abi/extern/extern-pass-TwoU64s.rs
+++ b/tests/ui/abi/extern/extern-pass-TwoU64s.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc for ffi testing
 
@@ -7,6 +6,7 @@
 // by value.
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(C)]
 pub struct TwoU64s {
     one: u64,
     two: u64,

--- a/tests/ui/abi/extern/extern-pass-TwoU8s.rs
+++ b/tests/ui/abi/extern/extern-pass-TwoU8s.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc for ffi testing
 
@@ -7,6 +6,7 @@
 // by value.
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(C)]
 pub struct TwoU8s {
     one: u8,
     two: u8,

--- a/tests/ui/abi/extern/extern-return-TwoU16s.rs
+++ b/tests/ui/abi/extern/extern-return-TwoU16s.rs
@@ -1,8 +1,8 @@
 // run-pass
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc to test ffi with
 
+#[repr(C)]
 pub struct TwoU16s {
     one: u16,
     two: u16,

--- a/tests/ui/abi/extern/extern-return-TwoU32s.rs
+++ b/tests/ui/abi/extern/extern-return-TwoU32s.rs
@@ -1,8 +1,8 @@
 // run-pass
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc to test ffi with
 
+#[repr(C)]
 pub struct TwoU32s {
     one: u32,
     two: u32,

--- a/tests/ui/abi/extern/extern-return-TwoU64s.rs
+++ b/tests/ui/abi/extern/extern-return-TwoU64s.rs
@@ -1,8 +1,8 @@
 // run-pass
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc to test ffi with
 
+#[repr(C)]
 pub struct TwoU64s {
     one: u64,
     two: u64,

--- a/tests/ui/abi/extern/extern-return-TwoU8s.rs
+++ b/tests/ui/abi/extern/extern-return-TwoU8s.rs
@@ -1,8 +1,8 @@
 // run-pass
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc to test ffi with
 
+#[repr(C)]
 pub struct TwoU8s {
     one: u8,
     two: u8,

--- a/tests/ui/abi/foreign/foreign-fn-with-byval.rs
+++ b/tests/ui/abi/foreign/foreign-fn-with-byval.rs
@@ -1,9 +1,9 @@
 // run-pass
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc to test ffi with
 
 #[derive(Copy, Clone)]
+#[repr(C)]
 pub struct S {
     x: u64,
     y: u64,

--- a/tests/ui/abi/issue-28676.rs
+++ b/tests/ui/abi/issue-28676.rs
@@ -1,10 +1,10 @@
 // run-pass
 #![allow(dead_code)]
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc to test ffi with
 
 #[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Quad {
     a: u64,
     b: u64,

--- a/tests/ui/abi/issues/issue-62350-sysv-neg-reg-counts.rs
+++ b/tests/ui/abi/issues/issue-62350-sysv-neg-reg-counts.rs
@@ -1,10 +1,10 @@
 // run-pass
 #![allow(dead_code)]
-#![allow(improper_ctypes)]
 
 // ignore-wasm32-bare no libc to test ffi with
 
 #[derive(Copy, Clone)]
+#[repr(C)]
 pub struct QuadFloats {
     a: f32,
     b: f32,

--- a/tests/ui/abi/issues/issue-97463-broken-abi-leaked-uninit-data.rs
+++ b/tests/ui/abi/issues/issue-97463-broken-abi-leaked-uninit-data.rs
@@ -1,7 +1,6 @@
 // run-pass
 // ignore-wasm
 #![allow(dead_code)]
-#![allow(improper_ctypes)]
 
 #[link(name = "rust_test_helpers", kind = "static")]
 extern "C" {

--- a/tests/ui/abi/variadic-ffi.rs
+++ b/tests/ui/abi/variadic-ffi.rs
@@ -8,11 +8,6 @@ use std::ffi::VaList;
 extern "C" {
     fn rust_interesting_average(_: u64, ...) -> f64;
 
-    // FIXME: we need to disable this lint for `VaList`,
-    // since it contains a `MaybeUninit<i32>` on the asmjs target,
-    // and this type isn't FFI-safe. This is OK for now,
-    // since the type is layout-compatible with `i32`.
-    #[cfg_attr(target_arch = "asmjs", allow(improper_ctypes))]
     fn rust_valist_interesting_average(_: u64, _: VaList) -> f64;
 }
 

--- a/tests/ui/cfg/conditional-compile.rs
+++ b/tests/ui/cfg/conditional-compile.rs
@@ -2,7 +2,6 @@
 #![allow(dead_code)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
-#![allow(improper_ctypes)]
 
 // Crate use statements
 
@@ -110,8 +109,8 @@ mod test_foreign_items {
     pub mod rustrt {
         extern "C" {
             #[cfg(bogus)]
-            pub fn write() -> String;
-            pub fn write() -> String;
+            pub fn write() -> u32;
+            pub fn write() -> u32;
         }
     }
 }

--- a/tests/ui/issues/issue-3656.rs
+++ b/tests/ui/issues/issue-3656.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(dead_code)]
-#![allow(improper_ctypes)]
 // Issue #3656
 // Incorrect struct size computation in the FFI, because of not taking
 // the alignment of elements into account.
@@ -12,6 +11,7 @@
 extern crate libc;
 use libc::{c_uint, c_void};
 
+#[repr(C)]
 pub struct KEYGEN {
     hash_algorithm: [c_uint; 2],
     count: u32,

--- a/tests/ui/issues/issue-51907.rs
+++ b/tests/ui/issues/issue-51907.rs
@@ -4,16 +4,18 @@ trait Foo {
     extern "C" fn take(self: Box<Self>);
 }
 
-struct Bar;
+#[repr(C)]
+struct Bar {
+    val: u8,
+}
+
 impl Foo for Bar {
-    #[allow(improper_ctypes_definitions)]
     extern "C" fn borrow(&self) {}
-    #[allow(improper_ctypes_definitions)]
     extern "C" fn take(self: Box<Self>) {}
 }
 
 fn main() {
-    let foo: Box<dyn Foo> = Box::new(Bar);
+    let foo: Box<dyn Foo> = Box::new(Bar { val: 0 });
     foo.borrow();
     foo.take()
 }

--- a/tests/ui/lint/clashing-extern-fn-recursion.rs
+++ b/tests/ui/lint/clashing-extern-fn-recursion.rs
@@ -92,12 +92,12 @@ mod ref_recursion_once_removed {
             reffy: &'a Reffy2<'a>,
         }
 
+        #[repr(C)]
         struct Reffy2<'a> {
             reffy: &'a Reffy1<'a>,
         }
 
         extern "C" {
-            #[allow(improper_ctypes)]
             fn reffy_once_removed(reffy: Reffy1);
         }
     }
@@ -107,6 +107,7 @@ mod ref_recursion_once_removed {
             reffy: &'a Reffy2<'a>,
         }
 
+        #[repr(C)]
         struct Reffy2<'a> {
             reffy: &'a Reffy1<'a>,
         }

--- a/tests/ui/lint/clashing-extern-fn.rs
+++ b/tests/ui/lint/clashing-extern-fn.rs
@@ -132,12 +132,12 @@ mod banana {
     mod three {
         // This _should_ trigger the lint, because repr(packed) should generate a struct that has a
         // different layout.
-        #[repr(packed)]
+        #[repr(C, packed)]
         struct Banana {
             weight: u32,
             length: u16,
         }
-        #[allow(improper_ctypes)]
+
         extern "C" {
             fn weigh_banana(count: *const Banana) -> u64;
             //~^ WARN `weigh_banana` redeclared with a different signature
@@ -223,7 +223,7 @@ mod transparent {
     }
 }
 
-#[allow(improper_ctypes)]
+#[allow(improper_ctypes)] // intentionally testing ZSTs
 mod zst {
     mod transparent {
         #[repr(transparent)]
@@ -382,7 +382,7 @@ mod null_optimised_enums {
     }
 }
 
-#[allow(improper_ctypes)]
+#[allow(improper_ctypes)] // intentionally testing repr(Rust)
 mod unknown_layout {
     mod a {
         extern "C" {

--- a/tests/ui/lint/lint-ctypes-fn.rs
+++ b/tests/ui/lint/lint-ctypes-fn.rs
@@ -1,5 +1,4 @@
 #![feature(rustc_private)]
-
 #![allow(private_in_public)]
 #![deny(improper_ctypes_definitions)]
 
@@ -10,16 +9,20 @@ use std::marker::PhantomData;
 
 trait Trait {}
 
-trait Mirror { type It: ?Sized; }
+trait Mirror {
+    type It: ?Sized;
+}
 
-impl<T: ?Sized> Mirror for T { type It = Self; }
+impl<T: ?Sized> Mirror for T {
+    type It = Self;
+}
 
 #[repr(C)]
 pub struct StructWithProjection(*mut <StructWithProjection as Mirror>::It);
 
 #[repr(C)]
 pub struct StructWithProjectionAndLifetime<'a>(
-    &'a mut <StructWithProjectionAndLifetime<'a> as Mirror>::It
+    &'a mut <StructWithProjectionAndLifetime<'a> as Mirror>::It,
 );
 
 pub type I32Pair = (i32, i32);
@@ -62,134 +65,133 @@ pub struct TransparentCustomZst(i32, ZeroSize);
 #[repr(C)]
 pub struct ZeroSizeWithPhantomData(PhantomData<i32>);
 
-pub extern "C" fn ptr_type1(size: *const Foo) { }
+pub extern "C" fn ptr_type1(size: *const Foo) {}
 
-pub extern "C" fn ptr_type2(size: *const Foo) { }
+pub extern "C" fn ptr_type2(size: *const Foo) {}
 
-pub extern "C" fn ptr_unit(p: *const ()) { }
+pub extern "C" fn ptr_unit(p: *const ()) {}
 
-pub extern "C" fn ptr_tuple(p: *const ((),)) { }
+pub extern "C" fn ptr_tuple(p: *const ((),)) {}
 
-pub extern "C" fn slice_type(p: &[u32]) { }
+pub extern "C" fn slice_type(p: &[u32]) {}
 //~^ ERROR: uses type `[u32]`
 
-pub extern "C" fn str_type(p: &str) { }
+pub extern "C" fn str_type(p: &str) {}
 //~^ ERROR: uses type `str`
 
-pub extern "C" fn box_type(p: Box<u32>) { }
+pub extern "C" fn box_type(p: Box<u32>) {}
 
-pub extern "C" fn opt_box_type(p: Option<Box<u32>>) { }
+pub extern "C" fn opt_box_type(p: Option<Box<u32>>) {}
 
-pub extern "C" fn boxed_slice(p: Box<[u8]>) { }
+pub extern "C" fn boxed_slice(p: Box<[u8]>) {}
 //~^ ERROR: uses type `Box<[u8]>`
 
-pub extern "C" fn boxed_string(p: Box<str>) { }
+pub extern "C" fn boxed_string(p: Box<str>) {}
 //~^ ERROR: uses type `Box<str>`
 
-pub extern "C" fn boxed_trait(p: Box<dyn Trait>) { }
+pub extern "C" fn boxed_trait(p: Box<dyn Trait>) {}
 //~^ ERROR: uses type `Box<dyn Trait>`
 
-pub extern "C" fn char_type(p: char) { }
+pub extern "C" fn char_type(p: char) {}
 //~^ ERROR uses type `char`
 
-pub extern "C" fn i128_type(p: i128) { }
+pub extern "C" fn i128_type(p: i128) {}
 //~^ ERROR uses type `i128`
 
-pub extern "C" fn u128_type(p: u128) { }
+pub extern "C" fn u128_type(p: u128) {}
 //~^ ERROR uses type `u128`
 
-pub extern "C" fn tuple_type(p: (i32, i32)) { }
+pub extern "C" fn tuple_type(p: (i32, i32)) {}
 //~^ ERROR uses type `(i32, i32)`
 
-pub extern "C" fn tuple_type2(p: I32Pair) { }
+pub extern "C" fn tuple_type2(p: I32Pair) {}
 //~^ ERROR uses type `(i32, i32)`
 
-pub extern "C" fn zero_size(p: ZeroSize) { }
+pub extern "C" fn zero_size(p: ZeroSize) {}
 //~^ ERROR uses type `ZeroSize`
 
-pub extern "C" fn zero_size_phantom(p: ZeroSizeWithPhantomData) { }
+pub extern "C" fn zero_size_phantom(p: ZeroSizeWithPhantomData) {}
 //~^ ERROR uses type `ZeroSizeWithPhantomData`
 
 pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
-//~^ ERROR uses type `PhantomData<bool>`
+    //~^ ERROR uses type `PhantomData<bool>`
     Default::default()
 }
 
-pub extern "C" fn fn_type(p: RustFn) { }
+pub extern "C" fn fn_type(p: RustFn) {}
 //~^ ERROR uses type `fn()`
 
-pub extern "C" fn fn_type2(p: fn()) { }
+pub extern "C" fn fn_type2(p: fn()) {}
 //~^ ERROR uses type `fn()`
 
-pub extern "C" fn fn_contained(p: RustBadRet) { }
+pub extern "C" fn fn_contained(p: RustBadRet) {}
 
-pub extern "C" fn transparent_i128(p: TransparentI128) { }
+pub extern "C" fn transparent_i128(p: TransparentI128) {}
 //~^ ERROR: uses type `i128`
 
-pub extern "C" fn transparent_str(p: TransparentStr) { }
+pub extern "C" fn transparent_str(p: TransparentStr) {}
 //~^ ERROR: uses type `str`
 
-pub extern "C" fn transparent_fn(p: TransparentBadFn) { }
+pub extern "C" fn transparent_fn(p: TransparentBadFn) {}
 
-pub extern "C" fn good3(fptr: Option<extern "C" fn()>) { }
+pub extern "C" fn good3(fptr: Option<extern "C" fn()>) {}
 
-pub extern "C" fn good4(aptr: &[u8; 4 as usize]) { }
+pub extern "C" fn good4(aptr: &[u8; 4 as usize]) {}
 
-pub extern "C" fn good5(s: StructWithProjection) { }
+pub extern "C" fn good5(s: StructWithProjection) {}
 
-pub extern "C" fn good6(s: StructWithProjectionAndLifetime) { }
+pub extern "C" fn good6(s: StructWithProjectionAndLifetime) {}
 
-pub extern "C" fn good7(fptr: extern "C" fn() -> ()) { }
+pub extern "C" fn good7(fptr: extern "C" fn() -> ()) {}
 
-pub extern "C" fn good8(fptr: extern "C" fn() -> !) { }
+pub extern "C" fn good8(fptr: extern "C" fn() -> !) {}
 
-pub extern "C" fn good9() -> () { }
+pub extern "C" fn good9() -> () {}
 
-pub extern "C" fn good10() -> CVoidRet { }
+pub extern "C" fn good10() -> CVoidRet {}
 
-pub extern "C" fn good11(size: isize) { }
+pub extern "C" fn good11(size: isize) {}
 
-pub extern "C" fn good12(size: usize) { }
+pub extern "C" fn good12(size: usize) {}
 
-pub extern "C" fn good13(n: TransparentInt) { }
+pub extern "C" fn good13(n: TransparentInt) {}
 
-pub extern "C" fn good14(p: TransparentRef) { }
+pub extern "C" fn good14(p: TransparentRef) {}
 
-pub extern "C" fn good15(p: TransparentLifetime) { }
+pub extern "C" fn good15(p: TransparentLifetime) {}
 
-pub extern "C" fn good16(p: TransparentUnit<ZeroSize>) { }
+pub extern "C" fn good16(p: TransparentUnit<ZeroSize>) {}
 
-pub extern "C" fn good17(p: TransparentCustomZst) { }
+pub extern "C" fn good17(p: TransparentCustomZst) {}
 
-#[allow(improper_ctypes_definitions)]
-pub extern "C" fn good18(_: &String) { }
-
-#[cfg(not(target_arch = "wasm32"))]
-pub extern "C" fn good1(size: *const libc::c_int) { }
+pub extern "C" fn good18(_: &String) {}
 
 #[cfg(not(target_arch = "wasm32"))]
-pub extern "C" fn good2(size: *const libc::c_uint) { }
+pub extern "C" fn good1(size: *const libc::c_int) {}
 
-pub extern "C" fn unused_generic1<T>(size: *const Foo) { }
+#[cfg(not(target_arch = "wasm32"))]
+pub extern "C" fn good2(size: *const libc::c_uint) {}
+
+pub extern "C" fn unused_generic1<T>(size: *const Foo) {}
 
 pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
-//~^ ERROR uses type `PhantomData<bool>`
+    //~^ ERROR uses type `PhantomData<bool>`
     Default::default()
 }
 
-pub extern "C" fn used_generic1<T>(x: T) { }
+pub extern "C" fn used_generic1<T>(x: T) {}
 
-pub extern "C" fn used_generic2<T>(x: T, size: *const Foo) { }
+pub extern "C" fn used_generic2<T>(x: T, size: *const Foo) {}
 
 pub extern "C" fn used_generic3<T: Default>() -> T {
     Default::default()
 }
 
-pub extern "C" fn used_generic4<T>(x: Vec<T>) { }
+pub extern "C" fn used_generic4<T>(x: Vec<T>) {}
 //~^ ERROR: uses type `Vec<T>`
 
 pub extern "C" fn used_generic5<T>() -> Vec<T> {
-//~^ ERROR: uses type `Vec<T>`
+    //~^ ERROR: uses type `Vec<T>`
     Default::default()
 }
 

--- a/tests/ui/lint/lint-ctypes-fn.stderr
+++ b/tests/ui/lint/lint-ctypes-fn.stderr
@@ -1,122 +1,122 @@
 error: `extern` fn uses type `[u32]`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:73:33
+  --> $DIR/lint-ctypes-fn.rs:76:33
    |
-LL | pub extern "C" fn slice_type(p: &[u32]) { }
+LL | pub extern "C" fn slice_type(p: &[u32]) {}
    |                                 ^^^^^^ not FFI-safe
    |
    = help: consider using a raw pointer instead
    = note: slices have no C equivalent
 note: the lint level is defined here
-  --> $DIR/lint-ctypes-fn.rs:4:9
+  --> $DIR/lint-ctypes-fn.rs:3:9
    |
 LL | #![deny(improper_ctypes_definitions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:76:31
+  --> $DIR/lint-ctypes-fn.rs:79:31
    |
-LL | pub extern "C" fn str_type(p: &str) { }
+LL | pub extern "C" fn str_type(p: &str) {}
    |                               ^^^^ not FFI-safe
    |
    = help: consider using `*const u8` and a length instead
    = note: string slices have no C equivalent
 
 error: `extern` fn uses type `Box<[u8]>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:83:34
+  --> $DIR/lint-ctypes-fn.rs:86:34
    |
-LL | pub extern "C" fn boxed_slice(p: Box<[u8]>) { }
+LL | pub extern "C" fn boxed_slice(p: Box<[u8]>) {}
    |                                  ^^^^^^^^^ not FFI-safe
    |
    = note: box cannot be represented as a single pointer
 
 error: `extern` fn uses type `Box<str>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:86:35
+  --> $DIR/lint-ctypes-fn.rs:89:35
    |
-LL | pub extern "C" fn boxed_string(p: Box<str>) { }
+LL | pub extern "C" fn boxed_string(p: Box<str>) {}
    |                                   ^^^^^^^^ not FFI-safe
    |
    = note: box cannot be represented as a single pointer
 
 error: `extern` fn uses type `Box<dyn Trait>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:89:34
+  --> $DIR/lint-ctypes-fn.rs:92:34
    |
-LL | pub extern "C" fn boxed_trait(p: Box<dyn Trait>) { }
+LL | pub extern "C" fn boxed_trait(p: Box<dyn Trait>) {}
    |                                  ^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: box cannot be represented as a single pointer
 
 error: `extern` fn uses type `char`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:92:32
+  --> $DIR/lint-ctypes-fn.rs:95:32
    |
-LL | pub extern "C" fn char_type(p: char) { }
+LL | pub extern "C" fn char_type(p: char) {}
    |                                ^^^^ not FFI-safe
    |
    = help: consider using `u32` or `libc::wchar_t` instead
    = note: the `char` type has no C equivalent
 
 error: `extern` fn uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:95:32
+  --> $DIR/lint-ctypes-fn.rs:98:32
    |
-LL | pub extern "C" fn i128_type(p: i128) { }
+LL | pub extern "C" fn i128_type(p: i128) {}
    |                                ^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` fn uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:98:32
+  --> $DIR/lint-ctypes-fn.rs:101:32
    |
-LL | pub extern "C" fn u128_type(p: u128) { }
+LL | pub extern "C" fn u128_type(p: u128) {}
    |                                ^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:101:33
+  --> $DIR/lint-ctypes-fn.rs:104:33
    |
-LL | pub extern "C" fn tuple_type(p: (i32, i32)) { }
+LL | pub extern "C" fn tuple_type(p: (i32, i32)) {}
    |                                 ^^^^^^^^^^ not FFI-safe
    |
    = help: consider using a struct instead
    = note: tuples have unspecified layout
 
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:104:34
+  --> $DIR/lint-ctypes-fn.rs:107:34
    |
-LL | pub extern "C" fn tuple_type2(p: I32Pair) { }
+LL | pub extern "C" fn tuple_type2(p: I32Pair) {}
    |                                  ^^^^^^^ not FFI-safe
    |
    = help: consider using a struct instead
    = note: tuples have unspecified layout
 
 error: `extern` fn uses type `ZeroSize`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:107:32
+  --> $DIR/lint-ctypes-fn.rs:110:32
    |
-LL | pub extern "C" fn zero_size(p: ZeroSize) { }
+LL | pub extern "C" fn zero_size(p: ZeroSize) {}
    |                                ^^^^^^^^ not FFI-safe
    |
    = help: consider adding a member to this struct
    = note: this struct has no fields
 note: the type is defined here
-  --> $DIR/lint-ctypes-fn.rs:28:1
+  --> $DIR/lint-ctypes-fn.rs:31:1
    |
 LL | pub struct ZeroSize;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `ZeroSizeWithPhantomData`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:110:40
+  --> $DIR/lint-ctypes-fn.rs:113:40
    |
-LL | pub extern "C" fn zero_size_phantom(p: ZeroSizeWithPhantomData) { }
+LL | pub extern "C" fn zero_size_phantom(p: ZeroSizeWithPhantomData) {}
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
 note: the type is defined here
-  --> $DIR/lint-ctypes-fn.rs:63:1
+  --> $DIR/lint-ctypes-fn.rs:66:1
    |
 LL | pub struct ZeroSizeWithPhantomData(PhantomData<i32>);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:113:51
+  --> $DIR/lint-ctypes-fn.rs:116:51
    |
 LL | pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
    |                                                   ^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -124,42 +124,42 @@ LL | pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
    = note: composed only of `PhantomData`
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:118:30
+  --> $DIR/lint-ctypes-fn.rs:121:30
    |
-LL | pub extern "C" fn fn_type(p: RustFn) { }
+LL | pub extern "C" fn fn_type(p: RustFn) {}
    |                              ^^^^^^ not FFI-safe
    |
    = help: consider using an `extern fn(...) -> ...` function pointer instead
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:121:31
+  --> $DIR/lint-ctypes-fn.rs:124:31
    |
-LL | pub extern "C" fn fn_type2(p: fn()) { }
+LL | pub extern "C" fn fn_type2(p: fn()) {}
    |                               ^^^^ not FFI-safe
    |
    = help: consider using an `extern fn(...) -> ...` function pointer instead
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` fn uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:126:39
+  --> $DIR/lint-ctypes-fn.rs:129:39
    |
-LL | pub extern "C" fn transparent_i128(p: TransparentI128) { }
+LL | pub extern "C" fn transparent_i128(p: TransparentI128) {}
    |                                       ^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` fn uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:129:38
+  --> $DIR/lint-ctypes-fn.rs:132:38
    |
-LL | pub extern "C" fn transparent_str(p: TransparentStr) { }
+LL | pub extern "C" fn transparent_str(p: TransparentStr) {}
    |                                      ^^^^^^^^^^^^^^ not FFI-safe
    |
    = help: consider using `*const u8` and a length instead
    = note: string slices have no C equivalent
 
 error: `extern` fn uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:175:43
+  --> $DIR/lint-ctypes-fn.rs:177:43
    |
 LL | pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
    |                                           ^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -167,16 +167,16 @@ LL | pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
    = note: composed only of `PhantomData`
 
 error: `extern` fn uses type `Vec<T>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:188:39
+  --> $DIR/lint-ctypes-fn.rs:190:39
    |
-LL | pub extern "C" fn used_generic4<T>(x: Vec<T>) { }
+LL | pub extern "C" fn used_generic4<T>(x: Vec<T>) {}
    |                                       ^^^^^^ not FFI-safe
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
 
 error: `extern` fn uses type `Vec<T>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:191:41
+  --> $DIR/lint-ctypes-fn.rs:193:41
    |
 LL | pub extern "C" fn used_generic5<T>() -> Vec<T> {
    |                                         ^^^^^^ not FFI-safe

--- a/tests/ui/lint/lint-ctypes.rs
+++ b/tests/ui/lint/lint-ctypes.rs
@@ -1,5 +1,4 @@
 #![feature(rustc_private)]
-
 #![allow(private_in_public)]
 #![deny(improper_ctypes)]
 
@@ -8,14 +7,18 @@ extern crate libc;
 use std::cell::UnsafeCell;
 use std::marker::PhantomData;
 
-trait Bar { }
-trait Mirror { type It: ?Sized; }
-impl<T: ?Sized> Mirror for T { type It = Self; }
+trait Bar {}
+trait Mirror {
+    type It: ?Sized;
+}
+impl<T: ?Sized> Mirror for T {
+    type It = Self;
+}
 #[repr(C)]
 pub struct StructWithProjection(*mut <StructWithProjection as Mirror>::It);
 #[repr(C)]
 pub struct StructWithProjectionAndLifetime<'a>(
-    &'a mut <StructWithProjectionAndLifetime<'a> as Mirror>::It
+    &'a mut <StructWithProjectionAndLifetime<'a> as Mirror>::It,
 );
 pub type I32Pair = (i32, i32);
 #[repr(C)]
@@ -63,8 +66,7 @@ extern "C" {
     pub fn zero_size(p: ZeroSize); //~ ERROR uses type `ZeroSize`
     pub fn zero_size_phantom(p: ZeroSizeWithPhantomData);
     //~^ ERROR uses type `ZeroSizeWithPhantomData`
-    pub fn zero_size_phantom_toplevel()
-        -> ::std::marker::PhantomData<bool>; //~ ERROR uses type `PhantomData<bool>`
+    pub fn zero_size_phantom_toplevel() -> ::std::marker::PhantomData<bool>; //~ ERROR uses type `PhantomData<bool>`
     pub fn fn_type(p: RustFn); //~ ERROR uses type `fn()`
     pub fn fn_type2(p: fn()); //~ ERROR uses type `fn()`
     pub fn fn_contained(p: RustBadRet); //~ ERROR: uses type `Box<u32>`
@@ -73,7 +75,7 @@ extern "C" {
     pub fn transparent_fn(p: TransparentBadFn); //~ ERROR: uses type `Box<u32>`
     pub fn raw_array(arr: [u8; 8]); //~ ERROR: uses type `[u8; 8]`
 
-    pub fn no_niche_a(a: Option<UnsafeCell<extern fn()>>);
+    pub fn no_niche_a(a: Option<UnsafeCell<extern "C" fn()>>);
     //~^ ERROR: uses type `Option<UnsafeCell<extern "C" fn()>>`
     pub fn no_niche_b(b: Option<UnsafeCell<&i32>>);
     //~^ ERROR: uses type `Option<UnsafeCell<&i32>>`
@@ -96,16 +98,20 @@ extern "C" {
     pub fn good15(p: TransparentLifetime);
     pub fn good16(p: TransparentUnit<ZeroSize>);
     pub fn good17(p: TransparentCustomZst);
-    #[allow(improper_ctypes)]
-    pub fn good18(_: &String);
     pub fn good20(arr: *const [u8; 8]);
     pub static good21: [u8; 8];
-
 }
 
+// test that the lint can be properly `allow`ed on the whole extern block
 #[allow(improper_ctypes)]
 extern "C" {
-    pub fn good19(_: &String);
+    pub fn attr_on_block(_: &str);
+}
+
+// test that the lint can properly be `allow`ed on the fn itself
+extern "C" {
+    #[allow(improper_ctypes)]
+    pub fn attr_on_fn(_: &str);
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -114,5 +120,4 @@ extern "C" {
     pub fn good2(size: *const libc::c_uint);
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/lint/lint-ctypes.stderr
+++ b/tests/ui/lint/lint-ctypes.stderr
@@ -1,5 +1,5 @@
 error: `extern` block uses type `Foo`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:48:28
+  --> $DIR/lint-ctypes.rs:51:28
    |
 LL |     pub fn ptr_type1(size: *const Foo);
    |                            ^^^^^^^^^^ not FFI-safe
@@ -7,18 +7,18 @@ LL |     pub fn ptr_type1(size: *const Foo);
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
 note: the type is defined here
-  --> $DIR/lint-ctypes.rs:26:1
+  --> $DIR/lint-ctypes.rs:29:1
    |
 LL | pub struct Foo;
    | ^^^^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/lint-ctypes.rs:4:9
+  --> $DIR/lint-ctypes.rs:3:9
    |
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `Foo`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:49:28
+  --> $DIR/lint-ctypes.rs:52:28
    |
 LL |     pub fn ptr_type2(size: *const Foo);
    |                            ^^^^^^^^^^ not FFI-safe
@@ -26,13 +26,13 @@ LL |     pub fn ptr_type2(size: *const Foo);
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
 note: the type is defined here
-  --> $DIR/lint-ctypes.rs:26:1
+  --> $DIR/lint-ctypes.rs:29:1
    |
 LL | pub struct Foo;
    | ^^^^^^^^^^^^^^
 
 error: `extern` block uses type `((),)`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:51:25
+  --> $DIR/lint-ctypes.rs:54:25
    |
 LL |     pub fn ptr_tuple(p: *const ((),));
    |                         ^^^^^^^^^^^^ not FFI-safe
@@ -41,7 +41,7 @@ LL |     pub fn ptr_tuple(p: *const ((),));
    = note: tuples have unspecified layout
 
 error: `extern` block uses type `[u32]`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:52:26
+  --> $DIR/lint-ctypes.rs:55:26
    |
 LL |     pub fn slice_type(p: &[u32]);
    |                          ^^^^^^ not FFI-safe
@@ -50,7 +50,7 @@ LL |     pub fn slice_type(p: &[u32]);
    = note: slices have no C equivalent
 
 error: `extern` block uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:53:24
+  --> $DIR/lint-ctypes.rs:56:24
    |
 LL |     pub fn str_type(p: &str);
    |                        ^^^^ not FFI-safe
@@ -59,7 +59,7 @@ LL |     pub fn str_type(p: &str);
    = note: string slices have no C equivalent
 
 error: `extern` block uses type `Box<u32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:54:24
+  --> $DIR/lint-ctypes.rs:57:24
    |
 LL |     pub fn box_type(p: Box<u32>);
    |                        ^^^^^^^^ not FFI-safe
@@ -68,7 +68,7 @@ LL |     pub fn box_type(p: Box<u32>);
    = note: this struct has unspecified layout
 
 error: `extern` block uses type `Option<Box<u32>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:55:28
+  --> $DIR/lint-ctypes.rs:58:28
    |
 LL |     pub fn opt_box_type(p: Option<Box<u32>>);
    |                            ^^^^^^^^^^^^^^^^ not FFI-safe
@@ -77,7 +77,7 @@ LL |     pub fn opt_box_type(p: Option<Box<u32>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `char`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:57:25
+  --> $DIR/lint-ctypes.rs:60:25
    |
 LL |     pub fn char_type(p: char);
    |                         ^^^^ not FFI-safe
@@ -86,7 +86,7 @@ LL |     pub fn char_type(p: char);
    = note: the `char` type has no C equivalent
 
 error: `extern` block uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:58:25
+  --> $DIR/lint-ctypes.rs:61:25
    |
 LL |     pub fn i128_type(p: i128);
    |                         ^^^^ not FFI-safe
@@ -94,7 +94,7 @@ LL |     pub fn i128_type(p: i128);
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:59:25
+  --> $DIR/lint-ctypes.rs:62:25
    |
 LL |     pub fn u128_type(p: u128);
    |                         ^^^^ not FFI-safe
@@ -102,7 +102,7 @@ LL |     pub fn u128_type(p: u128);
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `dyn Bar`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:60:26
+  --> $DIR/lint-ctypes.rs:63:26
    |
 LL |     pub fn trait_type(p: &dyn Bar);
    |                          ^^^^^^^^ not FFI-safe
@@ -110,7 +110,7 @@ LL |     pub fn trait_type(p: &dyn Bar);
    = note: trait objects have no C equivalent
 
 error: `extern` block uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:61:26
+  --> $DIR/lint-ctypes.rs:64:26
    |
 LL |     pub fn tuple_type(p: (i32, i32));
    |                          ^^^^^^^^^^ not FFI-safe
@@ -119,7 +119,7 @@ LL |     pub fn tuple_type(p: (i32, i32));
    = note: tuples have unspecified layout
 
 error: `extern` block uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:62:27
+  --> $DIR/lint-ctypes.rs:65:27
    |
 LL |     pub fn tuple_type2(p: I32Pair);
    |                           ^^^^^^^ not FFI-safe
@@ -128,7 +128,7 @@ LL |     pub fn tuple_type2(p: I32Pair);
    = note: tuples have unspecified layout
 
 error: `extern` block uses type `ZeroSize`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:63:25
+  --> $DIR/lint-ctypes.rs:66:25
    |
 LL |     pub fn zero_size(p: ZeroSize);
    |                         ^^^^^^^^ not FFI-safe
@@ -136,34 +136,34 @@ LL |     pub fn zero_size(p: ZeroSize);
    = help: consider adding a member to this struct
    = note: this struct has no fields
 note: the type is defined here
-  --> $DIR/lint-ctypes.rs:22:1
+  --> $DIR/lint-ctypes.rs:25:1
    |
 LL | pub struct ZeroSize;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `ZeroSizeWithPhantomData`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:64:33
+  --> $DIR/lint-ctypes.rs:67:33
    |
 LL |     pub fn zero_size_phantom(p: ZeroSizeWithPhantomData);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
 note: the type is defined here
-  --> $DIR/lint-ctypes.rs:45:1
+  --> $DIR/lint-ctypes.rs:48:1
    |
 LL | pub struct ZeroSizeWithPhantomData(::std::marker::PhantomData<i32>);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:67:12
+  --> $DIR/lint-ctypes.rs:69:44
    |
-LL |         -> ::std::marker::PhantomData<bool>;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+LL |     pub fn zero_size_phantom_toplevel() -> ::std::marker::PhantomData<bool>;
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
 
 error: `extern` block uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:68:23
+  --> $DIR/lint-ctypes.rs:70:23
    |
 LL |     pub fn fn_type(p: RustFn);
    |                       ^^^^^^ not FFI-safe
@@ -172,7 +172,7 @@ LL |     pub fn fn_type(p: RustFn);
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` block uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:69:24
+  --> $DIR/lint-ctypes.rs:71:24
    |
 LL |     pub fn fn_type2(p: fn());
    |                        ^^^^ not FFI-safe
@@ -181,7 +181,7 @@ LL |     pub fn fn_type2(p: fn());
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` block uses type `Box<u32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:70:28
+  --> $DIR/lint-ctypes.rs:72:28
    |
 LL |     pub fn fn_contained(p: RustBadRet);
    |                            ^^^^^^^^^^ not FFI-safe
@@ -190,7 +190,7 @@ LL |     pub fn fn_contained(p: RustBadRet);
    = note: this struct has unspecified layout
 
 error: `extern` block uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:71:32
+  --> $DIR/lint-ctypes.rs:73:32
    |
 LL |     pub fn transparent_i128(p: TransparentI128);
    |                                ^^^^^^^^^^^^^^^ not FFI-safe
@@ -198,7 +198,7 @@ LL |     pub fn transparent_i128(p: TransparentI128);
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:72:31
+  --> $DIR/lint-ctypes.rs:74:31
    |
 LL |     pub fn transparent_str(p: TransparentStr);
    |                               ^^^^^^^^^^^^^^ not FFI-safe
@@ -207,7 +207,7 @@ LL |     pub fn transparent_str(p: TransparentStr);
    = note: string slices have no C equivalent
 
 error: `extern` block uses type `Box<u32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:73:30
+  --> $DIR/lint-ctypes.rs:75:30
    |
 LL |     pub fn transparent_fn(p: TransparentBadFn);
    |                              ^^^^^^^^^^^^^^^^ not FFI-safe
@@ -216,7 +216,7 @@ LL |     pub fn transparent_fn(p: TransparentBadFn);
    = note: this struct has unspecified layout
 
 error: `extern` block uses type `[u8; 8]`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:74:27
+  --> $DIR/lint-ctypes.rs:76:27
    |
 LL |     pub fn raw_array(arr: [u8; 8]);
    |                           ^^^^^^^ not FFI-safe
@@ -225,16 +225,16 @@ LL |     pub fn raw_array(arr: [u8; 8]);
    = note: passing raw arrays by value is not FFI-safe
 
 error: `extern` block uses type `Option<UnsafeCell<extern "C" fn()>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:76:26
+  --> $DIR/lint-ctypes.rs:78:26
    |
-LL |     pub fn no_niche_a(a: Option<UnsafeCell<extern fn()>>);
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+LL |     pub fn no_niche_a(a: Option<UnsafeCell<extern "C" fn()>>);
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 
 error: `extern` block uses type `Option<UnsafeCell<&i32>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:78:26
+  --> $DIR/lint-ctypes.rs:80:26
    |
 LL |     pub fn no_niche_b(b: Option<UnsafeCell<&i32>>);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -243,7 +243,7 @@ LL |     pub fn no_niche_b(b: Option<UnsafeCell<&i32>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:81:34
+  --> $DIR/lint-ctypes.rs:83:34
    |
 LL |     pub static static_u128_type: u128;
    |                                  ^^^^ not FFI-safe
@@ -251,7 +251,7 @@ LL |     pub static static_u128_type: u128;
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:82:40
+  --> $DIR/lint-ctypes.rs:84:40
    |
 LL |     pub static static_u128_array_type: [u128; 16];
    |                                        ^^^^^^^^^^ not FFI-safe

--- a/tests/ui/privacy/private-in-public-warn.rs
+++ b/tests/ui/privacy/private-in-public-warn.rs
@@ -3,10 +3,10 @@
 
 #![feature(associated_type_defaults)]
 #![deny(private_in_public)]
-#![allow(improper_ctypes)]
 
 mod types {
-    struct Priv;
+    #[repr(C)]
+    struct Priv(u8);
     pub struct Pub;
     pub trait PubTr {
         type Alias;
@@ -21,7 +21,7 @@ mod types {
         //~^ WARNING hard error
     }
     pub trait Tr {
-        const C: Priv = Priv; //~ ERROR private type `types::Priv` in public interface
+        const C: Priv = Priv(0); //~ ERROR private type `types::Priv` in public interface
         //~^ WARNING hard error
         type Alias = Priv; //~ ERROR private type `types::Priv` in public interface
         fn f1(arg: Priv) {} //~ ERROR private type `types::Priv` in public interface

--- a/tests/ui/privacy/private-in-public-warn.stderr
+++ b/tests/ui/privacy/private-in-public-warn.stderr
@@ -33,7 +33,7 @@ LL |         V2 { field: Priv },
 error: private type `types::Priv` in public interface (error E0446)
   --> $DIR/private-in-public-warn.rs:24:9
    |
-LL |         const C: Priv = Priv;
+LL |         const C: Priv = Priv(0);
    |         ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -42,7 +42,7 @@ LL |         const C: Priv = Priv;
 error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:26:9
    |
-LL |     struct Priv;
+LL |     struct Priv(u8);
    |     ----------- `types::Priv` declared as private
 ...
 LL |         type Alias = Priv;
@@ -96,7 +96,7 @@ LL |         pub fn ef2() -> Priv;
 error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:41:9
    |
-LL |     struct Priv;
+LL |     struct Priv(u8);
    |     ----------- `types::Priv` declared as private
 ...
 LL |         type Alias = Priv;

--- a/tests/ui/repr/align-with-extern-c-fn.rs
+++ b/tests/ui/repr/align-with-extern-c-fn.rs
@@ -1,17 +1,11 @@
 // run-pass
 
-#![allow(stable_features)]
-#![allow(unused_variables)]
-
 // #45662
 
-#![feature(repr_align)]
+#[repr(C, align(16))]
+pub struct A(i64);
 
-#[repr(align(16))]
-pub struct A(#[allow(unused_tuple_struct_fields)] i64);
-
-#[allow(improper_ctypes_definitions)]
-pub extern "C" fn foo(x: A) {}
+pub extern "C" fn foo(_x: A) {}
 
 fn main() {
     foo(A(0));


### PR DESCRIPTION
Addresses most of #53858

### Summary of changes:
#### `allow(improper_ctypes)` removed (it was not doing anything anymore)
- `tests/ui/lint/lint-ctypes-fn.rs`
- `tests/ui/abi/variadic-ffi.rs`
- `tests/ui/abi/issues/issue-97463-broken-abi-leaked-uninit-data.rs`
- `tests/ui/abi/foreign/foreign-fn-with-byval.rs`
- `tests/debuginfo/type-names.rs`
- `tests/codegen/riscv-abi/riscv64-lp64-lp64f-lp64d-abi.rs` (note: it's suspicious that there's an empty struct here that works, why is that the case?)

#### Lint removed by addressing the root problem
- `tests/ui/issues/issue-3656.rs`
- `tests/ui/issues/issue-51907.rs`
- `tests/ui/repr/align-with-extern-c-fn.rs`
- `tests/ui/lint/clashing-extern-fn.rs`
- `tests/ui/lint/clashing-extern-fn-recursion.rs`
- `tests/ui/abi/issue-28676.rs`
- `tests/ui/abi/issues/issue-62350-sysv-neg-reg-counts.rs`
- `tests/ui/abi/extern/extern-pass-TwoU8s.rs`
- `tests/ui/abi/extern/extern-pass-TwoU16s.rs`
- `tests/ui/abi/extern/extern-pass-TwoU32s.rs`
- `tests/ui/abi/extern/extern-pass-TwoU64s.rs`
- `tests/ui/abi/extern/extern-return-TwoU8s.rs`
- `tests/ui/abi/extern/extern-return-TwoU16s.rs`
- `tests/ui/abi/extern/extern-return-TwoU32s.rs`
- `tests/ui/abi/extern/extern-return-TwoU64s.rs`
- `tests/ui/abi/abi-sysv64-register-usage.rs`
- `tests/ui/cfg/conditional-compile.rs`
- `tests/ui/abi/abi-sysv64-arg-passing.rs` (note: one instance here is intentional in the test, can this be fixed?)
- `tests/ui/lint/clashing-extern-fn.rs` (note: two instances here are intentional)

#### Intentional or the lint firing/not firing is part of the test
- `tests/ui/lint/warn-ctypes-inhibit.rs`
- `tests/ui/issues/issue-16441.rs`
- `tests/ui/lint/lint-ctypes.rs`
- `tests/ui/abi/extern/extern-pass-empty.rs` (note: `#![allow(improper_ctypes)] // FIXME: this test is inherently not FFI-safe.`)

#### Unknown/Not addressed in this PR/Needs more investigation
- `tests/ui/issues/issue-28600.rs` (possibly intentional for ICE)
- `tests/ui/issues/issue-26997.rs` (possibly intentional for ICE)
- `tests/ui/issues/issue-38763.rs` (possibly intentional for ICE)
- `tests/ui/issues/issue-5754.rs` (possibly intentional for ICE)
- `tests/ui/foreign/nil-decl-in-foreign.rs` (maybe an LLVM bug test? It was fixed with no links to how.)
- `tests/ui/mir/mir_cast_fn_ret.rs` (I don't know enough about this test)
- `tests/ui/mir/mir_codegen_calls.rs` (I don't know enough about this test)
- `tests/ui/abi/numbers-arithmetic/i128-ffi.rs` (note: it's testing 128-bit ints in FFI, this is a known problem cc #54341 #78473 )