### PR TITLE
Make errors from `x doc` less verbose

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1915,10 +1915,10 @@ impl<'a> Builder<'a> {
         }
 
         // For `cargo doc` invocations, make rustdoc print the Rust version into the docs
-        // This replaces spaces with newlines because RUSTDOCFLAGS does not
+        // This replaces spaces with tabs because RUSTDOCFLAGS does not
         // support arguments with regular spaces. Hopefully someday Cargo will
         // have space support.
-        let rust_version = self.rust_version().replace(' ', "\n");
+        let rust_version = self.rust_version().replace(' ', "\t");
         rustdocflags.arg("--crate-version").arg(&rust_version);
 
         // Environment variables *required* throughout the build


### PR DESCRIPTION
before:
```
error: could not document `bootstrap`

Caused by:
  process didn't exit successfully: `/home/jyn/src/rust/build/bootstrap/debug/rustdoc ... --crate-version '1.71.0
  (eb9da7bfa
  2023-05-25)
  (a
  long
  description
  goes
  here)' --document-private-items --enable-index-page --show-type-layout --generate-link-to-definition -Zunstable-options` (exit status: 1)
```

after:
```
error: could not document `bootstrap`

Caused by:
  process didn't exit successfully: `/home/jyn/src/rust/build/bootstrap/debug/rustdoc ... --crate-version '1.71.0        (eb9da7bfa      2023-05-25)     (a     long     description    goes     here)' --document-private-items --enable-index-page --show-type-layout --generate-link-to-definition -Zunstable-options` (exit status: 1)
```