### PR TITLE
Use a single codegen unit for fully optimized builds.

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -429,12 +429,13 @@ changelog-seen = 2
 # Set this to `true` to download unconditionally (useful if e.g. you are only changing doc-comments).
 #download-rustc = false
 
-# Number of codegen units to use for each compiler invocation. A value of 0
-# means "the number of cores on this machine", and 1+ is passed through to the
-# compiler.
+# Number of codegen units to use for each compiler invocation. If specified: a
+# value of 0 means "the number of cores on this machine", and 1+ is passed
+# through to the compiler.
 #
-# Uses the rustc defaults: https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
-#codegen-units = if incremental { 256 } else { 16 }
+# The default value depends on various things, and is also described here:
+# https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
+#codegen-units = if optimize && !debug && !incremental { 1 } else if incremental { 256 } else { 16 }
 
 # Sets the number of codegen units to build the standard library with,
 # regardless of what the codegen-unit setting for the rest of the compiler is.

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -31,6 +31,7 @@ Supported values can also be discovered by running `rustc --print code-models`.
 
 ## codegen-units
 
+njn: wrong about 0
 This flag controls how many code generation units the crate is split into. It
 takes an integer greater than 0.
 
@@ -39,6 +40,7 @@ them in parallel. Increasing parallelism may speed up compile times, but may
 also produce slower code. Setting this to 1 may improve the performance of
 generated code, but may be slower to compile.
 
+njn: update
 The default value, if not specified, is 16 for non-incremental builds. For
 incremental builds the default is 256 which allows caching to be more granular.
 


### PR DESCRIPTION
r? @ghost