### PR TITLE
Respect CARGOFLAGS in bootstrap.py

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -917,6 +917,10 @@ class RustBuild(object):
             args.append("--color=always")
         elif color == "never":
             args.append("--color=never")
+        try:
+            args += env["CARGOFLAGS"].split()
+        except KeyError:
+            pass
 
         # Run this from the source directory so cargo finds .cargo/config
         run(args, env=env, verbose=self.verbose, cwd=self.rust_root)


### PR DESCRIPTION
This makes it possible to pass flags to bootstrap itself, for consistency with std/rustc: https://github.com/rust-lang/rust/blob/04265621f9a82cfc2fc2278b935dcc5d4a1c39b7/src/bootstrap/builder.rs#L1446-L1447
Like RUSTFLAGS, this doesn't support CARGOFLAGS_BOOTSTRAP: https://github.com/rust-lang/rust/blob/6674dcda7a1da4c66e0aa0cfc67b27e42f4ebb34/src/bootstrap/bootstrap.py#L883-L884

I found this useful recently when I wanted to pass `-Zsparse-registry` to an old checkout of the compiler from before it was stabilized in cargo.