### PR TITLE
fix: prevent infinity evaluate predicate for auto-trait

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -535,7 +535,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         }
                     }
                 }
-
+                ty::Adt(def, _) => {
+                    let ty = def.sized_constraint(self.tcx()).0;
+                    if !(ty.len() == 1 && matches!(ty[0].kind(), ty::Error(_))) {
+                        candidates.vec.push(AutoImplCandidate)
+                    }
+                }
                 _ => candidates.vec.push(AutoImplCandidate),
             }
         }

--- a/tests/ui/traits/issue-105231.rs
+++ b/tests/ui/traits/issue-105231.rs
@@ -1,0 +1,8 @@
+struct A<T>(B<T>);
+//~^ ERROR: recursive types `A` and `B` have infinite size
+struct B<T>(A<A<T>>);
+trait Foo {}
+impl<T> Foo for T where T: Send {}
+impl Foo for B<u8> {}
+
+fn main() {}

--- a/tests/ui/traits/issue-105231.stderr
+++ b/tests/ui/traits/issue-105231.stderr
@@ -1,0 +1,19 @@
+error[E0072]: recursive types `A` and `B` have infinite size
+  --> $DIR/issue-105231.rs:1:1
+   |
+LL | struct A<T>(B<T>);
+   | ^^^^^^^^^^^ ---- recursive without indirection
+LL |
+LL | struct B<T>(A<A<T>>);
+   | ^^^^^^^^^^^ ------- recursive without indirection
+   |
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
+   |
+LL ~ struct A<T>(Box<B<T>>);
+LL |
+LL ~ struct B<T>(Box<A<A<T>>>);
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0072`.


### PR DESCRIPTION
Fixes #105231

In #105231, an infinity function call occurred when evaluating `B<u8> as Send`, and the stack was `B<u8>` -> `A<A<u8>` -> `B<A<u8>` -> `A<A<A<u8>>>` ->  xxxx. Although the recursion limit was reached, the error was not emitted directly because #102890 had discarded the `cycle_delay_bug`, instead, it returned an [Error](https://github.com/rust-lang/rust/blob/d300bffa4f0036e9138ef752610d08fc63f87a77/compiler/rustc_trait_selection/src/traits/select/mod.rs#L1367-L1369) finally, and the panic occurred at [expect](https://github.com/rust-lang/rust/blob/d300bffa4f0036e9138ef752610d08fc63f87a77/compiler/rustc_trait_selection/src/traits/select/mod.rs#L528).

To address this issue, I added a size check before the predicate. If the struct size is infinite, the `AutoImplCandidate` will not be appended to `candidates`.