### PR TITLE
return `NoSolution` for default assoc items

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -19,7 +19,7 @@ use rustc_middle::ty::{
     self, OpaqueTypeKey, Ty, TyCtxt, TypeFoldable, TypeSuperVisitable, TypeVisitable,
     TypeVisitableExt, TypeVisitor,
 };
-use rustc_span::DUMMY_SP;
+use rustc_span::{ErrorGuaranteed, DUMMY_SP};
 use std::ops::ControlFlow;
 
 use crate::traits::specialization_graph;
@@ -558,6 +558,17 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         match kind.unpack() {
             ty::TermKind::Ty(_) => self.next_ty_infer().into(),
             ty::TermKind::Const(ct) => self.next_const_infer(ct.ty()).into(),
+        }
+    }
+
+    pub(super) fn term_error_of_kind(
+        &self,
+        kind: ty::Term<'tcx>,
+        guar: ErrorGuaranteed,
+    ) -> ty::Term<'tcx> {
+        match kind.unpack() {
+            ty::TermKind::Ty(_) => self.tcx().ty_error(guar).into(),
+            ty::TermKind::Const(ct) => self.tcx().const_error(ct.ty(), guar).into(),
         }
     }
 

--- a/tests/ui/traits/new-solver/specialization/specialization-default-no-solution.rs
+++ b/tests/ui/traits/new-solver/specialization/specialization-default-no-solution.rs
@@ -1,0 +1,26 @@
+// check-pass
+// compile-flags: -Ztrait-solver=next
+#![feature(specialization)]
+#![allow(incomplete_features)]
+trait Trait {
+    type Assoc;
+}
+
+impl<T> Trait for T {
+    default type Assoc = u32;
+}
+
+impl Trait for u32 {
+    type Assoc = u32;
+}
+
+fn generic<T: Trait<Assoc = u32>>(_: T) {}
+
+fn main() {
+    generic(1)
+    // We want `normalizes-to(<{integer} as Trait>::Assoc, u32)`
+    // to succeed as there is only one impl that can be used for
+    // this function to compile, even if the default impl would
+    // also satisfy this. This is different from coherence where
+    // doing so would be unsound.
+}

--- a/tests/ui/traits/new-solver/specialization/specialization-transmute.rs
+++ b/tests/ui/traits/new-solver/specialization/specialization-transmute.rs
@@ -14,7 +14,7 @@ impl<T> Default for T {
 
    fn intu(&self) -> &Self::Id {
         self
-        //~^ ERROR cannot satisfy `T <: <T as Default>::Id`
+        //~^ ERROR mismatched types
    }
 }
 
@@ -25,6 +25,6 @@ fn transmute<T: Default<Id = U>, U: Copy>(t: T) -> U {
 use std::num::NonZeroU8;
 fn main() {
     let s = transmute::<u8, Option<NonZeroU8>>(0);
-    //~^ ERROR cannot satisfy `<u8 as Default>::Id == Option<NonZeroU8>
+    //~^ ERROR type mismatch resolving `<u8 as Default>::Id == Option<NonZeroU8>`
     assert_eq!(s, None);
 }

--- a/tests/ui/traits/new-solver/specialization/specialization-transmute.stderr
+++ b/tests/ui/traits/new-solver/specialization/specialization-transmute.stderr
@@ -8,18 +8,30 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0284]: type annotations needed: cannot satisfy `T <: <T as Default>::Id`
+error[E0308]: mismatched types
   --> $DIR/specialization-transmute.rs:16:9
    |
+LL |    fn intu(&self) -> &Self::Id {
+   |                      --------- expected `&<T as Default>::Id` because of return type
 LL |         self
-   |         ^^^^ cannot satisfy `T <: <T as Default>::Id`
+   |         ^^^^ types differ
+   |
+   = note: expected reference `&<T as Default>::Id`
+              found reference `&T`
 
-error[E0284]: type annotations needed: cannot satisfy `<u8 as Default>::Id == Option<NonZeroU8>`
-  --> $DIR/specialization-transmute.rs:27:13
+error[E0271]: type mismatch resolving `<u8 as Default>::Id == Option<NonZeroU8>`
+  --> $DIR/specialization-transmute.rs:27:48
    |
 LL |     let s = transmute::<u8, Option<NonZeroU8>>(0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `<u8 as Default>::Id == Option<NonZeroU8>`
+   |             ---------------------------------- ^ type mismatch resolving `<u8 as Default>::Id == Option<NonZeroU8>`
+   |             |
+   |             required by a bound introduced by this call
    |
+note: types differ
+  --> $DIR/specialization-transmute.rs:13:22
+   |
+LL |    default type Id = T;
+   |                      ^
 note: required by a bound in `transmute`
   --> $DIR/specialization-transmute.rs:21:25
    |
@@ -28,4 +40,5 @@ LL | fn transmute<T: Default<Id = U>, U: Copy>(t: T) -> U {
 
 error: aborting due to 2 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0284`.
+Some errors have detailed explanations: E0271, E0308.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/traits/new-solver/specialization/specialization-unconstrained.rs
+++ b/tests/ui/traits/new-solver/specialization/specialization-unconstrained.rs
@@ -18,5 +18,5 @@ fn test<T: Default<Id = U>, U>() {}
 
 fn main() {
     test::<u32, ()>();
-    //~^ ERROR cannot satisfy `<u32 as Default>::Id == ()`
+    //~^ ERROR type mismatch resolving `<u32 as Default>::Id == ()`
 }

--- a/tests/ui/traits/new-solver/specialization/specialization-unconstrained.stderr
+++ b/tests/ui/traits/new-solver/specialization/specialization-unconstrained.stderr
@@ -8,12 +8,17 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0284]: type annotations needed: cannot satisfy `<u32 as Default>::Id == ()`
-  --> $DIR/specialization-unconstrained.rs:20:5
+error[E0271]: type mismatch resolving `<u32 as Default>::Id == ()`
+  --> $DIR/specialization-unconstrained.rs:20:12
    |
 LL |     test::<u32, ()>();
-   |     ^^^^^^^^^^^^^^^ cannot satisfy `<u32 as Default>::Id == ()`
+   |            ^^^ type mismatch resolving `<u32 as Default>::Id == ()`
    |
+note: types differ
+  --> $DIR/specialization-unconstrained.rs:14:22
+   |
+LL |    default type Id = T;
+   |                      ^
 note: required by a bound in `test`
   --> $DIR/specialization-unconstrained.rs:17:20
    |
@@ -22,4 +27,4 @@ LL | fn test<T: Default<Id = U>, U>() {}
 
 error: aborting due to previous error; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
still return ambiguity in coherence as this would otherwise be unsound.

r? @BoxyUwU 