### PR TITLE
Fix re-export of doc hidden macro not showing up

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2592,7 +2592,8 @@ fn clean_use_statement_inner<'tcx>(
     } else {
         if inline_attr.is_none()
             && let Res::Def(DefKind::Mod, did) = path.res
-            && !did.is_local() && did.is_crate_root()
+            && !did.is_local()
+            && did.is_crate_root()
         {
             // if we're `pub use`ing an extern crate root, don't inline it unless we
             // were specifically asked for it

--- a/tests/rustdoc/reexport-doc-hidden.rs
+++ b/tests/rustdoc/reexport-doc-hidden.rs
@@ -21,6 +21,5 @@ macro_rules! foo {
     () => {};
 }
 
-// This is a bug: https://github.com/rust-lang/rust/issues/59368
-// @!has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
+// @has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
 pub use crate::foo as Macro;

--- a/tests/rustdoc/reexport-hidden-macro.rs
+++ b/tests/rustdoc/reexport-hidden-macro.rs
@@ -15,7 +15,7 @@ macro_rules! foo {
     () => {};
 }
 
-/// not displayed
+// @has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
 pub use crate::foo as Macro;
 /// Displayed
 #[doc(inline)]

--- a/tests/rustdoc/reexport-hidden-macro.rs
+++ b/tests/rustdoc/reexport-hidden-macro.rs
@@ -5,6 +5,7 @@
 
 // @has 'foo/index.html'
 // @has - '//*[@id="main-content"]//a[@href="macro.Macro2.html"]' 'Macro2'
+// @has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
 
 // @has 'foo/macro.Macro2.html'
 // @has - '//*[@class="docblock"]' 'Displayed'
@@ -15,7 +16,6 @@ macro_rules! foo {
     () => {};
 }
 
-// @has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
 pub use crate::foo as Macro;
 /// Displayed
 #[doc(inline)]

--- a/tests/rustdoc/reexport-of-doc-hidden.rs
+++ b/tests/rustdoc/reexport-of-doc-hidden.rs
@@ -1,0 +1,42 @@
+// This test ensures that all re-exports of doc hidden elements are displayed.
+
+#![crate_name = "foo"]
+
+#[doc(hidden)]
+pub struct Bar;
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! foo {
+    () => {};
+}
+
+// @has 'foo/index.html'
+// @has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
+pub use crate::foo as Macro;
+// @has - '//*[@id="reexport.Macro2"]/code' 'pub use crate::foo as Macro2;'
+pub use crate::foo as Macro2;
+// @has - '//*[@id="reexport.Boo"]/code' 'pub use crate::Bar as Boo;'
+pub use crate::Bar as Boo;
+// @has - '//*[@id="reexport.Boo2"]/code' 'pub use crate::Bar as Boo2;'
+pub use crate::Bar as Boo2;
+
+pub fn fofo() {}
+
+// @has - '//*[@id="reexport.f1"]/code' 'pub use crate::fofo as f1;'
+pub use crate::fofo as f1;
+// @has - '//*[@id="reexport.f2"]/code' 'pub use crate::fofo as f2;'
+pub use crate::fofo as f2;
+
+pub mod sub {
+    // @has 'foo/sub/index.html'
+    // @has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
+    pub use crate::foo as Macro;
+    // @has - '//*[@id="reexport.Macro2"]/code' 'pub use crate::foo as Macro2;'
+    pub use crate::foo as Macro2;
+
+    // @has - '//*[@id="reexport.f1"]/code' 'pub use crate::fofo as f1;'
+    pub use crate::fofo as f1;
+    // @has - '//*[@id="reexport.f2"]/code' 'pub use crate::fofo as f2;'
+    pub use crate::fofo as f2;
+}


### PR DESCRIPTION
It's part of the follow-up of https://github.com/rust-lang/rust/pull/109697.

Re-exports of doc hidden macros should be visible. It was the only kind of re-export of doc hidden item that didn't show up.

r? @notriddle 