### PR TITLE
Avoid one `rustc` rebuild in the optimized build pipeline

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -118,6 +118,10 @@ impl Step for Std {
             || builder.config.keep_stage_std.contains(&compiler.stage)
         {
             builder.info("Warning: Using a potentially old libstd. This may not behave well.");
+
+            copy_third_party_objects(builder, &compiler, target);
+            copy_self_contained_objects(builder, &compiler, target);
+
             builder.ensure(StdLink::from_std(self, compiler));
             return;
         }

--- a/src/ci/stage-build.py
+++ b/src/ci/stage-build.py
@@ -973,6 +973,12 @@ def execute_build_pipeline(timer: Timer, pipeline: Pipeline, runner: BenchmarkRu
             ]
             print_free_disk_space(pipeline)
 
+    # We want to keep the already built PGO-optimized `rustc`.
+    dist_build_args += [
+        "--keep-stage", "0",
+        "--keep-stage", "1"
+    ]
+
     """
     Final stage: Build PGO optimized rustc + PGO/BOLT optimized LLVM
     """


### PR DESCRIPTION
This PR changes the optimized build pipeline to avoid one `rustc` rebuild, inspired by [this comment](https://github.com/rust-lang/rust/issues/112011#issuecomment-1564991175). This speeds up the pipeline by 5-10 minutes. After this change, we **no longer gather LLVM PGO profiles from compiling stage 2 of `rustc`**.

Now we build `rustc` two times (1x PGO instrumented, 1x PGO optimized) and LLVM three times (1x normal, 1x PGO instrumented, 1x PGO optimized). It should be possible to cache the normal LLVM build, but I'll leave that for another PR.