### PR TITLE
Check nested obligations during coercion unify in new solver

### DIFF
--- a/tests/ui/impl-trait/autoderef.rs
+++ b/tests/ui/impl-trait/autoderef.rs
@@ -1,3 +1,5 @@
+// revisions: current next
+//[next] compile-flag: -Ztrait-solver=next
 // check-pass
 
 use std::path::Path;


### PR DESCRIPTION
Found when triaging failing opaque tests with new solver.

r? @lcnr