### PR TITLE
Don't check for misaligned raw pointer derefs inside Rvalue::AddressOf

### DIFF
--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -75,6 +75,14 @@ struct PointerFinder<'tcx, 'a> {
 }
 
 impl<'tcx, 'a> Visitor<'tcx> for PointerFinder<'tcx, 'a> {
+    fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
+        if let Rvalue::AddressOf(..) = rvalue {
+            // Ignore dereferences inside of an AddressOf
+            return;
+        }
+        self.super_rvalue(rvalue, location);
+    }
+
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, _location: Location) {
         if let PlaceContext::NonUse(_) = context {
             return;

--- a/tests/ui/mir/addrof_alignment.rs
+++ b/tests/ui/mir/addrof_alignment.rs
@@ -1,0 +1,15 @@
+// run-pass
+// ignore-wasm32-bare: No panic messages
+// compile-flags: -C debug-assertions
+
+struct Misalignment {
+    a: u32,
+}
+
+fn main() {
+    let items: [Misalignment; 2] = [Misalignment { a: 0 }, Misalignment { a: 1 }];
+    unsafe {
+        let ptr: *const Misalignment = items.as_ptr().cast::<u8>().add(1).cast::<Misalignment>();
+        let _ptr = core::ptr::addr_of!((*ptr).a);
+    }
+}


### PR DESCRIPTION
From https://github.com/rust-lang/rust/pull/112026#issuecomment-1565686697:

rustc 1.70 (stable next week) added a Mir pass to add pointer alignment checks in debug mode. Adding these checks caused some crates to break, but that was expected, since they contain broken code (https://github.com/rust-lang/rust/issues/111487) for tracking that.

However, the checks added are slightly more aggressive than they should have been. Specifically, they also check the place in an `addr_of!` expression. Whether lack of alignment there is or isn't UB is unclear. This PR modifies the pass to not affect those cases.

I spot checked the crater regressions and the ones I saw were not the case that this PR is modifying. It still seems good to not land anything overaggressive though