### PR TITLE
Recover upon mistyped error on typo'd `const` in const param def

### DIFF
--- a/tests/ui/parser/typod-const-in-const-param-def.rs
+++ b/tests/ui/parser/typod-const-in-const-param-def.rs
@@ -1,0 +1,16 @@
+pub fn foo<Const N: u8>() {}
+//~^ ERROR `const` keyword was mistyped as `Const`
+
+pub fn bar<Const>() {}
+// OK
+
+pub fn baz<Const N: u8, T>() {}
+//~^ ERROR `const` keyword was mistyped as `Const`
+
+pub fn qux<T, Const N: u8>() {}
+//~^ ERROR `const` keyword was mistyped as `Const`
+
+pub fn quux<T, Const N: u8, U>() {}
+//~^ ERROR `const` keyword was mistyped as `Const`
+
+fn main() {}

--- a/tests/ui/parser/typod-const-in-const-param-def.stderr
+++ b/tests/ui/parser/typod-const-in-const-param-def.stderr
@@ -1,0 +1,46 @@
+error: `const` keyword was mistyped as `Const`
+  --> $DIR/typod-const-in-const-param-def.rs:1:12
+   |
+LL | pub fn foo<Const N: u8>() {}
+   |            ^^^^^
+   |
+help: use the `const` keyword
+   |
+LL | pub fn foo<const N: u8>() {}
+   |            ~~~~~
+
+error: `const` keyword was mistyped as `Const`
+  --> $DIR/typod-const-in-const-param-def.rs:7:12
+   |
+LL | pub fn baz<Const N: u8, T>() {}
+   |            ^^^^^
+   |
+help: use the `const` keyword
+   |
+LL | pub fn baz<const N: u8, T>() {}
+   |            ~~~~~
+
+error: `const` keyword was mistyped as `Const`
+  --> $DIR/typod-const-in-const-param-def.rs:10:15
+   |
+LL | pub fn qux<T, Const N: u8>() {}
+   |               ^^^^^
+   |
+help: use the `const` keyword
+   |
+LL | pub fn qux<T, const N: u8>() {}
+   |               ~~~~~
+
+error: `const` keyword was mistyped as `Const`
+  --> $DIR/typod-const-in-const-param-def.rs:13:16
+   |
+LL | pub fn quux<T, Const N: u8, U>() {}
+   |                ^^^^^
+   |
+help: use the `const` keyword
+   |
+LL | pub fn quux<T, const N: u8, U>() {}
+   |                ~~~~~
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
And add machine-applicable fix for the typo'd `const` keyword.

### Before

```
error: expected one of `,`, `:`, `=`, or `>`, found `N`
 --> src/lib.rs:1:18
  |
1 | pub fn bar<Const N: u8>() {}
  |                  ^ expected one of `,`, `:`, `=`, or `>`
```

### After This PR

```
error: `const` keyword was mistyped as `Const`
 --> test.rs:1:8
  |
1 | fn bar<Const N: u8>() {}
  |        ^^^^^
  |
help: use the `const` keyword
  |
1 | fn bar<const N: u8>() {}
  |        ~~~~~

```

Fixes #111941.