### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0133.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0133.md
@@ -1,4 +1,4 @@
-Unsafe code was used outside of an unsafe function or block.
+Unsafe code was used outside of an unsafe block.
 
 Erroneous code example:
 
@@ -29,5 +29,22 @@ fn main() {
 ```
 
 See the [unsafe section][unsafe-section] of the Book for more details.
+
+#### Unsafe code in functions
+
+Unsafe code is currently accepted in unsafe functions, but that is being phased
+out in favor of requiring unsafe blocks here too.
+
+```
+unsafe fn f() { return; }
+
+unsafe fn g() {
+    f(); // Is accepted, but no longer recommended
+    unsafe { f(); } // Recommended way to write this
+}
+```
+
+Linting against this is controlled via the `unsafe_op_in_unsafe_fn` lint, which
+is `allow` by default but will be upgraded to `warn` in a future edition.
 
 [unsafe-section]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html

--- a/compiler/rustc_target/src/spec/x86_64_pc_solaris.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_solaris.rs
@@ -7,7 +7,7 @@ pub fn target() -> Target {
     base.vendor = "pc".into();
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::X86;
-    base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI;
+    base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::THREAD;
 
     Target {
         llvm_target: "x86_64-pc-solaris".into(),

--- a/compiler/rustc_target/src/spec/x86_64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_illumos.rs
@@ -5,7 +5,7 @@ pub fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-m64", "-std=c99"]);
     base.cpu = "x86-64".into();
     base.max_atomic_width = Some(64);
-    base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI;
+    base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::THREAD;
 
     Target {
         // LLVM does not currently have a separate illumos target,

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3113,8 +3113,9 @@ impl<T> [T] {
     ///
     /// # Current implementation
     ///
-    /// The current algorithm is based on the quickselect portion of the same quicksort algorithm
-    /// used for [`sort_unstable`].
+    /// The current algorithm is an introselect implementation based on Pattern Defeating Quicksort, which is also
+    /// the basis for [`sort_unstable`]. The fallback algorithm is Median of Medians using Tukey's Ninther for
+    /// pivot selection, which guarantees linear runtime for all inputs.
     ///
     /// [`sort_unstable`]: slice::sort_unstable
     ///

--- a/tests/rustdoc-gui/search-result-display.goml
+++ b/tests/rustdoc-gui/search-result-display.goml
@@ -57,22 +57,22 @@ define-function: (
 
 call-function: ("check-filter", {
     "theme": "ayu",
-    "border": "rgb(92, 103, 115)",
+    "border": "#5c6773",
     "filter": "invert(0.41) sepia(0.12) saturate(4.87) hue-rotate(171deg) brightness(0.94) contrast(0.94)",
-    "hover_border": "rgb(224, 224, 224)",
+    "hover_border": "#e0e0e0",
     "hover_filter": "invert(0.98) sepia(0.12) saturate(0.81) hue-rotate(343deg) brightness(1.13) contrast(0.76)",
 })
 call-function: ("check-filter", {
     "theme": "dark",
-    "border": "rgb(224, 224, 224)",
+    "border": "#e0e0e0",
     "filter": "invert(0.94) sepia(0) saturate(7.21) hue-rotate(255deg) brightness(0.9) contrast(0.9)",
-    "hover_border": "rgb(33, 150, 243)",
+    "hover_border": "#2196f3",
     "hover_filter": "invert(0.69) sepia(0.6) saturate(66.13) hue-rotate(184deg) brightness(1) contrast(0.91)",
 })
 call-function: ("check-filter", {
     "theme": "light",
-    "border": "rgb(224, 224, 224)",
+    "border": "#e0e0e0",
     "filter": "invert(1) sepia(0) saturate(42.23) hue-rotate(289deg) brightness(1.14) contrast(0.76)",
-    "hover_border": "rgb(113, 113, 113)",
+    "hover_border": "#717171",
     "hover_filter": "invert(0.44) sepia(0.18) saturate(0.23) hue-rotate(317deg) brightness(0.96) contrast(0.93)",
 })

--- a/tests/ui/parser/typod-const-in-const-param-def.rs
+++ b/tests/ui/parser/typod-const-in-const-param-def.rs
@@ -1,0 +1,16 @@
+pub fn foo<Const N: u8>() {}
+//~^ ERROR `const` keyword was mistyped as `Const`
+
+pub fn bar<Const>() {}
+// OK
+
+pub fn baz<Const N: u8, T>() {}
+//~^ ERROR `const` keyword was mistyped as `Const`
+
+pub fn qux<T, Const N: u8>() {}
+//~^ ERROR `const` keyword was mistyped as `Const`
+
+pub fn quux<T, Const N: u8, U>() {}
+//~^ ERROR `const` keyword was mistyped as `Const`
+
+fn main() {}

--- a/tests/ui/parser/typod-const-in-const-param-def.stderr
+++ b/tests/ui/parser/typod-const-in-const-param-def.stderr
@@ -1,0 +1,46 @@
+error: `const` keyword was mistyped as `Const`
+  --> $DIR/typod-const-in-const-param-def.rs:1:12
+   |
+LL | pub fn foo<Const N: u8>() {}
+   |            ^^^^^
+   |
+help: use the `const` keyword
+   |
+LL | pub fn foo<const N: u8>() {}
+   |            ~~~~~
+
+error: `const` keyword was mistyped as `Const`
+  --> $DIR/typod-const-in-const-param-def.rs:7:12
+   |
+LL | pub fn baz<Const N: u8, T>() {}
+   |            ^^^^^
+   |
+help: use the `const` keyword
+   |
+LL | pub fn baz<const N: u8, T>() {}
+   |            ~~~~~
+
+error: `const` keyword was mistyped as `Const`
+  --> $DIR/typod-const-in-const-param-def.rs:10:15
+   |
+LL | pub fn qux<T, Const N: u8>() {}
+   |               ^^^^^
+   |
+help: use the `const` keyword
+   |
+LL | pub fn qux<T, const N: u8>() {}
+   |               ~~~~~
+
+error: `const` keyword was mistyped as `Const`
+  --> $DIR/typod-const-in-const-param-def.rs:13:16
+   |
+LL | pub fn quux<T, Const N: u8, U>() {}
+   |                ^^^^^
+   |
+help: use the `const` keyword
+   |
+LL | pub fn quux<T, const N: u8, U>() {}
+   |                ~~~~~
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #112029 (Recover upon mistyped error on typo'd `const` in const param def)
 - #112037 (Add details about `unsafe_op_in_unsafe_fn` to E0133)
 - #112039 (compiler: update solaris/illumos to enable tsan support.)
 - #112042 (Migrate GUI colors test to original CSS color format)
 - #112045 (Followup to #111973)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112029,112037,112039,112042,112045)
<!-- homu-ignore:end -->