### PR TITLE
offset_of: don't require type to be `Sized`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -668,11 +668,16 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
             mir::Rvalue::NullaryOp(ref null_op, ty) => {
                 let ty = self.monomorphize(ty);
-                assert!(bx.cx().type_is_sized(ty));
                 let layout = bx.cx().layout_of(ty);
                 let val = match null_op {
-                    mir::NullOp::SizeOf => layout.size.bytes(),
-                    mir::NullOp::AlignOf => layout.align.abi.bytes(),
+                    mir::NullOp::SizeOf => {
+                        assert!(bx.cx().type_is_sized(ty));
+                        layout.size.bytes()
+                    }
+                    mir::NullOp::AlignOf => {
+                        assert!(bx.cx().type_is_sized(ty));
+                        layout.align.abi.bytes()
+                    }
                     mir::NullOp::OffsetOf(fields) => {
                         layout.offset_of_subfield(bx.cx(), fields.iter().map(|f| f.index())).bytes()
                     }

--- a/tests/ui/offset-of/offset-of-unsized.rs
+++ b/tests/ui/offset-of/offset-of-unsized.rs
@@ -1,0 +1,15 @@
+// build-pass
+// regression test for #112051
+
+#![feature(offset_of)]
+
+struct S<T: ?Sized> {
+    a: u64,
+    b: T,
+}
+trait Tr {}
+
+fn main() {
+    let _a = core::mem::offset_of!(S<dyn Tr>, a);
+    let _b = core::mem::offset_of!((u64, dyn Tr), 0);
+}


### PR DESCRIPTION
Fixes #112051

~~The RFC [explicitly forbids](https://rust-lang.github.io/rfcs/3308-offset_of.html#limitations) non-`Sized` types, but it looks like only the fields being recursed into were checked. The sized check also seemed to have been completely missing for tuples~~
