### PR TITLE
Avoid ICE on `#![doc(test(...)]` with literal parameter

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -214,6 +214,8 @@ passes_doc_keyword_only_impl =
 passes_doc_test_takes_list =
     `#[doc(test(...)]` takes a list of attributes
 
+passes_doc_test_literal = `#![doc(test(...)]` does not take a literal
+
 passes_doc_test_unknown =
     unknown `doc(test)` attribute `{$path}`
 

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -211,10 +211,10 @@ passes_doc_keyword_not_mod =
 passes_doc_keyword_only_impl =
     `#[doc(keyword = "...")]` should be used on impl blocks
 
+passes_doc_test_literal = `#![doc(test(...)]` does not take a literal
+
 passes_doc_test_takes_list =
     `#[doc(test(...)]` takes a list of attributes
-
-passes_doc_test_literal = `#![doc(test(...)]` does not take a literal
 
 passes_doc_test_unknown =
     unknown `doc(test)` attribute `{$path}`

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -282,6 +282,10 @@ pub struct DocTestUnknown {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(passes_doc_test_literal)]
+pub struct DocTestLiteral;
+
+#[derive(LintDiagnostic)]
 #[diag(passes_doc_test_takes_list)]
 pub struct DocTestTakesList;
 

--- a/tests/ui/attributes/doc-test-literal.rs
+++ b/tests/ui/attributes/doc-test-literal.rs
@@ -1,0 +1,7 @@
+#![deny(warnings)]
+
+#![doc(test(""))]
+//~^ ERROR `#![doc(test(...)]` does not take a literal
+//~^^ WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+fn main() {}

--- a/tests/ui/attributes/doc-test-literal.stderr
+++ b/tests/ui/attributes/doc-test-literal.stderr
@@ -1,0 +1,17 @@
+error: `#![doc(test(...)]` does not take a literal
+  --> $DIR/doc-test-literal.rs:3:13
+   |
+LL | #![doc(test(""))]
+   |             ^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+note: the lint level is defined here
+  --> $DIR/doc-test-literal.rs:1:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Close #109066

r? @compiler-errors 