### PR TITLE
Add a note when suggesting to use Impl Trait

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -856,7 +856,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             format!("impl {}", all_bounds_str),
             Applicability::MaybeIncorrect,
         );
-        err.note(format!("the type of `{}` is chosen by the caller", expected_ty_as_param.name));
+
+        let ty::Param(found_ty_as_param) = found.kind() else { return };
+        err.note(format!("the type of `{}` is chosen by the caller and may be a type that is different than `{}`", expected_ty_as_param.name, found_ty_as_param.name));
     }
 
     pub(in super::super) fn suggest_missing_break_or_return_expr(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -856,6 +856,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             format!("impl {}", all_bounds_str),
             Applicability::MaybeIncorrect,
         );
+        err.note(format!("the type of `{}` is chosen by the caller", expected_ty_as_param.name));
     }
 
     pub(in super::super) fn suggest_missing_break_or_return_expr(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -858,7 +858,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         );
 
         let ty::Param(found_ty_as_param) = found.kind() else { return };
-        err.note(format!("the type of `{}` is chosen by the caller and may be a type that is different than `{}`", expected_ty_as_param.name, found_ty_as_param.name));
+        err.note(format!("the type of `{}` is chosen by the caller and may be a type that is different from `{}`", expected_ty_as_param.name, found_ty_as_param.name));
     }
 
     pub(in super::super) fn suggest_missing_break_or_return_expr(

--- a/tests/ui/return/return-impl-trait-bad.stderr
+++ b/tests/ui/return/return-impl-trait-bad.stderr
@@ -53,6 +53,7 @@ LL |     "don't suggest this, because the generic param is used in the bound."
    |
    = note: expected type parameter `T`
                    found reference `&'static str`
+   = note: the type of `T` is chosen by the caller
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/return/return-impl-trait-bad.stderr
+++ b/tests/ui/return/return-impl-trait-bad.stderr
@@ -53,7 +53,7 @@ LL |     "don't suggest this, because the generic param is used in the bound."
    |
    = note: expected type parameter `T`
                    found reference `&'static str`
-   = note: the type of `T` is chosen by the caller
+   = note: the type of `T` is chosen by the caller and may be a type that is different than `T`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/return/return-impl-trait.stderr
+++ b/tests/ui/return/return-impl-trait.stderr
@@ -12,6 +12,7 @@ LL |     ()
    |
    = note: expected type parameter `T`
                    found unit type `()`
+   = note: the type of `T` is chosen by the caller
 
 error[E0308]: mismatched types
   --> $DIR/return-impl-trait.rs:23:5
@@ -28,6 +29,7 @@ LL |     ()
    |
    = note: expected type parameter `T`
                    found unit type `()`
+   = note: the type of `T` is chosen by the caller
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/return/return-impl-trait.stderr
+++ b/tests/ui/return/return-impl-trait.stderr
@@ -12,7 +12,7 @@ LL |     ()
    |
    = note: expected type parameter `T`
                    found unit type `()`
-   = note: the type of `T` is chosen by the caller
+   = note: the type of `T` is chosen by the caller and may be a type that is different than `T`
 
 error[E0308]: mismatched types
   --> $DIR/return-impl-trait.rs:23:5
@@ -29,7 +29,7 @@ LL |     ()
    |
    = note: expected type parameter `T`
                    found unit type `()`
-   = note: the type of `T` is chosen by the caller
+   = note: the type of `T` is chosen by the caller and may be a type that is different than `T`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Add a note to E308 explaining that generic type variables are chosen by the caller rather than the implementer, when suggesting to use impl Trait instead of a generic type variable.

```rust
error[E0308]: mismatched types
 --> src/lib.rs:3:5
  |
2 | fn foo<T: Clone>() -> T {
  |        -              -
  |        |              |
  |        |              expected `T` because of return type
  |        |              help: consider using an impl return type: `impl Clone`
  |        this type parameter
3 |     "hello"
  |     ^^^^^^^ expected type parameter `T`, found `&str`
  |
  = note: expected type parameter `T`
                  found reference `&'static str`
  = note: the caller chooses the value of a type parameter
  ```
  
  This PR completes the work left here https://github.com/rust-lang/rust/pull/104755
  
r? rust-lang/diagnostics