### PR TITLE
Don't typecheck recovered method call from suggestion

### DIFF
--- a/tests/ui/typeck/issue-106929.rs
+++ b/tests/ui/typeck/issue-106929.rs
@@ -1,0 +1,13 @@
+struct Client;
+
+impl Client {
+    fn post<T: std::ops::Add>(&self, _: T, _: T) {}
+}
+
+fn f() {
+    let c = Client;
+    post(c, ());
+    //~^ ERROR cannot find function `post` in this scope
+}
+
+fn main() {}

--- a/tests/ui/typeck/issue-106929.stderr
+++ b/tests/ui/typeck/issue-106929.stderr
@@ -1,0 +1,15 @@
+error[E0425]: cannot find function `post` in this scope
+  --> $DIR/issue-106929.rs:9:5
+   |
+LL |     post(c, ());
+   |     ^^^^ not found in this scope
+   |
+help: use the `.` operator to call the method `post` on `&Client`
+   |
+LL -     post(c, ());
+LL +     c.post(());
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Only make the use-dot-operator-to-call-method suggestion, but do not double down and use the recovered type to perform method call typechecking as it will produce confusing diagnostics relevant for the *fixed* code.

### Code Sample

```rust
struct Client;

impl Client {
    fn post<T: std::ops::Add>(&self, _: T, _: T) {}
}

fn f() {
    let c = Client;
    post(c, ());
}
```

### Before This PR

```
error[[E0277]](https://doc.rust-lang.org/stable/error_codes/E0277.html): cannot add `()` to `()`
 --> src/lib.rs:9:5
  |
9 |     post(c, ());
  |     ^^^^^^^^^^^ no implementation for `() + ()`
  |
  = help: the trait `Add` is not implemented for `()`
note: required by a bound in `Client::post`
 --> src/lib.rs:4:16
  |
4 |     fn post<T: std::ops::Add>(&self, _: T, _: T) {}
  |                ^^^^^^^^^^^^^ required by this bound in `Client::post`

error[[E0061]](https://doc.rust-lang.org/stable/error_codes/E0061.html): this function takes 2 arguments but 1 argument was supplied
 --> src/lib.rs:9:5
  |
9 |     post(c, ());
  |     ^^^^ an argument of type `()` is missing
  |
note: method defined here
 --> src/lib.rs:4:8
  |
4 |     fn post<T: std::ops::Add>(&self, _: T, _: T) {}
  |        ^^^^                   -----  ----  ----
help: provide the argument
  |
9 |     post((), ())(c, ());
  |         ++++++++

error[[E0425]](https://doc.rust-lang.org/stable/error_codes/E0425.html): cannot find function `post` in this scope
 --> src/lib.rs:9:5
  |
9 |     post(c, ());
  |     ^^^^ not found in this scope
  |
help: use the `.` operator to call the method `post` on `&Client`
  |
9 -     post(c, ());
9 +     c.post(());
  |

Some errors have detailed explanations: E0061, E0277, E0425.
For more information about an error, try `rustc --explain E0061`.
```

### After This PR

```
error[E0425]: cannot find function `post` in this scope
 --> tests/ui/typeck/issue-106929.rs:9:5
  |
9 |     post(c, ());
  |     ^^^^ not found in this scope
  |
help: use the `.` operator to call the method `post` on `&Client`
  |
9 -     post(c, ());
9 +     c.post(());
  |

error: aborting due to previous error

For more information about this error, try `rustc --explain E0425`.
```

Fixes #106929.