### PR TITLE
[stable] 1.70.0 (backport)

### DIFF
--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -75,6 +75,14 @@ struct PointerFinder<'tcx, 'a> {
 }
 
 impl<'tcx, 'a> Visitor<'tcx> for PointerFinder<'tcx, 'a> {
+    fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
+        if let Rvalue::AddressOf(..) = rvalue {
+            // Ignore dereferences inside of an AddressOf
+            return;
+        }
+        self.super_rvalue(rvalue, location);
+    }
+
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, _location: Location) {
         if let PlaceContext::NonUse(_) = context {
             return;

--- a/tests/ui/mir/addrof_alignment.rs
+++ b/tests/ui/mir/addrof_alignment.rs
@@ -1,0 +1,15 @@
+// run-pass
+// ignore-wasm32-bare: No panic messages
+// compile-flags: -C debug-assertions
+
+struct Misalignment {
+    a: u32,
+}
+
+fn main() {
+    let items: [Misalignment; 2] = [Misalignment { a: 0 }, Misalignment { a: 1 }];
+    unsafe {
+        let ptr: *const Misalignment = items.as_ptr().cast::<u8>().add(1).cast::<Misalignment>();
+        let _ptr = core::ptr::addr_of!((*ptr).a);
+    }
+}


### PR DESCRIPTION
Backport https://github.com/rust-lang/rust/pull/112026 into 1.70.0 stable. Will rebuild dev-static artifacts after this gets built.

r? @Mark-Simulacrum 