### PR TITLE
Don't print unsupported split-debuginfo modes with `-Zunstable-options`

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -764,9 +764,7 @@ fn print_crate_info(
                 use rustc_target::spec::SplitDebuginfo::{Off, Packed, Unpacked};
 
                 for split in &[Off, Packed, Unpacked] {
-                    let stable = sess.target.options.supported_split_debuginfo.contains(split);
-                    let unstable_ok = sess.unstable_options();
-                    if stable || unstable_ok {
+                    if sess.target.options.supported_split_debuginfo.contains(split) {
                         safe_println!("{split}");
                     }
                 }


### PR DESCRIPTION
Currently unsupported `split-debuginfo` options are enabled by `-Zunstable-options`, for projects that have `-Zunstable-options` for other reasons this can be [an unexpected interaction](https://github.com/rust-lang/rust-clippy/pull/10516#issuecomment-1562604764)

This PR makes it so that `--print split-debuginfo -Zunstable-options` doesn't print unsupported modes, so that a cargo config of e.g.

```toml
[profile.dev]
split-debuginfo = "unpacked"
```

Would not cause an unsupported mode to be enabled on `x86_64-pc-windows-msvc`


