### PR TITLE
Update cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "1"
 members = [
   "compiler/rustc",
   "library/std",

--- a/library/portable-simd/Cargo.toml
+++ b/library/portable-simd/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "1"
 members = [
     "crates/core_simd",
     "crates/std_float",

--- a/src/ci/docker/host-x86_64/test-various/uefi_qemu_test/Cargo.toml
+++ b/src/ci/docker/host-x86_64/test-various/uefi_qemu_test/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [workspace]
+resolver = "1"
 
 [dependencies]
 r-efi = "4.1.0"

--- a/src/etc/test-float-parse/Cargo.toml
+++ b/src/etc/test-float-parse/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [workspace]
+resolver = "1"
 
 [dependencies]
 rand = "0.4"


### PR DESCRIPTION
17 commits in 64fb38c97ac4d3a327fc9032c862dd28c8833b17..f7b95e31642e09c2b6eabb18ed75007dda6677a0
2023-05-23 18:53:23 +0000 to 2023-05-30 19:25:02 +0000
- chore: detect the channel a PR wants to merge into (rust-lang/cargo#12181)
- refactor: de-depulicate `make_dep_prefix` implementation (rust-lang/cargo#12203)
- Re-enable code_generation test on Windows (rust-lang/cargo#12199)
- docs: add doc comments for git source and friends (rust-lang/cargo#12192)
- test: set retry sleep to 1ms for all tests (rust-lang/cargo#12194)
- fix(add): Reduce the chance we re-format the user's `[features]` table (rust-lang/cargo#12191)
- test(add): Remove expensive test (rust-lang/cargo#12188)
- Add a description of `Cargo.lock` conflicts in the Cargo FAQ (rust-lang/cargo#12185)
- refactor(tests): Reduce cargo-add setup load (rust-lang/cargo#12189)
- Warn when an edition 2021 crate is in a virtual workspace with default resolver (rust-lang/cargo#10910)
- refactor(tests): Reduce cargo-remove setup load (rust-lang/cargo#12184)
- chore: Lexicographically order `-Z` flags (rust-lang/cargo#12182)
- chore(ci): remove temporary fix for rustup 1.24.1 (rust-lang/cargo#12180)
- fix: AIX searches dynamic libraries in `LIBPATH`. (rust-lang/cargo#11968)
- deps: remove unused features from windows-sys (rust-lang/cargo#12176)
- Automatically inherit workspace lints when running cargo new/init (rust-lang/cargo#12174)
- Test that the new `debuginfo` options match between cargo and rustc (rust-lang/cargo#12022)

r? @ghost