### PR TITLE
[EXPERIMENTAL] Allow enabling only a single lint via command line

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -140,28 +140,6 @@ fn test_switch_implies_cfg_test_unless_cfg_test() {
 }
 
 #[test]
-fn test_can_print_warnings() {
-    rustc_span::create_default_session_globals_then(|| {
-        let matches = optgroups().parse(&["-Awarnings".to_string()]).unwrap();
-        let (sess, _) = mk_session(matches);
-        assert!(!sess.diagnostic().can_emit_warnings());
-    });
-
-    rustc_span::create_default_session_globals_then(|| {
-        let matches =
-            optgroups().parse(&["-Awarnings".to_string(), "-Dwarnings".to_string()]).unwrap();
-        let (sess, _) = mk_session(matches);
-        assert!(sess.diagnostic().can_emit_warnings());
-    });
-
-    rustc_span::create_default_session_globals_then(|| {
-        let matches = optgroups().parse(&["-Adead_code".to_string()]).unwrap();
-        let (sess, _) = mk_session(matches);
-        assert!(sess.diagnostic().can_emit_warnings());
-    });
-}
-
-#[test]
 fn test_output_types_tracking_hash_different_paths() {
     let mut v1 = Options::default();
     let mut v2 = Options::default();

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -873,9 +873,9 @@ impl Options {
 }
 
 impl UnstableOptions {
-    pub fn diagnostic_handler_flags(&self, can_emit_warnings: bool) -> HandlerFlags {
+    pub fn diagnostic_handler_flags(&self, cap_lints_allow: bool) -> HandlerFlags {
         HandlerFlags {
-            can_emit_warnings,
+            cap_lints_allow,
             treat_err_as_bug: self.treat_err_as_bug,
             dont_buffer_diagnostics: self.dont_buffer_diagnostics,
             report_delayed_bugs: self.report_delayed_bugs,


### PR DESCRIPTION
To address the use case to "silence all but one particular rustc lint" (#105104: enabling a only a single lint is not intuitive), that is, to support a use case like

```bash
rustc -Awarnings -Wdead-code
```

We propose to change how the special `warnings` lint is handled:

- The command line `warnings` level take highest precedence, e.g. `-Awarnings`, `-Dwarnings`.
- Command line specific lints level are next in precedence. e.g. `-Awarnings -Dunreachable-code` will allow all warnings but deny `unreachable_code` lint.
- And then, lint level attributes are probed from source code attributes.

This also addresses a FIXME in https://github.com/rust-lang/rust/blob/f51fca3af344686d734c3ff6b4399642c4f92305/compiler/rustc_session/src/session.rs#L1362-L1383

> FIXME: This is not general enough to make the warning lint completely
> override normal diagnostic warnings, since the warning lint can also
> be denied and changed later via the source code.

This change makes it so that the command line `warnings` lint level overrides any source code `warnings` lint level attributes.

### Unresolved Questions

- Right now, this change causes stage1 stdlib to stop building because the command line `-D warnings` takes precedence over any source code `#[allow]` attributes. Is this precedence correct? Can we even make a change to support enabling only a single lint without breaking use cases like this, since it seems like the current behaviour of source code overriding command line might be relied upon?
- What even *is* the ideal precedence? Is it different for `-Awarnings -Dspecific-lint` vs `-Dwarnings` and source-code `#[allow]`?