### PR TITLE
Ignore parent locals when resolving in local items

### DIFF
--- a/tests/ui/resolve/local-item-access-parent-local.rs
+++ b/tests/ui/resolve/local-item-access-parent-local.rs
@@ -1,0 +1,19 @@
+#![allow(unused_variables, dead_code)]
+
+fn f2() {
+    let foo = 0;
+    fn f() {
+        foo;
+        //~^ ERROR can't capture dynamic
+    }
+    const C: () = {
+        foo;
+        //~^ ERROR attempt to
+    };
+    static S: () = {
+        foo;
+        //~^ ERROR attempt to
+    };
+}
+
+fn main() {}

--- a/tests/ui/resolve/local-item-access-parent-local.stderr
+++ b/tests/ui/resolve/local-item-access-parent-local.stderr
@@ -1,0 +1,28 @@
+error[E0434]: can't capture dynamic environment in a fn item
+  --> $DIR/local-item-access-parent-local.rs:6:9
+   |
+LL |         foo;
+   |         ^^^
+   |
+   = help: use the `|| { ... }` closure form instead
+
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/local-item-access-parent-local.rs:10:9
+   |
+LL |     const C: () = {
+   |     ------- help: consider using `let` instead of `const`: `let C`
+LL |         foo;
+   |         ^^^ non-constant value
+
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/local-item-access-parent-local.rs:14:9
+   |
+LL |     static S: () = {
+   |     -------- help: consider using `let` instead of `static`: `let S`
+LL |         foo;
+   |         ^^^ non-constant value
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0434, E0435.
+For more information about an error, try `rustc --explain E0434`.

--- a/tests/ui/resolve/local-item-does-not-eagerly-resolve-parent-locals.rs
+++ b/tests/ui/resolve/local-item-does-not-eagerly-resolve-parent-locals.rs
@@ -1,0 +1,31 @@
+// run-pass
+#![allow(unused_variables, dead_code)]
+const fn foo() {}
+
+fn f1() {
+    fn f() {
+        foo();
+    }
+    const C: () = {
+        foo();
+    };
+    static S: () = {
+        foo();
+    };
+    let foo = 0;
+}
+
+fn f2() {
+    let foo = 0;
+    fn f() {
+        foo();
+    }
+    const C: () = {
+        foo();
+    };
+    static S: () = {
+        foo();
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
An attempt at fixing https://github.com/rust-lang/rust/issues/33118

I do want more tests for this, if there are ideas do tell as I couldn't immediately come up with more interesting cases. I'm mainly worried that there might be certain cases where we get multiple errors now.