### PR TITLE
Fix `src/etc/pre-push.sh` when `build.locked-deps` is already set

### DIFF
--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -14,4 +14,4 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 echo "Running pre-push script $ROOT_DIR/x test tidy"
 
 cd "$ROOT_DIR"
-CARGOFLAGS="--locked" ./x test tidy
+./x test tidy --set build.locked-deps=true


### PR DESCRIPTION
Before, cargo would error:
```
; git push
Running pre-push script /home/jyn/src/rust/x test tidy
Building bootstrap
    Finished dev [unoptimized] target(s) in 0.02s
Build stage0 tool tidy (x86_64-unknown-linux-gnu)
error: the argument '--locked' cannot be used multiple times

Usage: cargo build [OPTIONS]

For more information, try '--help'.
Build completed unsuccessfully in 0:00:00
error: failed to push some refs to 'github.com:jyn514/rust.git'
```