### PR TITLE
Support 128-bit atomics on all x86_64 Apple targets

### DIFF
--- a/compiler/rustc_target/src/spec/x86_64_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_ios.rs
@@ -13,7 +13,7 @@ pub fn target() -> Target {
             .into(),
         arch: arch.target_arch(),
         options: TargetOptions {
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(128),
             stack_probes: StackProbeType::X86,
             ..base
         },

--- a/compiler/rustc_target/src/spec/x86_64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_ios_macabi.rs
@@ -15,7 +15,7 @@ pub fn target() -> Target {
             .into(),
         arch: arch.target_arch(),
         options: TargetOptions {
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(128),
             stack_probes: StackProbeType::X86,
             ..base
         },

--- a/compiler/rustc_target/src/spec/x86_64_apple_tvos.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_tvos.rs
@@ -9,7 +9,7 @@ pub fn target() -> Target {
         data_layout: "e-m:o-i64:64-f80:128-n8:16:32:64-S128".into(),
         arch: arch.target_arch(),
         options: TargetOptions {
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(128),
             stack_probes: StackProbeType::X86,
             ..opts("tvos", arch)
         },

--- a/compiler/rustc_target/src/spec/x86_64_apple_watchos_sim.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_watchos_sim.rs
@@ -10,7 +10,7 @@ pub fn target() -> Target {
             .into(),
         arch: arch.target_arch(),
         options: TargetOptions {
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(128),
             stack_probes: StackProbeType::X86,
             forces_embed_bitcode: true,
             // Taken from a clang build on Xcode 11.4.1.


### PR DESCRIPTION
On x86_64, we currently set `max_atomic_width` to 128 only on macOS.

https://github.com/rust-lang/rust/blob/ad8304a0d5280de30856b39c19df7b306957e878/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs#L8

However, other x86_64 Apple targets (iOS, tvOS, and watchOS) are also core2+ and support cmpxchg16b.

https://github.com/rust-lang/rust/blob/ad8304a0d5280de30856b39c19df7b306957e878/compiler/rustc_target/src/spec/apple_base.rs#L71-L76

```console
# Script to get targets that support cmpxchg16b by default:
$ (for target in $(rustc --print target-list); do [[ $target == "x86_64"* ]] && rustc --print cfg --target "$target" | grep -q cmpxchg16b && echo "$target"; done)
x86_64-apple-darwin
x86_64-apple-ios
x86_64-apple-ios-macabi
x86_64-apple-tvos
x86_64-apple-watchos-sim
x86_64h-apple-darwin
```

r? @Amanieu