### PR TITLE
Fix the progress message for `x doc rustc`

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -571,7 +571,7 @@ impl<'a> ShouldRun<'a> {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum Kind {
     #[clap(alias = "b")]
     Build,
@@ -642,7 +642,10 @@ impl Kind {
             Kind::Doc => "Documenting",
             Kind::Run => "Running",
             Kind::Suggest => "Suggesting",
-            _ => return format!("{self:?}"),
+            _ => {
+                let title_letter = self.as_str()[0..1].to_ascii_uppercase();
+                return format!("{title_letter}{}ing", &self.as_str()[1..]);
+            }
         }
         .to_owned()
     }

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -680,7 +680,7 @@ impl Step for Rustc {
         let compiler = builder.compiler(stage, builder.config.build);
         builder.ensure(compile::Std::new(compiler, builder.config.build));
 
-        let _guard = builder.msg(
+        let _guard = builder.msg_sysroot_tool(
             Kind::Doc,
             stage,
             &format!("compiler{}", crate_description(&self.crates)),

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1045,8 +1045,8 @@ impl Build {
         what: impl Display,
         target: TargetSelection,
     ) -> Option<gha::Group> {
-        let action = action.into();
-        let msg = format!("{action:?}ing {what} for {target}");
+        let action = action.into().description();
+        let msg = format!("{action} {what} for {target}");
         self.group(&msg)
     }
 
@@ -1058,8 +1058,8 @@ impl Build {
         host: TargetSelection,
         target: TargetSelection,
     ) -> Option<gha::Group> {
-        let action = action.into();
-        let msg = |fmt| format!("{action:?}ing {what} {fmt}");
+        let action = action.into().description();
+        let msg = |fmt| format!("{action} {what} {fmt}");
         let msg = if host == target {
             msg(format_args!("(stage{stage} -> stage{}, {target})", stage + 1))
         } else {


### PR DESCRIPTION
This makes it more clear that we're using stage 0 *to document* rustc, not that we're documenting stage0 rustc itself.

It also fixes a bug in `msg_sysroot_tool` that would print `Docing`, and removes the `Debug` impl for `Kind` to make sure it doesn't happen again.

Before:
```
Documenting stage0 compiler {rustc-main} (aarch64-apple-darwin)
```

After:
```
Documenting compiler {rustc-main} (stage0 -> stage1, aarch64-apple-darwin)
```

thanks @BoxyUwU for catching this!