### PR TITLE
Fix bug in utf16_to_utf8 for zero length strings

### DIFF
--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -11,6 +11,9 @@ use crate::sys::cvt;
 use crate::sys::handle::Handle;
 use core::str::utf8_char_width;
 
+#[cfg(test)]
+mod tests;
+
 // Don't cache handles but get them fresh for every read/write. This allows us to track changes to
 // the value over time (such as if a process calls `SetStdHandle` while it's running). See #40490.
 pub struct Stdin {
@@ -382,6 +385,10 @@ fn read_u16s(handle: c::HANDLE, buf: &mut [MaybeUninit<u16>]) -> io::Result<usiz
 fn utf16_to_utf8(utf16: &[u16], utf8: &mut [u8]) -> io::Result<usize> {
     debug_assert!(utf16.len() <= c::c_int::MAX as usize);
     debug_assert!(utf8.len() <= c::c_int::MAX as usize);
+
+    if utf16.is_empty() {
+        return Ok(0);
+    }
 
     let result = unsafe {
         c::WideCharToMultiByte(

--- a/library/std/src/sys/windows/stdio/tests.rs
+++ b/library/std/src/sys/windows/stdio/tests.rs
@@ -1,0 +1,6 @@
+use super::utf16_to_utf8;
+
+#[test]
+fn zero_size_read() {
+    assert_eq!(utf16_to_utf8(&[], &mut []).unwrap(), 0);
+}


### PR DESCRIPTION
This fixes the behavior of sending EOF by pressing Ctrl+Z => Enter in a windows console.

Previously, that would trip the unpaired surrogate error, whereas now we correctly detect EOF.