### PR TITLE
Resurrect: rustc_target: Add alignment to indirectly-passed by-value types, correcting the alignment of byval on x86 in the process.

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -40,7 +40,7 @@ pub trait LayoutCalculator {
             largest_niche,
             align,
             size,
-            has_repr_align: false,
+            repr_align: None,
         }
     }
 
@@ -123,7 +123,7 @@ pub trait LayoutCalculator {
             largest_niche: None,
             align: dl.i8_align,
             size: Size::ZERO,
-            has_repr_align: false,
+            repr_align: None,
         }
     }
 
@@ -424,7 +424,7 @@ pub trait LayoutCalculator {
                 largest_niche,
                 size,
                 align,
-                has_repr_align: repr.align.is_some(),
+                repr_align: repr.align,
             };
 
             Some(TmpLayout { layout, variants: variant_layouts })
@@ -694,7 +694,7 @@ pub trait LayoutCalculator {
             abi,
             align,
             size,
-            has_repr_align: repr.align.is_some(),
+            repr_align: repr.align,
         };
 
         let tagged_layout = TmpLayout { layout: tagged_layout, variants: layout_variants };
@@ -813,7 +813,7 @@ pub trait LayoutCalculator {
             largest_niche: None,
             align,
             size: size.align_to(align.abi),
-            has_repr_align: repr.align.is_some(),
+            repr_align: repr.align,
         })
     }
 }
@@ -1111,9 +1111,9 @@ fn univariant(
         abi = Abi::Uninhabited;
     }
 
-    let has_repr_align = repr.align.is_some()
-        || repr.transparent()
-            && layout_of_single_non_zst_field.map_or(false, |l| l.has_repr_align());
+    let repr_align = repr.align.or_else(|| {
+        if repr.transparent() { layout_of_single_non_zst_field?.repr_align() } else { None }
+    });
 
     Some(LayoutS {
         variants: Variants::Single { index: FIRST_VARIANT },
@@ -1122,7 +1122,7 @@ fn univariant(
         largest_niche,
         align,
         size,
-        has_repr_align,
+        repr_align,
     })
 }
 

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1531,6 +1531,11 @@ pub struct LayoutS {
 
     pub align: AbiAndPrefAlign,
     pub size: Size,
+
+    /// True if the alignment was explicitly requested with `repr(align)`.
+    /// Only used on i686-windows, where the argument passing ABI is different when alignment is
+    /// requested, even if the requested alignment is equal to or less than the natural alignment.
+    pub has_repr_align: bool,
 }
 
 impl LayoutS {
@@ -1545,6 +1550,7 @@ impl LayoutS {
             largest_niche,
             size,
             align,
+            has_repr_align: false,
         }
     }
 }
@@ -1554,7 +1560,7 @@ impl fmt::Debug for LayoutS {
         // This is how `Layout` used to print before it become
         // `Interned<LayoutS>`. We print it like this to avoid having to update
         // expected output in a lot of tests.
-        let LayoutS { size, align, abi, fields, largest_niche, variants } = self;
+        let LayoutS { size, align, abi, fields, largest_niche, variants, has_repr_align } = self;
         f.debug_struct("Layout")
             .field("size", size)
             .field("align", align)
@@ -1562,6 +1568,7 @@ impl fmt::Debug for LayoutS {
             .field("fields", fields)
             .field("largest_niche", largest_niche)
             .field("variants", variants)
+            .field("has_repr_align", has_repr_align)
             .finish()
     }
 }
@@ -1600,6 +1607,10 @@ impl<'a> Layout<'a> {
 
     pub fn size(self) -> Size {
         self.0.0.size
+    }
+
+    pub fn has_repr_align(self) -> bool {
+        self.0.0.has_repr_align
     }
 
     /// Whether the layout is from a type that implements [`std::marker::PointerLike`].

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1532,10 +1532,10 @@ pub struct LayoutS {
     pub align: AbiAndPrefAlign,
     pub size: Size,
 
-    /// True if the alignment was explicitly requested with `repr(align)`.
+    /// The alignment explicitly requested with `repr(align)`.
     /// Only used on i686-windows, where the argument passing ABI is different when alignment is
-    /// requested, even if the requested alignment is equal to or less than the natural alignment.
-    pub has_repr_align: bool,
+    /// requested, even if the requested alignment is equal to the natural alignment.
+    pub repr_align: Option<Align>,
 }
 
 impl LayoutS {
@@ -1550,7 +1550,7 @@ impl LayoutS {
             largest_niche,
             size,
             align,
-            has_repr_align: false,
+            repr_align: None,
         }
     }
 }
@@ -1560,7 +1560,7 @@ impl fmt::Debug for LayoutS {
         // This is how `Layout` used to print before it become
         // `Interned<LayoutS>`. We print it like this to avoid having to update
         // expected output in a lot of tests.
-        let LayoutS { size, align, abi, fields, largest_niche, variants, has_repr_align } = self;
+        let LayoutS { size, align, abi, fields, largest_niche, variants, repr_align } = self;
         f.debug_struct("Layout")
             .field("size", size)
             .field("align", align)
@@ -1568,7 +1568,7 @@ impl fmt::Debug for LayoutS {
             .field("fields", fields)
             .field("largest_niche", largest_niche)
             .field("variants", variants)
-            .field("has_repr_align", has_repr_align)
+            .field("repr_align", repr_align)
             .finish()
     }
 }
@@ -1609,8 +1609,8 @@ impl<'a> Layout<'a> {
         self.0.0.size
     }
 
-    pub fn has_repr_align(self) -> bool {
-        self.0.0.has_repr_align
+    pub fn repr_align(self) -> Option<Align> {
+        self.0.0.repr_align
     }
 
     /// Whether the layout is from a type that implements [`std::marker::PointerLike`].

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1532,10 +1532,10 @@ pub struct LayoutS {
     pub align: AbiAndPrefAlign,
     pub size: Size,
 
-    /// The alignment explicitly requested with `repr(align)`.
+    /// The largest alignment explicitly requested with `repr(align)` on this type or any field.
     /// Only used on i686-windows, where the argument passing ABI is different when alignment is
     /// requested, even if the requested alignment is equal to the natural alignment.
-    pub repr_align: Option<Align>,
+    pub max_repr_align: Option<Align>,
 
     /// The alignment the type would have, ignoring any `repr(align)` but including `repr(packed)`.
     /// Only used on aarch64-linux, where the argument passing ABI ignores the requested alignment
@@ -1555,7 +1555,7 @@ impl LayoutS {
             largest_niche,
             size,
             align,
-            repr_align: None,
+            max_repr_align: None,
             unadjusted_abi_align: align.abi,
         }
     }
@@ -1573,7 +1573,7 @@ impl fmt::Debug for LayoutS {
             fields,
             largest_niche,
             variants,
-            repr_align,
+            max_repr_align,
             unadjusted_abi_align,
         } = self;
         f.debug_struct("Layout")
@@ -1583,7 +1583,7 @@ impl fmt::Debug for LayoutS {
             .field("fields", fields)
             .field("largest_niche", largest_niche)
             .field("variants", variants)
-            .field("repr_align", repr_align)
+            .field("max_repr_align", max_repr_align)
             .field("unadjusted_abi_align", unadjusted_abi_align)
             .finish()
     }
@@ -1625,8 +1625,8 @@ impl<'a> Layout<'a> {
         self.0.0.size
     }
 
-    pub fn repr_align(self) -> Option<Align> {
-        self.0.0.repr_align
+    pub fn max_repr_align(self) -> Option<Align> {
+        self.0.0.max_repr_align
     }
 
     pub fn unadjusted_abi_align(self) -> Align {

--- a/compiler/rustc_codegen_cranelift/src/abi/comments.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/comments.rs
@@ -83,7 +83,7 @@ pub(super) fn add_local_place_comments<'tcx>(
     let rustc_target::abi::LayoutS {
         size,
         align,
-        has_repr_align: _,
+        repr_align: _,
         abi: _,
         variants: _,
         fields: _,

--- a/compiler/rustc_codegen_cranelift/src/abi/comments.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/comments.rs
@@ -83,6 +83,7 @@ pub(super) fn add_local_place_comments<'tcx>(
     let rustc_target::abi::LayoutS {
         size,
         align,
+        has_repr_align: _,
         abi: _,
         variants: _,
         fields: _,

--- a/compiler/rustc_codegen_cranelift/src/abi/comments.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/comments.rs
@@ -80,15 +80,7 @@ pub(super) fn add_local_place_comments<'tcx>(
         return;
     }
     let TyAndLayout { ty, layout } = place.layout();
-    let rustc_target::abi::LayoutS {
-        size,
-        align,
-        repr_align: _,
-        abi: _,
-        variants: _,
-        fields: _,
-        largest_niche: _,
-    } = layout.0.0;
+    let rustc_target::abi::LayoutS { size, align, .. } = layout.0.0;
 
     let (kind, extra) = place.debug_comment();
 

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -23,6 +23,8 @@ use rustc_target::abi::call::{ArgAbi, FnAbi, PassMode, Reg};
 use rustc_target::abi::{self, HasDataLayout, WrappingRange};
 use rustc_target::spec::abi::Abi;
 
+use std::cmp;
+
 // Indicates if we are in the middle of merging a BB's successor into it. This
 // can happen when BB jumps directly to its successor and the successor has no
 // other predecessors.
@@ -1360,36 +1362,58 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // Force by-ref if we have to load through a cast pointer.
         let (mut llval, align, by_ref) = match op.val {
             Immediate(_) | Pair(..) => match arg.mode {
-                PassMode::Indirect { .. } | PassMode::Cast(..) => {
+                PassMode::Indirect { attrs, .. } => {
+                    // Indirect argument may have higher alignment requirements than the type's alignment.
+                    // This can happen, e.g. when passing types with <4 byte alignment on the stack on x86.
+                    let required_align = match attrs.pointee_align {
+                        Some(pointee_align) => cmp::max(pointee_align, arg.layout.align.abi),
+                        None => arg.layout.align.abi,
+                    };
+                    let scratch = PlaceRef::alloca_aligned(bx, arg.layout, required_align);
+                    op.val.store(bx, scratch);
+                    (scratch.llval, scratch.align, true)
+                }
+                PassMode::Cast(..) => {
                     let scratch = PlaceRef::alloca(bx, arg.layout);
                     op.val.store(bx, scratch);
                     (scratch.llval, scratch.align, true)
                 }
                 _ => (op.immediate_or_packed_pair(bx), arg.layout.align.abi, false),
             },
-            Ref(llval, _, align) => {
-                if arg.is_indirect() && align < arg.layout.align.abi {
-                    // `foo(packed.large_field)`. We can't pass the (unaligned) field directly. I
-                    // think that ATM (Rust 1.16) we only pass temporaries, but we shouldn't
-                    // have scary latent bugs around.
-
-                    let scratch = PlaceRef::alloca(bx, arg.layout);
-                    base::memcpy_ty(
-                        bx,
-                        scratch.llval,
-                        scratch.align,
-                        llval,
-                        align,
-                        op.layout,
-                        MemFlags::empty(),
-                    );
-                    (scratch.llval, scratch.align, true)
-                } else {
-                    (llval, align, true)
+            Ref(llval, _, align) => match arg.mode {
+                PassMode::Indirect { attrs, .. } => {
+                    let required_align = match attrs.pointee_align {
+                        Some(pointee_align) => cmp::max(pointee_align, arg.layout.align.abi),
+                        None => arg.layout.align.abi,
+                    };
+                    if align < required_align {
+                        // For `foo(packed.large_field)`, and types with <4 byte alignment on x86,
+                        // alignment requirements may be higher than the type's alignment, so copy
+                        // to a higher-aligned alloca.
+                        let scratch = PlaceRef::alloca_aligned(bx, arg.layout, required_align);
+                        base::memcpy_ty(
+                            bx,
+                            scratch.llval,
+                            scratch.align,
+                            llval,
+                            align,
+                            op.layout,
+                            MemFlags::empty(),
+                        );
+                        (scratch.llval, scratch.align, true)
+                    } else {
+                        (llval, align, true)
+                    }
                 }
-            }
+                _ => (llval, align, true),
+            },
             ZeroSized => match arg.mode {
-                PassMode::Indirect { .. } => {
+                PassMode::Indirect { on_stack, .. } => {
+                    if on_stack {
+                        // It doesn't seem like any target can have `byval` ZSTs, so this assert
+                        // is here to replace a would-be untested codepath.
+                        bug!("ZST {op:?} passed on stack with abi {arg:?}");
+                    }
                     // Though `extern "Rust"` doesn't pass ZSTs, some ABIs pass
                     // a pointer for `repr(C)` structs even when empty, so get
                     // one from an `alloca` (which can be left uninitialized).

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -48,9 +48,17 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
         bx: &mut Bx,
         layout: TyAndLayout<'tcx>,
     ) -> Self {
+        Self::alloca_aligned(bx, layout, layout.align.abi)
+    }
+
+    pub fn alloca_aligned<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
+        bx: &mut Bx,
+        layout: TyAndLayout<'tcx>,
+        align: Align,
+    ) -> Self {
         assert!(layout.is_sized(), "tried to statically allocate unsized place");
-        let tmp = bx.alloca(bx.cx().backend_type(layout), layout.align.abi);
-        Self::new_sized(tmp, layout)
+        let tmp = bx.alloca(bx.cx().backend_type(layout), align);
+        Self::new_sized_aligned(tmp, layout, align)
     }
 
     /// Returns a place for an indirect reference to an unsized place.

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -755,7 +755,7 @@ where
                     largest_niche: None,
                     align: tcx.data_layout.i8_align,
                     size: Size::ZERO,
-                    has_repr_align: false,
+                    repr_align: None,
                 })
             }
 

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1104,6 +1104,15 @@ where
     fn is_unit(this: TyAndLayout<'tcx>) -> bool {
         matches!(this.ty.kind(), ty::Tuple(list) if list.len() == 0)
     }
+
+    fn repr_options(this: TyAndLayout<'tcx>) -> ReprOptions {
+        match *this.ty.kind() {
+            ty::Adt(def, ..) => def.repr(),
+            _ => {
+                bug!("TyAndLayout::repr_options({:?}): not applicable", this)
+            }
+        }
+    }
 }
 
 /// Calculates whether a function's ABI can unwind or not.

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -756,6 +756,7 @@ where
                     align: tcx.data_layout.i8_align,
                     size: Size::ZERO,
                     repr_align: None,
+                    unadjusted_abi_align: tcx.data_layout.i8_align.abi,
                 })
             }
 

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -755,7 +755,7 @@ where
                     largest_niche: None,
                     align: tcx.data_layout.i8_align,
                     size: Size::ZERO,
-                    repr_align: None,
+                    max_repr_align: None,
                     unadjusted_abi_align: tcx.data_layout.i8_align.abi,
                 })
             }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -755,6 +755,7 @@ where
                     largest_niche: None,
                     align: tcx.data_layout.i8_align,
                     size: Size::ZERO,
+                    has_repr_align: false,
                 })
             }
 
@@ -1103,15 +1104,6 @@ where
 
     fn is_unit(this: TyAndLayout<'tcx>) -> bool {
         matches!(this.ty.kind(), ty::Tuple(list) if list.len() == 0)
-    }
-
-    fn repr_options(this: TyAndLayout<'tcx>) -> ReprOptions {
-        match *this.ty.kind() {
-            ty::Adt(def, ..) => def.repr(),
-            _ => {
-                bug!("TyAndLayout::repr_options({:?}): not applicable", this)
-            }
-        }
     }
 }
 

--- a/compiler/rustc_target/src/abi/call/m68k.rs
+++ b/compiler/rustc_target/src/abi/call/m68k.rs
@@ -10,7 +10,7 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
 
 fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
     if arg.layout.is_aggregate() {
-        arg.make_indirect_byval();
+        arg.make_indirect_byval(None);
     } else {
         arg.extend_integer_width_to(32);
     }

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -494,9 +494,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
             .set(ArgAttribute::NonNull)
             .set(ArgAttribute::NoUndef);
         attrs.pointee_size = layout.size;
-        // FIXME(eddyb) We should be doing this, but at least on
-        // i686-pc-windows-msvc, it results in wrong stack offsets.
-        // attrs.pointee_align = Some(layout.align.abi);
+        attrs.pointee_align = Some(layout.align.abi);
 
         let extra_attrs = layout.is_unsized().then_some(ArgAttributes::new());
 
@@ -513,11 +511,19 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
         self.mode = Self::indirect_pass_mode(&self.layout);
     }
 
-    pub fn make_indirect_byval(&mut self) {
+    pub fn make_indirect_byval(&mut self, byval_align: Option<Align>) {
         self.make_indirect();
         match self.mode {
-            PassMode::Indirect { attrs: _, extra_attrs: _, ref mut on_stack } => {
+            PassMode::Indirect { ref mut attrs, extra_attrs: _, ref mut on_stack } => {
                 *on_stack = true;
+
+                // Some platforms, like 32-bit x86, change the alignment of the type when passing
+                // `byval`. Account for that.
+                if let Some(byval_align) = byval_align {
+                    // On all targets with byval align this is currently true, so let's assert it.
+                    debug_assert!(byval_align >= Align::from_bytes(4).unwrap());
+                    attrs.pointee_align = Some(byval_align);
+                }
             }
             _ => unreachable!(),
         }
@@ -644,7 +650,8 @@ impl<'a, Ty> FnAbi<'a, Ty> {
     {
         if abi == spec::abi::Abi::X86Interrupt {
             if let Some(arg) = self.args.first_mut() {
-                arg.make_indirect_byval();
+                // FIXME(pcwalton): This probably should use the x86 `byval` ABI...
+                arg.make_indirect_byval(None);
             }
             return Ok(());
         }

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -679,12 +679,14 @@ impl<'a, Ty> FnAbi<'a, Ty> {
                 }
             },
             "aarch64" => {
-                let param_policy = if cx.target_spec().is_like_osx {
-                    aarch64::ParamExtension::ExtendTo32Bits
+                let kind = if cx.target_spec().is_like_osx {
+                    aarch64::AbiKind::DarwinPCS
+                } else if cx.target_spec().is_like_windows {
+                    aarch64::AbiKind::Win64
                 } else {
-                    aarch64::ParamExtension::NoExtension
+                    aarch64::AbiKind::AAPCS
                 };
-                aarch64::compute_abi_info(cx, self, param_policy)
+                aarch64::compute_abi_info(cx, self, kind)
             }
             "amdgpu" => amdgpu::compute_abi_info(cx, self),
             "arm" => arm::compute_abi_info(cx, self),

--- a/compiler/rustc_target/src/abi/call/wasm.rs
+++ b/compiler/rustc_target/src/abi/call/wasm.rs
@@ -36,7 +36,7 @@ where
 {
     arg.extend_integer_width_to(32);
     if arg.layout.is_aggregate() && !unwrap_trivial_aggregate(cx, arg) {
-        arg.make_indirect_byval();
+        arg.make_indirect_byval(None);
     }
 }
 

--- a/compiler/rustc_target/src/abi/call/x86.rs
+++ b/compiler/rustc_target/src/abi/call/x86.rs
@@ -1,5 +1,5 @@
 use crate::abi::call::{ArgAttribute, FnAbi, PassMode, Reg, RegKind};
-use crate::abi::{Align, HasDataLayout, TyAbiInterface};
+use crate::abi::{Abi, Align, HasDataLayout, TyAbiInterface, TyAndLayout};
 use crate::spec::HasTargetSpec;
 
 #[derive(PartialEq)]
@@ -53,38 +53,58 @@ where
         if arg.is_ignore() {
             continue;
         }
-        if !arg.layout.is_aggregate() {
-            arg.extend_integer_width_to(32);
-            continue;
-        }
 
-        // We need to compute the alignment of the `byval` argument. The rules can be found in
-        // `X86_32ABIInfo::getTypeStackAlignInBytes` in Clang's `TargetInfo.cpp`. Summarized here,
-        // they are:
-        //
-        // 1. If the natural alignment of the type is less than or equal to 4, the alignment is 4.
-        //
-        // 2. Otherwise, on Linux, the alignment of any vector type is the natural alignment.
-        // (This doesn't matter here because we ensure we have an aggregate with the check above.)
-        //
-        // 3. Otherwise, on Apple platforms, the alignment of anything that contains a vector type
-        // is 16.
-        //
-        // 4. If none of these conditions are true, the alignment is 4.
-        let t = cx.target_spec();
-        let align_4 = Align::from_bytes(4).unwrap();
-        let align_16 = Align::from_bytes(16).unwrap();
-        let byval_align = if arg.layout.align.abi < align_4 {
-            align_4
-        } else if t.is_like_osx && arg.layout.align.abi >= align_16 {
-            // FIXME(pcwalton): This is dubious--we should actually be looking inside the type to
-            // determine if it contains SIMD vector values--but I think it's fine?
-            align_16
+        if arg.layout.is_aggregate() {
+            // We need to compute the alignment of the `byval` argument. The rules can be found in
+            // `X86_32ABIInfo::getTypeStackAlignInBytes` in Clang's `TargetInfo.cpp`. Summarized
+            // here, they are:
+            //
+            // 1. If the natural alignment of the type is <= 4, the alignment is 4.
+            //
+            // 2. Otherwise, on Linux, the alignment of any vector type is the natural alignment.
+            // This doesn't matter here because we only pass aggregates via `byval`, not vectors.
+            //
+            // 3. Otherwise, on Apple platforms, the alignment of anything that contains a vector
+            // type is 16.
+            //
+            // 4. If none of these conditions are true, the alignment is 4.
+
+            fn contains_vector<'a, Ty, C>(cx: &C, layout: TyAndLayout<'a, Ty>) -> bool
+            where
+                Ty: TyAbiInterface<'a, C> + Copy,
+            {
+                match layout.abi {
+                    Abi::Uninhabited | Abi::Scalar(_) | Abi::ScalarPair(..) => false,
+                    Abi::Vector { .. } => true,
+                    Abi::Aggregate { .. } => {
+                        for i in 0..layout.fields.count() {
+                            if contains_vector(cx, layout.field(cx, i)) {
+                                return true;
+                            }
+                        }
+                        false
+                    }
+                }
+            }
+
+            let t = cx.target_spec();
+            let align_4 = Align::from_bytes(4).unwrap();
+            let align_16 = Align::from_bytes(16).unwrap();
+            let byval_align = if arg.layout.align.abi < align_4 {
+                // (1.)
+                align_4
+            } else if t.is_like_osx && contains_vector(cx, arg.layout) {
+                // (3.)
+                align_16
+            } else {
+                // (4.)
+                align_4
+            };
+
+            arg.make_indirect_byval(Some(byval_align));
         } else {
-            align_4
-        };
-
-        arg.make_indirect_byval(Some(byval_align));
+            arg.extend_integer_width_to(32);
+        }
     }
 
     if flavor == Flavor::FastcallOrVectorcall {

--- a/compiler/rustc_target/src/abi/call/x86.rs
+++ b/compiler/rustc_target/src/abi/call/x86.rs
@@ -63,8 +63,8 @@ where
 
         if t.is_like_msvc
             && arg.layout.is_adt()
-            && let Some(requested_align) = arg.layout.repr_options().align
-            && requested_align > align_4
+            && arg.layout.has_repr_align
+            && arg.layout.align.abi > align_4
         {
             // MSVC has special rules for overaligned arguments: https://reviews.llvm.org/D72114.
             // Summarized here:
@@ -72,11 +72,6 @@ where
             // - For backwards compatibility, arguments with natural alignment > 4 are still passed
             //   on stack (via `byval`). For example, this includes `double`, `int64_t`,
             //   and structs containing them, provided they lack an explicit alignment attribute.
-            assert!(arg.layout.align.abi >= requested_align,
-                "abi alignment {:?} less than requested alignment {:?}",
-                arg.layout.align.abi,
-                requested_align
-            );
             arg.make_indirect();
         } else if arg.layout.is_aggregate() {
             // We need to compute the alignment of the `byval` argument. The rules can be found in

--- a/compiler/rustc_target/src/abi/call/x86.rs
+++ b/compiler/rustc_target/src/abi/call/x86.rs
@@ -63,8 +63,8 @@ where
 
         if t.is_like_msvc
             && arg.layout.is_adt()
-            && arg.layout.has_repr_align
-            && arg.layout.align.abi > align_4
+            && let Some(repr_align) = arg.layout.repr_align
+            && repr_align > align_4
         {
             // MSVC has special rules for overaligned arguments: https://reviews.llvm.org/D72114.
             // Summarized here:
@@ -72,6 +72,10 @@ where
             // - For backwards compatibility, arguments with natural alignment > 4 are still passed
             //   on stack (via `byval`). For example, this includes `double`, `int64_t`,
             //   and structs containing them, provided they lack an explicit alignment attribute.
+            assert!(arg.layout.align.abi >= repr_align,
+                "abi alignment {:?} less than requested alignment {repr_align:?}",
+                arg.layout.align.abi,
+            );
             arg.make_indirect();
         } else if arg.layout.is_aggregate() {
             // We need to compute the alignment of the `byval` argument. The rules can be found in

--- a/compiler/rustc_target/src/abi/call/x86.rs
+++ b/compiler/rustc_target/src/abi/call/x86.rs
@@ -63,8 +63,8 @@ where
 
         if t.is_like_msvc
             && arg.layout.is_adt()
-            && let Some(repr_align) = arg.layout.repr_align
-            && repr_align > align_4
+            && let Some(max_repr_align) = arg.layout.max_repr_align
+            && max_repr_align > align_4
         {
             // MSVC has special rules for overaligned arguments: https://reviews.llvm.org/D72114.
             // Summarized here:
@@ -72,8 +72,8 @@ where
             // - For backwards compatibility, arguments with natural alignment > 4 are still passed
             //   on stack (via `byval`). For example, this includes `double`, `int64_t`,
             //   and structs containing them, provided they lack an explicit alignment attribute.
-            assert!(arg.layout.align.abi >= repr_align,
-                "abi alignment {:?} less than requested alignment {repr_align:?}",
+            assert!(arg.layout.align.abi >= max_repr_align,
+                "abi alignment {:?} less than requested alignment {max_repr_align:?}",
                 arg.layout.align.abi,
             );
             arg.make_indirect();

--- a/compiler/rustc_target/src/abi/call/x86_64.rs
+++ b/compiler/rustc_target/src/abi/call/x86_64.rs
@@ -213,7 +213,7 @@ where
         match cls_or_mem {
             Err(Memory) => {
                 if is_arg {
-                    arg.make_indirect_byval();
+                    arg.make_indirect_byval(None);
                 } else {
                     // `sret` parameter thus one less integer register available
                     arg.make_indirect();

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -55,7 +55,6 @@ pub trait TyAbiInterface<'a, C>: Sized {
     fn is_never(this: TyAndLayout<'a, Self>) -> bool;
     fn is_tuple(this: TyAndLayout<'a, Self>) -> bool;
     fn is_unit(this: TyAndLayout<'a, Self>) -> bool;
-    fn repr_options(this: TyAndLayout<'a, Self>) -> ReprOptions;
 }
 
 impl<'a, Ty> TyAndLayout<'a, Ty> {
@@ -124,13 +123,6 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         Ty: TyAbiInterface<'a, C>,
     {
         Ty::is_unit(self)
-    }
-
-    pub fn repr_options<C>(self) -> ReprOptions
-    where
-        Ty: TyAbiInterface<'a, C>,
-    {
-        Ty::repr_options(self)
     }
 
     pub fn offset_of_subfield<C>(self, cx: &C, indices: impl Iterator<Item = usize>) -> Size

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -55,6 +55,7 @@ pub trait TyAbiInterface<'a, C>: Sized {
     fn is_never(this: TyAndLayout<'a, Self>) -> bool;
     fn is_tuple(this: TyAndLayout<'a, Self>) -> bool;
     fn is_unit(this: TyAndLayout<'a, Self>) -> bool;
+    fn repr_options(this: TyAndLayout<'a, Self>) -> ReprOptions;
 }
 
 impl<'a, Ty> TyAndLayout<'a, Ty> {
@@ -123,6 +124,13 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         Ty: TyAbiInterface<'a, C>,
     {
         Ty::is_unit(self)
+    }
+
+    pub fn repr_options<C>(self) -> ReprOptions
+    where
+        Ty: TyAbiInterface<'a, C>,
+    {
+        Ty::repr_options(self)
     }
 
     pub fn offset_of_subfield<C>(self, cx: &C, indices: impl Iterator<Item = usize>) -> Size

--- a/compiler/rustc_target/src/lib.rs
+++ b/compiler/rustc_target/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(associated_type_bounds)]
 #![feature(exhaustive_patterns)]
 #![feature(iter_intersperse)]
+#![feature(let_chains)]
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(rustc_attrs)]

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -258,7 +258,7 @@ fn layout_of_uncached<'tcx>(
                 largest_niche,
                 align: element.align,
                 size,
-                has_repr_align: false,
+                repr_align: None,
             })
         }
         ty::Slice(element) => {
@@ -270,7 +270,7 @@ fn layout_of_uncached<'tcx>(
                 largest_niche: None,
                 align: element.align,
                 size: Size::ZERO,
-                has_repr_align: false,
+                repr_align: None,
             })
         }
         ty::Str => tcx.mk_layout(LayoutS {
@@ -280,7 +280,7 @@ fn layout_of_uncached<'tcx>(
             largest_niche: None,
             align: dl.i8_align,
             size: Size::ZERO,
-            has_repr_align: false,
+            repr_align: None,
         }),
 
         // Odd unit types.
@@ -434,7 +434,7 @@ fn layout_of_uncached<'tcx>(
                 largest_niche: e_ly.largest_niche,
                 size,
                 align,
-                has_repr_align: false,
+                repr_align: None,
             })
         }
 
@@ -883,7 +883,7 @@ fn generator_layout<'tcx>(
         largest_niche: prefix.largest_niche,
         size,
         align,
-        has_repr_align: false,
+        repr_align: None,
     });
     debug!("generator layout ({:?}): {:#?}", ty, layout);
     Ok(layout)

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -258,7 +258,7 @@ fn layout_of_uncached<'tcx>(
                 largest_niche,
                 align: element.align,
                 size,
-                repr_align: None,
+                max_repr_align: None,
                 unadjusted_abi_align: element.align.abi,
             })
         }
@@ -271,7 +271,7 @@ fn layout_of_uncached<'tcx>(
                 largest_niche: None,
                 align: element.align,
                 size: Size::ZERO,
-                repr_align: None,
+                max_repr_align: None,
                 unadjusted_abi_align: element.align.abi,
             })
         }
@@ -282,7 +282,7 @@ fn layout_of_uncached<'tcx>(
             largest_niche: None,
             align: dl.i8_align,
             size: Size::ZERO,
-            repr_align: None,
+            max_repr_align: None,
             unadjusted_abi_align: dl.i8_align.abi,
         }),
 
@@ -437,7 +437,7 @@ fn layout_of_uncached<'tcx>(
                 largest_niche: e_ly.largest_niche,
                 size,
                 align,
-                repr_align: None,
+                max_repr_align: None,
                 unadjusted_abi_align: align.abi,
             })
         }
@@ -887,7 +887,7 @@ fn generator_layout<'tcx>(
         largest_niche: prefix.largest_niche,
         size,
         align,
-        repr_align: None,
+        max_repr_align: None,
         unadjusted_abi_align: align.abi,
     });
     debug!("generator layout ({:?}): {:#?}", ty, layout);

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -258,6 +258,7 @@ fn layout_of_uncached<'tcx>(
                 largest_niche,
                 align: element.align,
                 size,
+                has_repr_align: false,
             })
         }
         ty::Slice(element) => {
@@ -269,6 +270,7 @@ fn layout_of_uncached<'tcx>(
                 largest_niche: None,
                 align: element.align,
                 size: Size::ZERO,
+                has_repr_align: false,
             })
         }
         ty::Str => tcx.mk_layout(LayoutS {
@@ -278,6 +280,7 @@ fn layout_of_uncached<'tcx>(
             largest_niche: None,
             align: dl.i8_align,
             size: Size::ZERO,
+            has_repr_align: false,
         }),
 
         // Odd unit types.
@@ -431,6 +434,7 @@ fn layout_of_uncached<'tcx>(
                 largest_niche: e_ly.largest_niche,
                 size,
                 align,
+                has_repr_align: false,
             })
         }
 
@@ -879,6 +883,7 @@ fn generator_layout<'tcx>(
         largest_niche: prefix.largest_niche,
         size,
         align,
+        has_repr_align: false,
     });
     debug!("generator layout ({:?}): {:#?}", ty, layout);
     Ok(layout)

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -259,6 +259,7 @@ fn layout_of_uncached<'tcx>(
                 align: element.align,
                 size,
                 repr_align: None,
+                unadjusted_abi_align: element.align.abi,
             })
         }
         ty::Slice(element) => {
@@ -271,6 +272,7 @@ fn layout_of_uncached<'tcx>(
                 align: element.align,
                 size: Size::ZERO,
                 repr_align: None,
+                unadjusted_abi_align: element.align.abi,
             })
         }
         ty::Str => tcx.mk_layout(LayoutS {
@@ -281,6 +283,7 @@ fn layout_of_uncached<'tcx>(
             align: dl.i8_align,
             size: Size::ZERO,
             repr_align: None,
+            unadjusted_abi_align: dl.i8_align.abi,
         }),
 
         // Odd unit types.
@@ -435,6 +438,7 @@ fn layout_of_uncached<'tcx>(
                 size,
                 align,
                 repr_align: None,
+                unadjusted_abi_align: align.abi,
             })
         }
 
@@ -884,6 +888,7 @@ fn generator_layout<'tcx>(
         size,
         align,
         repr_align: None,
+        unadjusted_abi_align: align.abi,
     });
     debug!("generator layout ({:?}): {:#?}", ty, layout);
     Ok(layout)

--- a/tests/codegen/aarch64-struct-align-128.rs
+++ b/tests/codegen/aarch64-struct-align-128.rs
@@ -1,0 +1,150 @@
+// Test that structs aligned to 128 bits are passed with the correct ABI on aarch64.
+
+// revisions:linux darwin windows
+//[linux] compile-flags: --target aarch64-unknown-linux-gnu
+//[darwin] compile-flags: --target aarch64-apple-darwin
+//[windows] compile-flags: --target aarch64-pc-windows-msvc
+//[linux] needs-llvm-components: aarch64
+//[darwin] needs-llvm-components: aarch64
+//[windows] needs-llvm-components: aarch64
+
+#![feature(no_core, lang_items)]
+#![crate_type = "lib"]
+#![no_core]
+
+#[lang="sized"]
+trait Sized { }
+#[lang="freeze"]
+trait Freeze { }
+#[lang="copy"]
+trait Copy { }
+
+
+
+// Passed as `[i64 x 2]`, since it's an aggregate with size <= 128 bits, align < 128 bits.
+#[repr(C)]
+pub struct Align8 {
+    pub a: u64,
+    pub b: u64,
+}
+
+// repr(transparent), so same as above.
+#[repr(transparent)]
+pub struct Transparent8 {
+    a: Align8
+}
+
+// Passed as `[i64 x 2]`, since it's an aggregate with size <= 128 bits, align < 128 bits.
+#[repr(C)]
+pub struct Wrapped8 {
+    a: Align8,
+}
+
+extern "C" {
+    // linux:   declare void @test_8([2 x i64], [2 x i64], [2 x i64])
+    // darwin:  declare void @test_8([2 x i64], [2 x i64], [2 x i64])
+    // windows: declare void @test_8([2 x i64], [2 x i64], [2 x i64])
+    fn test_8(a: Align8, b: Transparent8, c: Wrapped8);
+}
+
+
+
+// Passed as `i128`, since it's an aggregate with size <= 128 bits, align = 128 bits.
+// EXCEPT on Linux, where there's a special case to use its unadjusted alignment,
+// making it the same as `Align8`, so it's be passed as `[i64 x 2]`.
+#[repr(C)]
+#[repr(align(16))]
+pub struct Align16 {
+    pub a: u64,
+    pub b: u64,
+}
+
+// repr(transparent), so same as above.
+#[repr(transparent)]
+pub struct Transparent16 {
+    a: Align16
+}
+
+// Passed as `i128`, since it's an aggregate with size <= 128 bits, align = 128 bits.
+// On Linux, the "unadjustedness" doesn't recurse into fields, so this is passed as `i128`.
+#[repr(C)]
+pub struct Wrapped16 {
+    pub a: Align16,
+}
+
+extern "C" {
+    // linux:   declare void @test_16([2 x i64], [2 x i64], i128)
+    // darwin:  declare void @test_16(i128, i128, i128)
+    // windows: declare void @test_16(i128, i128, i128)
+    fn test_16(a: Align16, b: Transparent16, c: Wrapped16);
+}
+
+
+
+// Passed as `i128`, since it's an aggregate with size <= 128 bits, align = 128 bits.
+#[repr(C)]
+pub struct I128 {
+    pub a: i128,
+}
+
+// repr(transparent), so same as above.
+#[repr(transparent)]
+pub struct TransparentI128 {
+    a: I128
+}
+
+// Passed as `i128`, since it's an aggregate with size <= 128 bits, align = 128 bits.
+#[repr(C)]
+pub struct WrappedI128 {
+    pub a: I128
+}
+
+extern "C" {
+    // linux:   declare void @test_i128(i128, i128, i128)
+    // darwin:  declare void @test_i128(i128, i128, i128)
+    // windows: declare void @test_i128(i128, i128, i128)
+    fn test_i128(a: I128, b: TransparentI128, c: WrappedI128);
+}
+
+
+
+// Passed as `[2 x i64]`, since it's an aggregate with size <= 128 bits, align < 128 bits.
+// Note that the Linux special case does not apply, because packing is not considered "adjustment".
+#[repr(C)]
+#[repr(packed)]
+pub struct Packed {
+    pub a: i128,
+}
+
+// repr(transparent), so same as above.
+#[repr(transparent)]
+pub struct TransparentPacked {
+    a: Packed
+}
+
+// Passed as `[2 x i64]`, since it's an aggregate with size <= 128 bits, align < 128 bits.
+#[repr(C)]
+pub struct WrappedPacked {
+    pub a: Packed
+}
+
+extern "C" {
+    // linux:   declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
+    // darwin:  declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
+    // windows: declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
+    fn test_packed(a: Packed, b: TransparentPacked, c: WrappedPacked);
+}
+
+
+
+pub unsafe fn main(
+    a1: Align8, a2: Transparent8, a3: Wrapped8,
+    b1: Align16, b2: Transparent16, b3: Wrapped16,
+    c1: I128, c2: TransparentI128, c3: WrappedI128,
+    d1: Packed, d2: TransparentPacked, d3: WrappedPacked,
+) {
+    test_8(a1, a2, a3);
+    test_16(b1, b2, b3);
+    test_i128(c1, c2, c3);
+    test_packed(d1, d2, d3);
+}

--- a/tests/codegen/addr-of-mutate.rs
+++ b/tests/codegen/addr-of-mutate.rs
@@ -6,7 +6,7 @@
 // Test for the absence of `readonly` on the argument when it is mutated via `&raw const`.
 // See <https://github.com/rust-lang/rust/issues/111502>.
 
-// CHECK: i8 @foo(ptr noalias nocapture noundef dereferenceable(128) %x)
+// CHECK: i8 @foo(ptr noalias nocapture noundef align 1 dereferenceable(128) %x)
 #[no_mangle]
 pub fn foo(x: [u8; 128]) -> u8 {
     let ptr = core::ptr::addr_of!(x).cast_mut();
@@ -16,7 +16,7 @@ pub fn foo(x: [u8; 128]) -> u8 {
     x[0]
 }
 
-// CHECK: i1 @second(ptr noalias nocapture noundef dereferenceable({{[0-9]+}}) %a_ptr_and_b)
+// CHECK: i1 @second(ptr noalias nocapture noundef align {{[0-9]+}} dereferenceable({{[0-9]+}}) %a_ptr_and_b)
 #[no_mangle]
 pub unsafe fn second(a_ptr_and_b: (*mut (i32, bool), (i64, bool))) -> bool {
     let b_bool_ptr = core::ptr::addr_of!(a_ptr_and_b.1.1).cast_mut();
@@ -25,7 +25,7 @@ pub unsafe fn second(a_ptr_and_b: (*mut (i32, bool), (i64, bool))) -> bool {
 }
 
 // If going through a deref (and there are no other mutating accesses), then `readonly` is fine.
-// CHECK: i1 @third(ptr noalias nocapture noundef readonly dereferenceable({{[0-9]+}}) %a_ptr_and_b)
+// CHECK: i1 @third(ptr noalias nocapture noundef readonly align {{[0-9]+}} dereferenceable({{[0-9]+}}) %a_ptr_and_b)
 #[no_mangle]
 pub unsafe fn third(a_ptr_and_b: (*mut (i32, bool), (i64, bool))) -> bool {
     let b_bool_ptr = core::ptr::addr_of!((*a_ptr_and_b.0).1).cast_mut();

--- a/tests/codegen/align-byval-vector.rs
+++ b/tests/codegen/align-byval-vector.rs
@@ -1,0 +1,58 @@
+// revisions:x86-linux x86-darwin
+
+//[x86-linux] compile-flags: --target i686-unknown-linux-gnu
+//[x86-linux] needs-llvm-components: x86
+//[x86-darwin] compile-flags: --target i686-apple-darwin
+//[x86-darwin] needs-llvm-components: x86
+
+// Tests that aggregates containing vector types get their alignment increased to 16 on Darwin.
+
+#![feature(no_core, lang_items, repr_simd, simd_ffi)]
+#![crate_type = "lib"]
+#![no_std]
+#![no_core]
+#![allow(non_camel_case_types)]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "freeze"]
+trait Freeze {}
+#[lang = "copy"]
+trait Copy {}
+
+#[repr(simd)]
+pub struct i32x4(i32, i32, i32, i32);
+
+#[repr(C)]
+pub struct Foo {
+    a: i32x4,
+    b: i8,
+}
+
+// This tests that we recursively check for vector types, not just at the top level.
+#[repr(C)]
+pub struct DoubleFoo {
+    one: Foo,
+    two: Foo,
+}
+
+extern "C" {
+    // x86-linux: declare void @f({{.*}}byval(%Foo) align 4{{.*}})
+    // x86-darwin: declare void @f({{.*}}byval(%Foo) align 16{{.*}})
+    fn f(foo: Foo);
+
+    // x86-linux: declare void @g({{.*}}byval(%DoubleFoo) align 4{{.*}})
+    // x86-darwin: declare void @g({{.*}}byval(%DoubleFoo) align 16{{.*}})
+    fn g(foo: DoubleFoo);
+}
+
+pub fn main() {
+    unsafe { f(Foo { a: i32x4(1, 2, 3, 4), b: 0 }) }
+
+    unsafe {
+        g(DoubleFoo {
+            one: Foo { a: i32x4(1, 2, 3, 4), b: 0 },
+            two: Foo { a: i32x4(1, 2, 3, 4), b: 0 },
+        })
+    }
+}

--- a/tests/codegen/align-byval.rs
+++ b/tests/codegen/align-byval.rs
@@ -1,0 +1,56 @@
+// ignore-x86
+// ignore-aarch64
+// ignore-aarch64_be
+// ignore-arm
+// ignore-armeb
+// ignore-avr
+// ignore-bpfel
+// ignore-bpfeb
+// ignore-hexagon
+// ignore-mips
+// ignore-mips64
+// ignore-msp430
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-powerpc
+// ignore-r600
+// ignore-amdgcn
+// ignore-sparc
+// ignore-sparcv9
+// ignore-sparcel
+// ignore-s390x
+// ignore-tce
+// ignore-thumb
+// ignore-thumbeb
+// ignore-xcore
+// ignore-nvptx
+// ignore-nvptx64
+// ignore-le32
+// ignore-le64
+// ignore-amdil
+// ignore-amdil64
+// ignore-hsail
+// ignore-hsail64
+// ignore-spir
+// ignore-spir64
+// ignore-kalimba
+// ignore-shave
+//
+// Tests that `byval` alignment is properly specified (#80127).
+// The only targets that use `byval` are m68k, wasm, x86-64, and x86. Note that
+// x86 has special rules (see #103830), and it's therefore ignored here.
+
+#[repr(C)]
+#[repr(align(16))]
+struct Foo {
+    a: [i32; 16],
+}
+
+extern "C" {
+    // CHECK: declare void @f({{.*}}byval(%Foo) align 16{{.*}})
+    fn f(foo: Foo);
+}
+
+pub fn main() {
+    unsafe { f(Foo { a: [1; 16] }) }
+}

--- a/tests/codegen/align-byval.rs
+++ b/tests/codegen/align-byval.rs
@@ -71,17 +71,16 @@ pub struct ForceAlign8 {
     c: i64
 }
 
-// On i686-windows, this is passed by reference because alignment is requested,
-// even though the requested alignment is less than the natural alignment.
+// On i686-windows, this is passed on stack, because requested alignment is <=4.
 #[repr(C)]
-#[repr(align(1))]
+#[repr(align(4))]
 pub struct LowerFA8 {
     a: i64,
     b: i64,
     c: i64
 }
 
-// On i686-windows, this is passed on stack again, because the wrapper struct does not have
+// On i686-windows, this is passed on stack, because the wrapper struct does not have
 // requested/forced alignment.
 #[repr(C)]
 pub struct WrappedFA8 {
@@ -287,9 +286,7 @@ extern "C" {
 
     // i686-linux: declare void @lower_fa8({{.*}}byval(%LowerFA8) align 4{{.*}})
 
-    // i686-windows: declare void @lower_fa8(
-    // i686-windows-NOT: byval
-    // i686-windows-SAME: align 8{{.*}})
+    // i686-windows: declare void @lower_fa8({{.*}}byval(%LowerFA8) align 4{{.*}})
     fn lower_fa8(x: LowerFA8);
 
     // m68k: declare void @wrapped_fa8({{.*}}byval(%WrappedFA8) align 8{{.*}})

--- a/tests/codegen/align-byval.rs
+++ b/tests/codegen/align-byval.rs
@@ -1,56 +1,51 @@
-// ignore-x86
-// ignore-aarch64
-// ignore-aarch64_be
-// ignore-arm
-// ignore-armeb
-// ignore-avr
-// ignore-bpfel
-// ignore-bpfeb
-// ignore-hexagon
-// ignore-mips
-// ignore-mips64
-// ignore-msp430
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-powerpc
-// ignore-r600
-// ignore-amdgcn
-// ignore-sparc
-// ignore-sparcv9
-// ignore-sparcel
-// ignore-s390x
-// ignore-tce
-// ignore-thumb
-// ignore-thumbeb
-// ignore-xcore
-// ignore-nvptx
-// ignore-nvptx64
-// ignore-le32
-// ignore-le64
-// ignore-amdil
-// ignore-amdil64
-// ignore-hsail
-// ignore-hsail64
-// ignore-spir
-// ignore-spir64
-// ignore-kalimba
-// ignore-shave
-//
+// revisions:m68k wasm x86_64-linux x86_64-windows
+
+//[m68k] compile-flags: --target m68k-unknown-linux-gnu
+//[m68k] needs-llvm-components: m68k
+//[wasm] compile-flags: --target wasm32-unknown-emscripten
+//[wasm] needs-llvm-components: webassembly
+//[x86_64-linux] compile-flags: --target x86_64-unknown-linux-gnu
+//[x86_64-linux] needs-llvm-components: x86
+//[x86_64-windows] compile-flags: --target x86_64-pc-windows-msvc
+//[x86_64-windows] needs-llvm-components: x86
+
 // Tests that `byval` alignment is properly specified (#80127).
 // The only targets that use `byval` are m68k, wasm, x86-64, and x86. Note that
 // x86 has special rules (see #103830), and it's therefore ignored here.
+// Note also that Windows mandates a by-ref ABI here, so it does not use byval.
+
+#![feature(no_core, lang_items)]
+#![crate_type = "lib"]
+#![no_std]
+#![no_core]
+
+#[lang="sized"] trait Sized { }
+#[lang="freeze"] trait Freeze { }
+#[lang="copy"] trait Copy { }
+
+impl Copy for i32 {}
+impl Copy for i64 {}
 
 #[repr(C)]
 #[repr(align(16))]
 struct Foo {
     a: [i32; 16],
+    b: i8
 }
 
 extern "C" {
-    // CHECK: declare void @f({{.*}}byval(%Foo) align 16{{.*}})
+    // m68k: declare void @f({{.*}}byval(%Foo) align 16{{.*}})
+
+    // wasm: declare void @f({{.*}}byval(%Foo) align 16{{.*}})
+
+    // x86_64-linux: declare void @f({{.*}}byval(%Foo) align 16{{.*}})
+
+    // x86_64-windows: declare void @f(
+    // x86_64-windows-NOT: byval
+    // x86_64-windows-SAME: align 16{{.*}})
     fn f(foo: Foo);
 }
 
 pub fn main() {
-    unsafe { f(Foo { a: [1; 16] }) }
+    unsafe { f(Foo { a: [1; 16], b: 2 }) }
 }

--- a/tests/codegen/align-byval.rs
+++ b/tests/codegen/align-byval.rs
@@ -1,4 +1,4 @@
-// revisions:m68k wasm x86_64-linux x86_64-windows
+// revisions:m68k wasm x86_64-linux x86_64-windows i686-linux i686-windows
 
 //[m68k] compile-flags: --target m68k-unknown-linux-gnu
 //[m68k] needs-llvm-components: m68k
@@ -8,10 +8,13 @@
 //[x86_64-linux] needs-llvm-components: x86
 //[x86_64-windows] compile-flags: --target x86_64-pc-windows-msvc
 //[x86_64-windows] needs-llvm-components: x86
+//[i686-linux] compile-flags: --target i686-unknown-linux-gnu
+//[i686-linux] needs-llvm-components: x86
+//[i686-windows] compile-flags: --target i686-pc-windows-msvc
+//[i686-windows] needs-llvm-components: x86
 
 // Tests that `byval` alignment is properly specified (#80127).
-// The only targets that use `byval` are m68k, wasm, x86-64, and x86. Note that
-// x86 has special rules (see #103830), and it's therefore ignored here.
+// The only targets that use `byval` are m68k, wasm, x86-64, and x86.
 // Note also that Windows mandates a by-ref ABI here, so it does not use byval.
 
 #![feature(no_core, lang_items)]
@@ -43,6 +46,12 @@ extern "C" {
     // x86_64-windows: declare void @f(
     // x86_64-windows-NOT: byval
     // x86_64-windows-SAME: align 16{{.*}})
+
+    // i686-linux: declare void @f({{.*}}byval(%Foo) align 4{{.*}})
+
+    // i686-windows: declare void @f(
+    // i686-windows-NOT: byval
+    // i686-windows-SAME: align 16{{.*}})
     fn f(foo: Foo);
 }
 

--- a/tests/codegen/align-byval.rs
+++ b/tests/codegen/align-byval.rs
@@ -80,7 +80,7 @@ pub struct LowerFA8 {
     c: i64
 }
 
-// On i686-windows, this is passed on stack, because the wrapper struct does not have
+// On i686-windows, this is passed by reference, because it contains a field with
 // requested/forced alignment.
 #[repr(C)]
 pub struct WrappedFA8 {
@@ -301,7 +301,9 @@ extern "C" {
 
     // i686-linux: declare void @wrapped_fa8({{.*}}byval(%WrappedFA8) align 4{{.*}})
 
-    // i686-windows: declare void @wrapped_fa8({{.*}}byval(%WrappedFA8) align 4{{.*}})
+    // i686-windows: declare void @wrapped_fa8(
+    // i686-windows-NOT: byval
+    // i686-windows-SAME: align 8{{.*}})
     fn wrapped_fa8(x: WrappedFA8);
 
     // m68k: declare void @transparent_fa8({{.*}}byval(%TransparentFA8) align 8{{.*}})

--- a/tests/codegen/array-map.rs
+++ b/tests/codegen/array-map.rs
@@ -30,7 +30,6 @@ pub fn short_integer_map(x: [u32; 8]) -> [u32; 8] {
 pub fn long_integer_map(x: [u32; 512]) -> [u32; 512] {
     // CHECK: start:
     // CHECK-NEXT: alloca [512 x i32]
-    // CHECK-NEXT: alloca %"core::mem::manually_drop::ManuallyDrop<[u32; 512]>"
     // CHECK-NOT: alloca
     // CHECK: mul <{{[0-9]+}} x i32>
     // CHECK: add <{{[0-9]+}} x i32>

--- a/tests/codegen/function-arguments-noopt.rs
+++ b/tests/codegen/function-arguments-noopt.rs
@@ -42,7 +42,7 @@ pub fn borrow_call(x: &i32, f: fn(&i32) -> &i32) -> &i32 {
   f(x)
 }
 
-// CHECK: void @struct_({{%S\*|ptr}} sret(%S){{( %_0)?}}, {{%S\*|ptr}} %x)
+// CHECK: void @struct_({{%S\*|ptr}} sret(%S) align 4{{( %_0)?}}, {{%S\*|ptr}} align 4 %x)
 #[no_mangle]
 pub fn struct_(x: S) -> S {
   x
@@ -51,7 +51,7 @@ pub fn struct_(x: S) -> S {
 // CHECK-LABEL: @struct_call
 #[no_mangle]
 pub fn struct_call(x: S, f: fn(S) -> S) -> S {
-  // CHECK: call void %f({{%S\*|ptr}} sret(%S){{( %_0)?}}, {{%S\*|ptr}} %{{.+}})
+  // CHECK: call void %f({{%S\*|ptr}} sret(%S) align 4{{( %_0)?}}, {{%S\*|ptr}} align 4 %{{.+}})
   f(x)
 }
 

--- a/tests/codegen/function-arguments.rs
+++ b/tests/codegen/function-arguments.rs
@@ -142,7 +142,7 @@ pub fn mutable_notunpin_borrow(_: &mut NotUnpin) {
 pub fn notunpin_borrow(_: &NotUnpin) {
 }
 
-// CHECK: @indirect_struct({{%S\*|ptr}} noalias nocapture noundef readonly dereferenceable(32) %_1)
+// CHECK: @indirect_struct({{%S\*|ptr}} noalias nocapture noundef readonly align 4 dereferenceable(32) %_1)
 #[no_mangle]
 pub fn indirect_struct(_: S) {
 }
@@ -188,7 +188,7 @@ pub fn notunpin_box(x: Box<NotUnpin>) -> Box<NotUnpin> {
   x
 }
 
-// CHECK: @struct_return({{%S\*|ptr}} noalias nocapture noundef sret(%S) dereferenceable(32){{( %_0)?}})
+// CHECK: @struct_return({{%S\*|ptr}} noalias nocapture noundef sret(%S) align 4 dereferenceable(32){{( %_0)?}})
 #[no_mangle]
 pub fn struct_return() -> S {
   S {

--- a/tests/run-make/extern-fn-explicit-align/Makefile
+++ b/tests/run-make/extern-fn-explicit-align/Makefile
@@ -1,0 +1,5 @@
+include ../tools.mk
+
+all: $(call NATIVE_STATICLIB,test)
+	$(RUSTC) test.rs
+	$(call RUN,test) || exit 1

--- a/tests/run-make/extern-fn-explicit-align/Makefile
+++ b/tests/run-make/extern-fn-explicit-align/Makefile
@@ -1,3 +1,4 @@
+# ignore-cross-compile
 include ../tools.mk
 
 all: $(call NATIVE_STATICLIB,test)

--- a/tests/run-make/extern-fn-explicit-align/test.c
+++ b/tests/run-make/extern-fn-explicit-align/test.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+struct TwoU64s
+{
+    uint64_t a;
+    uint64_t b;
+} __attribute__((aligned(16)));
+
+struct BoolAndU32
+{
+    bool a;
+    uint32_t b;
+};
+
+int32_t many_args(
+    void *a,
+    void *b,
+    const char *c,
+    uint64_t d,
+    bool e,
+    struct BoolAndU32 f,
+    void *g,
+    struct TwoU64s h,
+    void *i,
+    void *j,
+    void *k,
+    void *l,
+    const char *m)
+{
+    assert(strcmp(m, "Hello world") == 0);
+    return 0;
+}

--- a/tests/run-make/extern-fn-explicit-align/test.c
+++ b/tests/run-make/extern-fn-explicit-align/test.c
@@ -3,6 +3,12 @@
 #include <stdint.h>
 #include <string.h>
 
+struct BoolAndU32
+{
+    bool a;
+    uint32_t b;
+};
+
 #ifdef _MSC_VER
 __declspec(align(16))
 struct TwoU64s
@@ -18,11 +24,27 @@ struct __attribute__((aligned(16))) TwoU64s
 };
 #endif
 
-struct BoolAndU32
+struct WrappedU64s
 {
-    bool a;
-    uint32_t b;
+    struct TwoU64s a;
 };
+
+#ifdef _MSC_VER
+__declspec(align(1))
+struct LowerAlign
+{
+    uint64_t a;
+    uint64_t b;
+};
+#else
+struct __attribute__((aligned(1))) LowerAlign
+{
+    uint64_t a;
+    uint64_t b;
+};
+#endif
+
+
 
 int32_t many_args(
     void *a,
@@ -34,11 +56,27 @@ int32_t many_args(
     void *g,
     struct TwoU64s h,
     void *i,
-    void *j,
+    struct WrappedU64s j,
     void *k,
-    void *l,
+    struct LowerAlign l,
     const char *m)
 {
+    assert(!a);
+    assert(!b);
+    assert(!c);
+    assert(d == 42);
+    assert(e);
+    assert(f.a);
+    assert(f.b == 1337);
+    assert(!g);
+    assert(h.a == 1);
+    assert(h.b == 2);
+    assert(!i);
+    assert(j.a.a == 3);
+    assert(j.a.b == 4);
+    assert(!k);
+    assert(l.a == 5);
+    assert(l.b == 6);
     assert(strcmp(m, "Hello world") == 0);
     return 0;
 }

--- a/tests/run-make/extern-fn-explicit-align/test.c
+++ b/tests/run-make/extern-fn-explicit-align/test.c
@@ -3,11 +3,20 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+__declspec(align(16))
 struct TwoU64s
 {
     uint64_t a;
     uint64_t b;
-} __attribute__((aligned(16)));
+};
+#else
+struct __attribute__((aligned(16))) TwoU64s
+{
+    uint64_t a;
+    uint64_t b;
+};
+#endif
 
 struct BoolAndU32
 {

--- a/tests/run-make/extern-fn-explicit-align/test.c
+++ b/tests/run-make/extern-fn-explicit-align/test.c
@@ -47,7 +47,8 @@ struct __attribute__((aligned(1))) LowerAlign
 #pragma pack(push, 1)
 struct Packed
 {
-    __uint128_t a;
+    uint64_t a;
+    uint64_t b;
 };
 #pragma pack(pop)
 
@@ -86,6 +87,7 @@ int32_t many_args(
     assert(l.b == 6);
     assert(!m);
     assert(n.a == 7);
+    assert(n.b == 8);
     assert(strcmp(o, "Hello world") == 0);
     return 0;
 }

--- a/tests/run-make/extern-fn-explicit-align/test.c
+++ b/tests/run-make/extern-fn-explicit-align/test.c
@@ -44,7 +44,12 @@ struct __attribute__((aligned(1))) LowerAlign
 };
 #endif
 
-
+#pragma pack(push, 1)
+struct Packed
+{
+    __uint128_t a;
+};
+#pragma pack(pop)
 
 int32_t many_args(
     void *a,
@@ -59,7 +64,9 @@ int32_t many_args(
     struct WrappedU64s j,
     void *k,
     struct LowerAlign l,
-    const char *m)
+    void *m,
+    struct Packed n,
+    const char *o)
 {
     assert(!a);
     assert(!b);
@@ -77,6 +84,8 @@ int32_t many_args(
     assert(!k);
     assert(l.a == 5);
     assert(l.b == 6);
-    assert(strcmp(m, "Hello world") == 0);
+    assert(!m);
+    assert(n.a == 7);
+    assert(strcmp(o, "Hello world") == 0);
     return 0;
 }

--- a/tests/run-make/extern-fn-explicit-align/test.rs
+++ b/tests/run-make/extern-fn-explicit-align/test.rs
@@ -1,0 +1,61 @@
+// Issue #80127: Passing structs via FFI should work with explicit alignment.
+
+use std::ffi::CString;
+use std::ptr::null_mut;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+#[repr(align(16))]
+pub struct TwoU64s {
+    pub a: u64,
+    pub b: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BoolAndU32 {
+    pub a: bool,
+    pub b: u32,
+}
+
+#[link(name = "test", kind = "static")]
+extern "C" {
+    fn many_args(
+        a: *mut (),
+        b: *mut (),
+        c: *const i8,
+        d: u64,
+        e: bool,
+        f: BoolAndU32,
+        g: *mut (),
+        h: TwoU64s,
+        i: *mut (),
+        j: *mut (),
+        k: *mut (),
+        l: *mut (),
+        m: *const i8,
+    ) -> i32;
+}
+
+fn main() {
+    let two_u64s = TwoU64s { a: 1, b: 2 };
+    let bool_and_u32 = BoolAndU32 { a: true, b: 3 };
+    let string = CString::new("Hello world").unwrap();
+    unsafe {
+        many_args(
+            null_mut(),
+            null_mut(),
+            null_mut(),
+            4,
+            true,
+            bool_and_u32,
+            null_mut(),
+            two_u64s,
+            null_mut(),
+            null_mut(),
+            null_mut(),
+            null_mut(),
+            string.as_ptr(),
+        );
+    }
+}

--- a/tests/run-make/extern-fn-explicit-align/test.rs
+++ b/tests/run-make/extern-fn-explicit-align/test.rs
@@ -38,7 +38,8 @@ pub struct LowerAlign {
 #[repr(C)]
 #[repr(packed)]
 pub struct Packed {
-    pub a: u128
+    pub a: u64,
+    pub b: u64,
 }
 
 #[link(name = "test", kind = "static")]
@@ -69,7 +70,7 @@ fn main() {
     let two_u64s = TwoU64s { a: 1, b: 2 };
     let wrapped = WrappedU64s { a: TwoU64s { a: 3, b: 4 } };
     let lower = LowerAlign { a: 5, b: 6 };
-    let packed = Packed { a: 7 };
+    let packed = Packed { a: 7, b: 8 };
     let string = STRING;
     unsafe {
         many_args(

--- a/tests/run-make/extern-fn-explicit-align/test.rs
+++ b/tests/run-make/extern-fn-explicit-align/test.rs
@@ -1,9 +1,9 @@
 // Issue #80127: Passing structs via FFI should work with explicit alignment.
 
-use std::ffi::{CString, c_char};
+use std::ffi::{CStr, c_char};
 use std::ptr::null_mut;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Copy, Clone)]
 #[repr(C)]
 #[repr(align(16))]
 pub struct TwoU64s {
@@ -12,7 +12,7 @@ pub struct TwoU64s {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct BoolAndU32 {
     pub a: bool,
     pub b: u32,
@@ -37,10 +37,12 @@ extern "C" {
     ) -> i32;
 }
 
+const STRING: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"Hello world\0") };
+
 fn main() {
     let two_u64s = TwoU64s { a: 1, b: 2 };
     let bool_and_u32 = BoolAndU32 { a: true, b: 3 };
-    let string = CString::new("Hello world").unwrap();
+    let string = STRING;
     unsafe {
         many_args(
             null_mut(),

--- a/tests/run-make/extern-fn-explicit-align/test.rs
+++ b/tests/run-make/extern-fn-explicit-align/test.rs
@@ -1,6 +1,6 @@
 // Issue #80127: Passing structs via FFI should work with explicit alignment.
 
-use std::ffi::CString;
+use std::ffi::{CString, c_char};
 use std::ptr::null_mut;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -23,7 +23,7 @@ extern "C" {
     fn many_args(
         a: *mut (),
         b: *mut (),
-        c: *const i8,
+        c: *const c_char,
         d: u64,
         e: bool,
         f: BoolAndU32,
@@ -33,7 +33,7 @@ extern "C" {
         j: *mut (),
         k: *mut (),
         l: *mut (),
-        m: *const i8,
+        m: *const c_char,
     ) -> i32;
 }
 

--- a/tests/run-make/extern-fn-explicit-align/test.rs
+++ b/tests/run-make/extern-fn-explicit-align/test.rs
@@ -34,6 +34,13 @@ pub struct LowerAlign {
     pub b: u64,
 }
 
+#[derive(Copy, Clone)]
+#[repr(C)]
+#[repr(packed)]
+pub struct Packed {
+    pub a: u128
+}
+
 #[link(name = "test", kind = "static")]
 extern "C" {
     fn many_args(
@@ -49,7 +56,9 @@ extern "C" {
         j: WrappedU64s,
         k: *mut (),
         l: LowerAlign,
-        m: *const c_char,
+        m: *mut (),
+        n: Packed,
+        o: *const c_char,
     ) -> i32;
 }
 
@@ -60,6 +69,7 @@ fn main() {
     let two_u64s = TwoU64s { a: 1, b: 2 };
     let wrapped = WrappedU64s { a: TwoU64s { a: 3, b: 4 } };
     let lower = LowerAlign { a: 5, b: 6 };
+    let packed = Packed { a: 7 };
     let string = STRING;
     unsafe {
         many_args(
@@ -75,6 +85,8 @@ fn main() {
             wrapped,
             null_mut(),
             lower,
+            null_mut(),
+            packed,
             string.as_ptr(),
         );
     }

--- a/tests/run-make/extern-fn-explicit-align/test.rs
+++ b/tests/run-make/extern-fn-explicit-align/test.rs
@@ -3,14 +3,12 @@
 use std::ffi::{CStr, c_char};
 use std::ptr::null_mut;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct BoolAndU32 {
     pub a: bool,
     pub b: u32,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 #[repr(align(16))]
 pub struct TwoU64s {
@@ -18,13 +16,11 @@ pub struct TwoU64s {
     pub b: u64,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct WrappedU64s {
     pub a: TwoU64s
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 // Even though requesting align 1 can never change the alignment, it still affects the ABI
 // on some platforms like i686-windows.
@@ -34,7 +30,6 @@ pub struct LowerAlign {
     pub b: u64,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 #[repr(packed)]
 pub struct Packed {

--- a/tests/run-make/extern-fn-struct-passing-abi/test.c
+++ b/tests/run-make/extern-fn-struct-passing-abi/test.c
@@ -28,6 +28,14 @@ struct Huge {
     int32_t e;
 };
 
+struct Huge64 {
+    int64_t a;
+    int64_t b;
+    int64_t c;
+    int64_t d;
+    int64_t e;
+};
+
 struct FloatPoint {
     double x;
     double y;
@@ -150,6 +158,21 @@ void byval_rect_with_many_huge(struct Huge a, struct Huge b, struct Huge c,
     assert(g.b == 456);
     assert(g.c == 789);
     assert(g.d == 420);
+}
+
+// System V x86_64 ABI:
+// a, b, d, e, f should be byval pointer (on the stack)
+// g passed via register (fixes #41375)
+//
+// i686-windows ABI:
+// a, b, d, e, f, g should be byval pointer
+void byval_rect_with_many_huge64(struct Huge64 a, struct Huge64 b, struct Huge64 c,
+                               struct Huge64 d, struct Huge64 e, struct Huge64 f,
+                               struct Rect g) {
+    assert(g.a == 1234);
+    assert(g.b == 4567);
+    assert(g.c == 7890);
+    assert(g.d == 4209);
 }
 
 // System V x86_64 & Win64 ABI:
@@ -275,6 +298,19 @@ struct Huge huge_struct(struct Huge s) {
     assert(s.c == 5649);
     assert(s.d == 5650);
     assert(s.e == 5651);
+
+    return s;
+}
+
+// System V x86_64 & i686-windows ABI:
+// s should be byval pointer
+// return should in a hidden sret pointer
+struct Huge64 huge64_struct(struct Huge64 s) {
+    assert(s.a == 1234);
+    assert(s.b == 1335);
+    assert(s.c == 1436);
+    assert(s.d == 1537);
+    assert(s.e == 1638);
 
     return s;
 }

--- a/tests/run-make/extern-fn-struct-passing-abi/test.rs
+++ b/tests/run-make/extern-fn-struct-passing-abi/test.rs
@@ -38,6 +38,16 @@ struct Huge {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C)]
+struct Huge64 {
+    a: i64,
+    b: i64,
+    c: i64,
+    d: i64,
+    e: i64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
 struct FloatPoint {
     x: f64,
     y: f64,
@@ -79,6 +89,8 @@ extern "C" {
 
     fn byval_rect_with_many_huge(a: Huge, b: Huge, c: Huge, d: Huge, e: Huge, f: Huge, g: Rect);
 
+    fn byval_rect_with_many_huge64(a: Huge64, b: Huge64, c: Huge64, d: Huge64, e: Huge64, f: Huge64, g: Rect);
+
     fn split_rect(a: i32, b: i32, s: Rect);
 
     fn split_rect_floats(a: f32, b: f32, s: FloatRect);
@@ -95,6 +107,8 @@ extern "C" {
 
     fn huge_struct(s: Huge) -> Huge;
 
+    fn huge64_struct(s: Huge64) -> Huge64;
+
     fn float_point(p: FloatPoint) -> FloatPoint;
 
     fn float_one(f: FloatOne) -> FloatOne;
@@ -107,6 +121,7 @@ fn main() {
     let t = BiggerRect { s: s, a: 27834, b: 7657 };
     let u = FloatRect { a: 3489, b: 3490, c: 8. };
     let v = Huge { a: 5647, b: 5648, c: 5649, d: 5650, e: 5651 };
+    let w = Huge64 { a: 1234, b: 1335, c: 1436, d: 1537, e: 1638 };
     let p = FloatPoint { x: 5., y: -3. };
     let f1 = FloatOne { x: 7. };
     let i = IntOdd { a: 1, b: 2, c: 3 };
@@ -117,12 +132,14 @@ fn main() {
         byval_rect_floats(1., 2., 3., 4., 5., 6., 7., s, u);
         byval_rect_with_float(1, 2, 3.0, 4, 5, 6, s);
         byval_rect_with_many_huge(v, v, v, v, v, v, Rect { a: 123, b: 456, c: 789, d: 420 });
+        byval_rect_with_many_huge64(w, w, w, w, w, w, Rect { a: 1234, b: 4567, c: 7890, d: 4209 });
         split_rect(1, 2, s);
         split_rect_floats(1., 2., u);
         split_rect_with_floats(1, 2, 3.0, 4, 5.0, 6, s);
         split_and_byval_rect(1, 2, 3, s, s);
         split_rect(1, 2, s);
         assert_eq!(huge_struct(v), v);
+        assert_eq!(huge64_struct(w), w);
         assert_eq!(split_ret_byval_struct(1, 2, s), s);
         assert_eq!(sret_byval_struct(1, 2, 3, 4, s), t);
         assert_eq!(sret_split_struct(1, 2, s), t);

--- a/tests/run-make/extern-fn-struct-passing-abi/test.rs
+++ b/tests/run-make/extern-fn-struct-passing-abi/test.rs
@@ -89,7 +89,11 @@ extern "C" {
 
     fn byval_rect_with_many_huge(a: Huge, b: Huge, c: Huge, d: Huge, e: Huge, f: Huge, g: Rect);
 
-    fn byval_rect_with_many_huge64(a: Huge64, b: Huge64, c: Huge64, d: Huge64, e: Huge64, f: Huge64, g: Rect);
+    fn byval_rect_with_many_huge64(
+        a: Huge64, b: Huge64, c: Huge64,
+        d: Huge64, e: Huge64, f: Huge64,
+        g: Rect,
+    );
 
     fn split_rect(a: i32, b: i32, s: Rect);
 

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -53,7 +53,7 @@ error: layout_of(E) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(12 bytes),
@@ -78,11 +78,11 @@ error: layout_of(E) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:7:1
    |
@@ -127,7 +127,7 @@ error: layout_of(S) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:10:1
    |
@@ -150,7 +150,7 @@ error: layout_of(U) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:13:1
    |
@@ -242,7 +242,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(8 bytes),
@@ -278,11 +278,11 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:16:1
    |
@@ -309,7 +309,7 @@ error: layout_of(i32) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:19:1
    |
@@ -332,7 +332,7 @@ error: layout_of(V) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:22:1
    |
@@ -355,7 +355,7 @@ error: layout_of(W) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:28:1
    |
@@ -378,7 +378,7 @@ error: layout_of(Y) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:34:1
    |
@@ -401,7 +401,7 @@ error: layout_of(P1) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:41:1
    |
@@ -424,7 +424,7 @@ error: layout_of(P2) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:45:1
    |
@@ -447,7 +447,7 @@ error: layout_of(P3) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:53:1
    |
@@ -470,7 +470,7 @@ error: layout_of(P4) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:57:1
    |
@@ -498,7 +498,7 @@ error: layout_of(P5) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:61:1
    |
@@ -526,7 +526,7 @@ error: layout_of(std::mem::MaybeUninit<u8>) = Layout {
            variants: Single {
                index: 0,
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/debug.rs:64:1
    |

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -53,7 +53,7 @@ error: layout_of(E) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
@@ -79,12 +79,12 @@ error: layout_of(E) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:7:1
@@ -130,7 +130,7 @@ error: layout_of(S) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:10:1
@@ -154,7 +154,7 @@ error: layout_of(U) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:13:1
@@ -247,7 +247,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
@@ -284,12 +284,12 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:16:1
@@ -317,7 +317,7 @@ error: layout_of(i32) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:19:1
@@ -341,7 +341,7 @@ error: layout_of(V) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/debug.rs:22:1
@@ -365,7 +365,7 @@ error: layout_of(W) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/debug.rs:28:1
@@ -389,7 +389,7 @@ error: layout_of(Y) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/debug.rs:34:1
@@ -413,7 +413,7 @@ error: layout_of(P1) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:41:1
@@ -437,7 +437,7 @@ error: layout_of(P2) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:45:1
@@ -461,7 +461,7 @@ error: layout_of(P3) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:53:1
@@ -485,7 +485,7 @@ error: layout_of(P4) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:57:1
@@ -514,7 +514,7 @@ error: layout_of(P5) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:61:1
@@ -543,7 +543,7 @@ error: layout_of(std::mem::MaybeUninit<u8>) = Layout {
            variants: Single {
                index: 0,
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:64:1

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -53,6 +53,7 @@ error: layout_of(E) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(12 bytes),
@@ -77,9 +78,11 @@ error: layout_of(E) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:7:1
    |
@@ -124,6 +127,7 @@ error: layout_of(S) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:10:1
    |
@@ -146,6 +150,7 @@ error: layout_of(U) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:13:1
    |
@@ -237,6 +242,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(8 bytes),
@@ -272,9 +278,11 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:16:1
    |
@@ -301,6 +309,7 @@ error: layout_of(i32) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:19:1
    |
@@ -323,6 +332,7 @@ error: layout_of(V) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:22:1
    |
@@ -345,6 +355,7 @@ error: layout_of(W) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:28:1
    |
@@ -367,6 +378,7 @@ error: layout_of(Y) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:34:1
    |
@@ -389,6 +401,7 @@ error: layout_of(P1) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:41:1
    |
@@ -411,6 +424,7 @@ error: layout_of(P2) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:45:1
    |
@@ -433,6 +447,7 @@ error: layout_of(P3) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:53:1
    |
@@ -455,6 +470,7 @@ error: layout_of(P4) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:57:1
    |
@@ -482,6 +498,7 @@ error: layout_of(P5) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:61:1
    |
@@ -509,6 +526,7 @@ error: layout_of(std::mem::MaybeUninit<u8>) = Layout {
            variants: Single {
                index: 0,
            },
+           has_repr_align: false,
        }
   --> $DIR/debug.rs:64:1
    |

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -54,6 +54,7 @@ error: layout_of(E) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(12 bytes),
@@ -79,10 +80,12 @@ error: layout_of(E) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:7:1
    |
@@ -128,6 +131,7 @@ error: layout_of(S) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:10:1
    |
@@ -151,6 +155,7 @@ error: layout_of(U) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:13:1
    |
@@ -243,6 +248,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
                        size: Size(8 bytes),
@@ -279,10 +285,12 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:16:1
    |
@@ -310,6 +318,7 @@ error: layout_of(i32) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/debug.rs:19:1
    |
@@ -333,6 +342,7 @@ error: layout_of(V) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/debug.rs:22:1
    |
@@ -356,6 +366,7 @@ error: layout_of(W) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/debug.rs:28:1
    |
@@ -379,6 +390,7 @@ error: layout_of(Y) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/debug.rs:34:1
    |
@@ -402,6 +414,7 @@ error: layout_of(P1) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:41:1
    |
@@ -425,6 +438,7 @@ error: layout_of(P2) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:45:1
    |
@@ -448,6 +462,7 @@ error: layout_of(P3) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:53:1
    |
@@ -471,6 +486,7 @@ error: layout_of(P4) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:57:1
    |
@@ -499,6 +515,7 @@ error: layout_of(P5) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:61:1
    |
@@ -527,6 +544,7 @@ error: layout_of(std::mem::MaybeUninit<u8>) = Layout {
                index: 0,
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/debug.rs:64:1
    |

--- a/tests/ui/layout/hexagon-enum.stderr
+++ b/tests/ui/layout/hexagon-enum.stderr
@@ -59,9 +59,11 @@ error: layout_of(A) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/hexagon-enum.rs:16:1
    |
@@ -129,9 +131,11 @@ error: layout_of(B) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/hexagon-enum.rs:20:1
    |
@@ -199,9 +203,11 @@ error: layout_of(C) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/hexagon-enum.rs:24:1
    |
@@ -269,9 +275,11 @@ error: layout_of(P) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/hexagon-enum.rs:28:1
    |
@@ -339,9 +347,11 @@ error: layout_of(T) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/hexagon-enum.rs:34:1
    |

--- a/tests/ui/layout/hexagon-enum.stderr
+++ b/tests/ui/layout/hexagon-enum.stderr
@@ -59,11 +59,11 @@ error: layout_of(A) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/hexagon-enum.rs:16:1
    |
@@ -131,11 +131,11 @@ error: layout_of(B) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/hexagon-enum.rs:20:1
    |
@@ -203,11 +203,11 @@ error: layout_of(C) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/hexagon-enum.rs:24:1
    |
@@ -275,11 +275,11 @@ error: layout_of(P) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/hexagon-enum.rs:28:1
    |
@@ -347,11 +347,11 @@ error: layout_of(T) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/hexagon-enum.rs:34:1
    |

--- a/tests/ui/layout/hexagon-enum.stderr
+++ b/tests/ui/layout/hexagon-enum.stderr
@@ -59,12 +59,12 @@ error: layout_of(A) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/hexagon-enum.rs:16:1
@@ -133,12 +133,12 @@ error: layout_of(B) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/hexagon-enum.rs:20:1
@@ -207,12 +207,12 @@ error: layout_of(C) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(2 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/hexagon-enum.rs:24:1
@@ -281,12 +281,12 @@ error: layout_of(P) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/hexagon-enum.rs:28:1
@@ -355,12 +355,12 @@ error: layout_of(T) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/hexagon-enum.rs:34:1

--- a/tests/ui/layout/hexagon-enum.stderr
+++ b/tests/ui/layout/hexagon-enum.stderr
@@ -60,10 +60,12 @@ error: layout_of(A) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/hexagon-enum.rs:16:1
    |
@@ -132,10 +134,12 @@ error: layout_of(B) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/hexagon-enum.rs:20:1
    |
@@ -204,10 +208,12 @@ error: layout_of(C) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(2 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/hexagon-enum.rs:24:1
    |
@@ -276,10 +282,12 @@ error: layout_of(P) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/hexagon-enum.rs:28:1
    |
@@ -348,10 +356,12 @@ error: layout_of(T) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/hexagon-enum.rs:34:1
    |

--- a/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -81,6 +81,7 @@ error: layout_of(MissingPayloadField) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(1 bytes),
@@ -99,9 +100,11 @@ error: layout_of(MissingPayloadField) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:16:1
    |
@@ -193,6 +196,7 @@ error: layout_of(CommonPayloadField) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -228,9 +232,11 @@ error: layout_of(CommonPayloadField) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:25:1
    |
@@ -320,6 +326,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -354,9 +361,11 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:33:1
    |
@@ -462,6 +471,7 @@ error: layout_of(NicheFirst) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -480,6 +490,7 @@ error: layout_of(NicheFirst) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -498,9 +509,11 @@ error: layout_of(NicheFirst) = Layout {
                        variants: Single {
                            index: 2,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:41:1
    |
@@ -606,6 +619,7 @@ error: layout_of(NicheSecond) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -624,6 +638,7 @@ error: layout_of(NicheSecond) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -642,9 +657,11 @@ error: layout_of(NicheSecond) = Layout {
                        variants: Single {
                            index: 2,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:50:1
    |

--- a/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -82,6 +82,7 @@ error: layout_of(MissingPayloadField) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(1 bytes),
@@ -101,10 +102,12 @@ error: layout_of(MissingPayloadField) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:16:1
    |
@@ -197,6 +200,7 @@ error: layout_of(CommonPayloadField) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -233,10 +237,12 @@ error: layout_of(CommonPayloadField) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:25:1
    |
@@ -327,6 +333,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -362,10 +369,12 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:33:1
    |
@@ -472,6 +481,7 @@ error: layout_of(NicheFirst) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -491,6 +501,7 @@ error: layout_of(NicheFirst) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -510,10 +521,12 @@ error: layout_of(NicheFirst) = Layout {
                            index: 2,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:41:1
    |
@@ -620,6 +633,7 @@ error: layout_of(NicheSecond) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -639,6 +653,7 @@ error: layout_of(NicheSecond) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -658,10 +673,12 @@ error: layout_of(NicheSecond) = Layout {
                            index: 2,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:50:1
    |

--- a/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -81,7 +81,7 @@ error: layout_of(MissingPayloadField) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(1 bytes),
@@ -100,11 +100,11 @@ error: layout_of(MissingPayloadField) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:16:1
    |
@@ -196,7 +196,7 @@ error: layout_of(CommonPayloadField) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -232,11 +232,11 @@ error: layout_of(CommonPayloadField) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:25:1
    |
@@ -326,7 +326,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -361,11 +361,11 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:33:1
    |
@@ -471,7 +471,7 @@ error: layout_of(NicheFirst) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -490,7 +490,7 @@ error: layout_of(NicheFirst) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -509,11 +509,11 @@ error: layout_of(NicheFirst) = Layout {
                        variants: Single {
                            index: 2,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:41:1
    |
@@ -619,7 +619,7 @@ error: layout_of(NicheSecond) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -638,7 +638,7 @@ error: layout_of(NicheSecond) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(0 bytes),
@@ -657,11 +657,11 @@ error: layout_of(NicheSecond) = Layout {
                        variants: Single {
                            index: 2,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:50:1
    |

--- a/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -81,7 +81,7 @@ error: layout_of(MissingPayloadField) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
@@ -101,12 +101,12 @@ error: layout_of(MissingPayloadField) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:16:1
@@ -199,7 +199,7 @@ error: layout_of(CommonPayloadField) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
@@ -236,12 +236,12 @@ error: layout_of(CommonPayloadField) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:25:1
@@ -332,7 +332,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
@@ -368,12 +368,12 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:33:1
@@ -480,7 +480,7 @@ error: layout_of(NicheFirst) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
@@ -500,7 +500,7 @@ error: layout_of(NicheFirst) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
@@ -520,12 +520,12 @@ error: layout_of(NicheFirst) = Layout {
                        variants: Single {
                            index: 2,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:41:1
@@ -632,7 +632,7 @@ error: layout_of(NicheSecond) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
@@ -652,7 +652,7 @@ error: layout_of(NicheSecond) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
@@ -672,12 +672,12 @@ error: layout_of(NicheSecond) = Layout {
                        variants: Single {
                            index: 2,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:50:1

--- a/tests/ui/layout/issue-96185-overaligned-enum.stderr
+++ b/tests/ui/layout/issue-96185-overaligned-enum.stderr
@@ -53,7 +53,7 @@ error: layout_of(Aligned1) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: Some(
+                       max_repr_align: Some(
                            Align(8 bytes),
                        ),
                        unadjusted_abi_align: Align(1 bytes),
@@ -75,14 +75,14 @@ error: layout_of(Aligned1) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: Some(
+                       max_repr_align: Some(
                            Align(8 bytes),
                        ),
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: Some(
+           max_repr_align: Some(
                Align(8 bytes),
            ),
            unadjusted_abi_align: Align(1 bytes),
@@ -153,7 +153,7 @@ error: layout_of(Aligned2) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: Some(
+                       max_repr_align: Some(
                            Align(1 bytes),
                        ),
                        unadjusted_abi_align: Align(1 bytes),
@@ -175,14 +175,14 @@ error: layout_of(Aligned2) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: Some(
+                       max_repr_align: Some(
                            Align(1 bytes),
                        ),
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: Some(
+           max_repr_align: Some(
                Align(1 bytes),
            ),
            unadjusted_abi_align: Align(1 bytes),

--- a/tests/ui/layout/issue-96185-overaligned-enum.stderr
+++ b/tests/ui/layout/issue-96185-overaligned-enum.stderr
@@ -53,7 +53,9 @@ error: layout_of(Aligned1) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: true,
+                       repr_align: Some(
+                           Align(8 bytes),
+                       ),
                    },
                    Layout {
                        size: Size(8 bytes),
@@ -72,11 +74,15 @@ error: layout_of(Aligned1) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: true,
+                       repr_align: Some(
+                           Align(8 bytes),
+                       ),
                    },
                ],
            },
-           has_repr_align: true,
+           repr_align: Some(
+               Align(8 bytes),
+           ),
        }
   --> $DIR/issue-96185-overaligned-enum.rs:8:1
    |
@@ -144,7 +150,9 @@ error: layout_of(Aligned2) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: true,
+                       repr_align: Some(
+                           Align(1 bytes),
+                       ),
                    },
                    Layout {
                        size: Size(1 bytes),
@@ -163,11 +171,15 @@ error: layout_of(Aligned2) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: true,
+                       repr_align: Some(
+                           Align(1 bytes),
+                       ),
                    },
                ],
            },
-           has_repr_align: true,
+           repr_align: Some(
+               Align(1 bytes),
+           ),
        }
   --> $DIR/issue-96185-overaligned-enum.rs:16:1
    |

--- a/tests/ui/layout/issue-96185-overaligned-enum.stderr
+++ b/tests/ui/layout/issue-96185-overaligned-enum.stderr
@@ -53,6 +53,7 @@ error: layout_of(Aligned1) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: true,
                    },
                    Layout {
                        size: Size(8 bytes),
@@ -71,9 +72,11 @@ error: layout_of(Aligned1) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: true,
                    },
                ],
            },
+           has_repr_align: true,
        }
   --> $DIR/issue-96185-overaligned-enum.rs:8:1
    |
@@ -141,6 +144,7 @@ error: layout_of(Aligned2) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: true,
                    },
                    Layout {
                        size: Size(1 bytes),
@@ -159,9 +163,11 @@ error: layout_of(Aligned2) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: true,
                    },
                ],
            },
+           has_repr_align: true,
        }
   --> $DIR/issue-96185-overaligned-enum.rs:16:1
    |

--- a/tests/ui/layout/issue-96185-overaligned-enum.stderr
+++ b/tests/ui/layout/issue-96185-overaligned-enum.stderr
@@ -56,6 +56,7 @@ error: layout_of(Aligned1) = Layout {
                        repr_align: Some(
                            Align(8 bytes),
                        ),
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(8 bytes),
@@ -77,12 +78,14 @@ error: layout_of(Aligned1) = Layout {
                        repr_align: Some(
                            Align(8 bytes),
                        ),
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: Some(
                Align(8 bytes),
            ),
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96185-overaligned-enum.rs:8:1
    |
@@ -153,6 +156,7 @@ error: layout_of(Aligned2) = Layout {
                        repr_align: Some(
                            Align(1 bytes),
                        ),
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                    Layout {
                        size: Size(1 bytes),
@@ -174,12 +178,14 @@ error: layout_of(Aligned2) = Layout {
                        repr_align: Some(
                            Align(1 bytes),
                        ),
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: Some(
                Align(1 bytes),
            ),
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/issue-96185-overaligned-enum.rs:16:1
    |

--- a/tests/ui/layout/thumb-enum.stderr
+++ b/tests/ui/layout/thumb-enum.stderr
@@ -59,12 +59,12 @@ error: layout_of(A) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/thumb-enum.rs:16:1
@@ -133,12 +133,12 @@ error: layout_of(B) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/thumb-enum.rs:20:1
@@ -207,12 +207,12 @@ error: layout_of(C) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(2 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/thumb-enum.rs:24:1
@@ -281,12 +281,12 @@ error: layout_of(P) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/thumb-enum.rs:28:1
@@ -355,12 +355,12 @@ error: layout_of(T) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/thumb-enum.rs:34:1

--- a/tests/ui/layout/thumb-enum.stderr
+++ b/tests/ui/layout/thumb-enum.stderr
@@ -60,10 +60,12 @@ error: layout_of(A) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/thumb-enum.rs:16:1
    |
@@ -132,10 +134,12 @@ error: layout_of(B) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(1 bytes),
        }
   --> $DIR/thumb-enum.rs:20:1
    |
@@ -204,10 +208,12 @@ error: layout_of(C) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(2 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(2 bytes),
        }
   --> $DIR/thumb-enum.rs:24:1
    |
@@ -276,10 +282,12 @@ error: layout_of(P) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/thumb-enum.rs:28:1
    |
@@ -348,10 +356,12 @@ error: layout_of(T) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/thumb-enum.rs:34:1
    |

--- a/tests/ui/layout/thumb-enum.stderr
+++ b/tests/ui/layout/thumb-enum.stderr
@@ -59,9 +59,11 @@ error: layout_of(A) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/thumb-enum.rs:16:1
    |
@@ -129,9 +131,11 @@ error: layout_of(B) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/thumb-enum.rs:20:1
    |
@@ -199,9 +203,11 @@ error: layout_of(C) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/thumb-enum.rs:24:1
    |
@@ -269,9 +275,11 @@ error: layout_of(P) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/thumb-enum.rs:28:1
    |
@@ -339,9 +347,11 @@ error: layout_of(T) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/thumb-enum.rs:34:1
    |

--- a/tests/ui/layout/thumb-enum.stderr
+++ b/tests/ui/layout/thumb-enum.stderr
@@ -59,11 +59,11 @@ error: layout_of(A) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/thumb-enum.rs:16:1
    |
@@ -131,11 +131,11 @@ error: layout_of(B) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/thumb-enum.rs:20:1
    |
@@ -203,11 +203,11 @@ error: layout_of(C) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/thumb-enum.rs:24:1
    |
@@ -275,11 +275,11 @@ error: layout_of(P) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/thumb-enum.rs:28:1
    |
@@ -347,11 +347,11 @@ error: layout_of(T) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/thumb-enum.rs:34:1
    |

--- a/tests/ui/layout/zero-sized-array-enum-niche.stderr
+++ b/tests/ui/layout/zero-sized-array-enum-niche.stderr
@@ -57,6 +57,7 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -88,9 +89,11 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/zero-sized-array-enum-niche.rs:13:1
    |
@@ -156,6 +159,7 @@ error: layout_of(MultipleAlignments) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(4 bytes),
@@ -178,6 +182,7 @@ error: layout_of(MultipleAlignments) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -209,9 +214,11 @@ error: layout_of(MultipleAlignments) = Layout {
                        variants: Single {
                            index: 2,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/zero-sized-array-enum-niche.rs:21:1
    |
@@ -277,6 +284,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(3 bytes),
@@ -308,9 +316,11 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/zero-sized-array-enum-niche.rs:37:1
    |
@@ -380,6 +390,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                        variants: Single {
                            index: 0,
                        },
+                       has_repr_align: false,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -411,9 +422,11 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                        variants: Single {
                            index: 1,
                        },
+                       has_repr_align: false,
                    },
                ],
            },
+           has_repr_align: false,
        }
   --> $DIR/zero-sized-array-enum-niche.rs:44:1
    |

--- a/tests/ui/layout/zero-sized-array-enum-niche.stderr
+++ b/tests/ui/layout/zero-sized-array-enum-niche.stderr
@@ -58,6 +58,7 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -90,10 +91,12 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/zero-sized-array-enum-niche.rs:13:1
    |
@@ -160,6 +163,7 @@ error: layout_of(MultipleAlignments) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(2 bytes),
                    },
                    Layout {
                        size: Size(4 bytes),
@@ -183,6 +187,7 @@ error: layout_of(MultipleAlignments) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -215,10 +220,12 @@ error: layout_of(MultipleAlignments) = Layout {
                            index: 2,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/zero-sized-array-enum-niche.rs:21:1
    |
@@ -285,6 +292,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
                        size: Size(3 bytes),
@@ -317,10 +325,12 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/zero-sized-array-enum-niche.rs:37:1
    |
@@ -391,6 +401,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                            index: 0,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -423,10 +434,12 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                            index: 1,
                        },
                        repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
            repr_align: None,
+           unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/zero-sized-array-enum-niche.rs:44:1
    |

--- a/tests/ui/layout/zero-sized-array-enum-niche.stderr
+++ b/tests/ui/layout/zero-sized-array-enum-niche.stderr
@@ -57,7 +57,7 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
@@ -90,12 +90,12 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/zero-sized-array-enum-niche.rs:13:1
@@ -162,7 +162,7 @@ error: layout_of(MultipleAlignments) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(2 bytes),
                    },
                    Layout {
@@ -186,7 +186,7 @@ error: layout_of(MultipleAlignments) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
@@ -219,12 +219,12 @@ error: layout_of(MultipleAlignments) = Layout {
                        variants: Single {
                            index: 2,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/zero-sized-array-enum-niche.rs:21:1
@@ -291,7 +291,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
@@ -324,12 +324,12 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/zero-sized-array-enum-niche.rs:37:1
@@ -400,7 +400,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(4 bytes),
                    },
                    Layout {
@@ -433,12 +433,12 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       repr_align: None,
+                       max_repr_align: None,
                        unadjusted_abi_align: Align(1 bytes),
                    },
                ],
            },
-           repr_align: None,
+           max_repr_align: None,
            unadjusted_abi_align: Align(4 bytes),
        }
   --> $DIR/zero-sized-array-enum-niche.rs:44:1

--- a/tests/ui/layout/zero-sized-array-enum-niche.stderr
+++ b/tests/ui/layout/zero-sized-array-enum-niche.stderr
@@ -57,7 +57,7 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -89,11 +89,11 @@ error: layout_of(std::result::Result<[u32; 0], bool>) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/zero-sized-array-enum-niche.rs:13:1
    |
@@ -159,7 +159,7 @@ error: layout_of(MultipleAlignments) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(4 bytes),
@@ -182,7 +182,7 @@ error: layout_of(MultipleAlignments) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -214,11 +214,11 @@ error: layout_of(MultipleAlignments) = Layout {
                        variants: Single {
                            index: 2,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/zero-sized-array-enum-niche.rs:21:1
    |
@@ -284,7 +284,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(3 bytes),
@@ -316,11 +316,11 @@ error: layout_of(std::result::Result<[u32; 0], Packed<std::num::NonZeroU16>>) = 
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/zero-sized-array-enum-niche.rs:37:1
    |
@@ -390,7 +390,7 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                        variants: Single {
                            index: 0,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                    Layout {
                        size: Size(2 bytes),
@@ -422,11 +422,11 @@ error: layout_of(std::result::Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                        variants: Single {
                            index: 1,
                        },
-                       has_repr_align: false,
+                       repr_align: None,
                    },
                ],
            },
-           has_repr_align: false,
+           repr_align: None,
        }
   --> $DIR/zero-sized-array-enum-niche.rs:44:1
    |


### PR DESCRIPTION
Same as #111551, which I [accidentally closed](https://github.com/rust-lang/rust/pull/111551#issuecomment-1571222612) :/

---

This resurrects PR #103830, which has sat idle for a while.

Beyond #103830, this also:
- fixes byval alignment for types containing vectors on Darwin (see `tests/codegen/align-byval-vector.rs`)
- fixes byval alignment for overaligned types on x86 Windows (see `tests/codegen/align-byval.rs`)
- fixes ABI for types with 128bit requested alignment on ARM64 Linux (see `tests/codegen/aarch64-struct-align-128.rs`)

r? @nikic

---

@pcwalton's original PR description is reproduced below:

Commit 88e4d2c from five years ago removed
support for alignment on indirectly-passed arguments because of problems with
the `i686-pc-windows-msvc` target. Unfortunately, the `memcpy` optimizations I
recently added to LLVM 16 depend on this to forward `memcpy`s. This commit
attempts to fix the problems with `byval` parameters on that target and now
correctly adds the `align` attribute.

The problem is summarized in [this comment] by @eddyb. Briefly, 32-bit x86 has
special alignment rules for `byval` parameters: for the most part, their
alignment is forced to 4. This is not well-documented anywhere but in the Clang
source. I looked at the logic in Clang `TargetInfo.cpp` and tried to replicate
it here. The relevant methods in that file are
`X86_32ABIInfo::getIndirectResult()` and
`X86_32ABIInfo::getTypeStackAlignInBytes()`. The `align` parameter attribute
for `byval` parameters in LLVM must match the platform ABI, or miscompilations
will occur. Note that this doesn't use the approach suggested by eddyb, because
I felt it was overkill to store the alignment in `on_stack` when special
handling is really only needed for 32-bit x86.

As a side effect, this should fix #80127, because it will make the `align`
parameter attribute for `byval` parameters match the platform ABI on LLVM
x86-64.

[this comment]: #80822 (comment)