### PR TITLE
Modifies the rendering of constant values in rustdoc.

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1491,22 +1491,23 @@ fn item_constant(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, c: &cle
         let value = c.value(tcx);
         let is_literal = c.is_literal(tcx);
         let expr = c.expr(tcx);
-        if value.is_some() || is_literal {
+        if is_literal {
             write!(w, " = {expr};", expr = Escape(&expr));
+        } else if let Some(ref value) = value {
+            write!(w, " = {value};", value = Escape(value));
         } else {
             w.write_str(";");
         }
 
-        if !is_literal {
-            if let Some(value) = &value {
-                let value_lowercase = value.to_lowercase();
-                let expr_lowercase = expr.to_lowercase();
+        let value_lowercase = value.as_ref().map(|s| s.to_lowercase());
+        let expr_lowercase = Some(expr.to_lowercase());
 
-                if value_lowercase != expr_lowercase
-                    && value_lowercase.trim_end_matches("i32") != expr_lowercase
-                {
-                    write!(w, " // {value}", value = Escape(value));
-                }
+        if value_lowercase != expr_lowercase
+            && value_lowercase.as_ref().map(|s| s.trim_end_matches("i32"))
+                != expr_lowercase.as_deref()
+        {
+            if let Some(ref value) = value {
+                write!(w, " // {value}", value = Escape(value.as_str()));
             }
         }
     });

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1498,18 +1498,6 @@ fn item_constant(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, c: &cle
         } else {
             w.write_str(";");
         }
-
-        let value_lowercase = value.as_ref().map(|s| s.to_lowercase());
-        let expr_lowercase = Some(expr.to_lowercase());
-
-        if value_lowercase != expr_lowercase
-            && value_lowercase.as_ref().map(|s| s.trim_end_matches("i32"))
-                != expr_lowercase.as_deref()
-        {
-            if let Some(ref value) = value {
-                write!(w, " // {value}", value = Escape(value.as_str()));
-            }
-        }
     });
 
     write!(w, "{}", document(cx, it, None, HeadingOffset::H2))

--- a/tests/rustdoc/const-value-display.rs
+++ b/tests/rustdoc/const-value-display.rs
@@ -1,9 +1,9 @@
 #![crate_name = "foo"]
 
 // @has 'foo/constant.HOUR_IN_SECONDS.html'
-// @has - '//*[@class="rust item-decl"]//code' 'pub const HOUR_IN_SECONDS: u64 = _; // 3_600u64'
+// @has - '//*[@class="rust item-decl"]//code' 'pub const HOUR_IN_SECONDS: u64 = 3_600u64'
 pub const HOUR_IN_SECONDS: u64 = 60 * 60;
 
 // @has 'foo/constant.NEGATIVE.html'
-// @has - '//*[@class="rust item-decl"]//code' 'pub const NEGATIVE: i64 = _; // -3_600i64'
+// @has - '//*[@class="rust item-decl"]//code' 'pub const NEGATIVE: i64 = -3_600i64'
 pub const NEGATIVE: i64 = -60 * 60;

--- a/tests/rustdoc/show-const-contents.rs
+++ b/tests/rustdoc/show-const-contents.rs
@@ -2,53 +2,43 @@
 // documentation.
 
 // @hasraw show_const_contents/constant.CONST_S.html 'show this'
-// @!hasraw show_const_contents/constant.CONST_S.html '; //'
 pub const CONST_S: &'static str = "show this";
 
 // @hasraw show_const_contents/constant.CONST_I32.html '= 42;'
-// @!hasraw show_const_contents/constant.CONST_I32.html '; //'
 pub const CONST_I32: i32 = 42;
 
 // @hasraw show_const_contents/constant.CONST_I32_HEX.html '= 0x42;'
-// @!hasraw show_const_contents/constant.CONST_I32_HEX.html ';'
 pub const CONST_I32_HEX: i32 = 0x42;
 
 // @hasraw show_const_contents/constant.CONST_NEG_I32.html '= -42;'
-// @!hasraw show_const_contents/constant.CONST_NEG_I32.html '; //'
 pub const CONST_NEG_I32: i32 = -42;
 
 // @hasraw show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '= 42i32;'
-// @!hasraw show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '// 42i32'
 pub const CONST_EQ_TO_VALUE_I32: i32 = 42i32;
 
 // @hasraw show_const_contents/constant.CONST_CALC_I32.html '= 43i32'
 pub const CONST_CALC_I32: i32 = 42 + 1;
 
 // @!hasraw show_const_contents/constant.CONST_REF_I32.html '= &42;'
-// @!hasraw show_const_contents/constant.CONST_REF_I32.html '; //'
 pub const CONST_REF_I32: &'static i32 = &42;
 
 // @hasraw show_const_contents/constant.CONST_I32_MAX.html '= 2_147_483_647i32'
 pub const CONST_I32_MAX: i32 = i32::MAX;
 
 // @!hasraw show_const_contents/constant.UNIT.html '= ();'
-// @!hasraw show_const_contents/constant.UNIT.html '; //'
 pub const UNIT: () = ();
 
 pub struct MyType(i32);
 
 // @!hasraw show_const_contents/constant.MY_TYPE.html '= MyType(42);'
-// @!hasraw show_const_contents/constant.MY_TYPE.html '; //'
 pub const MY_TYPE: MyType = MyType(42);
 
 pub struct MyTypeWithStr(&'static str);
 
 // @!hasraw show_const_contents/constant.MY_TYPE_WITH_STR.html '= MyTypeWithStr("show this");'
-// @!hasraw show_const_contents/constant.MY_TYPE_WITH_STR.html '; //'
 pub const MY_TYPE_WITH_STR: MyTypeWithStr = MyTypeWithStr("show this");
 
-// @hasraw show_const_contents/constant.PI.html '= 3.14159265358979323846264338327950288f32;'
-// @hasraw show_const_contents/constant.PI.html '; // 3.14159274f32'
+// @hasraw show_const_contents/constant.PI.html '= 3.14159274f32;'
 pub use std::f32::consts::PI;
 
 // @hasraw show_const_contents/constant.MAX.html '= 2_147_483_647i32'

--- a/tests/rustdoc/show-const-contents.rs
+++ b/tests/rustdoc/show-const-contents.rs
@@ -10,7 +10,7 @@ pub const CONST_S: &'static str = "show this";
 pub const CONST_I32: i32 = 42;
 
 // @hasraw show_const_contents/constant.CONST_I32_HEX.html '= 0x42;'
-// @!hasraw show_const_contents/constant.CONST_I32_HEX.html '; //'
+// @!hasraw show_const_contents/constant.CONST_I32_HEX.html ';'
 pub const CONST_I32_HEX: i32 = 0x42;
 
 // @hasraw show_const_contents/constant.CONST_NEG_I32.html '= -42;'
@@ -21,14 +21,14 @@ pub const CONST_NEG_I32: i32 = -42;
 // @!hasraw show_const_contents/constant.CONST_EQ_TO_VALUE_I32.html '// 42i32'
 pub const CONST_EQ_TO_VALUE_I32: i32 = 42i32;
 
-// @hasraw show_const_contents/constant.CONST_CALC_I32.html '= _; // 43i32'
+// @hasraw show_const_contents/constant.CONST_CALC_I32.html '= 43i32'
 pub const CONST_CALC_I32: i32 = 42 + 1;
 
 // @!hasraw show_const_contents/constant.CONST_REF_I32.html '= &42;'
 // @!hasraw show_const_contents/constant.CONST_REF_I32.html '; //'
 pub const CONST_REF_I32: &'static i32 = &42;
 
-// @hasraw show_const_contents/constant.CONST_I32_MAX.html '= i32::MAX; // 2_147_483_647i32'
+// @hasraw show_const_contents/constant.CONST_I32_MAX.html '= 2_147_483_647i32'
 pub const CONST_I32_MAX: i32 = i32::MAX;
 
 // @!hasraw show_const_contents/constant.UNIT.html '= ();'
@@ -51,7 +51,7 @@ pub const MY_TYPE_WITH_STR: MyTypeWithStr = MyTypeWithStr("show this");
 // @hasraw show_const_contents/constant.PI.html '; // 3.14159274f32'
 pub use std::f32::consts::PI;
 
-// @hasraw show_const_contents/constant.MAX.html '= i32::MAX; // 2_147_483_647i32'
+// @hasraw show_const_contents/constant.MAX.html '= 2_147_483_647i32'
 #[allow(deprecated, deprecated_in_future)]
 pub use std::i32::MAX;
 
@@ -61,7 +61,7 @@ macro_rules! int_module {
     )
 }
 
-// @hasraw show_const_contents/constant.MIN.html '= i16::MIN; // -32_768i16'
+// @hasraw show_const_contents/constant.MIN.html '= -32_768i16'
 int_module!(i16);
 
 // @has show_const_contents/constant.ESCAPE.html //pre '= r#"<script>alert("ESCAPE");</script>"#;'


### PR DESCRIPTION
Previously, non-literal expressions (like 50 + 50) would be printed alongside their value as a comment (like  = _; // 100i32). This approach often resulted in confusing documentation, especially for complex expressions.

To improve clarity, this commit changes the rendering to display the evaluated value of the expression directly (like  = 100i32;) unless the constant is a literal expression. The original expression is still included as a comment if it
doesn't match the evaluated value.

These changes aim to improve the readability and usefulness of constant value documentation generated by rustdoc.