### PR TITLE
Print the full arguments passed to `./configure` in CI

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -53,6 +53,7 @@ if ! isCI || isCiBranch auto || isCiBranch beta || isCiBranch try || isCiBranch 
     HAS_METRICS=1
 fi
 
+RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-verbose-configure"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-sccache"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-manage-submodules"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-locked-deps"


### PR DESCRIPTION
This is useful to replicate CI failures locally. Before, the arguments would be truncated and it would be hard to tell what it was actually doing.

Before:
```
configure: build.configure-args := ['--build=x86_64-unknown-linux-gnu', '--save-t ...
```

After:
```
configure: build.configure-args := ['--build=x86_64-unknown-linux-gnu', '--save-toolstates=/tmp/toolstate/toolstates.json', '--enable-verbose', '--enable-sccache', '--disable-manage-submodules', '--enable-locked-deps', '--enable-cargo-native-static', '--set', 'rust.codegen-units-std=1', '--set', 'dist.compression-profile=balanced', '--dist-compression-formats=xz', '--disable-dist-src', '--set', 'rust.download-rustc=if-unchanged', '--release-channel=nightly', '--enable-debug-assertions', '--enable-overflow-checks', '--enable-llvm-assertions', '--set', 'rust.verify-llvm-ir', '--set', 'llvm.download-ci-llvm=if-available', '--enable-missing-tools']
```