### PR TITLE
Fix bug where private item with intermediate doc hidden re-export was not inlined

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2180,7 +2180,8 @@ fn get_all_import_attributes<'hir>(
             // This is the "original" reexport so we get all its attributes without filtering them.
             attrs = import_attrs.iter().map(|attr| (Cow::Borrowed(attr), Some(def_id))).collect();
             first = false;
-        } else {
+        // We don't add attributes of an intermediate re-export if it has `#[doc(hidden)]`.
+        } else if !cx.tcx.is_doc_hidden(def_id) {
             add_without_unwanted_attributes(&mut attrs, import_attrs, is_inline, Some(def_id));
         }
     }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -246,7 +246,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         glob: bool,
         please_inline: bool,
     ) -> bool {
-        debug!("maybe_inline_local res: {:?}", res);
+        debug!("maybe_inline_local (renamed: {renamed:?}) res: {res:?}");
 
         if renamed == Some(kw::Underscore) {
             // We never inline `_` reexports.
@@ -308,6 +308,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     .cache
                     .effective_visibilities
                     .is_directly_public(tcx, item_def_id.to_def_id()) &&
+                !tcx.is_doc_hidden(item_def_id) &&
                 !inherits_doc_hidden(tcx, item_def_id, None)
             {
                 // The imported item is public and not `doc(hidden)` so no need to inline it.

--- a/tests/rustdoc/inline-private-with-intermediate-doc-hidden.rs
+++ b/tests/rustdoc/inline-private-with-intermediate-doc-hidden.rs
@@ -1,0 +1,23 @@
+// This test ensures that if a private item is re-exported with an intermediate
+// `#[doc(hidden)]` re-export, it'll still be inlined (and not include any attribute
+// from the doc hidden re-export.
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+// There should only be one struct displayed.
+// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 1
+// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Structs'
+// @has - '//*[@id="main-content"]//a[@href="struct.Reexport.html"]' 'Reexport'
+// @has - '//*[@id="main-content"]//*[@class="desc docblock-short"]' 'Visible. Original.'
+
+mod private {
+    /// Original.
+    pub struct Bar3;
+}
+
+/// Hidden.
+#[doc(hidden)]
+pub use crate::private::Bar3;
+/// Visible.
+pub use self::Bar3 as Reexport;

--- a/tests/rustdoc/reexport-attr-merge.rs
+++ b/tests/rustdoc/reexport-attr-merge.rs
@@ -19,9 +19,9 @@ pub use Foo1 as Foo2;
 // First we ensure that only the reexport `Bar2` and the inlined struct `Bar`
 // are inlined.
 // @count - '//a[@class="struct"]' 2
-// Then we check that both `cfg` are displayed.
+// Then we check that `cfg` is displayed for base item, but not for intermediate re-exports.
 // @has - '//*[@class="stab portability"]' 'foo'
-// @has - '//*[@class="stab portability"]' 'bar'
+// @!has - '//*[@class="stab portability"]' 'bar'
 // And finally we check that the only element displayed is `Bar`.
 // @has - '//a[@class="struct"]' 'Bar'
 #[doc(inline)]


### PR DESCRIPTION
This fixes this bug:

```rust
mod private {
    /// Original.
    pub struct Bar3;
}

/// Hidden.
#[doc(hidden)]
pub use crate::private::Bar3;
/// Visible.
pub use self::Bar3 as Reexport;
```

In this case, `private::Bar3` should be inlined and renamed `Reexport` but instead we have:

```
pub use self::Bar3 as Reexport;
```

and no links.

There were actually two issues: the first one is that we forgot to check if the next intermediate re-export was doc hidden. The second was that we made the `#[doc(hidden)]` attribute inheritable, which shouldn't be possible.

r? @notriddle 