### PR TITLE
Normalize anon consts in new solver

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -50,7 +50,7 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
                 // We do not allow generic parameters in anon consts if we are inside
                 // of a const parameter type, e.g. `struct Foo<const N: usize, const M: [u8; N]>` is not allowed.
                 None
-            } else if tcx.lazy_normalization() {
+            } else if tcx.features().generic_const_exprs {
                 let parent_node = tcx.hir().get_parent(hir_id);
                 if let Node::Variant(Variant { disr_expr: Some(constant), .. }) = parent_node
                     && constant.hir_id == hir_id

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -463,7 +463,7 @@ pub(super) fn explicit_predicates_of<'tcx>(
             }
         }
     } else {
-        if matches!(def_kind, DefKind::AnonConst) && tcx.lazy_normalization() {
+        if matches!(def_kind, DefKind::AnonConst) && tcx.features().generic_const_exprs {
             let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
             let parent_def_id = tcx.hir().get_parent_item(hir_id);
 

--- a/compiler/rustc_hir_analysis/src/outlives/mod.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/mod.rs
@@ -20,7 +20,8 @@ pub fn provide(providers: &mut Providers) {
 fn inferred_outlives_of(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[(ty::Clause<'_>, Span)] {
     let id = tcx.hir().local_def_id_to_hir_id(item_def_id);
 
-    if matches!(tcx.def_kind(item_def_id), hir::def::DefKind::AnonConst) && tcx.lazy_normalization()
+    if matches!(tcx.def_kind(item_def_id), hir::def::DefKind::AnonConst)
+        && tcx.features().generic_const_exprs
     {
         if tcx.hir().opt_const_param_default_param_def_id(id).is_some() {
             // In `generics_of` we set the generics' parent to be our parent's parent which means that

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -227,7 +227,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 return self.unify_const_variable(vid, a, relation.param_env());
             }
             (ty::ConstKind::Unevaluated(..), _) | (_, ty::ConstKind::Unevaluated(..))
-                if self.tcx.features().generic_const_exprs =>
+                if self.tcx.features().generic_const_exprs || self.tcx.trait_solver_next() =>
             {
                 relation.register_const_equate_obligation(a, b);
                 return Ok(b);

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -227,7 +227,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 return self.unify_const_variable(vid, a, relation.param_env());
             }
             (ty::ConstKind::Unevaluated(..), _) | (_, ty::ConstKind::Unevaluated(..))
-                if self.tcx.lazy_normalization() =>
+                if self.tcx.features().generic_const_exprs =>
             {
                 relation.register_const_equate_obligation(a, b);
                 return Ok(b);

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1015,15 +1015,6 @@ impl<'tcx> TyCtxt<'tcx> {
         self.query_system.on_disk_cache.as_ref().map_or(Ok(0), |c| c.serialize(self, encoder))
     }
 
-    /// If `true`, we should use lazy normalization for constants, otherwise
-    /// we still evaluate them eagerly.
-    #[inline]
-    pub fn lazy_normalization(self) -> bool {
-        let features = self.features();
-        // Note: We only use lazy normalization for generic const expressions.
-        features.generic_const_exprs
-    }
-
     #[inline]
     pub fn local_crate_exports_generics(self) -> bool {
         debug_assert!(self.sess.opts.share_generics());

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -322,9 +322,12 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
                 ty::PredicateKind::Ambiguous => {
                     self.evaluate_added_goals_and_make_canonical_response(Certainty::AMBIGUOUS)
                 }
-                // FIXME: implement these predicates :)
-                ty::PredicateKind::ConstEvaluatable(_) | ty::PredicateKind::ConstEquate(_, _) => {
+                // FIXME: implement this predicate :)
+                ty::PredicateKind::ConstEvaluatable(_) => {
                     self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+                }
+                ty::PredicateKind::ConstEquate(_, _) => {
+                    bug!("ConstEquate should not be emitted when `-Ztrait-solver=next` is active")
                 }
                 ty::PredicateKind::TypeWellFormedFromEnv(..) => {
                     bug!("TypeWellFormedFromEnv is only used for Chalk")

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -118,16 +118,6 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
                                         TypeError::Sorts(expected_found),
                                     )
                                 }
-                                ty::PredicateKind::ConstEquate(a, b) => {
-                                    let (a, b) = infcx.instantiate_binder_with_placeholders(
-                                        goal.predicate.kind().rebind((a, b)),
-                                    );
-                                    let expected_found = ExpectedFound::new(true, a, b);
-                                    FulfillmentErrorCode::CodeConstEquateError(
-                                        expected_found,
-                                        TypeError::ConstMismatch(expected_found),
-                                    )
-                                }
                                 ty::PredicateKind::Clause(_)
                                 | ty::PredicateKind::WellFormed(_)
                                 | ty::PredicateKind::ObjectSafe(_)
@@ -138,7 +128,8 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
                                         SelectionError::Unimplemented,
                                     )
                                 }
-                                ty::PredicateKind::TypeWellFormedFromEnv(_) => {
+                                ty::PredicateKind::ConstEquate(..)
+                                | ty::PredicateKind::TypeWellFormedFromEnv(_) => {
                                     bug!("unexpected goal: {goal:?}")
                                 }
                             },

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -672,7 +672,9 @@ impl<'a, 'b, 'tcx> TypeFolder<TyCtxt<'tcx>> for AssocTypeNormalizer<'a, 'b, 'tcx
     #[instrument(skip(self), level = "debug")]
     fn fold_const(&mut self, constant: ty::Const<'tcx>) -> ty::Const<'tcx> {
         let tcx = self.selcx.tcx();
-        if tcx.lazy_normalization() || !needs_normalization(&constant, self.param_env.reveal()) {
+        if tcx.features().generic_const_exprs
+            || !needs_normalization(&constant, self.param_env.reveal())
+        {
             constant
         } else {
             let constant = constant.super_fold_with(self);

--- a/tests/ui/traits/new-solver/array-default.rs
+++ b/tests/ui/traits/new-solver/array-default.rs
@@ -1,0 +1,8 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+fn has_default<const N: usize>() where [(); N]: Default {}
+
+fn main() {
+    has_default::<1>();
+}

--- a/tests/ui/traits/new-solver/structural-resolve-field.rs
+++ b/tests/ui/traits/new-solver/structural-resolve-field.rs
@@ -1,35 +1,13 @@
 // compile-flags: -Ztrait-solver=next
 // check-pass
 
+#[derive(Default)]
 struct Foo {
     x: i32,
 }
 
-impl MyDefault for Foo {
-    fn my_default() -> Self {
-        Self {
-            x: 0,
-        }
-    }
-}
-
-trait MyDefault {
-    fn my_default() -> Self;
-}
-
-impl MyDefault for [Foo; 0]  {
-    fn my_default() -> Self {
-        []
-    }
-}
-impl MyDefault for [Foo; 1] {
-    fn my_default() -> Self {
-        [Foo::my_default(); 1]
-    }
-}
-
 fn main() {
-    let mut xs = <[Foo; 1]>::my_default();
+    let mut xs = <[Foo; 1]>::default();
     xs[0].x = 1;
     (&mut xs[0]).x = 2;
 }

--- a/tests/ui/traits/new-solver/unevaluated-const-impl-trait-ref.fails.stderr
+++ b/tests/ui/traits/new-solver/unevaluated-const-impl-trait-ref.fails.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `(): Trait<1>` is not satisfied
+  --> $DIR/unevaluated-const-impl-trait-ref.rs:20:13
+   |
+LL |     needs::<1>();
+   |             ^ the trait `Trait<1>` is not implemented for `()`
+   |
+   = help: the following other types implement trait `Trait<N>`:
+             <() as Trait<0>>
+             <() as Trait<2>>
+note: required by a bound in `needs`
+  --> $DIR/unevaluated-const-impl-trait-ref.rs:10:38
+   |
+LL | fn needs<const N: usize>() where (): Trait<N> {}
+   |                                      ^^^^^^^^ required by this bound in `needs`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/new-solver/unevaluated-const-impl-trait-ref.rs
+++ b/tests/ui/traits/new-solver/unevaluated-const-impl-trait-ref.rs
@@ -1,0 +1,22 @@
+// compile-flags: -Ztrait-solver=next
+// revisions: works fails
+//[works] check-pass
+
+trait Trait<const N: usize> {}
+
+impl Trait<{ 1 - 1 }> for () {}
+impl Trait<{ 1 + 1 }> for () {}
+
+fn needs<const N: usize>() where (): Trait<N> {}
+
+#[cfg(works)]
+fn main() {
+    needs::<0>();
+    needs::<2>();
+}
+
+#[cfg(fails)]
+fn main() {
+    needs::<1>();
+    //[fails]~^ ERROR the trait bound `(): Trait<1>` is not satisfied
+}


### PR DESCRIPTION
We don't do any of that `expand_abstract_consts` stuff so this isn't sufficient to make GCE work, but it does allow, e.g. `[(); 1]: Default`, to solve.

r? @BoxyUwU 