### PR TITLE
Resolve vars in result from `scrape_region_constraints`

### DIFF
--- a/tests/ui/issues/issue-13167.rs
+++ b/tests/ui/issues/issue-13167.rs
@@ -1,5 +1,7 @@
 // check-pass
 // pretty-expanded FIXME #23616
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 
 use std::slice;
 

--- a/tests/ui/issues/issue-15734.rs
+++ b/tests/ui/issues/issue-15734.rs
@@ -1,6 +1,6 @@
 // run-pass
-// If `Index` used an associated type for its output, this test would
-// work more smoothly.
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 
 use std::ops::Index;
 

--- a/tests/ui/nll/issue-53119.rs
+++ b/tests/ui/nll/issue-53119.rs
@@ -1,4 +1,6 @@
 // check-pass
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 
 use std::ops::Deref;
 


### PR DESCRIPTION
Since we perform `type_op::Normalize` in the local infcx when the new solver is enabled, vars aren't necessarily resolved, which triggers this ICE:

https://github.com/rust-lang/rust/blob/f85ab544dfbbce7448993c490ad16c176339b939/compiler/rustc_infer/src/infer/nll_relate/mod.rs#L481 

There are more tests that go from ICE -> pass due to this change, but I just added revisions to a few for CI.

r? @lcnr