### PR TITLE
Fix suggestion for matching struct with `..` on both ends

### DIFF
--- a/tests/ui/parser/issue-112188.fixed
+++ b/tests/ui/parser/issue-112188.fixed
@@ -1,0 +1,14 @@
+// run-rustfix
+
+#![allow(unused)]
+
+struct Foo { x: i32 }
+
+fn main() {
+    let f = Foo { x: 0 };
+    let Foo { .. } = f;
+    let Foo { .. } = f; //~ ERROR expected `}`, found `,`
+    let Foo { x, .. } = f;
+    let Foo { x, .. } = f; //~ ERROR expected `}`, found `,`
+    let Foo { x, .. } = f; //~ ERROR expected `}`, found `,`
+}

--- a/tests/ui/parser/issue-112188.rs
+++ b/tests/ui/parser/issue-112188.rs
@@ -1,0 +1,14 @@
+// run-rustfix
+
+#![allow(unused)]
+
+struct Foo { x: i32 }
+
+fn main() {
+    let f = Foo { x: 0 };
+    let Foo { .. } = f;
+    let Foo { .., } = f; //~ ERROR expected `}`, found `,`
+    let Foo { x, .. } = f;
+    let Foo { .., x } = f; //~ ERROR expected `}`, found `,`
+    let Foo { .., x, .. } = f; //~ ERROR expected `}`, found `,`
+}

--- a/tests/ui/parser/issue-112188.stderr
+++ b/tests/ui/parser/issue-112188.stderr
@@ -1,0 +1,37 @@
+error: expected `}`, found `,`
+  --> $DIR/issue-112188.rs:10:17
+   |
+LL |     let Foo { .., } = f;
+   |               --^
+   |               | |
+   |               | expected `}`
+   |               | help: remove this comma
+   |               `..` must be at the end and cannot have a trailing comma
+
+error: expected `}`, found `,`
+  --> $DIR/issue-112188.rs:12:17
+   |
+LL |     let Foo { .., x } = f;
+   |               --^
+   |               | |
+   |               | expected `}`
+   |               `..` must be at the end and cannot have a trailing comma
+   |
+help: move the `..` to the end of the field list
+   |
+LL -     let Foo { .., x } = f;
+LL +     let Foo { x, .. } = f;
+   |
+
+error: expected `}`, found `,`
+  --> $DIR/issue-112188.rs:13:17
+   |
+LL |     let Foo { .., x, .. } = f;
+   |               --^-
+   |               | |
+   |               | expected `}`
+   |               `..` must be at the end and cannot have a trailing comma
+   |               help: remove the starting `..`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/parser/issue-49257.stderr
+++ b/tests/ui/parser/issue-49257.stderr
@@ -25,7 +25,7 @@ LL |     let Point { .., y } = p;
 help: move the `..` to the end of the field list
    |
 LL -     let Point { .., y } = p;
-LL +     let Point { y , .. } = p;
+LL +     let Point { y, .. } = p;
    |
 
 error: expected `}`, found `,`


### PR DESCRIPTION
### Before This PR

```
error: expected `}`, found `,`
 --> src\main.rs:8:17
  |
8 |         Foo { .., x, .. } => (),
  |               --^
  |               | |
  |               | expected `}`
  |               `..` must be at the end and cannot have a trailing comma
  |
help: move the `..` to the end of the field list
  |
8 -         Foo { .., x, .. } => (),
8 +         Foo { .., x,  , .. } => (),
  |
```

### After This PR

```
error: expected `}`, found `,`
  --> tests/ui/parser/issue-112188.rs:11:17
   |
11 |     let Foo { .., x, .. } = f; //~ ERROR expected `}`, found `,`
   |               --^-
   |               | |
   |               | expected `}`
   |               `..` must be at the end and cannot have a trailing comma
   |               help: remove the starting `..`
```

Fixes #112188.