### PR TITLE
Add rustdoc test for double-hyphen to dash doc comment conversion

### DIFF
--- a/tests/rustdoc/double-hyphen-to-dash.rs
+++ b/tests/rustdoc/double-hyphen-to-dash.rs
@@ -1,0 +1,9 @@
+// This test ensures that `--` (double-hyphen) is correctly converted into `–` (dash).
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html' '//*[@class="desc docblock-short"]' '–'
+// @has 'foo/struct.Bar.html' '//*[@class="docblock"]' '–'
+
+/// --
+pub struct Bar;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/64081.

This PR adds a regression test for #64081 so the issue can be closed.

r? @notriddle 