### PR TITLE
only suppress coercion error if type is definitely unsized

### DIFF
--- a/tests/ui/typeck/return-dyn-type-mismatch-2.rs
+++ b/tests/ui/typeck/return-dyn-type-mismatch-2.rs
@@ -1,0 +1,11 @@
+trait Trait<T> {}
+
+fn foo<T>() -> dyn Trait<T>
+where
+    dyn Trait<T>: Sized, // pesky sized predicate
+{
+    42
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/typeck/return-dyn-type-mismatch-2.stderr
+++ b/tests/ui/typeck/return-dyn-type-mismatch-2.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/return-dyn-type-mismatch-2.rs:7:5
+   |
+LL | fn foo<T>() -> dyn Trait<T>
+   |                ------------ expected `(dyn Trait<T> + 'static)` because of return type
+...
+LL |     42
+   |     ^^ expected `dyn Trait`, found integer
+   |
+   = note: expected trait object `(dyn Trait<T> + 'static)`
+                      found type `{integer}`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/return-dyn-type-mismatch.rs
+++ b/tests/ui/typeck/return-dyn-type-mismatch.rs
@@ -1,0 +1,21 @@
+pub trait TestTrait {
+    type MyType;
+
+    fn func() -> Option<Self>
+    where
+        Self: Sized;
+}
+
+impl<T> dyn TestTrait<MyType = T>
+where
+    Self: Sized, // pesky sized predicate
+{
+    fn other_func() -> dyn TestTrait<MyType = T> {
+        match Self::func() {
+            None => None,
+            //~^ ERROR mismatched types
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/typeck/return-dyn-type-mismatch.stderr
+++ b/tests/ui/typeck/return-dyn-type-mismatch.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/return-dyn-type-mismatch.rs:15:21
+   |
+LL |     fn other_func() -> dyn TestTrait<MyType = T> {
+   |                        ------------------------- expected `(dyn TestTrait<MyType = T> + 'static)` because of return type
+LL |         match Self::func() {
+LL |             None => None,
+   |                     ^^^^ expected `dyn TestTrait`, found `Option<_>`
+   |
+   = note: expected trait object `(dyn TestTrait<MyType = T> + 'static)`
+                      found enum `Option<_>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
we previously suppressed coercion errors when the return type was `dyn Trait` because we expect a far more descriptive `Sized` trait error to be emitted instead, however the code that does this suppression does not consider where-clause predicates since it just looked at the HIR. let's do that instead by creating an obligation and checking if it may hold. 

fixes #110683
fixes #112208