### PR TITLE
Cleanup some `EarlyBinder::skip_binder()` -> `EarlyBinder::subst_identity()`

### DIFF
--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -586,7 +586,7 @@ impl<'tcx> Instance<'tcx> {
         if let Some(substs) = self.substs_for_mir_body() {
             v.subst(tcx, substs)
         } else {
-            v.skip_binder()
+            v.subst_identity()
         }
     }
 

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -647,7 +647,7 @@ fn build_call_shim<'tcx>(
     let mut sig = if let Some(sig_substs) = sig_substs {
         sig.subst(tcx, &sig_substs)
     } else {
-        sig.skip_binder()
+        sig.subst_identity()
     };
 
     if let CallKind::Indirect(fnty) = call_kind {

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -104,10 +104,10 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                         // the post-inference `trait_ref`, as it's more accurate.
                         trait_: Some(clean_trait_ref_with_bindings(
                             cx,
-                            ty::Binder::dummy(trait_ref.skip_binder()),
+                            ty::Binder::dummy(trait_ref.subst_identity()),
                             ThinVec::new(),
                         )),
-                        for_: clean_middle_ty(ty::Binder::dummy(ty.skip_binder()), cx, None),
+                        for_: clean_middle_ty(ty::Binder::dummy(ty.subst_identity()), cx, None),
                         items: cx
                             .tcx
                             .associated_items(impl_def_id)
@@ -116,7 +116,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                             .collect::<Vec<_>>(),
                         polarity: ty::ImplPolarity::Positive,
                         kind: ImplKind::Blanket(Box::new(clean_middle_ty(
-                            ty::Binder::dummy(trait_ref.skip_binder().self_ty()),
+                            ty::Binder::dummy(trait_ref.subst_identity().self_ty()),
                             cx,
                             None,
                         ))),


### PR DESCRIPTION
fix some incorrect `skip_binder()`'s as identified in https://github.com/rust-lang/rust/pull/112006#pullrequestreview-1448369203

r? @compiler-errors @lcnr @jackh726

(hope it's alright to just tag everyone who commented :sweat_smile:)