### PR TITLE
Don't ICE in new solver when auto traits have associated types

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -193,10 +193,14 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
     }
 
     fn consider_auto_trait_candidate(
-        _ecx: &mut EvalCtxt<'_, 'tcx>,
+        ecx: &mut EvalCtxt<'_, 'tcx>,
         goal: Goal<'tcx, Self>,
     ) -> QueryResult<'tcx> {
-        bug!("auto traits do not have associated types: {:?}", goal);
+        ecx.tcx().sess.delay_span_bug(
+            ecx.tcx().def_span(goal.predicate.def_id()),
+            "associated types not allowed on auto traits",
+        );
+        Err(NoSolution)
     }
 
     fn consider_trait_alias_candidate(

--- a/tests/ui/auto-traits/issue-23080-2.current.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.current.stderr
@@ -1,5 +1,5 @@
 error[E0380]: auto traits cannot have associated items
-  --> $DIR/issue-23080-2.rs:5:10
+  --> $DIR/issue-23080-2.rs:8:10
    |
 LL | unsafe auto trait Trait {
    |                   ----- auto traits cannot have associated items

--- a/tests/ui/auto-traits/issue-23080-2.next.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.next.stderr
@@ -1,0 +1,11 @@
+error[E0380]: auto traits cannot have associated items
+  --> $DIR/issue-23080-2.rs:8:10
+   |
+LL | unsafe auto trait Trait {
+   |                   ----- auto traits cannot have associated items
+LL |     type Output;
+   |     -----^^^^^^- help: remove these associated items
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0380`.

--- a/tests/ui/auto-traits/issue-23080-2.rs
+++ b/tests/ui/auto-traits/issue-23080-2.rs
@@ -1,3 +1,6 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+
 #![feature(auto_traits)]
 #![feature(negative_impls)]
 


### PR DESCRIPTION
People can write malformed auto traits, and that shouldn't cause the new solver to ICE