### PR TITLE
Specialize count for range iterators

### DIFF
--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -766,6 +766,15 @@ impl<A: Step> Iterator for ops::Range<A> {
     }
 
     #[inline]
+    fn count(self) -> usize {
+        if self.start < self.end {
+            Step::steps_between(&self.start, &self.end).expect("count overflowed usize")
+        } else {
+            0
+        }
+    }
+
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<A> {
         self.spec_nth(n)
     }
@@ -1160,6 +1169,17 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
             Some(hint) => (hint.saturating_add(1), hint.checked_add(1)),
             None => (usize::MAX, None),
         }
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        if self.is_empty() {
+            return 0;
+        }
+
+        Step::steps_between(&self.start, &self.end)
+            .and_then(|steps| steps.checked_add(1))
+            .expect("count overflowed usize")
     }
 
     #[inline]


### PR DESCRIPTION
Since `size_hint` is already specialized, it feels apt to specialize `count` as well. Without any specialized version of `ExactSizeIterator::len` or `Step::steps_between`, this feels like a more reliable way of accessing this without having to rely on knowing that `size_hint` is correct.

In my case, this is particularly useful to access the `steps_between` implementation for `char` from the standard library without having to compute it manually.

I didn't think it was worth modifying the `Step` trait to add a version of `steps_between` that used native overflow checks since this is just doing one subtraction in most cases anyway, and so I decided to make the inclusive version use `checked_add` so it didn't have this lopsided overflow-checks-but-only-sometimes logic.