### PR TITLE
rustdoc-search: clean up type unification and "unboxing"

### DIFF
--- a/src/librustdoc/html/static/js/externs.js
+++ b/src/librustdoc/html/static/js/externs.js
@@ -53,7 +53,7 @@ let ParsedQuery;
  *    parent: (Object|null|undefined),
  *    path: string,
  *    ty: (Number|null|number),
- *    type: (Array<?>|null)
+ *    type: FunctionSearchType?
  * }}
  */
 let Row;
@@ -135,7 +135,7 @@ let RawFunctionType;
 /**
  * @typedef {{
  *     inputs: Array<FunctionType>,
- *     outputs: Array<FunctionType>,
+ *     output: Array<FunctionType>,
  * }}
  */
 let FunctionSearchType;

--- a/tests/rustdoc-js-std/bufread-fill-buf.js
+++ b/tests/rustdoc-js-std/bufread-fill-buf.js
@@ -1,11 +1,8 @@
 // ignore-order
 
-const QUERY = [
-    'bufread -> result<u8>',
-];
-
 const EXPECTED = [
     {
+        'query': 'bufread -> result<u8>',
         'others': [
             { 'path': 'std::io::Split', 'name': 'next' },
             { 'path': 'std::boxed::Box', 'name': 'fill_buf' },

--- a/tests/rustdoc-js-std/bufread-fill-buf.js
+++ b/tests/rustdoc-js-std/bufread-fill-buf.js
@@ -1,0 +1,16 @@
+// ignore-order
+
+const QUERY = [
+    'bufread -> result<u8>',
+];
+
+const EXPECTED = [
+    {
+        'others': [
+            { 'path': 'std::io::Split', 'name': 'next' },
+            { 'path': 'std::boxed::Box', 'name': 'fill_buf' },
+            { 'path': 'std::io::Chain', 'name': 'fill_buf' },
+            { 'path': 'std::io::Take', 'name': 'fill_buf' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/generics-match-ambiguity.js
+++ b/tests/rustdoc-js/generics-match-ambiguity.js
@@ -1,0 +1,91 @@
+// ignore-order
+// exact-check
+
+// Make sure that results are order-agnostic, even when there's search items that only differ
+// by generics.
+
+const EXPECTED = [
+    {
+        'query': 'Wrap',
+        'in_args': [
+            { 'path': 'generics_match_ambiguity', 'name': 'bar' },
+            { 'path': 'generics_match_ambiguity', 'name': 'foo' },
+        ],
+    },
+    {
+        'query': 'Wrap<i32>',
+        'in_args': [
+            { 'path': 'generics_match_ambiguity', 'name': 'bar' },
+            { 'path': 'generics_match_ambiguity', 'name': 'foo' },
+        ],
+    },
+    {
+        'query': 'Wrap<i32>, Wrap<i32, u32>',
+        'others': [
+            { 'path': 'generics_match_ambiguity', 'name': 'bar' },
+            { 'path': 'generics_match_ambiguity', 'name': 'foo' },
+        ],
+    },
+    {
+        'query': 'Wrap<i32, u32>, Wrap<i32>',
+        'others': [
+            { 'path': 'generics_match_ambiguity', 'name': 'bar' },
+            { 'path': 'generics_match_ambiguity', 'name': 'foo' },
+        ],
+    },
+    {
+        'query': 'W3<i32>, W3<i32, u32>',
+        'others': [
+            { 'path': 'generics_match_ambiguity', 'name': 'baaa' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baab' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baac' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baad' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baae' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baaf' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baag' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baah' },
+        ],
+    },
+    {
+        'query': 'W3<i32, u32>, W3<i32>',
+        'others': [
+            { 'path': 'generics_match_ambiguity', 'name': 'baaa' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baab' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baac' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baad' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baae' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baaf' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baag' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baah' },
+        ],
+    },
+    {
+        'query': 'W2<i32>, W2<i32, u32>',
+        'others': [
+            { 'path': 'generics_match_ambiguity', 'name': 'baag' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baah' },
+        ],
+    },
+    {
+        'query': 'W2<i32, u32>, W2<i32>',
+        'others': [
+            { 'path': 'generics_match_ambiguity', 'name': 'baag' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baah' },
+        ],
+    },
+    {
+        'query': 'W2<i32>, W3<i32, u32>',
+        'others': [
+            { 'path': 'generics_match_ambiguity', 'name': 'baac' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baaf' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baag' },
+        ],
+    },
+    {
+        'query': 'W2<i32>, W2<i32>',
+        'others': [
+            { 'path': 'generics_match_ambiguity', 'name': 'baag' },
+            { 'path': 'generics_match_ambiguity', 'name': 'baah' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/generics-match-ambiguity.rs
+++ b/tests/rustdoc-js/generics-match-ambiguity.rs
@@ -1,0 +1,17 @@
+pub struct Wrap<T, U = ()>(pub T, pub U);
+
+pub fn foo(a: Wrap<i32>, b: Wrap<i32, u32>) {}
+pub fn bar(a: Wrap<i32, u32>, b: Wrap<i32>) {}
+
+pub struct W2<T>(pub T);
+pub struct W3<T, U = ()>(pub T, pub U);
+
+pub fn baaa(a: W3<i32>, b: W3<i32, u32>) {}
+pub fn baab(a: W3<i32, u32>, b: W3<i32>) {}
+pub fn baac(a: W2<W3<i32>>, b: W3<i32, u32>) {}
+pub fn baad(a: W2<W3<i32, u32>>, b: W3<i32>) {}
+pub fn baae(a: W3<i32>, b: W2<W3<i32, u32>>) {}
+pub fn baaf(a: W3<i32, u32>, b: W2<W3<i32>>) {}
+pub fn baag(a: W2<W3<i32>>, b: W2<W3<i32, u32>>) {}
+pub fn baah(a: W2<W3<i32, u32>>, b: W2<W3<i32>>) {}
+//

--- a/tests/rustdoc-js/nested-unboxed.js
+++ b/tests/rustdoc-js/nested-unboxed.js
@@ -1,0 +1,68 @@
+// exact-check
+
+const EXPECTED = [
+    {
+        'query': '-> Result<Object, bool>',
+        'others': [
+            { 'path': 'nested_unboxed', 'name': 'something' },
+        ],
+    },
+    {
+        'query': '-> Result<Object<i32, u32>, bool>',
+        'others': [
+            { 'path': 'nested_unboxed', 'name': 'something' },
+        ],
+    },
+    {
+        'query': '-> Object, bool',
+        'others': [
+            { 'path': 'nested_unboxed', 'name': 'something' },
+        ],
+    },
+    {
+        'query': '-> Object<i32, u32>, bool',
+        'others': [
+            { 'path': 'nested_unboxed', 'name': 'something' },
+        ],
+    },
+    {
+        'query': '-> i32, u32, bool',
+        'others': [
+            { 'path': 'nested_unboxed', 'name': 'something' },
+        ],
+    },
+    {
+        'query': '-> Result<i32, u32, bool>',
+        'others': [
+            { 'path': 'nested_unboxed', 'name': 'something' },
+        ],
+    },
+    {
+        'query': '-> Result<Object<i32>, bool>',
+        'others': [
+            { 'path': 'nested_unboxed', 'name': 'something' },
+        ],
+    },
+    {
+        'query': '-> Result<Object<u32>, bool>',
+        'others': [
+            { 'path': 'nested_unboxed', 'name': 'something' },
+        ],
+    },
+    {
+        'query': '-> Result<Object<i32>, u32, bool>',
+        'others': [],
+    },
+    {
+        'query': '-> Result<i32, Object<u32>, bool>',
+        'others': [],
+    },
+    {
+        'query': '-> Result<i32, u32, Object<bool>>',
+        'others': [],
+    },
+    {
+        'query': '-> Result<Object<i32>, Object<u32>, bool>',
+        'others': [],
+    },
+];

--- a/tests/rustdoc-js/nested-unboxed.rs
+++ b/tests/rustdoc-js/nested-unboxed.rs
@@ -1,0 +1,5 @@
+pub struct Object<T, U>(T, U);
+
+pub fn something() -> Result<Object<i32, u32>, bool> {
+    loop {}
+}


### PR DESCRIPTION
This PR redesigns parameter matching, return matching, and generics matching to use a single function that compares two lists of types.

It also makes the algorithms more consistent, so the "unboxing" behavior where `Vec<i32>` is considered a match for `i32` works inside generics, and not just at the top level.