### PR TITLE
Diagnostic translation for `borrow_check:errors` 

### DIFF
--- a/compiler/rustc_borrowck/messages.ftl
+++ b/compiler/rustc_borrowck/messages.ftl
@@ -19,8 +19,6 @@ borrowck_borrow_due_to_use_generator =
 borrowck_calling_operator_moves_lhs =
     calling this operator moves the left-hand side
 
-borrowck_cannot_use_when_mutably_borrowed = cannot use `{$desc}` when mutably borrowed
-
 borrowck_cannot_move_when_borrowed =
     cannot move out of {$place ->
         [value] value
@@ -34,6 +32,8 @@ borrowck_cannot_move_when_borrowed =
         [value] value
         *[other] {$value_place}
     } occurs here
+
+borrowck_cannot_use_when_mutably_borrowed = cannot use `{$desc}` when mutably borrowed
 
 borrowck_capture_immute =
     capture is immutable because of use here

--- a/compiler/rustc_borrowck/messages.ftl
+++ b/compiler/rustc_borrowck/messages.ftl
@@ -19,6 +19,8 @@ borrowck_borrow_due_to_use_generator =
 borrowck_calling_operator_moves_lhs =
     calling this operator moves the left-hand side
 
+borrowck_cannot_use_when_mutably_borrowed = cannot use `{$desc}` when mutably borrowed
+
 borrowck_cannot_move_when_borrowed =
     cannot move out of {$place ->
         [value] value

--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -1,3 +1,4 @@
+use crate::session_diagnostics::CannotUseWhenMutablyBorrowed;
 use rustc_errors::{
     struct_span_err, DiagnosticBuilder, DiagnosticId, DiagnosticMessage, ErrorGuaranteed, MultiSpan,
 };
@@ -29,17 +30,18 @@ impl<'cx, 'tcx> crate::MirBorrowckCtxt<'cx, 'tcx> {
         borrow_span: Span,
         borrow_desc: &str,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        let mut err = struct_span_err!(
-            self,
-            span,
-            E0503,
-            "cannot use {} because it was mutably borrowed",
-            desc,
-        );
+        create_err(CannotUseWhenMutablyBorrowed { span, desc })
+        // let mut err = struct_span_err!(
+        //     self,
+        //     span,
+        //     E0503,
+        //     "cannot use {} because it was mutably borrowed",
+        //     desc,
+        // );
 
-        err.span_label(borrow_span, format!("{} is borrowed here", borrow_desc));
-        err.span_label(span, format!("use of borrowed {}", borrow_desc));
-        err
+        // err.span_label(borrow_span, format!("{} is borrowed here", borrow_desc));
+        // err.span_label(span, format!("use of borrowed {}", borrow_desc));
+        // err
     }
 
     pub(crate) fn cannot_mutably_borrow_multiply(

--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -30,18 +30,12 @@ impl<'cx, 'tcx> crate::MirBorrowckCtxt<'cx, 'tcx> {
         borrow_span: Span,
         borrow_desc: &str,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        create_err(CannotUseWhenMutablyBorrowed { span, desc })
-        // let mut err = struct_span_err!(
-        //     self,
-        //     span,
-        //     E0503,
-        //     "cannot use {} because it was mutably borrowed",
-        //     desc,
-        // );
-
-        // err.span_label(borrow_span, format!("{} is borrowed here", borrow_desc));
-        // err.span_label(span, format!("use of borrowed {}", borrow_desc));
-        // err
+        self.infcx.tcx.sess.create_err(CannotUseWhenMutablyBorrowed {
+            span,
+            borrow_span,
+            borrow_desc,
+            desc,
+        })
     }
 
     pub(crate) fn cannot_mutably_borrow_multiply(

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -6,7 +6,7 @@ use rustc_span::Span;
 use crate::diagnostics::RegionName;
 
 #[derive(Diagnostic)]
-#[diag(borrowck_cannot_use_when_mutably_borrowed)]
+#[diag(borrowck_cannot_use_when_mutably_borrowed, code = "E0503")]
 pub(crate) struct CannotUseWhenMutablyBorrowed {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -6,6 +6,14 @@ use rustc_span::Span;
 use crate::diagnostics::RegionName;
 
 #[derive(Diagnostic)]
+#[diag(borrowck_cannot_use_when_mutably_borrowed)]
+pub(crate) struct CannotUseWhenMutablyBorrowed {
+    #[primary_span]
+    pub span: Span,
+    desc: &'static str,
+}
+
+#[derive(Diagnostic)]
 #[diag(borrowck_move_unsized, code = "E0161")]
 pub(crate) struct MoveUnsized<'tcx> {
     pub ty: Ty<'tcx>,

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -7,10 +7,13 @@ use crate::diagnostics::RegionName;
 
 #[derive(Diagnostic)]
 #[diag(borrowck_cannot_use_when_mutably_borrowed, code = "E0503")]
-pub(crate) struct CannotUseWhenMutablyBorrowed {
+pub(crate) struct CannotUseWhenMutablyBorrowed<'a> {
     #[primary_span]
     pub span: Span,
-    desc: &'static str,
+    #[label]
+    pub borrow_span: Span,
+    pub borrow_desc: &'a str,
+    pub desc: &'a str,
 }
 
 #[derive(Diagnostic)]


### PR DESCRIPTION
Migrate diagnostics to use the struct derive and be translatable.

r? @davidtwco