### PR TITLE
Only check inlining counter after recursing.

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -145,13 +145,16 @@ impl<'tcx> Inliner<'tcx> {
                 Ok(new_blocks) => {
                     debug!("inlined {}", callsite.callee);
                     self.changed = true;
-                    inlined_count += 1;
-                    if inlined_count == inline_limit {
-                        return;
-                    }
+
                     self.history.push(callsite.callee.def_id());
                     self.process_blocks(caller_body, new_blocks);
                     self.history.pop();
+
+                    inlined_count += 1;
+                    if inlined_count == inline_limit {
+                        debug!("inline count reached");
+                        return;
+                    }
                 }
             }
         }

--- a/tests/mir-opt/inline/cycle.main.Inline.diff
+++ b/tests/mir-opt/inline/cycle.main.Inline.diff
@@ -11,6 +11,14 @@
 +         let mut _3: &fn() {g};           // in scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         let _4: ();                      // in scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         scope 2 (inlined <fn() {g} as Fn<()>>::call - shim(fn() {g})) { // at $DIR/cycle.rs:6:5: 6:8
++             scope 3 (inlined g) {        // at $SRC_DIR/core/src/ops/function.rs:LL:COL
++                 scope 4 (inlined f::<fn() {main}>) { // at $DIR/cycle.rs:12:5: 12:12
++                     debug g => main;     // in scope 4 at $DIR/cycle.rs:5:6: 5:7
++                     let _6: ();          // in scope 4 at $DIR/cycle.rs:6:5: 6:8
++                     scope 5 (inlined <fn() {main} as Fn<()>>::call - shim(fn() {main})) { // at $DIR/cycle.rs:6:5: 6:8
++                     }
++                 }
++             }
 +         }
 +     }
   
@@ -30,7 +38,11 @@
 +         _3 = &_2;                        // scope 1 at $DIR/cycle.rs:6:5: 6:6
 +         StorageLive(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         _5 = const ();                   // scope 1 at $DIR/cycle.rs:6:5: 6:8
-+         _4 = move (*_3)() -> [return: bb4, unwind: bb2]; // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++         StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++         _6 = main() -> [return: bb4, unwind: bb2]; // scope 5 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++                                          // mir::Constant
++                                          // + span: no-location
++                                          // + literal: Const { ty: fn() {main}, val: Value(<ZST>) }
       }
   
       bb1: {
@@ -50,6 +62,7 @@
 +     }
 + 
 +     bb4: {
++         StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
 +         StorageDead(_5);                 // scope 1 at $DIR/cycle.rs:6:5: 6:8
 +         StorageDead(_3);                 // scope 1 at $DIR/cycle.rs:6:7: 6:8
 +         drop(_2) -> bb1;                 // scope 1 at $DIR/cycle.rs:7:1: 7:2

--- a/tests/mir-opt/inline/exponential_runtime.main.Inline.diff
+++ b/tests/mir-opt/inline/exponential_runtime.main.Inline.diff
@@ -12,6 +12,26 @@
 +             let _5: ();                  // in scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
 +             let _6: ();                  // in scope 2 at $DIR/exponential_runtime.rs:63:9: 63:25
 +             let _7: ();                  // in scope 2 at $DIR/exponential_runtime.rs:64:9: 64:25
++             scope 3 (inlined <() as E>::call) { // at $DIR/exponential_runtime.rs:62:9: 62:25
++                 let _8: ();              // in scope 3 at $DIR/exponential_runtime.rs:50:9: 50:25
++                 let _9: ();              // in scope 3 at $DIR/exponential_runtime.rs:51:9: 51:25
++                 let _10: ();             // in scope 3 at $DIR/exponential_runtime.rs:52:9: 52:25
++                 scope 4 (inlined <() as D>::call) { // at $DIR/exponential_runtime.rs:50:9: 50:25
++                     let _11: ();         // in scope 4 at $DIR/exponential_runtime.rs:38:9: 38:25
++                     let _12: ();         // in scope 4 at $DIR/exponential_runtime.rs:39:9: 39:25
++                     let _13: ();         // in scope 4 at $DIR/exponential_runtime.rs:40:9: 40:25
++                     scope 5 (inlined <() as C>::call) { // at $DIR/exponential_runtime.rs:38:9: 38:25
++                         let _14: ();     // in scope 5 at $DIR/exponential_runtime.rs:26:9: 26:25
++                         let _15: ();     // in scope 5 at $DIR/exponential_runtime.rs:27:9: 27:25
++                         let _16: ();     // in scope 5 at $DIR/exponential_runtime.rs:28:9: 28:25
++                         scope 6 (inlined <() as B>::call) { // at $DIR/exponential_runtime.rs:26:9: 26:25
++                             let _17: (); // in scope 6 at $DIR/exponential_runtime.rs:14:9: 14:25
++                             let _18: (); // in scope 6 at $DIR/exponential_runtime.rs:15:9: 15:25
++                             let _19: (); // in scope 6 at $DIR/exponential_runtime.rs:16:9: 16:25
++                         }
++                     }
++                 }
++             }
 +         }
 +     }
   
@@ -24,12 +44,24 @@
 +         StorageLive(_5);                 // scope 1 at $DIR/exponential_runtime.rs:74:9: 74:25
 +         StorageLive(_6);                 // scope 1 at $DIR/exponential_runtime.rs:74:9: 74:25
 +         StorageLive(_7);                 // scope 1 at $DIR/exponential_runtime.rs:74:9: 74:25
-+         _5 = <() as E>::call() -> bb4;   // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
++         StorageLive(_8);                 // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
++         StorageLive(_9);                 // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
++         StorageLive(_10);                // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
++         StorageLive(_11);                // scope 3 at $DIR/exponential_runtime.rs:50:9: 50:25
++         StorageLive(_12);                // scope 3 at $DIR/exponential_runtime.rs:50:9: 50:25
++         StorageLive(_13);                // scope 3 at $DIR/exponential_runtime.rs:50:9: 50:25
++         StorageLive(_14);                // scope 4 at $DIR/exponential_runtime.rs:38:9: 38:25
++         StorageLive(_15);                // scope 4 at $DIR/exponential_runtime.rs:38:9: 38:25
++         StorageLive(_16);                // scope 4 at $DIR/exponential_runtime.rs:38:9: 38:25
++         StorageLive(_17);                // scope 5 at $DIR/exponential_runtime.rs:26:9: 26:25
++         StorageLive(_18);                // scope 5 at $DIR/exponential_runtime.rs:26:9: 26:25
++         StorageLive(_19);                // scope 5 at $DIR/exponential_runtime.rs:26:9: 26:25
++         _17 = <() as A>::call() -> bb12; // scope 6 at $DIR/exponential_runtime.rs:14:9: 14:25
                                            // mir::Constant
 -                                          // + span: $DIR/exponential_runtime.rs:87:5: 87:20
 -                                          // + literal: Const { ty: fn() {<() as G>::call}, val: Value(<ZST>) }
-+                                          // + span: $DIR/exponential_runtime.rs:62:9: 62:23
-+                                          // + literal: Const { ty: fn() {<() as E>::call}, val: Value(<ZST>) }
++                                          // + span: $DIR/exponential_runtime.rs:14:9: 14:23
++                                          // + literal: Const { ty: fn() {<() as A>::call}, val: Value(<ZST>) }
       }
   
       bb1: {
@@ -59,6 +91,9 @@
 +     }
 + 
 +     bb4: {
++         StorageDead(_10);                // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
++         StorageDead(_9);                 // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
++         StorageDead(_8);                 // scope 2 at $DIR/exponential_runtime.rs:62:9: 62:25
 +         _6 = <() as E>::call() -> bb5;   // scope 2 at $DIR/exponential_runtime.rs:63:9: 63:25
 +                                          // mir::Constant
 +                                          // + span: $DIR/exponential_runtime.rs:63:9: 63:23
@@ -70,6 +105,71 @@
 +                                          // mir::Constant
 +                                          // + span: $DIR/exponential_runtime.rs:64:9: 64:23
 +                                          // + literal: Const { ty: fn() {<() as E>::call}, val: Value(<ZST>) }
++     }
++ 
++     bb6: {
++         StorageDead(_13);                // scope 3 at $DIR/exponential_runtime.rs:50:9: 50:25
++         StorageDead(_12);                // scope 3 at $DIR/exponential_runtime.rs:50:9: 50:25
++         StorageDead(_11);                // scope 3 at $DIR/exponential_runtime.rs:50:9: 50:25
++         _9 = <() as D>::call() -> bb7;   // scope 3 at $DIR/exponential_runtime.rs:51:9: 51:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:51:9: 51:23
++                                          // + literal: Const { ty: fn() {<() as D>::call}, val: Value(<ZST>) }
++     }
++ 
++     bb7: {
++         _10 = <() as D>::call() -> bb4;  // scope 3 at $DIR/exponential_runtime.rs:52:9: 52:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:52:9: 52:23
++                                          // + literal: Const { ty: fn() {<() as D>::call}, val: Value(<ZST>) }
++     }
++ 
++     bb8: {
++         StorageDead(_16);                // scope 4 at $DIR/exponential_runtime.rs:38:9: 38:25
++         StorageDead(_15);                // scope 4 at $DIR/exponential_runtime.rs:38:9: 38:25
++         StorageDead(_14);                // scope 4 at $DIR/exponential_runtime.rs:38:9: 38:25
++         _12 = <() as C>::call() -> bb9;  // scope 4 at $DIR/exponential_runtime.rs:39:9: 39:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:39:9: 39:23
++                                          // + literal: Const { ty: fn() {<() as C>::call}, val: Value(<ZST>) }
++     }
++ 
++     bb9: {
++         _13 = <() as C>::call() -> bb6;  // scope 4 at $DIR/exponential_runtime.rs:40:9: 40:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:40:9: 40:23
++                                          // + literal: Const { ty: fn() {<() as C>::call}, val: Value(<ZST>) }
++     }
++ 
++     bb10: {
++         StorageDead(_19);                // scope 5 at $DIR/exponential_runtime.rs:26:9: 26:25
++         StorageDead(_18);                // scope 5 at $DIR/exponential_runtime.rs:26:9: 26:25
++         StorageDead(_17);                // scope 5 at $DIR/exponential_runtime.rs:26:9: 26:25
++         _15 = <() as B>::call() -> bb11; // scope 5 at $DIR/exponential_runtime.rs:27:9: 27:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:27:9: 27:23
++                                          // + literal: Const { ty: fn() {<() as B>::call}, val: Value(<ZST>) }
++     }
++ 
++     bb11: {
++         _16 = <() as B>::call() -> bb8;  // scope 5 at $DIR/exponential_runtime.rs:28:9: 28:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:28:9: 28:23
++                                          // + literal: Const { ty: fn() {<() as B>::call}, val: Value(<ZST>) }
++     }
++ 
++     bb12: {
++         _18 = <() as A>::call() -> bb13; // scope 6 at $DIR/exponential_runtime.rs:15:9: 15:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:15:9: 15:23
++                                          // + literal: Const { ty: fn() {<() as A>::call}, val: Value(<ZST>) }
++     }
++ 
++     bb13: {
++         _19 = <() as A>::call() -> bb10; // scope 6 at $DIR/exponential_runtime.rs:16:9: 16:25
++                                          // mir::Constant
++                                          // + span: $DIR/exponential_runtime.rs:16:9: 16:23
++                                          // + literal: Const { ty: fn() {<() as A>::call}, val: Value(<ZST>) }
       }
   }
   

--- a/tests/mir-opt/inline/inline_cycle.two.Inline.diff
+++ b/tests/mir-opt/inline/inline_cycle.two.Inline.diff
@@ -10,6 +10,14 @@
 +         debug f => _2;                   // in scope 1 at $DIR/inline_cycle.rs:54:22: 54:23
 +         let _3: ();                      // in scope 1 at $DIR/inline_cycle.rs:55:5: 55:8
 +         scope 2 (inlined <fn() {f} as FnOnce<()>>::call_once - shim(fn() {f})) { // at $DIR/inline_cycle.rs:55:5: 55:8
++             scope 3 (inlined f) {        // at $SRC_DIR/core/src/ops/function.rs:LL:COL
++                 scope 4 (inlined call::<fn() {f}>) { // at $DIR/inline_cycle.rs:60:5: 60:12
++                     debug f => f;        // in scope 4 at $DIR/inline_cycle.rs:54:22: 54:23
++                     let _5: ();          // in scope 4 at $DIR/inline_cycle.rs:55:5: 55:8
++                     scope 5 (inlined <fn() {f} as FnOnce<()>>::call_once - shim(fn() {f})) { // at $DIR/inline_cycle.rs:55:5: 55:8
++                     }
++                 }
++             }
 +         }
 +     }
   
@@ -27,10 +35,15 @@
 +         StorageLive(_3);                 // scope 0 at $DIR/inline_cycle.rs:+1:5: +1:12
 +         StorageLive(_4);                 // scope 1 at $DIR/inline_cycle.rs:55:5: 55:8
 +         _4 = const ();                   // scope 1 at $DIR/inline_cycle.rs:55:5: 55:8
-+         _3 = move _2() -> bb1;           // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++         StorageLive(_5);                 // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++         _5 = f() -> bb1;                 // scope 5 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++                                          // mir::Constant
++                                          // + span: no-location
++                                          // + literal: Const { ty: fn() {f}, val: Value(<ZST>) }
       }
   
       bb1: {
++         StorageDead(_5);                 // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
 +         StorageDead(_4);                 // scope 1 at $DIR/inline_cycle.rs:55:5: 55:8
 +         StorageDead(_3);                 // scope 0 at $DIR/inline_cycle.rs:+1:5: +1:12
 +         StorageDead(_2);                 // scope 0 at $DIR/inline_cycle.rs:+1:5: +1:12

--- a/tests/mir-opt/inline/inline_cycle_generic.main.Inline.diff
+++ b/tests/mir-opt/inline/inline_cycle_generic.main.Inline.diff
@@ -6,18 +6,20 @@
       let _1: ();                          // in scope 0 at $DIR/inline_cycle_generic.rs:+1:5: +1:24
 +     scope 1 (inlined <C as Call>::call) { // at $DIR/inline_cycle_generic.rs:10:5: 10:24
 +         scope 2 (inlined <B<A> as Call>::call) { // at $DIR/inline_cycle_generic.rs:39:9: 39:31
++             scope 3 (inlined <A as Call>::call) { // at $DIR/inline_cycle_generic.rs:32:9: 32:28
++             }
 +         }
 +     }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline_cycle_generic.rs:+1:5: +1:24
 -         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline_cycle_generic.rs:+1:5: +1:24
-+         _1 = <A as Call>::call() -> bb1; // scope 2 at $DIR/inline_cycle_generic.rs:32:9: 32:28
++         _1 = <B<C> as Call>::call() -> bb1; // scope 3 at $DIR/inline_cycle_generic.rs:24:9: 24:31
                                            // mir::Constant
 -                                          // + span: $DIR/inline_cycle_generic.rs:10:5: 10:22
 -                                          // + literal: Const { ty: fn() {<C as Call>::call}, val: Value(<ZST>) }
-+                                          // + span: $DIR/inline_cycle_generic.rs:32:9: 32:26
-+                                          // + literal: Const { ty: fn() {<A as Call>::call}, val: Value(<ZST>) }
++                                          // + span: $DIR/inline_cycle_generic.rs:24:9: 24:29
++                                          // + literal: Const { ty: fn() {<B<C> as Call>::call}, val: Value(<ZST>) }
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/tests/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -20,6 +20,8 @@
 +             }
 +         }
 +         scope 4 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline_diverging.rs:27:13: 27:16
++             scope 5 (inlined sleep) {    // at $SRC_DIR/core/src/ops/function.rs:LL:COL
++             }
 +         }
 +     }
   
@@ -40,44 +42,11 @@
 +         _3 = &_2;                        // scope 1 at $DIR/inline_diverging.rs:27:13: 27:14
 +         StorageLive(_8);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
 +         _8 = const ();                   // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
-+         _4 = move (*_3)() -> [return: bb6, unwind: bb4]; // scope 4 at $SRC_DIR/core/src/ops/function.rs:LL:COL
++         goto -> bb1;                     // scope 5 at $DIR/inline_diverging.rs:39:5: 39:12
 +     }
 + 
 +     bb1: {
-+         StorageDead(_5);                 // scope 2 at $DIR/inline_diverging.rs:28:15: 28:16
-+         StorageLive(_7);                 // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
-+         _7 = move _4;                    // scope 3 at $DIR/inline_diverging.rs:29:6: 29:7
-+         _1 = (move _7, move _6);         // scope 3 at $DIR/inline_diverging.rs:29:5: 29:11
-+         StorageDead(_7);                 // scope 3 at $DIR/inline_diverging.rs:29:10: 29:11
-+         StorageDead(_4);                 // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
-+         drop(_2) -> bb2;                 // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
-+     }
-+ 
-+     bb2: {
-+         unreachable;                     // scope 0 at $DIR/inline_diverging.rs:30:2: 30:2
-+     }
-+ 
-+     bb3 (cleanup): {
-+         drop(_4) -> [return: bb4, unwind terminate]; // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
-+     }
-+ 
-+     bb4 (cleanup): {
-+         drop(_2) -> [return: bb5, unwind terminate]; // scope 1 at $DIR/inline_diverging.rs:30:1: 30:2
-+     }
-+ 
-+     bb5 (cleanup): {
-+         resume;                          // scope 1 at $DIR/inline_diverging.rs:26:1: 30:2
-+     }
-+ 
-+     bb6: {
-+         StorageDead(_8);                 // scope 1 at $DIR/inline_diverging.rs:27:13: 27:16
-+         StorageDead(_3);                 // scope 1 at $DIR/inline_diverging.rs:27:15: 27:16
-+         StorageLive(_5);                 // scope 2 at $DIR/inline_diverging.rs:28:13: 28:14
-+         _5 = &_2;                        // scope 2 at $DIR/inline_diverging.rs:28:13: 28:14
-+         _6 = <fn() -> ! {sleep} as Fn<()>>::call(move _5, const ()) -> [return: bb1, unwind: bb3]; // scope 2 at $DIR/inline_diverging.rs:28:13: 28:16
-+                                          // mir::Constant
-+                                          // + span: $DIR/inline_diverging.rs:28:13: 28:14
-+                                          // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a fn() -> ! {sleep}, ()) -> <fn() -> ! {sleep} as FnOnce<()>>::Output {<fn() -> ! {sleep} as Fn<()>>::call}, val: Value(<ZST>) }
++         goto -> bb1;                     // scope 5 at $DIR/inline_diverging.rs:39:5: 39:12
       }
   }
   

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
@@ -38,37 +38,37 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
                                         debug self => _4; // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                                         scope 11 (inlined <u32 as TryFrom<u32>>::try_from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                                             debug value => _4; // in scope 11 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-                                            scope 21 (inlined <u32 as Into<u32>>::into) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-                                                debug self => _4; // in scope 21 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-                                                scope 22 (inlined <u32 as From<u32>>::from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-                                                    debug t => _4; // in scope 22 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                                            scope 12 (inlined <u32 as Into<u32>>::into) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                                                debug self => _4; // in scope 12 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                                                scope 13 (inlined <u32 as From<u32>>::from) { // at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                                                    debug t => _4; // in scope 13 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                                                 }
                                             }
                                         }
                                     }
-                                    scope 12 (inlined Result::<u32, Infallible>::ok) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                                        debug self => _5; // in scope 12 at $SRC_DIR/core/src/result.rs:LL:COL
-                                        let _6: u32; // in scope 12 at $SRC_DIR/core/src/result.rs:LL:COL
-                                        scope 13 {
-                                            debug x => _6; // in scope 13 at $SRC_DIR/core/src/result.rs:LL:COL
+                                    scope 14 (inlined Result::<u32, Infallible>::ok) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                                        debug self => _5; // in scope 14 at $SRC_DIR/core/src/result.rs:LL:COL
+                                        let _6: u32; // in scope 14 at $SRC_DIR/core/src/result.rs:LL:COL
+                                        scope 15 {
+                                            debug x => _6; // in scope 15 at $SRC_DIR/core/src/result.rs:LL:COL
                                         }
                                     }
-                                    scope 14 (inlined #[track_caller] Option::<u32>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
-                                        debug self => _7; // in scope 14 at $SRC_DIR/core/src/option.rs:LL:COL
-                                        let mut _13: &std::option::Option<u32>; // in scope 14 at $SRC_DIR/core/src/option.rs:LL:COL
-                                        scope 15 {
-                                            debug val => _8; // in scope 15 at $SRC_DIR/core/src/option.rs:LL:COL
+                                    scope 16 (inlined #[track_caller] Option::<u32>::unwrap_unchecked) { // at $SRC_DIR/core/src/num/mod.rs:LL:COL
+                                        debug self => _7; // in scope 16 at $SRC_DIR/core/src/option.rs:LL:COL
+                                        let mut _13: &std::option::Option<u32>; // in scope 16 at $SRC_DIR/core/src/option.rs:LL:COL
+                                        scope 17 {
+                                            debug val => _8; // in scope 17 at $SRC_DIR/core/src/option.rs:LL:COL
                                         }
-                                        scope 16 {
-                                            scope 18 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
-                                                scope 19 {
-                                                    scope 20 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+                                        scope 18 {
+                                            scope 20 (inlined unreachable_unchecked) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                                                scope 21 {
+                                                    scope 22 (inlined unreachable_unchecked::runtime) { // at $SRC_DIR/core/src/intrinsics.rs:LL:COL
                                                     }
                                                 }
                                             }
                                         }
-                                        scope 17 (inlined Option::<u32>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
-                                            debug self => _13; // in scope 17 at $SRC_DIR/core/src/option.rs:LL:COL
+                                        scope 19 (inlined Option::<u32>::is_some) { // at $SRC_DIR/core/src/option.rs:LL:COL
+                                            debug self => _13; // in scope 19 at $SRC_DIR/core/src/option.rs:LL:COL
                                         }
                                     }
                                 }
@@ -84,7 +84,7 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
         StorageLive(_10);                // scope 0 at $DIR/checked_ops.rs:+1:7: +1:23
         StorageLive(_11);                // scope 0 at $DIR/checked_ops.rs:+1:7: +1:23
         StorageLive(_9);                 // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-        StorageLive(_4);                 // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        StorageLive(_4);                 // scope 5 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
         StorageLive(_3);                 // scope 5 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
         _3 = const 31_u32;               // scope 5 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
         _4 = BitAnd(_2, move _3);        // scope 5 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
@@ -94,12 +94,12 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
         StorageLive(_5);                 // scope 9 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         _5 = Result::<u32, Infallible>::Ok(_4); // scope 11 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         StorageLive(_6);                 // scope 9 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _6 = move ((_5 as Ok).0: u32);   // scope 12 at $SRC_DIR/core/src/result.rs:LL:COL
-        _7 = Option::<u32>::Some(move _6); // scope 13 at $SRC_DIR/core/src/result.rs:LL:COL
+        _6 = move ((_5 as Ok).0: u32);   // scope 14 at $SRC_DIR/core/src/result.rs:LL:COL
+        _7 = Option::<u32>::Some(move _6); // scope 15 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_6);                 // scope 9 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageDead(_5);                 // scope 9 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageLive(_13);                // scope 9 at $SRC_DIR/core/src/num/mod.rs:LL:COL
-        _8 = move ((_7 as Some).0: u32); // scope 14 at $SRC_DIR/core/src/option.rs:LL:COL
+        _8 = move ((_7 as Some).0: u32); // scope 16 at $SRC_DIR/core/src/option.rs:LL:COL
         StorageDead(_13);                // scope 9 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         StorageDead(_7);                 // scope 9 at $SRC_DIR/core/src/num/mod.rs:LL:COL
         _9 = unchecked_shl::<u32>(_1, move _8) -> [return: bb1, unwind unreachable]; // scope 7 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
@@ -110,7 +110,7 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
 
     bb1: {
         StorageDead(_8);                 // scope 7 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
-        StorageDead(_4);                 // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
+        StorageDead(_4);                 // scope 5 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
         _10 = Ge(_2, const _);           // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
         _11 = move _9;                   // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL
         StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/num/uint_macros.rs:LL:COL

--- a/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
@@ -7,14 +7,14 @@ fn int_range(_1: usize, _2: usize) -> () {
     let mut _3: std::ops::Range<usize>;  // in scope 0 at $DIR/loops.rs:+1:14: +1:24
     let mut _4: std::ops::Range<usize>;  // in scope 0 at $DIR/loops.rs:+1:14: +1:24
     let mut _5: &mut std::ops::Range<usize>; // in scope 0 at $DIR/loops.rs:+1:14: +1:24
-    let mut _9: std::option::Option<usize>; // in scope 0 at $DIR/loops.rs:+1:14: +1:24
-    let mut _12: isize;                  // in scope 0 at $DIR/loops.rs:+1:5: +3:6
-    let _14: ();                         // in scope 0 at $DIR/loops.rs:+1:14: +1:24
+    let mut _11: std::option::Option<usize>; // in scope 0 at $DIR/loops.rs:+1:14: +1:24
+    let mut _14: isize;                  // in scope 0 at $DIR/loops.rs:+1:5: +3:6
+    let _16: ();                         // in scope 0 at $DIR/loops.rs:+1:14: +1:24
     scope 1 {
         debug iter => _4;                // in scope 1 at $DIR/loops.rs:+1:14: +1:24
-        let _13: usize;                  // in scope 1 at $DIR/loops.rs:+1:9: +1:10
+        let _15: usize;                  // in scope 1 at $DIR/loops.rs:+1:9: +1:10
         scope 2 {
-            debug i => _13;              // in scope 2 at $DIR/loops.rs:+1:9: +1:10
+            debug i => _15;              // in scope 2 at $DIR/loops.rs:+1:9: +1:10
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) { // at $DIR/loops.rs:8:14: 8:24
             debug self => _5;            // in scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
@@ -22,13 +22,19 @@ fn int_range(_1: usize, _2: usize) -> () {
                 debug self => _5;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 let mut _6: &usize;      // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 let mut _7: &usize;      // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                let mut _8: bool;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                let _10: usize;          // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                let mut _11: usize;      // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                let mut _10: bool;       // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                let _12: usize;          // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                let mut _13: usize;      // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 scope 6 {
-                    debug old => _10;    // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                    debug old => _12;    // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                     scope 7 {
                     }
+                }
+                scope 8 (inlined cmp::impls::<impl PartialOrd for usize>::lt) { // at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                    debug self => _6;    // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                    debug other => _7;   // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                    let mut _8: usize;   // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                    let mut _9: usize;   // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
                 }
             }
         }
@@ -45,74 +51,74 @@ fn int_range(_1: usize, _2: usize) -> () {
     }
 
     bb1: {
-        StorageLive(_9);                 // scope 1 at $DIR/loops.rs:+1:14: +1:24
+        StorageLive(_11);                // scope 1 at $DIR/loops.rs:+1:14: +1:24
         _5 = &mut _4;                    // scope 1 at $DIR/loops.rs:+1:14: +1:24
-        StorageLive(_10);                // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageLive(_8);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_10);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         StorageLive(_6);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         _6 = &((*_5).0: usize);          // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         StorageLive(_7);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         _7 = &((*_5).1: usize);          // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _8 = <usize as PartialOrd>::lt(move _6, move _7) -> bb2; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b> fn(&'a usize, &'b usize) -> bool {<usize as PartialOrd>::lt}, val: Value(<ZST>) }
+        StorageLive(_8);                 // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _8 = (*_6);                      // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageLive(_9);                 // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _9 = (*_7);                      // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _10 = Lt(move _8, move _9);      // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_9);                 // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_8);                 // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_7);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        switchInt(move _10) -> [0: bb2, otherwise: bb3]; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
     }
 
     bb2: {
-        StorageDead(_7);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        switchInt(move _8) -> [0: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _11 = Option::<usize>::None;     // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        goto -> bb5;                     // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
     }
 
     bb3: {
-        _9 = Option::<usize>::None;      // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        goto -> bb6;                     // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-    }
-
-    bb4: {
-        _10 = ((*_5).0: usize);          // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _11 = <usize as Step>::forward_unchecked(_10, const 1_usize) -> bb5; // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _12 = ((*_5).0: usize);          // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_13);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _13 = <usize as Step>::forward_unchecked(_12, const 1_usize) -> bb4; // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> usize {<usize as Step>::forward_unchecked}, val: Value(<ZST>) }
     }
 
+    bb4: {
+        ((*_5).0: usize) = move _13;     // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_13);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _11 = Option::<usize>::Some(_12); // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        goto -> bb5;                     // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+    }
+
     bb5: {
-        ((*_5).0: usize) = move _11;     // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _9 = Option::<usize>::Some(_10); // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        goto -> bb6;                     // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_10);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _14 = discriminant(_11);         // scope 1 at $DIR/loops.rs:+1:14: +1:24
+        switchInt(move _14) -> [0: bb6, 1: bb7, otherwise: bb9]; // scope 1 at $DIR/loops.rs:+1:14: +1:24
     }
 
     bb6: {
-        StorageDead(_8);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_10);                // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _12 = discriminant(_9);          // scope 1 at $DIR/loops.rs:+1:14: +1:24
-        switchInt(move _12) -> [0: bb7, 1: bb8, otherwise: bb10]; // scope 1 at $DIR/loops.rs:+1:14: +1:24
-    }
-
-    bb7: {
-        StorageDead(_9);                 // scope 1 at $DIR/loops.rs:+3:5: +3:6
+        StorageDead(_11);                // scope 1 at $DIR/loops.rs:+3:5: +3:6
         StorageDead(_4);                 // scope 0 at $DIR/loops.rs:+3:5: +3:6
         return;                          // scope 0 at $DIR/loops.rs:+4:2: +4:2
     }
 
-    bb8: {
-        _13 = ((_9 as Some).0: usize);   // scope 1 at $DIR/loops.rs:+1:9: +1:10
-        _14 = opaque::<usize>(_13) -> bb9; // scope 2 at $DIR/loops.rs:+2:9: +2:18
+    bb7: {
+        _15 = ((_11 as Some).0: usize);  // scope 1 at $DIR/loops.rs:+1:9: +1:10
+        _16 = opaque::<usize>(_15) -> bb8; // scope 2 at $DIR/loops.rs:+2:9: +2:18
                                          // mir::Constant
                                          // + span: $DIR/loops.rs:9:9: 9:15
                                          // + literal: Const { ty: fn(usize) {opaque::<usize>}, val: Value(<ZST>) }
     }
 
-    bb9: {
-        StorageDead(_9);                 // scope 1 at $DIR/loops.rs:+3:5: +3:6
+    bb8: {
+        StorageDead(_11);                // scope 1 at $DIR/loops.rs:+3:5: +3:6
         goto -> bb1;                     // scope 1 at $DIR/loops.rs:+1:5: +3:6
     }
 
-    bb10: {
+    bb9: {
         unreachable;                     // scope 1 at $DIR/loops.rs:+1:14: +1:24
     }
 }

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.mir
@@ -8,16 +8,16 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     let mut _4: std::ops::Range<u32>;    // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
     let mut _5: std::ops::Range<u32>;    // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
     let mut _6: &mut std::ops::Range<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
-    let mut _10: std::option::Option<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
-    let mut _13: isize;                  // in scope 0 at $DIR/range_iter.rs:+1:5: +3:6
-    let mut _15: &impl Fn(u32);          // in scope 0 at $DIR/range_iter.rs:+2:9: +2:10
-    let mut _16: (u32,);                 // in scope 0 at $DIR/range_iter.rs:+2:9: +2:13
-    let _17: ();                         // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
+    let mut _12: std::option::Option<u32>; // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
+    let mut _15: isize;                  // in scope 0 at $DIR/range_iter.rs:+1:5: +3:6
+    let mut _17: &impl Fn(u32);          // in scope 0 at $DIR/range_iter.rs:+2:9: +2:10
+    let mut _18: (u32,);                 // in scope 0 at $DIR/range_iter.rs:+2:9: +2:13
+    let _19: ();                         // in scope 0 at $DIR/range_iter.rs:+1:14: +1:24
     scope 1 {
         debug iter => _5;                // in scope 1 at $DIR/range_iter.rs:+1:14: +1:24
-        let _14: u32;                    // in scope 1 at $DIR/range_iter.rs:+1:9: +1:10
+        let _16: u32;                    // in scope 1 at $DIR/range_iter.rs:+1:9: +1:10
         scope 2 {
-            debug x => _14;              // in scope 2 at $DIR/range_iter.rs:+1:9: +1:10
+            debug x => _16;              // in scope 2 at $DIR/range_iter.rs:+1:9: +1:10
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) { // at $DIR/range_iter.rs:21:14: 21:24
             debug self => _6;            // in scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
@@ -25,13 +25,19 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
                 debug self => _6;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 let mut _7: &u32;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 let mut _8: &u32;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                let mut _9: bool;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                let _11: u32;            // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                let mut _12: u32;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                let mut _11: bool;       // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                let _13: u32;            // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                let mut _14: u32;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 scope 6 {
-                    debug old => _11;    // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                    debug old => _13;    // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                     scope 7 {
                     }
+                }
+                scope 8 (inlined cmp::impls::<impl PartialOrd for u32>::lt) { // at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                    debug self => _7;    // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                    debug other => _8;   // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                    let mut _9: u32;     // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                    let mut _10: u32;    // in scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
                 }
             }
         }
@@ -48,92 +54,92 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb1: {
-        StorageLive(_10);                // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
+        StorageLive(_12);                // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
         _6 = &mut _5;                    // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
-        StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageLive(_9);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         StorageLive(_7);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         _7 = &((*_6).0: u32);            // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         StorageLive(_8);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         _8 = &((*_6).1: u32);            // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _9 = <u32 as PartialOrd>::lt(move _7, move _8) -> [return: bb2, unwind: bb12]; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b> fn(&'a u32, &'b u32) -> bool {<u32 as PartialOrd>::lt}, val: Value(<ZST>) }
+        StorageLive(_9);                 // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _9 = (*_7);                      // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageLive(_10);                // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _10 = (*_8);                     // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _11 = Lt(move _9, move _10);     // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_10);                // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_9);                 // scope 8 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_8);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_7);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        switchInt(move _11) -> [0: bb2, otherwise: bb3]; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
     }
 
     bb2: {
-        StorageDead(_8);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_7);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        switchInt(move _9) -> [0: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _12 = Option::<u32>::None;       // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        goto -> bb5;                     // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
     }
 
     bb3: {
-        _10 = Option::<u32>::None;       // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        goto -> bb6;                     // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-    }
-
-    bb4: {
-        _11 = ((*_6).0: u32);            // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _12 = <u32 as Step>::forward_unchecked(_11, const 1_usize) -> [return: bb5, unwind: bb12]; // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _13 = ((*_6).0: u32);            // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_14);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _14 = <u32 as Step>::forward_unchecked(_13, const 1_usize) -> [return: bb4, unwind: bb11]; // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // + literal: Const { ty: unsafe fn(u32, usize) -> u32 {<u32 as Step>::forward_unchecked}, val: Value(<ZST>) }
     }
 
+    bb4: {
+        ((*_6).0: u32) = move _14;       // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_14);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _12 = Option::<u32>::Some(_13);  // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        goto -> bb5;                     // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+    }
+
     bb5: {
-        ((*_6).0: u32) = move _12;       // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _10 = Option::<u32>::Some(_11);  // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        goto -> bb6;                     // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_13);                // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _15 = discriminant(_12);         // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
+        switchInt(move _15) -> [0: bb6, 1: bb8, otherwise: bb10]; // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
     }
 
     bb6: {
-        StorageDead(_9);                 // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _13 = discriminant(_10);         // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
-        switchInt(move _13) -> [0: bb7, 1: bb9, otherwise: bb11]; // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
+        StorageDead(_12);                // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
+        StorageDead(_5);                 // scope 0 at $DIR/range_iter.rs:+3:5: +3:6
+        drop(_3) -> bb7;                 // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
     }
 
     bb7: {
-        StorageDead(_10);                // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
-        StorageDead(_5);                 // scope 0 at $DIR/range_iter.rs:+3:5: +3:6
-        drop(_3) -> bb8;                 // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
-    }
-
-    bb8: {
         return;                          // scope 0 at $DIR/range_iter.rs:+4:2: +4:2
     }
 
-    bb9: {
-        _14 = ((_10 as Some).0: u32);    // scope 1 at $DIR/range_iter.rs:+1:9: +1:10
-        StorageLive(_15);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
-        _15 = &_3;                       // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
-        StorageLive(_16);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
-        _16 = (_14,);                    // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
-        _17 = <impl Fn(u32) as Fn<(u32,)>>::call(move _15, move _16) -> [return: bb10, unwind: bb12]; // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
+    bb8: {
+        _16 = ((_12 as Some).0: u32);    // scope 1 at $DIR/range_iter.rs:+1:9: +1:10
+        StorageLive(_17);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
+        _17 = &_3;                       // scope 2 at $DIR/range_iter.rs:+2:9: +2:10
+        StorageLive(_18);                // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
+        _18 = (_16,);                    // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
+        _19 = <impl Fn(u32) as Fn<(u32,)>>::call(move _17, move _18) -> [return: bb9, unwind: bb11]; // scope 2 at $DIR/range_iter.rs:+2:9: +2:13
                                          // mir::Constant
                                          // + span: $DIR/range_iter.rs:22:9: 22:10
                                          // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a impl Fn(u32), (u32,)) -> <impl Fn(u32) as FnOnce<(u32,)>>::Output {<impl Fn(u32) as Fn<(u32,)>>::call}, val: Value(<ZST>) }
     }
 
-    bb10: {
-        StorageDead(_16);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
-        StorageDead(_15);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
-        StorageDead(_10);                // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
+    bb9: {
+        StorageDead(_18);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
+        StorageDead(_17);                // scope 2 at $DIR/range_iter.rs:+2:12: +2:13
+        StorageDead(_12);                // scope 1 at $DIR/range_iter.rs:+3:5: +3:6
         goto -> bb1;                     // scope 1 at $DIR/range_iter.rs:+1:5: +3:6
     }
 
-    bb11: {
+    bb10: {
         unreachable;                     // scope 1 at $DIR/range_iter.rs:+1:14: +1:24
     }
 
-    bb12 (cleanup): {
-        drop(_3) -> [return: bb13, unwind terminate]; // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
+    bb11 (cleanup): {
+        drop(_3) -> [return: bb12, unwind terminate]; // scope 0 at $DIR/range_iter.rs:+4:1: +4:2
     }
 
-    bb13 (cleanup): {
+    bb12 (cleanup): {
         resume;                          // scope 0 at $DIR/range_iter.rs:+0:1: +4:2
     }
 }

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.mir
@@ -9,60 +9,66 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
             debug self => _1;            // in scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
             let mut _2: &u32;            // in scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
             let mut _3: &u32;            // in scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-            let mut _4: bool;            // in scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-            let _5: u32;                 // in scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-            let mut _6: u32;             // in scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+            let mut _6: bool;            // in scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+            let _7: u32;                 // in scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+            let mut _8: u32;             // in scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
             scope 3 {
-                debug old => _5;         // in scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                debug old => _7;         // in scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 scope 4 {
                 }
+            }
+            scope 5 (inlined cmp::impls::<impl PartialOrd for u32>::lt) { // at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                debug self => _2;        // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                debug other => _3;       // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                let mut _4: u32;         // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                let mut _5: u32;         // in scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
             }
         }
     }
 
     bb0: {
-        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageLive(_4);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_7);                 // scope 1 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_6);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         StorageLive(_2);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         _2 = &((*_1).0: u32);            // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         StorageLive(_3);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         _3 = &((*_1).1: u32);            // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _4 = <u32 as PartialOrd>::lt(move _2, move _3) -> bb1; // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b> fn(&'a u32, &'b u32) -> bool {<u32 as PartialOrd>::lt}, val: Value(<ZST>) }
+        StorageLive(_4);                 // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _4 = (*_2);                      // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageLive(_5);                 // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _5 = (*_3);                      // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _6 = Lt(move _4, move _5);       // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_5);                 // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_4);                 // scope 5 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        switchInt(move _6) -> [0: bb1, otherwise: bb2]; // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_2);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        switchInt(move _4) -> [0: bb2, otherwise: bb3]; // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _0 = Option::<u32>::None;        // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        goto -> bb4;                     // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
     }
 
     bb2: {
-        _0 = Option::<u32>::None;        // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-    }
-
-    bb3: {
-        _5 = ((*_1).0: u32);             // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageLive(_6);                 // scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _6 = <u32 as Step>::forward_unchecked(_5, const 1_usize) -> bb4; // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _7 = ((*_1).0: u32);             // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _8 = <u32 as Step>::forward_unchecked(_7, const 1_usize) -> bb3; // scope 4 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // + literal: Const { ty: unsafe fn(u32, usize) -> u32 {<u32 as Step>::forward_unchecked}, val: Value(<ZST>) }
     }
 
-    bb4: {
-        ((*_1).0: u32) = move _6;        // scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_6);                 // scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _0 = Option::<u32>::Some(_5);    // scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        goto -> bb5;                     // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+    bb3: {
+        ((*_1).0: u32) = move _8;        // scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _0 = Option::<u32>::Some(_7);    // scope 3 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        goto -> bb4;                     // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
     }
 
-    bb5: {
-        StorageDead(_4);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+    bb4: {
+        StorageDead(_6);                 // scope 2 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_7);                 // scope 1 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         return;                          // scope 0 at $DIR/range_iter.rs:+2:2: +2:2
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.mir
@@ -8,21 +8,21 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     let mut _4: std::ops::Range<usize>;  // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:28
     let mut _5: std::ops::Range<usize>;  // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:28
     let mut _6: &mut std::ops::Range<usize>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:28
-    let mut _10: std::option::Option<usize>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:28
-    let mut _13: isize;                  // in scope 0 at $DIR/slice_iter.rs:+1:5: +4:6
-    let mut _15: usize;                  // in scope 0 at $DIR/slice_iter.rs:+2:18: +2:26
-    let mut _16: bool;                   // in scope 0 at $DIR/slice_iter.rs:+2:18: +2:26
-    let mut _18: &impl Fn(usize, &T);    // in scope 0 at $DIR/slice_iter.rs:+3:9: +3:10
-    let mut _19: (usize, &T);            // in scope 0 at $DIR/slice_iter.rs:+3:9: +3:16
-    let _20: ();                         // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:28
+    let mut _12: std::option::Option<usize>; // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:28
+    let mut _15: isize;                  // in scope 0 at $DIR/slice_iter.rs:+1:5: +4:6
+    let mut _17: usize;                  // in scope 0 at $DIR/slice_iter.rs:+2:18: +2:26
+    let mut _18: bool;                   // in scope 0 at $DIR/slice_iter.rs:+2:18: +2:26
+    let mut _20: &impl Fn(usize, &T);    // in scope 0 at $DIR/slice_iter.rs:+3:9: +3:10
+    let mut _21: (usize, &T);            // in scope 0 at $DIR/slice_iter.rs:+3:9: +3:16
+    let _22: ();                         // in scope 0 at $DIR/slice_iter.rs:+1:14: +1:28
     scope 1 {
         debug iter => _5;                // in scope 1 at $DIR/slice_iter.rs:+1:14: +1:28
-        let _14: usize;                  // in scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
+        let _16: usize;                  // in scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
         scope 2 {
-            debug i => _14;              // in scope 2 at $DIR/slice_iter.rs:+1:9: +1:10
-            let _17: &T;                 // in scope 2 at $DIR/slice_iter.rs:+2:13: +2:14
+            debug i => _16;              // in scope 2 at $DIR/slice_iter.rs:+1:9: +1:10
+            let _19: &T;                 // in scope 2 at $DIR/slice_iter.rs:+2:13: +2:14
             scope 3 {
-                debug x => _17;          // in scope 3 at $DIR/slice_iter.rs:+2:13: +2:14
+                debug x => _19;          // in scope 3 at $DIR/slice_iter.rs:+2:13: +2:14
             }
         }
         scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) { // at $DIR/slice_iter.rs:49:14: 49:28
@@ -31,13 +31,19 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                 debug self => _6;        // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 let mut _7: &usize;      // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 let mut _8: &usize;      // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                let mut _9: bool;        // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                let _11: usize;          // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                let mut _12: usize;      // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                let mut _11: bool;       // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                let _13: usize;          // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                let mut _14: usize;      // in scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                 scope 7 {
-                    debug old => _11;    // in scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                    debug old => _13;    // in scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                     scope 8 {
                     }
+                }
+                scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::lt) { // at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                    debug self => _7;    // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                    debug other => _8;   // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                    let mut _9: usize;   // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+                    let mut _10: usize;  // in scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
                 }
             }
         }
@@ -57,99 +63,99 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb1: {
-        StorageLive(_10);                // scope 1 at $DIR/slice_iter.rs:+1:14: +1:28
+        StorageLive(_12);                // scope 1 at $DIR/slice_iter.rs:+1:14: +1:28
         _6 = &mut _5;                    // scope 1 at $DIR/slice_iter.rs:+1:14: +1:28
-        StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageLive(_9);                 // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         StorageLive(_7);                 // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         _7 = &((*_6).0: usize);          // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         StorageLive(_8);                 // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
         _8 = &((*_6).1: usize);          // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _9 = <usize as PartialOrd>::lt(move _7, move _8) -> [return: bb2, unwind: bb13]; // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                         // mir::Constant
-                                         // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                         // + literal: Const { ty: for<'a, 'b> fn(&'a usize, &'b usize) -> bool {<usize as PartialOrd>::lt}, val: Value(<ZST>) }
+        StorageLive(_9);                 // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _9 = (*_7);                      // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageLive(_10);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _10 = (*_8);                     // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        _11 = Lt(move _9, move _10);     // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_10);                // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_9);                 // scope 9 at $SRC_DIR/core/src/cmp.rs:LL:COL
+        StorageDead(_8);                 // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        switchInt(move _11) -> [0: bb2, otherwise: bb3]; // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
     }
 
     bb2: {
-        StorageDead(_8);                 // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_7);                 // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        switchInt(move _9) -> [0: bb3, otherwise: bb4]; // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _12 = Option::<usize>::None;     // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        goto -> bb5;                     // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
     }
 
     bb3: {
-        _10 = Option::<usize>::None;     // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        goto -> bb6;                     // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-    }
-
-    bb4: {
-        _11 = ((*_6).0: usize);          // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageLive(_12);                // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _12 = <usize as Step>::forward_unchecked(_11, const 1_usize) -> [return: bb5, unwind: bb13]; // scope 8 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _13 = ((*_6).0: usize);          // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _14 = <usize as Step>::forward_unchecked(_13, const 1_usize) -> [return: bb4, unwind: bb12]; // scope 8 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> usize {<usize as Step>::forward_unchecked}, val: Value(<ZST>) }
     }
 
+    bb4: {
+        ((*_6).0: usize) = move _14;     // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _12 = Option::<usize>::Some(_13); // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        goto -> bb5;                     // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+    }
+
     bb5: {
-        ((*_6).0: usize) = move _12;     // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_12);                // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _10 = Option::<usize>::Some(_11); // scope 7 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        goto -> bb6;                     // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+        _15 = discriminant(_12);         // scope 1 at $DIR/slice_iter.rs:+1:14: +1:28
+        switchInt(move _15) -> [0: bb6, 1: bb8, otherwise: bb11]; // scope 1 at $DIR/slice_iter.rs:+1:14: +1:28
     }
 
     bb6: {
-        StorageDead(_9);                 // scope 6 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-        _13 = discriminant(_10);         // scope 1 at $DIR/slice_iter.rs:+1:14: +1:28
-        switchInt(move _13) -> [0: bb7, 1: bb9, otherwise: bb12]; // scope 1 at $DIR/slice_iter.rs:+1:14: +1:28
+        StorageDead(_12);                // scope 1 at $DIR/slice_iter.rs:+4:5: +4:6
+        StorageDead(_5);                 // scope 0 at $DIR/slice_iter.rs:+4:5: +4:6
+        drop(_2) -> bb7;                 // scope 0 at $DIR/slice_iter.rs:+5:1: +5:2
     }
 
     bb7: {
-        StorageDead(_10);                // scope 1 at $DIR/slice_iter.rs:+4:5: +4:6
-        StorageDead(_5);                 // scope 0 at $DIR/slice_iter.rs:+4:5: +4:6
-        drop(_2) -> bb8;                 // scope 0 at $DIR/slice_iter.rs:+5:1: +5:2
-    }
-
-    bb8: {
         return;                          // scope 0 at $DIR/slice_iter.rs:+5:2: +5:2
     }
 
-    bb9: {
-        _14 = ((_10 as Some).0: usize);  // scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
-        _15 = Len((*_1));                // scope 2 at $DIR/slice_iter.rs:+2:18: +2:26
-        _16 = Lt(_14, _15);              // scope 2 at $DIR/slice_iter.rs:+2:18: +2:26
-        assert(move _16, "index out of bounds: the length is {} but the index is {}", move _15, _14) -> [success: bb10, unwind: bb13]; // scope 2 at $DIR/slice_iter.rs:+2:18: +2:26
+    bb8: {
+        _16 = ((_12 as Some).0: usize);  // scope 1 at $DIR/slice_iter.rs:+1:9: +1:10
+        _17 = Len((*_1));                // scope 2 at $DIR/slice_iter.rs:+2:18: +2:26
+        _18 = Lt(_16, _17);              // scope 2 at $DIR/slice_iter.rs:+2:18: +2:26
+        assert(move _18, "index out of bounds: the length is {} but the index is {}", move _17, _16) -> [success: bb9, unwind: bb12]; // scope 2 at $DIR/slice_iter.rs:+2:18: +2:26
     }
 
-    bb10: {
-        _17 = &(*_1)[_14];               // scope 2 at $DIR/slice_iter.rs:+2:17: +2:26
-        StorageLive(_18);                // scope 3 at $DIR/slice_iter.rs:+3:9: +3:10
-        _18 = &_2;                       // scope 3 at $DIR/slice_iter.rs:+3:9: +3:10
-        StorageLive(_19);                // scope 3 at $DIR/slice_iter.rs:+3:9: +3:16
-        _19 = (_14, _17);                // scope 3 at $DIR/slice_iter.rs:+3:9: +3:16
-        _20 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _18, move _19) -> [return: bb11, unwind: bb13]; // scope 3 at $DIR/slice_iter.rs:+3:9: +3:16
+    bb9: {
+        _19 = &(*_1)[_16];               // scope 2 at $DIR/slice_iter.rs:+2:17: +2:26
+        StorageLive(_20);                // scope 3 at $DIR/slice_iter.rs:+3:9: +3:10
+        _20 = &_2;                       // scope 3 at $DIR/slice_iter.rs:+3:9: +3:10
+        StorageLive(_21);                // scope 3 at $DIR/slice_iter.rs:+3:9: +3:16
+        _21 = (_16, _19);                // scope 3 at $DIR/slice_iter.rs:+3:9: +3:16
+        _22 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _20, move _21) -> [return: bb10, unwind: bb12]; // scope 3 at $DIR/slice_iter.rs:+3:9: +3:16
                                          // mir::Constant
                                          // + span: $DIR/slice_iter.rs:51:9: 51:10
                                          // + literal: Const { ty: for<'a> extern "rust-call" fn(&'a impl Fn(usize, &T), (usize, &T)) -> <impl Fn(usize, &T) as FnOnce<(usize, &T)>>::Output {<impl Fn(usize, &T) as Fn<(usize, &T)>>::call}, val: Value(<ZST>) }
     }
 
-    bb11: {
-        StorageDead(_19);                // scope 3 at $DIR/slice_iter.rs:+3:15: +3:16
-        StorageDead(_18);                // scope 3 at $DIR/slice_iter.rs:+3:15: +3:16
-        StorageDead(_10);                // scope 1 at $DIR/slice_iter.rs:+4:5: +4:6
+    bb10: {
+        StorageDead(_21);                // scope 3 at $DIR/slice_iter.rs:+3:15: +3:16
+        StorageDead(_20);                // scope 3 at $DIR/slice_iter.rs:+3:15: +3:16
+        StorageDead(_12);                // scope 1 at $DIR/slice_iter.rs:+4:5: +4:6
         goto -> bb1;                     // scope 1 at $DIR/slice_iter.rs:+1:5: +4:6
     }
 
-    bb12: {
+    bb11: {
         unreachable;                     // scope 1 at $DIR/slice_iter.rs:+1:14: +1:28
     }
 
-    bb13 (cleanup): {
-        drop(_2) -> [return: bb14, unwind terminate]; // scope 0 at $DIR/slice_iter.rs:+5:1: +5:2
+    bb12 (cleanup): {
+        drop(_2) -> [return: bb13, unwind terminate]; // scope 0 at $DIR/slice_iter.rs:+5:1: +5:2
     }
 
-    bb14 (cleanup): {
+    bb13 (cleanup): {
         resume;                          // scope 0 at $DIR/slice_iter.rs:+0:1: +5:2
     }
 }


### PR DESCRIPTION
This PR aims to reduce the strength of https://github.com/rust-lang/rust/pull/105119 even more.

In the current implementation, we check the inline count before recursing. This means that we never actually reach inlining depth 3.

This PR checks the counter after recursion, to give a chance to inline at depth >= 3.

r? @scottmcm 
cc @JakobDegen 