### PR TITLE
Remove unneeded `Buffer` allocations when `&mut fmt::Write` can be used directly

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1038,9 +1038,9 @@ fn render_attributes_in_pre<'a, 'b: 'a>(
 
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
-fn render_attributes_in_code(w: &mut Buffer, it: &clean::Item, tcx: TyCtxt<'_>) {
+fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, tcx: TyCtxt<'_>) {
     for a in it.attributes(tcx, false) {
-        write!(w, "<div class=\"code-attribute\">{}</div>", a);
+        write!(w, "<div class=\"code-attribute\">{}</div>", a).unwrap();
     }
 }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1039,8 +1039,8 @@ fn render_attributes_in_pre<'a, 'b: 'a>(
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
 fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, tcx: TyCtxt<'_>) {
-    for a in it.attributes(tcx, false) {
-        write!(w, "<div class=\"code-attribute\">{}</div>", a).unwrap();
+    for attr in it.attributes(tcx, false) {
+        write!(w, "<div class=\"code-attribute\">{attr}</div>").unwrap();
     }
 }
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1435,17 +1435,17 @@ fn item_proc_macro(
         let name = it.name.expect("proc-macros always have names");
         match m.kind {
             MacroKind::Bang => {
-                write!(buffer, "{}!() {{ /* proc-macro */ }}", name).unwrap();
+                write!(buffer, "{name}!() {{ /* proc-macro */ }}").unwrap();
             }
             MacroKind::Attr => {
-                write!(buffer, "#[{}]", name).unwrap();
+                write!(buffer, "#[{name}]").unwrap();
             }
             MacroKind::Derive => {
-                write!(buffer, "#[derive({})]", name).unwrap();
+                write!(buffer, "#[derive({name})]").unwrap();
                 if !m.helpers.is_empty() {
                     buffer.write_str("\n{\n    // Attributes available to this derive:\n").unwrap();
                     for attr in &m.helpers {
-                        writeln!(buffer, "    #[{}]", attr).unwrap();
+                        writeln!(buffer, "    #[{attr}]").unwrap();
                     }
                     buffer.write_str("}\n").unwrap();
                 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1431,30 +1431,28 @@ fn item_proc_macro(
     it: &clean::Item,
     m: &clean::ProcMacro,
 ) {
-    let mut buffer = Buffer::new();
-    wrap_item(&mut buffer, |buffer| {
+    wrap_item(w, |buffer| {
         let name = it.name.expect("proc-macros always have names");
         match m.kind {
             MacroKind::Bang => {
-                write!(buffer, "{}!() {{ /* proc-macro */ }}", name);
+                write!(buffer, "{}!() {{ /* proc-macro */ }}", name).unwrap();
             }
             MacroKind::Attr => {
-                write!(buffer, "#[{}]", name);
+                write!(buffer, "#[{}]", name).unwrap();
             }
             MacroKind::Derive => {
-                write!(buffer, "#[derive({})]", name);
+                write!(buffer, "#[derive({})]", name).unwrap();
                 if !m.helpers.is_empty() {
-                    buffer.push_str("\n{\n");
-                    buffer.push_str("    // Attributes available to this derive:\n");
+                    buffer.write_str("\n{\n    // Attributes available to this derive:\n").unwrap();
                     for attr in &m.helpers {
-                        writeln!(buffer, "    #[{}]", attr);
+                        writeln!(buffer, "    #[{}]", attr).unwrap();
                     }
-                    buffer.push_str("}\n");
+                    buffer.write_str("}\n").unwrap();
                 }
             }
         }
     });
-    write!(w, "{}{}", buffer.into_inner(), document(cx, it, None, HeadingOffset::H2)).unwrap();
+    write!(w, "{}", document(cx, it, None, HeadingOffset::H2)).unwrap();
 }
 
 fn item_primitive(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item) {
@@ -1571,8 +1569,7 @@ fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean
 }
 
 fn item_static(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Item, s: &clean::Static) {
-    let mut buffer = Buffer::new();
-    wrap_item(&mut buffer, |buffer| {
+    wrap_item(w, |buffer| {
         render_attributes_in_code(buffer, it, cx.tcx());
         write!(
             buffer,
@@ -1581,29 +1578,27 @@ fn item_static(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Item, 
             mutability = s.mutability.print_with_space(),
             name = it.name.unwrap(),
             typ = s.type_.print(cx)
-        );
+        )
+        .unwrap();
     });
-
-    write!(w, "{}", buffer.into_inner()).unwrap();
 
     write!(w, "{}", document(cx, it, None, HeadingOffset::H2)).unwrap();
 }
 
 fn item_foreign_type(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Item) {
-    let mut buffer = Buffer::new();
-    wrap_item(&mut buffer, |buffer| {
-        buffer.write_str("extern {\n");
+    wrap_item(w, |buffer| {
+        buffer.write_str("extern {\n").unwrap();
         render_attributes_in_code(buffer, it, cx.tcx());
         write!(
             buffer,
             "    {}type {};\n}}",
             visibility_print_with_space(it.visibility(cx.tcx()), it.item_id, cx),
             it.name.unwrap(),
-        );
+        )
+        .unwrap();
     });
 
-    write!(w, "{}{}", buffer.into_inner(), document(cx, it, None, HeadingOffset::H2)).unwrap();
-
+    write!(w, "{}", document(cx, it, None, HeadingOffset::H2)).unwrap();
     write!(w, "{}", render_assoc_items(cx, it, it.item_id.expect_def_id(), AssocItemRender::All))
         .unwrap();
 }


### PR DESCRIPTION
With the recent changes, `wrap_item` can now directly take `&mut Write`, which makes some `Buffer` creations unneeded.

r? @notriddle 