### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -27,7 +27,6 @@ use rustc_infer::infer::error_reporting::TypeErrCtxt;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::{DefineOpaqueTypes, InferOk, LateBoundRegionConversionTime};
 use rustc_middle::hir::map;
-use rustc_middle::query::Key;
 use rustc_middle::ty::error::TypeError::{self, Sorts};
 use rustc_middle::ty::{
     self, suggest_arbitrary_trait_bound, suggest_constraining_type_param, AdtKind,
@@ -3701,8 +3700,8 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         let Some(typeck_results) = self.typeck_results.as_ref() else { return };
 
         // Make sure we're dealing with the `Option` type.
-        let Some(ty_adt_did) = typeck_results.expr_ty_adjusted(expr).ty_adt_id() else { return };
-        if !tcx.is_diagnostic_item(sym::Option, ty_adt_did) {
+        let Some(option_ty_adt) = typeck_results.expr_ty_adjusted(expr).ty_adt_def() else { return };
+        if !tcx.is_diagnostic_item(sym::Option, option_ty_adt.did()) {
             return;
         }
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1138,7 +1138,7 @@ impl<T> Option<T> {
     /// Computes a default function result (if none), or
     /// applies a different function to the contained value (if any).
     ///
-    /// # Examples
+    /// # Basic examples
     ///
     /// ```
     /// let k = 21;
@@ -1148,6 +1148,25 @@ impl<T> Option<T> {
     ///
     /// let x: Option<&str> = None;
     /// assert_eq!(x.map_or_else(|| 2 * k, |v| v.len()), 42);
+    /// ```
+    ///
+    /// # Handling a Result-based fallback
+    ///
+    /// A somewhat common occurrence when dealing with optional values
+    /// in combination with [`Result<T, E>`] is the case where one wants to invoke
+    /// a fallible fallback if the option is not present.  This example
+    /// parses a command line argument (if present), or the contents of a file to
+    /// an integer.  However, unlike accessing the command line argument, reading
+    /// the file is fallible, so it must be wrapped with `Ok`.
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let v: u64 = std::env::args()
+    ///    .nth(1)
+    ///    .map_or_else(|| std::fs::read_to_string("/etc/someconfig.conf"), Ok)?
+    ///    .parse()?;
+    /// #   Ok(())
+    /// # }
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "once_cell",
  "opener",
  "pretty_assertions",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -644,6 +645,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -57,6 +57,7 @@ walkdir = "2"
 sysinfo = { version = "0.26.0", optional = true }
 clap = { version = "4.2.4", default-features = false, features = ["std", "usage", "help", "derive", "error-context"] }
 clap_complete = "4.2.2"
+semver = "1.0.17"
 
 # Solaris doesn't support flock() and thus fd-lock is not option now
 [target.'cfg(not(target_os = "solaris"))'.dependencies]

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -25,6 +25,7 @@ use crate::flags::{Color, Flags, Warnings};
 use crate::util::{exe, output, t};
 use build_helper::detail_exit_macro;
 use once_cell::sync::OnceCell;
+use semver::Version;
 use serde::{Deserialize, Deserializer};
 use serde_derive::Deserialize;
 
@@ -1114,10 +1115,14 @@ impl Config {
             config.out = crate::util::absolute(&config.out);
         }
 
-        config.initial_rustc = build.rustc.map(PathBuf::from).unwrap_or_else(|| {
+        config.initial_rustc = if let Some(rustc) = build.rustc {
+            config.check_build_rustc_version(&rustc);
+            PathBuf::from(rustc)
+        } else {
             config.download_beta_toolchain();
             config.out.join(config.build.triple).join("stage0/bin/rustc")
-        });
+        };
+
         config.initial_cargo = build
             .cargo
             .map(|cargo| {
@@ -1777,6 +1782,42 @@ impl Config {
 
     pub fn default_codegen_backend(&self) -> Option<Interned<String>> {
         self.rust_codegen_backends.get(0).cloned()
+    }
+
+    pub fn check_build_rustc_version(&self, rustc_path: &str) {
+        if self.dry_run() {
+            return;
+        }
+
+        // check rustc version is same or lower with 1 apart from the building one
+        let mut cmd = Command::new(rustc_path);
+        cmd.arg("--version");
+        let rustc_output = output(&mut cmd)
+            .lines()
+            .next()
+            .unwrap()
+            .split(' ')
+            .nth(1)
+            .unwrap()
+            .split('-')
+            .next()
+            .unwrap()
+            .to_owned();
+        let rustc_version = Version::parse(&rustc_output.trim()).unwrap();
+        let source_version =
+            Version::parse(&fs::read_to_string(self.src.join("src/version")).unwrap().trim())
+                .unwrap();
+        if !(source_version == rustc_version
+            || (source_version.major == rustc_version.major
+                && source_version.minor == rustc_version.minor + 1))
+        {
+            let prev_version = format!("{}.{}.x", source_version.major, source_version.minor - 1);
+            eprintln!(
+                "Unexpected rustc version: {}, we should use {}/{} to build source with {}",
+                rustc_version, prev_version, source_version, source_version
+            );
+            detail_exit_macro!(1);
+        }
     }
 
     /// Returns the commit to download, or `None` if we shouldn't download CI artifacts.

--- a/tests/codegen/box-maybe-uninit-llvm14.rs
+++ b/tests/codegen/box-maybe-uninit-llvm14.rs
@@ -31,4 +31,4 @@ pub fn box_uninitialized2() -> Box<MaybeUninit<[usize; 1024 * 1024]>> {
 // Hide the LLVM 15+ `allocalign` attribute in the declaration of __rust_alloc
 // from the CHECK-NOT above. We don't check the attributes here because we can't rely
 // on all of them being set until LLVM 15.
-// CHECK: declare noalias{{.*}} @__rust_alloc(i{{[0-9]+}} noundef, i{{[0-9]+.*}} noundef)
+// CHECK: declare {{(dso_local )?}}noalias{{.*}} @__rust_alloc(i{{[0-9]+}} noundef, i{{[0-9]+.*}} noundef)

--- a/tests/codegen/box-maybe-uninit.rs
+++ b/tests/codegen/box-maybe-uninit.rs
@@ -30,4 +30,4 @@ pub fn box_uninitialized2() -> Box<MaybeUninit<[usize; 1024 * 1024]>> {
 // from the CHECK-NOT above, and also verify the attributes got set reasonably.
 // CHECK: declare {{(dso_local )?}}noalias noundef ptr @__rust_alloc(i{{[0-9]+}} noundef, i{{[0-9]+}} allocalign noundef) unnamed_addr [[RUST_ALLOC_ATTRS:#[0-9]+]]
 
-// CHECK-DAG: attributes [[RUST_ALLOC_ATTRS]] = { {{.*}} allockind("alloc,uninitialized,aligned") allocsize(0) uwtable "alloc-family"="__rust_alloc" {{.*}} }
+// CHECK-DAG: attributes [[RUST_ALLOC_ATTRS]] = { {{.*}} allockind("alloc,uninitialized,aligned") allocsize(0) {{(uwtable )?}}"alloc-family"="__rust_alloc" {{.*}} }

--- a/tests/codegen/box-maybe-uninit.rs
+++ b/tests/codegen/box-maybe-uninit.rs
@@ -28,6 +28,6 @@ pub fn box_uninitialized2() -> Box<MaybeUninit<[usize; 1024 * 1024]>> {
 
 // Hide the `allocalign` attribute in the declaration of __rust_alloc
 // from the CHECK-NOT above, and also verify the attributes got set reasonably.
-// CHECK: declare noalias noundef ptr @__rust_alloc(i{{[0-9]+}} noundef, i{{[0-9]+}} allocalign noundef) unnamed_addr [[RUST_ALLOC_ATTRS:#[0-9]+]]
+// CHECK: declare {{(dso_local )?}}noalias noundef ptr @__rust_alloc(i{{[0-9]+}} noundef, i{{[0-9]+}} allocalign noundef) unnamed_addr [[RUST_ALLOC_ATTRS:#[0-9]+]]
 
 // CHECK-DAG: attributes [[RUST_ALLOC_ATTRS]] = { {{.*}} allockind("alloc,uninitialized,aligned") allocsize(0) uwtable "alloc-family"="__rust_alloc" {{.*}} }

--- a/tests/codegen/call-metadata.rs
+++ b/tests/codegen/call-metadata.rs
@@ -6,7 +6,7 @@
 #![crate_type = "lib"]
 
 pub fn test() {
-    // CHECK: call noundef i8 @some_true(), !range [[R0:![0-9]+]]
+    // CHECK: call noundef i8 @some_true(){{( #[0-9]+)?}}, !range [[R0:![0-9]+]]
     // CHECK: [[R0]] = !{i8 0, i8 3}
     some_true();
 }

--- a/tests/codegen/debug-column.rs
+++ b/tests/codegen/debug-column.rs
@@ -6,11 +6,11 @@
 fn main() {
     unsafe {
         // Column numbers are 1-based. Regression test for #65437.
-        // CHECK: call void @giraffe(), !dbg [[A:!.*]]
+        // CHECK: call void @giraffe(){{( #[0-9]+)?}}, !dbg [[A:!.*]]
         giraffe();
 
         // Column numbers use byte offests. Regression test for #67360
-        // CHECK: call void @turtle(), !dbg [[B:!.*]]
+        // CHECK: call void @turtle(){{( #[0-9]+)?}}, !dbg [[B:!.*]]
 /* ż */ turtle();
 
         // CHECK: [[A]] = !DILocation(line: 10, column: 9,

--- a/tests/codegen/drop.rs
+++ b/tests/codegen/drop.rs
@@ -1,4 +1,5 @@
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-unwind - this test verifies the amount of drop calls when unwinding is used
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]

--- a/tests/codegen/external-no-mangle-statics.rs
+++ b/tests/codegen/external-no-mangle-statics.rs
@@ -6,72 +6,72 @@
 // `#[no_mangle]`d static variables always have external linkage, i.e., no `internal` in their
 // definitions
 
-// CHECK: @A = local_unnamed_addr constant
+// CHECK: @A = {{(dso_local )?}}local_unnamed_addr constant
 #[no_mangle]
 static A: u8 = 0;
 
-// CHECK: @B = local_unnamed_addr global
+// CHECK: @B = {{(dso_local )?}}local_unnamed_addr global
 #[no_mangle]
 static mut B: u8 = 0;
 
-// CHECK: @C = local_unnamed_addr constant
+// CHECK: @C = {{(dso_local )?}}local_unnamed_addr constant
 #[no_mangle]
 pub static C: u8 = 0;
 
-// CHECK: @D = local_unnamed_addr global
+// CHECK: @D = {{(dso_local )?}}local_unnamed_addr global
 #[no_mangle]
 pub static mut D: u8 = 0;
 
 mod private {
-    // CHECK: @E = local_unnamed_addr constant
+    // CHECK: @E = {{(dso_local )?}}local_unnamed_addr constant
     #[no_mangle]
     static E: u8 = 0;
 
-    // CHECK: @F = local_unnamed_addr global
+    // CHECK: @F = {{(dso_local )?}}local_unnamed_addr global
     #[no_mangle]
     static mut F: u8 = 0;
 
-    // CHECK: @G = local_unnamed_addr constant
+    // CHECK: @G = {{(dso_local )?}}local_unnamed_addr constant
     #[no_mangle]
     pub static G: u8 = 0;
 
-    // CHECK: @H = local_unnamed_addr global
+    // CHECK: @H = {{(dso_local )?}}local_unnamed_addr global
     #[no_mangle]
     pub static mut H: u8 = 0;
 }
 
 const HIDDEN: () = {
-    // CHECK: @I = local_unnamed_addr constant
+    // CHECK: @I = {{(dso_local )?}}local_unnamed_addr constant
     #[no_mangle]
     static I: u8 = 0;
 
-    // CHECK: @J = local_unnamed_addr global
+    // CHECK: @J = {{(dso_local )?}}local_unnamed_addr global
     #[no_mangle]
     static mut J: u8 = 0;
 
-    // CHECK: @K = local_unnamed_addr constant
+    // CHECK: @K = {{(dso_local )?}}local_unnamed_addr constant
     #[no_mangle]
     pub static K: u8 = 0;
 
-    // CHECK: @L = local_unnamed_addr global
+    // CHECK: @L = {{(dso_local )?}}local_unnamed_addr global
     #[no_mangle]
     pub static mut L: u8 = 0;
 };
 
 fn x() {
-    // CHECK: @M = local_unnamed_addr constant
+    // CHECK: @M = {{(dso_local )?}}local_unnamed_addr constant
     #[no_mangle]
     static M: fn() = x;
 
-    // CHECK: @N = local_unnamed_addr global
+    // CHECK: @N = {{(dso_local )?}}local_unnamed_addr global
     #[no_mangle]
     static mut N: u8 = 0;
 
-    // CHECK: @O = local_unnamed_addr constant
+    // CHECK: @O = {{(dso_local )?}}local_unnamed_addr constant
     #[no_mangle]
     pub static O: u8 = 0;
 
-    // CHECK: @P = local_unnamed_addr global
+    // CHECK: @P = {{(dso_local )?}}local_unnamed_addr global
     #[no_mangle]
     pub static mut P: u8 = 0;
 }

--- a/tests/codegen/issues/issue-86106.rs
+++ b/tests/codegen/issues/issue-86106.rs
@@ -7,7 +7,7 @@
 
 #![crate_type = "lib"]
 
-// CHECK-LABEL: define void @string_new
+// CHECK-LABEL: define {{(dso_local )?}}void @string_new
 #[no_mangle]
 pub fn string_new() -> String {
     // CHECK: store ptr inttoptr
@@ -17,7 +17,7 @@ pub fn string_new() -> String {
     String::new()
 }
 
-// CHECK-LABEL: define void @empty_to_string
+// CHECK-LABEL: define {{(dso_local )?}}void @empty_to_string
 #[no_mangle]
 pub fn empty_to_string() -> String {
     // CHECK: store ptr inttoptr

--- a/tests/codegen/link_section.rs
+++ b/tests/codegen/link_section.rs
@@ -3,7 +3,7 @@
 
 #![crate_type = "lib"]
 
-// CHECK: @VAR1 = constant <{ [4 x i8] }> <{ [4 x i8] c"\01\00\00\00" }>, section ".test_one"
+// CHECK: @VAR1 = {{(dso_local )?}}constant <{ [4 x i8] }> <{ [4 x i8] c"\01\00\00\00" }>, section ".test_one"
 #[no_mangle]
 #[link_section = ".test_one"]
 #[cfg(target_endian = "little")]
@@ -19,17 +19,17 @@ pub enum E {
     B(f32)
 }
 
-// CHECK: @VAR2 = constant {{.*}}, section ".test_two"
+// CHECK: @VAR2 = {{(dso_local )?}}constant {{.*}}, section ".test_two"
 #[no_mangle]
 #[link_section = ".test_two"]
 pub static VAR2: E = E::A(666);
 
-// CHECK: @VAR3 = constant {{.*}}, section ".test_three"
+// CHECK: @VAR3 = {{(dso_local )?}}constant {{.*}}, section ".test_three"
 #[no_mangle]
 #[link_section = ".test_three"]
 pub static VAR3: E = E::B(1.);
 
-// CHECK: define void @fn1() {{.*}} section ".test_four" {
+// CHECK: define {{(dso_local )?}}void @fn1() {{.*}} section ".test_four" {
 #[no_mangle]
 #[link_section = ".test_four"]
 pub fn fn1() {}

--- a/tests/codegen/mir-inlined-line-numbers.rs
+++ b/tests/codegen/mir-inlined-line-numbers.rs
@@ -19,7 +19,7 @@ pub fn example() {
 }
 
 // CHECK-LABEL: @example
-// CHECK:   tail call void @bar(), !dbg [[DBG_ID:![0-9]+]]
+// CHECK:   tail call void @bar(){{( #[0-9]+)?}}, !dbg [[DBG_ID:![0-9]+]]
 // CHECK: [[DBG_ID]] = !DILocation(line: 7,
 // CHECK-SAME:                     inlinedAt: [[INLINE_ID:![0-9]+]])
 // CHECK: [[INLINE_ID]] = !DILocation(line: 18,

--- a/tests/codegen/naked-noinline.rs
+++ b/tests/codegen/naked-noinline.rs
@@ -12,7 +12,7 @@ use std::arch::asm;
 pub unsafe extern "C" fn f() {
     // Check that f has naked and noinline attributes.
     //
-    // CHECK:       define void @f() unnamed_addr [[ATTR:#[0-9]+]]
+    // CHECK:       define {{(dso_local )?}}void @f() unnamed_addr [[ATTR:#[0-9]+]]
     // CHECK-NEXT:  start:
     // CHECK-NEXT:    call void asm
     asm!("", options(noreturn));
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn f() {
 pub unsafe fn g() {
     // Check that call to f is not inlined.
     //
-    // CHECK-LABEL: define void @g()
+    // CHECK-LABEL: define {{(dso_local )?}}void @g()
     // CHECK-NEXT:  start:
     // CHECK-NEXT:    call void @f()
     f();

--- a/tests/codegen/personality_lifetimes.rs
+++ b/tests/codegen/personality_lifetimes.rs
@@ -1,5 +1,6 @@
 // ignore-msvc
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-unwind
 
 // compile-flags: -O -C no-prepopulate-passes
 

--- a/tests/codegen/ptr-read-metadata.rs
+++ b/tests/codegen/ptr-read-metadata.rs
@@ -9,7 +9,7 @@
 
 use std::mem::MaybeUninit;
 
-// CHECK-LABEL: define noundef i8 @copy_byte(
+// CHECK-LABEL: define {{(dso_local )?}}noundef i8 @copy_byte(
 #[no_mangle]
 pub unsafe fn copy_byte(p: *const u8) -> u8 {
     // CHECK-NOT: load
@@ -19,7 +19,7 @@ pub unsafe fn copy_byte(p: *const u8) -> u8 {
     *p
 }
 
-// CHECK-LABEL: define noundef i8 @read_byte(
+// CHECK-LABEL: define {{(dso_local )?}}noundef i8 @read_byte(
 #[no_mangle]
 pub unsafe fn read_byte(p: *const u8) -> u8 {
     // CHECK-NOT: load
@@ -29,7 +29,7 @@ pub unsafe fn read_byte(p: *const u8) -> u8 {
     p.read()
 }
 
-// CHECK-LABEL: define i8 @read_byte_maybe_uninit(
+// CHECK-LABEL: define {{(dso_local )?}}i8 @read_byte_maybe_uninit(
 #[no_mangle]
 pub unsafe fn read_byte_maybe_uninit(p: *const MaybeUninit<u8>) -> MaybeUninit<u8> {
     // CHECK-NOT: load
@@ -39,7 +39,7 @@ pub unsafe fn read_byte_maybe_uninit(p: *const MaybeUninit<u8>) -> MaybeUninit<u
     p.read()
 }
 
-// CHECK-LABEL: define noundef i8 @read_byte_assume_init(
+// CHECK-LABEL: define {{(dso_local )?}}noundef i8 @read_byte_assume_init(
 #[no_mangle]
 pub unsafe fn read_byte_assume_init(p: &MaybeUninit<u8>) -> u8 {
     // CHECK-NOT: load
@@ -49,7 +49,7 @@ pub unsafe fn read_byte_assume_init(p: &MaybeUninit<u8>) -> u8 {
     p.assume_init_read()
 }
 
-// CHECK-LABEL: define noundef i32 @copy_char(
+// CHECK-LABEL: define {{(dso_local )?}}noundef i32 @copy_char(
 #[no_mangle]
 pub unsafe fn copy_char(p: *const char) -> char {
     // CHECK-NOT: load
@@ -60,7 +60,7 @@ pub unsafe fn copy_char(p: *const char) -> char {
     *p
 }
 
-// CHECK-LABEL: define noundef i32 @read_char(
+// CHECK-LABEL: define {{(dso_local )?}}noundef i32 @read_char(
 #[no_mangle]
 pub unsafe fn read_char(p: *const char) -> char {
     // CHECK-NOT: load
@@ -71,7 +71,7 @@ pub unsafe fn read_char(p: *const char) -> char {
     p.read()
 }
 
-// CHECK-LABEL: define i32 @read_char_maybe_uninit(
+// CHECK-LABEL: define {{(dso_local )?}}i32 @read_char_maybe_uninit(
 #[no_mangle]
 pub unsafe fn read_char_maybe_uninit(p: *const MaybeUninit<char>) -> MaybeUninit<char> {
     // CHECK-NOT: load
@@ -82,7 +82,7 @@ pub unsafe fn read_char_maybe_uninit(p: *const MaybeUninit<char>) -> MaybeUninit
     p.read()
 }
 
-// CHECK-LABEL: define noundef i32 @read_char_assume_init(
+// CHECK-LABEL: define {{(dso_local )?}}noundef i32 @read_char_assume_init(
 #[no_mangle]
 pub unsafe fn read_char_assume_init(p: &MaybeUninit<char>) -> char {
     // CHECK-NOT: load

--- a/tests/codegen/tuple-layout-opt.rs
+++ b/tests/codegen/tuple-layout-opt.rs
@@ -6,31 +6,31 @@
 #![crate_type="lib"]
 
 type ScalarZstLast = (u128, ());
-// CHECK: define i128 @test_ScalarZstLast(i128 %_1)
+// CHECK: define {{(dso_local )?}}i128 @test_ScalarZstLast(i128 %_1)
 #[no_mangle]
 pub fn test_ScalarZstLast(_: ScalarZstLast) -> ScalarZstLast { loop {} }
 
 type ScalarZstFirst = ((), u128);
-// CHECK: define i128 @test_ScalarZstFirst(i128 %_1)
+// CHECK: define {{(dso_local )?}}i128 @test_ScalarZstFirst(i128 %_1)
 #[no_mangle]
 pub fn test_ScalarZstFirst(_: ScalarZstFirst) -> ScalarZstFirst { loop {} }
 
 type ScalarPairZstLast = (u8, u128, ());
-// CHECK: define { i128, i8 } @test_ScalarPairZstLast(i128 %_1.0, i8 %_1.1)
+// CHECK: define {{(dso_local )?}}{ i128, i8 } @test_ScalarPairZstLast(i128 %_1.0, i8 %_1.1)
 #[no_mangle]
 pub fn test_ScalarPairZstLast(_: ScalarPairZstLast) -> ScalarPairZstLast { loop {} }
 
 type ScalarPairZstFirst = ((), u8, u128);
-// CHECK: define { i8, i128 } @test_ScalarPairZstFirst(i8 %_1.0, i128 %_1.1)
+// CHECK: define {{(dso_local )?}}{ i8, i128 } @test_ScalarPairZstFirst(i8 %_1.0, i128 %_1.1)
 #[no_mangle]
 pub fn test_ScalarPairZstFirst(_: ScalarPairZstFirst) -> ScalarPairZstFirst { loop {} }
 
 type ScalarPairLotsOfZsts = ((), u8, (), u128, ());
-// CHECK: define { i128, i8 } @test_ScalarPairLotsOfZsts(i128 %_1.0, i8 %_1.1)
+// CHECK: define {{(dso_local )?}}{ i128, i8 } @test_ScalarPairLotsOfZsts(i128 %_1.0, i8 %_1.1)
 #[no_mangle]
 pub fn test_ScalarPairLotsOfZsts(_: ScalarPairLotsOfZsts) -> ScalarPairLotsOfZsts { loop {} }
 
 type ScalarPairLottaNesting = (((), ((), u8, (), u128, ())), ());
-// CHECK: define { i128, i8 } @test_ScalarPairLottaNesting(i128 %_1.0, i8 %_1.1)
+// CHECK: define {{(dso_local )?}}{ i128, i8 } @test_ScalarPairLottaNesting(i128 %_1.0, i8 %_1.1)
 #[no_mangle]
 pub fn test_ScalarPairLottaNesting(_: ScalarPairLottaNesting) -> ScalarPairLottaNesting { loop {} }

--- a/tests/codegen/union-abi.rs
+++ b/tests/codegen/union-abi.rs
@@ -17,60 +17,60 @@ pub struct i64x4(i64, i64, i64, i64);
 #[derive(Copy, Clone)]
 pub union UnionI64x4{ a:(), b: i64x4 }
 
-// CHECK: define void @test_UnionI64x4({{<4 x i64>\*|ptr}} {{.*}} %_1)
+// CHECK: define {{(dso_local )?}}void @test_UnionI64x4({{<4 x i64>\*|ptr}} {{.*}} %_1)
 #[no_mangle]
 pub fn test_UnionI64x4(_: UnionI64x4) { loop {} }
 
 pub union UnionI64x4_{ a: i64x4, b: (), c:i64x4, d: Unhab, e: ((),()), f: UnionI64x4 }
 
-// CHECK: define void @test_UnionI64x4_({{<4 x i64>\*|ptr}} {{.*}} %_1)
+// CHECK: define {{(dso_local )?}}void @test_UnionI64x4_({{<4 x i64>\*|ptr}} {{.*}} %_1)
 #[no_mangle]
 pub fn test_UnionI64x4_(_: UnionI64x4_) { loop {} }
 
 pub union UnionI64x4I64{ a: i64x4, b: i64 }
 
-// CHECK: define void @test_UnionI64x4I64({{%UnionI64x4I64\*|ptr}} {{.*}} %_1)
+// CHECK: define {{(dso_local )?}}void @test_UnionI64x4I64({{%UnionI64x4I64\*|ptr}} {{.*}} %_1)
 #[no_mangle]
 pub fn test_UnionI64x4I64(_: UnionI64x4I64) { loop {} }
 
 pub union UnionI64x4Tuple{ a: i64x4, b: (i64, i64, i64, i64) }
 
-// CHECK: define void @test_UnionI64x4Tuple({{%UnionI64x4Tuple\*|ptr}} {{.*}} %_1)
+// CHECK: define {{(dso_local )?}}void @test_UnionI64x4Tuple({{%UnionI64x4Tuple\*|ptr}} {{.*}} %_1)
 #[no_mangle]
 pub fn test_UnionI64x4Tuple(_: UnionI64x4Tuple) { loop {} }
 
 
 pub union UnionF32{a:f32}
 
-// CHECK: define float @test_UnionF32(float %_1)
+// CHECK: define {{(dso_local )?}}float @test_UnionF32(float %_1)
 #[no_mangle]
 pub fn test_UnionF32(_: UnionF32) -> UnionF32 { loop {} }
 
 pub union UnionF32F32{a:f32, b:f32}
 
-// CHECK: define float @test_UnionF32F32(float %_1)
+// CHECK: define {{(dso_local )?}}float @test_UnionF32F32(float %_1)
 #[no_mangle]
 pub fn test_UnionF32F32(_: UnionF32F32) -> UnionF32F32 { loop {} }
 
 pub union UnionF32U32{a:f32, b:u32}
 
-// CHECK: define i32 @test_UnionF32U32(i32{{( %0)?}})
+// CHECK: define {{(dso_local )?}}i32 @test_UnionF32U32(i32{{( %0)?}})
 #[no_mangle]
 pub fn test_UnionF32U32(_: UnionF32U32) -> UnionF32U32 { loop {} }
 
 pub union UnionU128{a:u128}
-// CHECK: define i128 @test_UnionU128(i128 %_1)
+// CHECK: define {{(dso_local )?}}i128 @test_UnionU128(i128 %_1)
 #[no_mangle]
 pub fn test_UnionU128(_: UnionU128) -> UnionU128 { loop {} }
 
 #[repr(C)]
 pub union CUnionU128{a:u128}
-// CHECK: define void @test_CUnionU128({{%CUnionU128\*|ptr}} {{.*}} %_1)
+// CHECK: define {{(dso_local )?}}void @test_CUnionU128({{%CUnionU128\*|ptr}} {{.*}} %_1)
 #[no_mangle]
 pub fn test_CUnionU128(_: CUnionU128) { loop {} }
 
 pub union UnionBool { b:bool }
-// CHECK: define noundef zeroext i1 @test_UnionBool(i8 %b)
+// CHECK: define {{(dso_local )?}}noundef zeroext i1 @test_UnionBool(i8 %b)
 #[no_mangle]
 pub fn test_UnionBool(b: UnionBool) -> bool { unsafe { b.b }  }
 // CHECK: %0 = trunc i8 %b to i1

--- a/tests/codegen/unwind-abis/c-unwind-abi.rs
+++ b/tests/codegen/unwind-abis/c-unwind-abi.rs
@@ -1,4 +1,5 @@
 // compile-flags: -C opt-level=0
+// needs-unwind
 
 // Test that `nounwind` attributes are correctly applied to exported `C` and `C-unwind` extern
 // functions. `C-unwind` functions MUST NOT have this attribute. We disable optimizations above

--- a/tests/codegen/unwind-abis/cdecl-unwind-abi.rs
+++ b/tests/codegen/unwind-abis/cdecl-unwind-abi.rs
@@ -1,4 +1,5 @@
 // compile-flags: -C opt-level=0
+// needs-unwind
 
 // Test that `nounwind` attributes are correctly applied to exported `cdecl` and
 // `cdecl-unwind` extern functions. `cdecl-unwind` functions MUST NOT have this attribute. We

--- a/tests/codegen/unwind-abis/nounwind-on-stable-panic-unwind.rs
+++ b/tests/codegen/unwind-abis/nounwind-on-stable-panic-unwind.rs
@@ -1,5 +1,6 @@
 // compile-flags: -C opt-level=0
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-unwind
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/unwind-abis/system-unwind-abi.rs
+++ b/tests/codegen/unwind-abis/system-unwind-abi.rs
@@ -1,4 +1,5 @@
 // compile-flags: -C opt-level=0
+// needs-unwind
 
 // Test that `nounwind` attributes are correctly applied to exported `system` and `system-unwind`
 // extern functions. `system-unwind` functions MUST NOT have this attribute. We disable

--- a/tests/codegen/unwind-extern-exports.rs
+++ b/tests/codegen/unwind-extern-exports.rs
@@ -1,5 +1,6 @@
 // compile-flags: -C opt-level=0
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-unwind
 
 #![crate_type = "lib"]
 #![feature(c_unwind)]

--- a/tests/codegen/unwind-extern-imports.rs
+++ b/tests/codegen/unwind-extern-imports.rs
@@ -1,5 +1,6 @@
 // compile-flags: -C no-prepopulate-passes
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-unwind
 
 #![crate_type = "lib"]
 #![feature(c_unwind)]

--- a/tests/codegen/vec-shrink-panik.rs
+++ b/tests/codegen/vec-shrink-panik.rs
@@ -5,6 +5,7 @@
 // [new]min-llvm-version: 17
 // compile-flags: -O
 // ignore-debug: the debug assertions get in the way
+// needs-unwind
 #![crate_type = "lib"]
 #![feature(shrink_to)]
 

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
@@ -1,0 +1,40 @@
+fn produces_string() -> Option<String> {
+    Some("my cool string".to_owned())
+}
+
+fn takes_str_but_too_many_refs(_: &&str) -> Option<()> {
+    Some(())
+}
+
+fn no_args() -> Option<()> {
+    Some(())
+}
+
+fn generic_ref<T>(_: &T) -> Option<()> {
+    Some(())
+}
+
+extern "C" fn takes_str_but_wrong_abi(_: &str) -> Option<()> {
+    Some(())
+}
+
+unsafe fn takes_str_but_unsafe(_: &str) -> Option<()> {
+    Some(())
+}
+
+struct TypeWithoutDeref;
+
+fn main() {
+    let _ = produces_string().and_then(takes_str_but_too_many_refs);
+    //~^ ERROR type mismatch in function arguments
+    let _ = produces_string().and_then(takes_str_but_wrong_abi);
+    //~^ ERROR expected a `FnOnce<(String,)>` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+    let _ = produces_string().and_then(takes_str_but_unsafe);
+    //~^ ERROR expected a `FnOnce<(String,)>` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+    let _ = produces_string().and_then(no_args);
+    //~^ ERROR function is expected to take 1 argument, but it takes 0 arguments
+    let _ = produces_string().and_then(generic_ref);
+    //~^ ERROR type mismatch in function arguments
+    let _ = Some(TypeWithoutDeref).and_then(takes_str_but_too_many_refs);
+    //~^ ERROR type mismatch in function arguments
+}

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
@@ -1,0 +1,96 @@
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef-unfixable.rs:28:40
+   |
+LL | fn takes_str_but_too_many_refs(_: &&str) -> Option<()> {
+   | ------------------------------------------------------ found signature defined here
+...
+LL |     let _ = produces_string().and_then(takes_str_but_too_many_refs);
+   |                               -------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected due to this
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a, 'b> fn(&'a &'b str) -> _`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error[E0277]: expected a `FnOnce<(String,)>` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+  --> $DIR/suggest-option-asderef-unfixable.rs:30:40
+   |
+LL |     let _ = produces_string().and_then(takes_str_but_wrong_abi);
+   |                               -------- ^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce<(String,)>` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error[E0277]: expected a `FnOnce<(String,)>` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+  --> $DIR/suggest-option-asderef-unfixable.rs:32:40
+   |
+LL |     let _ = produces_string().and_then(takes_str_but_unsafe);
+   |                               -------- ^^^^^^^^^^^^^^^^^^^^ call the function in a closure: `|| unsafe { /* code */ }`
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+   = note: unsafe function cannot be called generically without an unsafe block
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error[E0593]: function is expected to take 1 argument, but it takes 0 arguments
+  --> $DIR/suggest-option-asderef-unfixable.rs:34:40
+   |
+LL | fn no_args() -> Option<()> {
+   | -------------------------- takes 0 arguments
+...
+LL |     let _ = produces_string().and_then(no_args);
+   |                               -------- ^^^^^^^ expected function that takes 1 argument
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef-unfixable.rs:36:40
+   |
+LL | fn generic_ref<T>(_: &T) -> Option<()> {
+   | -------------------------------------- found signature defined here
+...
+LL |     let _ = produces_string().and_then(generic_ref);
+   |                               -------- ^^^^^^^^^^^ expected due to this
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a> fn(&'a _) -> _`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+help: do not borrow the argument
+   |
+LL - fn generic_ref<T>(_: &T) -> Option<()> {
+LL + fn generic_ref<T>(_: T) -> Option<()> {
+   |
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef-unfixable.rs:38:45
+   |
+LL | fn takes_str_but_too_many_refs(_: &&str) -> Option<()> {
+   | ------------------------------------------------------ found signature defined here
+...
+LL |     let _ = Some(TypeWithoutDeref).and_then(takes_str_but_too_many_refs);
+   |                                    -------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected due to this
+   |                                    |
+   |                                    required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(TypeWithoutDeref) -> _`
+              found function signature `for<'a, 'b> fn(&'a &'b str) -> _`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0593, E0631.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/mismatched_types/suggest-option-asderef.fixed
+++ b/tests/ui/mismatched_types/suggest-option-asderef.fixed
@@ -1,0 +1,30 @@
+// run-rustfix
+
+fn produces_string() -> Option<String> {
+    Some("my cool string".to_owned())
+}
+
+fn takes_str(_: &str) -> Option<()> {
+    Some(())
+}
+
+fn takes_str_mut(_: &mut str) -> Option<()> {
+    Some(())
+}
+
+fn generic<T>(_: T) -> Option<()> {
+    Some(())
+}
+
+fn main() {
+    let _: Option<()> = produces_string().as_deref().and_then(takes_str);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref()` first
+    let _: Option<Option<()>> = produces_string().as_deref().map(takes_str);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref()` first
+    let _: Option<Option<()>> = produces_string().as_deref_mut().map(takes_str_mut);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref_mut()` first
+    let _ = produces_string().and_then(generic);
+}

--- a/tests/ui/mismatched_types/suggest-option-asderef.rs
+++ b/tests/ui/mismatched_types/suggest-option-asderef.rs
@@ -1,0 +1,30 @@
+// run-rustfix
+
+fn produces_string() -> Option<String> {
+    Some("my cool string".to_owned())
+}
+
+fn takes_str(_: &str) -> Option<()> {
+    Some(())
+}
+
+fn takes_str_mut(_: &mut str) -> Option<()> {
+    Some(())
+}
+
+fn generic<T>(_: T) -> Option<()> {
+    Some(())
+}
+
+fn main() {
+    let _: Option<()> = produces_string().and_then(takes_str);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref()` first
+    let _: Option<Option<()>> = produces_string().map(takes_str);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref()` first
+    let _: Option<Option<()>> = produces_string().map(takes_str_mut);
+    //~^ ERROR type mismatch in function arguments
+    //~| HELP call `Option::as_deref_mut()` first
+    let _ = produces_string().and_then(generic);
+}

--- a/tests/ui/mismatched_types/suggest-option-asderef.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef.stderr
@@ -1,0 +1,63 @@
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef.rs:20:52
+   |
+LL | fn takes_str(_: &str) -> Option<()> {
+   | ----------------------------------- found signature defined here
+...
+LL |     let _: Option<()> = produces_string().and_then(takes_str);
+   |                                           -------- ^^^^^^^^^ expected due to this
+   |                                           |
+   |                                           required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a> fn(&'a str) -> _`
+note: required by a bound in `Option::<T>::and_then`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+help: call `Option::as_deref()` first
+   |
+LL |     let _: Option<()> = produces_string().as_deref().and_then(takes_str);
+   |                                          +++++++++++
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef.rs:23:55
+   |
+LL | fn takes_str(_: &str) -> Option<()> {
+   | ----------------------------------- found signature defined here
+...
+LL |     let _: Option<Option<()>> = produces_string().map(takes_str);
+   |                                                   --- ^^^^^^^^^ expected due to this
+   |                                                   |
+   |                                                   required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a> fn(&'a str) -> _`
+note: required by a bound in `Option::<T>::map`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+help: call `Option::as_deref()` first
+   |
+LL |     let _: Option<Option<()>> = produces_string().as_deref().map(takes_str);
+   |                                                  +++++++++++
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/suggest-option-asderef.rs:26:55
+   |
+LL | fn takes_str_mut(_: &mut str) -> Option<()> {
+   | ------------------------------------------- found signature defined here
+...
+LL |     let _: Option<Option<()>> = produces_string().map(takes_str_mut);
+   |                                                   --- ^^^^^^^^^^^^^ expected due to this
+   |                                                   |
+   |                                                   required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(String) -> _`
+              found function signature `for<'a> fn(&'a mut str) -> _`
+note: required by a bound in `Option::<T>::map`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+help: call `Option::as_deref_mut()` first
+   |
+LL |     let _: Option<Option<()>> = produces_string().as_deref_mut().map(takes_str_mut);
+   |                                                  +++++++++++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0631`.

--- a/tests/ui/typeck/return-dyn-type-mismatch-2.rs
+++ b/tests/ui/typeck/return-dyn-type-mismatch-2.rs
@@ -1,0 +1,11 @@
+trait Trait<T> {}
+
+fn foo<T>() -> dyn Trait<T>
+where
+    dyn Trait<T>: Sized, // pesky sized predicate
+{
+    42
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/typeck/return-dyn-type-mismatch-2.stderr
+++ b/tests/ui/typeck/return-dyn-type-mismatch-2.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/return-dyn-type-mismatch-2.rs:7:5
+   |
+LL | fn foo<T>() -> dyn Trait<T>
+   |                ------------ expected `(dyn Trait<T> + 'static)` because of return type
+...
+LL |     42
+   |     ^^ expected `dyn Trait`, found integer
+   |
+   = note: expected trait object `(dyn Trait<T> + 'static)`
+                      found type `{integer}`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/return-dyn-type-mismatch.rs
+++ b/tests/ui/typeck/return-dyn-type-mismatch.rs
@@ -1,0 +1,21 @@
+pub trait TestTrait {
+    type MyType;
+
+    fn func() -> Option<Self>
+    where
+        Self: Sized;
+}
+
+impl<T> dyn TestTrait<MyType = T>
+where
+    Self: Sized, // pesky sized predicate
+{
+    fn other_func() -> dyn TestTrait<MyType = T> {
+        match Self::func() {
+            None => None,
+            //~^ ERROR mismatched types
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/typeck/return-dyn-type-mismatch.stderr
+++ b/tests/ui/typeck/return-dyn-type-mismatch.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/return-dyn-type-mismatch.rs:15:21
+   |
+LL |     fn other_func() -> dyn TestTrait<MyType = T> {
+   |                        ------------------------- expected `(dyn TestTrait<MyType = T> + 'static)` because of return type
+LL |         match Self::func() {
+LL |             None => None,
+   |                     ^^^^ expected `dyn TestTrait`, found `Option<_>`
+   |
+   = note: expected trait object `(dyn TestTrait<MyType = T> + 'static)`
+                      found enum `Option<_>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #111659 (suggest `Option::as_deref(_mut)` on type mismatch in option combinator if it passes typeck)
 - #111702 (Option::map_or_else: Show an example of integrating with Result)
 - #111878 (Fix codegen test suite for bare-metal-like targets)
 - #112215 (only suppress coercion error if type is definitely unsized)
 - #112231 (Make sure the build.rustc version is either the same or 1 apart (revised))

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=111659,111702,111878,112215,112231)
<!-- homu-ignore:end -->