### PR TITLE
Don't compile rustc to self-test compiletest

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -959,21 +959,21 @@ impl Step for UnstableBookGen {
     }
 }
 
-fn symlink_dir_force(config: &Config, src: &Path, dst: &Path) -> io::Result<()> {
+fn symlink_dir_force(config: &Config, original: &Path, link: &Path) -> io::Result<()> {
     if config.dry_run() {
         return Ok(());
     }
-    if let Ok(m) = fs::symlink_metadata(dst) {
+    if let Ok(m) = fs::symlink_metadata(link) {
         if m.file_type().is_dir() {
-            fs::remove_dir_all(dst)?;
+            fs::remove_dir_all(link)?;
         } else {
             // handle directory junctions on windows by falling back to
             // `remove_dir`.
-            fs::remove_file(dst).or_else(|_| fs::remove_dir(dst))?;
+            fs::remove_file(link).or_else(|_| fs::remove_dir(link))?;
         }
     }
 
-    symlink_dir(config, src, dst)
+    symlink_dir(config, original, link)
 }
 
 #[derive(Ord, PartialOrd, Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -693,6 +693,7 @@ impl Step for Rustc {
         // rustc. rustdoc needs to be able to see everything, for example when
         // merging the search index, or generating local (relative) links.
         let out_dir = builder.stage_out(compiler, Mode::Rustc).join(target.triple).join("doc");
+        t!(fs::create_dir_all(out_dir.parent().unwrap()));
         symlink_dir_force(&builder.config, &out, &out_dir);
         // Cargo puts proc macros in `target/doc` even if you pass `--target`
         // explicitly (https://github.com/rust-lang/cargo/issues/7677).

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -700,7 +700,7 @@ impl Step for CompiletestTest {
     /// Runs `cargo test` for compiletest.
     fn run(self, builder: &Builder<'_>) {
         let host = self.host;
-        let compiler = builder.compiler(1, host);
+        let compiler = builder.compiler(builder.top_stage, host);
 
         // We need `ToolStd` for the locally-built sysroot because
         // compiletest uses unstable features of the `test` crate.

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -134,17 +134,17 @@ pub(crate) fn program_out_of_date(stamp: &Path, key: &str) -> bool {
 
 /// Symlinks two directories, using junctions on Windows and normal symlinks on
 /// Unix.
-pub fn symlink_dir(config: &Config, src: &Path, dest: &Path) -> io::Result<()> {
+pub fn symlink_dir(config: &Config, original: &Path, link: &Path) -> io::Result<()> {
     if config.dry_run() {
         return Ok(());
     }
-    let _ = fs::remove_dir(dest);
-    return symlink_dir_inner(src, dest);
+    let _ = fs::remove_dir(link);
+    return symlink_dir_inner(original, link);
 
     #[cfg(not(windows))]
-    fn symlink_dir_inner(src: &Path, dest: &Path) -> io::Result<()> {
+    fn symlink_dir_inner(original: &Path, link: &Path) -> io::Result<()> {
         use std::os::unix::fs;
-        fs::symlink(src, dest)
+        fs::symlink(original, link)
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
This was changed from stage 0 to 1 in https://github.com/rust-lang/rust/pull/108905, but I'm not sure why. Change it to `top_stage` instead to allow people to choose the stage.

This should save quite a bit of time in the `mingw-check` builder, which explicitly runs `x test --stage 0 compiletest`.

Note that this also fixes a latent bug that depended on running `x build compiler` before `x doc compiler`, as well as a couple cleanups related to symlinks (which made the latent bug easier to find).

cc @pietroalbini