### PR TITLE
Remove ExtendElement, ExtendWith, extend_with

### DIFF
--- a/library/alloc/src/vec/spec_from_elem.rs
+++ b/library/alloc/src/vec/spec_from_elem.rs
@@ -3,7 +3,7 @@ use core::ptr;
 use crate::alloc::Allocator;
 use crate::raw_vec::RawVec;
 
-use super::{ExtendElement, IsZero, Vec};
+use super::{IsZero, Vec};
 
 // Specialization trait used for Vec::from_elem
 pub(super) trait SpecFromElem: Sized {
@@ -13,7 +13,7 @@ pub(super) trait SpecFromElem: Sized {
 impl<T: Clone> SpecFromElem for T {
     default fn from_elem<A: Allocator>(elem: Self, n: usize, alloc: A) -> Vec<Self, A> {
         let mut v = Vec::with_capacity_in(n, alloc);
-        v.extend_with(n, ExtendElement(elem));
+        v.extend_with(n, elem);
         v
     }
 }
@@ -25,7 +25,7 @@ impl<T: Clone + IsZero> SpecFromElem for T {
             return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
         }
         let mut v = Vec::with_capacity_in(n, alloc);
-        v.extend_with(n, ExtendElement(elem));
+        v.extend_with(n, elem);
         v
     }
 }


### PR DESCRIPTION
Related to  #104624, broken up into two commits. The first removes wrapper trait ExtendWith and its only implementer struct ExtendElement. The second may have perf issues so may be reverted/removed if no alternate fix is found; it should be profiled.

r? @scottmcm 