### PR TITLE
Show note for type ascription on a local binding interpreted as a constant pattern and not a new variable

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -443,7 +443,12 @@ impl<'p, 'tcx> MatchVisitor<'_, 'p, 'tcx> {
         let mut let_suggestion = None;
         let mut misc_suggestion = None;
         let mut interpreted_as_const = None;
-        if let PatKind::Constant { .. } = pat.kind
+
+        if let PatKind::Constant { .. }
+            | PatKind::AscribeUserType {
+                subpattern: box Pat { kind: PatKind::Constant { .. }, .. },
+                ..
+              } = pat.kind
             && let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(pat.span)
         {
             // If the pattern to match is an integer literal:

--- a/tests/ui/mir/issue-112269.rs
+++ b/tests/ui/mir/issue-112269.rs
@@ -1,0 +1,9 @@
+pub fn main() {
+    const x: i32 = 4;
+    let x: i32 = 3;
+    //~^ ERROR refutable pattern in local binding
+
+    const y: i32 = 3;
+    let y = 4;
+    //~^ ERROR refutable pattern in local binding
+}

--- a/tests/ui/mir/issue-112269.stderr
+++ b/tests/ui/mir/issue-112269.stderr
@@ -1,0 +1,31 @@
+error[E0005]: refutable pattern in local binding
+  --> $DIR/issue-112269.rs:3:9
+   |
+LL |     let x: i32 = 3;
+   |         ^
+   |         |
+   |         patterns `i32::MIN..=3_i32` and `5_i32..=i32::MAX` not covered
+   |         missing patterns are not covered because `x` is interpreted as a constant pattern, not a new variable
+   |         help: introduce a variable instead: `x_var`
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/issue-112269.rs:7:9
+   |
+LL |     let y = 4;
+   |         ^
+   |         |
+   |         patterns `i32::MIN..=2_i32` and `4_i32..=i32::MAX` not covered
+   |         missing patterns are not covered because `y` is interpreted as a constant pattern, not a new variable
+   |         help: introduce a variable instead: `y_var`
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0005`.


### PR DESCRIPTION
Given the code

```rust
pub fn main() {
    const y: i32 = 4;
    let y: i32 = 3;
}
```

`y` in the let binding is actually interpreted as a constant pattern and is not a new variable, causing confusing diagnostics about refutable patterns in local binding.

This PR extends the note for type ascription of a constant pattern to `AscribeUserType` patterns which have `Constant` subpatterns.

Fixes #112269.