### PR TITLE
Ignore the always part of #[inline(always)] in MIR inlining

### DIFF
--- a/src/tools/miri/tests/fail/terminate-terminator.rs
+++ b/src/tools/miri/tests/fail/terminate-terminator.rs
@@ -1,4 +1,4 @@
-//@compile-flags: -Zmir-opt-level=3
+//@compile-flags: -Zmir-opt-level=3 -Zinline-mir-hint-threshold=1000
 // Enable MIR inlining to ensure that `TerminatorKind::Terminate` is generated
 // instead of just `UnwindAction::Terminate`.
 

--- a/tests/mir-opt/inline/asm_unwind.rs
+++ b/tests/mir-opt/inline/asm_unwind.rs
@@ -2,6 +2,7 @@
 //
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // needs-asm-support
+// compile-flags: -Zinline-mir-hint-threshold=1000
 #![feature(asm_unwind)]
 
 struct D;
@@ -10,7 +11,7 @@ impl Drop for D {
     fn drop(&mut self) {}
 }
 
-#[inline(always)]
+#[inline]
 fn foo() {
     let _d = D;
     unsafe { std::arch::asm!("", options(may_unwind)) };

--- a/tests/mir-opt/inline/cycle.rs
+++ b/tests/mir-opt/inline/cycle.rs
@@ -1,4 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+// compile-flags: -Zinline-mir-hint-threshold=1000
 
 // EMIT_MIR cycle.f.Inline.diff
 #[inline(always)]

--- a/tests/mir-opt/inline/inline_diverging.rs
+++ b/tests/mir-opt/inline/inline_diverging.rs
@@ -1,6 +1,7 @@
 // Tests inlining of diverging calls.
 //
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+// compile-flags: -Zinline-mir-hint-threshold=1000
 #![crate_type = "lib"]
 
 // EMIT_MIR inline_diverging.f.Inline.diff

--- a/tests/mir-opt/inline/inline_generator.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_generator.main.Inline.panic-abort.diff
@@ -4,30 +4,30 @@
   fn main() -> () {
       let mut _0: ();
       let _1: std::ops::GeneratorState<i32, bool>;
-      let mut _2: std::pin::Pin<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>;
-      let mut _3: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8];
-      let mut _4: [generator@$DIR/inline_generator.rs:15:5: 15:8];
+      let mut _2: std::pin::Pin<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]>;
+      let mut _3: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8];
+      let mut _4: [generator@$DIR/inline_generator.rs:16:5: 16:8];
 +     let mut _5: bool;
       scope 1 {
           debug _r => _1;
       }
 +     scope 2 (inlined g) {
 +     }
-+     scope 3 (inlined Pin::<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>::new) {
++     scope 3 (inlined Pin::<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]>::new) {
 +         debug pointer => _3;
 +         scope 4 {
-+             scope 5 (inlined Pin::<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>::new_unchecked) {
++             scope 5 (inlined Pin::<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]>::new_unchecked) {
 +                 debug pointer => _3;
 +             }
 +         }
 +     }
 +     scope 6 (inlined g::{closure#0}) {
 +         debug a => _5;
-+         let mut _6: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8];
++         let mut _6: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8];
 +         let mut _7: u32;
 +         let mut _8: i32;
-+         let mut _9: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8];
-+         let mut _10: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8];
++         let mut _9: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8];
++         let mut _10: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8];
 +     }
   
       bb0: {
@@ -39,18 +39,18 @@
 -     }
 - 
 -     bb1: {
-+         _4 = [generator@$DIR/inline_generator.rs:15:5: 15:8 (#0)];
++         _4 = [generator@$DIR/inline_generator.rs:16:5: 16:8 (#0)];
           _3 = &mut _4;
--         _2 = Pin::<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>::new(move _3) -> [return: bb2, unwind unreachable];
+-         _2 = Pin::<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]>::new(move _3) -> [return: bb2, unwind unreachable];
 -     }
 - 
 -     bb2: {
-+         _2 = Pin::<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]> { pointer: move _3 };
++         _2 = Pin::<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]> { pointer: move _3 };
           StorageDead(_3);
--         _1 = <[generator@$DIR/inline_generator.rs:15:5: 15:8] as Generator<bool>>::resume(move _2, const false) -> [return: bb3, unwind unreachable];
+-         _1 = <[generator@$DIR/inline_generator.rs:16:5: 16:8] as Generator<bool>>::resume(move _2, const false) -> [return: bb3, unwind unreachable];
 +         StorageLive(_5);
 +         _5 = const false;
-+         _6 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]);
++         _6 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8]);
 +         _7 = discriminant((*_6));
 +         switchInt(move _7) -> [0: bb2, 1: bb6, 3: bb7, otherwise: bb8];
       }
@@ -82,7 +82,7 @@
 + 
 +     bb5: {
 +         _1 = GeneratorState::<i32, bool>::Yielded(move _8);
-+         _9 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]);
++         _9 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8]);
 +         discriminant((*_9)) = 3;
 +         goto -> bb1;
 +     }
@@ -95,7 +95,7 @@
 +         StorageLive(_8);
 +         StorageDead(_8);
 +         _1 = GeneratorState::<i32, bool>::Complete(_5);
-+         _10 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]);
++         _10 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8]);
 +         discriminant((*_10)) = 1;
 +         goto -> bb1;
 +     }

--- a/tests/mir-opt/inline/inline_generator.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_generator.main.Inline.panic-unwind.diff
@@ -4,30 +4,30 @@
   fn main() -> () {
       let mut _0: ();
       let _1: std::ops::GeneratorState<i32, bool>;
-      let mut _2: std::pin::Pin<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>;
-      let mut _3: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8];
-      let mut _4: [generator@$DIR/inline_generator.rs:15:5: 15:8];
+      let mut _2: std::pin::Pin<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]>;
+      let mut _3: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8];
+      let mut _4: [generator@$DIR/inline_generator.rs:16:5: 16:8];
 +     let mut _5: bool;
       scope 1 {
           debug _r => _1;
       }
 +     scope 2 (inlined g) {
 +     }
-+     scope 3 (inlined Pin::<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>::new) {
++     scope 3 (inlined Pin::<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]>::new) {
 +         debug pointer => _3;
 +         scope 4 {
-+             scope 5 (inlined Pin::<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>::new_unchecked) {
++             scope 5 (inlined Pin::<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]>::new_unchecked) {
 +                 debug pointer => _3;
 +             }
 +         }
 +     }
 +     scope 6 (inlined g::{closure#0}) {
 +         debug a => _5;
-+         let mut _6: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8];
++         let mut _6: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8];
 +         let mut _7: u32;
 +         let mut _8: i32;
-+         let mut _9: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8];
-+         let mut _10: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8];
++         let mut _9: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8];
++         let mut _10: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8];
 +     }
   
       bb0: {
@@ -39,18 +39,18 @@
 -     }
 - 
 -     bb1: {
-+         _4 = [generator@$DIR/inline_generator.rs:15:5: 15:8 (#0)];
++         _4 = [generator@$DIR/inline_generator.rs:16:5: 16:8 (#0)];
           _3 = &mut _4;
--         _2 = Pin::<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]>::new(move _3) -> [return: bb2, unwind: bb4];
+-         _2 = Pin::<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]>::new(move _3) -> [return: bb2, unwind: bb4];
 -     }
 - 
 -     bb2: {
-+         _2 = Pin::<&mut [generator@$DIR/inline_generator.rs:15:5: 15:8]> { pointer: move _3 };
++         _2 = Pin::<&mut [generator@$DIR/inline_generator.rs:16:5: 16:8]> { pointer: move _3 };
           StorageDead(_3);
--         _1 = <[generator@$DIR/inline_generator.rs:15:5: 15:8] as Generator<bool>>::resume(move _2, const false) -> [return: bb3, unwind: bb4];
+-         _1 = <[generator@$DIR/inline_generator.rs:16:5: 16:8] as Generator<bool>>::resume(move _2, const false) -> [return: bb3, unwind: bb4];
 +         StorageLive(_5);
 +         _5 = const false;
-+         _6 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]);
++         _6 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8]);
 +         _7 = discriminant((*_6));
 +         switchInt(move _7) -> [0: bb3, 1: bb7, 3: bb8, otherwise: bb9];
       }
@@ -87,7 +87,7 @@
 + 
 +     bb6: {
 +         _1 = GeneratorState::<i32, bool>::Yielded(move _8);
-+         _9 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]);
++         _9 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8]);
 +         discriminant((*_9)) = 3;
 +         goto -> bb1;
 +     }
@@ -100,7 +100,7 @@
 +         StorageLive(_8);
 +         StorageDead(_8);
 +         _1 = GeneratorState::<i32, bool>::Complete(_5);
-+         _10 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:15:5: 15:8]);
++         _10 = deref_copy (_2.0: &mut [generator@$DIR/inline_generator.rs:16:5: 16:8]);
 +         discriminant((*_10)) = 1;
 +         goto -> bb1;
 +     }

--- a/tests/mir-opt/inline/inline_generator.rs
+++ b/tests/mir-opt/inline/inline_generator.rs
@@ -1,4 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+// compile-flags: -Zinline-mir-hint-threshold=1000
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;
@@ -9,8 +10,8 @@ fn main() {
     let _r = Pin::new(&mut g()).resume(false);
 }
 
-#[inline(always)]
+#[inline]
 pub fn g() -> impl Generator<bool> {
-    #[inline(always)]
+    #[inline]
     |a| { yield if a { 7 } else { 13 } }
 }

--- a/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-abort.diff
@@ -18,6 +18,99 @@
 +         let mut _6: *mut u8;
 +         let mut _7: *const std::vec::Vec<u32>;
 +         scope 4 {
++             scope 5 (inlined alloc::alloc::exchange_malloc) {
++                 debug size => _4;
++                 debug align => _5;
++                 let _8: std::alloc::Layout;
++                 let mut _9: std::result::Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError>;
++                 let mut _10: isize;
++                 let mut _12: !;
++                 scope 6 {
++                     debug layout => _8;
++                     let _11: std::ptr::NonNull<[u8]>;
++                     let mut _13: &std::alloc::Global;
++                     scope 8 {
++                         debug ptr => _11;
++                         scope 18 (inlined NonNull::<[u8]>::as_mut_ptr) {
++                             debug self => _11;
++                             let mut _15: std::ptr::NonNull<u8>;
++                             scope 19 (inlined NonNull::<[u8]>::as_non_null_ptr) {
++                                 debug self => _11;
++                                 let mut _16: *mut u8;
++                                 let mut _17: *mut [u8];
++                                 scope 20 {
++                                     scope 21 (inlined NonNull::<[u8]>::as_ptr) {
++                                         debug self => _11;
++                                         let mut _18: *const [u8];
++                                     }
++                                     scope 22 (inlined ptr::mut_ptr::<impl *mut [u8]>::as_mut_ptr) {
++                                         debug self => _17;
++                                     }
++                                     scope 23 (inlined NonNull::<u8>::new_unchecked) {
++                                         debug ptr => _16;
++                                         let mut _19: *const u8;
++                                         scope 24 {
++                                             scope 25 (inlined NonNull::<T>::new_unchecked::runtime::<u8>) {
++                                                 debug ptr => _16;
++                                                 scope 26 (inlined ptr::mut_ptr::<impl *mut u8>::is_null) {
++                                                     debug self => _16;
++                                                     let mut _20: *mut u8;
++                                                     scope 27 {
++                                                         scope 28 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
++                                                             debug ptr => _20;
++                                                             scope 29 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
++                                                                 debug self => _20;
++                                                                 scope 30 {
++                                                                     scope 31 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
++                                                                         debug self => _20;
++                                                                     }
++                                                                 }
++                                                             }
++                                                         }
++                                                     }
++                                                 }
++                                             }
++                                         }
++                                     }
++                                 }
++                             }
++                             scope 32 (inlined NonNull::<u8>::as_ptr) {
++                                 debug self => _15;
++                                 let mut _21: *const u8;
++                             }
++                         }
++                     }
++                     scope 17 (inlined <std::alloc::Global as Allocator>::allocate) {
++                         debug self => const _;
++                         debug layout => _8;
++                     }
++                 }
++                 scope 7 {
++                     scope 9 (inlined Layout::from_size_align_unchecked) {
++                         debug size => _4;
++                         debug align => _5;
++                         let mut _14: std::ptr::Alignment;
++                         scope 10 {
++                             scope 11 (inlined std::ptr::Alignment::new_unchecked) {
++                                 debug align => _5;
++                                 scope 12 {
++                                     scope 14 (inlined std::ptr::Alignment::new_unchecked::runtime) {
++                                         debug align => _5;
++                                         scope 15 (inlined core::num::<impl usize>::is_power_of_two) {
++                                             debug self => _5;
++                                             scope 16 (inlined core::num::<impl usize>::count_ones) {
++                                                 debug self => _5;
++                                             }
++                                         }
++                                     }
++                                 }
++                                 scope 13 {
++                                 }
++                             }
++                         }
++                     }
++                 }
++             }
 +         }
 +     }
   
@@ -31,7 +124,17 @@
 +         StorageDead(_3);
 +         _4 = SizeOf(std::vec::Vec<u32>);
 +         _5 = AlignOf(std::vec::Vec<u32>);
-+         _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> [return: bb2, unwind unreachable];
++         StorageLive(_8);
++         StorageLive(_11);
++         StorageLive(_12);
++         StorageLive(_13);
++         StorageLive(_14);
++         _14 = _5 as std::ptr::Alignment (Transmute);
++         _8 = Layout { size: _4, align: move _14 };
++         StorageDead(_14);
++         StorageLive(_9);
++         _13 = const _;
++         _9 = std::alloc::Global::alloc_impl(_13, _8, const false) -> [return: bb5, unwind unreachable];
       }
   
       bb1: {
@@ -41,18 +144,56 @@
       }
   
       bb2: {
++         _12 = handle_alloc_error(_8) -> unwind unreachable;
++     }
++ 
++     bb3: {
++         unreachable;
++     }
++ 
++     bb4: {
++         _11 = ((_9 as Ok).0: std::ptr::NonNull<[u8]>);
++         StorageLive(_15);
++         StorageLive(_16);
++         StorageLive(_17);
++         StorageLive(_18);
++         _18 = (_11.0: *const [u8]);
++         _17 = move _18 as *mut [u8] (PtrToPtr);
++         StorageDead(_18);
++         _16 = _17 as *mut u8 (PtrToPtr);
++         StorageDead(_17);
++         StorageLive(_19);
++         StorageLive(_20);
++         _19 = _16 as *const u8 (Pointer(MutToConstPointer));
++         _15 = NonNull::<u8> { pointer: _19 };
++         StorageDead(_20);
++         StorageDead(_19);
++         StorageDead(_16);
++         StorageLive(_21);
++         _21 = (_15.0: *const u8);
++         _6 = move _21 as *mut u8 (PtrToPtr);
++         StorageDead(_21);
++         StorageDead(_15);
++         StorageDead(_9);
++         StorageDead(_13);
++         StorageDead(_12);
++         StorageDead(_11);
++         StorageDead(_8);
 +         _1 = ShallowInitBox(move _6, std::vec::Vec<u32>);
 +         _7 = (((_1.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>);
 +         (*_7) = move _2;
           StorageDead(_2);
           _0 = const ();
 -         drop(_1) -> [return: bb3, unwind unreachable];
--     }
-- 
++         drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
 -     bb3: {
 -         StorageDead(_1);
 -         return;
-+         drop(_1) -> [return: bb1, unwind unreachable];
++     bb5: {
++         _10 = discriminant(_9);
++         switchInt(move _10) -> [0: bb4, 1: bb2, otherwise: bb3];
       }
   }
   

--- a/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
@@ -18,6 +18,99 @@
 +         let mut _6: *mut u8;
 +         let mut _7: *const std::vec::Vec<u32>;
 +         scope 4 {
++             scope 5 (inlined alloc::alloc::exchange_malloc) {
++                 debug size => _4;
++                 debug align => _5;
++                 let _8: std::alloc::Layout;
++                 let mut _9: std::result::Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError>;
++                 let mut _10: isize;
++                 let mut _12: !;
++                 scope 6 {
++                     debug layout => _8;
++                     let _11: std::ptr::NonNull<[u8]>;
++                     let mut _13: &std::alloc::Global;
++                     scope 8 {
++                         debug ptr => _11;
++                         scope 18 (inlined NonNull::<[u8]>::as_mut_ptr) {
++                             debug self => _11;
++                             let mut _15: std::ptr::NonNull<u8>;
++                             scope 19 (inlined NonNull::<[u8]>::as_non_null_ptr) {
++                                 debug self => _11;
++                                 let mut _16: *mut u8;
++                                 let mut _17: *mut [u8];
++                                 scope 20 {
++                                     scope 21 (inlined NonNull::<[u8]>::as_ptr) {
++                                         debug self => _11;
++                                         let mut _18: *const [u8];
++                                     }
++                                     scope 22 (inlined ptr::mut_ptr::<impl *mut [u8]>::as_mut_ptr) {
++                                         debug self => _17;
++                                     }
++                                     scope 23 (inlined NonNull::<u8>::new_unchecked) {
++                                         debug ptr => _16;
++                                         let mut _19: *const u8;
++                                         scope 24 {
++                                             scope 25 (inlined NonNull::<T>::new_unchecked::runtime::<u8>) {
++                                                 debug ptr => _16;
++                                                 scope 26 (inlined ptr::mut_ptr::<impl *mut u8>::is_null) {
++                                                     debug self => _16;
++                                                     let mut _20: *mut u8;
++                                                     scope 27 {
++                                                         scope 28 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
++                                                             debug ptr => _20;
++                                                             scope 29 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
++                                                                 debug self => _20;
++                                                                 scope 30 {
++                                                                     scope 31 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
++                                                                         debug self => _20;
++                                                                     }
++                                                                 }
++                                                             }
++                                                         }
++                                                     }
++                                                 }
++                                             }
++                                         }
++                                     }
++                                 }
++                             }
++                             scope 32 (inlined NonNull::<u8>::as_ptr) {
++                                 debug self => _15;
++                                 let mut _21: *const u8;
++                             }
++                         }
++                     }
++                     scope 17 (inlined <std::alloc::Global as Allocator>::allocate) {
++                         debug self => const _;
++                         debug layout => _8;
++                     }
++                 }
++                 scope 7 {
++                     scope 9 (inlined Layout::from_size_align_unchecked) {
++                         debug size => _4;
++                         debug align => _5;
++                         let mut _14: std::ptr::Alignment;
++                         scope 10 {
++                             scope 11 (inlined std::ptr::Alignment::new_unchecked) {
++                                 debug align => _5;
++                                 scope 12 {
++                                     scope 14 (inlined std::ptr::Alignment::new_unchecked::runtime) {
++                                         debug align => _5;
++                                         scope 15 (inlined core::num::<impl usize>::is_power_of_two) {
++                                             debug self => _5;
++                                             scope 16 (inlined core::num::<impl usize>::count_ones) {
++                                                 debug self => _5;
++                                             }
++                                         }
++                                     }
++                                 }
++                                 scope 13 {
++                                 }
++                             }
++                         }
++                     }
++                 }
++             }
 +         }
 +     }
   
@@ -31,7 +124,17 @@
 +         StorageDead(_3);
 +         _4 = SizeOf(std::vec::Vec<u32>);
 +         _5 = AlignOf(std::vec::Vec<u32>);
-+         _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> [return: bb3, unwind: bb4];
++         StorageLive(_8);
++         StorageLive(_11);
++         StorageLive(_12);
++         StorageLive(_13);
++         StorageLive(_14);
++         _14 = _5 as std::ptr::Alignment (Transmute);
++         _8 = Layout { size: _4, align: move _14 };
++         StorageDead(_14);
++         StorageLive(_9);
++         _13 = const _;
++         _9 = std::alloc::Global::alloc_impl(_13, _8, const false) -> [return: bb7, unwind: bb3];
       }
   
       bb1: {
@@ -48,20 +151,62 @@
 +         resume;
       }
   
-      bb3: {
+-     bb3: {
 -         StorageDead(_1);
 -         return;
++     bb3 (cleanup): {
++         drop(_2) -> [return: bb2, unwind terminate];
+      }
+  
+-     bb4 (cleanup): {
+-         resume;
++     bb4: {
++         _12 = handle_alloc_error(_8) -> bb3;
++     }
++ 
++     bb5: {
++         unreachable;
++     }
++ 
++     bb6: {
++         _11 = ((_9 as Ok).0: std::ptr::NonNull<[u8]>);
++         StorageLive(_15);
++         StorageLive(_16);
++         StorageLive(_17);
++         StorageLive(_18);
++         _18 = (_11.0: *const [u8]);
++         _17 = move _18 as *mut [u8] (PtrToPtr);
++         StorageDead(_18);
++         _16 = _17 as *mut u8 (PtrToPtr);
++         StorageDead(_17);
++         StorageLive(_19);
++         StorageLive(_20);
++         _19 = _16 as *const u8 (Pointer(MutToConstPointer));
++         _15 = NonNull::<u8> { pointer: _19 };
++         StorageDead(_20);
++         StorageDead(_19);
++         StorageDead(_16);
++         StorageLive(_21);
++         _21 = (_15.0: *const u8);
++         _6 = move _21 as *mut u8 (PtrToPtr);
++         StorageDead(_21);
++         StorageDead(_15);
++         StorageDead(_9);
++         StorageDead(_13);
++         StorageDead(_12);
++         StorageDead(_11);
++         StorageDead(_8);
 +         _1 = ShallowInitBox(move _6, std::vec::Vec<u32>);
 +         _7 = (((_1.0: std::ptr::Unique<std::vec::Vec<u32>>).0: std::ptr::NonNull<std::vec::Vec<u32>>).0: *const std::vec::Vec<u32>);
 +         (*_7) = move _2;
 +         StorageDead(_2);
 +         _0 = const ();
 +         drop(_1) -> [return: bb1, unwind: bb2];
-      }
-  
-      bb4 (cleanup): {
--         resume;
-+         drop(_2) -> [return: bb2, unwind terminate];
++     }
++ 
++     bb7: {
++         _10 = discriminant(_9);
++         switchInt(move _10) -> [0: bb6, 1: bb4, otherwise: bb5];
       }
   }
   

--- a/tests/mir-opt/inline/inline_into_box_place.rs
+++ b/tests/mir-opt/inline/inline_into_box_place.rs
@@ -1,7 +1,7 @@
 // ignore-endian-big
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // ignore-debug MIR alignment checks in std alter the diff, breaking the test
-// compile-flags: -Z mir-opt-level=4
+// compile-flags: -Zmir-opt-level=4 -Zinline-mir-hint-threshold=200
 
 // EMIT_MIR inline_into_box_place.main.Inline.diff
 fn main() {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
@@ -7,129 +7,19 @@
       let mut _0: u16;
       let mut _3: u16;
       let mut _4: u32;
-+     scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
-+         debug self => _3;
-+         debug rhs => _4;
-+         let mut _5: u16;
-+         scope 2 {
-+             scope 3 (inlined core::num::<impl u16>::unchecked_shl::conv) {
-+                 debug x => _4;
-+                 let mut _6: std::option::Option<u16>;
-+                 let mut _7: std::result::Result<u16, std::num::TryFromIntError>;
-+                 scope 4 {
-+                     scope 5 (inlined <u32 as TryInto<u16>>::try_into) {
-+                         debug self => _4;
-+                         scope 6 (inlined convert::num::<impl TryFrom<u32> for u16>::try_from) {
-+                             debug u => _4;
-+                             let mut _8: bool;
-+                             let mut _9: u32;
-+                             let mut _10: u16;
-+                         }
-+                     }
-+                     scope 7 (inlined Result::<u16, TryFromIntError>::ok) {
-+                         debug self => _7;
-+                         let mut _11: isize;
-+                         let _12: u16;
-+                         scope 8 {
-+                             debug x => _12;
-+                         }
-+                     }
-+                     scope 9 (inlined #[track_caller] Option::<u16>::unwrap_unchecked) {
-+                         debug self => _6;
-+                         let mut _13: &std::option::Option<u16>;
-+                         let mut _14: isize;
-+                         scope 10 {
-+                             debug val => _5;
-+                         }
-+                         scope 11 {
-+                             scope 13 (inlined unreachable_unchecked) {
-+                                 scope 14 {
-+                                     scope 15 (inlined unreachable_unchecked::runtime) {
-+                                     }
-+                                 }
-+                             }
-+                         }
-+                         scope 12 (inlined Option::<u16>::is_some) {
-+                             debug self => _13;
-+                         }
-+                     }
-+                 }
-+             }
-+         }
-+     }
   
       bb0: {
           StorageLive(_3);
           _3 = _1;
           StorageLive(_4);
           _4 = _2;
--         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind unreachable];
-+         StorageLive(_5);
-+         StorageLive(_6);
-+         StorageLive(_7);
-+         StorageLive(_8);
-+         StorageLive(_9);
-+         _9 = const 65535_u32;
-+         _8 = Gt(_4, move _9);
-+         StorageDead(_9);
-+         switchInt(move _8) -> [0: bb3, otherwise: bb2];
+          _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
-+         StorageDead(_5);
           StorageDead(_4);
           StorageDead(_3);
           return;
-+     }
-+ 
-+     bb2: {
-+         _7 = Result::<u16, TryFromIntError>::Err(const TryFromIntError(()));
-+         goto -> bb4;
-+     }
-+ 
-+     bb3: {
-+         StorageLive(_10);
-+         _10 = _4 as u16 (IntToInt);
-+         _7 = Result::<u16, TryFromIntError>::Ok(move _10);
-+         StorageDead(_10);
-+         goto -> bb4;
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_8);
-+         StorageLive(_12);
-+         _11 = discriminant(_7);
-+         switchInt(move _11) -> [0: bb7, 1: bb5, otherwise: bb6];
-+     }
-+ 
-+     bb5: {
-+         _6 = Option::<u16>::None;
-+         goto -> bb8;
-+     }
-+ 
-+     bb6: {
-+         unreachable;
-+     }
-+ 
-+     bb7: {
-+         _12 = move ((_7 as Ok).0: u16);
-+         _6 = Option::<u16>::Some(move _12);
-+         goto -> bb8;
-+     }
-+ 
-+     bb8: {
-+         StorageDead(_12);
-+         StorageDead(_7);
-+         StorageLive(_13);
-+         _14 = discriminant(_6);
-+         switchInt(move _14) -> [1: bb9, otherwise: bb6];
-+     }
-+ 
-+     bb9: {
-+         _5 = move ((_6 as Some).0: u16);
-+         StorageDead(_13);
-+         StorageDead(_6);
-+         _0 = unchecked_shl::<u16>(_3, move _5) -> [return: bb1, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
@@ -7,129 +7,19 @@
       let mut _0: u16;
       let mut _3: u16;
       let mut _4: u32;
-+     scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
-+         debug self => _3;
-+         debug rhs => _4;
-+         let mut _5: u16;
-+         scope 2 {
-+             scope 3 (inlined core::num::<impl u16>::unchecked_shl::conv) {
-+                 debug x => _4;
-+                 let mut _6: std::option::Option<u16>;
-+                 let mut _7: std::result::Result<u16, std::num::TryFromIntError>;
-+                 scope 4 {
-+                     scope 5 (inlined <u32 as TryInto<u16>>::try_into) {
-+                         debug self => _4;
-+                         scope 6 (inlined convert::num::<impl TryFrom<u32> for u16>::try_from) {
-+                             debug u => _4;
-+                             let mut _8: bool;
-+                             let mut _9: u32;
-+                             let mut _10: u16;
-+                         }
-+                     }
-+                     scope 7 (inlined Result::<u16, TryFromIntError>::ok) {
-+                         debug self => _7;
-+                         let mut _11: isize;
-+                         let _12: u16;
-+                         scope 8 {
-+                             debug x => _12;
-+                         }
-+                     }
-+                     scope 9 (inlined #[track_caller] Option::<u16>::unwrap_unchecked) {
-+                         debug self => _6;
-+                         let mut _13: &std::option::Option<u16>;
-+                         let mut _14: isize;
-+                         scope 10 {
-+                             debug val => _5;
-+                         }
-+                         scope 11 {
-+                             scope 13 (inlined unreachable_unchecked) {
-+                                 scope 14 {
-+                                     scope 15 (inlined unreachable_unchecked::runtime) {
-+                                     }
-+                                 }
-+                             }
-+                         }
-+                         scope 12 (inlined Option::<u16>::is_some) {
-+                             debug self => _13;
-+                         }
-+                     }
-+                 }
-+             }
-+         }
-+     }
   
       bb0: {
           StorageLive(_3);
           _3 = _1;
           StorageLive(_4);
           _4 = _2;
--         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> bb1;
-+         StorageLive(_5);
-+         StorageLive(_6);
-+         StorageLive(_7);
-+         StorageLive(_8);
-+         StorageLive(_9);
-+         _9 = const 65535_u32;
-+         _8 = Gt(_4, move _9);
-+         StorageDead(_9);
-+         switchInt(move _8) -> [0: bb3, otherwise: bb2];
+          _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> bb1;
       }
   
       bb1: {
-+         StorageDead(_5);
           StorageDead(_4);
           StorageDead(_3);
           return;
-+     }
-+ 
-+     bb2: {
-+         _7 = Result::<u16, TryFromIntError>::Err(const TryFromIntError(()));
-+         goto -> bb4;
-+     }
-+ 
-+     bb3: {
-+         StorageLive(_10);
-+         _10 = _4 as u16 (IntToInt);
-+         _7 = Result::<u16, TryFromIntError>::Ok(move _10);
-+         StorageDead(_10);
-+         goto -> bb4;
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_8);
-+         StorageLive(_12);
-+         _11 = discriminant(_7);
-+         switchInt(move _11) -> [0: bb7, 1: bb5, otherwise: bb6];
-+     }
-+ 
-+     bb5: {
-+         _6 = Option::<u16>::None;
-+         goto -> bb8;
-+     }
-+ 
-+     bb6: {
-+         unreachable;
-+     }
-+ 
-+     bb7: {
-+         _12 = move ((_7 as Ok).0: u16);
-+         _6 = Option::<u16>::Some(move _12);
-+         goto -> bb8;
-+     }
-+ 
-+     bb8: {
-+         StorageDead(_12);
-+         StorageDead(_7);
-+         StorageLive(_13);
-+         _14 = discriminant(_6);
-+         switchInt(move _14) -> [1: bb9, otherwise: bb6];
-+     }
-+ 
-+     bb9: {
-+         _5 = move ((_6 as Some).0: u16);
-+         StorageDead(_13);
-+         StorageDead(_6);
-+         _0 = unchecked_shl::<u16>(_3, move _5) -> [return: bb1, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-abort.mir
@@ -4,121 +4,12 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
     debug a => _1;
     debug b => _2;
     let mut _0: u16;
-    scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
-        debug self => _1;
-        debug rhs => _2;
-        let mut _11: u16;
-        scope 2 {
-            scope 3 (inlined core::num::<impl u16>::unchecked_shl::conv) {
-                debug x => _2;
-                let mut _6: std::result::Result<u16, std::num::TryFromIntError>;
-                let mut _9: std::option::Option<u16>;
-                scope 4 {
-                    scope 5 (inlined <u32 as TryInto<u16>>::try_into) {
-                        debug self => _2;
-                        scope 6 (inlined convert::num::<impl TryFrom<u32> for u16>::try_from) {
-                            debug u => _2;
-                            let mut _3: u32;
-                            let mut _4: bool;
-                            let mut _5: u16;
-                        }
-                    }
-                    scope 7 (inlined Result::<u16, TryFromIntError>::ok) {
-                        debug self => _6;
-                        let mut _7: isize;
-                        let _8: u16;
-                        scope 8 {
-                            debug x => _8;
-                        }
-                    }
-                    scope 9 (inlined #[track_caller] Option::<u16>::unwrap_unchecked) {
-                        debug self => _9;
-                        let mut _10: isize;
-                        let mut _12: &std::option::Option<u16>;
-                        scope 10 {
-                            debug val => _11;
-                        }
-                        scope 11 {
-                            scope 13 (inlined unreachable_unchecked) {
-                                scope 14 {
-                                    scope 15 (inlined unreachable_unchecked::runtime) {
-                                    }
-                                }
-                            }
-                        }
-                        scope 12 (inlined Option::<u16>::is_some) {
-                            debug self => _12;
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     bb0: {
-        StorageLive(_11);
-        StorageLive(_9);
-        StorageLive(_6);
-        StorageLive(_4);
-        StorageLive(_3);
-        _3 = const 65535_u32;
-        _4 = Gt(_2, move _3);
-        StorageDead(_3);
-        switchInt(move _4) -> [0: bb1, otherwise: bb2];
+        _0 = core::num::<impl u16>::unchecked_shl(_1, _2) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        StorageLive(_5);
-        _5 = _2 as u16 (IntToInt);
-        _6 = Result::<u16, TryFromIntError>::Ok(move _5);
-        StorageDead(_5);
-        goto -> bb3;
-    }
-
-    bb2: {
-        _6 = Result::<u16, TryFromIntError>::Err(const TryFromIntError(()));
-        goto -> bb3;
-    }
-
-    bb3: {
-        StorageDead(_4);
-        StorageLive(_8);
-        _7 = discriminant(_6);
-        switchInt(move _7) -> [0: bb4, 1: bb5, otherwise: bb9];
-    }
-
-    bb4: {
-        _8 = move ((_6 as Ok).0: u16);
-        _9 = Option::<u16>::Some(move _8);
-        goto -> bb6;
-    }
-
-    bb5: {
-        _9 = Option::<u16>::None;
-        goto -> bb6;
-    }
-
-    bb6: {
-        StorageDead(_8);
-        StorageDead(_6);
-        StorageLive(_12);
-        _10 = discriminant(_9);
-        switchInt(move _10) -> [1: bb7, otherwise: bb9];
-    }
-
-    bb7: {
-        _11 = move ((_9 as Some).0: u16);
-        StorageDead(_12);
-        StorageDead(_9);
-        _0 = unchecked_shl::<u16>(_1, move _11) -> [return: bb8, unwind unreachable];
-    }
-
-    bb8: {
-        StorageDead(_11);
         return;
-    }
-
-    bb9: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-unwind.mir
@@ -4,121 +4,12 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
     debug a => _1;
     debug b => _2;
     let mut _0: u16;
-    scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
-        debug self => _1;
-        debug rhs => _2;
-        let mut _11: u16;
-        scope 2 {
-            scope 3 (inlined core::num::<impl u16>::unchecked_shl::conv) {
-                debug x => _2;
-                let mut _6: std::result::Result<u16, std::num::TryFromIntError>;
-                let mut _9: std::option::Option<u16>;
-                scope 4 {
-                    scope 5 (inlined <u32 as TryInto<u16>>::try_into) {
-                        debug self => _2;
-                        scope 6 (inlined convert::num::<impl TryFrom<u32> for u16>::try_from) {
-                            debug u => _2;
-                            let mut _3: u32;
-                            let mut _4: bool;
-                            let mut _5: u16;
-                        }
-                    }
-                    scope 7 (inlined Result::<u16, TryFromIntError>::ok) {
-                        debug self => _6;
-                        let mut _7: isize;
-                        let _8: u16;
-                        scope 8 {
-                            debug x => _8;
-                        }
-                    }
-                    scope 9 (inlined #[track_caller] Option::<u16>::unwrap_unchecked) {
-                        debug self => _9;
-                        let mut _10: isize;
-                        let mut _12: &std::option::Option<u16>;
-                        scope 10 {
-                            debug val => _11;
-                        }
-                        scope 11 {
-                            scope 13 (inlined unreachable_unchecked) {
-                                scope 14 {
-                                    scope 15 (inlined unreachable_unchecked::runtime) {
-                                    }
-                                }
-                            }
-                        }
-                        scope 12 (inlined Option::<u16>::is_some) {
-                            debug self => _12;
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     bb0: {
-        StorageLive(_11);
-        StorageLive(_9);
-        StorageLive(_6);
-        StorageLive(_4);
-        StorageLive(_3);
-        _3 = const 65535_u32;
-        _4 = Gt(_2, move _3);
-        StorageDead(_3);
-        switchInt(move _4) -> [0: bb1, otherwise: bb2];
+        _0 = core::num::<impl u16>::unchecked_shl(_1, _2) -> bb1;
     }
 
     bb1: {
-        StorageLive(_5);
-        _5 = _2 as u16 (IntToInt);
-        _6 = Result::<u16, TryFromIntError>::Ok(move _5);
-        StorageDead(_5);
-        goto -> bb3;
-    }
-
-    bb2: {
-        _6 = Result::<u16, TryFromIntError>::Err(const TryFromIntError(()));
-        goto -> bb3;
-    }
-
-    bb3: {
-        StorageDead(_4);
-        StorageLive(_8);
-        _7 = discriminant(_6);
-        switchInt(move _7) -> [0: bb4, 1: bb5, otherwise: bb9];
-    }
-
-    bb4: {
-        _8 = move ((_6 as Ok).0: u16);
-        _9 = Option::<u16>::Some(move _8);
-        goto -> bb6;
-    }
-
-    bb5: {
-        _9 = Option::<u16>::None;
-        goto -> bb6;
-    }
-
-    bb6: {
-        StorageDead(_8);
-        StorageDead(_6);
-        StorageLive(_12);
-        _10 = discriminant(_9);
-        switchInt(move _10) -> [1: bb7, otherwise: bb9];
-    }
-
-    bb7: {
-        _11 = move ((_9 as Some).0: u16);
-        StorageDead(_12);
-        StorageDead(_9);
-        _0 = unchecked_shl::<u16>(_1, move _11) -> [return: bb8, unwind unreachable];
-    }
-
-    bb8: {
-        StorageDead(_11);
         return;
-    }
-
-    bb9: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-abort.diff
@@ -7,129 +7,19 @@
       let mut _0: i16;
       let mut _3: i16;
       let mut _4: u32;
-+     scope 1 (inlined core::num::<impl i16>::unchecked_shr) {
-+         debug self => _3;
-+         debug rhs => _4;
-+         let mut _5: i16;
-+         scope 2 {
-+             scope 3 (inlined core::num::<impl i16>::unchecked_shr::conv) {
-+                 debug x => _4;
-+                 let mut _6: std::option::Option<i16>;
-+                 let mut _7: std::result::Result<i16, std::num::TryFromIntError>;
-+                 scope 4 {
-+                     scope 5 (inlined <u32 as TryInto<i16>>::try_into) {
-+                         debug self => _4;
-+                         scope 6 (inlined convert::num::<impl TryFrom<u32> for i16>::try_from) {
-+                             debug u => _4;
-+                             let mut _8: bool;
-+                             let mut _9: u32;
-+                             let mut _10: i16;
-+                         }
-+                     }
-+                     scope 7 (inlined Result::<i16, TryFromIntError>::ok) {
-+                         debug self => _7;
-+                         let mut _11: isize;
-+                         let _12: i16;
-+                         scope 8 {
-+                             debug x => _12;
-+                         }
-+                     }
-+                     scope 9 (inlined #[track_caller] Option::<i16>::unwrap_unchecked) {
-+                         debug self => _6;
-+                         let mut _13: &std::option::Option<i16>;
-+                         let mut _14: isize;
-+                         scope 10 {
-+                             debug val => _5;
-+                         }
-+                         scope 11 {
-+                             scope 13 (inlined unreachable_unchecked) {
-+                                 scope 14 {
-+                                     scope 15 (inlined unreachable_unchecked::runtime) {
-+                                     }
-+                                 }
-+                             }
-+                         }
-+                         scope 12 (inlined Option::<i16>::is_some) {
-+                             debug self => _13;
-+                         }
-+                     }
-+                 }
-+             }
-+         }
-+     }
   
       bb0: {
           StorageLive(_3);
           _3 = _1;
           StorageLive(_4);
           _4 = _2;
--         _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind unreachable];
-+         StorageLive(_5);
-+         StorageLive(_6);
-+         StorageLive(_7);
-+         StorageLive(_8);
-+         StorageLive(_9);
-+         _9 = const 32767_u32;
-+         _8 = Gt(_4, move _9);
-+         StorageDead(_9);
-+         switchInt(move _8) -> [0: bb3, otherwise: bb2];
+          _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
-+         StorageDead(_5);
           StorageDead(_4);
           StorageDead(_3);
           return;
-+     }
-+ 
-+     bb2: {
-+         _7 = Result::<i16, TryFromIntError>::Err(const TryFromIntError(()));
-+         goto -> bb4;
-+     }
-+ 
-+     bb3: {
-+         StorageLive(_10);
-+         _10 = _4 as i16 (IntToInt);
-+         _7 = Result::<i16, TryFromIntError>::Ok(move _10);
-+         StorageDead(_10);
-+         goto -> bb4;
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_8);
-+         StorageLive(_12);
-+         _11 = discriminant(_7);
-+         switchInt(move _11) -> [0: bb7, 1: bb5, otherwise: bb6];
-+     }
-+ 
-+     bb5: {
-+         _6 = Option::<i16>::None;
-+         goto -> bb8;
-+     }
-+ 
-+     bb6: {
-+         unreachable;
-+     }
-+ 
-+     bb7: {
-+         _12 = move ((_7 as Ok).0: i16);
-+         _6 = Option::<i16>::Some(move _12);
-+         goto -> bb8;
-+     }
-+ 
-+     bb8: {
-+         StorageDead(_12);
-+         StorageDead(_7);
-+         StorageLive(_13);
-+         _14 = discriminant(_6);
-+         switchInt(move _14) -> [1: bb9, otherwise: bb6];
-+     }
-+ 
-+     bb9: {
-+         _5 = move ((_6 as Some).0: i16);
-+         StorageDead(_13);
-+         StorageDead(_6);
-+         _0 = unchecked_shr::<i16>(_3, move _5) -> [return: bb1, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-unwind.diff
@@ -7,129 +7,19 @@
       let mut _0: i16;
       let mut _3: i16;
       let mut _4: u32;
-+     scope 1 (inlined core::num::<impl i16>::unchecked_shr) {
-+         debug self => _3;
-+         debug rhs => _4;
-+         let mut _5: i16;
-+         scope 2 {
-+             scope 3 (inlined core::num::<impl i16>::unchecked_shr::conv) {
-+                 debug x => _4;
-+                 let mut _6: std::option::Option<i16>;
-+                 let mut _7: std::result::Result<i16, std::num::TryFromIntError>;
-+                 scope 4 {
-+                     scope 5 (inlined <u32 as TryInto<i16>>::try_into) {
-+                         debug self => _4;
-+                         scope 6 (inlined convert::num::<impl TryFrom<u32> for i16>::try_from) {
-+                             debug u => _4;
-+                             let mut _8: bool;
-+                             let mut _9: u32;
-+                             let mut _10: i16;
-+                         }
-+                     }
-+                     scope 7 (inlined Result::<i16, TryFromIntError>::ok) {
-+                         debug self => _7;
-+                         let mut _11: isize;
-+                         let _12: i16;
-+                         scope 8 {
-+                             debug x => _12;
-+                         }
-+                     }
-+                     scope 9 (inlined #[track_caller] Option::<i16>::unwrap_unchecked) {
-+                         debug self => _6;
-+                         let mut _13: &std::option::Option<i16>;
-+                         let mut _14: isize;
-+                         scope 10 {
-+                             debug val => _5;
-+                         }
-+                         scope 11 {
-+                             scope 13 (inlined unreachable_unchecked) {
-+                                 scope 14 {
-+                                     scope 15 (inlined unreachable_unchecked::runtime) {
-+                                     }
-+                                 }
-+                             }
-+                         }
-+                         scope 12 (inlined Option::<i16>::is_some) {
-+                             debug self => _13;
-+                         }
-+                     }
-+                 }
-+             }
-+         }
-+     }
   
       bb0: {
           StorageLive(_3);
           _3 = _1;
           StorageLive(_4);
           _4 = _2;
--         _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> bb1;
-+         StorageLive(_5);
-+         StorageLive(_6);
-+         StorageLive(_7);
-+         StorageLive(_8);
-+         StorageLive(_9);
-+         _9 = const 32767_u32;
-+         _8 = Gt(_4, move _9);
-+         StorageDead(_9);
-+         switchInt(move _8) -> [0: bb3, otherwise: bb2];
+          _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> bb1;
       }
   
       bb1: {
-+         StorageDead(_5);
           StorageDead(_4);
           StorageDead(_3);
           return;
-+     }
-+ 
-+     bb2: {
-+         _7 = Result::<i16, TryFromIntError>::Err(const TryFromIntError(()));
-+         goto -> bb4;
-+     }
-+ 
-+     bb3: {
-+         StorageLive(_10);
-+         _10 = _4 as i16 (IntToInt);
-+         _7 = Result::<i16, TryFromIntError>::Ok(move _10);
-+         StorageDead(_10);
-+         goto -> bb4;
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_8);
-+         StorageLive(_12);
-+         _11 = discriminant(_7);
-+         switchInt(move _11) -> [0: bb7, 1: bb5, otherwise: bb6];
-+     }
-+ 
-+     bb5: {
-+         _6 = Option::<i16>::None;
-+         goto -> bb8;
-+     }
-+ 
-+     bb6: {
-+         unreachable;
-+     }
-+ 
-+     bb7: {
-+         _12 = move ((_7 as Ok).0: i16);
-+         _6 = Option::<i16>::Some(move _12);
-+         goto -> bb8;
-+     }
-+ 
-+     bb8: {
-+         StorageDead(_12);
-+         StorageDead(_7);
-+         StorageLive(_13);
-+         _14 = discriminant(_6);
-+         switchInt(move _14) -> [1: bb9, otherwise: bb6];
-+     }
-+ 
-+     bb9: {
-+         _5 = move ((_6 as Some).0: i16);
-+         StorageDead(_13);
-+         StorageDead(_6);
-+         _0 = unchecked_shr::<i16>(_3, move _5) -> [return: bb1, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-abort.mir
@@ -4,121 +4,12 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
     debug a => _1;
     debug b => _2;
     let mut _0: i16;
-    scope 1 (inlined core::num::<impl i16>::unchecked_shr) {
-        debug self => _1;
-        debug rhs => _2;
-        let mut _11: i16;
-        scope 2 {
-            scope 3 (inlined core::num::<impl i16>::unchecked_shr::conv) {
-                debug x => _2;
-                let mut _6: std::result::Result<i16, std::num::TryFromIntError>;
-                let mut _9: std::option::Option<i16>;
-                scope 4 {
-                    scope 5 (inlined <u32 as TryInto<i16>>::try_into) {
-                        debug self => _2;
-                        scope 6 (inlined convert::num::<impl TryFrom<u32> for i16>::try_from) {
-                            debug u => _2;
-                            let mut _3: u32;
-                            let mut _4: bool;
-                            let mut _5: i16;
-                        }
-                    }
-                    scope 7 (inlined Result::<i16, TryFromIntError>::ok) {
-                        debug self => _6;
-                        let mut _7: isize;
-                        let _8: i16;
-                        scope 8 {
-                            debug x => _8;
-                        }
-                    }
-                    scope 9 (inlined #[track_caller] Option::<i16>::unwrap_unchecked) {
-                        debug self => _9;
-                        let mut _10: isize;
-                        let mut _12: &std::option::Option<i16>;
-                        scope 10 {
-                            debug val => _11;
-                        }
-                        scope 11 {
-                            scope 13 (inlined unreachable_unchecked) {
-                                scope 14 {
-                                    scope 15 (inlined unreachable_unchecked::runtime) {
-                                    }
-                                }
-                            }
-                        }
-                        scope 12 (inlined Option::<i16>::is_some) {
-                            debug self => _12;
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     bb0: {
-        StorageLive(_11);
-        StorageLive(_9);
-        StorageLive(_6);
-        StorageLive(_4);
-        StorageLive(_3);
-        _3 = const 32767_u32;
-        _4 = Gt(_2, move _3);
-        StorageDead(_3);
-        switchInt(move _4) -> [0: bb1, otherwise: bb2];
+        _0 = core::num::<impl i16>::unchecked_shr(_1, _2) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        StorageLive(_5);
-        _5 = _2 as i16 (IntToInt);
-        _6 = Result::<i16, TryFromIntError>::Ok(move _5);
-        StorageDead(_5);
-        goto -> bb3;
-    }
-
-    bb2: {
-        _6 = Result::<i16, TryFromIntError>::Err(const TryFromIntError(()));
-        goto -> bb3;
-    }
-
-    bb3: {
-        StorageDead(_4);
-        StorageLive(_8);
-        _7 = discriminant(_6);
-        switchInt(move _7) -> [0: bb4, 1: bb5, otherwise: bb9];
-    }
-
-    bb4: {
-        _8 = move ((_6 as Ok).0: i16);
-        _9 = Option::<i16>::Some(move _8);
-        goto -> bb6;
-    }
-
-    bb5: {
-        _9 = Option::<i16>::None;
-        goto -> bb6;
-    }
-
-    bb6: {
-        StorageDead(_8);
-        StorageDead(_6);
-        StorageLive(_12);
-        _10 = discriminant(_9);
-        switchInt(move _10) -> [1: bb7, otherwise: bb9];
-    }
-
-    bb7: {
-        _11 = move ((_9 as Some).0: i16);
-        StorageDead(_12);
-        StorageDead(_9);
-        _0 = unchecked_shr::<i16>(_1, move _11) -> [return: bb8, unwind unreachable];
-    }
-
-    bb8: {
-        StorageDead(_11);
         return;
-    }
-
-    bb9: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-unwind.mir
@@ -4,121 +4,12 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
     debug a => _1;
     debug b => _2;
     let mut _0: i16;
-    scope 1 (inlined core::num::<impl i16>::unchecked_shr) {
-        debug self => _1;
-        debug rhs => _2;
-        let mut _11: i16;
-        scope 2 {
-            scope 3 (inlined core::num::<impl i16>::unchecked_shr::conv) {
-                debug x => _2;
-                let mut _6: std::result::Result<i16, std::num::TryFromIntError>;
-                let mut _9: std::option::Option<i16>;
-                scope 4 {
-                    scope 5 (inlined <u32 as TryInto<i16>>::try_into) {
-                        debug self => _2;
-                        scope 6 (inlined convert::num::<impl TryFrom<u32> for i16>::try_from) {
-                            debug u => _2;
-                            let mut _3: u32;
-                            let mut _4: bool;
-                            let mut _5: i16;
-                        }
-                    }
-                    scope 7 (inlined Result::<i16, TryFromIntError>::ok) {
-                        debug self => _6;
-                        let mut _7: isize;
-                        let _8: i16;
-                        scope 8 {
-                            debug x => _8;
-                        }
-                    }
-                    scope 9 (inlined #[track_caller] Option::<i16>::unwrap_unchecked) {
-                        debug self => _9;
-                        let mut _10: isize;
-                        let mut _12: &std::option::Option<i16>;
-                        scope 10 {
-                            debug val => _11;
-                        }
-                        scope 11 {
-                            scope 13 (inlined unreachable_unchecked) {
-                                scope 14 {
-                                    scope 15 (inlined unreachable_unchecked::runtime) {
-                                    }
-                                }
-                            }
-                        }
-                        scope 12 (inlined Option::<i16>::is_some) {
-                            debug self => _12;
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     bb0: {
-        StorageLive(_11);
-        StorageLive(_9);
-        StorageLive(_6);
-        StorageLive(_4);
-        StorageLive(_3);
-        _3 = const 32767_u32;
-        _4 = Gt(_2, move _3);
-        StorageDead(_3);
-        switchInt(move _4) -> [0: bb1, otherwise: bb2];
+        _0 = core::num::<impl i16>::unchecked_shr(_1, _2) -> bb1;
     }
 
     bb1: {
-        StorageLive(_5);
-        _5 = _2 as i16 (IntToInt);
-        _6 = Result::<i16, TryFromIntError>::Ok(move _5);
-        StorageDead(_5);
-        goto -> bb3;
-    }
-
-    bb2: {
-        _6 = Result::<i16, TryFromIntError>::Err(const TryFromIntError(()));
-        goto -> bb3;
-    }
-
-    bb3: {
-        StorageDead(_4);
-        StorageLive(_8);
-        _7 = discriminant(_6);
-        switchInt(move _7) -> [0: bb4, 1: bb5, otherwise: bb9];
-    }
-
-    bb4: {
-        _8 = move ((_6 as Ok).0: i16);
-        _9 = Option::<i16>::Some(move _8);
-        goto -> bb6;
-    }
-
-    bb5: {
-        _9 = Option::<i16>::None;
-        goto -> bb6;
-    }
-
-    bb6: {
-        StorageDead(_8);
-        StorageDead(_6);
-        StorageLive(_12);
-        _10 = discriminant(_9);
-        switchInt(move _10) -> [1: bb7, otherwise: bb9];
-    }
-
-    bb7: {
-        _11 = move ((_9 as Some).0: i16);
-        StorageDead(_12);
-        StorageDead(_9);
-        _0 = unchecked_shr::<i16>(_1, move _11) -> [return: bb8, unwind unreachable];
-    }
-
-    bb8: {
-        StorageDead(_11);
         return;
-    }
-
-    bb9: {
-        unreachable;
     }
 }


### PR DESCRIPTION
`#[inline(always)]` is used in two cases: for functions that are so trivial it is always profitable to inline them, but also for functions which LLVM thinks are a bad inlining candidate, but which actually turn out to be profitable to inline. That second justification doesn't apply to the MIR inliner, so ignoring our cost estimation for these functions is not necessarily the right right thing to do.

This is basically a wash on non-check runs and a perf benefit in check runs. There are some notable regressions, and I think we might be able to claw those back by turning `#[inline(always)]` into a stronger hint. But I think this PR stands decently on its own as a tidy simplification.