### PR TITLE
Fix the tests-listing-format-json test on Windows

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3712,8 +3712,11 @@ impl<'test> TestCx<'test> {
     }
 
     fn normalize_output(&self, output: &str, custom_rules: &[(String, String)]) -> String {
+        let rflags = self.props.run_flags.as_ref();
         let cflags = self.props.compile_flags.join(" ");
-        let json = cflags.contains("--error-format json")
+        let json = rflags
+            .map_or(false, |s| s.contains("--format json") || s.contains("--format=json"))
+            || cflags.contains("--error-format json")
             || cflags.contains("--error-format pretty-json")
             || cflags.contains("--error-format=json")
             || cflags.contains("--error-format=pretty-json")


### PR DESCRIPTION
tests/ui/test-attrs/tests-listing-json-format.rs was failing on Windows because each path in the json-formatted output contained "\\\\" instead of "\\". `runtest::TestCx::normalize_output` already checks the compile flags for json-related arguments to handle this case, so I added an equivalent check for the new run flag.