### PR TITLE
Test `x86_64-gnu` in PR CI, not x86_64-gnu-llvm-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           - name: mingw-check-tidy
             os: ubuntu-20.04-16core-64gb
             env: {}
-          - name: x86_64-gnu-llvm-14
+          - name: x86_64-gnu
             os: ubuntu-20.04-16core-64gb
             env: {}
           - name: x86_64-gnu-tools

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-14/Dockerfile
@@ -4,7 +4,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   g++ \
-  gcc-multilib \
   make \
   ninja-build \
   file \
@@ -26,11 +25,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
-# Install powershell (universal package) so we can test x.ps1 on Linux
-RUN curl -sL "https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/powershell_7.3.1-1.deb_amd64.deb" > powershell.deb && \
-    dpkg -i powershell.deb && \
-    rm -f powershell.deb
-
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
@@ -49,20 +43,4 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-llvm-link-shared \
       --set rust.thin-lto-import-instr-limit=10
 
-# NOTE: intentionally uses all of `x.py`, `x`, and `x.ps1` to make sure they all work on Linux.
-ENV SCRIPT ../x.py --stage 2 test --exclude src/tools/tidy && \
-           # Run the `mir-opt` tests again but this time for a 32-bit target.
-           # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
-           # both 32-bit and 64-bit outputs updated by the PR author, before
-           # the PR is approved and tested for merging.
-           # It will also detect tests lacking `// EMIT_MIR_FOR_EACH_BIT_WIDTH`,
-           # despite having different output on 32-bit vs 64-bit targets.
-           ../x --stage 2 test tests/mir-opt \
-                             --host='' --target=i686-unknown-linux-gnu && \
-           # Run the UI test suite again, but in `--pass=check` mode
-           #
-           # This is intended to make sure that both `--pass=check` continues to
-           # work.
-           #
-           ../x.ps1 --stage 2 test tests/ui --pass=check \
-                             --host='' --target=i686-unknown-linux-gnu
+ENV SCRIPT ../x.py --stage 2 test

--- a/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
   g++ \
+  gcc-multilib \
   make \
   ninja-build \
   file \
@@ -19,6 +20,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
+# Install powershell (universal package) so we can test x.ps1 on Linux
+RUN curl -sL "https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/powershell_7.3.1-1.deb_amd64.deb" > powershell.deb && \
+    dpkg -i powershell.deb && \
+    rm -f powershell.deb
+
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
@@ -27,4 +33,20 @@ ENV RUST_CONFIGURE_ARGS \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs
-ENV SCRIPT python3 ../x.py --stage 2 test
+
+# NOTE: intentionally uses all of `x.py`, `x`, and `x.ps1` to make sure they all work on Linux.
+ENV SCRIPT ../x.py --stage 2 test --exclude src/tools/tidy && \
+           # Run the `mir-opt` tests again but this time for a 32-bit target.
+           # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
+           # both 32-bit and 64-bit outputs updated by the PR author, before
+           # the PR is approved and tested for merging.
+           # It will also detect tests lacking `// EMIT_MIR_FOR_EACH_BIT_WIDTH`,
+           # despite having different output on 32-bit vs 64-bit targets.
+           ../x --stage 2 test tests/mir-opt \
+                             --host='' --target=i686-unknown-linux-gnu && \
+           # Run the UI test suite again, but in `--pass=check` mode
+           #
+           # This is intended to make sure that both `--pass=check` continues to
+           # work.
+           ../x.ps1 --stage 2 test tests/ui --pass=check \
+                             --host='' --target=i686-unknown-linux-gnu

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -308,7 +308,7 @@ jobs:
           - name: mingw-check-tidy
             <<: *job-linux-16c
 
-          - name: x86_64-gnu-llvm-14
+          - name: x86_64-gnu
             <<: *job-linux-16c
 
           - name: x86_64-gnu-tools

--- a/tests/ui/sanitize/address.rs
+++ b/tests/ui/sanitize/address.rs
@@ -1,11 +1,12 @@
 // needs-sanitizer-support
 // needs-sanitizer-address
+// ignore-cross-compile
 //
 // compile-flags: -Z sanitizer=address -O -g
 //
 // run-fail
 // error-pattern: AddressSanitizer: stack-buffer-overflow
-// error-pattern: 'xs' (line 13) <== Memory access at offset
+// error-pattern: 'xs' (line 14) <== Memory access at offset
 
 use std::hint::black_box;
 

--- a/tests/ui/sanitize/badfree.rs
+++ b/tests/ui/sanitize/badfree.rs
@@ -1,5 +1,6 @@
 // needs-sanitizer-support
 // needs-sanitizer-address
+// ignore-cross-compile
 //
 // compile-flags: -Z sanitizer=address -O
 //

--- a/tests/ui/sanitize/issue-72154-lifetime-markers.rs
+++ b/tests/ui/sanitize/issue-72154-lifetime-markers.rs
@@ -5,6 +5,7 @@
 //
 // needs-sanitizer-support
 // needs-sanitizer-address
+// ignore-cross-compile
 //
 // compile-flags: -Copt-level=0 -Zsanitizer=address
 // run-pass

--- a/tests/ui/sanitize/new-llvm-pass-manager-thin-lto.rs
+++ b/tests/ui/sanitize/new-llvm-pass-manager-thin-lto.rs
@@ -4,6 +4,7 @@
 //
 // needs-sanitizer-support
 // needs-sanitizer-address
+// ignore-cross-compile
 //
 // no-prefer-dynamic
 // revisions: opt0 opt1

--- a/tests/ui/sanitize/use-after-scope.rs
+++ b/tests/ui/sanitize/use-after-scope.rs
@@ -1,5 +1,6 @@
 // needs-sanitizer-support
 // needs-sanitizer-address
+// ignore-cross-compile
 //
 // compile-flags: -Zsanitizer=address
 // run-fail


### PR DESCRIPTION
This is a pre-requisite for https://github.com/rust-lang/rust/pull/112143, which wants to start using download-rustc in PRs. download-rustc doesn't allow providing an external LLVM.

r? @ghost