### PR TITLE
Don't double-print status messages in GHA

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1069,7 +1069,6 @@ impl Build {
     }
 
     fn group(&self, msg: &str) -> Option<gha::Group> {
-        self.info(&msg);
         match self.config.dry_run {
             DryRun::SelfCheck => None,
             DryRun::Disabled | DryRun::UserSelected => Some(gha::group(&msg)),

--- a/src/tools/build_helper/src/ci.rs
+++ b/src/tools/build_helper/src/ci.rs
@@ -46,6 +46,8 @@ pub mod gha {
     pub fn group(name: impl std::fmt::Display) -> Group {
         if std::env::var_os("GITHUB_ACTIONS").is_some() {
             eprintln!("::group::{name}");
+        } else {
+            eprintln!("{name}")
         }
         Group(())
     }


### PR DESCRIPTION
Before:

```
Building stage0 tool jsondocck (x86_64-unknown-linux-gnu)
  Building stage0 tool jsondocck (x86_64-unknown-linux-gnu)
   Downloading crates ...
```

After:

```
Building stage0 tool jsondocck (x86_64-unknown-linux-gnu)
   Downloading crates ...
```

r? @oli-obk