### PR TITLE
Suggest using `ptr::null_mut` when user provided `ptr::null` to a function expecting `ptr::null_mut`

### DIFF
--- a/compiler/rustc_hir_typeck/messages.ftl
+++ b/compiler/rustc_hir_typeck/messages.ftl
@@ -87,6 +87,8 @@ hir_typeck_suggest_boxing_note = for more on the distinction between the stack a
 
 hir_typeck_suggest_boxing_when_appropriate = store this in the heap by calling `Box::new`
 
+hir_typeck_suggest_ptr_null_mut = consider using `core::ptr::null_mut` instead
+
 hir_typeck_union_pat_dotdot = `..` cannot be used in union patterns
 
 hir_typeck_union_pat_multiple_fields = union patterns should have exactly one field

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -298,6 +298,17 @@ pub enum SuggestBoxing {
     },
 }
 
+#[derive(Subdiagnostic)]
+#[suggestion(
+    hir_typeck_suggest_ptr_null_mut,
+    applicability = "maybe-incorrect",
+    code = "core::ptr::null_mut()"
+)]
+pub struct SuggestPtrNullMut {
+    #[primary_span]
+    pub span: Span,
+}
+
 #[derive(Diagnostic)]
 #[diag(hir_typeck_no_associated_item, code = "E0599")]
 pub struct NoAssociatedItem {

--- a/tests/ui/typeck/ptr-null-mutability-suggestions.fixed
+++ b/tests/ui/typeck/ptr-null-mutability-suggestions.fixed
@@ -1,0 +1,11 @@
+// run-rustfix
+
+#[allow(unused_imports)]
+use std::ptr;
+
+fn expecting_null_mut(_: *mut u8) {}
+
+fn main() {
+    expecting_null_mut(core::ptr::null_mut());
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/typeck/ptr-null-mutability-suggestions.rs
+++ b/tests/ui/typeck/ptr-null-mutability-suggestions.rs
@@ -1,0 +1,11 @@
+// run-rustfix
+
+#[allow(unused_imports)]
+use std::ptr;
+
+fn expecting_null_mut(_: *mut u8) {}
+
+fn main() {
+    expecting_null_mut(ptr::null());
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/typeck/ptr-null-mutability-suggestions.stderr
+++ b/tests/ui/typeck/ptr-null-mutability-suggestions.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/ptr-null-mutability-suggestions.rs:9:24
+   |
+LL |     expecting_null_mut(ptr::null());
+   |     ------------------ ^^^^^^^^^^^
+   |     |                  |
+   |     |                  types differ in mutability
+   |     |                  help: consider using `core::ptr::null_mut` instead: `core::ptr::null_mut()`
+   |     arguments to this function are incorrect
+   |
+   = note: expected raw pointer `*mut u8`
+              found raw pointer `*const _`
+note: function defined here
+  --> $DIR/ptr-null-mutability-suggestions.rs:6:4
+   |
+LL | fn expecting_null_mut(_: *mut u8) {}
+   |    ^^^^^^^^^^^^^^^^^^ ----------
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
```
error[E0308]: mismatched types
  --> $DIR/ptr-null-mutability-suggestions.rs:9:24
   |
LL |     expecting_null_mut(ptr::null());
   |     ------------------ ^^^^^^^^^^^
   |     |                  |
   |     |                  types differ in mutability
   |     |                  help: consider using `core::ptr::null_mut` instead: `core::ptr::null_mut()`
   |     arguments to this function are incorrect
   |
   = note: expected raw pointer `*mut u8`
              found raw pointer `*const _`
note: function defined here
  --> $DIR/ptr-null-mutability-suggestions.rs:6:4
   |
LL | fn expecting_null_mut(_: *mut u8) {}
   |    ^^^^^^^^^^^^^^^^^^ ----------
```

Closes #85184.