### PR TITLE
Add new Tier-3 targets: `loongarch64-unknown-none*`

### DIFF
--- a/compiler/rustc_target/src/spec/loongarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/loongarch64_unknown_none.rs
@@ -1,0 +1,23 @@
+use super::{Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy};
+use super::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "loongarch64-unknown-none".into(),
+        pointer_width: 64,
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n64-S128".into(),
+        arch: "loongarch64".into(),
+        options: TargetOptions {
+            cpu: "generic".into(),
+            features: "+f,+d".into(),
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::No),
+            llvm_abiname: "lp64d".into(),
+            max_atomic_width: Some(64),
+            position_independent_executables: true,
+            static_position_independent_executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            code_model: Some(CodeModel::Small),
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/loongarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/loongarch64_unknown_none_softfloat.rs
@@ -1,0 +1,24 @@
+use super::{Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy};
+use super::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "loongarch64-unknown-none-softfloat".into(),
+        pointer_width: 64,
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n64-S128".into(),
+        arch: "loongarch64".into(),
+        options: TargetOptions {
+            cpu: "generic".into(),
+            features: "-f,-d".into(),
+            abi: "softfloat".into(),
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::No),
+            llvm_abiname: "lp64s".into(),
+            max_atomic_width: Some(64),
+            position_independent_executables: true,
+            static_position_independent_executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            code_model: Some(CodeModel::Small),
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1293,6 +1293,9 @@ supported_targets! {
     ("riscv64gc-unknown-linux-gnu", riscv64gc_unknown_linux_gnu),
     ("riscv64gc-unknown-linux-musl", riscv64gc_unknown_linux_musl),
 
+    ("loongarch64-unknown-none", loongarch64_unknown_none),
+    ("loongarch64-unknown-none-softfloat", loongarch64_unknown_none_softfloat),
+
     ("aarch64-unknown-none", aarch64_unknown_none),
     ("aarch64-unknown-none-softfloat", aarch64_unknown_none_softfloat),
 

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -31,6 +31,7 @@
     - [\*-unknown-fuchsia](platform-support/fuchsia.md)
     - [\*-kmc-solid_\*](platform-support/kmc-solid.md)
     - [loongarch\*-unknown-linux-\*](platform-support/loongarch-linux.md)
+    - [loongarch\*-unknown-none\*](platform-support/loongarch-none.md)
     - [m68k-unknown-linux-gnu](platform-support/m68k-unknown-linux-gnu.md)
     - [mips64-openwrt-linux-musl](platform-support/mips64-openwrt-linux-musl.md)
     - [mipsel-sony-psx](platform-support/mipsel-sony-psx.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -267,6 +267,8 @@ target | std | host | notes
 `i686-uwp-windows-gnu` | ? |  |
 `i686-uwp-windows-msvc` | ? |  |
 `i686-wrs-vxworks` | ? |  |
+[`loongarch64-unknown-none`](platform-support/loongarch-none.md) | * | LoongArch64 Bare-metal (LP64D ABI)
+[`loongarch64-unknown-none-softfloat`](platform-support/loongarch-none.md) | * | LoongArch64 Bare-metal (LP64S ABI)
 [`m68k-unknown-linux-gnu`](platform-support/m68k-unknown-linux-gnu.md) | ? |  | Motorola 680x0 Linux
 `mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc
 [`mips64-openwrt-linux-musl`](platform-support/mips64-openwrt-linux-musl.md) | ? |  | MIPS64 for OpenWrt Linux MUSL

--- a/src/doc/rustc/src/platform-support/loongarch-none.md
+++ b/src/doc/rustc/src/platform-support/loongarch-none.md
@@ -1,0 +1,79 @@
+# `loongarch*-unknown-none*`
+
+**Tier: 3**
+
+Freestanding/bare-metal LoongArch64 binaries in ELF format: firmware, kernels, etc.
+
+| Target                             | Descriptions                                          |
+|------------------------------------|-------------------------------------------------------|
+| loongarch64-unknown-none           | LoongArch 64-bit, LP64D ABI (freestanding, hardfloat) |
+| loongarch64-unknown-none-softfloat | LoongArch 64-bit, LP64S ABI (freestanding, softfloat) |
+
+## Target maintainers
+
+- [WANG Rui](https://github.com/heiher) `wangrui@loongson.cn`
+- [WANG Xuerui](https://github.com/xen0n) `git@xen0n.name`
+
+## Requirements
+
+This target is cross-compiled. There is no support for `std`. There is no
+default allocator, but it's possible to use `alloc` by supplying an allocator.
+
+This allows the generated code to run in environments, such as kernels, which
+may need to avoid the use of such registers or which may have special considerations
+about the use of such registers (e.g. saving and restoring them to avoid breaking
+userspace code using the same registers). You can change code generation to use
+additional CPU features via the `-C target-feature=` codegen options to rustc, or
+via the `#[target_feature]` mechanism within Rust code.
+
+By default, code generated with this target should run on any `loongarch`
+hardware; enabling additional target features may raise this baseline.
+
+Code generated with this target will use the `small` code model by default.
+You can change this using the `-C code-model=` option to rustc.
+
+On `loongarch64-unknown-none*`, `extern "C"` uses the [standard calling
+convention](https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html).
+
+This target generates binaries in the ELF format. Any alternate formats or
+special considerations for binary layout will require linker options or linker
+scripts.
+
+## Building the target
+
+You can build Rust with support for the target by adding it to the `target`
+list in `config.toml`:
+
+```toml
+[build]
+build-stage = 1
+target = ["loongarch64-unknown-none"]
+```
+
+## Building Rust programs
+
+```text
+# target flag may be used with any cargo or rustc command
+cargo build --target loongarch64-unknown-none
+```
+
+## Testing
+
+As `loongarch64-unknown-none*` supports a variety of different environments and does
+not support `std`, this target does not support running the Rust test suite.
+
+## Cross-compilation toolchains and C code
+
+If you want to compile C code along with Rust (such as for Rust crates with C
+dependencies), you will need an appropriate `loongarch` toolchain.
+
+Rust *may* be able to use an `loongarch64-unknown-linux-gnu-` toolchain with
+appropriate standalone flags to build for this toolchain (depending on the assumptions
+of that toolchain, see below), or you may wish to use a separate
+`loongarch64-unknown-none` toolchain.
+
+On some `loongarch` hosts that use ELF binaries, you *may* be able to use the host
+C toolchain, if it does not introduce assumptions about the host environment
+that don't match the expectations of a standalone environment. Otherwise, you
+may need a separate toolchain for standalone/freestanding development, just as
+when cross-compiling from a non-`loongarch` platform.


### PR DESCRIPTION
This PR adds new Tier-3 targets `loongarch64-unknown-none*` that are introduced by MCP rust-lang/compiler-team#628