### PR TITLE
Ignore fluent message reordering in `git blame`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -14,3 +14,5 @@ c34fbfaad38cf5829ef5cfe780dc9d58480adeaa
 cf2dff2b1e3fa55fa5415d524200070d0d7aacfe
 # Run rustfmt on bootstrap
 b39a1d6f1a30ba29f25d7141038b9a5bf0126e36
+# reorder fluent message files
+f97fddab91fbf290ea5b691fe355d6f915220b6e


### PR DESCRIPTION
This commit reordered most of our Fluent message files. Since `git blame` can be useful in tracking mistakes made while adapting to translatable diagnostics, ignore this commit in `blame`.
r? @jyn514 