### PR TITLE
Ignore `core`, `alloc` and `test` tests that require unwinding on `-C panic=abort`

### DIFF
--- a/compiler/rustc_codegen_cranelift/patches/0023-coretests-Ignore-failing-tests.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0023-coretests-Ignore-failing-tests.patch
@@ -10,42 +10,6 @@ Subject: [PATCH] [core] Ignore failing tests
  library/core/tests/time.rs       |  1 +
  4 files changed, 18 insertions(+), 2 deletions(-)
 
-diff --git a/array.rs b/array.rs
-index 4bc44e9..8e3c7a4 100644
---- a/array.rs
-+++ b/array.rs
-@@ -242,6 +242,7 @@ fn iterator_drops() {
-     assert_eq!(i.get(), 5);
- }
- 
-+/*
- // This test does not work on targets without panic=unwind support.
- // To work around this problem, test is marked is should_panic, so it will
- // be automagically skipped on unsuitable targets, such as
-@@ -283,6 +284,7 @@ fn array_default_impl_avoids_leaks_on_panic() {
-     assert_eq!(COUNTER.load(Relaxed), 0);
-     panic!("test succeeded")
- }
-+*/
- 
- #[test]
- fn empty_array_is_always_default() {
-@@ -304,6 +304,7 @@ fn array_map() {
-     assert_eq!(b, [1, 2, 3]);
- }
- 
-+/*
- // See note on above test for why `should_panic` is used.
- #[test]
- #[should_panic(expected = "test succeeded")]
-@@ -332,6 +333,7 @@ fn array_map_drop_safety() {
-     assert_eq!(DROPPED.load(Ordering::SeqCst), num_to_create);
-     panic!("test succeeded")
- }
-+*/
- 
- #[test]
- fn cell_allows_array_cycle() {
 diff --git a/atomic.rs b/atomic.rs
 index 13b12db..96fe4b9 100644
 --- a/atomic.rs

--- a/library/alloc/src/collections/binary_heap/tests.rs
+++ b/library/alloc/src/collections/binary_heap/tests.rs
@@ -309,6 +309,7 @@ fn test_drain_sorted() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_drain_sorted_leak() {
     let d0 = CrashTestDummy::new(0);
     let d1 = CrashTestDummy::new(1);
@@ -475,6 +476,7 @@ fn test_retain() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_retain_catch_unwind() {
     let mut heap = BinaryHeap::from(vec![3, 1, 2]);
 
@@ -502,6 +504,7 @@ fn test_retain_catch_unwind() {
 // FIXME: re-enable emscripten once it can unwind again
 #[test]
 #[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn panic_safe() {
     use rand::seq::SliceRandom;
     use std::cmp;

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -1155,6 +1155,7 @@ mod test_drain_filter {
     }
 
     #[test]
+    #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
     fn drop_panic_leak() {
         let a = CrashTestDummy::new(0);
         let b = CrashTestDummy::new(1);
@@ -1175,6 +1176,7 @@ mod test_drain_filter {
     }
 
     #[test]
+    #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
     fn pred_panic_leak() {
         let a = CrashTestDummy::new(0);
         let b = CrashTestDummy::new(1);
@@ -1201,6 +1203,7 @@ mod test_drain_filter {
 
     // Same as above, but attempt to use the iterator again after the panic in the predicate
     #[test]
+    #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
     fn pred_panic_reuse() {
         let a = CrashTestDummy::new(0);
         let b = CrashTestDummy::new(1);
@@ -1449,6 +1452,7 @@ fn test_clear() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_clear_drop_panic_leak() {
     let a = CrashTestDummy::new(0);
     let b = CrashTestDummy::new(1);
@@ -1540,11 +1544,13 @@ fn test_clone_panic_leak(size: usize) {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_clone_panic_leak_height_0() {
     test_clone_panic_leak(3)
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_clone_panic_leak_height_1() {
     test_clone_panic_leak(MIN_INSERTS_HEIGHT_1)
 }
@@ -2099,6 +2105,7 @@ create_append_test!(test_append_239, 239);
 create_append_test!(test_append_1700, 1700);
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_append_drop_leak() {
     let a = CrashTestDummy::new(0);
     let b = CrashTestDummy::new(1);
@@ -2240,6 +2247,7 @@ fn test_split_off_large_random_sorted() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_into_iter_drop_leak_height_0() {
     let a = CrashTestDummy::new(0);
     let b = CrashTestDummy::new(1);
@@ -2263,6 +2271,7 @@ fn test_into_iter_drop_leak_height_0() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_into_iter_drop_leak_height_1() {
     let size = MIN_INSERTS_HEIGHT_1;
     for panic_point in vec![0, 1, size - 2, size - 1] {

--- a/library/alloc/src/collections/btree/set/tests.rs
+++ b/library/alloc/src/collections/btree/set/tests.rs
@@ -377,6 +377,7 @@ fn test_drain_filter() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_drain_filter_drop_panic_leak() {
     let a = CrashTestDummy::new(0);
     let b = CrashTestDummy::new(1);
@@ -397,6 +398,7 @@ fn test_drain_filter_drop_panic_leak() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_drain_filter_pred_panic_leak() {
     let a = CrashTestDummy::new(0);
     let b = CrashTestDummy::new(1);

--- a/library/alloc/src/collections/linked_list/tests.rs
+++ b/library/alloc/src/collections/linked_list/tests.rs
@@ -985,6 +985,7 @@ fn drain_filter_complex() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn drain_filter_drop_panic_leak() {
     let d0 = CrashTestDummy::new(0);
     let d1 = CrashTestDummy::new(1);
@@ -1018,6 +1019,7 @@ fn drain_filter_drop_panic_leak() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn drain_filter_pred_panic_leak() {
     static mut DROPS: i32 = 0;
 
@@ -1124,6 +1126,7 @@ fn test_drop_clear() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_drop_panic() {
     static mut DROPS: i32 = 0;
 

--- a/library/alloc/src/slice/tests.rs
+++ b/library/alloc/src/slice/tests.rs
@@ -187,6 +187,7 @@ std::thread_local!(static SILENCE_PANIC: Cell<bool> = Cell::new(false));
 
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)] // no threads
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn panic_safe() {
     panic::update_hook(move |prev, info| {
         if !SILENCE_PANIC.with(|s| s.get()) {

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1418,6 +1418,7 @@ fn test_box_slice_clone() {
 #[test]
 #[allow(unused_must_use)] // here, we care about the side effects of `.clone()`
 #[cfg_attr(target_os = "emscripten", ignore)]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_box_slice_clone_panics() {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;

--- a/library/alloc/tests/string.rs
+++ b/library/alloc/tests/string.rs
@@ -394,6 +394,7 @@ fn test_remove_matches() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_retain() {
     let mut s = String::from("α_β_γ");
 

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -314,6 +314,7 @@ fn test_retain_predicate_order() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_retain_pred_panic_with_hole() {
     let v = (0..5).map(Rc::new).collect::<Vec<_>>();
     catch_unwind(AssertUnwindSafe(|| {
@@ -331,6 +332,7 @@ fn test_retain_pred_panic_with_hole() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_retain_pred_panic_no_hole() {
     let v = (0..5).map(Rc::new).collect::<Vec<_>>();
     catch_unwind(AssertUnwindSafe(|| {
@@ -346,6 +348,7 @@ fn test_retain_pred_panic_no_hole() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_retain_drop_panic() {
     struct Wrap(Rc<i32>);
 
@@ -806,6 +809,7 @@ fn test_drain_end_overflow() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_drain_leak() {
     static mut DROPS: i32 = 0;
 
@@ -1038,6 +1042,7 @@ fn test_into_iter_clone() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_into_iter_leak() {
     static mut DROPS: i32 = 0;
 
@@ -1195,6 +1200,7 @@ fn test_from_iter_specialization_head_tail_drop() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_from_iter_specialization_panic_during_iteration_drops() {
     let drop_count: Vec<_> = (0..=2).map(|_| Rc::new(())).collect();
     let src: Vec<_> = drop_count.iter().cloned().collect();
@@ -1219,6 +1225,7 @@ fn test_from_iter_specialization_panic_during_iteration_drops() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_from_iter_specialization_panic_during_drop_doesnt_leak() {
     static mut DROP_COUNTER_OLD: [usize; 5] = [0; 5];
     static mut DROP_COUNTER_NEW: [usize; 2] = [0; 2];
@@ -1494,6 +1501,7 @@ fn drain_filter_complex() {
 // FIXME: re-enable emscripten once it can unwind again
 #[test]
 #[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn drain_filter_consumed_panic() {
     use std::rc::Rc;
     use std::sync::Mutex;
@@ -1546,6 +1554,7 @@ fn drain_filter_consumed_panic() {
 // FIXME: Re-enable emscripten once it can catch panics
 #[test]
 #[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn drain_filter_unconsumed_panic() {
     use std::rc::Rc;
     use std::sync::Mutex;
@@ -2414,6 +2423,7 @@ fn test_vec_dedup() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_vec_dedup_panicking() {
     #[derive(Debug)]
     struct Panic<'a> {
@@ -2470,6 +2480,7 @@ fn test_vec_dedup_panicking() {
 
 // Regression test for issue #82533
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_extend_from_within_panicking_clone() {
     struct Panic<'dc> {
         drop_count: &'dc AtomicU32,

--- a/library/alloc/tests/vec_deque.rs
+++ b/library/alloc/tests/vec_deque.rs
@@ -747,6 +747,7 @@ fn test_drop_clear() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_drop_panic() {
     static mut DROPS: i32 = 0;
 
@@ -1601,6 +1602,7 @@ fn test_try_rfold_moves_iter() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn truncate_leak() {
     static mut DROPS: i32 = 0;
 
@@ -1634,6 +1636,7 @@ fn truncate_leak() {
 }
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_drain_leak() {
     static mut DROPS: i32 = 0;
 

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -257,14 +257,8 @@ fn iterator_drops() {
     assert_eq!(i.get(), 5);
 }
 
-// This test does not work on targets without panic=unwind support.
-// To work around this problem, test is marked is should_panic, so it will
-// be automagically skipped on unsuitable targets, such as
-// wasm32-unknown-unknown.
-//
-// It means that we use panic for indicating success.
 #[test]
-#[should_panic(expected = "test succeeded")]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn array_default_impl_avoids_leaks_on_panic() {
     use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -296,7 +290,6 @@ fn array_default_impl_avoids_leaks_on_panic() {
     assert_eq!(*panic_msg, "bomb limit exceeded");
     // check that all bombs are successfully dropped
     assert_eq!(COUNTER.load(Relaxed), 0);
-    panic!("test succeeded")
 }
 
 #[test]
@@ -317,9 +310,8 @@ fn array_map() {
     assert_eq!(b, [1, 2, 3]);
 }
 
-// See note on above test for why `should_panic` is used.
 #[test]
-#[should_panic(expected = "test succeeded")]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn array_map_drop_safety() {
     static DROPPED: AtomicUsize = AtomicUsize::new(0);
     struct DropCounter;
@@ -341,7 +333,6 @@ fn array_map_drop_safety() {
     });
     assert!(success.is_err());
     assert_eq!(DROPPED.load(Ordering::SeqCst), num_to_create);
-    panic!("test succeeded")
 }
 
 #[test]

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -154,6 +154,7 @@ pub fn ignored_tests_result_in_ignored() {
 // FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
 #[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic() {
     fn f() -> Result<(), String> {
         panic!();
@@ -184,6 +185,7 @@ fn test_should_panic() {
 // FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
 #[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_good_message() {
     fn f() -> Result<(), String> {
         panic!("an error message");
@@ -214,6 +216,7 @@ fn test_should_panic_good_message() {
 // FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
 #[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_bad_message() {
     use crate::tests::TrFailedMsg;
     fn f() -> Result<(), String> {
@@ -249,6 +252,7 @@ fn test_should_panic_bad_message() {
 // FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
 #[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_non_string_message_type() {
     use crate::tests::TrFailedMsg;
     use std::any::TypeId;
@@ -288,6 +292,7 @@ fn test_should_panic_non_string_message_type() {
 // FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
 #[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_but_succeeds() {
     let should_panic_variants = [ShouldPanic::Yes, ShouldPanic::YesWithMessage("error message")];
 


### PR DESCRIPTION
Some of the tests for `core` and `alloc` require unwinding through their use of `catch_unwind`. These tests fail when testing using `-C panic=abort` (in my case through a target without unwinding support, and `-Z panic-abort-tests`), while they should be ignored as they don't indicate a failure.

This PR marks all of these tests with this attribute:

```rust
#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
```

I'm not aware of a way to test this on rust-lang/rust's CI, as we don't test any target with `-C panic=abort`, but I tested this locally on a Ferrocene target and it does indeed make the test suite pass.