### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -14,3 +14,5 @@ c34fbfaad38cf5829ef5cfe780dc9d58480adeaa
 cf2dff2b1e3fa55fa5415d524200070d0d7aacfe
 # Run rustfmt on bootstrap
 b39a1d6f1a30ba29f25d7141038b9a5bf0126e36
+# reorder fluent message files
+f97fddab91fbf290ea5b691fe355d6f915220b6e

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1,4 +1,4 @@
-// This crate is intentionally empty and a rexport of `rustc_driver_impl` to allow the code in
+// This crate is intentionally empty and a re-export of `rustc_driver_impl` to allow the code in
 // `rustc_driver_impl` to be compiled in parallel with other crates.
 
 pub use rustc_driver_impl::*;

--- a/library/alloc/src/vec/spec_from_elem.rs
+++ b/library/alloc/src/vec/spec_from_elem.rs
@@ -3,7 +3,7 @@ use core::ptr;
 use crate::alloc::Allocator;
 use crate::raw_vec::RawVec;
 
-use super::{ExtendElement, IsZero, Vec};
+use super::{IsZero, Vec};
 
 // Specialization trait used for Vec::from_elem
 pub(super) trait SpecFromElem: Sized {
@@ -13,7 +13,7 @@ pub(super) trait SpecFromElem: Sized {
 impl<T: Clone> SpecFromElem for T {
     default fn from_elem<A: Allocator>(elem: Self, n: usize, alloc: A) -> Vec<Self, A> {
         let mut v = Vec::with_capacity_in(n, alloc);
-        v.extend_with(n, ExtendElement(elem));
+        v.extend_with(n, elem);
         v
     }
 }
@@ -25,7 +25,7 @@ impl<T: Clone + IsZero> SpecFromElem for T {
             return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
         }
         let mut v = Vec::with_capacity_in(n, alloc);
-        v.extend_with(n, ExtendElement(elem));
+        v.extend_with(n, elem);
         v
     }
 }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -703,8 +703,8 @@ impl<'a> Builder<'a> {
                 check::CargoMiri,
                 check::MiroptTestTools,
                 check::Rls,
-                check::RustAnalyzer,
                 check::Rustfmt,
+                check::RustAnalyzer,
                 check::Bootstrap
             ),
             Kind::Test => describe!(

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -347,7 +347,7 @@ pub struct RustAnalyzer {
 impl Step for RustAnalyzer {
     type Output = ();
     const ONLY_HOSTS: bool = true;
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/rust-analyzer")

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1069,7 +1069,6 @@ impl Build {
     }
 
     fn group(&self, msg: &str) -> Option<gha::Group> {
-        self.info(&msg);
         match self.config.dry_run {
             DryRun::SelfCheck => None,
             DryRun::Disabled | DryRun::UserSelected => Some(gha::group(&msg)),

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1038,9 +1038,9 @@ fn render_attributes_in_pre<'a, 'b: 'a>(
 
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
-fn render_attributes_in_code(w: &mut Buffer, it: &clean::Item, tcx: TyCtxt<'_>) {
+fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, tcx: TyCtxt<'_>) {
     for a in it.attributes(tcx, false) {
-        write!(w, "<div class=\"code-attribute\">{}</div>", a);
+        write!(w, "<div class=\"code-attribute\">{}</div>", a).unwrap();
     }
 }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1039,8 +1039,8 @@ fn render_attributes_in_pre<'a, 'b: 'a>(
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
 fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, tcx: TyCtxt<'_>) {
-    for a in it.attributes(tcx, false) {
-        write!(w, "<div class=\"code-attribute\">{}</div>", a).unwrap();
+    for attr in it.attributes(tcx, false) {
+        write!(w, "<div class=\"code-attribute\">{attr}</div>").unwrap();
     }
 }
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1435,17 +1435,17 @@ fn item_proc_macro(
         let name = it.name.expect("proc-macros always have names");
         match m.kind {
             MacroKind::Bang => {
-                write!(buffer, "{}!() {{ /* proc-macro */ }}", name).unwrap();
+                write!(buffer, "{name}!() {{ /* proc-macro */ }}").unwrap();
             }
             MacroKind::Attr => {
-                write!(buffer, "#[{}]", name).unwrap();
+                write!(buffer, "#[{name}]").unwrap();
             }
             MacroKind::Derive => {
-                write!(buffer, "#[derive({})]", name).unwrap();
+                write!(buffer, "#[derive({name})]").unwrap();
                 if !m.helpers.is_empty() {
                     buffer.write_str("\n{\n    // Attributes available to this derive:\n").unwrap();
                     for attr in &m.helpers {
-                        writeln!(buffer, "    #[{}]", attr).unwrap();
+                        writeln!(buffer, "    #[{attr}]").unwrap();
                     }
                     buffer.write_str("}\n").unwrap();
                 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1431,30 +1431,28 @@ fn item_proc_macro(
     it: &clean::Item,
     m: &clean::ProcMacro,
 ) {
-    let mut buffer = Buffer::new();
-    wrap_item(&mut buffer, |buffer| {
+    wrap_item(w, |buffer| {
         let name = it.name.expect("proc-macros always have names");
         match m.kind {
             MacroKind::Bang => {
-                write!(buffer, "{}!() {{ /* proc-macro */ }}", name);
+                write!(buffer, "{}!() {{ /* proc-macro */ }}", name).unwrap();
             }
             MacroKind::Attr => {
-                write!(buffer, "#[{}]", name);
+                write!(buffer, "#[{}]", name).unwrap();
             }
             MacroKind::Derive => {
-                write!(buffer, "#[derive({})]", name);
+                write!(buffer, "#[derive({})]", name).unwrap();
                 if !m.helpers.is_empty() {
-                    buffer.push_str("\n{\n");
-                    buffer.push_str("    // Attributes available to this derive:\n");
+                    buffer.write_str("\n{\n    // Attributes available to this derive:\n").unwrap();
                     for attr in &m.helpers {
-                        writeln!(buffer, "    #[{}]", attr);
+                        writeln!(buffer, "    #[{}]", attr).unwrap();
                     }
-                    buffer.push_str("}\n");
+                    buffer.write_str("}\n").unwrap();
                 }
             }
         }
     });
-    write!(w, "{}{}", buffer.into_inner(), document(cx, it, None, HeadingOffset::H2)).unwrap();
+    write!(w, "{}", document(cx, it, None, HeadingOffset::H2)).unwrap();
 }
 
 fn item_primitive(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item) {
@@ -1571,8 +1569,7 @@ fn item_struct(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, s: &clean
 }
 
 fn item_static(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Item, s: &clean::Static) {
-    let mut buffer = Buffer::new();
-    wrap_item(&mut buffer, |buffer| {
+    wrap_item(w, |buffer| {
         render_attributes_in_code(buffer, it, cx.tcx());
         write!(
             buffer,
@@ -1581,29 +1578,27 @@ fn item_static(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Item, 
             mutability = s.mutability.print_with_space(),
             name = it.name.unwrap(),
             typ = s.type_.print(cx)
-        );
+        )
+        .unwrap();
     });
-
-    write!(w, "{}", buffer.into_inner()).unwrap();
 
     write!(w, "{}", document(cx, it, None, HeadingOffset::H2)).unwrap();
 }
 
 fn item_foreign_type(w: &mut impl fmt::Write, cx: &mut Context<'_>, it: &clean::Item) {
-    let mut buffer = Buffer::new();
-    wrap_item(&mut buffer, |buffer| {
-        buffer.write_str("extern {\n");
+    wrap_item(w, |buffer| {
+        buffer.write_str("extern {\n").unwrap();
         render_attributes_in_code(buffer, it, cx.tcx());
         write!(
             buffer,
             "    {}type {};\n}}",
             visibility_print_with_space(it.visibility(cx.tcx()), it.item_id, cx),
             it.name.unwrap(),
-        );
+        )
+        .unwrap();
     });
 
-    write!(w, "{}{}", buffer.into_inner(), document(cx, it, None, HeadingOffset::H2)).unwrap();
-
+    write!(w, "{}", document(cx, it, None, HeadingOffset::H2)).unwrap();
     write!(w, "{}", render_assoc_items(cx, it, it.item_id.expect_def_id(), AssocItemRender::All))
         .unwrap();
 }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -147,9 +147,9 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
 
         // `#[macro_export] macro_rules!` items are reexported at the top level of the
         // crate, regardless of where they're defined. We want to document the
-        // top level rexport of the macro, not its original definition, since
-        // the rexport defines the path that a user will actually see. Accordingly,
-        // we add the rexport as an item here, and then skip over the original
+        // top level re-export of the macro, not its original definition, since
+        // the re-export defines the path that a user will actually see. Accordingly,
+        // we add the re-export as an item here, and then skip over the original
         // definition in `visit_item()` below.
         //
         // We also skip `#[macro_export] macro_rules!` that have already been inserted,

--- a/src/tools/build_helper/src/ci.rs
+++ b/src/tools/build_helper/src/ci.rs
@@ -46,6 +46,8 @@ pub mod gha {
     pub fn group(name: impl std::fmt::Display) -> Group {
         if std::env::var_os("GITHUB_ACTIONS").is_some() {
             eprintln!("::group::{name}");
+        } else {
+            eprintln!("{name}")
         }
         Group(())
     }


### PR DESCRIPTION
Successful merges:

 - #112243 (Remove unneeded `Buffer` allocations when `&mut fmt::Write` can be used directly)
 - #112263 (Remove ExtendElement, ExtendWith, extend_with)
 - #112291 (Disable RustAnalyzer check by default, run Rustfmt check before)
 - #112299 (Don't double-print status messages in GHA)
 - #112311 (Ignore fluent message reordering in `git blame`)
 - #112315 (fix spelling error)

Failed merges:

 - #112251 (rustdoc: convert `if let Some()` that always matches to variable)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112243,112263,112291,112299,112311,112315)
<!-- homu-ignore:end -->