### PR TITLE
ci: Upgrade loongarch64-linux-gnu GCC to 13.1.0

### DIFF
--- a/src/ci/docker/README.md
+++ b/src/ci/docker/README.md
@@ -270,7 +270,7 @@ For targets: `loongarch64-unknown-linux-gnu`
 - Operating System > Linux kernel version = 5.19.16
 - Binary utilities > Version of binutils = 2.40
 - C-library > glibc version = 2.36
-- C compiler > gcc version = 12.2.0
+- C compiler > gcc version = 13.1.0
 - C compiler > C++ = ENABLE -- to cross compile LLVM
 
 ### `mips-linux-gnu.defconfig`

--- a/src/ci/docker/scripts/crosstool-ng-git.sh
+++ b/src/ci/docker/scripts/crosstool-ng-git.sh
@@ -2,7 +2,7 @@
 set -ex
 
 URL=https://github.com/crosstool-ng/crosstool-ng
-REV=943364711a650d9b9e84c1b42c91cc0265b6ab5c
+REV=227d99d7f3115f3a078595a580d2b307dcd23e93
 
 mkdir crosstool-ng
 cd crosstool-ng


### PR DESCRIPTION
This PR upgrades GCC to 13.1.0 for the `loongarch64-unknown-linux-gnu` target. This upgrade was suggested in a previous review discussion: https://github.com/rust-lang/rust/pull/110519#discussion_r1184613749