### PR TITLE
Fix rust-analyzer proc macro server

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -711,7 +711,7 @@ impl Step for RustAnalyzerProcMacroSrv {
             tool: "rust-analyzer-proc-macro-srv",
             mode: Mode::ToolStd,
             path: "src/tools/rust-analyzer/crates/proc-macro-srv-cli",
-            extra_features: vec!["proc-macro-srv/sysroot-abi".to_owned()],
+            extra_features: vec!["sysroot-abi".to_owned()],
             is_optional_tool: false,
             source_type: SourceType::InTree,
             allow_features: RustAnalyzer::ALLOW_FEATURES,


### PR DESCRIPTION
The feature now exists on `proc-macro-srv-cli`, and without it the proc macro server will bail rigth out.

CC https://github.com/rust-lang/rust-analyzer/issues/14991
