### PR TITLE
Prevent emitting `missing_docs` for `pub extern crate`

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -548,8 +548,12 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
 
     fn check_item(&mut self, cx: &LateContext<'_>, it: &hir::Item<'_>) {
         // Previously the Impl and Use types have been excluded from missing docs,
-        // so we will continue to exclude them for compatibility
-        if let hir::ItemKind::Impl(..) | hir::ItemKind::Use(..) = it.kind {
+        // so we will continue to exclude them for compatibility.
+        //
+        // The documentation on `ExternCrate` is not used at the moment so no need to warn for it.
+        if let hir::ItemKind::Impl(..) | hir::ItemKind::Use(..) | hir::ItemKind::ExternCrate(_) =
+            it.kind
+        {
             return;
         }
 

--- a/tests/ui/lint/auxiliary/missing_docs.rs
+++ b/tests/ui/lint/auxiliary/missing_docs.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/ui/lint/lint-missing-doc.rs
+++ b/tests/ui/lint/lint-missing-doc.rs
@@ -1,5 +1,6 @@
 // When denying at the crate level, be sure to not get random warnings from the
 // injected intrinsics by the compiler.
+// aux-build:missing_docs.rs
 #![deny(missing_docs)]
 #![allow(dead_code)]
 #![feature(associated_type_defaults, extern_types)]
@@ -7,6 +8,9 @@
 
 //! Some garbage docs for the crate here
 #![doc="More garbage"]
+
+// There should be not "missing_docs" warning on "pub extern crate".
+pub extern crate missing_docs;
 
 type Typedef = String;
 pub type PubTypedef = String; //~ ERROR: missing documentation for a type alias

--- a/tests/ui/lint/lint-missing-doc.stderr
+++ b/tests/ui/lint/lint-missing-doc.stderr
@@ -1,155 +1,155 @@
 error: missing documentation for a type alias
-  --> $DIR/lint-missing-doc.rs:12:1
+  --> $DIR/lint-missing-doc.rs:16:1
    |
 LL | pub type PubTypedef = String;
    | ^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/lint-missing-doc.rs:3:9
+  --> $DIR/lint-missing-doc.rs:4:9
    |
 LL | #![deny(missing_docs)]
    |         ^^^^^^^^^^^^
 
 error: missing documentation for a struct
-  --> $DIR/lint-missing-doc.rs:19:1
+  --> $DIR/lint-missing-doc.rs:23:1
    |
 LL | pub struct PubFoo {
    | ^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a struct field
-  --> $DIR/lint-missing-doc.rs:20:5
+  --> $DIR/lint-missing-doc.rs:24:5
    |
 LL |     pub a: isize,
    |     ^^^^^^^^^^^^
 
 error: missing documentation for a module
-  --> $DIR/lint-missing-doc.rs:31:1
+  --> $DIR/lint-missing-doc.rs:35:1
    |
 LL | pub mod pub_module_no_dox {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:35:1
+  --> $DIR/lint-missing-doc.rs:39:1
    |
 LL | pub fn foo2() {}
    | ^^^^^^^^^^^^^
 
 error: missing documentation for a trait
-  --> $DIR/lint-missing-doc.rs:53:1
+  --> $DIR/lint-missing-doc.rs:57:1
    |
 LL | pub trait C {
    | ^^^^^^^^^^^
 
 error: missing documentation for a method
-  --> $DIR/lint-missing-doc.rs:54:5
+  --> $DIR/lint-missing-doc.rs:58:5
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
 
 error: missing documentation for a method
-  --> $DIR/lint-missing-doc.rs:55:5
+  --> $DIR/lint-missing-doc.rs:59:5
    |
 LL |     fn foo_with_impl(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:56:5
+  --> $DIR/lint-missing-doc.rs:60:5
    |
 LL |     fn foo_no_self();
    |     ^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:57:5
+  --> $DIR/lint-missing-doc.rs:61:5
    |
 LL |     fn foo_no_self_with_impl() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated type
-  --> $DIR/lint-missing-doc.rs:67:5
+  --> $DIR/lint-missing-doc.rs:71:5
    |
 LL |     type AssociatedType;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated type
-  --> $DIR/lint-missing-doc.rs:68:5
+  --> $DIR/lint-missing-doc.rs:72:5
    |
 LL |     type AssociatedTypeDef = Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:84:5
+  --> $DIR/lint-missing-doc.rs:88:5
    |
 LL |     pub fn foo() {}
    |     ^^^^^^^^^^^^
 
 error: missing documentation for an enum
-  --> $DIR/lint-missing-doc.rs:121:1
+  --> $DIR/lint-missing-doc.rs:125:1
    |
 LL | pub enum PubBaz {
    | ^^^^^^^^^^^^^^^
 
 error: missing documentation for a variant
-  --> $DIR/lint-missing-doc.rs:122:5
+  --> $DIR/lint-missing-doc.rs:126:5
    |
 LL |     PubBazA {
    |     ^^^^^^^
 
 error: missing documentation for a struct field
-  --> $DIR/lint-missing-doc.rs:123:9
+  --> $DIR/lint-missing-doc.rs:127:9
    |
 LL |         a: isize,
    |         ^^^^^^^^
 
 error: missing documentation for a constant
-  --> $DIR/lint-missing-doc.rs:154:1
+  --> $DIR/lint-missing-doc.rs:158:1
    |
 LL | pub const FOO4: u32 = 0;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a static
-  --> $DIR/lint-missing-doc.rs:164:1
+  --> $DIR/lint-missing-doc.rs:168:1
    |
 LL | pub static BAR4: u32 = 0;
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:170:5
+  --> $DIR/lint-missing-doc.rs:174:5
    |
 LL |     pub fn undocumented1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:171:5
+  --> $DIR/lint-missing-doc.rs:175:5
    |
 LL |     pub fn undocumented2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:177:9
+  --> $DIR/lint-missing-doc.rs:181:9
    |
 LL |         pub fn also_undocumented1() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:192:5
+  --> $DIR/lint-missing-doc.rs:196:5
    |
 LL |     pub fn extern_fn_undocumented(f: f32) -> f32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a static
-  --> $DIR/lint-missing-doc.rs:197:5
+  --> $DIR/lint-missing-doc.rs:201:5
    |
 LL |     pub static EXTERN_STATIC_UNDOCUMENTED: u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a foreign type
-  --> $DIR/lint-missing-doc.rs:202:5
+  --> $DIR/lint-missing-doc.rs:206:5
    |
 LL |     pub type ExternTyUndocumented;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a trait alias
-  --> $DIR/lint-missing-doc.rs:206:1
+  --> $DIR/lint-missing-doc.rs:210:1
    |
 LL | pub trait T = Sync;
    | ^^^^^^^^^^^


### PR DESCRIPTION
Fixes #112308.

r? @notriddle 