### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -96,7 +96,19 @@ pub(super) fn check_fn<'a, 'tcx>(
         // for simple cases like `fn foo(x: Trait)`,
         // where we would error once on the parameter as a whole, and once on the binding `x`.
         if param.pat.simple_ident().is_none() && !params_can_be_unsized {
-            fcx.require_type_is_sized(param_ty, param.pat.span, traits::SizedArgumentType(ty_span));
+            fcx.require_type_is_sized(
+                param_ty,
+                param.pat.span,
+                // ty_span == binding_span iff this is a closure parameter with no type ascription,
+                // or if it's an implicit `self` parameter
+                traits::SizedArgumentType(
+                    if ty_span == Some(param.span) && tcx.is_closure(fn_def_id.into()) {
+                        None
+                    } else {
+                        ty_span
+                    },
+                ),
+            );
         }
 
         fcx.write_ty(param.hir_id, param_ty);

--- a/compiler/rustc_hir_typeck/src/gather_locals.rs
+++ b/compiler/rustc_hir_typeck/src/gather_locals.rs
@@ -129,7 +129,17 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
                     self.fcx.require_type_is_sized(
                         var_ty,
                         p.span,
-                        traits::SizedArgumentType(Some(ty_span)),
+                        // ty_span == ident.span iff this is a closure parameter with no type
+                        // ascription, or if it's an implicit `self` parameter
+                        traits::SizedArgumentType(
+                            if ty_span == ident.span
+                                && self.fcx.tcx.is_closure(self.fcx.body_id.into())
+                            {
+                                None
+                            } else {
+                                Some(ty_span)
+                            },
+                        ),
                     );
                 }
             } else {

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -586,7 +586,7 @@ impl<'tcx> Instance<'tcx> {
         if let Some(substs) = self.substs_for_mir_body() {
             v.subst(tcx, substs)
         } else {
-            v.skip_binder()
+            v.subst_identity()
         }
     }
 

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -647,7 +647,7 @@ fn build_call_shim<'tcx>(
     let mut sig = if let Some(sig_substs) = sig_substs {
         sig.subst(tcx, &sig_substs)
     } else {
-        sig.skip_binder()
+        sig.subst_identity()
     };
 
     if let CallKind::Indirect(fnty) = call_kind {

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1284,6 +1284,7 @@ supported_targets! {
     ("riscv32im-unknown-none-elf", riscv32im_unknown_none_elf),
     ("riscv32imc-unknown-none-elf", riscv32imc_unknown_none_elf),
     ("riscv32imc-esp-espidf", riscv32imc_esp_espidf),
+    ("riscv32imac-esp-espidf", riscv32imac_esp_espidf),
     ("riscv32imac-unknown-none-elf", riscv32imac_unknown_none_elf),
     ("riscv32imac-unknown-xous-elf", riscv32imac_unknown_xous_elf),
     ("riscv32gc-unknown-linux-gnu", riscv32gc_unknown_linux_gnu),

--- a/compiler/rustc_target/src/spec/riscv32imac_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/riscv32imac_esp_espidf.rs
@@ -1,0 +1,31 @@
+use crate::spec::{cvs, PanicStrategy, RelocModel, Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        data_layout: "e-m:e-p:32:32-i64:64-n32-S128".into(),
+        llvm_target: "riscv32".into(),
+        pointer_width: 32,
+        arch: "riscv32".into(),
+
+        options: TargetOptions {
+            families: cvs!["unix"],
+            os: "espidf".into(),
+            env: "newlib".into(),
+            vendor: "espressif".into(),
+            linker: Some("riscv32-esp-elf-gcc".into()),
+            cpu: "generic-rv32".into(),
+
+            // As RiscV32IMAC architecture does natively support atomics,
+            // automatically enable the support for the Rust STD library.
+            max_atomic_width: Some(64),
+            atomic_cas: true,
+
+            features: "+m,+a,+c".into(),
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            emit_debug_gdb_scripts: false,
+            eh_frame_header: false,
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2807,8 +2807,8 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     err.help("unsized locals are gated as an unstable feature");
                 }
             }
-            ObligationCauseCode::SizedArgumentType(sp) => {
-                if let Some(span) = sp {
+            ObligationCauseCode::SizedArgumentType(ty_span) => {
+                if let Some(span) = ty_span {
                     if let ty::PredicateKind::Clause(clause) = predicate.kind().skip_binder()
                         && let ty::Clause::Trait(trait_pred) = clause
                         && let ty::Dynamic(..) = trait_pred.self_ty().kind()

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -298,6 +298,7 @@ target | std | host | notes
 `riscv32im-unknown-none-elf` | * |  | Bare RISC-V (RV32IM ISA)
 [`riscv32imac-unknown-xous-elf`](platform-support/riscv32imac-unknown-xous-elf.md) | ? |  | RISC-V Xous (RV32IMAC ISA)
 [`riscv32imc-esp-espidf`](platform-support/esp-idf.md) | ✓ |  | RISC-V ESP-IDF
+[`riscv32imac-esp-espidf`](platform-support/esp-idf.md) | ✓ |  | RISC-V ESP-IDF
 `riscv64gc-unknown-freebsd` |   |   | RISC-V FreeBSD
 `riscv64gc-unknown-fuchsia` |   |   | RISC-V Fuchsia
 `riscv64gc-unknown-linux-musl` |   |   | RISC-V Linux (kernel 4.20, musl 1.2.0)

--- a/src/doc/rustc/src/platform-support/esp-idf.md
+++ b/src/doc/rustc/src/platform-support/esp-idf.md
@@ -13,11 +13,12 @@ Targets for the [ESP-IDF](https://github.com/espressif/esp-idf) development fram
 
 The target names follow this format: `$ARCH-esp-espidf`, where `$ARCH` specifies the target processor architecture. The following targets are currently defined:
 
-|          Target name           | Target CPU(s)         |
-|--------------------------------|-----------------------|
-| `riscv32imc-esp-espidf`        |  [ESP32-C3](https://www.espressif.com/en/products/socs/esp32-c3)             |
+|          Target name           | Target CPU(s)         | Minimum ESP-IDF version |
+|--------------------------------|-----------------------|-------------------------|
+| `riscv32imc-esp-espidf`        |  [ESP32-C3](https://www.espressif.com/en/products/socs/esp32-c3)             | `v4.3`                |
+| `riscv32imac-esp-espidf`       |  [ESP32-C6](https://www.espressif.com/en/products/socs/esp32-c6)             | `v5.1`                |
 
-The minimum supported ESP-IDF version is `v4.3`, though it is recommended to use the latest stable release if possible.
+It is recommended to use the latest ESP-IDF stable release if possible.
 
 ## Building the target
 

--- a/src/etc/gdb_load_rust_pretty_printers.py
+++ b/src/etc/gdb_load_rust_pretty_printers.py
@@ -1,3 +1,14 @@
+# Add this folder to the python sys path; GDB Python-interpreter will now find modules in this path
+import sys
+from os import path
+self_dir = path.dirname(path.realpath(__file__))
+sys.path.append(self_dir)
+
 import gdb
 import gdb_lookup
-gdb_lookup.register_printers(gdb.current_objfile())
+
+# current_objfile can be none; even with `gdb foo-app`; sourcing this file after gdb init now works
+try:
+    gdb_lookup.register_printers(gdb.current_objfile())
+except Exception:
+    gdb_lookup.register_printers(gdb.selected_inferior().progspace)

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -104,10 +104,10 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                         // the post-inference `trait_ref`, as it's more accurate.
                         trait_: Some(clean_trait_ref_with_bindings(
                             cx,
-                            ty::Binder::dummy(trait_ref.skip_binder()),
+                            ty::Binder::dummy(trait_ref.subst_identity()),
                             ThinVec::new(),
                         )),
-                        for_: clean_middle_ty(ty::Binder::dummy(ty.skip_binder()), cx, None),
+                        for_: clean_middle_ty(ty::Binder::dummy(ty.subst_identity()), cx, None),
                         items: cx
                             .tcx
                             .associated_items(impl_def_id)
@@ -116,7 +116,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                             .collect::<Vec<_>>(),
                         polarity: ty::ImplPolarity::Positive,
                         kind: ImplKind::Blanket(Box::new(clean_middle_ty(
-                            ty::Binder::dummy(trait_ref.skip_binder().self_ty()),
+                            ty::Binder::dummy(trait_ref.subst_identity().self_ty()),
                             cx,
                             None,
                         ))),

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/print.checks
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/print.checks
@@ -1,6 +1,6 @@
 CHECK: print
 CHECK:      lfence
-CHECK:      lfence
-CHECK:      lfence
-CHECK:      callq 0x{{[[:xdigit:]]*}} <_Unwind_Resume>
-CHECK-NEXT: ud2
+CHECK:      popq
+CHECK-NEXT: popq [[REGISTER:%[a-z]+]]
+CHECK-NEXT: lfence
+CHECK-NEXT: jmpq *[[REGISTER]]

--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/script.sh
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/script.sh
@@ -33,6 +33,15 @@ function check {
     ${objdump} --disassemble-symbols="${func}" --demangle \
       ${enclave} > ${asm}
     ${filecheck} --input-file ${asm} ${checks}
+
+    if [ "${func_re}" != "rust_plus_one_global_asm" &&
+         "${func_re}" != "cmake_plus_one_c_global_asm" ]; then
+        # The assembler cannot avoid explicit `ret` instructions. Sequences
+        # of `shlq $0x0, (%rsp); lfence; retq` are used instead.
+        # https://www.intel.com/content/www/us/en/developer/articles/technical/
+        #     software-security-guidance/technical-documentation/load-value-injection.html
+        ${filecheck} --implicit-check-not ret --input-file ${asm} ${checks}
+    fi
 }
 
 build

--- a/tests/ui/borrowck/issue-111554.rs
+++ b/tests/ui/borrowck/issue-111554.rs
@@ -1,0 +1,28 @@
+struct Foo {}
+
+impl Foo {
+    pub fn foo(&mut self) {
+        || bar(&mut self);
+        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable
+    }
+
+    pub fn baz(&self) {
+        || bar(&mut self);
+        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable
+        //~| ERROR cannot borrow data in a `&` reference as mutable
+    }
+
+    pub fn qux(mut self) {
+        || bar(&mut self);
+        // OK
+    }
+
+    pub fn quux(self) {
+        || bar(&mut self);
+        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable
+    }
+}
+
+fn bar(_: &mut Foo) {}
+
+fn main() {}

--- a/tests/ui/borrowck/issue-111554.stderr
+++ b/tests/ui/borrowck/issue-111554.stderr
@@ -1,0 +1,29 @@
+error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+  --> $DIR/issue-111554.rs:5:16
+   |
+LL |         || bar(&mut self);
+   |                ^^^^^^^^^ cannot borrow as mutable
+
+error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+  --> $DIR/issue-111554.rs:10:16
+   |
+LL |         || bar(&mut self);
+   |                ^^^^^^^^^ cannot borrow as mutable
+
+error[E0596]: cannot borrow data in a `&` reference as mutable
+  --> $DIR/issue-111554.rs:10:16
+   |
+LL |         || bar(&mut self);
+   |                ^^^^^^^^^ cannot borrow as mutable
+
+error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+  --> $DIR/issue-111554.rs:21:16
+   |
+LL |     pub fn quux(self) {
+   |                 ---- help: consider changing this to be mutable: `mut self`
+LL |         || bar(&mut self);
+   |                ^^^^^^^^^ cannot borrow as mutable
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/closures/issue-111932.rs
+++ b/tests/ui/closures/issue-111932.rs
@@ -1,0 +1,9 @@
+trait Foo: std::fmt::Debug {}
+
+fn print_foos(foos: impl Iterator<Item = dyn Foo>) {
+    foos.for_each(|foo| { //~ ERROR [E0277]
+        println!("{:?}", foo); //~ ERROR [E0277]
+    });
+}
+
+fn main() {}

--- a/tests/ui/closures/issue-111932.stderr
+++ b/tests/ui/closures/issue-111932.stderr
@@ -1,0 +1,26 @@
+error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+  --> $DIR/issue-111932.rs:4:20
+   |
+LL |     foos.for_each(|foo| {
+   |                    ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = note: all function arguments must have a statically known size
+   = help: unsized fn params are gated as an unstable feature
+
+error[E0277]: the size for values of type `dyn Foo` cannot be known at compilation time
+  --> $DIR/issue-111932.rs:5:26
+   |
+LL |         println!("{:?}", foo);
+   |                   ----   ^^^ doesn't have a size known at compile-time
+   |                   |
+   |                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `dyn Foo`
+note: required by a bound in `core::fmt::rt::Argument::<'a>::new_debug`
+  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/parser/issue-112188.fixed
+++ b/tests/ui/parser/issue-112188.fixed
@@ -1,0 +1,14 @@
+// run-rustfix
+
+#![allow(unused)]
+
+struct Foo { x: i32 }
+
+fn main() {
+    let f = Foo { x: 0 };
+    let Foo { .. } = f;
+    let Foo { .. } = f; //~ ERROR expected `}`, found `,`
+    let Foo { x, .. } = f;
+    let Foo { x, .. } = f; //~ ERROR expected `}`, found `,`
+    let Foo { x, .. } = f; //~ ERROR expected `}`, found `,`
+}

--- a/tests/ui/parser/issue-112188.rs
+++ b/tests/ui/parser/issue-112188.rs
@@ -1,0 +1,14 @@
+// run-rustfix
+
+#![allow(unused)]
+
+struct Foo { x: i32 }
+
+fn main() {
+    let f = Foo { x: 0 };
+    let Foo { .. } = f;
+    let Foo { .., } = f; //~ ERROR expected `}`, found `,`
+    let Foo { x, .. } = f;
+    let Foo { .., x } = f; //~ ERROR expected `}`, found `,`
+    let Foo { .., x, .. } = f; //~ ERROR expected `}`, found `,`
+}

--- a/tests/ui/parser/issue-112188.stderr
+++ b/tests/ui/parser/issue-112188.stderr
@@ -1,0 +1,37 @@
+error: expected `}`, found `,`
+  --> $DIR/issue-112188.rs:10:17
+   |
+LL |     let Foo { .., } = f;
+   |               --^
+   |               | |
+   |               | expected `}`
+   |               | help: remove this comma
+   |               `..` must be at the end and cannot have a trailing comma
+
+error: expected `}`, found `,`
+  --> $DIR/issue-112188.rs:12:17
+   |
+LL |     let Foo { .., x } = f;
+   |               --^
+   |               | |
+   |               | expected `}`
+   |               `..` must be at the end and cannot have a trailing comma
+   |
+help: move the `..` to the end of the field list
+   |
+LL -     let Foo { .., x } = f;
+LL +     let Foo { x, .. } = f;
+   |
+
+error: expected `}`, found `,`
+  --> $DIR/issue-112188.rs:13:17
+   |
+LL |     let Foo { .., x, .. } = f;
+   |               --^-
+   |               | |
+   |               | expected `}`
+   |               `..` must be at the end and cannot have a trailing comma
+   |               help: remove the starting `..`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/parser/issue-49257.stderr
+++ b/tests/ui/parser/issue-49257.stderr
@@ -25,7 +25,7 @@ LL |     let Point { .., y } = p;
 help: move the `..` to the end of the field list
    |
 LL -     let Point { .., y } = p;
-LL +     let Point { y , .. } = p;
+LL +     let Point { y, .. } = p;
    |
 
 error: expected `}`, found `,`

--- a/tests/ui/unsized-locals/issue-67981.stderr
+++ b/tests/ui/unsized-locals/issue-67981.stderr
@@ -5,10 +5,7 @@ LL |     let f: fn([u8]) = |_| {};
    |                        ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-help: function arguments must have a statically known size, borrowed types always have a known size
-   |
-LL |     let f: fn([u8]) = |&_| {};
-   |                        +
+   = note: all function arguments must have a statically known size
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #111058 (Correct fortanix LVI test print function)
 - #111369 (Added custom risc32-imac for esp-espidf target)
 - #111962 (Make GDB Python Pretty Printers loadable after spawning GDB, avoiding required `rust-gdb`)
 - #112019 (Don't suggest changing `&self` and `&mut self` in function signature to be mutable when taking `&mut self` in closure)
 - #112199 (Fix suggestion for matching struct with `..` on both ends)
 - #112220 (Cleanup some `EarlyBinder::skip_binder()` -> `EarlyBinder::subst_identity()`)
 - #112325 (diagnostics: do not suggest type name tweaks on type-inferred closure args)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=111058,111369,111962,112019,112199,112220,112325)
<!-- homu-ignore:end -->