### PR TITLE
Add InlineAsm Terminator conversion from MIR to SMIR

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -334,6 +334,15 @@ fn rustc_terminator_to_terminator(
         GeneratorDrop => Terminator::GeneratorDrop,
         FalseEdge { .. } => todo!(),
         FalseUnwind { .. } => todo!(),
-        InlineAsm { .. } => todo!(),
+        InlineAsm { template, operands, options, line_spans, destination, unwind } => {
+            Terminator::InlineAsm {
+                template: format!("{:?}", template),
+                operands: format!("{:?}", operands),
+                options: format!("{:?}", options),
+                line_spans: format!("{:?}", line_spans),
+                destination: destination.map(|d| d.as_usize()),
+                unwind: rustc_unwind_to_unwind(unwind),
+            }
+        }
     }
 }

--- a/compiler/rustc_smir/src/stable_mir/mir/body.rs
+++ b/compiler/rustc_smir/src/stable_mir/mir/body.rs
@@ -46,6 +46,14 @@ pub enum Terminator {
         unwind: UnwindAction,
     },
     GeneratorDrop,
+    InlineAsm {
+        template: String,
+        operands: String,
+        options: String,
+        line_spans: String,
+        destination: Option<usize>,
+        unwind: UnwindAction,
+    },
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This is the last variant that needed to be covered for Terminator. As we've discussed with @oli-obk I've made a lot of it's fields be `String`s.

r? @oli-obk 