### PR TITLE
new solver proof tree generation

### DIFF
--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -981,7 +981,7 @@ pub enum CodegenObligationError {
     FulfillmentError,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, TypeFoldable, TypeVisitable)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub enum DefiningAnchor {
     /// `DefId` of the item.
     Bind(LocalDefId),

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -991,3 +991,9 @@ pub enum DefiningAnchor {
     /// Used to catch type mismatch errors when handling opaque types.
     Error,
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, HashStable)]
+pub enum IsNormalizesToHack {
+    Yes,
+    No,
+}

--- a/compiler/rustc_middle/src/traits/query.rs
+++ b/compiler/rustc_middle/src/traits/query.rs
@@ -92,7 +92,7 @@ pub type CanonicalTypeOpProvePredicateGoal<'tcx> =
 pub type CanonicalTypeOpNormalizeGoal<'tcx, T> =
     Canonical<'tcx, ty::ParamEnvAnd<'tcx, type_op::Normalize<T>>>;
 
-#[derive(Copy, Clone, Debug, HashStable, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, HashStable, PartialEq, Eq)]
 pub struct NoSolution;
 
 impl<'tcx> From<TypeError<'tcx>> for NoSolution {

--- a/compiler/rustc_middle/src/traits/solve.rs
+++ b/compiler/rustc_middle/src/traits/solve.rs
@@ -11,6 +11,8 @@ use crate::ty::{
     TypeVisitor,
 };
 
+pub mod inspect;
+
 pub type EvaluationCache<'tcx> = Cache<CanonicalInput<'tcx>, QueryResult<'tcx>>;
 
 /// A goal is a statement, i.e. `predicate`, we want to prove
@@ -18,7 +20,7 @@ pub type EvaluationCache<'tcx> = Cache<CanonicalInput<'tcx>, QueryResult<'tcx>>;
 ///
 /// Most of the time the `param_env` contains the `where`-bounds of the function
 /// we're currently typechecking while the `predicate` is some trait bound.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, TypeFoldable, TypeVisitable)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub struct Goal<'tcx, P> {
     pub predicate: P,
     pub param_env: ty::ParamEnv<'tcx>,
@@ -39,7 +41,7 @@ impl<'tcx, P> Goal<'tcx, P> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, TypeFoldable, TypeVisitable)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub struct Response<'tcx> {
     pub certainty: Certainty,
     pub var_values: CanonicalVarValues<'tcx>,
@@ -47,7 +49,7 @@ pub struct Response<'tcx> {
     pub external_constraints: ExternalConstraints<'tcx>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, TypeFoldable, TypeVisitable)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub enum Certainty {
     Yes,
     Maybe(MaybeCause),
@@ -86,7 +88,7 @@ impl Certainty {
 }
 
 /// Why we failed to evaluate a goal.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, TypeFoldable, TypeVisitable)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub enum MaybeCause {
     /// We failed due to ambiguity. This ambiguity can either
     /// be a true ambiguity, i.e. there are multiple different answers,
@@ -96,7 +98,7 @@ pub enum MaybeCause {
     Overflow,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, TypeFoldable, TypeVisitable)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub struct QueryInput<'tcx, T> {
     pub goal: Goal<'tcx, T>,
     pub anchor: DefiningAnchor,
@@ -104,12 +106,12 @@ pub struct QueryInput<'tcx, T> {
 }
 
 /// Additional constraints returned on success.
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, HashStable, Default)]
 pub struct PredefinedOpaquesData<'tcx> {
     pub opaque_types: Vec<(ty::OpaqueTypeKey<'tcx>, Ty<'tcx>)>,
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, HashStable)]
 pub struct PredefinedOpaques<'tcx>(pub(crate) Interned<'tcx, PredefinedOpaquesData<'tcx>>);
 
 impl<'tcx> std::ops::Deref for PredefinedOpaques<'tcx> {
@@ -132,7 +134,7 @@ pub type CanonicalResponse<'tcx> = Canonical<'tcx, Response<'tcx>>;
 /// solver, merge the two responses again.
 pub type QueryResult<'tcx> = Result<CanonicalResponse<'tcx>, NoSolution>;
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, HashStable)]
 pub struct ExternalConstraints<'tcx>(pub(crate) Interned<'tcx, ExternalConstraintsData<'tcx>>);
 
 impl<'tcx> std::ops::Deref for ExternalConstraints<'tcx> {
@@ -144,7 +146,7 @@ impl<'tcx> std::ops::Deref for ExternalConstraints<'tcx> {
 }
 
 /// Additional constraints returned on success.
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, HashStable, Default)]
 pub struct ExternalConstraintsData<'tcx> {
     // FIXME: implement this.
     pub region_constraints: QueryRegionConstraints<'tcx>,

--- a/compiler/rustc_middle/src/traits/solve/inspect.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect.rs
@@ -1,0 +1,168 @@
+use super::{CanonicalInput, Certainty, Goal, NoSolution, QueryInput, QueryResult};
+use crate::ty;
+use std::fmt::{Debug, Write};
+
+#[derive(Eq, PartialEq, Hash, HashStable)]
+pub struct GoalEvaluation<'tcx> {
+    pub uncanonicalized_goal: Goal<'tcx, ty::Predicate<'tcx>>,
+    pub canonicalized_goal: Option<CanonicalInput<'tcx>>,
+
+    /// To handle coinductive cycles we can end up re-evaluating a goal
+    /// multiple times with different results for a nested goal. Each rerun
+    /// is represented as an entry in this vec.
+    pub evaluation_steps: Vec<GoalEvaluationStep<'tcx>>,
+
+    pub cache_hit: bool,
+
+    pub result: Option<QueryResult<'tcx>>,
+}
+impl Debug for GoalEvaluation<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        ProofTreeFormatter { f, on_newline: true }.format_goal_evaluation(self)
+    }
+}
+
+#[derive(Eq, PartialEq, Hash, HashStable)]
+pub struct AddedGoalsEvaluation<'tcx> {
+    pub evaluations: Vec<Vec<GoalEvaluation<'tcx>>>,
+    pub result: Option<Result<Certainty, NoSolution>>,
+}
+impl Debug for AddedGoalsEvaluation<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        ProofTreeFormatter { f, on_newline: true }.format_nested_goal_evaluation(self)
+    }
+}
+
+#[derive(Eq, PartialEq, Hash, HashStable)]
+pub struct GoalEvaluationStep<'tcx> {
+    pub instantiated_goal: QueryInput<'tcx, ty::Predicate<'tcx>>,
+
+    pub nested_goal_evaluations: Vec<AddedGoalsEvaluation<'tcx>>,
+    pub candidates: Vec<GoalCandidate<'tcx>>,
+
+    pub result: Option<QueryResult<'tcx>>,
+}
+impl Debug for GoalEvaluationStep<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        ProofTreeFormatter { f, on_newline: true }.format_evaluation_step(self)
+    }
+}
+
+#[derive(Eq, PartialEq, Hash, HashStable)]
+pub struct GoalCandidate<'tcx> {
+    pub nested_goal_evaluations: Vec<AddedGoalsEvaluation<'tcx>>,
+    pub candidates: Vec<GoalCandidate<'tcx>>,
+
+    pub name: Option<String>,
+    pub result: Option<QueryResult<'tcx>>,
+}
+impl Debug for GoalCandidate<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        ProofTreeFormatter { f, on_newline: true }.format_candidate(self)
+    }
+}
+
+struct ProofTreeFormatter<'a, 'b> {
+    f: &'a mut (dyn Write + 'b),
+    on_newline: bool,
+}
+
+impl Write for ProofTreeFormatter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        for line in s.split_inclusive("\n") {
+            if self.on_newline {
+                self.f.write_str("    ")?;
+            }
+            self.on_newline = line.ends_with("\n");
+            self.f.write_str(line)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ProofTreeFormatter<'_, '_> {
+    fn nested(&mut self) -> ProofTreeFormatter<'_, '_> {
+        ProofTreeFormatter { f: self, on_newline: true }
+    }
+
+    fn format_goal_evaluation(&mut self, goal: &GoalEvaluation<'_>) -> std::fmt::Result {
+        let f = &mut *self.f;
+        writeln!(f, "GOAL: {:?}", goal.uncanonicalized_goal)?;
+        writeln!(f, "CANONICALIZED: {:?}", goal.canonicalized_goal)?;
+
+        match goal.cache_hit {
+            true => writeln!(f, "CACHE HIT: {:?}", goal.result),
+            false => {
+                for (n, step) in goal.evaluation_steps.iter().enumerate() {
+                    let f = &mut *self.f;
+                    writeln!(f, "REVISION {n}: {:?}", step.result.unwrap())?;
+                    let mut f = self.nested();
+                    f.format_evaluation_step(step)?;
+                }
+
+                let f = &mut *self.f;
+                writeln!(f, "RESULT: {:?}", goal.result.unwrap())
+            }
+        }
+    }
+
+    fn format_evaluation_step(
+        &mut self,
+        evaluation_step: &GoalEvaluationStep<'_>,
+    ) -> std::fmt::Result {
+        let f = &mut *self.f;
+        writeln!(f, "INSTANTIATED: {:?}", evaluation_step.instantiated_goal)?;
+
+        for candidate in &evaluation_step.candidates {
+            let mut f = self.nested();
+            f.format_candidate(candidate)?;
+        }
+        for nested_goal_evaluation in &evaluation_step.nested_goal_evaluations {
+            let mut f = self.nested();
+            f.format_nested_goal_evaluation(nested_goal_evaluation)?;
+        }
+
+        Ok(())
+    }
+
+    fn format_candidate(&mut self, candidate: &GoalCandidate<'_>) -> std::fmt::Result {
+        let f = &mut *self.f;
+
+        match (candidate.name.as_ref(), candidate.result) {
+            (Some(name), Some(result)) => writeln!(f, "CANDIDATE {}: {:?}", name, result,)?,
+            (None, None) => writeln!(f, "MISC PROBE")?,
+            (None, Some(_)) => unreachable!("unexpected probe with no name but a result"),
+            (Some(_), None) => unreachable!("unexpected probe with a name but no candidate"),
+        };
+
+        let mut f = self.nested();
+        for candidate in &candidate.candidates {
+            f.format_candidate(candidate)?;
+        }
+        for nested_evaluations in &candidate.nested_goal_evaluations {
+            f.format_nested_goal_evaluation(nested_evaluations)?;
+        }
+
+        Ok(())
+    }
+
+    fn format_nested_goal_evaluation(
+        &mut self,
+        nested_goal_evaluation: &AddedGoalsEvaluation<'_>,
+    ) -> std::fmt::Result {
+        let f = &mut *self.f;
+        writeln!(f, "TRY_EVALUATE_ADDED_GOALS: {:?}", nested_goal_evaluation.result.unwrap())?;
+
+        for (n, revision) in nested_goal_evaluation.evaluations.iter().enumerate() {
+            let f = &mut *self.f;
+            writeln!(f, "REVISION {n}")?;
+            let mut f = self.nested();
+            for goal_evaluation in revision {
+                f.format_goal_evaluation(goal_evaluation)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/compiler/rustc_middle/src/traits/solve/inspect.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect.rs
@@ -1,6 +1,9 @@
 use super::{CanonicalInput, Certainty, Goal, NoSolution, QueryInput, QueryResult};
 use crate::{traits::IsNormalizesToHack, ty};
+use format::ProofTreeFormatter;
 use std::fmt::{Debug, Write};
+
+mod format;
 
 #[derive(Eq, PartialEq, Debug, Hash, HashStable)]
 pub enum CacheHit {
@@ -72,135 +75,5 @@ pub enum CandidateKind<'tcx> {
 impl Debug for GoalCandidate<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         ProofTreeFormatter { f, on_newline: true }.format_candidate(self)
-    }
-}
-
-struct ProofTreeFormatter<'a, 'b> {
-    f: &'a mut (dyn Write + 'b),
-    on_newline: bool,
-}
-
-impl Write for ProofTreeFormatter<'_, '_> {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        for line in s.split_inclusive("\n") {
-            if self.on_newline {
-                self.f.write_str("    ")?;
-            }
-            self.on_newline = line.ends_with("\n");
-            self.f.write_str(line)?;
-        }
-
-        Ok(())
-    }
-}
-
-impl ProofTreeFormatter<'_, '_> {
-    fn nested(&mut self) -> ProofTreeFormatter<'_, '_> {
-        ProofTreeFormatter { f: self, on_newline: true }
-    }
-
-    fn format_goal_evaluation(&mut self, goal: &GoalEvaluation<'_>) -> std::fmt::Result {
-        let f = &mut *self.f;
-
-        let goal_text = match goal.is_normalizes_to_hack {
-            IsNormalizesToHack::Yes => "NORMALIZES-TO HACK GOAL",
-            IsNormalizesToHack::No => "GOAL",
-        };
-
-        writeln!(f, "{}: {:?}", goal_text, goal.uncanonicalized_goal,)?;
-        writeln!(f, "CANONICALIZED: {:?}", goal.canonicalized_goal)?;
-
-        match &goal.kind {
-            GoalEvaluationKind::CacheHit(CacheHit::Global) => {
-                writeln!(f, "GLOBAL CACHE HIT: {:?}", goal.result)
-            }
-            GoalEvaluationKind::CacheHit(CacheHit::Provisional) => {
-                writeln!(f, "PROVISIONAL CACHE HIT: {:?}", goal.result)
-            }
-            GoalEvaluationKind::Uncached { revisions } => {
-                for (n, step) in revisions.iter().enumerate() {
-                    let f = &mut *self.f;
-                    writeln!(f, "REVISION {n}: {:?}", step.result)?;
-                    let mut f = self.nested();
-                    f.format_evaluation_step(step)?;
-                }
-
-                let f = &mut *self.f;
-                writeln!(f, "RESULT: {:?}", goal.result)
-            }
-        }?;
-
-        if goal.returned_goals.len() > 0 {
-            let f = &mut *self.f;
-            writeln!(f, "NESTED GOALS ADDED TO CALLER: [")?;
-            let mut f = self.nested();
-            for goal in goal.returned_goals.iter() {
-                writeln!(f, "ADDED GOAL: {:?},", goal)?;
-            }
-            writeln!(self.f, "]")?;
-        }
-
-        Ok(())
-    }
-
-    fn format_evaluation_step(
-        &mut self,
-        evaluation_step: &GoalEvaluationStep<'_>,
-    ) -> std::fmt::Result {
-        let f = &mut *self.f;
-        writeln!(f, "INSTANTIATED: {:?}", evaluation_step.instantiated_goal)?;
-
-        for candidate in &evaluation_step.candidates {
-            let mut f = self.nested();
-            f.format_candidate(candidate)?;
-        }
-        for nested_goal_evaluation in &evaluation_step.nested_goal_evaluations {
-            let mut f = self.nested();
-            f.format_nested_goal_evaluation(nested_goal_evaluation)?;
-        }
-
-        Ok(())
-    }
-
-    fn format_candidate(&mut self, candidate: &GoalCandidate<'_>) -> std::fmt::Result {
-        let f = &mut *self.f;
-
-        match &candidate.kind {
-            CandidateKind::NormalizedSelfTyAssembly => {
-                writeln!(f, "NORMALIZING SELF TY FOR ASSEMBLY:")
-            }
-            CandidateKind::Candidate { name, result } => {
-                writeln!(f, "CANDIDATE {}: {:?}", name, result)
-            }
-        }?;
-
-        let mut f = self.nested();
-        for candidate in &candidate.candidates {
-            f.format_candidate(candidate)?;
-        }
-        for nested_evaluations in &candidate.nested_goal_evaluations {
-            f.format_nested_goal_evaluation(nested_evaluations)?;
-        }
-
-        Ok(())
-    }
-
-    fn format_nested_goal_evaluation(
-        &mut self,
-        nested_goal_evaluation: &AddedGoalsEvaluation<'_>,
-    ) -> std::fmt::Result {
-        let f = &mut *self.f;
-        writeln!(f, "TRY_EVALUATE_ADDED_GOALS: {:?}", nested_goal_evaluation.result)?;
-
-        for (n, revision) in nested_goal_evaluation.evaluations.iter().enumerate() {
-            let f = &mut *self.f;
-            writeln!(f, "REVISION {n}")?;
-            let mut f = self.nested();
-            for goal_evaluation in revision {
-                f.format_goal_evaluation(goal_evaluation)?;
-            }
-        }
-
-        Ok(())
     }
 }

--- a/compiler/rustc_middle/src/traits/solve/inspect/format.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect/format.rs
@@ -1,0 +1,131 @@
+use super::*;
+
+pub(super) struct ProofTreeFormatter<'a, 'b> {
+    pub(super) f: &'a mut (dyn Write + 'b),
+    pub(super) on_newline: bool,
+}
+
+impl Write for ProofTreeFormatter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        for line in s.split_inclusive("\n") {
+            if self.on_newline {
+                self.f.write_str("    ")?;
+            }
+            self.on_newline = line.ends_with("\n");
+            self.f.write_str(line)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ProofTreeFormatter<'_, '_> {
+    fn nested(&mut self) -> ProofTreeFormatter<'_, '_> {
+        ProofTreeFormatter { f: self, on_newline: true }
+    }
+
+    pub(super) fn format_goal_evaluation(&mut self, goal: &GoalEvaluation<'_>) -> std::fmt::Result {
+        let f = &mut *self.f;
+
+        let goal_text = match goal.is_normalizes_to_hack {
+            IsNormalizesToHack::Yes => "NORMALIZES-TO HACK GOAL",
+            IsNormalizesToHack::No => "GOAL",
+        };
+
+        writeln!(f, "{}: {:?}", goal_text, goal.uncanonicalized_goal,)?;
+        writeln!(f, "CANONICALIZED: {:?}", goal.canonicalized_goal)?;
+
+        match &goal.kind {
+            GoalEvaluationKind::CacheHit(CacheHit::Global) => {
+                writeln!(f, "GLOBAL CACHE HIT: {:?}", goal.result)
+            }
+            GoalEvaluationKind::CacheHit(CacheHit::Provisional) => {
+                writeln!(f, "PROVISIONAL CACHE HIT: {:?}", goal.result)
+            }
+            GoalEvaluationKind::Uncached { revisions } => {
+                for (n, step) in revisions.iter().enumerate() {
+                    let f = &mut *self.f;
+                    writeln!(f, "REVISION {n}: {:?}", step.result)?;
+                    let mut f = self.nested();
+                    f.format_evaluation_step(step)?;
+                }
+
+                let f = &mut *self.f;
+                writeln!(f, "RESULT: {:?}", goal.result)
+            }
+        }?;
+
+        if goal.returned_goals.len() > 0 {
+            let f = &mut *self.f;
+            writeln!(f, "NESTED GOALS ADDED TO CALLER: [")?;
+            let mut f = self.nested();
+            for goal in goal.returned_goals.iter() {
+                writeln!(f, "ADDED GOAL: {:?},", goal)?;
+            }
+            writeln!(self.f, "]")?;
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn format_evaluation_step(
+        &mut self,
+        evaluation_step: &GoalEvaluationStep<'_>,
+    ) -> std::fmt::Result {
+        let f = &mut *self.f;
+        writeln!(f, "INSTANTIATED: {:?}", evaluation_step.instantiated_goal)?;
+
+        for candidate in &evaluation_step.candidates {
+            let mut f = self.nested();
+            f.format_candidate(candidate)?;
+        }
+        for nested_goal_evaluation in &evaluation_step.nested_goal_evaluations {
+            let mut f = self.nested();
+            f.format_nested_goal_evaluation(nested_goal_evaluation)?;
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn format_candidate(&mut self, candidate: &GoalCandidate<'_>) -> std::fmt::Result {
+        let f = &mut *self.f;
+
+        match &candidate.kind {
+            CandidateKind::NormalizedSelfTyAssembly => {
+                writeln!(f, "NORMALIZING SELF TY FOR ASSEMBLY:")
+            }
+            CandidateKind::Candidate { name, result } => {
+                writeln!(f, "CANDIDATE {}: {:?}", name, result)
+            }
+        }?;
+
+        let mut f = self.nested();
+        for candidate in &candidate.candidates {
+            f.format_candidate(candidate)?;
+        }
+        for nested_evaluations in &candidate.nested_goal_evaluations {
+            f.format_nested_goal_evaluation(nested_evaluations)?;
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn format_nested_goal_evaluation(
+        &mut self,
+        nested_goal_evaluation: &AddedGoalsEvaluation<'_>,
+    ) -> std::fmt::Result {
+        let f = &mut *self.f;
+        writeln!(f, "TRY_EVALUATE_ADDED_GOALS: {:?}", nested_goal_evaluation.result)?;
+
+        for (n, revision) in nested_goal_evaluation.evaluations.iter().enumerate() {
+            let f = &mut *self.f;
+            writeln!(f, "REVISION {n}")?;
+            let mut f = self.nested();
+            for goal_evaluation in revision {
+                f.format_goal_evaluation(goal_evaluation)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1436,6 +1436,8 @@ options! {
         "output statistics about monomorphization collection"),
     dump_mono_stats_format: DumpMonoStatsFormat = (DumpMonoStatsFormat::Markdown, parse_dump_mono_stats, [UNTRACKED],
         "the format to use for -Z dump-mono-stats (`markdown` (default) or `json`)"),
+    dump_solver_proof_tree: bool = (false, parse_bool, [UNTRACKED],
+        "dump a proof tree for every goal evaluated by the new trait solver"),
     dwarf_version: Option<u32> = (None, parse_opt_number, [TRACKED],
         "version of DWARF debug information to emit (default: 2 or 4, depending on platform)"),
     dylib_lto: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_trait_selection/src/solve/alias_relate.rs
+++ b/compiler/rustc_trait_selection/src/solve/alias_relate.rs
@@ -1,5 +1,6 @@
 use super::{EvalCtxt, SolverMode};
 use rustc_infer::traits::query::NoSolution;
+use rustc_middle::traits::solve::inspect::CandidateKind;
 use rustc_middle::traits::solve::{Certainty, Goal, QueryResult};
 use rustc_middle::ty;
 
@@ -109,12 +110,12 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         direction: ty::AliasRelationDirection,
         invert: Invert,
     ) -> QueryResult<'tcx> {
-        self.probe_candidate(
+        self.probe(
             |ecx| {
                 ecx.normalizes_to_inner(param_env, alias, other, direction, invert)?;
                 ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
             },
-            || "normalizes-to".into(),
+            |r| CandidateKind::Candidate { name: "normalizes-to".into(), result: *r },
         )
     }
 
@@ -156,7 +157,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         alias_rhs: ty::AliasTy<'tcx>,
         direction: ty::AliasRelationDirection,
     ) -> QueryResult<'tcx> {
-        self.probe_candidate(
+        self.probe(
             |ecx| {
                 match direction {
                     ty::AliasRelationDirection::Equate => {
@@ -169,7 +170,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
 
                 ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
             },
-            || "substs relate".into(),
+            |r| CandidateKind::Candidate { name: "substs relate".into(), result: *r },
         )
     }
 
@@ -180,7 +181,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         rhs: ty::Term<'tcx>,
         direction: ty::AliasRelationDirection,
     ) -> QueryResult<'tcx> {
-        self.probe_candidate(
+        self.probe(
             |ecx| {
                 ecx.normalizes_to_inner(
                     param_env,
@@ -198,7 +199,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
                 )?;
                 ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
             },
-            || "bidir normalizes-to".into(),
+            |r| CandidateKind::Candidate { name: "bidir normalizes-to".into(), result: *r },
         )
     }
 }

--- a/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
@@ -8,6 +8,7 @@ use rustc_hir::def_id::DefId;
 use rustc_infer::traits::query::NoSolution;
 use rustc_infer::traits::util::elaborate;
 use rustc_infer::traits::Reveal;
+use rustc_middle::traits::solve::inspect::CandidateKind;
 use rustc_middle::traits::solve::{CanonicalResponse, Certainty, Goal, MaybeCause, QueryResult};
 use rustc_middle::ty::fast_reject::TreatProjections;
 use rustc_middle::ty::TypeFoldable;
@@ -336,37 +337,40 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             return
         };
 
-        let normalized_self_candidates: Result<_, NoSolution> = self.probe(|ecx| {
-            ecx.with_incremented_depth(
-                |ecx| {
-                    let result = ecx.evaluate_added_goals_and_make_canonical_response(
-                        Certainty::Maybe(MaybeCause::Overflow),
-                    )?;
-                    Ok(vec![Candidate { source: CandidateSource::BuiltinImpl, result }])
-                },
-                |ecx| {
-                    let normalized_ty = ecx.next_ty_infer();
-                    let normalizes_to_goal = goal.with(
-                        tcx,
-                        ty::Binder::dummy(ty::ProjectionPredicate {
-                            projection_ty,
-                            term: normalized_ty.into(),
-                        }),
-                    );
-                    ecx.add_goal(normalizes_to_goal);
-                    let _ = ecx.try_evaluate_added_goals().inspect_err(|_| {
-                        debug!("self type normalization failed");
-                    })?;
-                    let normalized_ty = ecx.resolve_vars_if_possible(normalized_ty);
-                    debug!(?normalized_ty, "self type normalized");
-                    // NOTE: Alternatively we could call `evaluate_goal` here and only
-                    // have a `Normalized` candidate. This doesn't work as long as we
-                    // use `CandidateSource` in winnowing.
-                    let goal = goal.with(tcx, goal.predicate.with_self_ty(tcx, normalized_ty));
-                    Ok(ecx.assemble_and_evaluate_candidates(goal))
-                },
-            )
-        });
+        let normalized_self_candidates: Result<_, NoSolution> = self.probe(
+            |ecx| {
+                ecx.with_incremented_depth(
+                    |ecx| {
+                        let result = ecx.evaluate_added_goals_and_make_canonical_response(
+                            Certainty::Maybe(MaybeCause::Overflow),
+                        )?;
+                        Ok(vec![Candidate { source: CandidateSource::BuiltinImpl, result }])
+                    },
+                    |ecx| {
+                        let normalized_ty = ecx.next_ty_infer();
+                        let normalizes_to_goal = goal.with(
+                            tcx,
+                            ty::Binder::dummy(ty::ProjectionPredicate {
+                                projection_ty,
+                                term: normalized_ty.into(),
+                            }),
+                        );
+                        ecx.add_goal(normalizes_to_goal);
+                        let _ = ecx.try_evaluate_added_goals().inspect_err(|_| {
+                            debug!("self type normalization failed");
+                        })?;
+                        let normalized_ty = ecx.resolve_vars_if_possible(normalized_ty);
+                        debug!(?normalized_ty, "self type normalized");
+                        // NOTE: Alternatively we could call `evaluate_goal` here and only
+                        // have a `Normalized` candidate. This doesn't work as long as we
+                        // use `CandidateSource` in winnowing.
+                        let goal = goal.with(tcx, goal.predicate.with_self_ty(tcx, normalized_ty));
+                        Ok(ecx.assemble_and_evaluate_candidates(goal))
+                    },
+                )
+            },
+            |_| CandidateKind::NormalizedSelfTyAssembly,
+        );
 
         if let Ok(normalized_self_candidates) = normalized_self_candidates {
             candidates.extend(normalized_self_candidates);

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -164,7 +164,8 @@ impl<'tcx> InferCtxtEvalExt<'tcx> for InferCtxt<'tcx> {
 
         let tree = ecx.inspect.finalize();
         if let Some(tree) = &tree {
-            debug!(?tree);
+            // module to allow more granular RUSTC_LOG filtering to just proof tree output
+            super::inspect::dump::print_tree(tree);
         }
 
         assert!(

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -10,6 +10,7 @@ use rustc_infer::traits::{
 use rustc_middle::ty;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 
+use super::eval_ctxt::GenerateProofTree;
 use super::{Certainty, InferCtxtEvalExt};
 
 /// A trait engine using the new trait solver.
@@ -46,8 +47,11 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
         self.obligations
             .drain(..)
             .map(|obligation| {
-                let code =
-                    infcx.probe(|_| match infcx.evaluate_root_goal(obligation.clone().into()) {
+                let code = infcx.probe(|_| {
+                    match infcx
+                        .evaluate_root_goal(obligation.clone().into(), GenerateProofTree::No)
+                        .0
+                    {
                         Ok((_, Certainty::Maybe(MaybeCause::Ambiguity), _)) => {
                             FulfillmentErrorCode::CodeAmbiguity { overflow: false }
                         }
@@ -60,7 +64,8 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
                         Err(_) => {
                             bug!("did not expect selection error when collecting ambiguity errors")
                         }
-                    });
+                    }
+                });
 
                 FulfillmentError {
                     obligation: obligation.clone(),
@@ -81,61 +86,62 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
             let mut has_changed = false;
             for obligation in mem::take(&mut self.obligations) {
                 let goal = obligation.clone().into();
-                let (changed, certainty, nested_goals) = match infcx.evaluate_root_goal(goal) {
-                    Ok(result) => result,
-                    Err(NoSolution) => {
-                        errors.push(FulfillmentError {
-                            obligation: obligation.clone(),
-                            code: match goal.predicate.kind().skip_binder() {
-                                ty::PredicateKind::Clause(ty::Clause::Projection(_)) => {
-                                    FulfillmentErrorCode::CodeProjectionError(
-                                        // FIXME: This could be a `Sorts` if the term is a type
-                                        MismatchedProjectionTypes { err: TypeError::Mismatch },
-                                    )
-                                }
-                                ty::PredicateKind::AliasRelate(_, _, _) => {
-                                    FulfillmentErrorCode::CodeProjectionError(
-                                        MismatchedProjectionTypes { err: TypeError::Mismatch },
-                                    )
-                                }
-                                ty::PredicateKind::Subtype(pred) => {
-                                    let (a, b) = infcx.instantiate_binder_with_placeholders(
-                                        goal.predicate.kind().rebind((pred.a, pred.b)),
-                                    );
-                                    let expected_found = ExpectedFound::new(true, a, b);
-                                    FulfillmentErrorCode::CodeSubtypeError(
-                                        expected_found,
-                                        TypeError::Sorts(expected_found),
-                                    )
-                                }
-                                ty::PredicateKind::Coerce(pred) => {
-                                    let (a, b) = infcx.instantiate_binder_with_placeholders(
-                                        goal.predicate.kind().rebind((pred.a, pred.b)),
-                                    );
-                                    let expected_found = ExpectedFound::new(false, a, b);
-                                    FulfillmentErrorCode::CodeSubtypeError(
-                                        expected_found,
-                                        TypeError::Sorts(expected_found),
-                                    )
-                                }
-                                ty::PredicateKind::Clause(_)
-                                | ty::PredicateKind::ObjectSafe(_)
-                                | ty::PredicateKind::ClosureKind(_, _, _)
-                                | ty::PredicateKind::Ambiguous => {
-                                    FulfillmentErrorCode::CodeSelectionError(
-                                        SelectionError::Unimplemented,
-                                    )
-                                }
-                                ty::PredicateKind::ConstEquate(..)
-                                | ty::PredicateKind::TypeWellFormedFromEnv(_) => {
-                                    bug!("unexpected goal: {goal:?}")
-                                }
-                            },
-                            root_obligation: obligation,
-                        });
-                        continue;
-                    }
-                };
+                let (changed, certainty, nested_goals) =
+                    match infcx.evaluate_root_goal(goal, GenerateProofTree::No).0 {
+                        Ok(result) => result,
+                        Err(NoSolution) => {
+                            errors.push(FulfillmentError {
+                                obligation: obligation.clone(),
+                                code: match goal.predicate.kind().skip_binder() {
+                                    ty::PredicateKind::Clause(ty::Clause::Projection(_)) => {
+                                        FulfillmentErrorCode::CodeProjectionError(
+                                            // FIXME: This could be a `Sorts` if the term is a type
+                                            MismatchedProjectionTypes { err: TypeError::Mismatch },
+                                        )
+                                    }
+                                    ty::PredicateKind::AliasRelate(_, _, _) => {
+                                        FulfillmentErrorCode::CodeProjectionError(
+                                            MismatchedProjectionTypes { err: TypeError::Mismatch },
+                                        )
+                                    }
+                                    ty::PredicateKind::Subtype(pred) => {
+                                        let (a, b) = infcx.instantiate_binder_with_placeholders(
+                                            goal.predicate.kind().rebind((pred.a, pred.b)),
+                                        );
+                                        let expected_found = ExpectedFound::new(true, a, b);
+                                        FulfillmentErrorCode::CodeSubtypeError(
+                                            expected_found,
+                                            TypeError::Sorts(expected_found),
+                                        )
+                                    }
+                                    ty::PredicateKind::Coerce(pred) => {
+                                        let (a, b) = infcx.instantiate_binder_with_placeholders(
+                                            goal.predicate.kind().rebind((pred.a, pred.b)),
+                                        );
+                                        let expected_found = ExpectedFound::new(false, a, b);
+                                        FulfillmentErrorCode::CodeSubtypeError(
+                                            expected_found,
+                                            TypeError::Sorts(expected_found),
+                                        )
+                                    }
+                                    ty::PredicateKind::Clause(_)
+                                    | ty::PredicateKind::ObjectSafe(_)
+                                    | ty::PredicateKind::ClosureKind(_, _, _)
+                                    | ty::PredicateKind::Ambiguous => {
+                                        FulfillmentErrorCode::CodeSelectionError(
+                                            SelectionError::Unimplemented,
+                                        )
+                                    }
+                                    ty::PredicateKind::ConstEquate(..)
+                                    | ty::PredicateKind::TypeWellFormedFromEnv(_) => {
+                                        bug!("unexpected goal: {goal:?}")
+                                    }
+                                },
+                                root_obligation: obligation,
+                            });
+                            continue;
+                        }
+                    };
                 // Push any nested goals that we get from unifying our canonical response
                 // with our obligation onto the fulfillment context.
                 self.obligations.extend(nested_goals.into_iter().map(|goal| {

--- a/compiler/rustc_trait_selection/src/solve/inspect.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect.rs
@@ -10,6 +10,8 @@ use rustc_middle::{
     ty,
 };
 
+pub mod dump;
+
 #[derive(Eq, PartialEq, Debug, Hash, HashStable)]
 pub struct WipGoalEvaluation<'tcx> {
     pub uncanonicalized_goal: Goal<'tcx, ty::Predicate<'tcx>>,

--- a/compiler/rustc_trait_selection/src/solve/inspect/dump.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/dump.rs
@@ -1,0 +1,5 @@
+use rustc_middle::traits::solve::inspect::GoalEvaluation;
+
+pub fn print_tree(tree: &GoalEvaluation<'_>) {
+    debug!(?tree);
+}

--- a/compiler/rustc_trait_selection/src/solve/inspect/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/mod.rs
@@ -23,7 +23,7 @@ pub trait InspectSolve<'tcx> {
         goal: Goal<'tcx, ty::Predicate<'tcx>>,
     ) -> Box<dyn InspectSolve<'tcx> + 'tcx>;
     fn canonicalized_goal(&mut self, canonical_goal: CanonicalInput<'tcx>);
-    fn cache_hit(&mut self);
+    fn cache_hit(&mut self, cache_hit: CacheHit);
     fn goal_evaluation(&mut self, goal_evaluation: Box<dyn InspectSolve<'tcx> + 'tcx>);
 
     fn new_goal_evaluation_step(
@@ -59,7 +59,7 @@ impl<'tcx> InspectSolve<'tcx> for () {
         Box::new(())
     }
     fn canonicalized_goal(&mut self, _canonical_goal: CanonicalInput<'tcx>) {}
-    fn cache_hit(&mut self) {}
+    fn cache_hit(&mut self, _cache_hit: CacheHit) {}
     fn goal_evaluation(&mut self, _goal_evaluation: Box<dyn InspectSolve<'tcx> + 'tcx>) {}
 
     fn new_goal_evaluation_step(
@@ -104,7 +104,7 @@ impl<'tcx> InspectSolve<'tcx> for DebugSolver<'tcx> {
             uncanonicalized_goal: goal,
             canonicalized_goal: None,
             evaluation_steps: vec![],
-            cache_hit: false,
+            cache_hit: None,
             result: None,
         }))
     }
@@ -117,9 +117,11 @@ impl<'tcx> InspectSolve<'tcx> for DebugSolver<'tcx> {
             _ => unreachable!(),
         }
     }
-    fn cache_hit(&mut self) {
+    fn cache_hit(&mut self, cache_hit: CacheHit) {
         match self {
-            DebugSolver::GoalEvaluation(goal_evaluation) => goal_evaluation.cache_hit = true,
+            DebugSolver::GoalEvaluation(goal_evaluation) => {
+                goal_evaluation.cache_hit = Some(cache_hit)
+            }
             _ => unreachable!(),
         };
     }

--- a/compiler/rustc_trait_selection/src/solve/inspect/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/mod.rs
@@ -1,0 +1,244 @@
+use rustc_middle::{
+    traits::{
+        query::NoSolution,
+        solve::{inspect::*, CanonicalInput, Certainty, Goal, QueryInput, QueryResult},
+    },
+    ty,
+};
+
+#[derive(Debug)]
+pub enum DebugSolver<'tcx> {
+    Root,
+    GoalEvaluation(GoalEvaluation<'tcx>),
+    AddedGoalsEvaluation(AddedGoalsEvaluation<'tcx>),
+    GoalEvaluationStep(GoalEvaluationStep<'tcx>),
+    GoalCandidate(GoalCandidate<'tcx>),
+}
+
+pub trait InspectSolve<'tcx> {
+    fn into_debug_solver(self: Box<Self>) -> Option<Box<DebugSolver<'tcx>>>;
+
+    fn new_goal_evaluation(
+        &mut self,
+        goal: Goal<'tcx, ty::Predicate<'tcx>>,
+    ) -> Box<dyn InspectSolve<'tcx> + 'tcx>;
+    fn canonicalized_goal(&mut self, canonical_goal: CanonicalInput<'tcx>);
+    fn cache_hit(&mut self);
+    fn goal_evaluation(&mut self, goal_evaluation: Box<dyn InspectSolve<'tcx> + 'tcx>);
+
+    fn new_goal_evaluation_step(
+        &mut self,
+        instantiated_goal: QueryInput<'tcx, ty::Predicate<'tcx>>,
+    ) -> Box<dyn InspectSolve<'tcx> + 'tcx>;
+    fn goal_evaluation_step(&mut self, goal_eval_step: Box<dyn InspectSolve<'tcx> + 'tcx>);
+
+    fn new_goal_candidate(&mut self) -> Box<dyn InspectSolve<'tcx> + 'tcx>;
+    fn candidate_name(&mut self, f: &mut dyn FnMut() -> String);
+    fn goal_candidate(&mut self, candidate: Box<dyn InspectSolve<'tcx> + 'tcx>);
+
+    fn new_evaluate_added_goals(&mut self) -> Box<dyn InspectSolve<'tcx> + 'tcx>;
+    fn evaluate_added_goals_loop_start(&mut self);
+    fn eval_added_goals_result(&mut self, result: Result<Certainty, NoSolution>);
+    fn added_goals_evaluation(&mut self, goals_evaluation: Box<dyn InspectSolve<'tcx> + 'tcx>);
+
+    fn query_result(&mut self, result: QueryResult<'tcx>);
+}
+
+/// No-op `InspectSolve` impl to use for normal trait solving when we do not want
+/// to take a performance hit from recording information about how things are being
+/// proven.
+impl<'tcx> InspectSolve<'tcx> for () {
+    fn into_debug_solver(self: Box<Self>) -> Option<Box<DebugSolver<'tcx>>> {
+        None
+    }
+
+    fn new_goal_evaluation(
+        &mut self,
+        _goal: Goal<'tcx, ty::Predicate<'tcx>>,
+    ) -> Box<dyn InspectSolve<'tcx> + 'tcx> {
+        Box::new(())
+    }
+    fn canonicalized_goal(&mut self, _canonical_goal: CanonicalInput<'tcx>) {}
+    fn cache_hit(&mut self) {}
+    fn goal_evaluation(&mut self, _goal_evaluation: Box<dyn InspectSolve<'tcx> + 'tcx>) {}
+
+    fn new_goal_evaluation_step(
+        &mut self,
+        _instantiated_goal: QueryInput<'tcx, ty::Predicate<'tcx>>,
+    ) -> Box<dyn InspectSolve<'tcx> + 'tcx> {
+        Box::new(())
+    }
+    fn goal_evaluation_step(&mut self, _goal_eval_step: Box<dyn InspectSolve<'tcx> + 'tcx>) {}
+
+    fn new_goal_candidate(&mut self) -> Box<dyn InspectSolve<'tcx> + 'tcx> {
+        Box::new(())
+    }
+    fn candidate_name(&mut self, _f: &mut dyn FnMut() -> String) {}
+    fn goal_candidate(&mut self, _candidate: Box<dyn InspectSolve<'tcx> + 'tcx>) {}
+
+    fn new_evaluate_added_goals(&mut self) -> Box<dyn InspectSolve<'tcx> + 'tcx> {
+        Box::new(())
+    }
+    fn evaluate_added_goals_loop_start(&mut self) {}
+    fn eval_added_goals_result(&mut self, _result: Result<Certainty, NoSolution>) {}
+    fn added_goals_evaluation(&mut self, _goals_evaluation: Box<dyn InspectSolve<'tcx> + 'tcx>) {}
+
+    fn query_result(&mut self, _result: QueryResult<'tcx>) {}
+}
+
+impl<'tcx> DebugSolver<'tcx> {
+    pub fn new() -> Self {
+        Self::Root
+    }
+}
+impl<'tcx> InspectSolve<'tcx> for DebugSolver<'tcx> {
+    fn into_debug_solver(self: Box<Self>) -> Option<Box<DebugSolver<'tcx>>> {
+        Some(self)
+    }
+
+    fn new_goal_evaluation(
+        &mut self,
+        goal: Goal<'tcx, ty::Predicate<'tcx>>,
+    ) -> Box<dyn InspectSolve<'tcx> + 'tcx> {
+        Box::new(DebugSolver::GoalEvaluation(GoalEvaluation {
+            uncanonicalized_goal: goal,
+            canonicalized_goal: None,
+            evaluation_steps: vec![],
+            cache_hit: false,
+            result: None,
+        }))
+    }
+    fn canonicalized_goal(&mut self, canonical_goal: CanonicalInput<'tcx>) {
+        match self {
+            DebugSolver::GoalEvaluation(goal_evaluation) => {
+                assert!(goal_evaluation.canonicalized_goal.is_none());
+                goal_evaluation.canonicalized_goal = Some(canonical_goal)
+            }
+            _ => unreachable!(),
+        }
+    }
+    fn cache_hit(&mut self) {
+        match self {
+            DebugSolver::GoalEvaluation(goal_evaluation) => goal_evaluation.cache_hit = true,
+            _ => unreachable!(),
+        };
+    }
+    fn goal_evaluation(&mut self, goal_evaluation: Box<dyn InspectSolve<'tcx> + 'tcx>) {
+        let goal_evaluation = goal_evaluation.into_debug_solver().unwrap();
+        match (self, *goal_evaluation) {
+            (
+                DebugSolver::AddedGoalsEvaluation(AddedGoalsEvaluation { evaluations, .. }),
+                DebugSolver::GoalEvaluation(goal_evaluation),
+            ) => evaluations.last_mut().unwrap().push(goal_evaluation),
+            (this @ DebugSolver::Root, goal_evaluation) => *this = goal_evaluation,
+            _ => unreachable!(),
+        }
+    }
+
+    fn new_goal_evaluation_step(
+        &mut self,
+        instantiated_goal: QueryInput<'tcx, ty::Predicate<'tcx>>,
+    ) -> Box<dyn InspectSolve<'tcx> + 'tcx> {
+        Box::new(DebugSolver::GoalEvaluationStep(GoalEvaluationStep {
+            instantiated_goal,
+            nested_goal_evaluations: vec![],
+            candidates: vec![],
+            result: None,
+        }))
+    }
+    fn goal_evaluation_step(&mut self, goal_eval_step: Box<dyn InspectSolve<'tcx> + 'tcx>) {
+        let goal_eval_step = goal_eval_step.into_debug_solver().unwrap();
+        match (self, *goal_eval_step) {
+            (DebugSolver::GoalEvaluation(goal_eval), DebugSolver::GoalEvaluationStep(step)) => {
+                goal_eval.evaluation_steps.push(step);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn new_goal_candidate(&mut self) -> Box<dyn InspectSolve<'tcx> + 'tcx> {
+        Box::new(DebugSolver::GoalCandidate(GoalCandidate {
+            nested_goal_evaluations: vec![],
+            candidates: vec![],
+            name: None,
+            result: None,
+        }))
+    }
+    fn candidate_name(&mut self, f: &mut dyn FnMut() -> String) {
+        let name = f();
+
+        match self {
+            DebugSolver::GoalCandidate(goal_candidate) => {
+                assert!(goal_candidate.name.is_none());
+                goal_candidate.name = Some(name);
+            }
+            _ => unreachable!(),
+        }
+    }
+    fn goal_candidate(&mut self, candidate: Box<dyn InspectSolve<'tcx> + 'tcx>) {
+        let candidate = candidate.into_debug_solver().unwrap();
+        match (self, *candidate) {
+            (
+                DebugSolver::GoalCandidate(GoalCandidate { candidates, .. })
+                | DebugSolver::GoalEvaluationStep(GoalEvaluationStep { candidates, .. }),
+                DebugSolver::GoalCandidate(candidate),
+            ) => candidates.push(candidate),
+            _ => unreachable!(),
+        }
+    }
+
+    fn new_evaluate_added_goals(&mut self) -> Box<dyn InspectSolve<'tcx> + 'tcx> {
+        Box::new(DebugSolver::AddedGoalsEvaluation(AddedGoalsEvaluation {
+            evaluations: vec![],
+            result: None,
+        }))
+    }
+    fn evaluate_added_goals_loop_start(&mut self) {
+        match self {
+            DebugSolver::AddedGoalsEvaluation(this) => {
+                this.evaluations.push(vec![]);
+            }
+            _ => unreachable!(),
+        }
+    }
+    fn eval_added_goals_result(&mut self, result: Result<Certainty, NoSolution>) {
+        match self {
+            DebugSolver::AddedGoalsEvaluation(this) => {
+                assert!(this.result.is_none());
+                this.result = Some(result);
+            }
+            _ => unreachable!(),
+        }
+    }
+    fn added_goals_evaluation(&mut self, goals_evaluation: Box<dyn InspectSolve<'tcx> + 'tcx>) {
+        let goals_evaluation = goals_evaluation.into_debug_solver().unwrap();
+        match (self, *goals_evaluation) {
+            (
+                DebugSolver::GoalEvaluationStep(GoalEvaluationStep {
+                    nested_goal_evaluations, ..
+                })
+                | DebugSolver::GoalCandidate(GoalCandidate { nested_goal_evaluations, .. }),
+                DebugSolver::AddedGoalsEvaluation(added_goals_evaluation),
+            ) => nested_goal_evaluations.push(added_goals_evaluation),
+            _ => unreachable!(),
+        }
+    }
+
+    fn query_result(&mut self, result: QueryResult<'tcx>) {
+        match self {
+            DebugSolver::GoalEvaluation(goal_evaluation) => {
+                assert!(goal_evaluation.result.is_none());
+                goal_evaluation.result = Some(result);
+            }
+            DebugSolver::Root | DebugSolver::AddedGoalsEvaluation(_) => unreachable!(),
+            DebugSolver::GoalEvaluationStep(evaluation_step) => {
+                assert!(evaluation_step.result.is_none());
+                evaluation_step.result = Some(result);
+            }
+            DebugSolver::GoalCandidate(candidate) => {
+                assert!(candidate.result.is_none());
+                candidate.result = Some(result);
+            }
+        }
+    }
+}

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -25,6 +25,7 @@ mod assembly;
 mod canonicalize;
 mod eval_ctxt;
 mod fulfill;
+pub mod inspect;
 mod opaques;
 mod project_goals;
 mod search_graph;

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -112,7 +112,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
         if let Some(projection_pred) = assumption.as_projection_clause()
             && projection_pred.projection_def_id() == goal.predicate.def_id()
         {
-            ecx.probe(|ecx| {
+            ecx.probe_candidate(|ecx| {
                 let assumption_projection_pred =
                     ecx.instantiate_binder_with_infer(projection_pred);
                 ecx.eq(
@@ -123,7 +123,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
                 ecx.eq(goal.param_env, goal.predicate.term, assumption_projection_pred.term)
                     .expect("expected goal term to be fully unconstrained");
                 then(ecx)
-            })
+            }, || "assumption".into())
         } else {
             Err(NoSolution)
         }
@@ -143,87 +143,90 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
             return Err(NoSolution);
         }
 
-        ecx.probe(|ecx| {
-            let impl_substs = ecx.fresh_substs_for_item(impl_def_id);
-            let impl_trait_ref = impl_trait_ref.subst(tcx, impl_substs);
+        ecx.probe_candidate(
+            |ecx| {
+                let impl_substs = ecx.fresh_substs_for_item(impl_def_id);
+                let impl_trait_ref = impl_trait_ref.subst(tcx, impl_substs);
 
-            ecx.eq(goal.param_env, goal_trait_ref, impl_trait_ref)?;
+                ecx.eq(goal.param_env, goal_trait_ref, impl_trait_ref)?;
 
-            let where_clause_bounds = tcx
-                .predicates_of(impl_def_id)
-                .instantiate(tcx, impl_substs)
-                .predicates
-                .into_iter()
-                .map(|pred| goal.with(tcx, pred));
-            ecx.add_goals(where_clause_bounds);
+                let where_clause_bounds = tcx
+                    .predicates_of(impl_def_id)
+                    .instantiate(tcx, impl_substs)
+                    .predicates
+                    .into_iter()
+                    .map(|pred| goal.with(tcx, pred));
+                ecx.add_goals(where_clause_bounds);
 
-            // In case the associated item is hidden due to specialization, we have to
-            // return ambiguity this would otherwise be incomplete, resulting in
-            // unsoundness during coherence (#105782).
-            let Some(assoc_def) = fetch_eligible_assoc_item_def(
-                ecx,
-                goal.param_env,
-                goal_trait_ref,
-                goal.predicate.def_id(),
-                impl_def_id
-            )? else {
-                return ecx.evaluate_added_goals_and_make_canonical_response(Certainty::AMBIGUOUS);
-            };
-
-            if !assoc_def.item.defaultness(tcx).has_value() {
-                let guar = tcx.sess.delay_span_bug(
-                    tcx.def_span(assoc_def.item.def_id),
-                    "missing value for assoc item in impl",
-                );
-                let error_term = match assoc_def.item.kind {
-                    ty::AssocKind::Const => tcx
-                        .const_error(
-                            tcx.type_of(goal.predicate.def_id())
-                                .subst(tcx, goal.predicate.projection_ty.substs),
-                            guar,
-                        )
-                        .into(),
-                    ty::AssocKind::Type => tcx.ty_error(guar).into(),
-                    ty::AssocKind::Fn => unreachable!(),
+                // In case the associated item is hidden due to specialization, we have to
+                // return ambiguity this would otherwise be incomplete, resulting in
+                // unsoundness during coherence (#105782).
+                let Some(assoc_def) = fetch_eligible_assoc_item_def(
+                    ecx,
+                    goal.param_env,
+                    goal_trait_ref,
+                    goal.predicate.def_id(),
+                    impl_def_id
+                )? else {
+                    return ecx.evaluate_added_goals_and_make_canonical_response(Certainty::AMBIGUOUS);
                 };
-                ecx.eq(goal.param_env, goal.predicate.term, error_term)
+
+                if !assoc_def.item.defaultness(tcx).has_value() {
+                    let guar = tcx.sess.delay_span_bug(
+                        tcx.def_span(assoc_def.item.def_id),
+                        "missing value for assoc item in impl",
+                    );
+                    let error_term = match assoc_def.item.kind {
+                        ty::AssocKind::Const => tcx
+                            .const_error(
+                                tcx.type_of(goal.predicate.def_id())
+                                    .subst(tcx, goal.predicate.projection_ty.substs),
+                                guar,
+                            )
+                            .into(),
+                        ty::AssocKind::Type => tcx.ty_error(guar).into(),
+                        ty::AssocKind::Fn => unreachable!(),
+                    };
+                    ecx.eq(goal.param_env, goal.predicate.term, error_term)
+                        .expect("expected goal term to be fully unconstrained");
+                    return ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes);
+                }
+
+                // Getting the right substitutions here is complex, e.g. given:
+                // - a goal `<Vec<u32> as Trait<i32>>::Assoc<u64>`
+                // - the applicable impl `impl<T> Trait<i32> for Vec<T>`
+                // - and the impl which defines `Assoc` being `impl<T, U> Trait<U> for Vec<T>`
+                //
+                // We first rebase the goal substs onto the impl, going from `[Vec<u32>, i32, u64]`
+                // to `[u32, u64]`.
+                //
+                // And then map these substs to the substs of the defining impl of `Assoc`, going
+                // from `[u32, u64]` to `[u32, i32, u64]`.
+                let impl_substs_with_gat = goal.predicate.projection_ty.substs.rebase_onto(
+                    tcx,
+                    goal_trait_ref.def_id,
+                    impl_substs,
+                );
+                let substs = ecx.translate_substs(
+                    goal.param_env,
+                    impl_def_id,
+                    impl_substs_with_gat,
+                    assoc_def.defining_node,
+                );
+
+                // Finally we construct the actual value of the associated type.
+                let term = match assoc_def.item.kind {
+                    ty::AssocKind::Type => tcx.type_of(assoc_def.item.def_id).map_bound(|ty| ty.into()),
+                    ty::AssocKind::Const => bug!("associated const projection is not supported yet"),
+                    ty::AssocKind::Fn => unreachable!("we should never project to a fn"),
+                };
+
+                ecx.eq(goal.param_env, goal.predicate.term, term.subst(tcx, substs))
                     .expect("expected goal term to be fully unconstrained");
-                return ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes);
-            }
-
-            // Getting the right substitutions here is complex, e.g. given:
-            // - a goal `<Vec<u32> as Trait<i32>>::Assoc<u64>`
-            // - the applicable impl `impl<T> Trait<i32> for Vec<T>`
-            // - and the impl which defines `Assoc` being `impl<T, U> Trait<U> for Vec<T>`
-            //
-            // We first rebase the goal substs onto the impl, going from `[Vec<u32>, i32, u64]`
-            // to `[u32, u64]`.
-            //
-            // And then map these substs to the substs of the defining impl of `Assoc`, going
-            // from `[u32, u64]` to `[u32, i32, u64]`.
-            let impl_substs_with_gat = goal.predicate.projection_ty.substs.rebase_onto(
-                tcx,
-                goal_trait_ref.def_id,
-                impl_substs,
-            );
-            let substs = ecx.translate_substs(
-                goal.param_env,
-                impl_def_id,
-                impl_substs_with_gat,
-                assoc_def.defining_node,
-            );
-
-            // Finally we construct the actual value of the associated type.
-            let term = match assoc_def.item.kind {
-                ty::AssocKind::Type => tcx.type_of(assoc_def.item.def_id).map_bound(|ty| ty.into()),
-                ty::AssocKind::Const => bug!("associated const projection is not supported yet"),
-                ty::AssocKind::Fn => unreachable!("we should never project to a fn"),
-            };
-
-            ecx.eq(goal.param_env, goal.predicate.term, term.subst(tcx, substs))
-                .expect("expected goal term to be fully unconstrained");
-            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-        })
+                ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+            },
+            || "impl".into(),
+        )
     }
 
     fn consider_auto_trait_candidate(
@@ -318,53 +321,69 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
         goal: Goal<'tcx, Self>,
     ) -> QueryResult<'tcx> {
         let tcx = ecx.tcx();
-        ecx.probe(|ecx| {
-            let metadata_ty = match goal.predicate.self_ty().kind() {
-                ty::Bool
-                | ty::Char
-                | ty::Int(..)
-                | ty::Uint(..)
-                | ty::Float(..)
-                | ty::Array(..)
-                | ty::RawPtr(..)
-                | ty::Ref(..)
-                | ty::FnDef(..)
-                | ty::FnPtr(..)
-                | ty::Closure(..)
-                | ty::Infer(ty::IntVar(..) | ty::FloatVar(..))
-                | ty::Generator(..)
-                | ty::GeneratorWitness(..)
-                | ty::GeneratorWitnessMIR(..)
-                | ty::Never
-                | ty::Foreign(..) => tcx.types.unit,
+        ecx.probe_candidate(
+            |ecx| {
+                let metadata_ty = match goal.predicate.self_ty().kind() {
+                    ty::Bool
+                    | ty::Char
+                    | ty::Int(..)
+                    | ty::Uint(..)
+                    | ty::Float(..)
+                    | ty::Array(..)
+                    | ty::RawPtr(..)
+                    | ty::Ref(..)
+                    | ty::FnDef(..)
+                    | ty::FnPtr(..)
+                    | ty::Closure(..)
+                    | ty::Infer(ty::IntVar(..) | ty::FloatVar(..))
+                    | ty::Generator(..)
+                    | ty::GeneratorWitness(..)
+                    | ty::GeneratorWitnessMIR(..)
+                    | ty::Never
+                    | ty::Foreign(..) => tcx.types.unit,
 
-                ty::Error(e) => tcx.ty_error(*e),
+                    ty::Error(e) => tcx.ty_error(*e),
 
-                ty::Str | ty::Slice(_) => tcx.types.usize,
+                    ty::Str | ty::Slice(_) => tcx.types.usize,
 
-                ty::Dynamic(_, _, _) => {
-                    let dyn_metadata = tcx.require_lang_item(LangItem::DynMetadata, None);
-                    tcx.type_of(dyn_metadata)
-                        .subst(tcx, &[ty::GenericArg::from(goal.predicate.self_ty())])
-                }
+                    ty::Dynamic(_, _, _) => {
+                        let dyn_metadata = tcx.require_lang_item(LangItem::DynMetadata, None);
+                        tcx.type_of(dyn_metadata)
+                            .subst(tcx, &[ty::GenericArg::from(goal.predicate.self_ty())])
+                    }
 
-                ty::Alias(_, _) | ty::Param(_) | ty::Placeholder(..) => {
-                    // FIXME(ptr_metadata): It would also be possible to return a `Ok(Ambig)` with no constraints.
-                    let sized_predicate = ty::TraitRef::from_lang_item(
-                        tcx,
-                        LangItem::Sized,
-                        DUMMY_SP,
-                        [ty::GenericArg::from(goal.predicate.self_ty())],
-                    );
-                    ecx.add_goal(goal.with(tcx, sized_predicate));
-                    tcx.types.unit
-                }
+                    ty::Alias(_, _) | ty::Param(_) | ty::Placeholder(..) => {
+                        // FIXME(ptr_metadata): It would also be possible to return a `Ok(Ambig)` with no constraints.
+                        let sized_predicate = ty::TraitRef::from_lang_item(
+                            tcx,
+                            LangItem::Sized,
+                            DUMMY_SP,
+                            [ty::GenericArg::from(goal.predicate.self_ty())],
+                        );
+                        ecx.add_goal(goal.with(tcx, sized_predicate));
+                        tcx.types.unit
+                    }
 
-                ty::Adt(def, substs) if def.is_struct() => {
-                    match def.non_enum_variant().fields.raw.last() {
+                    ty::Adt(def, substs) if def.is_struct() => {
+                        match def.non_enum_variant().fields.raw.last() {
+                            None => tcx.types.unit,
+                            Some(field_def) => {
+                                let self_ty = field_def.ty(tcx, substs);
+                                ecx.add_goal(goal.with(
+                                    tcx,
+                                    ty::Binder::dummy(goal.predicate.with_self_ty(tcx, self_ty)),
+                                ));
+                                return ecx.evaluate_added_goals_and_make_canonical_response(
+                                    Certainty::Yes,
+                                );
+                            }
+                        }
+                    }
+                    ty::Adt(_, _) => tcx.types.unit,
+
+                    ty::Tuple(elements) => match elements.last() {
                         None => tcx.types.unit,
-                        Some(field_def) => {
-                            let self_ty = field_def.ty(tcx, substs);
+                        Some(&self_ty) => {
                             ecx.add_goal(goal.with(
                                 tcx,
                                 ty::Binder::dummy(goal.predicate.with_self_ty(tcx, self_ty)),
@@ -372,35 +391,23 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
                             return ecx
                                 .evaluate_added_goals_and_make_canonical_response(Certainty::Yes);
                         }
-                    }
-                }
-                ty::Adt(_, _) => tcx.types.unit,
+                    },
 
-                ty::Tuple(elements) => match elements.last() {
-                    None => tcx.types.unit,
-                    Some(&self_ty) => {
-                        ecx.add_goal(goal.with(
-                            tcx,
-                            ty::Binder::dummy(goal.predicate.with_self_ty(tcx, self_ty)),
-                        ));
-                        return ecx
-                            .evaluate_added_goals_and_make_canonical_response(Certainty::Yes);
-                    }
-                },
+                    ty::Infer(
+                        ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_),
+                    )
+                    | ty::Bound(..) => bug!(
+                        "unexpected self ty `{:?}` when normalizing `<T as Pointee>::Metadata`",
+                        goal.predicate.self_ty()
+                    ),
+                };
 
-                ty::Infer(
-                    ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_),
-                )
-                | ty::Bound(..) => bug!(
-                    "unexpected self ty `{:?}` when normalizing `<T as Pointee>::Metadata`",
-                    goal.predicate.self_ty()
-                ),
-            };
-
-            ecx.eq(goal.param_env, goal.predicate.term, metadata_ty.into())
-                .expect("expected goal term to be fully unconstrained");
-            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-        })
+                ecx.eq(goal.param_env, goal.predicate.term, metadata_ty.into())
+                    .expect("expected goal term to be fully unconstrained");
+                ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+            },
+            || "builtin pointee".into(),
+        )
     }
 
     fn consider_builtin_future_candidate(
@@ -535,11 +542,14 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
             ),
         };
 
-        ecx.probe(|ecx| {
-            ecx.eq(goal.param_env, goal.predicate.term, discriminant_ty.into())
-                .expect("expected goal term to be fully unconstrained");
-            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-        })
+        ecx.probe_candidate(
+            |ecx| {
+                ecx.eq(goal.param_env, goal.predicate.term, discriminant_ty.into())
+                    .expect("expected goal term to be fully unconstrained");
+                ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+            },
+            || "builtin discriminant kind".into(),
+        )
     }
 
     fn consider_builtin_destruct_candidate(

--- a/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
@@ -13,7 +13,7 @@ use rustc_middle::traits::solve::{CanonicalInput, Certainty, MaybeCause, QueryRe
 use rustc_middle::ty::TyCtxt;
 use std::{collections::hash_map::Entry, mem};
 
-use super::inspect::InspectSolve;
+use super::inspect::ProofTreeBuilder;
 use super::SolverMode;
 
 rustc_index::newtype_index! {
@@ -95,7 +95,7 @@ impl<'tcx> SearchGraph<'tcx> {
         &mut self,
         tcx: TyCtxt<'tcx>,
         input: CanonicalInput<'tcx>,
-        inspect: &mut dyn InspectSolve<'tcx>,
+        inspect: &mut ProofTreeBuilder<'tcx>,
     ) -> Result<(), QueryResult<'tcx>> {
         // Look at the provisional cache to check for cycles.
         let cache = &mut self.provisional_cache;
@@ -210,8 +210,8 @@ impl<'tcx> SearchGraph<'tcx> {
         &mut self,
         tcx: TyCtxt<'tcx>,
         canonical_input: CanonicalInput<'tcx>,
-        inspect: &mut dyn InspectSolve<'tcx>,
-        mut loop_body: impl FnMut(&mut Self, &mut dyn InspectSolve<'tcx>) -> QueryResult<'tcx>,
+        inspect: &mut ProofTreeBuilder<'tcx>,
+        mut loop_body: impl FnMut(&mut Self, &mut ProofTreeBuilder<'tcx>) -> QueryResult<'tcx>,
     ) -> QueryResult<'tcx> {
         if self.should_use_global_cache() {
             if let Some(result) = tcx.new_solver_evaluation_cache.get(&canonical_input, tcx) {

--- a/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
@@ -2,6 +2,7 @@ mod cache;
 mod overflow;
 
 pub(super) use overflow::OverflowHandler;
+use rustc_middle::traits::solve::inspect::CacheHit;
 
 use self::cache::ProvisionalEntry;
 use cache::ProvisionalCache;
@@ -89,11 +90,12 @@ impl<'tcx> SearchGraph<'tcx> {
     /// Tries putting the new goal on the stack, returning an error if it is already cached.
     ///
     /// This correctly updates the provisional cache if there is a cycle.
-    #[instrument(level = "debug", skip(self, tcx), ret)]
+    #[instrument(level = "debug", skip(self, tcx, inspect), ret)]
     fn try_push_stack(
         &mut self,
         tcx: TyCtxt<'tcx>,
         input: CanonicalInput<'tcx>,
+        inspect: &mut dyn InspectSolve<'tcx>,
     ) -> Result<(), QueryResult<'tcx>> {
         // Look at the provisional cache to check for cycles.
         let cache = &mut self.provisional_cache;
@@ -120,6 +122,8 @@ impl<'tcx> SearchGraph<'tcx> {
             // Finally we can return either the provisional response for that goal if we have a
             // coinductive cycle or an ambiguous result if the cycle is inductive.
             Entry::Occupied(entry_index) => {
+                inspect.cache_hit(CacheHit::Provisional);
+
                 let entry_index = *entry_index.get();
 
                 let stack_depth = cache.depth(entry_index);
@@ -212,12 +216,12 @@ impl<'tcx> SearchGraph<'tcx> {
         if self.should_use_global_cache() {
             if let Some(result) = tcx.new_solver_evaluation_cache.get(&canonical_input, tcx) {
                 debug!(?canonical_input, ?result, "cache hit");
-                inspect.cache_hit();
+                inspect.cache_hit(CacheHit::Global);
                 return result;
             }
         }
 
-        match self.try_push_stack(tcx, canonical_input) {
+        match self.try_push_stack(tcx, canonical_input, inspect) {
             Ok(()) => {}
             // Our goal is already on the stack, eager return.
             Err(response) => return response,

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -61,21 +61,24 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
             },
         };
 
-        ecx.probe(|ecx| {
-            let impl_substs = ecx.fresh_substs_for_item(impl_def_id);
-            let impl_trait_ref = impl_trait_ref.subst(tcx, impl_substs);
+        ecx.probe_candidate(
+            |ecx| {
+                let impl_substs = ecx.fresh_substs_for_item(impl_def_id);
+                let impl_trait_ref = impl_trait_ref.subst(tcx, impl_substs);
 
-            ecx.eq(goal.param_env, goal.predicate.trait_ref, impl_trait_ref)?;
-            let where_clause_bounds = tcx
-                .predicates_of(impl_def_id)
-                .instantiate(tcx, impl_substs)
-                .predicates
-                .into_iter()
-                .map(|pred| goal.with(tcx, pred));
-            ecx.add_goals(where_clause_bounds);
+                ecx.eq(goal.param_env, goal.predicate.trait_ref, impl_trait_ref)?;
+                let where_clause_bounds = tcx
+                    .predicates_of(impl_def_id)
+                    .instantiate(tcx, impl_substs)
+                    .predicates
+                    .into_iter()
+                    .map(|pred| goal.with(tcx, pred));
+                ecx.add_goals(where_clause_bounds);
 
-            ecx.evaluate_added_goals_and_make_canonical_response(maximal_certainty)
-        })
+                ecx.evaluate_added_goals_and_make_canonical_response(maximal_certainty)
+            },
+            || "impl".into(),
+        )
     }
 
     fn probe_and_match_goal_against_assumption(
@@ -89,7 +92,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
             && trait_clause.polarity() == goal.predicate.polarity
         {
             // FIXME: Constness
-            ecx.probe(|ecx| {
+            ecx.probe_candidate(|ecx| {
                 let assumption_trait_pred =
                     ecx.instantiate_binder_with_infer(trait_clause);
                 ecx.eq(
@@ -98,7 +101,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
                     assumption_trait_pred.trait_ref,
                 )?;
                 then(ecx)
-            })
+            }, || "assumption".into())
         } else {
             Err(NoSolution)
         }
@@ -132,13 +135,16 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
 
         let tcx = ecx.tcx();
 
-        ecx.probe(|ecx| {
-            let nested_obligations = tcx
-                .predicates_of(goal.predicate.def_id())
-                .instantiate(tcx, goal.predicate.trait_ref.substs);
-            ecx.add_goals(nested_obligations.predicates.into_iter().map(|p| goal.with(tcx, p)));
-            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-        })
+        ecx.probe_candidate(
+            |ecx| {
+                let nested_obligations = tcx
+                    .predicates_of(goal.predicate.def_id())
+                    .instantiate(tcx, goal.predicate.trait_ref.substs);
+                ecx.add_goals(nested_obligations.predicates.into_iter().map(|p| goal.with(tcx, p)));
+                ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+            },
+            || "trait alias".into(),
+        )
     }
 
     fn consider_builtin_sized_candidate(
@@ -344,109 +350,116 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
         if b_ty.is_ty_var() {
             return ecx.evaluate_added_goals_and_make_canonical_response(Certainty::AMBIGUOUS);
         }
-        ecx.probe(|ecx| {
-            match (a_ty.kind(), b_ty.kind()) {
-                // Trait upcasting, or `dyn Trait + Auto + 'a` -> `dyn Trait + 'b`
-                (&ty::Dynamic(_, _, ty::Dyn), &ty::Dynamic(_, _, ty::Dyn)) => {
-                    // Dyn upcasting is handled separately, since due to upcasting,
-                    // when there are two supertraits that differ by substs, we
-                    // may return more than one query response.
-                    Err(NoSolution)
-                }
-                // `T` -> `dyn Trait` unsizing
-                (_, &ty::Dynamic(data, region, ty::Dyn)) => {
-                    // Can only unsize to an object-safe type
-                    if data
-                        .principal_def_id()
-                        .is_some_and(|def_id| !tcx.check_is_object_safe(def_id))
-                    {
-                        return Err(NoSolution);
+        ecx.probe_candidate(
+            |ecx| {
+                match (a_ty.kind(), b_ty.kind()) {
+                    // Trait upcasting, or `dyn Trait + Auto + 'a` -> `dyn Trait + 'b`
+                    (&ty::Dynamic(_, _, ty::Dyn), &ty::Dynamic(_, _, ty::Dyn)) => {
+                        // Dyn upcasting is handled separately, since due to upcasting,
+                        // when there are two supertraits that differ by substs, we
+                        // may return more than one query response.
+                        Err(NoSolution)
                     }
+                    // `T` -> `dyn Trait` unsizing
+                    (_, &ty::Dynamic(data, region, ty::Dyn)) => {
+                        // Can only unsize to an object-safe type
+                        if data
+                            .principal_def_id()
+                            .is_some_and(|def_id| !tcx.check_is_object_safe(def_id))
+                        {
+                            return Err(NoSolution);
+                        }
 
-                    let Some(sized_def_id) = tcx.lang_items().sized_trait() else {
+                        let Some(sized_def_id) = tcx.lang_items().sized_trait() else {
                         return Err(NoSolution);
                     };
-                    // Check that the type implements all of the predicates of the def-id.
-                    // (i.e. the principal, all of the associated types match, and any auto traits)
-                    ecx.add_goals(
-                        data.iter().map(|pred| goal.with(tcx, pred.with_self_ty(tcx, a_ty))),
-                    );
-                    // The type must be Sized to be unsized.
-                    ecx.add_goal(goal.with(tcx, ty::TraitRef::new(tcx, sized_def_id, [a_ty])));
-                    // The type must outlive the lifetime of the `dyn` we're unsizing into.
-                    ecx.add_goal(
-                        goal.with(tcx, ty::Binder::dummy(ty::OutlivesPredicate(a_ty, region))),
-                    );
-                    ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-                }
-                // `[T; n]` -> `[T]` unsizing
-                (&ty::Array(a_elem_ty, ..), &ty::Slice(b_elem_ty)) => {
-                    // We just require that the element type stays the same
-                    ecx.eq(goal.param_env, a_elem_ty, b_elem_ty)?;
-                    ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-                }
-                // Struct unsizing `Struct<T>` -> `Struct<U>` where `T: Unsize<U>`
-                (&ty::Adt(a_def, a_substs), &ty::Adt(b_def, b_substs))
-                    if a_def.is_struct() && a_def.did() == b_def.did() =>
-                {
-                    let unsizing_params = tcx.unsizing_params_for_adt(a_def.did());
-                    // We must be unsizing some type parameters. This also implies
-                    // that the struct has a tail field.
-                    if unsizing_params.is_empty() {
-                        return Err(NoSolution);
+                        // Check that the type implements all of the predicates of the def-id.
+                        // (i.e. the principal, all of the associated types match, and any auto traits)
+                        ecx.add_goals(
+                            data.iter().map(|pred| goal.with(tcx, pred.with_self_ty(tcx, a_ty))),
+                        );
+                        // The type must be Sized to be unsized.
+                        ecx.add_goal(goal.with(tcx, ty::TraitRef::new(tcx, sized_def_id, [a_ty])));
+                        // The type must outlive the lifetime of the `dyn` we're unsizing into.
+                        ecx.add_goal(
+                            goal.with(tcx, ty::Binder::dummy(ty::OutlivesPredicate(a_ty, region))),
+                        );
+                        ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
                     }
+                    // `[T; n]` -> `[T]` unsizing
+                    (&ty::Array(a_elem_ty, ..), &ty::Slice(b_elem_ty)) => {
+                        // We just require that the element type stays the same
+                        ecx.eq(goal.param_env, a_elem_ty, b_elem_ty)?;
+                        ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+                    }
+                    // Struct unsizing `Struct<T>` -> `Struct<U>` where `T: Unsize<U>`
+                    (&ty::Adt(a_def, a_substs), &ty::Adt(b_def, b_substs))
+                        if a_def.is_struct() && a_def.did() == b_def.did() =>
+                    {
+                        let unsizing_params = tcx.unsizing_params_for_adt(a_def.did());
+                        // We must be unsizing some type parameters. This also implies
+                        // that the struct has a tail field.
+                        if unsizing_params.is_empty() {
+                            return Err(NoSolution);
+                        }
 
-                    let tail_field = a_def
-                        .non_enum_variant()
-                        .fields
-                        .raw
-                        .last()
-                        .expect("expected unsized ADT to have a tail field");
-                    let tail_field_ty = tcx.type_of(tail_field.did);
+                        let tail_field = a_def
+                            .non_enum_variant()
+                            .fields
+                            .raw
+                            .last()
+                            .expect("expected unsized ADT to have a tail field");
+                        let tail_field_ty = tcx.type_of(tail_field.did);
 
-                    let a_tail_ty = tail_field_ty.subst(tcx, a_substs);
-                    let b_tail_ty = tail_field_ty.subst(tcx, b_substs);
+                        let a_tail_ty = tail_field_ty.subst(tcx, a_substs);
+                        let b_tail_ty = tail_field_ty.subst(tcx, b_substs);
 
-                    // Substitute just the unsizing params from B into A. The type after
-                    // this substitution must be equal to B. This is so we don't unsize
-                    // unrelated type parameters.
-                    let new_a_substs =
-                        tcx.mk_substs_from_iter(a_substs.iter().enumerate().map(|(i, a)| {
-                            if unsizing_params.contains(i as u32) { b_substs[i] } else { a }
-                        }));
-                    let unsized_a_ty = tcx.mk_adt(a_def, new_a_substs);
+                        // Substitute just the unsizing params from B into A. The type after
+                        // this substitution must be equal to B. This is so we don't unsize
+                        // unrelated type parameters.
+                        let new_a_substs =
+                            tcx.mk_substs_from_iter(a_substs.iter().enumerate().map(|(i, a)| {
+                                if unsizing_params.contains(i as u32) { b_substs[i] } else { a }
+                            }));
+                        let unsized_a_ty = tcx.mk_adt(a_def, new_a_substs);
 
-                    // Finally, we require that `TailA: Unsize<TailB>` for the tail field
-                    // types.
-                    ecx.eq(goal.param_env, unsized_a_ty, b_ty)?;
-                    ecx.add_goal(goal.with(
-                        tcx,
-                        ty::TraitRef::new(tcx, goal.predicate.def_id(), [a_tail_ty, b_tail_ty]),
-                    ));
-                    ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+                        // Finally, we require that `TailA: Unsize<TailB>` for the tail field
+                        // types.
+                        ecx.eq(goal.param_env, unsized_a_ty, b_ty)?;
+                        ecx.add_goal(goal.with(
+                            tcx,
+                            ty::TraitRef::new(tcx, goal.predicate.def_id(), [a_tail_ty, b_tail_ty]),
+                        ));
+                        ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+                    }
+                    // Tuple unsizing `(.., T)` -> `(.., U)` where `T: Unsize<U>`
+                    (&ty::Tuple(a_tys), &ty::Tuple(b_tys))
+                        if a_tys.len() == b_tys.len() && !a_tys.is_empty() =>
+                    {
+                        let (a_last_ty, a_rest_tys) = a_tys.split_last().unwrap();
+                        let b_last_ty = b_tys.last().unwrap();
+
+                        // Substitute just the tail field of B., and require that they're equal.
+                        let unsized_a_ty =
+                            tcx.mk_tup_from_iter(a_rest_tys.iter().chain([b_last_ty]).copied());
+                        ecx.eq(goal.param_env, unsized_a_ty, b_ty)?;
+
+                        // Similar to ADTs, require that the rest of the fields are equal.
+                        ecx.add_goal(goal.with(
+                            tcx,
+                            ty::TraitRef::new(
+                                tcx,
+                                goal.predicate.def_id(),
+                                [*a_last_ty, *b_last_ty],
+                            ),
+                        ));
+                        ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+                    }
+                    _ => Err(NoSolution),
                 }
-                // Tuple unsizing `(.., T)` -> `(.., U)` where `T: Unsize<U>`
-                (&ty::Tuple(a_tys), &ty::Tuple(b_tys))
-                    if a_tys.len() == b_tys.len() && !a_tys.is_empty() =>
-                {
-                    let (a_last_ty, a_rest_tys) = a_tys.split_last().unwrap();
-                    let b_last_ty = b_tys.last().unwrap();
-
-                    // Substitute just the tail field of B., and require that they're equal.
-                    let unsized_a_ty =
-                        tcx.mk_tup_from_iter(a_rest_tys.iter().chain([b_last_ty]).copied());
-                    ecx.eq(goal.param_env, unsized_a_ty, b_ty)?;
-
-                    // Similar to ADTs, require that the rest of the fields are equal.
-                    ecx.add_goal(goal.with(
-                        tcx,
-                        ty::TraitRef::new(tcx, goal.predicate.def_id(), [*a_last_ty, *b_last_ty]),
-                    ));
-                    ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-                }
-                _ => Err(NoSolution),
-            }
-        })
+            },
+            || "builtin unsize".into(),
+        )
     }
 
     fn consider_builtin_dyn_upcast_candidates(
@@ -475,34 +488,39 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
             return vec![];
         }
 
-        let mut unsize_dyn_to_principal = |principal: Option<ty::PolyExistentialTraitRef<'tcx>>| {
-            ecx.probe(|ecx| -> Result<_, NoSolution> {
-                // Require that all of the trait predicates from A match B, except for
-                // the auto traits. We do this by constructing a new A type with B's
-                // auto traits, and equating these types.
-                let new_a_data = principal
-                    .into_iter()
-                    .map(|trait_ref| trait_ref.map_bound(ty::ExistentialPredicate::Trait))
-                    .chain(a_data.iter().filter(|a| {
-                        matches!(a.skip_binder(), ty::ExistentialPredicate::Projection(_))
-                    }))
-                    .chain(
-                        b_data
-                            .auto_traits()
-                            .map(ty::ExistentialPredicate::AutoTrait)
-                            .map(ty::Binder::dummy),
-                    );
-                let new_a_data = tcx.mk_poly_existential_predicates_from_iter(new_a_data);
-                let new_a_ty = tcx.mk_dynamic(new_a_data, b_region, ty::Dyn);
+        let mut unsize_dyn_to_principal =
+            |principal: Option<ty::PolyExistentialTraitRef<'tcx>>| {
+                ecx.probe_candidate(
+                    |ecx| -> Result<_, NoSolution> {
+                        // Require that all of the trait predicates from A match B, except for
+                        // the auto traits. We do this by constructing a new A type with B's
+                        // auto traits, and equating these types.
+                        let new_a_data = principal
+                            .into_iter()
+                            .map(|trait_ref| trait_ref.map_bound(ty::ExistentialPredicate::Trait))
+                            .chain(a_data.iter().filter(|a| {
+                                matches!(a.skip_binder(), ty::ExistentialPredicate::Projection(_))
+                            }))
+                            .chain(
+                                b_data
+                                    .auto_traits()
+                                    .map(ty::ExistentialPredicate::AutoTrait)
+                                    .map(ty::Binder::dummy),
+                            );
+                        let new_a_data = tcx.mk_poly_existential_predicates_from_iter(new_a_data);
+                        let new_a_ty = tcx.mk_dynamic(new_a_data, b_region, ty::Dyn);
 
-                // We also require that A's lifetime outlives B's lifetime.
-                ecx.eq(goal.param_env, new_a_ty, b_ty)?;
-                ecx.add_goal(
-                    goal.with(tcx, ty::Binder::dummy(ty::OutlivesPredicate(a_region, b_region))),
-                );
-                ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-            })
-        };
+                        // We also require that A's lifetime outlives B's lifetime.
+                        ecx.eq(goal.param_env, new_a_ty, b_ty)?;
+                        ecx.add_goal(goal.with(
+                            tcx,
+                            ty::Binder::dummy(ty::OutlivesPredicate(a_region, b_region)),
+                        ));
+                        ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+                    },
+                    || "upcast dyn to principle".into(),
+                )
+            };
 
         let mut responses = vec![];
         // If the principal def ids match (or are both none), then we're not doing
@@ -698,20 +716,23 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         goal: Goal<'tcx, TraitPredicate<'tcx>>,
         constituent_tys: impl Fn(&EvalCtxt<'_, 'tcx>, Ty<'tcx>) -> Result<Vec<Ty<'tcx>>, NoSolution>,
     ) -> QueryResult<'tcx> {
-        self.probe(|ecx| {
-            ecx.add_goals(
-                constituent_tys(ecx, goal.predicate.self_ty())?
-                    .into_iter()
-                    .map(|ty| {
-                        goal.with(
-                            ecx.tcx(),
-                            ty::Binder::dummy(goal.predicate.with_self_ty(ecx.tcx(), ty)),
-                        )
-                    })
-                    .collect::<Vec<_>>(),
-            );
-            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-        })
+        self.probe_candidate(
+            |ecx| {
+                ecx.add_goals(
+                    constituent_tys(ecx, goal.predicate.self_ty())?
+                        .into_iter()
+                        .map(|ty| {
+                            goal.with(
+                                ecx.tcx(),
+                                ty::Binder::dummy(goal.predicate.with_self_ty(ecx.tcx(), ty)),
+                            )
+                        })
+                        .collect::<Vec<_>>(),
+                );
+                ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+            },
+            || "constituent tys".into(),
+        )
     }
 
     #[instrument(level = "debug", skip(self))]


### PR DESCRIPTION
Adds a new `-Z` flag `-Zdump-solver-proof-tree` which causes us to generate proof trees for each call to `infcx.evaluate_root_goal`. Currently these just get `debug!`'d out rather than put in a file.

Callers of `infcx.evaluate_root_goal` get the proof tree returned to them and can force one to be generated by passing in `GenerateProofTree::Yes`. Currently we do not disable the global cache or do anything about the provisional cache when generating proof trees is enabled, this is optimal for debugging but not so much for diagnostics. 

Personally I think the exact formatting of proof trees here is not ideal but it's easy to change after this PR lands and would like to avoid bikeshedding the exact way we output this before we even have any of the logic merged to get all the information out of the solver.

This PR is best reviewed with whitespace changes hidden, there is also probably no point going commit by commit

r? @lcnr 

Below is the proof tree output for the `AliasRelate(TAIT, sub, Alias)` case in rust-lang/trait-system-refactor-initiative#25 from the following command:
``RUSTC_LOG="rustc_trait_selection::solve::inspect::dump=debug" RUSTFLAGS="-Ztrait-solver=next -Zverbose -Zdump-solver-proof-tree" cargo +stage1 check``

<details><summary><strong>Proof tree</strong></summary>
<p>

```

DEBUG rustc_trait_selection::solve::inspect::dump tree=GOAL: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), [])), Subtype, Term::Ty(<?8t as std::iter::IntoIterator>::IntoIter)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), [])), Subtype, Term::Ty(<^1_0 as std::iter::IntoIterator>::IntoIter)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
    INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), [])), Subtype, Term::Ty(<?0t as std::iter::IntoIterator>::IntoIter)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [] }, PrivateZst)) }
        CANDIDATE normalizes-to: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
            TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
            REVISION 0
                GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}) }, Term::Ty(<^1_0 as std::iter::IntoIterator>::IntoIter)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                    INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}) }, Term::Ty(<?0t as std::iter::IntoIterator>::IntoIter)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [] }, PrivateZst)) }
                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                        REVISION 0
                            GOAL: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::IntoIter as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<^1_0 as std::iter::IntoIterator>::IntoIter as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                            REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::IntoIter as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }
                                    NORMALIZING SELF TY FOR ASSEMBLY:
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                        REVISION 0
                                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                            REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                                    REVISION 0
                                            RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                        REVISION 0
                                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                    CANDIDATE constituent tys: Err(NoSolution)
                                    CANDIDATE assumption: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                        REVISION 0
                            RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                            GOAL: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::IntoIter as std::iter::Iterator>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<^1_0 as std::iter::IntoIterator>::IntoIter as std::iter::Iterator>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                            REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::IntoIter as std::iter::Iterator>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }
                                    NORMALIZING SELF TY FOR ASSEMBLY:
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                        REVISION 0
                                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                        REVISION 0
                                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                    CANDIDATE assumption: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                        REVISION 0
                            RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<?0t as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<^1_0 as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                            REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<?0t as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }
                                    TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                    REVISION 0
                                        NORMALIZES-TO HACK GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<?0t as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<^1_0 as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                        REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, <^0 as std::iter::IntoIterator>::Item] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                            INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<?0t as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }
                                                NORMALIZING SELF TY FOR ASSEMBLY:
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                    REVISION 0
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?2t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                    REVISION 0
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?2t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                CANDIDATE assumption: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, <^0 as std::iter::IntoIterator>::Item] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                                    REVISION 0
                                        RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, <^0 as std::iter::IntoIterator>::Item] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        GOAL: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), [])), Equate, Term::Ty(<?0t as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), [])), Equate, Term::Ty(<^1_0 as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                        REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                            INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), [])), Equate, Term::Ty(<?0t as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }
                                                CANDIDATE normalizes-to: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                    REVISION 0
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}) }, Term::Ty(<?0t as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}) }, Term::Ty(<^1_0 as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                            INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}) }, Term::Ty(<?0t as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }
                                                                TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                                REVISION 0
                                                                    GOAL: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::Item as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                                    CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<^1_0 as std::iter::IntoIterator>::Item as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                                    REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                                        INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::Item as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::Item)] }, PrivateZst)) }
                                                                            NORMALIZING SELF TY FOR ASSEMBLY:
                                                                                TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                                                REVISION 0
                                                                                    GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                                                    CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                                                    REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                                                        INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::Item)] }, PrivateZst)) }
                                                                                            TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                                                                            REVISION 0
                                                                                    RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                                                TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                                                REVISION 0
                                                                                    GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                                                    CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                                                    GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                                            CANDIDATE constituent tys: Err(NoSolution)
                                                                            CANDIDATE assumption: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                                                TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                                                                REVISION 0
                                                                    RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                                    GOAL: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::Item as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                                    CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<^1_0 as std::iter::IntoIterator>::Item as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                                    GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                        RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                    REVISION 1
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}) }, Term::Ty(<?0t as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}) }, Term::Ty(<^1_0 as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                CANDIDATE normalizes-to: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                    REVISION 0
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                            INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }
                                                                TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                                REVISION 0
                                                                    NORMALIZES-TO HACK GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                                    CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                                    REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                                        INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }
                                                                            TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                                                            REVISION 0
                                                                    RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                        RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                CANDIDATE substs relate: Err(NoSolution)
                                                CANDIDATE bidir normalizes-to: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                    REVISION 0
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}) }, Term::Ty(<?0t as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}) }, Term::Ty(<^1_0 as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                            INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::Item)] }, PrivateZst)) }
                                                                TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                                REVISION 0
                                                                    NORMALIZES-TO HACK GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                                    CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                                    GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                        RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                    REVISION 1
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}) }, Term::Ty(<?0t as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}) }, Term::Ty(<^1_0 as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7203 ~ core[b962]::iter::traits::collect::IntoIterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                    REVISION 1
                                        NORMALIZES-TO HACK GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<?0t as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(?2t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<^1_0 as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                        REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, <^0 as std::iter::IntoIterator>::Item] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                            INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<?0t as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::Item)] }, PrivateZst)) }
                                                NORMALIZING SELF TY FOR ASSEMBLY:
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                    REVISION 0
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?2t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                            INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::Item)] }, PrivateZst)) }
                                                                TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                                                REVISION 0
                                                        RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                                    REVISION 0
                                                        GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?2t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                                        GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                CANDIDATE assumption: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, <^0 as std::iter::IntoIterator>::Item] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                                    TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                                    REVISION 0
                                        RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, <^0 as std::iter::IntoIterator>::Item] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        GOAL: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), [])), Equate, Term::Ty(<?0t as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), [])), Equate, Term::Ty(<^1_0 as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                        GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        GOAL: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), [])), Equate, Term::Ty(<?0t as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                        CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(AliasRelate(Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), [])), Equate, Term::Ty(<^1_0 as std::iter::IntoIterator>::Item)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                        GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                            RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                        REVISION 1
                            GOAL: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::IntoIter as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<^1_0 as std::iter::IntoIterator>::IntoIter as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                            REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::IntoIter as std::marker::Sized>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::Item)] }, PrivateZst)) }
                                    NORMALIZING SELF TY FOR ASSEMBLY:
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                        REVISION 0
                                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                        REVISION 0
                                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                    CANDIDATE constituent tys: Err(NoSolution)
                                    CANDIDATE assumption: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                        REVISION 0
                            RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                            GOAL: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::IntoIter as std::iter::Iterator>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<^1_0 as std::iter::IntoIterator>::IntoIter as std::iter::Iterator>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                            REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(TraitPredicate(<<?0t as std::iter::IntoIterator>::IntoIter as std::iter::Iterator>, polarity:Positive), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::Item)] }, PrivateZst)) }
                                    NORMALIZING SELF TY FOR ASSEMBLY:
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                        REVISION 0
                                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                                        REVISION 0
                                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                    CANDIDATE assumption: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                                        TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
                                        REVISION 0
                            RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                            GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<?0t as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [<^1_0 as std::iter::IntoIterator>::IntoIter], def_id: DefId(2:7319 ~ core[b962]::iter::traits::iterator::Iterator::Item) }, Term::Ty(Opaque(DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
            REVISION 1
                GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}) }, Term::Ty(<^1_0 as std::iter::IntoIterator>::IntoIter)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
        CANDIDATE normalizes-to: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
            TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
            REVISION 0
                GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(Opaque(DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                    INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(Opaque(DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [] }, PrivateZst)) }
                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                        REVISION 0
                            NORMALIZES-TO HACK GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
        CANDIDATE substs relate: Err(NoSolution)
        CANDIDATE bidir normalizes-to: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
            TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
            REVISION 0
                GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}) }, Term::Ty(<^1_0 as std::iter::IntoIterator>::IntoIter)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?2t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(Opaque(DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                REVISION 0: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                    INSTANTIATED: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(Opaque(DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <?0t as std::iter::IntoIterator>::Item)] }, PrivateZst)) }
                        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
                        REVISION 0
                            NORMALIZES-TO HACK GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                            CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(^1_1)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
                            GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0, ^1] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] })
                RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
            REVISION 1
                GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}) }, Term::Ty(?1t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [], def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}) }, Term::Ty(<^1_0 as std::iter::IntoIterator>::IntoIter)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
                GOAL: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [?0t], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(?2t)), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }
                CANONICALIZED: Canonical { value: QueryInput { goal: Goal { predicate: Binder(ProjectionPredicate(AliasTy { substs: [^1_0], def_id: DefId(2:7204 ~ core[b962]::iter::traits::collect::IntoIterator::IntoIter) }, Term::Ty(Opaque(DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), []))), []), param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bind(DefId(0:6 ~ playground_proof_tree[b494]::a)), predefined_opaques_in_body: PredefinedOpaques(Interned(PredefinedOpaquesData { opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
                GLOBAL CACHE HIT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
RESULT: Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(Interned(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [(OpaqueTypeKey { def_id: DefId(0:8 ~ playground_proof_tree[b494]::Tait::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::IntoIter), (OpaqueTypeKey { def_id: DefId(0:9 ~ playground_proof_tree[b494]::Tait::{opaque#0}::{opaque#0}), substs: [] }, <^0 as std::iter::IntoIterator>::Item)] }, PrivateZst)) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })

```

</p>
</details>
