### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/constraint_generation.rs
+++ b/compiler/rustc_borrowck/src/constraint_generation.rs
@@ -4,8 +4,8 @@ use rustc_infer::infer::InferCtxt;
 use rustc_middle::mir::visit::TyContext;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::{
-    BasicBlock, BasicBlockData, Body, Local, Location, Place, PlaceRef, ProjectionElem, Rvalue,
-    SourceInfo, Statement, StatementKind, Terminator, TerminatorKind, UserTypeProjection,
+    Body, Local, Location, Place, PlaceRef, ProjectionElem, Rvalue, SourceInfo, Statement,
+    StatementKind, Terminator, TerminatorKind, UserTypeProjection,
 };
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::visit::TypeVisitable;
@@ -49,10 +49,6 @@ struct ConstraintGeneration<'cg, 'tcx> {
 }
 
 impl<'cg, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'tcx> {
-    fn visit_basic_block_data(&mut self, bb: BasicBlock, data: &BasicBlockData<'tcx>) {
-        self.super_basic_block_data(bb, data);
-    }
-
     /// We sometimes have `substs` within an rvalue, or within a
     /// call. Make them live at the location where they appear.
     fn visit_substs(&mut self, substs: &SubstsRef<'tcx>, location: Location) {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -477,9 +477,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'tcx> {
 
     fn visit_body(&mut self, body: &Body<'tcx>) {
         self.sanitize_type(&"return type", body.return_ty());
-        for local_decl in &body.local_decls {
-            self.sanitize_type(local_decl, local_decl.ty);
-        }
+        // The types of local_decls are checked above which is called in super_body.
         self.super_body(body);
     }
 }

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1745,9 +1745,11 @@ fn check_variances_for_type_defn<'tcx>(
     item: &hir::Item<'tcx>,
     hir_generics: &hir::Generics<'_>,
 ) {
-    let ty = tcx.type_of(item.owner_id).subst_identity();
-    if tcx.has_error_field(ty) {
-        return;
+    let identity_substs = ty::InternalSubsts::identity_for_item(tcx, item.owner_id);
+    for field in tcx.adt_def(item.owner_id).all_fields() {
+        if field.ty(tcx, identity_substs).references_error() {
+            return;
+        }
     }
 
     let ty_predicates = tcx.predicates_of(item.owner_id);

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1195,15 +1195,15 @@ impl<'tcx> InferCtxt<'tcx> {
             .var_origin(vid)
     }
 
-    /// Takes ownership of the list of variable regions. This implies
-    /// that all the region constraints have already been taken, and
-    /// hence that `resolve_regions_and_report_errors` can never be
-    /// called. This is used only during NLL processing to "hand off" ownership
-    /// of the set of region variables into the NLL region context.
+    /// Clone the list of variable regions. This is used only during NLL processing
+    /// to put the set of region variables into the NLL region context.
     pub fn get_region_var_origins(&self) -> VarInfos {
         let mut inner = self.inner.borrow_mut();
         let (var_infos, data) = inner
             .region_constraint_storage
+            // We clone instead of taking because borrowck still wants to use
+            // the inference context after calling this for diagnostics
+            // and the new trait solver.
             .clone()
             .expect("regions already resolved")
             .with_log(&mut inner.undo_log)

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -548,8 +548,12 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
 
     fn check_item(&mut self, cx: &LateContext<'_>, it: &hir::Item<'_>) {
         // Previously the Impl and Use types have been excluded from missing docs,
-        // so we will continue to exclude them for compatibility
-        if let hir::ItemKind::Impl(..) | hir::ItemKind::Use(..) = it.kind {
+        // so we will continue to exclude them for compatibility.
+        //
+        // The documentation on `ExternCrate` is not used at the moment so no need to warn for it.
+        if let hir::ItemKind::Impl(..) | hir::ItemKind::Use(..) | hir::ItemKind::ExternCrate(_) =
+            it.kind
+        {
             return;
         }
 

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -173,18 +173,6 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    pub fn has_error_field(self, ty: Ty<'tcx>) -> bool {
-        if let ty::Adt(def, substs) = *ty.kind() {
-            for field in def.all_fields() {
-                let field_ty = field.ty(self, substs);
-                if let ty::Error(_) = field_ty.kind() {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
     /// Attempts to returns the deeply last field of nested structures, but
     /// does not apply any normalization in its search. Returns the same type
     /// if input `ty` is not a structure at all.

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -330,10 +330,7 @@ fn rustc_terminator_to_terminator(
             target: target.as_usize(),
             unwind: rustc_unwind_to_unwind(unwind),
         },
-        Yield { .. } => todo!(),
-        GeneratorDrop => Terminator::GeneratorDrop,
-        FalseEdge { .. } => todo!(),
-        FalseUnwind { .. } => todo!(),
         InlineAsm { .. } => todo!(),
+        Yield { .. } | GeneratorDrop | FalseEdge { .. } | FalseUnwind { .. } => unreachable!(),
     }
 }

--- a/compiler/rustc_target/src/spec/loongarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/loongarch64_unknown_none.rs
@@ -1,0 +1,23 @@
+use super::{Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy};
+use super::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "loongarch64-unknown-none".into(),
+        pointer_width: 64,
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n64-S128".into(),
+        arch: "loongarch64".into(),
+        options: TargetOptions {
+            cpu: "generic".into(),
+            features: "+f,+d".into(),
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::No),
+            llvm_abiname: "lp64d".into(),
+            max_atomic_width: Some(64),
+            position_independent_executables: true,
+            static_position_independent_executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            code_model: Some(CodeModel::Small),
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/loongarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/loongarch64_unknown_none_softfloat.rs
@@ -1,0 +1,24 @@
+use super::{Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy};
+use super::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "loongarch64-unknown-none-softfloat".into(),
+        pointer_width: 64,
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n64-S128".into(),
+        arch: "loongarch64".into(),
+        options: TargetOptions {
+            cpu: "generic".into(),
+            features: "-f,-d".into(),
+            abi: "softfloat".into(),
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::No),
+            llvm_abiname: "lp64s".into(),
+            max_atomic_width: Some(64),
+            position_independent_executables: true,
+            static_position_independent_executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            code_model: Some(CodeModel::Small),
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1293,6 +1293,9 @@ supported_targets! {
     ("riscv64gc-unknown-linux-gnu", riscv64gc_unknown_linux_gnu),
     ("riscv64gc-unknown-linux-musl", riscv64gc_unknown_linux_musl),
 
+    ("loongarch64-unknown-none", loongarch64_unknown_none),
+    ("loongarch64-unknown-none-softfloat", loongarch64_unknown_none_softfloat),
+
     ("aarch64-unknown-none", aarch64_unknown_none),
     ("aarch64-unknown-none-softfloat", aarch64_unknown_none_softfloat),
 

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -31,6 +31,7 @@
     - [\*-unknown-fuchsia](platform-support/fuchsia.md)
     - [\*-kmc-solid_\*](platform-support/kmc-solid.md)
     - [loongarch\*-unknown-linux-\*](platform-support/loongarch-linux.md)
+    - [loongarch\*-unknown-none\*](platform-support/loongarch-none.md)
     - [m68k-unknown-linux-gnu](platform-support/m68k-unknown-linux-gnu.md)
     - [mips64-openwrt-linux-musl](platform-support/mips64-openwrt-linux-musl.md)
     - [mipsel-sony-psx](platform-support/mipsel-sony-psx.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -267,6 +267,8 @@ target | std | host | notes
 `i686-uwp-windows-gnu` | ? |  |
 `i686-uwp-windows-msvc` | ? |  |
 `i686-wrs-vxworks` | ? |  |
+[`loongarch64-unknown-none`](platform-support/loongarch-none.md) | * | LoongArch64 Bare-metal (LP64D ABI)
+[`loongarch64-unknown-none-softfloat`](platform-support/loongarch-none.md) | * | LoongArch64 Bare-metal (LP64S ABI)
 [`m68k-unknown-linux-gnu`](platform-support/m68k-unknown-linux-gnu.md) | ? |  | Motorola 680x0 Linux
 `mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc
 [`mips64-openwrt-linux-musl`](platform-support/mips64-openwrt-linux-musl.md) | ? |  | MIPS64 for OpenWrt Linux MUSL

--- a/src/doc/rustc/src/platform-support/loongarch-none.md
+++ b/src/doc/rustc/src/platform-support/loongarch-none.md
@@ -1,0 +1,79 @@
+# `loongarch*-unknown-none*`
+
+**Tier: 3**
+
+Freestanding/bare-metal LoongArch64 binaries in ELF format: firmware, kernels, etc.
+
+| Target                             | Descriptions                                          |
+|------------------------------------|-------------------------------------------------------|
+| loongarch64-unknown-none           | LoongArch 64-bit, LP64D ABI (freestanding, hardfloat) |
+| loongarch64-unknown-none-softfloat | LoongArch 64-bit, LP64S ABI (freestanding, softfloat) |
+
+## Target maintainers
+
+- [WANG Rui](https://github.com/heiher) `wangrui@loongson.cn`
+- [WANG Xuerui](https://github.com/xen0n) `git@xen0n.name`
+
+## Requirements
+
+This target is cross-compiled. There is no support for `std`. There is no
+default allocator, but it's possible to use `alloc` by supplying an allocator.
+
+This allows the generated code to run in environments, such as kernels, which
+may need to avoid the use of such registers or which may have special considerations
+about the use of such registers (e.g. saving and restoring them to avoid breaking
+userspace code using the same registers). You can change code generation to use
+additional CPU features via the `-C target-feature=` codegen options to rustc, or
+via the `#[target_feature]` mechanism within Rust code.
+
+By default, code generated with this target should run on any `loongarch`
+hardware; enabling additional target features may raise this baseline.
+
+Code generated with this target will use the `small` code model by default.
+You can change this using the `-C code-model=` option to rustc.
+
+On `loongarch64-unknown-none*`, `extern "C"` uses the [standard calling
+convention](https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html).
+
+This target generates binaries in the ELF format. Any alternate formats or
+special considerations for binary layout will require linker options or linker
+scripts.
+
+## Building the target
+
+You can build Rust with support for the target by adding it to the `target`
+list in `config.toml`:
+
+```toml
+[build]
+build-stage = 1
+target = ["loongarch64-unknown-none"]
+```
+
+## Building Rust programs
+
+```text
+# target flag may be used with any cargo or rustc command
+cargo build --target loongarch64-unknown-none
+```
+
+## Testing
+
+As `loongarch64-unknown-none*` supports a variety of different environments and does
+not support `std`, this target does not support running the Rust test suite.
+
+## Cross-compilation toolchains and C code
+
+If you want to compile C code along with Rust (such as for Rust crates with C
+dependencies), you will need an appropriate `loongarch` toolchain.
+
+Rust *may* be able to use an `loongarch64-unknown-linux-gnu-` toolchain with
+appropriate standalone flags to build for this toolchain (depending on the assumptions
+of that toolchain, see below), or you may wish to use a separate
+`loongarch64-unknown-none` toolchain.
+
+On some `loongarch` hosts that use ELF binaries, you *may* be able to use the host
+C toolchain, if it does not introduce assumptions about the host environment
+that don't match the expectations of a standalone environment. Otherwise, you
+may need a separate toolchain for standalone/freestanding development, just as
+when cross-compiling from a non-`loongarch` platform.

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param.full.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param.full.stderr
@@ -6,16 +6,6 @@ LL | pub struct Dependent<T, const X: T>([(); X]);
    |
    = note: type parameters may not be used in the type of const parameters
 
-error[E0392]: parameter `T` is never used
-  --> $DIR/const-param-type-depends-on-type-param.rs:11:22
-   |
-LL | pub struct Dependent<T, const X: T>([(); X]);
-   |                      ^ unused parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0392, E0770.
-For more information about an error, try `rustc --explain E0392`.
+For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param.min.stderr
@@ -6,16 +6,6 @@ LL | pub struct Dependent<T, const X: T>([(); X]);
    |
    = note: type parameters may not be used in the type of const parameters
 
-error[E0392]: parameter `T` is never used
-  --> $DIR/const-param-type-depends-on-type-param.rs:11:22
-   |
-LL | pub struct Dependent<T, const X: T>([(); X]);
-   |                      ^ unused parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0392, E0770.
-For more information about an error, try `rustc --explain E0392`.
+For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param.rs
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param.rs
@@ -10,6 +10,5 @@
 
 pub struct Dependent<T, const X: T>([(); X]);
 //~^ ERROR: the type of const parameters must not depend on other generic parameters
-//~| ERROR: parameter `T` is never used
 
 fn main() {}

--- a/tests/ui/lint/auxiliary/missing_docs.rs
+++ b/tests/ui/lint/auxiliary/missing_docs.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/ui/lint/lint-missing-doc.rs
+++ b/tests/ui/lint/lint-missing-doc.rs
@@ -1,5 +1,6 @@
 // When denying at the crate level, be sure to not get random warnings from the
 // injected intrinsics by the compiler.
+// aux-build:missing_docs.rs
 #![deny(missing_docs)]
 #![allow(dead_code)]
 #![feature(associated_type_defaults, extern_types)]
@@ -7,6 +8,9 @@
 
 //! Some garbage docs for the crate here
 #![doc="More garbage"]
+
+// There should be not "missing_docs" warning on "pub extern crate".
+pub extern crate missing_docs;
 
 type Typedef = String;
 pub type PubTypedef = String; //~ ERROR: missing documentation for a type alias

--- a/tests/ui/lint/lint-missing-doc.stderr
+++ b/tests/ui/lint/lint-missing-doc.stderr
@@ -1,155 +1,155 @@
 error: missing documentation for a type alias
-  --> $DIR/lint-missing-doc.rs:12:1
+  --> $DIR/lint-missing-doc.rs:16:1
    |
 LL | pub type PubTypedef = String;
    | ^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/lint-missing-doc.rs:3:9
+  --> $DIR/lint-missing-doc.rs:4:9
    |
 LL | #![deny(missing_docs)]
    |         ^^^^^^^^^^^^
 
 error: missing documentation for a struct
-  --> $DIR/lint-missing-doc.rs:19:1
+  --> $DIR/lint-missing-doc.rs:23:1
    |
 LL | pub struct PubFoo {
    | ^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a struct field
-  --> $DIR/lint-missing-doc.rs:20:5
+  --> $DIR/lint-missing-doc.rs:24:5
    |
 LL |     pub a: isize,
    |     ^^^^^^^^^^^^
 
 error: missing documentation for a module
-  --> $DIR/lint-missing-doc.rs:31:1
+  --> $DIR/lint-missing-doc.rs:35:1
    |
 LL | pub mod pub_module_no_dox {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:35:1
+  --> $DIR/lint-missing-doc.rs:39:1
    |
 LL | pub fn foo2() {}
    | ^^^^^^^^^^^^^
 
 error: missing documentation for a trait
-  --> $DIR/lint-missing-doc.rs:53:1
+  --> $DIR/lint-missing-doc.rs:57:1
    |
 LL | pub trait C {
    | ^^^^^^^^^^^
 
 error: missing documentation for a method
-  --> $DIR/lint-missing-doc.rs:54:5
+  --> $DIR/lint-missing-doc.rs:58:5
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
 
 error: missing documentation for a method
-  --> $DIR/lint-missing-doc.rs:55:5
+  --> $DIR/lint-missing-doc.rs:59:5
    |
 LL |     fn foo_with_impl(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:56:5
+  --> $DIR/lint-missing-doc.rs:60:5
    |
 LL |     fn foo_no_self();
    |     ^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:57:5
+  --> $DIR/lint-missing-doc.rs:61:5
    |
 LL |     fn foo_no_self_with_impl() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated type
-  --> $DIR/lint-missing-doc.rs:67:5
+  --> $DIR/lint-missing-doc.rs:71:5
    |
 LL |     type AssociatedType;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated type
-  --> $DIR/lint-missing-doc.rs:68:5
+  --> $DIR/lint-missing-doc.rs:72:5
    |
 LL |     type AssociatedTypeDef = Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for an associated function
-  --> $DIR/lint-missing-doc.rs:84:5
+  --> $DIR/lint-missing-doc.rs:88:5
    |
 LL |     pub fn foo() {}
    |     ^^^^^^^^^^^^
 
 error: missing documentation for an enum
-  --> $DIR/lint-missing-doc.rs:121:1
+  --> $DIR/lint-missing-doc.rs:125:1
    |
 LL | pub enum PubBaz {
    | ^^^^^^^^^^^^^^^
 
 error: missing documentation for a variant
-  --> $DIR/lint-missing-doc.rs:122:5
+  --> $DIR/lint-missing-doc.rs:126:5
    |
 LL |     PubBazA {
    |     ^^^^^^^
 
 error: missing documentation for a struct field
-  --> $DIR/lint-missing-doc.rs:123:9
+  --> $DIR/lint-missing-doc.rs:127:9
    |
 LL |         a: isize,
    |         ^^^^^^^^
 
 error: missing documentation for a constant
-  --> $DIR/lint-missing-doc.rs:154:1
+  --> $DIR/lint-missing-doc.rs:158:1
    |
 LL | pub const FOO4: u32 = 0;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a static
-  --> $DIR/lint-missing-doc.rs:164:1
+  --> $DIR/lint-missing-doc.rs:168:1
    |
 LL | pub static BAR4: u32 = 0;
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:170:5
+  --> $DIR/lint-missing-doc.rs:174:5
    |
 LL |     pub fn undocumented1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:171:5
+  --> $DIR/lint-missing-doc.rs:175:5
    |
 LL |     pub fn undocumented2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:177:9
+  --> $DIR/lint-missing-doc.rs:181:9
    |
 LL |         pub fn also_undocumented1() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/lint-missing-doc.rs:192:5
+  --> $DIR/lint-missing-doc.rs:196:5
    |
 LL |     pub fn extern_fn_undocumented(f: f32) -> f32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a static
-  --> $DIR/lint-missing-doc.rs:197:5
+  --> $DIR/lint-missing-doc.rs:201:5
    |
 LL |     pub static EXTERN_STATIC_UNDOCUMENTED: u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a foreign type
-  --> $DIR/lint-missing-doc.rs:202:5
+  --> $DIR/lint-missing-doc.rs:206:5
    |
 LL |     pub type ExternTyUndocumented;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a trait alias
-  --> $DIR/lint-missing-doc.rs:206:1
+  --> $DIR/lint-missing-doc.rs:210:1
    |
 LL | pub trait T = Sync;
    | ^^^^^^^^^^^

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -496,6 +496,7 @@ compiler-team-contributors = [
     "@TaKO8Ki",
     "@WaffleLapkin",
     "@b-naber",
+    "@fee1-dead",
 ]
 compiler = [
     "compiler-team",


### PR DESCRIPTION
Successful merges:

 - #111250 (Add Terminator conversion from MIR to SMIR, part #2)
 - #112310 (Add new Tier-3 targets: `loongarch64-unknown-none*`)
 - #112334 (Add myself to highfive rotation)
 - #112340 (remove `TyCtxt::has_error_field` helper method)
 - #112343 (Prevent emitting `missing_docs` for `pub extern crate`)
 - #112350 (Avoid duplicate type sanitization of local decls in borrowck)
 - #112356 (Fix comment for `get_region_var_origins`)
 - #112358 (Remove default visitor impl in region constraint generation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=111250,112310,112334,112340,112343,112350,112356,112358)
<!-- homu-ignore:end -->