### PR TITLE
Lower matches against constant slices into better MIR

### DIFF
--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -106,6 +106,7 @@ macro_rules! arena_types {
             [] tys: rustc_type_ir::WithCachedTypeInfo<rustc_middle::ty::TyKind<'tcx>>,
             [] predicates: rustc_type_ir::WithCachedTypeInfo<rustc_middle::ty::PredicateKind<'tcx>>,
             [] consts: rustc_middle::ty::ConstData<'tcx>,
+            [] pats: rustc_middle::thir::Pat<'tcx>,
 
             // Note that this deliberately duplicates items in the `rustc_hir::arena`,
             // since we need to allocate this type on both the `rustc_hir` arena

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -24,7 +24,7 @@ use super::sty::ConstKind;
 /// Use this rather than `ConstData`, whenever possible.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable)]
 #[rustc_pass_by_value]
-pub struct Const<'tcx>(pub(super) Interned<'tcx, ConstData<'tcx>>);
+pub struct Const<'tcx>(pub Interned<'tcx, ConstData<'tcx>>);
 
 /// Typed constant value.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, HashStable, TyEncodable, TyDecodable)]

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -63,6 +63,12 @@ impl<'tcx> ValTree<'tcx> {
         Self::Branch(interned)
     }
 
+    pub fn from_scalars<'a>(tcx: TyCtxt<'tcx>, scalars: &'a [ScalarInt]) -> Self {
+        let interned = tcx.arena.alloc_from_iter(scalars.iter().map(|&s| Self::Leaf(s)));
+
+        Self::Branch(interned)
+    }
+
     pub fn from_scalar_int(i: ScalarInt) -> Self {
         Self::Leaf(i)
     }

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -63,7 +63,7 @@ impl<'tcx> ValTree<'tcx> {
         Self::Branch(interned)
     }
 
-    pub fn from_scalars<'a>(tcx: TyCtxt<'tcx>, scalars: &'a [ScalarInt]) -> Self {
+    pub fn from_scalars(tcx: TyCtxt<'tcx>, scalars: impl IntoIter<Item = ScalarInt>) -> Self {
         let interned = tcx.arena.alloc_from_iter(scalars.iter().map(|&s| Self::Leaf(s)));
 
         Self::Branch(interned)

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -94,10 +94,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         };
 
         match match_pair.pattern.kind {
-            PatKind::Constant { value } => {
+            PatKind::Constant {
+                value
+            } if let Some(result) = value.try_eval_bits(self.tcx, self.param_env, switch_ty) => {
                 options
                     .entry(value)
-                    .or_insert_with(|| value.eval_bits(self.tcx, self.param_env, switch_ty));
+                    .or_insert(result);
                 true
             }
             PatKind::Variant { .. } => {
@@ -108,6 +110,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.values_not_contained_in_range(&*range, options).unwrap_or(false)
             }
             PatKind::Slice { .. }
+            | PatKind::Constant { .. }
             | PatKind::Array { .. }
             | PatKind::Wild
             | PatKind::Or { .. }


### PR DESCRIPTION
Fixes #110870 (eventually)

The approach I've been trying so far is lowering `PatKind::Array` (when it is a fixed array with only constants in it) to a constant pattern in `mir_build`. Currently there are two issues here:
* I am hitting an assertion around unexpected types for constants
* I don't know how to allocate the `Pat` into the `tcx` to get the lifetimes right (hence the `Box::leak` hack)

I will continue toying around with this but wanted to open the PR to see if this is the wrong way of doing it. Should I be doing it in a different MIR stage/a MIR opt pass?