### PR TITLE
Add lints for raw string literals

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -735,7 +735,7 @@ fn link_natively<'a>(
     info!("{:?}", &cmd);
     let retry_on_segfault = env::var("RUSTC_RETRY_LINKER_ON_SEGFAULT").is_ok();
     let unknown_arg_regex =
-        Regex::new(r"(unknown|unrecognized) (command line )?(option|argument)").unwrap();
+        Regex::new("(unknown|unrecognized) (command line )?(option|argument)").unwrap();
     let mut prog;
     let mut i = 0;
     loop {

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -783,7 +783,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     rustc_attr!(
         rustc_doc_primitive, Normal, template!(NameValueStr: "primitive name"), ErrorFollowing,
-        r"`rustc_doc_primitive` is a rustc internal attribute",
+        "`rustc_doc_primitive` is a rustc internal attribute",
     ),
 
     // ==========================================================================

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -783,7 +783,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     rustc_attr!(
         rustc_doc_primitive, Normal, template!(NameValueStr: "primitive name"), ErrorFollowing,
-        r#"`rustc_doc_primitive` is a rustc internal attribute"#,
+        r"`rustc_doc_primitive` is a rustc internal attribute",
     ),
 
     // ==========================================================================

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -541,23 +541,23 @@ lint_unused_op = unused {$op} that must be used
     .label = the {$op} produces a value
     .suggestion = use `let _ = ...` to ignore the resulting value
 
-lint_unused_result = unused result of type `{$ty}`
-
-lint_variant_size_differences =
-    enum variant is more than three times larger ({$largest} bytes) than the next largest
+lint_unused_raw_string = string literal does not need to be raw.
+    .label = removing the {$contains_hashes ->
+        *[true] `r` and hashes
+        [false] `r`
+    } would result in the same value
 
 lint_unused_raw_string_hash =
     raw string literal uses more hashes than it needs.
     .label = this raw string requires {$hash_req} {$hash_req ->
         [one] hash
-        *[other]  hashes
+        *[other] hashes
     }, but {$hash_count} {$hash_count ->
         [one] is
         *[other] are
     } used
 
-lint_unused_raw_string = string literal does not need to be raw.
-    .label = removing the {$contains_hashes -> 
-        *[true] `r` and hashes
-        [false] `r`
-    } would result in the same value
+lint_unused_result = unused result of type `{$ty}`
+
+lint_variant_size_differences =
+    enum variant is more than three times larger ({$largest} bytes) than the next largest

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -548,10 +548,16 @@ lint_variant_size_differences =
 
 lint_unused_raw_string_hash =
     raw string literal uses more hashes than it needs.
-    .label = This raw string requires {$hash_req} {$hash_req ->
+    .label = this raw string requires {$hash_req} {$hash_req ->
         [one] hash
         *[other]  hashes
     }, but {$hash_count} {$hash_count ->
         [one] is
         *[other] are
     } used
+
+lint_unused_raw_string = string literal does not need to be raw.
+    .label = removing the {$contains_hashes -> 
+        *[true] `r` and hashes
+        [false] `r`
+    } would result in the same value

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -545,3 +545,13 @@ lint_unused_result = unused result of type `{$ty}`
 
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest
+
+lint_unused_raw_string_hash =
+    raw string literal uses more hashes than it needs.
+    .label = This raw string requires {$hash_req} {$hash_req ->
+        [one] hash
+        *[other]  hashes
+    }, but {$hash_count} {$hash_count ->
+        [one] is
+        *[other] are
+    } used

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -76,11 +76,11 @@ mod noop_method_call;
 mod opaque_hidden_inferred_bound;
 mod pass_by_value;
 mod passes;
+mod raw_strings;
 mod redundant_semicolon;
 mod traits;
 mod types;
 mod unused;
-mod raw_strings;
 
 pub use array_into_iter::ARRAY_INTO_ITER;
 
@@ -117,11 +117,11 @@ use nonstandard_style::*;
 use noop_method_call::*;
 use opaque_hidden_inferred_bound::*;
 use pass_by_value::*;
+use raw_strings::*;
 use redundant_semicolon::*;
 use traits::*;
 use types::*;
 use unused::*;
-use raw_strings::*;
 
 /// Useful for other parts of the compiler / Clippy.
 pub use builtin::SoftLints;

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -178,6 +178,7 @@ early_lint_methods!(
             UnusedDocComment: UnusedDocComment,
             UnexpectedCfgs: UnexpectedCfgs,
             UnusedRawStringHash: UnusedRawStringHash,
+            UnusedRawString: UnusedRawString,
         ]
     ]
 );
@@ -315,6 +316,7 @@ fn register_builtins(store: &mut LintStore) {
         UNUSED_BRACES,
         REDUNDANT_SEMICOLONS,
         UNUSED_RAW_STRING_HASH,
+        UNUSED_RAW_STRING,
         MAP_UNIT_FN
     );
 

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -80,6 +80,7 @@ mod redundant_semicolon;
 mod traits;
 mod types;
 mod unused;
+mod raw_strings;
 
 pub use array_into_iter::ARRAY_INTO_ITER;
 
@@ -120,6 +121,7 @@ use redundant_semicolon::*;
 use traits::*;
 use types::*;
 use unused::*;
+use raw_strings::*;
 
 /// Useful for other parts of the compiler / Clippy.
 pub use builtin::SoftLints;
@@ -175,6 +177,7 @@ early_lint_methods!(
             RedundantSemicolons: RedundantSemicolons,
             UnusedDocComment: UnusedDocComment,
             UnexpectedCfgs: UnexpectedCfgs,
+            UnusedRawStringHash: UnusedRawStringHash,
         ]
     ]
 );
@@ -311,6 +314,7 @@ fn register_builtins(store: &mut LintStore) {
         UNUSED_PARENS,
         UNUSED_BRACES,
         REDUNDANT_SEMICOLONS,
+        UNUSED_RAW_STRING_HASH,
         MAP_UNIT_FN
     );
 

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1623,3 +1623,12 @@ pub struct UnusedAllocationDiag;
 #[derive(LintDiagnostic)]
 #[diag(lint_unused_allocation_mut)]
 pub struct UnusedAllocationMutDiag;
+
+#[derive(LintDiagnostic)]
+#[diag(lint_unused_raw_string_hash)]
+pub struct UnusedRawStringHashDiag {
+    #[label]
+    pub span: Span,
+    pub hash_count: usize,
+    pub hash_req: usize,
+}

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1632,3 +1632,11 @@ pub struct UnusedRawStringHashDiag {
     pub hash_count: usize,
     pub hash_req: usize,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(lint_unused_raw_string)]
+pub struct UnusedRawStringDiag {
+    #[label]
+    pub span: Span,
+    pub contains_hashes: bool,
+}

--- a/compiler/rustc_lint/src/raw_strings.rs
+++ b/compiler/rustc_lint/src/raw_strings.rs
@@ -1,0 +1,76 @@
+use crate::lints::UnusedRawStringHashDiag;
+use crate::{EarlyContext, EarlyLintPass, LintContext};
+use rustc_ast::{Expr, ExprKind, token::LitKind};
+
+// Examples / Intuition:
+// Must be raw, but hashes are just right   r#" " "#  (neither warning)
+// Must be raw, but has too many hashes     r#" \ "#
+// Non-raw and has too many hashes          r#" ! "#  (both warnings)
+// Non-raw and hashes are just right         r" ! "
+
+declare_lint! {
+    /// The `unused_raw_string_hash` lint checks raw strings that
+    /// use more hashes than they need.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(unused_raw_string_hash)]
+    /// fn main() {
+    ///     let x = r####"Use the r#"..."# notation for raw strings"####;
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// The hashes are not needed and should be removed.
+    pub UNUSED_RAW_STRING_HASH,
+    Warn,
+    "Raw string literal has unneeded hashes"
+}
+
+declare_lint_pass!(UnusedRawStringHash => [UNUSED_RAW_STRING_HASH]);
+
+impl EarlyLintPass for UnusedRawStringHash {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        if let ExprKind::Lit(lit) = expr.kind {
+            // Check all raw string variants with one or more hashes
+            use LitKind::{StrRaw, ByteStrRaw, CStrRaw};
+            if let StrRaw(hc @1..) | ByteStrRaw(hc @1..) | CStrRaw(hc @1..) = lit.kind {
+                // Now check if `hash_count` hashes are actually required
+                let hash_count = hc as usize;
+                let contents = lit.symbol.as_str();
+                let hash_req = Self::required_hashes(contents);
+                if hash_req < hash_count {
+                    cx.emit_spanned_lint(
+                        UNUSED_RAW_STRING_HASH,
+                        expr.span,
+                        UnusedRawStringHashDiag {
+                            span: expr.span,
+                            hash_count,
+                            hash_req,
+                        },
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl UnusedRawStringHash {
+    fn required_hashes(contents: &str) -> usize {
+        // How many hashes are needed to wrap the input string?
+        // aka length of longest "#* sequence or zero if none exists
+
+        // TODO potential speedup: short-circuit max() if `hash_count` found
+
+        contents.as_bytes()
+            .split(|&b| b == b'"')
+            .skip(1)  // first element is the only one not starting with "
+            .map(|bs| 1 + bs.iter().take_while(|&&b| b == b'#').count())
+            .max()
+            .unwrap_or(0)
+    }
+}

--- a/compiler/rustc_middle/src/mir/spanview.rs
+++ b/compiler/rustc_middle/src/mir/spanview.rs
@@ -14,13 +14,13 @@ const CARET: char = '\u{2038}'; // Unicode `CARET`
 const ANNOTATION_LEFT_BRACKET: char = '\u{298a}'; // Unicode `Z NOTATION RIGHT BINDING BRACKET`
 const ANNOTATION_RIGHT_BRACKET: char = '\u{2989}'; // Unicode `Z NOTATION LEFT BINDING BRACKET`
 const NEW_LINE_SPAN: &str = "</span>\n<span class=\"line\">";
-const HEADER: &str = r#"<!DOCTYPE html>
+const HEADER: &str = r"<!DOCTYPE html>
 <html>
-<head>"#;
-const START_BODY: &str = r#"</head>
-<body>"#;
-const FOOTER: &str = r#"</body>
-</html>"#;
+<head>";
+const START_BODY: &str = r"</head>
+<body>";
+const FOOTER: &str = r"</body>
+</html>";
 
 const STYLE_SECTION: &str = r#"<style>
     .line {

--- a/compiler/rustc_middle/src/mir/spanview.rs
+++ b/compiler/rustc_middle/src/mir/spanview.rs
@@ -14,12 +14,12 @@ const CARET: char = '\u{2038}'; // Unicode `CARET`
 const ANNOTATION_LEFT_BRACKET: char = '\u{298a}'; // Unicode `Z NOTATION RIGHT BINDING BRACKET`
 const ANNOTATION_RIGHT_BRACKET: char = '\u{2989}'; // Unicode `Z NOTATION LEFT BINDING BRACKET`
 const NEW_LINE_SPAN: &str = "</span>\n<span class=\"line\">";
-const HEADER: &str = r"<!DOCTYPE html>
+const HEADER: &str = "<!DOCTYPE html>
 <html>
 <head>";
-const START_BODY: &str = r"</head>
+const START_BODY: &str = "</head>
 <body>";
-const FOOTER: &str = r"</body>
+const FOOTER: &str = "</body>
 </html>";
 
 const STYLE_SECTION: &str = r#"<style>

--- a/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
@@ -625,7 +625,7 @@ where
     let html_diff = re.replace_all(&raw_diff, |captures: &regex::Captures<'_>| {
         let mut ret = String::new();
         if inside_font_tag {
-            ret.push_str(r#"</font>"#);
+            ret.push_str(r"</font>");
         }
 
         let tag = match &captures[1] {

--- a/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
@@ -625,7 +625,7 @@ where
     let html_diff = re.replace_all(&raw_diff, |captures: &regex::Captures<'_>| {
         let mut ret = String::new();
         if inside_font_tag {
-            ret.push_str(r"</font>");
+            ret.push_str("</font>");
         }
 
         let tag = match &captures[1] {


### PR DESCRIPTION
This PR introduces two lints related to raw {ε, byte, c} string literals. Though these literals currently allow up to 255 hashes to surround them, my main thought was that lines like

`let x = r#^{200}" normal string "#^{200};`

should never occur (without a warning) in code.

The first lint, `unused_raw_string_hash`, triggers when a raw string literal is surrounded by more hashes than it needs. In a way, it's similar to the `unused_parens` lint, but for hashes.

The second lint expands on the idea of unnessesary raw string syntax. When a string literal contains no escapes and no quotes, prefixing it with an `r` has no impact on its value. The `unused_raw_string` lint triggers when a string literal is raw without needing to be.

With the current implementation, a file containing
```rust
let x = [
    r#" " "#,  // just right
    r#" \ "#,  // too many hashes
    r#" ! "#,  // too many hashes, not raw
     r" ! ",   // not raw
    
];
```
emits
```
warning: raw string literal uses more hashes than it needs.
  --> /home/user/dev/test/test.rs:13:9
   |
13 |         r#" \ "#,
   |         ^^^^^^^^ this raw string requires 0 hashes, but 1 is used
   |
   = note: `#[warn(unused_raw_string_hash)]` on by default

warning: raw string literal uses more hashes than it needs.
  --> /home/user/dev/test/test.rs:14:9
   |
14 |         r#" ! "#,
   |         ^^^^^^^^ this raw string requires 0 hashes, but 1 is used

warning: string literal does not need to be raw.
  --> /home/user/dev/test/test.rs:14:9
   |
14 |         r#" ! "#,
   |         ^^^^^^^^ removing the `r` and hashes would result in the same value
   |
   = note: `#[warn(unused_raw_string)]` on by default

warning: string literal does not need to be raw.
  --> /home/user/dev/test/test.rs:15:10
   |
15 |          r" ! ",
   |          ^^^^^^ removing the `r` would result in the same value
```

Some related thoughts:
- This PR is currently not mergable, many improvements can (and should) still be made. This is just a proof-of-concept which emits the warnings.
- These lints are closely related. If hashes are present, triggering `unused_raw_string` will also trigger `unused_raw_string_hash`. The latter would be redundant information, so perhaps should be supressed.
- I have not implemented suggestions, but these should be `MachineApplicable` without issue.
- It may be that the `unused_raw_string_hash` lint is too strict. It could be amended to trigger if
    - there are `n` too many hashes, or perhaps
    - there are too many and more than `n` hashes
though this treatment is not given to `unused_parens`.

Please let me know if this is worth pursuing futher, if any code/ideas should be adapted, or if anything else comes to mind :)

@rustbot label: +T-lang