### PR TITLE
loongarch64-unknown-none*: Set default relocation model to static

### DIFF
--- a/compiler/rustc_target/src/spec/loongarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/loongarch64_unknown_none.rs
@@ -1,4 +1,4 @@
-use super::{Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy};
+use super::{Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel};
 use super::{Target, TargetOptions};
 
 pub fn target() -> Target {
@@ -13,8 +13,7 @@ pub fn target() -> Target {
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::No),
             llvm_abiname: "lp64d".into(),
             max_atomic_width: Some(64),
-            position_independent_executables: true,
-            static_position_independent_executables: true,
+            relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             code_model: Some(CodeModel::Small),
             ..Default::default()

--- a/compiler/rustc_target/src/spec/loongarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/loongarch64_unknown_none_softfloat.rs
@@ -1,4 +1,4 @@
-use super::{Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy};
+use super::{Cc, CodeModel, LinkerFlavor, Lld, PanicStrategy, RelocModel};
 use super::{Target, TargetOptions};
 
 pub fn target() -> Target {
@@ -14,8 +14,7 @@ pub fn target() -> Target {
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::No),
             llvm_abiname: "lp64s".into(),
             max_atomic_width: Some(64),
-            position_independent_executables: true,
-            static_position_independent_executables: true,
+            relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             code_model: Some(CodeModel::Small),
             ..Default::default()


### PR DESCRIPTION
This PR sets the default relocation model to `static` for `loongarch64-unknown-none*` targets. This change aims to streamline the development of the bare-metal project by removing the need for the executable program loader to implement relocation.