### PR TITLE
Track more diagnostics in `rustc_expand`

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1108,6 +1108,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_err<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -1116,6 +1117,7 @@ impl<'a> ExtCtxt<'a> {
         self.sess.parse_sess.span_diagnostic.struct_span_err(sp, msg)
     }
 
+    #[track_caller]
     pub fn create_err(
         &self,
         err: impl IntoDiagnostic<'a>,
@@ -1123,6 +1125,7 @@ impl<'a> ExtCtxt<'a> {
         self.sess.create_err(err)
     }
 
+    #[track_caller]
     pub fn emit_err(&self, err: impl IntoDiagnostic<'a>) -> ErrorGuaranteed {
         self.sess.emit_err(err)
     }
@@ -1133,10 +1136,12 @@ impl<'a> ExtCtxt<'a> {
     /// Compilation will be stopped in the near future (at the end of
     /// the macro expansion phase).
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_err<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<DiagnosticMessage>) {
         self.sess.parse_sess.span_diagnostic.span_err(sp, msg);
     }
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<DiagnosticMessage>) {
         self.sess.parse_sess.span_diagnostic.span_warn(sp, msg);
     }


### PR DESCRIPTION
I wish we could lint this somehow...