### PR TITLE
Collect VTable stats & add `-Zprint-vtable-sizes`

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -430,6 +430,13 @@ fn run_compiler(
                 sess.code_stats.print_type_sizes();
             }
 
+            if sess.opts.unstable_opts.print_vtable_sizes {
+                let crate_name =
+                    compiler.session().opts.crate_name.as_deref().unwrap_or("<UNKNOWN_CRATE>");
+
+                sess.code_stats.print_vtable_sizes(crate_name);
+            }
+
             let linker = queries.linker()?;
             Ok(Some(linker))
         })?;

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -333,6 +333,7 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
                 };
 
                 let prof = compiler.sess.prof.clone();
+
                 prof.generic_activity("drop_compiler").run(move || drop(compiler));
                 r
             })

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -918,24 +918,15 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
                     }
 
                     traits::vtable::VtblSegment::TraitOwnEntries { trait_ref, emit_vptr } => {
-                        let existential_trait_ref = trait_ref.map_bound(|trait_ref| {
-                            ty::ExistentialTraitRef::erase_self_ty(tcx, trait_ref)
-                        });
-
                         // Lookup the shape of vtable for the trait.
                         let own_existential_entries =
-                            tcx.own_existential_vtable_entries(existential_trait_ref.def_id());
+                            tcx.own_existential_vtable_entries(trait_ref.def_id());
 
-                        let own_entries = own_existential_entries.iter().copied().map(|_def_id| {
-                            // The original code here ignores the method if its predicates are impossible.
-                            // We can't really do that as, for example, all not trivial bounds on generic
-                            // parameters are impossible (since we don't know the parameters...),
-                            // see the comment above.
-
-                            1
-                        });
-
-                        unupcasted_cost += own_entries.sum::<usize>();
+                        // The original code here ignores the method if its predicates are impossible.
+                        // We can't really do that as, for example, all not trivial bounds on generic
+                        // parameters are impossible (since we don't know the parameters...),
+                        // see the comment above.
+                        unupcasted_cost += own_existential_entries.len();
 
                         if emit_vptr {
                             upcast_cost += 1;

--- a/compiler/rustc_session/src/code_stats.rs
+++ b/compiler/rustc_session/src/code_stats.rs
@@ -232,9 +232,13 @@ impl CodeStats {
             .map(|(_did, stats)| stats)
             .collect::<Vec<_>>();
 
-        // Sort by the cost % in reverse order (from biggest to smallest)
+        // Primary sort: cost % in reverse order (from largest to smallest)
+        // Secondary sort: trait_name
         infos.sort_by(|a, b| {
-            a.upcasting_cost_percent.total_cmp(&b.upcasting_cost_percent).reverse()
+            a.upcasting_cost_percent
+                .total_cmp(&b.upcasting_cost_percent)
+                .reverse()
+                .then_with(|| a.trait_name.cmp(&b.trait_name))
         });
 
         for VTableSizeInfo {

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -27,7 +27,7 @@ pub use lint::{declare_lint, declare_lint_pass, declare_tool_lint, impl_lint_pas
 pub use rustc_lint_defs as lint;
 pub mod parse;
 
-mod code_stats;
+pub mod code_stats;
 #[macro_use]
 pub mod config;
 pub mod cstore;

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1632,6 +1632,8 @@ options! {
         "print the result of the monomorphization collection pass"),
     print_type_sizes: bool = (false, parse_bool, [UNTRACKED],
         "print layout information for each type encountered (default: no)"),
+    print_vtable_sizes: bool = (false, parse_bool, [UNTRACKED],
+        "print size comparison between old and new vtable layouts (default: no)"),
     proc_macro_backtrace: bool = (false, parse_bool, [UNTRACKED],
          "show backtraces for panics during proc-macro execution (default: no)"),
     proc_macro_execution_strategy: ProcMacroExecutionStrategy = (ProcMacroExecutionStrategy::SameThread,

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -21,7 +21,7 @@ mod structural_match;
 mod structural_normalize;
 #[cfg_attr(not(bootstrap), allow(hidden_glob_reexports))]
 mod util;
-mod vtable;
+pub mod vtable;
 pub mod wf;
 
 use crate::infer::outlives::env::OutlivesEnvironment;

--- a/compiler/rustc_trait_selection/src/traits/vtable.rs
+++ b/compiler/rustc_trait_selection/src/traits/vtable.rs
@@ -15,13 +15,13 @@ use std::fmt::Debug;
 use std::ops::ControlFlow;
 
 #[derive(Clone, Debug)]
-pub(super) enum VtblSegment<'tcx> {
+pub enum VtblSegment<'tcx> {
     MetadataDSA,
     TraitOwnEntries { trait_ref: ty::PolyTraitRef<'tcx>, emit_vptr: bool },
 }
 
 /// Prepare the segments for a vtable
-pub(super) fn prepare_vtable_segments<'tcx, T>(
+pub fn prepare_vtable_segments<'tcx, T>(
     tcx: TyCtxt<'tcx>,
     trait_ref: ty::PolyTraitRef<'tcx>,
     mut segment_visitor: impl FnMut(VtblSegment<'tcx>) -> ControlFlow<T>,

--- a/tests/ui/traits/object/print_vtable_sizes.rs
+++ b/tests/ui/traits/object/print_vtable_sizes.rs
@@ -1,0 +1,61 @@
+// check-pass
+// compile-flags: -Z print-vtable-sizes
+#![crate_type = "lib"]
+
+trait A<T: help::V>: AsRef<[T::V]> + AsMut<[T::V]> {}
+
+trait B<T>: AsRef<T> + AsRef<T> + AsRef<T> + AsRef<T> {}
+
+trait C {
+    fn x() {} // not object safe, shouldn't be reported
+}
+
+// This ideally should not have any upcasting cost,
+// but currently does due to a bug
+trait D: Send + Sync + help::MarkerWithSuper {}
+
+// This can't have no cost without reordering,
+// because `Super::f`.
+trait E: help::MarkerWithSuper + Send + Sync {}
+
+trait F {
+    fn a(&self);
+    fn b(&self);
+    fn c(&self);
+
+    fn d() -> Self
+    where
+        Self: Sized;
+}
+
+trait G: AsRef<u8> + AsRef<u16> + help::MarkerWithSuper {
+    fn a(&self);
+    fn b(&self);
+    fn c(&self);
+    fn d(&self);
+    fn e(&self);
+
+    fn f() -> Self
+    where
+        Self: Sized;
+}
+
+// Traits with the same name
+const _: () = {
+    trait S {}
+};
+const _: () = {
+    trait S {}
+};
+
+mod help {
+    pub trait V {
+        type V;
+    }
+
+    pub trait MarkerWithSuper: Super {}
+
+    pub trait Super {
+        fn f(&self);
+    }
+}

--- a/tests/ui/traits/object/print_vtable_sizes.stdout
+++ b/tests/ui/traits/object/print_vtable_sizes.stdout
@@ -1,0 +1,11 @@
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "D", "entries": "7", "entries_ignoring_upcasting": "4", "entries_for_upcasting": "3", "upcasting_cost_percent": "75" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "E", "entries": "6", "entries_ignoring_upcasting": "4", "entries_for_upcasting": "2", "upcasting_cost_percent": "50" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "G", "entries": "14", "entries_ignoring_upcasting": "11", "entries_for_upcasting": "3", "upcasting_cost_percent": "27.27272727272727" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "A", "entries": "6", "entries_ignoring_upcasting": "5", "entries_for_upcasting": "1", "upcasting_cost_percent": "20" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "B", "entries": "4", "entries_ignoring_upcasting": "4", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "F", "entries": "6", "entries_ignoring_upcasting": "6", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "_::S", "entries": "3", "entries_ignoring_upcasting": "3", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "_::S", "entries": "3", "entries_ignoring_upcasting": "3", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "help::MarkerWithSuper", "entries": "4", "entries_ignoring_upcasting": "4", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "help::Super", "entries": "4", "entries_ignoring_upcasting": "4", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "help::V", "entries": "3", "entries_ignoring_upcasting": "3", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }


### PR DESCRIPTION
This is a bit hacky/buggy, but I'm not entirely sure how to fix it, so I want to ask reviewers for help...

To try this, use either of those:
- `cargo clean && RUSTFLAGS="-Zprint-vtable-sizes" cargo +toolchain b`
- `cargo clean && cargo rustc +toolchain -Zprint-vtable-sizes`
- `rustc +toolchain -Zprint-vtable-sizes ./file.rs`