### PR TITLE
Don't `use compile_error as print`

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -58,11 +58,18 @@ use std::str;
 use std::sync::OnceLock;
 use std::time::Instant;
 
+#[allow(unused_macros)]
+macro do_not_use_print($($t:tt)*) {
+    std::compile_error!(
+        "Don't use `print` or `println` here, use `safe_print` or `safe_println` instead"
+    )
+}
+
 // This import blocks the use of panicking `print` and `println` in all the code
 // below. Please use `safe_print` and `safe_println` to avoid ICE when
 // encountering an I/O error during print.
 #[allow(unused_imports)]
-use std::{compile_error as print, compile_error as println};
+use {do_not_use_print as print, do_not_use_print as println};
 
 pub mod args;
 pub mod pretty;


### PR DESCRIPTION
I've spent **1.5 hours** debugging this while trying to compile #112400, if we use `compile_error!`, we should not just forward user input to it, but issue a reasonable error message.

The better solution would be to use a lint like `clippy::print_stdout`, but since we don't have clippy in CI, let's at least make the macro error better.

Also note that some functions called here actually do use `println` (see for example `print_type_sizes` function).