### PR TITLE
Prevent `.eh_frame` from being emitted for `-C panic=abort`

### DIFF
--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -9,6 +9,7 @@ use rustc_middle::mir::{
 };
 use rustc_middle::ty::{Ty, TyCtxt, TypeAndMut};
 use rustc_session::Session;
+use rustc_target::spec::PanicStrategy;
 
 pub struct CheckAlignment;
 
@@ -236,7 +237,11 @@ fn insert_alignment_check<'tcx>(
                 required: Operand::Copy(alignment),
                 found: Operand::Copy(addr),
             }),
-            unwind: UnwindAction::Terminate,
+            unwind: if tcx.sess.panic_strategy() == PanicStrategy::Unwind {
+                UnwindAction::Terminate
+            } else {
+                UnwindAction::Unreachable
+            },
         },
     });
 }

--- a/tests/run-make/panic-abort-eh_frame/Makefile
+++ b/tests/run-make/panic-abort-eh_frame/Makefile
@@ -1,0 +1,10 @@
+# only-linux
+#
+# This test ensures that `panic=abort` code (without `C-unwind`, that is) should not have any
+# unwinding related `.eh_frame` sections emitted.
+
+include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs --crate-type=lib --emit=obj=$(TMPDIR)/foo.o -Cpanic=abort
+	objdump --dwarf=frames $(TMPDIR)/foo.o | $(CGREP) -v 'DW_CFA'

--- a/tests/run-make/panic-abort-eh_frame/foo.rs
+++ b/tests/run-make/panic-abort-eh_frame/foo.rs
@@ -1,0 +1,10 @@
+#![no_std]
+
+#[panic_handler]
+fn handler(_: &core::panic::PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+pub unsafe fn oops(x: *const u32) -> u32 {
+    *x
+}


### PR DESCRIPTION
Since `CheckAlignment` pass is after the `AbortUnwindingCalls` pass, the `UnwindAction::Terminate` inserted in it has no chance to be converted to `UnwindAction::Unreachable` anymore, causing us to emit landing pads that are not necessary. Although these landing pads can themselves be eliminated by LLVM, `.eh_frame` sections are still generated. This causes trouble for Rust-for-Linux project recently.

This PR changes it to generate `UnwindAction::Terminate` when we opt for `-Cpanic=unwind`, and `UnwindAction::Unreachable` for `-Cpanic=abort`.

@ojeda 