### PR TITLE
Adjust span labels for `HIDDEN_GLOB_REEXPORTS`

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -953,8 +953,8 @@ pub trait LintContext: Sized {
                     db.span_label(duplicate_reexport_span, format!("but the name `{}` in the {} namespace is also re-exported here", name, namespace));
                 }
                 BuiltinLintDiagnostics::HiddenGlobReexports { name, namespace, glob_reexport_span, private_item_span } => {
-                    db.span_label(glob_reexport_span, format!("the name `{}` in the {} namespace is supposed to be publicly re-exported here", name, namespace));
-                    db.span_label(private_item_span, "but the private item here shadows it");
+                    db.span_note(glob_reexport_span, format!("the name `{}` in the {} namespace is supposed to be publicly re-exported here", name, namespace));
+                    db.span_note(private_item_span, "but the private item here shadows it".to_owned());
                 }
             }
             // Rewrap `db`, and pass control to the user.

--- a/tests/ui/resolve/hidden_glob_reexports.rs
+++ b/tests/ui/resolve/hidden_glob_reexports.rs
@@ -6,10 +6,10 @@ pub mod upstream_a {
         pub struct Bar {}
     }
 
-    pub use self::inner::*;
-
     struct Foo;
     //~^ WARN private item shadows public glob re-export
+
+    pub use self::inner::*;
 }
 
 pub mod upstream_b {

--- a/tests/ui/resolve/hidden_glob_reexports.stderr
+++ b/tests/ui/resolve/hidden_glob_reexports.stderr
@@ -1,31 +1,54 @@
 warning: private item shadows public glob re-export
-  --> $DIR/hidden_glob_reexports.rs:11:5
+  --> $DIR/hidden_glob_reexports.rs:9:5
+   |
+LL |     struct Foo;
+   |     ^^^^^^^^^^^
+   |
+note: the name `Foo` in the type namespace is supposed to be publicly re-exported here
+  --> $DIR/hidden_glob_reexports.rs:12:13
    |
 LL |     pub use self::inner::*;
-   |             -------------- the name `Foo` in the type namespace is supposed to be publicly re-exported here
-LL |
-LL |     struct Foo;
-   |     ^^^^^^^^^^^ but the private item here shadows it
+   |             ^^^^^^^^^^^^^^
+note: but the private item here shadows it
+  --> $DIR/hidden_glob_reexports.rs:9:5
    |
+LL |     struct Foo;
+   |     ^^^^^^^^^^^
    = note: `#[warn(hidden_glob_reexports)]` on by default
 
 warning: private item shadows public glob re-export
   --> $DIR/hidden_glob_reexports.rs:27:9
    |
-LL |     pub use self::inner::*;
-   |             -------------- the name `Foo` in the type namespace is supposed to be publicly re-exported here
-LL |
 LL |     use self::other::Foo;
-   |         ^^^^^^^^^^^^^^^^ but the private item here shadows it
+   |         ^^^^^^^^^^^^^^^^
+   |
+note: the name `Foo` in the type namespace is supposed to be publicly re-exported here
+  --> $DIR/hidden_glob_reexports.rs:25:13
+   |
+LL |     pub use self::inner::*;
+   |             ^^^^^^^^^^^^^^
+note: but the private item here shadows it
+  --> $DIR/hidden_glob_reexports.rs:27:9
+   |
+LL |     use self::other::Foo;
+   |         ^^^^^^^^^^^^^^^^
 
 warning: private item shadows public glob re-export
   --> $DIR/hidden_glob_reexports.rs:40:9
    |
-LL |     pub use self::no_def_id::*;
-   |             ------------------ the name `u8` in the type namespace is supposed to be publicly re-exported here
-LL |
 LL |     use std::primitive::u8;
-   |         ^^^^^^^^^^^^^^^^^^ but the private item here shadows it
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+note: the name `u8` in the type namespace is supposed to be publicly re-exported here
+  --> $DIR/hidden_glob_reexports.rs:38:13
+   |
+LL |     pub use self::no_def_id::*;
+   |             ^^^^^^^^^^^^^^^^^^
+note: but the private item here shadows it
+  --> $DIR/hidden_glob_reexports.rs:40:9
+   |
+LL |     use std::primitive::u8;
+   |         ^^^^^^^^^^^^^^^^^^
 
 warning: 3 warnings emitted
 


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/pull/111378#issuecomment-1581226063.

### Before This PR

The possibility that the private item comes before the glob re-export was not account for, causing the span label messages to say "but private item here shadows it" before "the name `Foo` in the type namespace is supposed to be publicly re-exported here".

### After This PR

```rust
warning: private item shadows public glob re-export
  --> $DIR/hidden_glob_reexports.rs:9:5
   |
LL |     struct Foo;
   |     ^^^^^^^^^^^ the private item here shadows the name `Foo` in the type namespace
...
LL |     pub use self::inner::*;
   |             -------------- but it is supposed to be publicly re-exported here
   |
   = note: `#[warn(hidden_glob_reexports)]` on by default

warning: private item shadows public glob re-export
  --> $DIR/hidden_glob_reexports.rs:27:9
   |
LL |     pub use self::inner::*;
   |             -------------- the name `Foo` in the type namespace is supposed to be publicly re-exported here
LL |
LL |     use self::other::Foo;
   |         ^^^^^^^^^^^^^^^^ but the private item here shadows it
```