### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -554,9 +554,6 @@ fn report_missing_placeholders(
     fmt_span: Span,
 ) {
     let mut diag = if let &[(span, named)] = &unused[..] {
-        //let mut diag = ecx.struct_span_err(span, msg);
-        //diag.span_label(span, msg);
-        //diag
         ecx.create_err(errors::FormatUnusedArg { span, named })
     } else {
         let unused_labels =

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2256,11 +2256,13 @@ fn add_order_independent_options(
     } else if flavor == LinkerFlavor::Bpf {
         cmd.arg("--cpu");
         cmd.arg(&codegen_results.crate_info.target_cpu);
-        cmd.arg("--cpu-features");
-        cmd.arg(match &sess.opts.cg.target_feature {
-            feat if !feat.is_empty() => feat.as_ref(),
-            _ => sess.target.options.features.as_ref(),
-        });
+        if let Some(feat) = [sess.opts.cg.target_feature.as_str(), &sess.target.options.features]
+            .into_iter()
+            .find(|feat| !feat.is_empty())
+        {
+            cmd.arg("--cpu-features");
+            cmd.arg(feat);
+        }
     }
 
     cmd.linker_plugin_lto();

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -58,11 +58,18 @@ use std::str;
 use std::sync::OnceLock;
 use std::time::Instant;
 
+#[allow(unused_macros)]
+macro do_not_use_print($($t:tt)*) {
+    std::compile_error!(
+        "Don't use `print` or `println` here, use `safe_print` or `safe_println` instead"
+    )
+}
+
 // This import blocks the use of panicking `print` and `println` in all the code
 // below. Please use `safe_print` and `safe_println` to avoid ICE when
 // encountering an I/O error during print.
 #[allow(unused_imports)]
-use std::{compile_error as print, compile_error as println};
+use {do_not_use_print as print, do_not_use_print as println};
 
 pub mod args;
 pub mod pretty;

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1108,6 +1108,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn struct_span_err<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -1116,6 +1117,7 @@ impl<'a> ExtCtxt<'a> {
         self.sess.parse_sess.span_diagnostic.struct_span_err(sp, msg)
     }
 
+    #[track_caller]
     pub fn create_err(
         &self,
         err: impl IntoDiagnostic<'a>,
@@ -1123,6 +1125,7 @@ impl<'a> ExtCtxt<'a> {
         self.sess.create_err(err)
     }
 
+    #[track_caller]
     pub fn emit_err(&self, err: impl IntoDiagnostic<'a>) -> ErrorGuaranteed {
         self.sess.emit_err(err)
     }
@@ -1133,10 +1136,12 @@ impl<'a> ExtCtxt<'a> {
     /// Compilation will be stopped in the near future (at the end of
     /// the macro expansion phase).
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_err<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<DiagnosticMessage>) {
         self.sess.parse_sess.span_diagnostic.span_err(sp, msg);
     }
     #[rustc_lint_diagnostics]
+    #[track_caller]
     pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<DiagnosticMessage>) {
         self.sess.parse_sess.span_diagnostic.span_warn(sp, msg);
     }

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -51,7 +51,6 @@ dependencies = [
  "filetime",
  "hex",
  "ignore",
- "is-terminal",
  "junction",
  "libc",
  "object",
@@ -383,18 +382,6 @@ checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
-dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
  "windows-sys",
 ]
 

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -30,7 +30,6 @@ path = "bin/sccache-plus-cl.rs"
 test = false
 
 [dependencies]
-is-terminal = "0.4"
 build_helper = { path = "../tools/build_helper" }
 cmake = "0.1.38"
 filetime = "0.2"

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -12,6 +12,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt;
 use std::fs;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
@@ -894,8 +895,6 @@ define_config! {
 
 impl Config {
     pub fn default_opts() -> Config {
-        use is_terminal::IsTerminal;
-
         let mut config = Config::default();
         config.llvm_optimize = true;
         config.ninja_in_file = true;

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1124,7 +1124,12 @@ fn item_trait_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &
     write!(w, "{}", render_assoc_items(cx, it, it.item_id.expect_def_id(), AssocItemRender::All))
 }
 
-fn item_opaque_ty(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean::OpaqueTy) {
+fn item_opaque_ty(
+    w: &mut impl fmt::Write,
+    cx: &mut Context<'_>,
+    it: &clean::Item,
+    t: &clean::OpaqueTy,
+) {
     wrap_item(w, |w| {
         write!(
             w,
@@ -1134,16 +1139,18 @@ fn item_opaque_ty(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &cl
             where_clause = print_where_clause(&t.generics, cx, 0, Ending::Newline),
             bounds = bounds(&t.bounds, false, cx),
             attrs = render_attributes_in_pre(it, "", cx.tcx()),
-        );
+        )
+        .unwrap();
     });
 
-    write!(w, "{}", document(cx, it, None, HeadingOffset::H2));
+    write!(w, "{}", document(cx, it, None, HeadingOffset::H2)).unwrap();
 
     // Render any items associated directly to this alias, as otherwise they
     // won't be visible anywhere in the docs. It would be nice to also show
     // associated items from the aliased type (see discussion in #32077), but
     // we need #14072 to make sense of the generics.
     write!(w, "{}", render_assoc_items(cx, it, it.item_id.expect_def_id(), AssocItemRender::All))
+        .unwrap();
 }
 
 fn item_typedef(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean::Typedef) {

--- a/tests/rustdoc-gui/theme-change.goml
+++ b/tests/rustdoc-gui/theme-change.goml
@@ -3,9 +3,9 @@ go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 set-local-storage: {"rustdoc-use-system-theme": "false", "rustdoc-theme": "dark"}
 reload:
 
-store-value: (background_light, "rgb(255, 255, 255)")
-store-value: (background_dark, "rgb(53, 53, 53)")
-store-value: (background_ayu, "rgb(15, 20, 25)")
+store-value: (background_light, "white")
+store-value: (background_dark, "#353535")
+store-value: (background_ayu, "#0f1419")
 
 click: "#settings-menu"
 wait-for: "#theme-ayu"

--- a/tests/ui/const-generics/generic_const_exprs/inline-const-in-const-generic-defaults.rs
+++ b/tests/ui/const-generics/generic_const_exprs/inline-const-in-const-generic-defaults.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![feature(generic_const_exprs)]
+#![feature(inline_const)]
+#![allow(incomplete_features)]
+
+pub struct ConstDefaultUnstable<const N: usize = { const { 3 } }>;
+
+pub fn main() {}

--- a/tests/ui/suggestions/while-let-typo.rs
+++ b/tests/ui/suggestions/while-let-typo.rs
@@ -2,7 +2,7 @@ fn main() {
     let foo = Some(0);
     let bar = None;
     while Some(x) = foo {} //~ ERROR cannot find value `x` in this scope
-    while Some(foo) = bar {}
+    while Some(foo) = bar {} //~ ERROR mismatched types
     while 3 = foo {} //~ ERROR mismatched types
     while Some(3) = foo {} //~ ERROR invalid left-hand side of assignment
     while x = 5 {} //~ ERROR cannot find value `x` in this scope

--- a/tests/ui/suggestions/while-let-typo.stderr
+++ b/tests/ui/suggestions/while-let-typo.stderr
@@ -21,6 +21,17 @@ LL |     while let x = 5 {}
    |           +++
 
 error[E0308]: mismatched types
+  --> $DIR/while-let-typo.rs:5:11
+   |
+LL |     while Some(foo) = bar {}
+   |           ^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: consider adding `let`
+   |
+LL |     while let Some(foo) = bar {}
+   |           +++
+
+error[E0308]: mismatched types
   --> $DIR/while-let-typo.rs:6:11
    |
 LL |     while 3 = foo {}
@@ -39,7 +50,7 @@ help: you might have meant to use pattern destructuring
 LL |     while let Some(3) = foo {}
    |           +++
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0070, E0308, E0425.
 For more information about an error, try `rustc --explain E0070`.

--- a/tests/ui/typeck/issue-112385-while-assign-lhs-place-expr-ice.rs
+++ b/tests/ui/typeck/issue-112385-while-assign-lhs-place-expr-ice.rs
@@ -1,0 +1,9 @@
+// Previously, the while loop with an assignment statement (mistakenly) as the condition
+// which has a place expr as the LHS would trigger an ICE in typeck.
+// Reduced from https://github.com/rust-lang/rust/issues/112385.
+
+fn main() {
+    let foo = Some(());
+    while Some(foo) = None {}
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/typeck/issue-112385-while-assign-lhs-place-expr-ice.stderr
+++ b/tests/ui/typeck/issue-112385-while-assign-lhs-place-expr-ice.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-112385-while-assign-lhs-place-expr-ice.rs:7:11
+   |
+LL |     while Some(foo) = None {}
+   |           ^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: consider adding `let`
+   |
+LL |     while let Some(foo) = None {}
+   |           +++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #112034 (Migrate `item_opaque_ty` to Askama)
 - #112179 (Avoid passing --cpu-features when empty)
 - #112309 (bootstrap: remove dependency `is-terminal`)
 - #112388 (Migrate GUI colors test to original CSS color format)
 - #112389 (Add a test for #105709)
 - #112392 (Fix ICE for while loop with assignment condition with LHS place expr)
 - #112394 (Remove accidental comment)
 - #112396 (Track more diagnostics in `rustc_expand`)
 - #112401 (Don't `use compile_error as print`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112034,112179,112309,112388,112389,112392,112394,112396,112401)
<!-- homu-ignore:end -->