### PR TITLE
increase the accuracy of effective visibilities calculation

### DIFF
--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -81,7 +81,7 @@ impl<'r, 'a, 'tcx> EffectiveVisibilitiesVisitor<'r, 'a, 'tcx> {
             def_effective_visibilities: Default::default(),
             import_effective_visibilities: Default::default(),
             current_private_vis: Visibility::Restricted(CRATE_DEF_ID),
-            changed: false,
+            changed: true,
         };
 
         visitor.def_effective_visibilities.update_root();

--- a/tests/ui/privacy/effective_visibilities_full_priv.rs
+++ b/tests/ui/privacy/effective_visibilities_full_priv.rs
@@ -1,0 +1,21 @@
+#![feature(rustc_attrs)]
+#![allow(private_in_public)]
+
+struct SemiPriv;
+
+mod m {
+    #[rustc_effective_visibility]
+    struct Priv;
+    //~^ ERROR Direct: pub(self), Reexported: pub(self), Reachable: pub(crate), ReachableThroughImplTrait: pub(crate)
+    //~| ERROR not in the table
+
+    #[rustc_effective_visibility]
+    pub fn foo() {} //~ ERROR Direct: pub(crate), Reexported: pub(crate), Reachable: pub(crate), ReachableThroughImplTrait: pub(crate)
+
+    #[rustc_effective_visibility]
+    impl crate::SemiPriv { //~ ERROR Direct: pub(crate), Reexported: pub(crate), Reachable: pub(crate), ReachableThroughImplTrait: pub(crate)
+        pub fn f(_: Priv) {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/privacy/effective_visibilities_full_priv.stderr
+++ b/tests/ui/privacy/effective_visibilities_full_priv.stderr
@@ -1,0 +1,26 @@
+error: Direct: pub(self), Reexported: pub(self), Reachable: pub(crate), ReachableThroughImplTrait: pub(crate)
+  --> $DIR/effective_visibilities_full_priv.rs:8:5
+   |
+LL |     struct Priv;
+   |     ^^^^^^^^^^^
+
+error: not in the table
+  --> $DIR/effective_visibilities_full_priv.rs:8:5
+   |
+LL |     struct Priv;
+   |     ^^^^^^^^^^^
+
+error: Direct: pub(crate), Reexported: pub(crate), Reachable: pub(crate), ReachableThroughImplTrait: pub(crate)
+  --> $DIR/effective_visibilities_full_priv.rs:13:5
+   |
+LL |     pub fn foo() {}
+   |     ^^^^^^^^^^^^
+
+error: Direct: pub(crate), Reexported: pub(crate), Reachable: pub(crate), ReachableThroughImplTrait: pub(crate)
+  --> $DIR/effective_visibilities_full_priv.rs:16:5
+   |
+LL |     impl crate::SemiPriv {
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Effective visibilities are calculated lazily due to performance restrictions.  Therefore

- crate should be walked at least 1 time in `compute_effective_visibilities` pass
- Impl's should always be in the effective visibilities table

to ensure that the table is filled in correctly.

r? @petrochenkov