### PR TITLE
Allow overwriting the sysroot compile flag via --rustc-args

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1951,7 +1951,9 @@ impl<'test> TestCx<'test> {
         rustc.arg("-Ztranslate-remapped-path-to-local-path=no");
 
         // Optionally prevent default --sysroot if specified in test compile-flags.
-        if !self.props.compile_flags.iter().any(|flag| flag.starts_with("--sysroot")) {
+        if !self.props.compile_flags.iter().any(|flag| flag.starts_with("--sysroot"))
+            && !self.config.host_rustcflags.iter().any(|flag| flag == "--sysroot")
+        {
             // In stage 0, make sure we use `stage0-sysroot` instead of the bootstrap sysroot.
             rustc.arg("--sysroot").arg(&self.config.sysroot_base);
         }


### PR DESCRIPTION
Hi.
As discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/How.20to.20overwrite.20sysroot.20in.20x.2Epy.20test/near/364272269), this is a solution to allow the codegens to overwrite the sysroot as part of their test suite.
Thanks for the review.