### PR TITLE
Deduplicate identical region constraints in new solver

### DIFF
--- a/tests/ui/traits/new-solver/dedup-regions.rs
+++ b/tests/ui/traits/new-solver/dedup-regions.rs
@@ -1,0 +1,31 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+struct A(*mut ());
+
+unsafe impl Send for A where A: 'static {}
+
+macro_rules! mk {
+    ($name:ident $ty:ty) => {
+        struct $name($ty, $ty, $ty, $ty, $ty, $ty, $ty, $ty, $ty, $ty);
+    };
+}
+
+mk!(B A);
+mk!(C B);
+mk!(D C);
+mk!(E D);
+mk!(F E);
+mk!(G F);
+mk!(H G);
+mk!(I H);
+mk!(J I);
+mk!(K J);
+mk!(L K);
+mk!(M L);
+
+fn needs_send<T: Send>() {}
+
+fn main() {
+    needs_send::<M>();
+}


### PR DESCRIPTION
the new solver doesn't track whether we've already proven a goal like the fulfillment context's obligation forest does, so we may be instantiating a canonical response (and specifically, its nested region obligations) quite a few times.

This may lead to exponentially gathering up identical region constraints for things like auto traits, so let's deduplicate region constraints when in `compute_external_query_constraints`.

r? @lcnr