### PR TITLE
Don't debug-print `Interned` or `PrivateZst`

### DIFF
--- a/compiler/rustc_data_structures/src/intern.rs
+++ b/compiler/rustc_data_structures/src/intern.rs
@@ -1,5 +1,6 @@
 use crate::stable_hasher::{HashStable, StableHasher};
 use std::cmp::Ordering;
+use std::fmt::{self, Debug};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::ptr;
@@ -20,7 +21,6 @@ mod private {
 /// The `PrivateZst` field means you can pattern match with `Interned(v, _)`
 /// but you can only construct a `Interned` with `new_unchecked`, and not
 /// directly.
-#[derive(Debug)]
 #[rustc_pass_by_value]
 pub struct Interned<'a, T>(pub &'a T, pub private::PrivateZst);
 
@@ -105,6 +105,12 @@ where
 {
     fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         self.0.hash_stable(hcx, hasher);
+    }
+}
+
+impl<T: Debug> Debug for Interned<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 


### PR DESCRIPTION
Instead of, e.g.

`PredefinedOpaques(Interned(PredefinedOpaquesData { ... }, PrivateZst))`

print:

`PredefinedOpaques(PredefinedOpaquesData { ... })`

Mostly observable in debug logs, or ICE backtraces where I saw this.

r? @nnethercote