### PR TITLE
Fix debug ICE when previous arg span during extra comma removal comes from macro context

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -937,7 +937,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             .get(ProvidedIdx::from_usize(arg_idx.index() - 1)
                         ) {
                             // Include previous comma
-                            span = prev.shrink_to_hi().to(span);
+                            // NOTE(#112437): we *manually* calculate the previous comma span here
+                            // because `Span::to` returns incomplete span when `prev` or `span`
+                            // involves macro contexts.
+                            span = Span::new(prev.hi(), span.hi(), span.ctxt(), span.parent());
                         }
 
                         // Is last argument for deletion in a row starting from the 0-th argument?

--- a/tests/ui/typeck/issue-112437-extra-arg-comma-removal-debug-ice.rs
+++ b/tests/ui/typeck/issue-112437-extra-arg-comma-removal-debug-ice.rs
@@ -1,0 +1,8 @@
+#![feature(never_type)]
+
+fn f(a: !) {}
+
+fn main() {
+    f(panic!(), 1);
+    //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+}

--- a/tests/ui/typeck/issue-112437-extra-arg-comma-removal-debug-ice.stderr
+++ b/tests/ui/typeck/issue-112437-extra-arg-comma-removal-debug-ice.stderr
@@ -1,0 +1,18 @@
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/issue-112437-extra-arg-comma-removal-debug-ice.rs:6:5
+   |
+LL |     f(panic!(), 1);
+   |     ^         ---
+   |               | |
+   |               | unexpected argument of type `{integer}`
+   |               help: remove the extra argument
+   |
+note: function defined here
+  --> $DIR/issue-112437-extra-arg-comma-removal-debug-ice.rs:3:4
+   |
+LL | fn f(a: !) {}
+   |    ^ ----
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
Manually calculate `prev.shrink_to_hi().to(span)` to avoid empty span when `prev` comes from a macro context, such as in the code below:

```rust
#![feature(never_type)]
fn f(a: !) {}

fn main() {
    f(panic!(), 1);
}
```

Fixes #112437.