### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_data_structures/src/intern.rs
+++ b/compiler/rustc_data_structures/src/intern.rs
@@ -1,5 +1,6 @@
 use crate::stable_hasher::{HashStable, StableHasher};
 use std::cmp::Ordering;
+use std::fmt::{self, Debug};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::ptr;
@@ -20,7 +21,6 @@ mod private {
 /// The `PrivateZst` field means you can pattern match with `Interned(v, _)`
 /// but you can only construct a `Interned` with `new_unchecked`, and not
 /// directly.
-#[derive(Debug)]
 #[rustc_pass_by_value]
 pub struct Interned<'a, T>(pub &'a T, pub private::PrivateZst);
 
@@ -105,6 +105,12 @@ where
 {
     fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         self.0.hash_stable(hcx, hasher);
+    }
+}
+
+impl<T: Debug> Debug for Interned<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -393,9 +393,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // They can denote both statically and dynamically-sized byte arrays.
         let mut pat_ty = ty;
         if let hir::ExprKind::Lit(Spanned { node: ast::LitKind::ByteStr(..), .. }) = lt.kind {
-            let expected = self.structurally_resolved_type(span, expected);
-            if let ty::Ref(_, inner_ty, _) = expected.kind()
-                && matches!(inner_ty.kind(), ty::Slice(_))
+            if let ty::Ref(_, inner_ty, _) = *self.structurally_resolved_type(span, expected).kind()
+                && self.structurally_resolved_type(span, inner_ty).is_slice()
             {
                 let tcx = self.tcx;
                 trace!(?lt.hir_id.local_id, "polymorphic byte string lit");

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -287,6 +287,27 @@ fn rustc_generator_to_generator(
     }
 }
 
+fn rustc_inline_asm_operand_to_inline_asm_operand(
+    operand: &rustc_middle::mir::InlineAsmOperand<'_>,
+) -> stable_mir::mir::InlineAsmOperand {
+    use rustc_middle::mir::InlineAsmOperand;
+
+    let (in_value, out_place) = match operand {
+        InlineAsmOperand::In { value, .. } => (Some(rustc_op_to_op(value)), None),
+        InlineAsmOperand::Out { place, .. } => {
+            (None, place.map(|place| rustc_place_to_place(&place)))
+        }
+        InlineAsmOperand::InOut { in_value, out_place, .. } => {
+            (Some(rustc_op_to_op(in_value)), out_place.map(|place| rustc_place_to_place(&place)))
+        }
+        InlineAsmOperand::Const { .. }
+        | InlineAsmOperand::SymFn { .. }
+        | InlineAsmOperand::SymStatic { .. } => (None, None),
+    };
+
+    stable_mir::mir::InlineAsmOperand { in_value, out_place, raw_rpr: format!("{:?}", operand) }
+}
+
 fn rustc_terminator_to_terminator(
     terminator: &rustc_middle::mir::Terminator<'_>,
 ) -> stable_mir::mir::Terminator {
@@ -330,7 +351,19 @@ fn rustc_terminator_to_terminator(
             target: target.as_usize(),
             unwind: rustc_unwind_to_unwind(unwind),
         },
-        InlineAsm { .. } => todo!(),
+        InlineAsm { template, operands, options, line_spans, destination, unwind } => {
+            Terminator::InlineAsm {
+                template: format!("{:?}", template),
+                operands: operands
+                    .iter()
+                    .map(|operand| rustc_inline_asm_operand_to_inline_asm_operand(operand))
+                    .collect(),
+                options: format!("{:?}", options),
+                line_spans: format!("{:?}", line_spans),
+                destination: destination.map(|d| d.as_usize()),
+                unwind: rustc_unwind_to_unwind(unwind),
+            }
+        }
         Yield { .. } | GeneratorDrop | FalseEdge { .. } | FalseUnwind { .. } => unreachable!(),
     }
 }

--- a/compiler/rustc_smir/src/stable_mir/mir/body.rs
+++ b/compiler/rustc_smir/src/stable_mir/mir/body.rs
@@ -46,6 +46,23 @@ pub enum Terminator {
         unwind: UnwindAction,
     },
     GeneratorDrop,
+    InlineAsm {
+        template: String,
+        operands: Vec<InlineAsmOperand>,
+        options: String,
+        line_spans: String,
+        destination: Option<usize>,
+        unwind: UnwindAction,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct InlineAsmOperand {
+    pub in_value: Option<Operand>,
+    pub out_place: Option<Place>,
+    // This field has a raw debug representation of MIR's InlineAsmOperand.
+    // For now we care about place/operand + the rest in a debug format.
+    pub raw_rpr: String,
 }
 
 #[derive(Clone, Debug)]

--- a/tests/ui/async-await/drop-track-bad-field-in-fru.stderr
+++ b/tests/ui/async-await/drop-track-bad-field-in-fru.stderr
@@ -3,6 +3,8 @@ error[E0559]: variant `Option<_>::None` has no field named `value`
    |
 LL |     None { value: (), ..Default::default() }.await;
    |            ^^^^^ `Option<_>::None` does not have this field
+   |
+   = note: all struct fields are already assigned
 
 error[E0277]: `Option<_>` is not a future
   --> $DIR/drop-track-bad-field-in-fru.rs:7:46

--- a/tests/ui/did_you_mean/issue-42599_available_fields_note.stderr
+++ b/tests/ui/did_you_mean/issue-42599_available_fields_note.stderr
@@ -10,7 +10,7 @@ error[E0560]: struct `Demo` has no field named `egregiously_nonexistent_field`
 LL |             Self { secret_integer: 3, egregiously_nonexistent_field: () }
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Demo` does not have this field
    |
-   = note: available fields are: `favorite_integer`, `secret_integer`, `innocently_misspellable`, `another_field`, `yet_another_field` ... and 2 others
+   = note: available fields are: `favorite_integer`, `innocently_misspellable`, `another_field`, `yet_another_field`, `always_more_fields`, `and_ever`
 
 error[E0609]: no field `inocently_mispellable` on type `Demo`
   --> $DIR/issue-42599_available_fields_note.rs:32:41

--- a/tests/ui/error-codes/E0560.stderr
+++ b/tests/ui/error-codes/E0560.stderr
@@ -4,7 +4,7 @@ error[E0560]: struct `Simba` has no field named `father`
 LL |     let s = Simba { mother: 1, father: 0 };
    |                                ^^^^^^ `Simba` does not have this field
    |
-   = note: available fields are: `mother`
+   = note: all struct fields are already assigned
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-5439.stderr
+++ b/tests/ui/issues/issue-5439.stderr
@@ -4,7 +4,7 @@ error[E0560]: struct `Foo` has no field named `nonexistent`
 LL |         return Box::new(Foo { nonexistent: self, foo: i });
    |                               ^^^^^^^^^^^ `Foo` does not have this field
    |
-   = note: available fields are: `foo`
+   = note: all struct fields are already assigned
 
 error: aborting due to previous error
 

--- a/tests/ui/proc-macro/span-preservation.stderr
+++ b/tests/ui/proc-macro/span-preservation.stderr
@@ -32,7 +32,7 @@ error[E0560]: struct `Foo` has no field named `b`
 LL |     let y = Foo { a: 10, b: 10isize };
    |                          ^ `Foo` does not have this field
    |
-   = note: available fields are: `a`
+   = note: all struct fields are already assigned
 
 error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:39:5

--- a/tests/ui/structs/struct-field-cfg.stderr
+++ b/tests/ui/structs/struct-field-cfg.stderr
@@ -10,7 +10,7 @@ error[E0560]: struct `Foo` has no field named `absent`
 LL |     let _ = Foo { present: (), #[cfg(all())] absent: () };
    |                                              ^^^^^^ `Foo` does not have this field
    |
-   = note: available fields are: `present`
+   = note: all struct fields are already assigned
 
 error[E0027]: pattern does not mention field `present`
   --> $DIR/struct-field-cfg.rs:13:9

--- a/tests/ui/structs/struct-fields-shorthand.stderr
+++ b/tests/ui/structs/struct-fields-shorthand.stderr
@@ -4,7 +4,7 @@ error[E0560]: struct `Foo` has no field named `z`
 LL |         x, y, z
    |               ^ `Foo` does not have this field
    |
-   = note: available fields are: `x`, `y`
+   = note: all struct fields are already assigned
 
 error: aborting due to previous error
 

--- a/tests/ui/structs/struct-fields-too-many.stderr
+++ b/tests/ui/structs/struct-fields-too-many.stderr
@@ -4,7 +4,7 @@ error[E0560]: struct `BuildData` has no field named `bar`
 LL |         bar: 0
    |         ^^^ `BuildData` does not have this field
    |
-   = note: available fields are: `foo`
+   = note: all struct fields are already assigned
 
 error: aborting due to previous error
 

--- a/tests/ui/traits/new-solver/slice-match-byte-lit.rs
+++ b/tests/ui/traits/new-solver/slice-match-byte-lit.rs
@@ -1,0 +1,11 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+fn test(s: &[u8]) {
+    match &s[0..3] {
+        b"uwu" => {}
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/union/union-fields-2.mirunsafeck.stderr
+++ b/tests/ui/union/union-fields-2.mirunsafeck.stderr
@@ -16,7 +16,7 @@ error[E0560]: union `U` has no field named `c`
 LL |     let u = U { a: 0, b: 1, c: 2 };
    |                             ^ `U` does not have this field
    |
-   = note: available fields are: `a`, `b`
+   = note: all struct fields are already assigned
 
 error[E0784]: union expressions should have exactly one field
   --> $DIR/union-fields-2.rs:13:13

--- a/tests/ui/union/union-fields-2.thirunsafeck.stderr
+++ b/tests/ui/union/union-fields-2.thirunsafeck.stderr
@@ -16,7 +16,7 @@ error[E0560]: union `U` has no field named `c`
 LL |     let u = U { a: 0, b: 1, c: 2 };
    |                             ^ `U` does not have this field
    |
-   = note: available fields are: `a`, `b`
+   = note: all struct fields are already assigned
 
 error[E0784]: union expressions should have exactly one field
   --> $DIR/union-fields-2.rs:13:13

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -378,7 +378,7 @@ Portable SIMD is developed in its own repository. If possible, consider \
 making this change to [rust-lang/portable-simd](https://github.com/rust-lang/portable-simd) \
 instead.
 """
-cc = ["@calebzulawski"]
+cc = ["@calebzulawski", "@programmerjake"]
 
 [mentions."src/librustdoc/clean/types.rs"]
 cc = ["@camelid"]


### PR DESCRIPTION
Successful merges:

 - #112323 (Don't mention already-set fields in struct constructor missing field error)
 - #112395 (Add Terminator::InlineAsm conversion from MIR to SMIR)
 - #112411 (add programmerjake to portable-simd cc list)
 - #112428 (Structurally resolve pointee in `check_pat_lit`)
 - #112444 (Don't debug-print `Interned` or `PrivateZst`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112323,112395,112411,112428,112444)
<!-- homu-ignore:end -->