### PR TITLE
Remove `Visibility::Protected`.

### DIFF
--- a/compiler/rustc_codegen_gcc/src/base.rs
+++ b/compiler/rustc_codegen_gcc/src/base.rs
@@ -27,7 +27,6 @@ pub fn visibility_to_gcc(linkage: Visibility) -> gccjit::Visibility {
     match linkage {
         Visibility::Default => gccjit::Visibility::Default,
         Visibility::Hidden => gccjit::Visibility::Hidden,
-        Visibility::Protected => gccjit::Visibility::Protected,
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -171,6 +171,5 @@ pub fn visibility_to_llvm(linkage: Visibility) -> llvm::Visibility {
     match linkage {
         Visibility::Default => llvm::Visibility::Default,
         Visibility::Hidden => llvm::Visibility::Hidden,
-        Visibility::Protected => llvm::Visibility::Protected,
     }
 }

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1632,7 +1632,6 @@ extern "C" bool LLVMRustConstInt128Get(LLVMValueRef CV, bool sext, uint64_t *hig
 enum class LLVMRustVisibility {
   Default = 0,
   Hidden = 1,
-  Protected = 2,
 };
 
 static LLVMRustVisibility toRust(LLVMVisibility Vis) {
@@ -1641,8 +1640,6 @@ static LLVMRustVisibility toRust(LLVMVisibility Vis) {
     return LLVMRustVisibility::Default;
   case LLVMHiddenVisibility:
     return LLVMRustVisibility::Hidden;
-  case LLVMProtectedVisibility:
-    return LLVMRustVisibility::Protected;
   }
   report_fatal_error("Invalid LLVMRustVisibility value!");
 }
@@ -1653,8 +1650,6 @@ static LLVMVisibility fromRust(LLVMRustVisibility Vis) {
     return LLVMDefaultVisibility;
   case LLVMRustVisibility::Hidden:
     return LLVMHiddenVisibility;
-  case LLVMRustVisibility::Protected:
-    return LLVMProtectedVisibility;
   }
   report_fatal_error("Invalid LLVMRustVisibility value!");
 }

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -256,11 +256,15 @@ pub enum Linkage {
     Common,
 }
 
+/// Specifies the visibility style for a `MonoItem`.
+///
+/// See <https://llvm.org/docs/LangRef.html#visibility-styles> for more details.
 #[derive(Copy, Clone, PartialEq, Debug, HashStable)]
 pub enum Visibility {
     Default,
     Hidden,
-    Protected,
+    // Unused within rustc. If it's ever needed, revert the commit in #112451.
+    //Protected,
 }
 
 impl<'tcx> CodegenUnit<'tcx> {


### PR DESCRIPTION
Because it's unused.

r? @bjorn3 