### PR TITLE
opaque type cleanup

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -251,91 +251,100 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
             return self.tcx.ty_error(e);
         }
 
-        let definition_ty = instantiated_ty
-            .remap_generic_params_to_declaration_params(opaque_type_key, self.tcx, false)
-            .ty;
-
         if let Err(guar) =
             check_opaque_type_parameter_valid(self.tcx, opaque_type_key, instantiated_ty.span)
         {
             return self.tcx.ty_error(guar);
         }
 
-        // Only check this for TAIT. RPIT already supports `tests/ui/impl-trait/nested-return-type2.rs`
-        // on stable and we'd break that.
-        let opaque_ty_hir = self.tcx.hir().expect_item(opaque_type_key.def_id);
-        let OpaqueTyOrigin::TyAlias { .. } = opaque_ty_hir.expect_opaque_ty().origin else {
-            return definition_ty;
-        };
-        let def_id = opaque_type_key.def_id;
-        // This logic duplicates most of `check_opaque_meets_bounds`.
-        // FIXME(oli-obk): Also do region checks here and then consider removing `check_opaque_meets_bounds` entirely.
-        let param_env = self.tcx.param_env(def_id);
-        // HACK This bubble is required for this tests to pass:
-        // nested-return-type2-tait2.rs
-        // nested-return-type2-tait3.rs
-        // FIXME(-Ztrait-solver=next): We probably should use `DefiningAnchor::Error`
-        // and prepopulate this `InferCtxt` with known opaque values, rather than
-        // using the `Bind` anchor here. For now it's fine.
-        let infcx = self
-            .tcx
-            .infer_ctxt()
-            .with_opaque_type_inference(if self.next_trait_solver() {
-                DefiningAnchor::Bind(def_id)
-            } else {
-                DefiningAnchor::Bubble
-            })
-            .build();
-        let ocx = ObligationCtxt::new(&infcx);
-        // Require the hidden type to be well-formed with only the generics of the opaque type.
-        // Defining use functions may have more bounds than the opaque type, which is ok, as long as the
-        // hidden type is well formed even without those bounds.
-        let predicate = ty::Binder::dummy(ty::PredicateKind::WellFormed(definition_ty.into()));
+        let definition_ty = instantiated_ty
+            .remap_generic_params_to_declaration_params(opaque_type_key, self.tcx, false)
+            .ty;
 
-        let id_substs = InternalSubsts::identity_for_item(self.tcx, def_id);
-
-        // Require that the hidden type actually fulfills all the bounds of the opaque type, even without
-        // the bounds that the function supplies.
-        let opaque_ty = self.tcx.mk_opaque(def_id.to_def_id(), id_substs);
-        if let Err(err) = ocx.eq(
-            &ObligationCause::misc(instantiated_ty.span, def_id),
-            param_env,
-            opaque_ty,
+        // `definition_ty` does not live in of the current inference context,
+        // so lets make sure that we don't accidentally misuse our current `infcx`.
+        match check_opaque_type_well_formed(
+            self.tcx,
+            self.next_trait_solver(),
+            opaque_type_key.def_id,
+            instantiated_ty.span,
             definition_ty,
         ) {
+            Ok(hidden_ty) => hidden_ty,
+            Err(guar) => self.tcx.ty_error(guar),
+        }
+    }
+}
+
+/// This logic duplicates most of `check_opaque_meets_bounds`.
+/// FIXME(oli-obk): Also do region checks here and then consider removing
+/// `check_opaque_meets_bounds` entirely.
+fn check_opaque_type_well_formed<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    next_trait_solver: bool,
+    def_id: LocalDefId,
+    definition_span: Span,
+    definition_ty: Ty<'tcx>,
+) -> Result<Ty<'tcx>, ErrorGuaranteed> {
+    // Only check this for TAIT. RPIT already supports `tests/ui/impl-trait/nested-return-type2.rs`
+    // on stable and we'd break that.
+    let opaque_ty_hir = tcx.hir().expect_item(def_id);
+    let OpaqueTyOrigin::TyAlias { .. } = opaque_ty_hir.expect_opaque_ty().origin else {
+        return Ok(definition_ty);
+    };
+    let param_env = tcx.param_env(def_id);
+    // HACK This bubble is required for this tests to pass:
+    // nested-return-type2-tait2.rs
+    // nested-return-type2-tait3.rs
+    // FIXME(-Ztrait-solver=next): We probably should use `DefiningAnchor::Error`
+    // and prepopulate this `InferCtxt` with known opaque values, rather than
+    // using the `Bind` anchor here. For now it's fine.
+    let infcx = tcx
+        .infer_ctxt()
+        .with_next_trait_solver(next_trait_solver)
+        .with_opaque_type_inference(if next_trait_solver {
+            DefiningAnchor::Bind(def_id)
+        } else {
+            DefiningAnchor::Bubble
+        })
+        .build();
+    let ocx = ObligationCtxt::new(&infcx);
+    let identity_substs = InternalSubsts::identity_for_item(tcx, def_id);
+
+    // Require that the hidden type actually fulfills all the bounds of the opaque type, even without
+    // the bounds that the function supplies.
+    let opaque_ty = tcx.mk_opaque(def_id.to_def_id(), identity_substs);
+    ocx.eq(&ObligationCause::misc(definition_span, def_id), param_env, opaque_ty, definition_ty)
+        .map_err(|err| {
             infcx
                 .err_ctxt()
                 .report_mismatched_types(
-                    &ObligationCause::misc(instantiated_ty.span, def_id),
+                    &ObligationCause::misc(definition_span, def_id),
                     opaque_ty,
                     definition_ty,
                     err,
                 )
-                .emit();
-        }
+                .emit()
+        })?;
 
-        ocx.register_obligation(Obligation::misc(
-            infcx.tcx,
-            instantiated_ty.span,
-            def_id,
-            param_env,
-            predicate,
-        ));
+    // Require the hidden type to be well-formed with only the generics of the opaque type.
+    // Defining use functions may have more bounds than the opaque type, which is ok, as long as the
+    // hidden type is well formed even without those bounds.
+    let predicate = ty::Binder::dummy(ty::PredicateKind::WellFormed(definition_ty.into()));
+    ocx.register_obligation(Obligation::misc(tcx, definition_span, def_id, param_env, predicate));
 
-        // Check that all obligations are satisfied by the implementation's
-        // version.
-        let errors = ocx.select_all_or_error();
+    // Check that all obligations are satisfied by the implementation's
+    // version.
+    let errors = ocx.select_all_or_error();
 
-        // This is still required for many(half of the tests in ui/type-alias-impl-trait)
-        // tests to pass
-        let _ = infcx.take_opaque_types();
+    // This is still required for many(half of the tests in ui/type-alias-impl-trait)
+    // tests to pass
+    let _ = infcx.take_opaque_types();
 
-        if errors.is_empty() {
-            definition_ty
-        } else {
-            let reported = infcx.err_ctxt().report_fulfillment_errors(&errors);
-            self.tcx.ty_error(reported)
-        }
+    if errors.is_empty() {
+        Ok(definition_ty)
+    } else {
+        Err(infcx.err_ctxt().report_fulfillment_errors(&errors))
     }
 }
 

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -27,6 +27,7 @@ use rustc_middle::mir::visit::{NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::AssertKind;
 use rustc_middle::mir::*;
 use rustc_middle::traits::query::NoSolution;
+use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::adjustment::PointerCast;
 use rustc_middle::ty::cast::CastTy;
 use rustc_middle::ty::subst::{SubstsRef, UserSubsts};
@@ -1051,15 +1052,28 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             ConstraintCategory::OpaqueType,
             CustomTypeOp::new(
                 |ocx| {
-                    for (key, hidden_ty) in renumbered_opaques {
-                        ocx.register_infer_ok_obligations(
-                            ocx.infcx.register_hidden_type_in_new_solver(
-                                key,
-                                param_env,
-                                hidden_ty.ty,
-                            )?,
+                    let mut obligations = Vec::new();
+                    for (opaque_type_key, hidden_ty) in renumbered_opaques {
+                        let cause = ObligationCause::dummy();
+                        ocx.infcx.insert_hidden_type(
+                            opaque_type_key,
+                            &cause,
+                            param_env,
+                            hidden_ty.ty,
+                            true,
+                            &mut obligations,
+                        )?;
+
+                        ocx.infcx.add_item_bounds_for_hidden_type(
+                            opaque_type_key,
+                            cause,
+                            param_env,
+                            hidden_ty.ty,
+                            &mut obligations,
                         );
                     }
+
+                    ocx.register_obligations(obligations);
                     Ok(())
                 },
                 "register pre-defined opaques",

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -7,7 +7,6 @@ use std::{fmt, iter, mem};
 
 use either::Either;
 
-use hir::OpaqueTyOrigin;
 use rustc_data_structures::frozen::Frozen;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_errors::ErrorGuaranteed;
@@ -241,7 +240,7 @@ pub(crate) fn type_check<'mir, 'tcx>(
                 hidden_type.ty = infcx.tcx.ty_error(reported);
             }
 
-            (opaque_type_key, (hidden_type, decl.origin))
+            (opaque_type_key, hidden_type)
         })
         .collect();
 
@@ -878,8 +877,7 @@ struct BorrowCheckContext<'a, 'tcx> {
 pub(crate) struct MirTypeckResults<'tcx> {
     pub(crate) constraints: MirTypeckRegionConstraints<'tcx>,
     pub(crate) universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
-    pub(crate) opaque_type_values:
-        FxIndexMap<OpaqueTypeKey<'tcx>, (OpaqueHiddenType<'tcx>, OpaqueTyOrigin)>,
+    pub(crate) opaque_type_values: FxIndexMap<OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>>,
 }
 
 /// A collection of region constraints that must be satisfied for the

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -33,9 +33,6 @@ pub struct OpaqueTypeDecl<'tcx> {
     /// There can be multiple, but they are all `lub`ed together at the end
     /// to obtain the canonical hidden type.
     pub hidden_type: OpaqueHiddenType<'tcx>,
-
-    /// The origin of the opaque type.
-    pub origin: hir::OpaqueTyOrigin,
 }
 
 impl<'tcx> InferCtxt<'tcx> {
@@ -108,7 +105,7 @@ impl<'tcx> InferCtxt<'tcx> {
         let process = |a: Ty<'tcx>, b: Ty<'tcx>, a_is_expected| match *a.kind() {
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, substs, .. }) if def_id.is_local() => {
                 let def_id = def_id.expect_local();
-                let origin = match self.defining_use_anchor {
+                match self.defining_use_anchor {
                     DefiningAnchor::Bind(_) => {
                         // Check that this is `impl Trait` type is
                         // declared by `parent_def_id` -- i.e., one whose
@@ -144,9 +141,11 @@ impl<'tcx> InferCtxt<'tcx> {
                         //     let x = || foo(); // returns the Opaque assoc with `foo`
                         // }
                         // ```
-                        self.opaque_type_origin(def_id)?
+                        if self.opaque_type_origin(def_id).is_none() {
+                            return None;
+                        }
                     }
-                    DefiningAnchor::Bubble => self.opaque_type_origin_unchecked(def_id),
+                    DefiningAnchor::Bubble => {}
                     DefiningAnchor::Error => return None,
                 };
                 if let ty::Alias(ty::Opaque, ty::AliasTy { def_id: b_def_id, .. }) = *b.kind() {
@@ -170,7 +169,6 @@ impl<'tcx> InferCtxt<'tcx> {
                     cause.clone(),
                     param_env,
                     b,
-                    origin,
                     a_is_expected,
                 ))
             }
@@ -524,7 +522,6 @@ impl<'tcx> InferCtxt<'tcx> {
         cause: ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         hidden_ty: Ty<'tcx>,
-        origin: hir::OpaqueTyOrigin,
         a_is_expected: bool,
     ) -> InferResult<'tcx, ()> {
         // Ideally, we'd get the span where *this specific `ty` came
@@ -544,11 +541,11 @@ impl<'tcx> InferCtxt<'tcx> {
                 ty::PredicateKind::Ambiguous,
             )]
         } else {
-            let prev = self.inner.borrow_mut().opaque_types().register(
-                opaque_type_key,
-                OpaqueHiddenType { ty: hidden_ty, span },
-                origin,
-            );
+            let prev = self
+                .inner
+                .borrow_mut()
+                .opaque_types()
+                .register(opaque_type_key, OpaqueHiddenType { ty: hidden_ty, span });
             if let Some(prev) = prev {
                 self.at(&cause, param_env)
                     .eq_exp(DefineOpaqueTypes::Yes, a_is_expected, prev, hidden_ty)?
@@ -579,15 +576,11 @@ impl<'tcx> InferCtxt<'tcx> {
         hidden_ty: Ty<'tcx>,
     ) -> InferResult<'tcx, ()> {
         assert!(self.next_trait_solver());
-        let origin = self
-            .opaque_type_origin(opaque_type_key.def_id)
-            .expect("should be called for defining usages only");
         self.register_hidden_type(
             opaque_type_key,
             ObligationCause::dummy(),
             param_env,
             hidden_ty,
-            origin,
             true,
         )
     }

--- a/compiler/rustc_infer/src/infer/opaque_types/table.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/table.rs
@@ -1,5 +1,4 @@
 use rustc_data_structures::undo_log::UndoLogs;
-use rustc_hir::OpaqueTyOrigin;
 use rustc_middle::ty::{self, OpaqueHiddenType, OpaqueTypeKey, Ty};
 use rustc_span::DUMMY_SP;
 
@@ -60,14 +59,13 @@ impl<'a, 'tcx> OpaqueTypeTable<'a, 'tcx> {
         &mut self,
         key: OpaqueTypeKey<'tcx>,
         hidden_type: OpaqueHiddenType<'tcx>,
-        origin: OpaqueTyOrigin,
     ) -> Option<Ty<'tcx>> {
         if let Some(decl) = self.storage.opaque_types.get_mut(&key) {
             let prev = std::mem::replace(&mut decl.hidden_type, hidden_type);
             self.undo_log.push(UndoLog::OpaqueTypes(key, Some(prev)));
             return Some(prev.ty);
         }
-        let decl = OpaqueTypeDecl { hidden_type, origin };
+        let decl = OpaqueTypeDecl { hidden_type };
         self.storage.opaque_types.insert(key, decl);
         self.undo_log.push(UndoLog::OpaqueTypes(key, None));
         None

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -15,7 +15,6 @@ use rustc_index::IndexVec;
 use rustc_infer::infer::canonical::query_response::make_query_region_constraints;
 use rustc_infer::infer::canonical::CanonicalVarValues;
 use rustc_infer::infer::canonical::{CanonicalExt, QueryRegionConstraints};
-use rustc_infer::infer::InferOk;
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::traits::solve::{
     ExternalConstraints, ExternalConstraintsData, MaybeCause, PredefinedOpaquesData, QueryInput,
@@ -317,12 +316,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         opaque_types: &[(ty::OpaqueTypeKey<'tcx>, Ty<'tcx>)],
     ) -> Result<(), NoSolution> {
-        for &(a, b) in opaque_types {
-            let InferOk { value: (), obligations } =
-                self.infcx.register_hidden_type_in_new_solver(a, param_env, b)?;
-            // It's sound to drop these obligations, since the normalizes-to goal
-            // is responsible for proving these obligations.
-            let _ = obligations;
+        for &(key, ty) in opaque_types {
+            self.insert_hidden_type(key, param_env, ty)?;
         }
         Ok(())
     }

--- a/compiler/rustc_trait_selection/src/solve/opaques.rs
+++ b/compiler/rustc_trait_selection/src/solve/opaques.rs
@@ -50,7 +50,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
                     }
                 }
                 // Otherwise, define a new opaque type
-                self.register_opaque_ty(opaque_ty, expected, goal.param_env)?;
+                self.insert_hidden_type(opaque_ty, goal.param_env, expected)?;
+                self.add_item_bounds_for_hidden_type(opaque_ty, goal.param_env, expected);
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
             }
             (Reveal::UserFacing, SolverMode::Coherence) => {


### PR DESCRIPTION
the commits are pretty self-contained.

r? @compiler-errors cc @oli-obk 