### PR TITLE
Change format of rustdoc-js tests by putting query and correction directly alongside the expected values

### DIFF
--- a/tests/rustdoc-js-std/alias-1.js
+++ b/tests/rustdoc-js-std/alias-1.js
@@ -1,6 +1,5 @@
-const QUERY = '&';
-
 const EXPECTED = {
+    'query': '&',
     'others': [
         { 'path': 'std', 'name': 'reference' },
     ],

--- a/tests/rustdoc-js-std/alias-2.js
+++ b/tests/rustdoc-js-std/alias-2.js
@@ -1,6 +1,5 @@
-const QUERY = '+';
-
 const EXPECTED = {
+    'query': '+',
     'others': [
         { 'path': 'std::ops', 'name': 'AddAssign' },
         { 'path': 'std::ops', 'name': 'Add' },

--- a/tests/rustdoc-js-std/alias-3.js
+++ b/tests/rustdoc-js-std/alias-3.js
@@ -1,6 +1,5 @@
-const QUERY = '!';
-
 const EXPECTED = {
+    'query': '!',
     'others': [
         { 'path': 'std', 'name': 'never' },
     ],

--- a/tests/rustdoc-js-std/alias-4.js
+++ b/tests/rustdoc-js-std/alias-4.js
@@ -1,6 +1,5 @@
-const QUERY = '<';
-
 const EXPECTED = {
+    'query': '<',
     'others': [
         { 'name': 'Ord' },
     ],

--- a/tests/rustdoc-js-std/alias.js
+++ b/tests/rustdoc-js-std/alias.js
@@ -1,8 +1,7 @@
 // ignore-order
 
-const QUERY = '[';
-
 const EXPECTED = {
+    'query': '[',
     'others': [
         { 'path': 'std', 'name': 'slice' },
         { 'path': 'std::ops', 'name': 'IndexMut' },

--- a/tests/rustdoc-js-std/asrawfd.js
+++ b/tests/rustdoc-js-std/asrawfd.js
@@ -1,8 +1,7 @@
 // ignore-order
 
-const QUERY = 'RawFd::as_raw_fd';
-
 const EXPECTED = {
+    'query': 'RawFd::as_raw_fd',
     'others': [
         // Reproduction test for https://github.com/rust-lang/rust/issues/78724
         // Validate that type alias methods get the correct path.

--- a/tests/rustdoc-js-std/basic.js
+++ b/tests/rustdoc-js-std/basic.js
@@ -1,6 +1,5 @@
-const QUERY = 'String';
-
 const EXPECTED = {
+    'query': 'String',
     'others': [
         { 'path': 'std::string', 'name': 'String' },
         { 'path': 'std::ffi', 'name': 'CString' },

--- a/tests/rustdoc-js-std/deduplication.js
+++ b/tests/rustdoc-js-std/deduplication.js
@@ -1,8 +1,7 @@
 // ignore-order
 
-const QUERY = 'is_nan';
-
 const EXPECTED = {
+    'query': 'is_nan',
     'others': [
         { 'path': 'std::f32', 'name': 'is_nan' },
         { 'path': 'std::f64', 'name': 'is_nan' },

--- a/tests/rustdoc-js-std/enum-option.js
+++ b/tests/rustdoc-js-std/enum-option.js
@@ -1,6 +1,5 @@
-const QUERY = 'enum:Option';
-
 const EXPECTED = {
+    'query': 'enum:Option',
     'others': [
         { 'path': 'std::option', 'name': 'Option' },
     ],

--- a/tests/rustdoc-js-std/filter-crate.js
+++ b/tests/rustdoc-js-std/filter-crate.js
@@ -1,9 +1,9 @@
 // exact-check
 
-const QUERY = '"hashmap"';
 const FILTER_CRATE = 'core';
 
 const EXPECTED = {
+    'query': 'hashmap',
     'others': [
     ],
 };

--- a/tests/rustdoc-js-std/fn-forget.js
+++ b/tests/rustdoc-js-std/fn-forget.js
@@ -1,6 +1,5 @@
-const QUERY = 'fn:forget';
-
 const EXPECTED = {
+    'query': 'fn:forget',
     'others': [
         { 'path': 'std::mem', 'name': 'forget' },
         { 'path': 'std::fmt', 'name': 'format' },

--- a/tests/rustdoc-js-std/from_u.js
+++ b/tests/rustdoc-js-std/from_u.js
@@ -1,6 +1,5 @@
-const QUERY = 'from_u';
-
 const EXPECTED = {
+    'query': 'from_u',
     'others': [
         { 'path': 'std::char', 'name': 'from_u32' },
         { 'path': 'std::str', 'name': 'from_utf8' },

--- a/tests/rustdoc-js-std/keyword.js
+++ b/tests/rustdoc-js-std/keyword.js
@@ -1,8 +1,7 @@
 // ignore-order
 
-const QUERY = 'fn';
-
 const EXPECTED = {
+    'query': 'fn',
     'others': [
         { 'path': 'std', 'name': 'fn', ty: 15 }, // 15 is for primitive types
         { 'path': 'std', 'name': 'fn', ty: 21 }, // 21 is for keywords

--- a/tests/rustdoc-js-std/macro-check.js
+++ b/tests/rustdoc-js-std/macro-check.js
@@ -1,8 +1,7 @@
 // ignore-order
 
-const QUERY = 'panic';
-
 const EXPECTED = {
+    'query': 'panic',
     'others': [
         { 'path': 'std', 'name': 'panic', ty: 14 }, // 15 is for macros
         { 'path': 'std', 'name': 'panic', ty: 0 }, // 0 is for modules

--- a/tests/rustdoc-js-std/macro-print.js
+++ b/tests/rustdoc-js-std/macro-print.js
@@ -1,6 +1,5 @@
-const QUERY = 'macro:print';
-
 const EXPECTED = {
+    'query': 'macro:print',
     'others': [
         { 'path': 'std', 'name': 'print' },
         { 'path': 'std', 'name': 'println' },

--- a/tests/rustdoc-js-std/never.js
+++ b/tests/rustdoc-js-std/never.js
@@ -1,6 +1,5 @@
-const QUERY = '!';
-
 const EXPECTED = {
+    'query': '!',
     'others': [
         { 'path': 'std', 'name': 'never' },
     ],

--- a/tests/rustdoc-js-std/option-type-signatures.js
+++ b/tests/rustdoc-js-std/option-type-signatures.js
@@ -1,15 +1,12 @@
-const QUERY = [
-    'option, fnonce -> option',
-    'option -> default',
-];
-
 const EXPECTED = [
     {
+        'query': 'option, fnonce -> option',
         'others': [
             { 'path': 'std::option::Option', 'name': 'map' },
         ],
     },
     {
+        'query': 'option -> default',
         'others': [
             { 'path': 'std::option::Option', 'name': 'unwrap_or_default' },
             { 'path': 'std::option::Option', 'name': 'get_or_insert_default' },

--- a/tests/rustdoc-js-std/parser-errors.js
+++ b/tests/rustdoc-js-std/parser-errors.js
@@ -1,50 +1,6 @@
-const QUERY = [
-    '<P>',
-    '-> <P>',
-    'a<"P">',
-    '"P" "P"',
-    'P "P"',
-    '"p" p',
-    '"const": p',
-    "a<:a>",
-    "a<::a>",
-    "((a))",
-    "(p -> p",
-    "::a::b",
-    "a::::b",
-    "a::b::",
-    ":a",
-    "a b:",
-    "a (b:",
-    "_:",
-    "_:a",
-    "a-bb",
-    "a>bb",
-    "ab'",
-    "a->",
-    '"p" <a>',
-    '"p" a<a>',
-    "a,<",
-    "aaaaa<>b",
-    "fn:aaaaa<>b",
-    "->a<>b",
-    "a<->",
-    "a:: a",
-    "a ::a",
-    "a<a>:",
-    "a<>:",
-    "a,:",
-    "  a<>  :",
-    "mod : :",
-    "a!a",
-    "a!!",
-    "mod:a!",
-    "a!::a",
-    "a<",
-];
-
 const PARSED = [
     {
+        query: '<P>',
         elems: [],
         foundElems: 0,
         original: "<P>",
@@ -53,6 +9,7 @@ const PARSED = [
         error: "Found generics without a path",
     },
     {
+        query: '-> <P>',
         elems: [],
         foundElems: 0,
         original: "-> <P>",
@@ -61,6 +18,7 @@ const PARSED = [
         error: "Found generics without a path",
     },
     {
+        query: 'a<"P">',
         elems: [],
         foundElems: 0,
         original: "a<\"P\">",
@@ -69,6 +27,7 @@ const PARSED = [
         error: "Unexpected `\"` in generics",
     },
     {
+        query: '"P" "P"',
         elems: [],
         foundElems: 0,
         original: "\"P\" \"P\"",
@@ -77,6 +36,7 @@ const PARSED = [
         error: "Cannot have more than one literal search element",
     },
     {
+        query: 'P "P"',
         elems: [],
         foundElems: 0,
         original: "P \"P\"",
@@ -85,6 +45,7 @@ const PARSED = [
         error: "Cannot use literal search when there is more than one element",
     },
     {
+        query: '"p" p',
         elems: [],
         foundElems: 0,
         original: "\"p\" p",
@@ -93,6 +54,7 @@ const PARSED = [
         error: "You cannot have more than one element if you use quotes",
     },
     {
+        query: '"const": p',
         elems: [],
         foundElems: 0,
         original: "\"const\": p",
@@ -101,6 +63,7 @@ const PARSED = [
         error: "You cannot use quotes on type filter",
     },
     {
+        query: "a<:a>",
         elems: [],
         foundElems: 0,
         original: "a<:a>",
@@ -109,6 +72,7 @@ const PARSED = [
         error: "Expected type filter before `:`",
     },
     {
+        query: "a<::a>",
         elems: [],
         foundElems: 0,
         original: "a<::a>",
@@ -117,6 +81,7 @@ const PARSED = [
         error: "Unexpected `::`: paths cannot start with `::`",
     },
     {
+        query: "((a))",
         elems: [],
         foundElems: 0,
         original: "((a))",
@@ -125,6 +90,7 @@ const PARSED = [
         error: "Unexpected `(`",
     },
     {
+        query: "(p -> p",
         elems: [],
         foundElems: 0,
         original: "(p -> p",
@@ -133,6 +99,7 @@ const PARSED = [
         error: "Unexpected `(`",
     },
     {
+        query: "::a::b",
         elems: [],
         foundElems: 0,
         original: "::a::b",
@@ -141,6 +108,7 @@ const PARSED = [
         error: "Paths cannot start with `::`",
     },
     {
+        query: "a::::b",
         elems: [],
         foundElems: 0,
         original: "a::::b",
@@ -149,6 +117,7 @@ const PARSED = [
         error: "Unexpected `::::`",
     },
     {
+        query: "a::b::",
         elems: [],
         foundElems: 0,
         original: "a::b::",
@@ -157,6 +126,7 @@ const PARSED = [
         error: "Paths cannot end with `::`",
     },
     {
+        query: ":a",
         elems: [],
         foundElems: 0,
         original: ":a",
@@ -165,6 +135,7 @@ const PARSED = [
         error: "Expected type filter before `:`",
     },
     {
+        query: "a b:",
         elems: [],
         foundElems: 0,
         original: "a b:",
@@ -173,6 +144,7 @@ const PARSED = [
         error: "Unexpected `:` (expected path after type filter)",
     },
     {
+        query: "a (b:",
         elems: [],
         foundElems: 0,
         original: "a (b:",
@@ -181,6 +153,7 @@ const PARSED = [
         error: "Unexpected `(`",
     },
     {
+        query: "_:",
         elems: [],
         foundElems: 0,
         original: "_:",
@@ -189,6 +162,7 @@ const PARSED = [
         error: "Unexpected `:` (expected path after type filter)",
     },
     {
+        query: "_:a",
         elems: [],
         foundElems: 0,
         original: "_:a",
@@ -197,6 +171,7 @@ const PARSED = [
         error: "Unknown type filter `_`",
     },
     {
+        query: "a-bb",
         elems: [],
         foundElems: 0,
         original: "a-bb",
@@ -205,6 +180,7 @@ const PARSED = [
         error: "Unexpected `-` (did you mean `->`?)",
     },
     {
+        query: "a>bb",
         elems: [],
         foundElems: 0,
         original: "a>bb",
@@ -213,6 +189,7 @@ const PARSED = [
         error: "Unexpected `>` (did you mean `->`?)",
     },
     {
+        query: "ab'",
         elems: [],
         foundElems: 0,
         original: "ab'",
@@ -221,6 +198,7 @@ const PARSED = [
         error: "Unexpected `'`",
     },
     {
+        query: "a->",
         elems: [],
         foundElems: 0,
         original: "a->",
@@ -229,6 +207,7 @@ const PARSED = [
         error: "Expected at least one item after `->`",
     },
     {
+        query: '"p" <a>',
         elems: [],
         foundElems: 0,
         original: '"p" <a>',
@@ -237,6 +216,7 @@ const PARSED = [
         error: "Found generics without a path",
     },
     {
+        query: '"p" a<a>',
         elems: [],
         foundElems: 0,
         original: '"p" a<a>',
@@ -245,6 +225,7 @@ const PARSED = [
         error: "You cannot have more than one element if you use quotes",
     },
     {
+        query: "a,<",
         elems: [],
         foundElems: 0,
         original: 'a,<',
@@ -253,6 +234,7 @@ const PARSED = [
         error: 'Found generics without a path',
     },
     {
+        query: "aaaaa<>b",
         elems: [],
         foundElems: 0,
         original: 'aaaaa<>b',
@@ -261,6 +243,7 @@ const PARSED = [
         error: 'Expected `,`, ` `, `:` or `->`, found `b`',
     },
     {
+        query: "fn:aaaaa<>b",
         elems: [],
         foundElems: 0,
         original: 'fn:aaaaa<>b',
@@ -269,6 +252,7 @@ const PARSED = [
         error: 'Expected `,`, ` `, `:` or `->`, found `b`',
     },
     {
+        query: "->a<>b",
         elems: [],
         foundElems: 0,
         original: '->a<>b',
@@ -277,6 +261,7 @@ const PARSED = [
         error: 'Expected `,` or ` `, found `b`',
     },
     {
+        query: "a<->",
         elems: [],
         foundElems: 0,
         original: 'a<->',
@@ -285,6 +270,7 @@ const PARSED = [
         error: 'Unexpected `-` after `<`',
     },
     {
+        query: "a:: a",
         elems: [],
         foundElems: 0,
         original: 'a:: a',
@@ -293,6 +279,7 @@ const PARSED = [
         error: 'Paths cannot end with `::`',
     },
     {
+        query: "a ::a",
         elems: [],
         foundElems: 0,
         original: 'a ::a',
@@ -301,6 +288,7 @@ const PARSED = [
         error: 'Paths cannot start with `::`',
     },
     {
+        query: "a<a>:",
         elems: [],
         foundElems: 0,
         original: "a<a>:",
@@ -309,6 +297,7 @@ const PARSED = [
         error: 'Unexpected `<` in type filter',
     },
     {
+        query: "a<>:",
         elems: [],
         foundElems: 0,
         original: "a<>:",
@@ -317,6 +306,7 @@ const PARSED = [
         error: 'Unexpected `<` in type filter',
     },
     {
+        query: "a,:",
         elems: [],
         foundElems: 0,
         original: "a,:",
@@ -325,6 +315,7 @@ const PARSED = [
         error: 'Unexpected `,` in type filter',
     },
     {
+        query: "  a<>  :",
         elems: [],
         foundElems: 0,
         original: "a<>  :",
@@ -333,6 +324,7 @@ const PARSED = [
         error: 'Unexpected `<` in type filter',
     },
     {
+        query: "mod : :",
         elems: [],
         foundElems: 0,
         original: "mod : :",
@@ -341,6 +333,7 @@ const PARSED = [
         error: 'Unexpected `:`',
     },
     {
+        query: "a!a",
         elems: [],
         foundElems: 0,
         original: "a!a",
@@ -349,6 +342,7 @@ const PARSED = [
         error: 'Unexpected `!`: it can only be at the end of an ident',
     },
     {
+        query: "a!!",
         elems: [],
         foundElems: 0,
         original: "a!!",
@@ -357,6 +351,7 @@ const PARSED = [
         error: 'Cannot have more than one `!` in an ident',
     },
     {
+        query: "mod:a!",
         elems: [],
         foundElems: 0,
         original: "mod:a!",
@@ -365,6 +360,7 @@ const PARSED = [
         error: 'Invalid search type: macro `!` and `mod` both specified',
     },
     {
+        query: "a!::a",
         elems: [],
         foundElems: 0,
         original: "a!::a",
@@ -373,6 +369,7 @@ const PARSED = [
         error: 'Cannot have associated items in macros',
     },
     {
+        query: "a<",
         elems: [],
         foundElems: 0,
         original: "a<",

--- a/tests/rustdoc-js-std/parser-filter.js
+++ b/tests/rustdoc-js-std/parser-filter.js
@@ -1,17 +1,6 @@
-const QUERY = [
-    'fn:foo',
-    'enum : foo',
-    'macro<f>:foo',
-    'macro!',
-    'macro:mac!',
-    'a::mac!',
-    '-> fn:foo',
-    '-> fn:foo<fn:bar>',
-    '-> fn:foo<fn:bar, enum : baz::fuzz>',
-];
-
 const PARSED = [
     {
+        query: 'fn:foo',
         elems: [{
             name: "foo",
             fullPath: ["foo"],
@@ -27,6 +16,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'enum : foo',
         elems: [{
             name: "foo",
             fullPath: ["foo"],
@@ -42,6 +32,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'macro<f>:foo',
         elems: [],
         foundElems: 0,
         original: "macro<f>:foo",
@@ -50,6 +41,7 @@ const PARSED = [
         error: "Unexpected `<` in type filter",
     },
     {
+        query: 'macro!',
         elems: [{
             name: "macro",
             fullPath: ["macro"],
@@ -65,6 +57,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'macro:mac!',
         elems: [{
             name: "mac",
             fullPath: ["mac"],
@@ -80,6 +73,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'a::mac!',
         elems: [{
             name: "a::mac",
             fullPath: ["a", "mac"],
@@ -95,6 +89,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: '-> fn:foo',
         elems: [],
         foundElems: 1,
         original: "-> fn:foo",
@@ -110,6 +105,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: '-> fn:foo<fn:bar>',
         elems: [],
         foundElems: 1,
         original: "-> fn:foo<fn:bar>",
@@ -134,6 +130,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: '-> fn:foo<fn:bar, enum : baz::fuzz>',
         elems: [],
         foundElems: 1,
         original: "-> fn:foo<fn:bar, enum : baz::fuzz>",

--- a/tests/rustdoc-js-std/parser-generics.js
+++ b/tests/rustdoc-js-std/parser-generics.js
@@ -1,14 +1,6 @@
-const QUERY = [
-    'A<B<C<D>,  E>',
-    'p<> u8',
-    '"p"<a>',
-    'p<u<x>>',
-    'p<u<x>, r>',
-    'p<u<x, r>>',
-];
-
 const PARSED = [
     {
+        query: 'A<B<C<D>,  E>',
         elems: [],
         foundElems: 0,
         original: 'A<B<C<D>,  E>',
@@ -17,6 +9,7 @@ const PARSED = [
         error: 'Unclosed `<`',
     },
     {
+        query: 'p<> u8',
         elems: [
             {
                 name: "p",
@@ -42,6 +35,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: '"p"<a>',
         elems: [
             {
                 name: "p",
@@ -67,6 +61,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'p<u<x>>',
         elems: [
             {
                 name: "p",
@@ -100,6 +95,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'p<u<x>, r>',
         elems: [
             {
                 name: "p",
@@ -140,6 +136,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'p<u<x, r>>',
         elems: [
             {
                 name: "p",

--- a/tests/rustdoc-js-std/parser-ident.js
+++ b/tests/rustdoc-js-std/parser-ident.js
@@ -1,14 +1,6 @@
-const QUERY = [
-    "R<!>",
-    "!",
-    "a!",
-    "a!::b",
-    "!::b",
-    "a!::b!",
-];
-
 const PARSED = [
     {
+        query: "R<!>",
         elems: [{
             name: "r",
             fullPath: ["r"],
@@ -32,6 +24,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: "!",
         elems: [{
             name: "!",
             fullPath: ["!"],
@@ -47,6 +40,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: "a!",
         elems: [{
             name: "a",
             fullPath: ["a"],
@@ -62,6 +56,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: "a!::b",
         elems: [],
         foundElems: 0,
         original: "a!::b",
@@ -70,6 +65,7 @@ const PARSED = [
         error: "Cannot have associated items in macros",
     },
     {
+        query: "!::b",
         elems: [{
             name: "!::b",
             fullPath: ["!", "b"],
@@ -85,6 +81,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: "a!::b!",
         elems: [],
         foundElems: 0,
         original: "a!::b!",

--- a/tests/rustdoc-js-std/parser-literal.js
+++ b/tests/rustdoc-js-std/parser-literal.js
@@ -1,7 +1,6 @@
-const QUERY = ['R<P>'];
-
 const PARSED = [
     {
+        query: 'R<P>',
         elems: [{
             name: "r",
             fullPath: ["r"],

--- a/tests/rustdoc-js-std/parser-paths.js
+++ b/tests/rustdoc-js-std/parser-paths.js
@@ -1,7 +1,6 @@
-const QUERY = ['A::B', 'A::B,C',  'A::B<f>,C', 'mod::a'];
-
 const PARSED = [
     {
+        query: 'A::B',
         elems: [{
             name: "a::b",
             fullPath: ["a", "b"],
@@ -17,6 +16,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'A::B,C',
         elems: [
             {
                 name: "a::b",
@@ -42,6 +42,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'A::B<f>,C',
         elems: [
             {
                 name: "a::b",
@@ -75,6 +76,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'mod::a',
         elems: [{
             name: "mod::a",
             fullPath: ["mod", "a"],

--- a/tests/rustdoc-js-std/parser-quote.js
+++ b/tests/rustdoc-js-std/parser-quote.js
@@ -1,15 +1,6 @@
-const QUERY = [
-    '-> "p"',
-    '"p",',
-    '"p" -> a',
-    '"a" -> "p"',
-    '->"-"',
-    '"a',
-    '""',
-];
-
 const PARSED = [
     {
+        query: '-> "p"',
         elems: [],
         foundElems: 1,
         original: '-> "p"',
@@ -25,6 +16,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: '"p",',
         elems: [{
             name: "p",
             fullPath: ["p"],
@@ -40,6 +32,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: '"p" -> a',
         elems: [],
         foundElems: 0,
         original: '"p" -> a',
@@ -48,6 +41,7 @@ const PARSED = [
         error: "You cannot have more than one element if you use quotes",
     },
     {
+        query: '"a" -> "p"',
         elems: [],
         foundElems: 0,
         original: '"a" -> "p"',
@@ -56,6 +50,7 @@ const PARSED = [
         error: "Cannot have more than one literal search element",
     },
     {
+        query: '->"-"',
         elems: [],
         foundElems: 0,
         original: '->"-"',
@@ -64,6 +59,7 @@ const PARSED = [
         error: 'Unexpected `-` in a string element',
     },
     {
+        query: '"a',
         elems: [],
         foundElems: 0,
         original: '"a',
@@ -72,6 +68,7 @@ const PARSED = [
         error: 'Unclosed `"`',
     },
     {
+        query: '""',
         elems: [],
         foundElems: 0,
         original: '""',

--- a/tests/rustdoc-js-std/parser-returned.js
+++ b/tests/rustdoc-js-std/parser-returned.js
@@ -1,13 +1,6 @@
-const QUERY = [
-    "-> F<P>",
-    "-> P",
-    "->,a",
-    "aaaaa->a",
-    "-> !",
-];
-
 const PARSED = [
     {
+        query: "-> F<P>",
         elems: [],
         foundElems: 1,
         original: "-> F<P>",
@@ -31,6 +24,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: "-> P",
         elems: [],
         foundElems: 1,
         original: "-> P",
@@ -46,6 +40,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: "->,a",
         elems: [],
         foundElems: 1,
         original: "->,a",
@@ -61,6 +56,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: "aaaaa->a",
         elems: [{
             name: "aaaaa",
             fullPath: ["aaaaa"],
@@ -83,6 +79,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: "-> !",
         elems: [],
         foundElems: 1,
         original: "-> !",

--- a/tests/rustdoc-js-std/parser-separators.js
+++ b/tests/rustdoc-js-std/parser-separators.js
@@ -1,17 +1,8 @@
 // ignore-tidy-tab
 
-const QUERY = [
-    'aaaaaa	b',
-    'a b',
-    'a,b',
-    'a\tb',
-    'a<b c>',
-    'a<b,c>',
-    'a<b\tc>',
-];
-
 const PARSED = [
     {
+        query: 'aaaaaa	b',
         elems: [
             {
                 name: 'aaaaaa',
@@ -37,6 +28,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'a b',
         elems: [
             {
                 name: 'a',
@@ -62,6 +54,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'a,b',
         elems: [
             {
                 name: 'a',
@@ -87,6 +80,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'a\tb',
         elems: [
             {
                 name: 'a',
@@ -112,6 +106,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'a<b c>',
         elems: [
             {
                 name: 'a',
@@ -144,6 +139,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'a<b,c>',
         elems: [
             {
                 name: 'a',
@@ -176,6 +172,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'a<b\tc>',
         elems: [
             {
                 name: 'a',

--- a/tests/rustdoc-js-std/parser-weird-queries.js
+++ b/tests/rustdoc-js-std/parser-weird-queries.js
@@ -1,18 +1,10 @@
 // This test is mostly to check that the parser still kinda outputs something
 // (and doesn't enter an infinite loop!) even though the query is completely
 // invalid.
-const QUERY = [
-    'a b',
-    'a   b',
-    'a,b(c)',
-    'aaa,a',
-    ',,,,',
-    'mod    :',
-    'mod\t:',
-];
 
 const PARSED = [
     {
+        query: 'a b',
         elems: [
             {
                 name: "a",
@@ -38,6 +30,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'a   b',
         elems: [
             {
                 name: "a",
@@ -63,6 +56,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'a,b(c)',
         elems: [],
         foundElems: 0,
         original: "a,b(c)",
@@ -71,6 +65,7 @@ const PARSED = [
         error: "Unexpected `(`",
     },
     {
+        query: 'aaa,a',
         elems: [
             {
                 name: "aaa",
@@ -96,6 +91,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: ',,,,',
         elems: [],
         foundElems: 0,
         original: ",,,,",
@@ -104,6 +100,7 @@ const PARSED = [
         error: null,
     },
     {
+        query: 'mod    :',
         elems: [],
         foundElems: 0,
         original: 'mod    :',
@@ -112,6 +109,7 @@ const PARSED = [
         error: "Unexpected `:` (expected path after type filter)",
     },
     {
+        query: 'mod\t:',
         elems: [],
         foundElems: 0,
         original: 'mod\t:',

--- a/tests/rustdoc-js-std/path-ordering.js
+++ b/tests/rustdoc-js-std/path-ordering.js
@@ -1,7 +1,6 @@
-const QUERY = 'hashset::insert';
-
 const EXPECTED = {
-    'others': [
+    query: 'hashset::insert',
+    others: [
         // ensure hashset::insert comes first
         { 'path': 'std::collections::hash_set::HashSet', 'name': 'insert' },
         { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert' },

--- a/tests/rustdoc-js-std/primitive.js
+++ b/tests/rustdoc-js-std/primitive.js
@@ -1,15 +1,6 @@
-const QUERY = [
-    'i8',
-    'u32',
-    'str',
-    'char',
-    'unit',
-    'tuple',
-    'fn',
-];
-
 const EXPECTED = [
     {
+        'query': 'i8',
         'others': [
             {
                 'path': 'std',
@@ -19,6 +10,7 @@ const EXPECTED = [
         ]
     },
     {
+        'query': 'u32',
         'others': [
             {
                 'path': 'std',
@@ -28,6 +20,7 @@ const EXPECTED = [
         ]
     },
     {
+        'query': 'str',
         'others': [
             {
                 'path': 'std',
@@ -37,6 +30,7 @@ const EXPECTED = [
         ]
     },
     {
+        'query': 'char',
         'others': [
             {
                 'path': 'std',
@@ -46,6 +40,7 @@ const EXPECTED = [
         ]
     },
     {
+        'query': 'unit',
         'others': [
             {
                 'path': 'std',
@@ -55,6 +50,7 @@ const EXPECTED = [
         ]
     },
     {
+        'query': 'tuple',
         'others': [
             {
                 'path': 'std',
@@ -64,6 +60,7 @@ const EXPECTED = [
         ]
     },
     {
+        'query': 'fn',
         'others': [
             {
                 'path': 'std',

--- a/tests/rustdoc-js-std/println-typo.js
+++ b/tests/rustdoc-js-std/println-typo.js
@@ -1,9 +1,9 @@
 // exact-check
 
-const QUERY = 'prinltn';
 const FILTER_CRATE = 'std';
 
 const EXPECTED = {
+    'query': 'prinltn',
     'others': [
         { 'path': 'std', 'name': 'println' },
         { 'path': 'std', 'name': 'print' },

--- a/tests/rustdoc-js-std/quoted.js
+++ b/tests/rustdoc-js-std/quoted.js
@@ -1,9 +1,9 @@
 // ignore-order
 
-const QUERY = '"error"';
 const FILTER_CRATE = 'std';
 
 const EXPECTED = {
+    'query': '"error"',
     'others': [
         { 'path': 'std', 'name': 'error' },
         { 'path': 'std::fmt', 'name': 'Error' },

--- a/tests/rustdoc-js-std/reference-shrink.js
+++ b/tests/rustdoc-js-std/reference-shrink.js
@@ -1,8 +1,7 @@
 // exact-check
 
-const QUERY = 'reference::shrink';
-
 const EXPECTED = {
+    'query': 'reference::shrink',
     // avoid including the method that's not going to be in the HTML
     'others': [],
 };

--- a/tests/rustdoc-js-std/regex.js
+++ b/tests/rustdoc-js-std/regex.js
@@ -1,9 +1,8 @@
 // exact-check
 
 // https://github.com/rust-lang/rust/issues/103357
-const QUERY = 'regex';
-
 const EXPECTED = {
+    'query': 'regex',
     'others': [],
     'in_args': [],
     'returned': [],

--- a/tests/rustdoc-js-std/return-specific-literal.js
+++ b/tests/rustdoc-js-std/return-specific-literal.js
@@ -1,6 +1,5 @@
-const QUERY = 'struct:"string"';
-
 const EXPECTED = {
+    'query': 'struct:"string"',
     'in_args': [
         { 'path': 'std::string::String', 'name': 'ne' },
     ],

--- a/tests/rustdoc-js-std/return-specific.js
+++ b/tests/rustdoc-js-std/return-specific.js
@@ -1,6 +1,5 @@
-const QUERY = 'struct:string';
-
 const EXPECTED = {
+    'query': 'struct:string',
     'in_args': [
         { 'path': 'std::string::String', 'name': 'ne' },
     ],

--- a/tests/rustdoc-js-std/should-fail.js
+++ b/tests/rustdoc-js-std/should-fail.js
@@ -1,8 +1,7 @@
 // should-fail
 
-const QUERY = 'fn';
-
 const EXPECTED = {
+    'query': 'fn',
     'others': [
         { 'path': 'std', 'name': 'fn', ty: 14 },
     ],

--- a/tests/rustdoc-js-std/string-from_ut.js
+++ b/tests/rustdoc-js-std/string-from_ut.js
@@ -1,6 +1,5 @@
-const QUERY = 'String::from_ut';
-
 const EXPECTED = {
+    'query': 'String::from_ut',
     'others': [
         { 'path': 'std::string::String', 'name': 'from_utf8' },
         { 'path': 'std::string::String', 'name': 'from_utf8' },

--- a/tests/rustdoc-js-std/struct-vec.js
+++ b/tests/rustdoc-js-std/struct-vec.js
@@ -1,6 +1,5 @@
-const QUERY = 'struct:VecD';
-
 const EXPECTED = {
+    'query': 'struct:VecD',
     'others': [
         { 'path': 'std::collections', 'name': 'VecDeque' },
         { 'path': 'std::vec', 'name': 'Vec' },

--- a/tests/rustdoc-js-std/typed-query.js
+++ b/tests/rustdoc-js-std/typed-query.js
@@ -1,9 +1,9 @@
 // exact-check
 
-const QUERY = 'macro:print';
 const FILTER_CRATE = 'std';
 
 const EXPECTED = {
+    'query': 'macro:print',
     'others': [
         { 'path': 'std', 'name': 'print' },
         { 'path': 'std', 'name': 'println' },

--- a/tests/rustdoc-js-std/vec-new.js
+++ b/tests/rustdoc-js-std/vec-new.js
@@ -1,6 +1,5 @@
-const QUERY = 'Vec::new';
-
 const EXPECTED = {
+    'query': 'Vec::new',
     'others': [
         { 'path': 'std::vec::Vec', 'name': 'new' },
         { 'path': 'alloc::vec::Vec', 'name': 'new' },

--- a/tests/rustdoc-js/basic.js
+++ b/tests/rustdoc-js/basic.js
@@ -1,6 +1,5 @@
-const QUERY = 'Fo';
-
 const EXPECTED = {
+    'query': 'Fo',
     'others': [
         { 'path': 'basic', 'name': 'Foo' },
     ],

--- a/tests/rustdoc-js/doc-alias-filter-out.js
+++ b/tests/rustdoc-js/doc-alias-filter-out.js
@@ -1,9 +1,8 @@
 // exact-check
 
-const QUERY = 'true';
-
 const FILTER_CRATE = 'some_other_crate';
 
 const EXPECTED = {
+    'query': 'true',
     'others': [],
 };

--- a/tests/rustdoc-js/doc-alias-filter.js
+++ b/tests/rustdoc-js/doc-alias-filter.js
@@ -1,10 +1,9 @@
 // exact-check
 
-const QUERY = '"true"';
-
 const FILTER_CRATE = 'doc_alias_filter';
 
 const EXPECTED = {
+    'query': '"true"',
     'others': [
         {
             'path': 'doc_alias_filter',

--- a/tests/rustdoc-js/doc-alias-whitespace.js
+++ b/tests/rustdoc-js/doc-alias-whitespace.js
@@ -1,11 +1,8 @@
 // exact-check
 
-const QUERY = [
-    'Demon Lord',
-];
-
 const EXPECTED = [
     {
+        'query': 'Demon Lord',
         'others': [
             {
                 'path': 'doc_alias_whitespace',

--- a/tests/rustdoc-js/doc-alias.js
+++ b/tests/rustdoc-js/doc-alias.js
@@ -1,31 +1,6 @@
-const QUERY = [
-    'StructItem',
-    'StructFieldItem',
-    'StructMethodItem',
-    'ImplTraitItem',
-    'StructImplConstItem',
-    'ImplTraitFunction',
-    'EnumItem',
-    'VariantItem',
-    'EnumMethodItem',
-    'TypedefItem',
-    'TraitItem',
-    'TraitTypeItem',
-    'AssociatedConstItem',
-    'TraitFunctionItem',
-    'FunctionItem',
-    'ModuleItem',
-    'ConstItem',
-    'StaticItem',
-    'UnionItem',
-    'UnionFieldItem',
-    'UnionMethodItem',
-    'MacroItem',
-];
-
 const EXPECTED = [
     {
-        // StructItem
+        'query': 'StructItem',
         'others': [
             {
                 'path': 'doc_alias',
@@ -37,7 +12,7 @@ const EXPECTED = [
         ],
     },
     {
-        // StructFieldItem
+        'query': 'StructFieldItem',
         'others': [
             {
                 'path': 'doc_alias::Struct',
@@ -49,7 +24,7 @@ const EXPECTED = [
         ],
     },
     {
-        // StructMethodItem
+        'query': 'StructMethodItem',
         'others': [
             {
                 'path': 'doc_alias::Struct',
@@ -61,11 +36,11 @@ const EXPECTED = [
         ],
     },
     {
-        // ImplTraitItem
+        'query': 'ImplTraitItem',
         'others': [],
     },
     {
-        // StructImplConstItem
+        'query': 'StructImplConstItem',
         'others': [
             {
                 'path': 'doc_alias::Struct',
@@ -77,7 +52,7 @@ const EXPECTED = [
         ],
     },
     {
-        // ImplTraitFunction
+        'query': 'ImplTraitFunction',
         'others': [
             {
                 'path': 'doc_alias::Struct',
@@ -89,7 +64,7 @@ const EXPECTED = [
         ],
     },
     {
-        // EnumItem
+        'query': 'EnumItem',
         'others': [
             {
                 'path': 'doc_alias',
@@ -101,7 +76,7 @@ const EXPECTED = [
         ],
     },
     {
-        // VariantItem
+        'query': 'VariantItem',
         'others': [
             {
                 'path': 'doc_alias::Enum',
@@ -113,7 +88,7 @@ const EXPECTED = [
         ],
     },
     {
-        // EnumMethodItem
+        'query': 'EnumMethodItem',
         'others': [
             {
                 'path': 'doc_alias::Enum',
@@ -125,7 +100,7 @@ const EXPECTED = [
         ],
     },
     {
-        // TypedefItem
+        'query': 'TypedefItem',
         'others': [
             {
                 'path': 'doc_alias',
@@ -137,7 +112,7 @@ const EXPECTED = [
         ],
     },
     {
-        // TraitItem
+        'query': 'TraitItem',
         'others': [
             {
                 'path': 'doc_alias',
@@ -149,7 +124,7 @@ const EXPECTED = [
         ],
     },
     {
-        // TraitTypeItem
+        'query': 'TraitTypeItem',
         'others': [
             {
                 'path': 'doc_alias::Trait',
@@ -161,7 +136,7 @@ const EXPECTED = [
         ],
     },
     {
-        // AssociatedConstItem
+        'query': 'AssociatedConstItem',
         'others': [
             {
                 'path': 'doc_alias::Trait',
@@ -173,7 +148,7 @@ const EXPECTED = [
         ],
     },
     {
-        // TraitFunctionItem
+        'query': 'TraitFunctionItem',
         'others': [
             {
                 'path': 'doc_alias::Trait',
@@ -185,7 +160,7 @@ const EXPECTED = [
         ],
     },
     {
-        // FunctionItem
+        'query': 'FunctionItem',
         'others': [
             {
                 'path': 'doc_alias',
@@ -197,7 +172,7 @@ const EXPECTED = [
         ],
     },
     {
-        // ModuleItem
+        'query': 'ModuleItem',
         'others': [
             {
                 'path': 'doc_alias',
@@ -209,7 +184,7 @@ const EXPECTED = [
         ],
     },
     {
-        // ConstItem
+        'query': 'ConstItem',
         'others': [
             {
                 'path': 'doc_alias',
@@ -225,7 +200,7 @@ const EXPECTED = [
         ],
     },
     {
-        // StaticItem
+        'query': 'StaticItem',
         'others': [
             {
                 'path': 'doc_alias',
@@ -237,7 +212,7 @@ const EXPECTED = [
         ],
     },
     {
-        // UnionItem
+        'query': 'UnionItem',
         'others': [
             {
                 'path': 'doc_alias',
@@ -255,7 +230,7 @@ const EXPECTED = [
         ],
     },
     {
-        // UnionFieldItem
+        'query': 'UnionFieldItem',
         'others': [
             {
                 'path': 'doc_alias::Union',
@@ -267,7 +242,7 @@ const EXPECTED = [
         ],
     },
     {
-        // UnionMethodItem
+        'query': 'UnionMethodItem',
         'others': [
             {
                 'path': 'doc_alias::Union',
@@ -279,7 +254,7 @@ const EXPECTED = [
         ],
     },
     {
-        // MacroItem
+        'query': 'MacroItem',
         'others': [
             {
                 'path': 'doc_alias',

--- a/tests/rustdoc-js/exact-match.js
+++ b/tests/rustdoc-js/exact-match.js
@@ -1,6 +1,5 @@
-const QUERY = 'si::pc';
-
 const EXPECTED = {
+    'query': 'si::pc',
     'others': [
         { 'path': 'exact_match::Si', 'name': 'pc' },
         { 'path': 'exact_match::Psi', 'name': 'pc' },

--- a/tests/rustdoc-js/foreign-type-path.js
+++ b/tests/rustdoc-js/foreign-type-path.js
@@ -1,6 +1,5 @@
-const QUERY = 'MyForeignType::my_method';
-
 const EXPECTED = {
+    'query': 'MyForeignType::my_method',
     'others': [
         // Test case for https://github.com/rust-lang/rust/pull/96887#pullrequestreview-967154358
         // Validates that the parent path for a foreign type method is correct.

--- a/tests/rustdoc-js/generics-impl.js
+++ b/tests/rustdoc-js/generics-impl.js
@@ -1,68 +1,56 @@
 // exact-check
 
-const QUERY = [
-    'Aaaaaaa -> u32',
-    'Aaaaaaa -> bool',
-    'Aaaaaaa -> usize',
-    'Read -> u64',
-    'trait:Read -> u64',
-    'struct:Read -> u64',
-    'bool -> u64',
-    'Ddddddd -> u64',
-    '-> Ddddddd'
-];
-
 const EXPECTED = [
     {
-        // Aaaaaaa -> u32
+        'query': 'Aaaaaaa -> u32',
         'others': [
             { 'path': 'generics_impl::Aaaaaaa', 'name': 'bbbbbbb' },
         ],
     },
     {
-        // Aaaaaaa -> bool
+        'query': 'Aaaaaaa -> bool',
         'others': [
             { 'path': 'generics_impl::Aaaaaaa', 'name': 'ccccccc' },
         ],
     },
     {
-        // Aaaaaaa -> usize
+        'query': 'Aaaaaaa -> usize',
         'others': [
             { 'path': 'generics_impl::Aaaaaaa', 'name': 'read' },
         ],
     },
     {
-        // Read -> u64
+        'query': 'Read -> u64',
         'others': [
             { 'path': 'generics_impl::Ddddddd', 'name': 'eeeeeee' },
             { 'path': 'generics_impl::Ddddddd', 'name': 'ggggggg' },
         ],
     },
     {
-        // trait:Read -> u64
+        'query': 'trait:Read -> u64',
         'others': [
             { 'path': 'generics_impl::Ddddddd', 'name': 'eeeeeee' },
             { 'path': 'generics_impl::Ddddddd', 'name': 'ggggggg' },
         ],
     },
     {
-        // struct:Read -> u64
+        'query': 'struct:Read -> u64',
         'others': [],
     },
     {
-        // bool -> u64
+        'query': 'bool -> u64',
         'others': [
             { 'path': 'generics_impl::Ddddddd', 'name': 'fffffff' },
         ],
     },
     {
-        // Ddddddd -> u64
+        'query': 'Ddddddd -> u64',
         'others': [
             { 'path': 'generics_impl::Ddddddd', 'name': 'ggggggg' },
         ],
     },
     {
-        // -> Ddddddd
+        'query': '-> Ddddddd',
         'others': [
             { 'path': 'generics_impl::Ddddddd', 'name': 'hhhhhhh' },
         ],

--- a/tests/rustdoc-js/generics-multi-trait.js
+++ b/tests/rustdoc-js/generics-multi-trait.js
@@ -1,14 +1,9 @@
 // exact-check
 
-const QUERY = [
-    'Result<SomeTrait>',
-    'Zzzzzzzzzzzzzzzzzz',
-    'Nonononononononono',
-];
-
 const EXPECTED = [
     // check one of the generic items
     {
+        'query': 'Result<SomeTrait>',
         'in_args': [
             { 'path': 'generics_multi_trait', 'name': 'beta' },
         ],
@@ -17,6 +12,7 @@ const EXPECTED = [
         ],
     },
     {
+        'query': 'Zzzzzzzzzzzzzzzzzz',
         'in_args': [
             { 'path': 'generics_multi_trait', 'name': 'beta' },
         ],
@@ -26,6 +22,7 @@ const EXPECTED = [
     },
     // ignore the name of the generic itself
     {
+        'query': 'Nonononononononono',
         'in_args': [],
         'returned': [],
     },

--- a/tests/rustdoc-js/generics-nested.js
+++ b/tests/rustdoc-js/generics-nested.js
@@ -1,31 +1,24 @@
 // exact-check
 
-const QUERY = [
-    '-> Out<First<Second>>',
-    '-> Out<Second<First>>',
-    '-> Out<First, Second>',
-    '-> Out<Second, First>',
-];
-
 const EXPECTED = [
     {
-        // -> Out<First<Second>>
+        'query': '-> Out<First<Second>>',
         'others': [
             { 'path': 'generics_nested', 'name': 'alef' },
         ],
     },
     {
-        // -> Out<Second<First>>
+        'query': '-> Out<Second<First>>',
         'others': [],
     },
     {
-        // -> Out<First, Second>
+        'query': '-> Out<First, Second>',
         'others': [
             { 'path': 'generics_nested', 'name': 'bet' },
         ],
     },
     {
-        // -> Out<Second, First>
+        'query': '-> Out<Second, First>',
         'others': [
             { 'path': 'generics_nested', 'name': 'bet' },
         ],

--- a/tests/rustdoc-js/generics-trait.js
+++ b/tests/rustdoc-js/generics-trait.js
@@ -1,22 +1,9 @@
 // exact-check
 
-const QUERY = [
-    'Result<SomeTrait>',
-    'Result<SomeTraiz>',
-    'OtherThingxxxxxxxx',
-    'OtherThingxxxxxxxy',
-];
-
-const CORRECTIONS = [
-    null,
-    null,
-    null,
-    'OtherThingxxxxxxxx',
-];
-
 const EXPECTED = [
-    // Result<SomeTrait>
     {
+        'query': 'Result<SomeTrait>',
+        'correction': null,
         'in_args': [
             { 'path': 'generics_trait', 'name': 'beta' },
         ],
@@ -24,13 +11,15 @@ const EXPECTED = [
             { 'path': 'generics_trait', 'name': 'bet' },
         ],
     },
-    // Result<SomeTraiz>
     {
+        'query': 'Result<SomeTraiz>',
+        'correction': null,
         'in_args': [],
         'returned': [],
     },
-    // OtherThingxxxxxxxx
     {
+        'query': 'OtherThingxxxxxxxx',
+        'correction': null,
         'in_args': [
             { 'path': 'generics_trait', 'name': 'alpha' },
         ],
@@ -38,8 +27,9 @@ const EXPECTED = [
             { 'path': 'generics_trait', 'name': 'alef' },
         ],
     },
-    // OtherThingxxxxxxxy
     {
+        'query': 'OtherThingxxxxxxxy',
+        'correction': 'OtherThingxxxxxxxx',
         'in_args': [
             { 'path': 'generics_trait', 'name': 'alpha' },
         ],

--- a/tests/rustdoc-js/generics.js
+++ b/tests/rustdoc-js/generics.js
@@ -1,20 +1,8 @@
 // exact-check
 
-const QUERY = [
-    'R<P>',
-    'R<struct:P>',
-    'R<enum:P>',
-    '"P"',
-    'P',
-    'ExtraCreditStructMulti<ExtraCreditInnerMulti, ExtraCreditInnerMulti>',
-    'TraitCat',
-    'TraitDog',
-    'Result<String>',
-];
-
 const EXPECTED = [
     {
-        // R<P>
+        'query': 'R<P>',
         'returned': [
             { 'path': 'generics', 'name': 'alef' },
         ],
@@ -23,7 +11,7 @@ const EXPECTED = [
         ],
     },
     {
-        // R<struct:P>
+        'query': 'R<struct:P>',
         'returned': [
             { 'path': 'generics', 'name': 'alef' },
         ],
@@ -32,12 +20,12 @@ const EXPECTED = [
         ],
     },
     {
-        // R<enum:P>
+        'query': 'R<enum:P>',
         'returned': [],
         'in_args': [],
     },
     {
-        // "P"
+        'query': '"P"',
         'others': [
             { 'path': 'generics', 'name': 'P' },
         ],
@@ -49,7 +37,7 @@ const EXPECTED = [
         ],
     },
     {
-        // P
+        'query': 'P',
         'returned': [
             { 'path': 'generics', 'name': 'alef' },
         ],
@@ -58,26 +46,26 @@ const EXPECTED = [
         ],
     },
     {
-        // "ExtraCreditStructMulti"<ExtraCreditInnerMulti, ExtraCreditInnerMulti>
+        'query': '"ExtraCreditStructMulti"<ExtraCreditInnerMulti, ExtraCreditInnerMulti>',
         'in_args': [
             { 'path': 'generics', 'name': 'extracreditlabhomework' },
         ],
         'returned': [],
     },
     {
-        // TraitCat
+        'query': 'TraitCat',
         'in_args': [
             { 'path': 'generics', 'name': 'gamma' },
         ],
     },
     {
-        // TraitDog
+        'query': 'TraitDog',
         'in_args': [
             { 'path': 'generics', 'name': 'gamma' },
         ],
     },
     {
-        // Result<String>
+        'query': 'Result<String>',
         'others': [],
         'returned': [
             { 'path': 'generics', 'name': 'super_soup' },

--- a/tests/rustdoc-js/impl-trait.js
+++ b/tests/rustdoc-js/impl-trait.js
@@ -1,32 +1,24 @@
 // ignore-order
 
-const QUERY = [
-    'Aaaaaaa -> i32',
-    'Aaaaaaa -> Aaaaaaa',
-    'Aaaaaaa -> usize',
-    '-> Aaaaaaa',
-    'Aaaaaaa',
-];
-
 const EXPECTED = [
     {
-        // Aaaaaaa -> i32
+        'query': 'Aaaaaaa -> i32',
         'others': [
             { 'path': 'impl_trait::Ccccccc', 'name': 'eeeeeee' },
         ],
     },
     {
-        // Aaaaaaa -> Aaaaaaa
+        'query': 'Aaaaaaa -> Aaaaaaa',
         'others': [
             { 'path': 'impl_trait::Ccccccc', 'name': 'fffffff' },
         ],
     },
     {
-        // Aaaaaaa -> usize
+        'query': 'Aaaaaaa -> usize',
         'others': [],
     },
     {
-        // -> Aaaaaaa
+        'query': '-> Aaaaaaa',
         'others': [
             { 'path': 'impl_trait::Ccccccc', 'name': 'fffffff' },
             { 'path': 'impl_trait::Ccccccc', 'name': 'ddddddd' },
@@ -34,7 +26,7 @@ const EXPECTED = [
         ],
     },
     {
-        // Aaaaaaa
+        'query': 'Aaaaaaa',
         'others': [
             { 'path': 'impl_trait', 'name': 'Aaaaaaa' },
         ],

--- a/tests/rustdoc-js/macro-search.js
+++ b/tests/rustdoc-js/macro-search.js
@@ -1,8 +1,7 @@
 // exact-check
 
-const QUERY = 'abracadabra!';
-
 const EXPECTED = {
+    'query': 'abracadabra!',
     'others': [
         { 'path': 'macro_search', 'name': 'abracadabra' },
         { 'path': 'macro_search', 'name': 'abracadabra_b' },

--- a/tests/rustdoc-js/module-substring.js
+++ b/tests/rustdoc-js/module-substring.js
@@ -1,6 +1,5 @@
-const QUERY = 'ig::pc';
-
 const EXPECTED = {
+    'query': 'ig::pc',
     'others': [
         { 'path': 'module_substring::Sig', 'name': 'pc' },
         { 'path': 'module_substring::Si', 'name': 'pc' },

--- a/tests/rustdoc-js/path-ordering.js
+++ b/tests/rustdoc-js/path-ordering.js
@@ -1,8 +1,7 @@
 // exact-check
 
-const QUERY = 'b::ccccccc';
-
 const EXPECTED = {
+    'query': 'b::ccccccc',
     'others': [
         // `ccccccc` is an exact match for all three of these.
         // However `b` is a closer match for `bb` than for any

--- a/tests/rustdoc-js/primitive.js
+++ b/tests/rustdoc-js/primitive.js
@@ -1,33 +1,30 @@
 // exact-check
 
-const QUERY = [
-    "i32",
-    "str",
-    "primitive:str",
-    "struct:str",
-    "TotoIsSomewhere",
-];
-
 const EXPECTED = [
     {
+        'query': 'i32',
         'in_args': [
             { 'path': 'primitive', 'name': 'foo' },
         ],
     },
     {
+        'query': 'str',
         'returned': [
             { 'path': 'primitive', 'name': 'foo' },
         ],
     },
     {
+        'query': 'primitive:str',
         'returned': [
             { 'path': 'primitive', 'name': 'foo' },
         ],
     },
     {
+        'query': 'struct:str',
         'returned': [],
     },
     {
+        'query': 'TotoIsSomewhere',
         'others': [],
         'in_args': [],
         'returned': [],

--- a/tests/rustdoc-js/prototype.js
+++ b/tests/rustdoc-js/prototype.js
@@ -1,14 +1,14 @@
 // exact-check
 
-const QUERY = ['constructor', '__proto__'];
-
 const EXPECTED = [
     {
+        'query': 'constructor',
         'others': [],
         'returned': [],
         'in_args': [],
     },
     {
+        'query': '__proto__',
         'others': [],
         'returned': [],
         'in_args': [],

--- a/tests/rustdoc-js/raw-pointer.js
+++ b/tests/rustdoc-js/raw-pointer.js
@@ -1,33 +1,25 @@
 // ignore-order
 
-const QUERY = [
-    'Aaaaaaa -> i32',
-    'Aaaaaaa -> Aaaaaaa',
-    'Aaaaaaa -> usize',
-    '-> Aaaaaaa',
-    'Aaaaaaa',
-];
-
 const EXPECTED = [
     {
-        // Aaaaaaa -> i32
+        'query': 'Aaaaaaa -> i32',
         'others': [
             { 'path': 'raw_pointer::Ccccccc', 'name': 'eeeeeee' },
         ],
     },
     {
-        // Aaaaaaa -> Aaaaaaa
+        'query': 'Aaaaaaa -> Aaaaaaa',
         'others': [
             { 'path': 'raw_pointer::Ccccccc', 'name': 'fffffff' },
             { 'path': 'raw_pointer::Ccccccc', 'name': 'ggggggg' },
         ],
     },
     {
-        // Aaaaaaa -> usize
+        'query': 'Aaaaaaa -> usize',
         'others': [],
     },
     {
-        // -> Aaaaaaa
+        'query': '-> Aaaaaaa',
         'others': [
             { 'path': 'raw_pointer::Ccccccc', 'name': 'fffffff' },
             { 'path': 'raw_pointer::Ccccccc', 'name': 'ggggggg' },
@@ -36,7 +28,7 @@ const EXPECTED = [
         ],
     },
     {
-        // Aaaaaaa
+        'query': 'Aaaaaaa',
         'others': [
             { 'path': 'raw_pointer', 'name': 'Aaaaaaa' },
         ],

--- a/tests/rustdoc-js/reexport.js
+++ b/tests/rustdoc-js/reexport.js
@@ -1,15 +1,15 @@
 // exact-check
 
-const QUERY = ['Subscriber', 'AnotherOne'];
-
 const EXPECTED = [
     {
+        'query': 'Subscriber',
         'others': [
             { 'path': 'reexport::fmt', 'name': 'Subscriber' },
             { 'path': 'reexport', 'name': 'FmtSubscriber' },
         ],
     },
     {
+        'query': 'AnotherOne',
         'others': [
             { 'path': 'reexport', 'name': 'AnotherOne' },
         ],

--- a/tests/rustdoc-js/search-bag-semantics.js
+++ b/tests/rustdoc-js/search-bag-semantics.js
@@ -1,18 +1,15 @@
 // exact-check
 
-const QUERY = [
-    'P',
-    'P, P',
-];
-
 const EXPECTED = [
     {
+        'query': 'P',
         'in_args': [
             { 'path': 'search_bag_semantics', 'name': 'alacazam' },
             { 'path': 'search_bag_semantics', 'name': 'abracadabra' },
         ],
     },
     {
+        'query': 'P, P',
         'others': [
             { 'path': 'search_bag_semantics', 'name': 'abracadabra' },
         ],

--- a/tests/rustdoc-js/search-short-types.js
+++ b/tests/rustdoc-js/search-short-types.js
@@ -1,6 +1,5 @@
-const QUERY = 'P';
-
 const EXPECTED = {
+    'query': 'P',
     'others': [
         { 'path': 'search_short_types', 'name': 'P' },
         { 'path': 'search_short_types::VeryLongTypeName', 'name': 'p' },

--- a/tests/rustdoc-js/slice-array.js
+++ b/tests/rustdoc-js/slice-array.js
@@ -1,63 +1,52 @@
 // exact-check
 
-const QUERY = [
-    'R<primitive:slice<P>>',
-    'primitive:slice<R<P>>',
-    'R<primitive:slice<Q>>',
-    'primitive:slice<R<Q>>',
-    'R<primitive:array<Q>>',
-    'primitive:array<R<Q>>',
-    'primitive:array<TraitCat>',
-    'primitive:array<TraitDog>',
-];
-
 const EXPECTED = [
     {
-        // R<primitive:slice<P>>
+        'query': 'R<primitive:slice<P>>',
         'returned': [],
         'in_args': [
             { 'path': 'slice_array', 'name': 'alpha' },
         ],
     },
     {
-        // primitive:slice<R<P>>
+        'query': 'primitive:slice<R<P>>',
         'returned': [
             { 'path': 'slice_array', 'name': 'alef' },
         ],
         'in_args': [],
     },
     {
-        // R<primitive:slice<Q>>
+        'query': 'R<primitive:slice<Q>>',
         'returned': [],
         'in_args': [],
     },
     {
-        // primitive:slice<R<Q>>
+        'query': 'primitive:slice<R<Q>>',
         'returned': [],
         'in_args': [],
     },
     {
-        // R<primitive:array<Q>>
+        'query': 'R<primitive:array<Q>>',
         'returned': [
             { 'path': 'slice_array', 'name': 'bet' },
         ],
         'in_args': [],
     },
     {
-        // primitive:array<R<Q>>
+        'query': 'primitive:array<R<Q>>',
         'returned': [],
         'in_args': [
             { 'path': 'slice_array', 'name': 'beta' },
         ],
     },
     {
-        // primitive::array<TraitCat>
+        'query': 'primitive:array<TraitCat>',
         'in_args': [
             { 'path': 'slice_array', 'name': 'gamma' },
         ],
     },
     {
-        // primitive::array<TraitDog>
+        'query': 'primitive:array<TraitDog>',
         'in_args': [
             { 'path': 'slice_array', 'name': 'gamma' },
         ],

--- a/tests/rustdoc-js/struct-like-variant.js
+++ b/tests/rustdoc-js/struct-like-variant.js
@@ -1,6 +1,5 @@
-const QUERY = 'name';
-
 const EXPECTED = {
+    'query': 'name',
     'others': [
         { 'path': 'struct_like_variant::Enum::Bar', 'name': 'name', 'desc': 'This is a name.' },
     ],

--- a/tests/rustdoc-js/substring.js
+++ b/tests/rustdoc-js/substring.js
@@ -1,6 +1,5 @@
-const QUERY = 'waker_from';
-
 const EXPECTED = {
+    'query': 'waker_from',
     'others': [
         { 'path': 'substring::SuperWaker', 'name': 'local_waker_from_nonlocal' },
         { 'path': 'substring::SuperWakerTask', 'name': 'local_waker_from_nonlocal' },

--- a/tests/rustdoc-js/summaries.js
+++ b/tests/rustdoc-js/summaries.js
@@ -1,19 +1,20 @@
 // ignore-tidy-linelength
 
-const QUERY = ['summaries', 'summaries::Sidebar', 'summaries::Sidebar2'];
-
 const EXPECTED = [
     {
+        'query': 'summaries',
         'others': [
            { 'path': '', 'name': 'summaries', 'desc': 'This <em>summary</em> has a link, [<code>code</code>], and <code>Sidebar2</code> intra-doc.' },
         ],
     },
     {
+        'query': 'summaries::Sidebar',
         'others': [
             { 'path': 'summaries', 'name': 'Sidebar', 'desc': 'This <code>code</code> will be rendered in a code tag.' },
         ],
     },
     {
+        'query': 'summaries::Sidebar2',
         'others': [
             { 'path': 'summaries', 'name': 'Sidebar2', 'desc': '' },
         ],

--- a/tests/rustdoc-js/where-clause.js
+++ b/tests/rustdoc-js/where-clause.js
@@ -1,28 +1,31 @@
-const QUERY = ['trait<nested>', '-> trait<nested>', 't1, t2', '-> shazam', 'drizzel -> shazam'];
-
 const EXPECTED = [
     {
+        'query': 'trait<nested>',
         'in_args': [
            { 'path': 'where_clause', 'name': 'abracadabra' },
         ],
     },
     {
+        'query': '-> trait<nested>',
         'others': [
             { 'path': 'where_clause', 'name': 'alacazam' },
         ],
     },
     {
+        'query': 't1, t2',
         'others': [
             { 'path': 'where_clause', 'name': 'presto' },
         ],
     },
     {
+        'query': '-> shazam',
         'others': [
             { 'path': 'where_clause', 'name': 'bippety' },
             { 'path': 'where_clause::Drizzel', 'name': 'boppety' },
         ],
     },
     {
+        'query': 'drizzel -> shazam',
         'others': [
             { 'path': 'where_clause::Drizzel', 'name': 'boppety' },
         ],


### PR DESCRIPTION
As I was working on fixing merge conflicts in #108537, I faced quite a big issue when trying to update the `rustdoc-js*` tests. To make it much simpler, this PR moves the `query` and `correction` directly alongside the expected data so now we know what is the query that is being run without needing to add comments or going back to the top of the file.

r? @notriddle 