### PR TITLE
Give more helpful progress messages in `Assemble`

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1415,6 +1415,10 @@ impl Step for Assemble {
             // Ensure that `libLLVM.so` ends up in the newly created target directory,
             // so that tools using `rustc_private` can use it.
             dist::maybe_install_llvm_target(builder, target_compiler.host, &sysroot);
+            // Lower stages use `ci-rustc-sysroot`, not stageN
+            if target_compiler.stage == builder.top_stage {
+                builder.info(&format!("Creating a sysroot for stage{stage} compiler (use `rustup toolchain link 'name' build/host/stage{stage}`)", stage=target_compiler.stage));
+            }
             return target_compiler;
         }
 
@@ -1452,11 +1456,18 @@ impl Step for Assemble {
 
         let stage = target_compiler.stage;
         let host = target_compiler.host;
-        let msg = if build_compiler.host == host {
-            format!("Assembling stage{} compiler", stage)
+        let (host_info, dir_name) = if build_compiler.host == host {
+            ("".into(), "host".into())
         } else {
-            format!("Assembling stage{} compiler ({})", stage, host)
+            (format!(" ({host})"), host.to_string())
         };
+        // NOTE: "Creating a sysroot" is somewhat inconsistent with our internal terminology, since
+        // sysroots can temporarily be empty until we put the compiler inside. However,
+        // `ensure(Sysroot)` isn't really something that's user facing, so there shouldn't be any
+        // ambiguity.
+        let msg = format!(
+            "Creating a sysroot for stage{stage} compiler{host_info} (use `rustup toolchain link 'name' build/{dir_name}/stage{stage}`)"
+        );
         builder.info(&msg);
 
         // Link in all dylibs to the libdir


### PR DESCRIPTION
Before (download-rustc):
```
    # no output
```

After (download-rustc):
```
Creating a sysroot for stage2 compiler (use `rustup toolchain link 'name' build/host/stage2`)
```

Before (compiling from source):
```
Building compiler artifacts (stage0 -> stage1, x86_64-unknown-linux-gnu)
Assembling stage1 compiler
Build stage1 library artifacts (x86_64-unknown-linux-gnu -> i686-unknown-linux-gnu)
Building compiler artifacts (stage0:x86_64-unknown-linux-gnu -> stage1:i686-unknown-linux-gnu)
Assembling stage1 compiler (i686-unknown-linux-gnu)
```

After (compiling from source):
```
Building compiler artifacts (stage0 -> stage1, x86_64-unknown-linux-gnu)
Creating a sysroot for stage1 compiler (use `rustup toolchain link 'name' build/host/stage1`)
Build stage1 library artifacts (x86_64-unknown-linux-gnu)
Building compiler artifacts (stage0:x86_64-unknown-linux-gnu -> stage1:i686-unknown-linux-gnu)
Creating a sysroot for stage1 compiler (i686-unknown-linux-gnu) (use `rustup toolchain link 'name' build/i686-unknown-linux-gnu/stage1`)
```
cc https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Unable.20to.20compile.20rustc.20MSVC, https://discord.com/channels/273534239310479360/957720175619215380/1116867245499498506