### PR TITLE
Ignore tests that hang in new solver

### DIFF
--- a/tests/ui/closures/issue-72408-nested-closures-exponential.rs
+++ b/tests/ui/closures/issue-72408-nested-closures-exponential.rs
@@ -1,4 +1,5 @@
 // build-pass
+// ignore-compare-mode-next-solver (hangs)
 
 // Closures include captured types twice in a type tree.
 //

--- a/tests/ui/issues/issue-37311-type-length-limit/issue-37311.rs
+++ b/tests/ui/issues/issue-37311-type-length-limit/issue-37311.rs
@@ -1,5 +1,6 @@
 // build-fail
 // normalize-stderr-test: ".nll/" -> "/"
+// ignore-compare-mode-next-solver (hangs)
 
 trait Mirror {
     type Image;

--- a/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
+++ b/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
@@ -1,11 +1,11 @@
 error: reached the recursion limit while instantiating `<(&(&(..., ...), ...), ...) as Foo>::recurse`
-  --> $DIR/issue-37311.rs:17:9
+  --> $DIR/issue-37311.rs:18:9
    |
 LL |         (self, self).recurse();
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `<T as Foo>::recurse` defined here
-  --> $DIR/issue-37311.rs:16:5
+  --> $DIR/issue-37311.rs:17:5
    |
 LL |     fn recurse(&self) {
    |     ^^^^^^^^^^^^^^^^^

--- a/tests/ui/iterators/issue-58952-filter-type-length.rs
+++ b/tests/ui/iterators/issue-58952-filter-type-length.rs
@@ -1,4 +1,6 @@
 // run-pass
+// ignore-compare-mode-next-solver (hangs)
+
 //! This snippet causes the type length to blowup exponentially,
 //! so check that we don't accidentally exceed the type length limit.
 // FIXME: Once the size of iterator adaptors is further reduced,

--- a/tests/ui/recursion/issue-83150.rs
+++ b/tests/ui/recursion/issue-83150.rs
@@ -2,6 +2,7 @@
 // compile-flags: -Copt-level=0
 // normalize-stderr-test: "long-type-\d+" -> "long-type-hash"
 //~^^^ ERROR overflow evaluating the requirement
+// ignore-compare-mode-next-solver (hangs)
 
 fn main() {
     let mut iter = 0u8..1;

--- a/tests/ui/recursion/issue-83150.stderr
+++ b/tests/ui/recursion/issue-83150.stderr
@@ -1,5 +1,5 @@
 warning: function cannot return without recursing
-  --> $DIR/issue-83150.rs:11:1
+  --> $DIR/issue-83150.rs:12:1
    |
 LL | fn func<T: Iterator<Item = u8>>(iter: &mut T) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
@@ -9,10 +9,10 @@ LL |     func(&mut iter.map(|x| x + 1))
    = help: a `loop` may express intention better if this is on purpose
    = note: `#[warn(unconditional_recursion)]` on by default
 
-error[E0275]: overflow evaluating the requirement `Map<&mut std::ops::Range<u8>, [closure@$DIR/issue-83150.rs:12:24: 12:27]>: Iterator`
+error[E0275]: overflow evaluating the requirement `Map<&mut std::ops::Range<u8>, [closure@$DIR/issue-83150.rs:13:24: 13:27]>: Iterator`
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_83150`)
-   = note: required for `&mut Map<&mut std::ops::Range<u8>, [closure@$DIR/issue-83150.rs:12:24: 12:27]>` to implement `Iterator`
+   = note: required for `&mut Map<&mut std::ops::Range<u8>, [closure@$DIR/issue-83150.rs:13:24: 13:27]>` to implement `Iterator`
    = note: 65 redundant requirements hidden
    = note: required for `&mut Map<&mut Map<&mut Map<&mut Map<&mut Map<&mut Map<&mut Map<..., ...>, ...>, ...>, ...>, ...>, ...>, ...>` to implement `Iterator`
    = note: the full type name has been written to '$TEST_BUILD_DIR/recursion/issue-83150/issue-83150.long-type-hash.txt'

--- a/tests/ui/traits/issue-91949-hangs-on-recursion.rs
+++ b/tests/ui/traits/issue-91949-hangs-on-recursion.rs
@@ -3,6 +3,7 @@
 // error-pattern: overflow evaluating the requirement `<std::iter::Empty<()> as Iterator>::Item == ()`
 // error-pattern: function cannot return without recursing
 // normalize-stderr-test: "long-type-\d+" -> "long-type-hash"
+// ignore-compare-mode-next-solver (hangs)
 
 // Regression test for #91949.
 // This hanged *forever* on 1.56, fixed by #90423.

--- a/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
+++ b/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
@@ -1,5 +1,5 @@
 warning: function cannot return without recursing
-  --> $DIR/issue-91949-hangs-on-recursion.rs:23:1
+  --> $DIR/issue-91949-hangs-on-recursion.rs:24:1
    |
 LL | / fn recurse<T>(elements: T) -> Vec<char>
 LL | | where
@@ -16,7 +16,7 @@ error[E0275]: overflow evaluating the requirement `<std::iter::Empty<()> as Iter
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "512"]` attribute to your crate (`issue_91949_hangs_on_recursion`)
 note: required for `IteratorOfWrapped<(), std::iter::Empty<()>>` to implement `Iterator`
-  --> $DIR/issue-91949-hangs-on-recursion.rs:16:32
+  --> $DIR/issue-91949-hangs-on-recursion.rs:17:32
    |
 LL | impl<T, I: Iterator<Item = T>> Iterator for IteratorOfWrapped<T, I> {
    |                     --------   ^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This makes it easier to run `--compare-mode=next-solver`, and we can revisit these tests later to find out how to make them less overflowy 😅 

r? @lcnr