### PR TITLE
Add deprecation warning to python versions <3.6 in x.py

### DIFF
--- a/x.py
+++ b/x.py
@@ -9,12 +9,17 @@
 if __name__ == '__main__':
     import os
     import sys
+    import warnings
+    from inspect import cleandoc
+
+    major = sys.version_info.major
+    minor = sys.version_info.minor
 
     # If this is python2, check if python3 is available and re-execute with that
     # interpreter. Only python3 allows downloading CI LLVM.
     #
     # This matters if someone's system `python` is python2.
-    if sys.version_info.major < 3:
+    if major < 3:
         try:
             os.execvp("py", ["py", "-3"] + sys.argv)
         except OSError:
@@ -23,6 +28,19 @@ if __name__ == '__main__':
             except OSError:
                 # Python 3 isn't available, fall back to python 2
                 pass
+
+    # soft deprecation of old python versions
+    skip_check = os.environ.get("RUST_IGNORE_OLD_PYTHON") == "1"
+    if major < 3 or (major == 3 and minor < 6):
+        msg = cleandoc("""
+            Using python {}.{} but >= 3.6 is recommended. Your python version
+            should continue to work for the near future, but this will
+            eventually change. If python >= 3.6 is not available on your system,
+            please file an issue to help us understand timelines.
+
+            This message can be suppressed by setting `RUST_IGNORE_OLD_PYTHON=1`
+        """.format(major, minor))
+        warnings.warn(msg)
 
     rust_dir = os.path.dirname(os.path.abspath(__file__))
     # For the import below, have Python search in src/bootstrap first.


### PR DESCRIPTION
Introduced based on conversation on Zulip. This is a repeat of #110439 with two changes:

- Warning rather than exit
- Can be suppressed via an environment variable

The min to not get the warning is set to 3.6 because that's a fairly recent "old" version (went EOL in 2021) and it's the first version to support useful modern features like f-strings and type hints.

cc @Nilstrieb (author of #110439) and @Mark-Simulacrum (reviewer of that PR)