### PR TITLE
Update documentation for `tools` defaults

### DIFF
--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -9,6 +9,8 @@ debug-logging = true
 incremental = true
 # Download rustc from CI instead of building it from source.
 # This cuts compile times by almost 60x, but means you can't modify the compiler.
+# Using these defaults will download the stage2 compiler (see `download-rustc`
+# setting) and the stage2 toolchain should therefore be used for these defaults.
 download-rustc = "if-unchanged"
 
 [build]

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -176,6 +176,14 @@ pub fn setup(config: &Config, profile: Profile) {
         );
     }
 
+    if profile == Profile::Tools {
+        eprintln!();
+        eprintln!(
+            "note: the `tools` profile sets up the `stage2` toolchain (use \
+            `rustup toolchain link 'name' host/build/stage2` to use rustc)"
+        )
+    }
+
     let path = &config.config.clone().unwrap_or(PathBuf::from("config.toml"));
     setup_config_toml(path, profile, config);
 }


### PR DESCRIPTION
This PR alters the information in the tools profile config to mention that `download-rustc` uses the stage2 toolchain and not the stage1 toolchain (see https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Unable.20to.20compile.20rustc.20MSVC and rust-lang/rustc-dev-guide#1694).