### PR TITLE
Migrate GUI colors test to original CSS color format

### DIFF
--- a/tests/rustdoc-gui/search-reexport.goml
+++ b/tests/rustdoc-gui/search-reexport.goml
@@ -17,7 +17,7 @@ assert-attribute: (
 assert-text: ("//a[@class='result-import']", "test_docs::TheStdReexport")
 click: "//a[@class='result-import']"
 // We check that it has the background modified thanks to the focus.
-wait-for-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "rgb(73, 74, 61)"})
+wait-for-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "#494a3d"})
 
 // We now check that the alias is working as well on the reexport.
 // To be SURE that the search will be run.
@@ -30,4 +30,4 @@ assert-text: (
 )
 // Same thing again, we click on it to ensure the background is once again set as expected.
 click: "//a[@class='result-import']"
-wait-for-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "rgb(73, 74, 61)"})
+wait-for-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "#494a3d"})


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/111459.

r? @notriddle