### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
@@ -1204,11 +1204,11 @@ dependencies = [
 
 [[package]]
 name = "field-offset"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cf3a800ff6e860c863ca6d4b16fd999db8b752819c1606884047b73e468535"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.0",
  "rustc_version",
 ]
 
@@ -2153,6 +2153,15 @@ name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -3988,7 +3997,7 @@ version = "0.0.0"
 dependencies = [
  "field-offset",
  "measureme",
- "memoffset",
+ "memoffset 0.9.0",
  "rustc-rayon-core",
  "rustc_ast",
  "rustc_data_structures",

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -953,8 +953,8 @@ pub trait LintContext: Sized {
                     db.span_label(duplicate_reexport_span, format!("but the name `{}` in the {} namespace is also re-exported here", name, namespace));
                 }
                 BuiltinLintDiagnostics::HiddenGlobReexports { name, namespace, glob_reexport_span, private_item_span } => {
-                    db.span_label(glob_reexport_span, format!("the name `{}` in the {} namespace is supposed to be publicly re-exported here", name, namespace));
-                    db.span_label(private_item_span, "but the private item here shadows it");
+                    db.span_note(glob_reexport_span, format!("the name `{}` in the {} namespace is supposed to be publicly re-exported here", name, namespace));
+                    db.span_note(private_item_span, "but the private item here shadows it".to_owned());
                 }
             }
             // Rewrap `db`, and pass control to the user.

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 
 [dependencies]
-memoffset = { version = "0.8.0", features = ["unstable_const"] }
 field-offset = "0.3.5"
 measureme = "10.0.0"
 rustc_ast = { path = "../rustc_ast" }
@@ -24,6 +23,9 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 thin-vec = "0.2.12"
 tracing = "0.1"
+
+# Not used directly, but included to enable the unstable_offset_of feature
+memoffset = { version = "0.9.0", features = ["unstable_offset_of"] }
 
 [features]
 rustc_use_parallel_compiler = ["rustc-rayon-core", "rustc_query_system/rustc_use_parallel_compiler"]

--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `x.py fmt` now formats only files modified between the merge-base of HEAD and the last commit in the master branch of the rust-lang repository and the current working directory. To restore old behaviour, use `x.py fmt .`. The check mode is not affected by this change. [#105702](https://github.com/rust-lang/rust/pull/105702)
 - The `llvm.version-check` config option has been removed. Older versions were never supported. If you still need to support older versions (e.g. you are applying custom patches), patch `check_llvm_version` in bootstrap to change the minimum version. [#108619](https://github.com/rust-lang/rust/pull/108619)
 - The `rust.ignore-git` option has been renamed to `rust.omit-git-hash`. [#110059](https://github.com/rust-lang/rust/pull/110059)
+- `--exclude` no longer accepts a `Kind` as part of a Step; instead it uses the top-level Kind of the subcommand. If this matches how you were already using --exclude (e.g. `x test --exclude test::std`), simply remove the kind: `--exclude std`. If you were using a kind that did not match the top-level subcommand, please open an issue explaining why you wanted this feature.
 
 ### Non-breaking changes
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -307,7 +307,7 @@ impl StepDescription {
     }
 
     fn is_excluded(&self, builder: &Builder<'_>, pathset: &PathSet) -> bool {
-        if builder.config.exclude.iter().any(|e| pathset.has(&e.path, e.kind)) {
+        if builder.config.exclude.iter().any(|e| pathset.has(&e.path, Some(builder.kind))) {
             println!("Skipping {:?} because it is excluded", pathset);
             return true;
         }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -8,7 +8,7 @@ use std::fs::{self, File};
 use std::hash::Hash;
 use std::io::{BufRead, BufReader};
 use std::ops::Deref;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
 
@@ -150,29 +150,6 @@ pub struct TaskPath {
     pub kind: Option<Kind>,
 }
 
-impl TaskPath {
-    pub fn parse(path: impl Into<PathBuf>) -> TaskPath {
-        let mut kind = None;
-        let mut path = path.into();
-
-        let mut components = path.components();
-        if let Some(Component::Normal(os_str)) = components.next() {
-            if let Some(str) = os_str.to_str() {
-                if let Some((found_kind, found_prefix)) = str.split_once("::") {
-                    if found_kind.is_empty() {
-                        panic!("empty kind in task path {}", path.display());
-                    }
-                    kind = Kind::parse(found_kind);
-                    assert!(kind.is_some());
-                    path = Path::new(found_prefix).join(components.as_path());
-                }
-            }
-        }
-
-        TaskPath { path, kind }
-    }
-}
-
 impl Debug for TaskPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(kind) = &self.kind {
@@ -216,7 +193,7 @@ impl PathSet {
         PathSet::Set(set)
     }
 
-    fn has(&self, needle: &Path, module: Option<Kind>) -> bool {
+    fn has(&self, needle: &Path, module: Kind) -> bool {
         match self {
             PathSet::Set(set) => set.iter().any(|p| Self::check(p, needle, module)),
             PathSet::Suite(suite) => Self::check(suite, needle, module),
@@ -224,9 +201,9 @@ impl PathSet {
     }
 
     // internal use only
-    fn check(p: &TaskPath, needle: &Path, module: Option<Kind>) -> bool {
-        if let (Some(p_kind), Some(kind)) = (&p.kind, module) {
-            p.path.ends_with(needle) && *p_kind == kind
+    fn check(p: &TaskPath, needle: &Path, module: Kind) -> bool {
+        if let Some(p_kind) = &p.kind {
+            p.path.ends_with(needle) && *p_kind == module
         } else {
             p.path.ends_with(needle)
         }
@@ -238,11 +215,7 @@ impl PathSet {
     /// This is used for `StepDescription::krate`, which passes all matching crates at once to
     /// `Step::make_run`, rather than calling it many times with a single crate.
     /// See `tests.rs` for examples.
-    fn intersection_removing_matches(
-        &self,
-        needles: &mut Vec<&Path>,
-        module: Option<Kind>,
-    ) -> PathSet {
+    fn intersection_removing_matches(&self, needles: &mut Vec<&Path>, module: Kind) -> PathSet {
         let mut check = |p| {
             for (i, n) in needles.iter().enumerate() {
                 let matched = Self::check(p, n, module);
@@ -307,7 +280,7 @@ impl StepDescription {
     }
 
     fn is_excluded(&self, builder: &Builder<'_>, pathset: &PathSet) -> bool {
-        if builder.config.exclude.iter().any(|e| pathset.has(&e.path, Some(builder.kind))) {
+        if builder.config.exclude.iter().any(|e| pathset.has(&e, builder.kind)) {
             println!("Skipping {:?} because it is excluded", pathset);
             return true;
         }
@@ -562,7 +535,7 @@ impl<'a> ShouldRun<'a> {
     ) -> Vec<PathSet> {
         let mut sets = vec![];
         for pathset in &self.paths {
-            let subset = pathset.intersection_removing_matches(paths, Some(kind));
+            let subset = pathset.intersection_removing_matches(paths, kind);
             if subset != PathSet::empty() {
                 sets.push(subset);
             }
@@ -2130,7 +2103,7 @@ impl<'a> Builder<'a> {
         let should_run = (desc.should_run)(ShouldRun::new(self, desc.kind));
 
         for path in &self.paths {
-            if should_run.paths.iter().any(|s| s.has(path, Some(desc.kind)))
+            if should_run.paths.iter().any(|s| s.has(path, desc.kind))
                 && !desc.is_excluded(
                     self,
                     &PathSet::Suite(TaskPath { path: path.clone(), kind: Some(desc.kind) }),

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -16,7 +16,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
-use crate::builder::TaskPath;
 use crate::cache::{Interned, INTERNER};
 use crate::cc_detect::{ndk_compiler, Language};
 use crate::channel::{self, GitInfo};
@@ -79,7 +78,7 @@ pub struct Config {
     pub sanitizers: bool,
     pub profiler: bool,
     pub omit_git_hash: bool,
-    pub exclude: Vec<TaskPath>,
+    pub exclude: Vec<PathBuf>,
     pub include_default_paths: bool,
     pub rustc_error_format: Option<String>,
     pub json_output: bool,
@@ -958,7 +957,7 @@ impl Config {
 
         // Set flags.
         config.paths = std::mem::take(&mut flags.paths);
-        config.exclude = flags.exclude.into_iter().map(|path| TaskPath::parse(path)).collect();
+        config.exclude = flags.exclude;
         config.include_default_paths = flags.include_default_paths;
         config.rustc_error_format = flags.rustc_error_format;
         config.json_output = flags.json_output;

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1529,7 +1529,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
 
         for exclude in &builder.config.exclude {
             cmd.arg("--skip");
-            cmd.arg(&exclude.path);
+            cmd.arg(&exclude);
         }
 
         // Get paths from cmd args

--- a/src/ci/docker/README.md
+++ b/src/ci/docker/README.md
@@ -270,7 +270,7 @@ For targets: `loongarch64-unknown-linux-gnu`
 - Operating System > Linux kernel version = 5.19.16
 - Binary utilities > Version of binutils = 2.40
 - C-library > glibc version = 2.36
-- C compiler > gcc version = 12.2.0
+- C compiler > gcc version = 13.1.0
 - C compiler > C++ = ENABLE -- to cross compile LLVM
 
 ### `mips-linux-gnu.defconfig`

--- a/src/ci/docker/scripts/crosstool-ng-git.sh
+++ b/src/ci/docker/scripts/crosstool-ng-git.sh
@@ -2,7 +2,7 @@
 set -ex
 
 URL=https://github.com/crosstool-ng/crosstool-ng
-REV=943364711a650d9b9e84c1b42c91cc0265b6ab5c
+REV=227d99d7f3115f3a078595a580d2b307dcd23e93
 
 mkdir crosstool-ng
 cd crosstool-ng

--- a/tests/ui/resolve/hidden_glob_reexports.rs
+++ b/tests/ui/resolve/hidden_glob_reexports.rs
@@ -6,10 +6,10 @@ pub mod upstream_a {
         pub struct Bar {}
     }
 
-    pub use self::inner::*;
-
     struct Foo;
     //~^ WARN private item shadows public glob re-export
+
+    pub use self::inner::*;
 }
 
 pub mod upstream_b {

--- a/tests/ui/resolve/hidden_glob_reexports.stderr
+++ b/tests/ui/resolve/hidden_glob_reexports.stderr
@@ -1,31 +1,54 @@
 warning: private item shadows public glob re-export
-  --> $DIR/hidden_glob_reexports.rs:11:5
+  --> $DIR/hidden_glob_reexports.rs:9:5
+   |
+LL |     struct Foo;
+   |     ^^^^^^^^^^^
+   |
+note: the name `Foo` in the type namespace is supposed to be publicly re-exported here
+  --> $DIR/hidden_glob_reexports.rs:12:13
    |
 LL |     pub use self::inner::*;
-   |             -------------- the name `Foo` in the type namespace is supposed to be publicly re-exported here
-LL |
-LL |     struct Foo;
-   |     ^^^^^^^^^^^ but the private item here shadows it
+   |             ^^^^^^^^^^^^^^
+note: but the private item here shadows it
+  --> $DIR/hidden_glob_reexports.rs:9:5
    |
+LL |     struct Foo;
+   |     ^^^^^^^^^^^
    = note: `#[warn(hidden_glob_reexports)]` on by default
 
 warning: private item shadows public glob re-export
   --> $DIR/hidden_glob_reexports.rs:27:9
    |
-LL |     pub use self::inner::*;
-   |             -------------- the name `Foo` in the type namespace is supposed to be publicly re-exported here
-LL |
 LL |     use self::other::Foo;
-   |         ^^^^^^^^^^^^^^^^ but the private item here shadows it
+   |         ^^^^^^^^^^^^^^^^
+   |
+note: the name `Foo` in the type namespace is supposed to be publicly re-exported here
+  --> $DIR/hidden_glob_reexports.rs:25:13
+   |
+LL |     pub use self::inner::*;
+   |             ^^^^^^^^^^^^^^
+note: but the private item here shadows it
+  --> $DIR/hidden_glob_reexports.rs:27:9
+   |
+LL |     use self::other::Foo;
+   |         ^^^^^^^^^^^^^^^^
 
 warning: private item shadows public glob re-export
   --> $DIR/hidden_glob_reexports.rs:40:9
    |
-LL |     pub use self::no_def_id::*;
-   |             ------------------ the name `u8` in the type namespace is supposed to be publicly re-exported here
-LL |
 LL |     use std::primitive::u8;
-   |         ^^^^^^^^^^^^^^^^^^ but the private item here shadows it
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+note: the name `u8` in the type namespace is supposed to be publicly re-exported here
+  --> $DIR/hidden_glob_reexports.rs:38:13
+   |
+LL |     pub use self::no_def_id::*;
+   |             ^^^^^^^^^^^^^^^^^^
+note: but the private item here shadows it
+  --> $DIR/hidden_glob_reexports.rs:40:9
+   |
+LL |     use std::primitive::u8;
+   |         ^^^^^^^^^^^^^^^^^^
 
 warning: 3 warnings emitted
 

--- a/x.py
+++ b/x.py
@@ -9,12 +9,17 @@
 if __name__ == '__main__':
     import os
     import sys
+    import warnings
+    from inspect import cleandoc
+
+    major = sys.version_info.major
+    minor = sys.version_info.minor
 
     # If this is python2, check if python3 is available and re-execute with that
     # interpreter. Only python3 allows downloading CI LLVM.
     #
     # This matters if someone's system `python` is python2.
-    if sys.version_info.major < 3:
+    if major < 3:
         try:
             os.execvp("py", ["py", "-3"] + sys.argv)
         except OSError:
@@ -23,6 +28,19 @@ if __name__ == '__main__':
             except OSError:
                 # Python 3 isn't available, fall back to python 2
                 pass
+
+    # soft deprecation of old python versions
+    skip_check = os.environ.get("RUST_IGNORE_OLD_PYTHON") == "1"
+    if major < 3 or (major == 3 and minor < 6):
+        msg = cleandoc("""
+            Using python {}.{} but >= 3.6 is recommended. Your python version
+            should continue to work for the near future, but this will
+            eventually change. If python >= 3.6 is not available on your system,
+            please file an issue to help us understand timelines.
+
+            This message can be suppressed by setting `RUST_IGNORE_OLD_PYTHON=1`
+        """.format(major, minor))
+        warnings.warn(msg)
 
     rust_dir = os.path.dirname(os.path.abspath(__file__))
     # For the import below, have Python search in src/bootstrap first.


### PR DESCRIPTION
Successful merges:

 - #112297 (bootstrap: Disallow `--exclude test::std`)
 - #112298 (Update field-offset and enable unstable_offset_of)
 - #112335 (ci: Upgrade loongarch64-linux-gnu GCC to 13.1.0)
 - #112413 (Adjust span labels for `HIDDEN_GLOB_REEXPORTS`)
 - #112483 (Add deprecation warning to python versions <3.6 in x.py)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112297,112298,112335,112413,112483)
<!-- homu-ignore:end -->