### PR TITLE
fix(resolve): update shadowed_glob more precision

### DIFF
--- a/tests/ui/resolve/issue-105069.stderr
+++ b/tests/ui/resolve/issue-105069.stderr
@@ -4,17 +4,19 @@ error[E0659]: `V` is ambiguous
 LL | use V;
    |     ^ ambiguous name
    |
-   = note: ambiguous because of multiple potential import sources
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `V` could refer to the variant imported here
   --> $DIR/issue-105069.rs:1:5
    |
 LL | use self::A::*;
    |     ^^^^^^^^^^
+   = help: consider adding an explicit import of `V` to disambiguate
 note: `V` could also refer to the variant imported here
   --> $DIR/issue-105069.rs:3:5
    |
 LL | use self::B::*;
    |     ^^^^^^^^^^
+   = help: consider adding an explicit import of `V` to disambiguate
 
 error: aborting due to previous error
 

--- a/tests/ui/resolve/issue-109153.rs
+++ b/tests/ui/resolve/issue-109153.rs
@@ -1,0 +1,14 @@
+use foo::*;
+
+mod foo {
+    pub mod bar {
+        pub mod bar {
+            pub mod bar {}
+        }
+    }
+}
+
+use bar::bar; //~ ERROR `bar` is ambiguous
+use bar::*;
+
+fn main() { }

--- a/tests/ui/resolve/issue-109153.stderr
+++ b/tests/ui/resolve/issue-109153.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `bar` is ambiguous
+  --> $DIR/issue-109153.rs:11:5
+   |
+LL | use bar::bar;
+   |     ^^^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `bar` could refer to the module imported here
+  --> $DIR/issue-109153.rs:1:5
+   |
+LL | use foo::*;
+   |     ^^^^^^
+   = help: consider adding an explicit import of `bar` to disambiguate
+note: `bar` could also refer to the module imported here
+  --> $DIR/issue-109153.rs:12:5
+   |
+LL | use bar::*;
+   |     ^^^^^^
+   = help: consider adding an explicit import of `bar` to disambiguate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0659`.


### PR DESCRIPTION
- Fixes #109153
- Fixes #109962

## Why does it panic?

We use #109153 as an illustration. 

The process of `resolve_imports` is:

| Iter | resolve     | resolution of **`(Mod(root), Ident(bar) in type ns)`** | 
| -    | -           | -      |
| 0 | `use foo::*`   | `binding` -> foo::bar, `shallowed_glob` -> `None` |
| 1 | `use bar::bar` | `binding` -> foo::bar::bar, `shallowed_glob` -> foo::bar    |
| 2 | `use bar::*`   | `binding` -> foo::bar::bar, `shallowed_glob` -> foo::bar::bar::bar |

So during `finalize_import`, the `root::bar` in `use bar::bar` had been pointed to `foo::bar::bar::bar`, which is different from the `initial_module` valued of `foo::bar`, therefore, the panic had been triggered.

## Try to solve it

~I think #109153 should check-pass rather than throw an ambiguous error. Following this idea, there are two ways to solve this problem:~

~1. Give up the `initial_module` and update `import.imported_module` after each resolution update. However, I think this method may have too much impact.~
~2. Do not update the `shadowed_glob` when it is defined.~

~To be honest, I am not sure if this is the right way to solve this ICE. Perhaps there is a better resolution.~

Edit: we had made the `resolution.shadowed_glob` update more detailed.

r? @petrochenkov 