### PR TITLE
Update links to Rust Reference in diagnostic

### DIFF
--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -158,7 +158,7 @@ pub(crate) fn emit_unescape_error(
 
                 diag.help(
                     "for more information, visit \
-                     <https://static.rust-lang.org/doc/master/reference.html#literals>",
+                     <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>",
                 );
             }
             diag.emit();

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -158,7 +158,7 @@ pub(crate) fn emit_unescape_error(
 
                 diag.help(
                     "for more information, visit \
-                     <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>",
+                     <https://doc.rust-lang.org/reference/tokens.html#literals>",
                 );
             }
             diag.emit();

--- a/tests/ui/lexer/lex-bad-char-literals-1.stderr
+++ b/tests/ui/lexer/lex-bad-char-literals-1.stderr
@@ -16,7 +16,7 @@ error: unknown character escape: `\u{25cf}`
 LL |     '\●'
    |       ^ unknown character escape
    |
-   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
+   = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
 LL |     r"\●"
@@ -28,7 +28,7 @@ error: unknown character escape: `\u{25cf}`
 LL |     "\●"
    |       ^ unknown character escape
    |
-   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
+   = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
 LL |     r"\●"

--- a/tests/ui/lexer/lex-bad-char-literals-1.stderr
+++ b/tests/ui/lexer/lex-bad-char-literals-1.stderr
@@ -16,7 +16,7 @@ error: unknown character escape: `\u{25cf}`
 LL |     '\●'
    |       ^ unknown character escape
    |
-   = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
 LL |     r"\●"
@@ -28,7 +28,7 @@ error: unknown character escape: `\u{25cf}`
 LL |     "\●"
    |       ^ unknown character escape
    |
-   = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
 LL |     r"\●"

--- a/tests/ui/parser/bad-escape-suggest-raw-string.rs
+++ b/tests/ui/parser/bad-escape-suggest-raw-string.rs
@@ -2,6 +2,6 @@ fn main() {
     let ok = r"ab\[c";
     let bad = "ab\[c";
     //~^ ERROR unknown character escape: `[`
-    //~| HELP for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
+    //~| HELP for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
     //~| HELP if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
 }

--- a/tests/ui/parser/bad-escape-suggest-raw-string.rs
+++ b/tests/ui/parser/bad-escape-suggest-raw-string.rs
@@ -2,6 +2,6 @@ fn main() {
     let ok = r"ab\[c";
     let bad = "ab\[c";
     //~^ ERROR unknown character escape: `[`
-    //~| HELP for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+    //~| HELP for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
     //~| HELP if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
 }

--- a/tests/ui/parser/bad-escape-suggest-raw-string.stderr
+++ b/tests/ui/parser/bad-escape-suggest-raw-string.stderr
@@ -4,7 +4,7 @@ error: unknown character escape: `[`
 LL |     let bad = "ab\[c";
    |                   ^ unknown character escape
    |
-   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
+   = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
 LL |     let bad = r"ab\[c";

--- a/tests/ui/parser/bad-escape-suggest-raw-string.stderr
+++ b/tests/ui/parser/bad-escape-suggest-raw-string.stderr
@@ -4,7 +4,7 @@ error: unknown character escape: `[`
 LL |     let bad = "ab\[c";
    |                   ^ unknown character escape
    |
-   = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
 LL |     let bad = r"ab\[c";

--- a/tests/ui/parser/byte-literals.stderr
+++ b/tests/ui/parser/byte-literals.stderr
@@ -4,7 +4,7 @@ error: unknown byte escape: `f`
 LL | static FOO: u8 = b'\f';
    |                     ^ unknown byte escape
    |
-   = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
 
 error: unknown byte escape: `f`
   --> $DIR/byte-literals.rs:6:8
@@ -12,7 +12,7 @@ error: unknown byte escape: `f`
 LL |     b'\f';
    |        ^ unknown byte escape
    |
-   = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
 
 error: invalid character in numeric character escape: `Z`
   --> $DIR/byte-literals.rs:7:10

--- a/tests/ui/parser/byte-literals.stderr
+++ b/tests/ui/parser/byte-literals.stderr
@@ -4,7 +4,7 @@ error: unknown byte escape: `f`
 LL | static FOO: u8 = b'\f';
    |                     ^ unknown byte escape
    |
-   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
+   = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 
 error: unknown byte escape: `f`
   --> $DIR/byte-literals.rs:6:8
@@ -12,7 +12,7 @@ error: unknown byte escape: `f`
 LL |     b'\f';
    |        ^ unknown byte escape
    |
-   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
+   = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 
 error: invalid character in numeric character escape: `Z`
   --> $DIR/byte-literals.rs:7:10

--- a/tests/ui/parser/byte-string-literals.stderr
+++ b/tests/ui/parser/byte-string-literals.stderr
@@ -4,7 +4,7 @@ error: unknown byte escape: `f`
 LL | static FOO: &'static [u8] = b"\f";
    |                                ^ unknown byte escape
    |
-   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
+   = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 
 error: unknown byte escape: `f`
   --> $DIR/byte-string-literals.rs:4:8
@@ -12,7 +12,7 @@ error: unknown byte escape: `f`
 LL |     b"\f";
    |        ^ unknown byte escape
    |
-   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
+   = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 
 error: invalid character in numeric character escape: `Z`
   --> $DIR/byte-string-literals.rs:5:10

--- a/tests/ui/parser/byte-string-literals.stderr
+++ b/tests/ui/parser/byte-string-literals.stderr
@@ -4,7 +4,7 @@ error: unknown byte escape: `f`
 LL | static FOO: &'static [u8] = b"\f";
    |                                ^ unknown byte escape
    |
-   = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
 
 error: unknown byte escape: `f`
   --> $DIR/byte-string-literals.rs:4:8
@@ -12,7 +12,7 @@ error: unknown byte escape: `f`
 LL |     b"\f";
    |        ^ unknown byte escape
    |
-   = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+   = help: for more information, visit <https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html>
 
 error: invalid character in numeric character escape: `Z`
   --> $DIR/byte-string-literals.rs:5:10


### PR DESCRIPTION
Instead of linking to the [old Rust Reference site](https://static.rust-lang.org/doc/master/reference.html#literals), which is severely outdated (Rust 1.17), link to the [current website](https://doc.rust-lang.org/stable/reference/expressions/literal-expr.html) in diagnostic about incorrect literals.