### PR TITLE
Properly check associated consts for infer placeholders

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -341,7 +341,12 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<Ty
                 .and_then(|body_id| {
                     is_suggestable_infer_ty(ty).then(|| {
                         infer_placeholder_type(
-                            tcx, def_id, body_id, ty.span, item.ident, "constant",
+                            tcx,
+                            def_id,
+                            body_id,
+                            ty.span,
+                            item.ident,
+                            "associated constant",
                         )
                     })
                 })
@@ -359,7 +364,14 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<Ty
             }
             ImplItemKind::Const(ty, body_id) => {
                 if is_suggestable_infer_ty(ty) {
-                    infer_placeholder_type(tcx, def_id, body_id, ty.span, item.ident, "constant")
+                    infer_placeholder_type(
+                        tcx,
+                        def_id,
+                        body_id,
+                        ty.span,
+                        item.ident,
+                        "associated constant",
+                    )
                 } else {
                     icx.to_ty(ty)
                 }

--- a/tests/ui/associated-consts/infer-placeholder-in-non-suggestable-pos.rs
+++ b/tests/ui/associated-consts/infer-placeholder-in-non-suggestable-pos.rs
@@ -1,0 +1,10 @@
+trait Trait {
+    const ASSOC: i32;
+}
+
+impl Trait for () {
+    const ASSOC: &dyn Fn(_) = 1i32;
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
+}
+
+fn main() {}

--- a/tests/ui/associated-consts/infer-placeholder-in-non-suggestable-pos.stderr
+++ b/tests/ui/associated-consts/infer-placeholder-in-non-suggestable-pos.stderr
@@ -1,0 +1,9 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/infer-placeholder-in-non-suggestable-pos.rs:6:26
+   |
+LL |     const ASSOC: &dyn Fn(_) = 1i32;
+   |                          ^ not allowed in type signatures
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.rs
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.rs
@@ -33,15 +33,15 @@ static TY_STATIC_MIXED: Bar<_, _> = Bar::<i32, 3>(0);
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for static variables
 trait ArrAssocConst {
     const ARR: [u8; _];
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
 }
 trait TyAssocConst {
     const ARR: Bar<i32, _>;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
 }
 trait TyAssocConstMixed {
     const ARR: Bar<_, _>;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
 }
 
 trait AssocTy {

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
@@ -74,19 +74,19 @@ LL | static TY_STATIC_MIXED: Bar<_, _> = Bar::<i32, 3>(0);
    |                         not allowed in type signatures
    |                         help: replace with the correct type: `Bar<i32, 3>`
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/in-signature.rs:35:21
    |
 LL |     const ARR: [u8; _];
    |                     ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/in-signature.rs:39:25
    |
 LL |     const ARR: Bar<i32, _>;
    |                         ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/in-signature.rs:43:20
    |
 LL |     const ARR: Bar<_, _>;

--- a/tests/ui/typeck/type-placeholder-fn-in-const.rs
+++ b/tests/ui/typeck/type-placeholder-fn-in-const.rs
@@ -3,12 +3,13 @@ struct MyStruct;
 trait Test {
     const TEST: fn() -> _;
     //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions [E0121]
-    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for constants [E0121]
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
 }
 
 impl Test for MyStruct {
     const TEST: fn() -> _ = 42;
     //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions [E0121]
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
 }
 
 fn main() {}

--- a/tests/ui/typeck/type-placeholder-fn-in-const.stderr
+++ b/tests/ui/typeck/type-placeholder-fn-in-const.stderr
@@ -4,7 +4,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     const TEST: fn() -> _;
    |                         ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/type-placeholder-fn-in-const.rs:4:25
    |
 LL |     const TEST: fn() -> _;
@@ -16,6 +16,12 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     const TEST: fn() -> _ = 42;
    |                         ^ not allowed in type signatures
 
-error: aborting due to 3 previous errors
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/type-placeholder-fn-in-const.rs:10:25
+   |
+LL |     const TEST: fn() -> _ = 42;
+   |                         ^ not allowed in type signatures
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -190,9 +190,9 @@ trait Qux {
     type B = _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
     const C: _;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
     const D: _ = 42;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
     // type E: _; // FIXME: make the parser propagate the existence of `B`
     type F: std::ops::Fn(_);
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
@@ -203,10 +203,10 @@ impl Qux for Struct {
     type B = _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
     const C: _;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
     //~| ERROR associated constant in `impl` without body
     const D: _ = 42;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
 }
 
 fn map<T>(_: fn() -> Option<&'static T>) -> Option<T> {

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -525,13 +525,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/typeck_type_placeholder_item.rs:192:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/typeck_type_placeholder_item.rs:194:14
    |
 LL |     const D: _ = 42;
@@ -642,13 +642,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/typeck_type_placeholder_item.rs:205:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/typeck_type_placeholder_item.rs:208:14
    |
 LL |     const D: _ = 42;

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -16,14 +16,14 @@ const TEST4: fn() -> _ = 42;
 
 trait Test5 {
     const TEST5: _ = 42;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
 }
 
 struct Test6;
 
 impl Test6 {
     const TEST6: _ = 13;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
 }
 
 pub fn main() {

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -37,7 +37,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/typeck_type_placeholder_item_help.rs:18:18
    |
 LL |     const TEST5: _ = 42;
@@ -46,7 +46,7 @@ LL |     const TEST5: _ = 42;
    |                  not allowed in type signatures
    |                  help: replace with the correct type: `i32`
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/typeck_type_placeholder_item_help.rs:25:18
    |
 LL |     const TEST6: _ = 13;


### PR DESCRIPTION
We only reported an error if it was in a "suggestable" position (according to `is_suggestable_infer_ty`) -- this isn't correct for infer tys that can show up in other places in the constant's type, like behind a dyn trait.

fixes #112491