### PR TITLE
Increase the precision of the exportable MIR check

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1554,6 +1554,13 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             self.tables.unused_generic_params.set(def_id.local_def_index, unused);
         }
 
+        // Encode promoted_mir for all functions that we inlined
+        let prev_len = tcx.inlined_internal_defs.lock().len();
+        for def_id in tcx.inlined_internal_defs.lock().clone() {
+            record!(self.tables.promoted_mir[def_id.to_def_id()] <- tcx.promoted_mir(def_id));
+        }
+        assert_eq!(tcx.inlined_internal_defs.lock().len(), prev_len);
+
         // Encode all the deduced parameter attributes for everything that has MIR, even for items
         // that can't be inlined. But don't if we aren't optimizing in non-incremental mode, to
         // save the query traffic.

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -558,6 +558,8 @@ pub struct GlobalCtxt<'tcx> {
 
     /// Stores memory for globals (statics/consts).
     pub(crate) alloc_map: Lock<interpret::AllocMap<'tcx>>,
+
+    pub inlined_internal_defs: Lock<FxHashSet<LocalDefId>>,
 }
 
 impl<'tcx> GlobalCtxt<'tcx> {
@@ -706,6 +708,7 @@ impl<'tcx> TyCtxt<'tcx> {
             new_solver_evaluation_cache: Default::default(),
             data_layout,
             alloc_map: Lock::new(interpret::AllocMap::new()),
+            inlined_internal_defs: Default::default(),
         }
     }
 

--- a/tests/codegen-units/item-collection/items-within-generic-items.rs
+++ b/tests/codegen-units/item-collection/items-within-generic-items.rs
@@ -3,6 +3,7 @@
 #![deny(dead_code)]
 #![feature(start)]
 
+#[inline(never)]
 fn generic_fn<T>(a: T) -> (T, i32) {
     //~ MONO_ITEM fn generic_fn::nested_fn
     fn nested_fn(a: i32) -> i32 {

--- a/tests/codegen/call-metadata.rs
+++ b/tests/codegen/call-metadata.rs
@@ -12,6 +12,7 @@ pub fn test() {
 }
 
 #[no_mangle]
+#[inline(never)]
 fn some_true() -> Option<bool> {
     Some(true)
 }

--- a/tests/codegen/cold-call-declare-and-call.rs
+++ b/tests/codegen/cold-call-declare-and-call.rs
@@ -9,6 +9,7 @@
 // CHECK: call coldcc void @this_should_never_happen(i16
 
 #[no_mangle]
+#[inline(never)]
 pub extern "rust-cold" fn this_should_never_happen(x: u16) {}
 
 pub fn do_things(x: u16) {

--- a/tests/codegen/drop.rs
+++ b/tests/codegen/drop.rs
@@ -11,6 +11,7 @@ impl Drop for SomeUniqueName {
     }
 }
 
+#[inline(never)]
 pub fn possibly_unwinding() {
 }
 

--- a/tests/codegen/personality_lifetimes.rs
+++ b/tests/codegen/personality_lifetimes.rs
@@ -13,6 +13,7 @@ impl Drop for S {
     }
 }
 
+#[inline(never)]
 fn might_unwind() {
 }
 

--- a/tests/codegen/target-cpu-on-functions.rs
+++ b/tests/codegen/target-cpu-on-functions.rs
@@ -15,7 +15,8 @@ pub extern "C" fn exported() {
 
 // CHECK-LABEL: ; target_cpu_on_functions::not_exported
 // CHECK-NEXT: ; Function Attrs:
-// CHECK-NEXT: define {{.*}}() {{.*}} #0
+// CHECK-NEXT: define {{.*}}() {{.*}} #1
+#[inline(never)]
 fn not_exported() {}
 
 // CHECK: attributes #0 = {{.*}} "target-cpu"="{{.*}}"

--- a/tests/codegen/tune-cpu-on-functions.rs
+++ b/tests/codegen/tune-cpu-on-functions.rs
@@ -15,7 +15,8 @@ pub extern fn exported() {
 
 // CHECK-LABEL: ; tune_cpu_on_functions::not_exported
 // CHECK-NEXT: ; Function Attrs:
-// CHECK-NEXT: define {{.*}}() {{.*}} #0
+// CHECK-NEXT: define {{.*}}() {{.*}} #1
+#[inline(never)]
 fn not_exported() {}
 
 // CHECK: attributes #0 = {{.*}} "tune-cpu"="{{.*}}"

--- a/tests/incremental/hashes/let_expressions.rs
+++ b/tests/incremental/hashes/let_expressions.rs
@@ -142,9 +142,9 @@ pub fn add_ref_in_pattern() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir,promoted_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir,promoted_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_ref_in_pattern() {
     let (ref _a, _b) = (1u8, 'y');

--- a/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-abort.diff
@@ -3,17 +3,42 @@
   
   fn main() -> () {
       let mut _0: ();
-      let _1: ();
-      let mut _2: ((), u8, u8);
+      let mut _5: ();
+      let mut _6: u8;
+      let mut _7: u8;
+      scope 1 (inlined encode) {
+          debug this => ((), u8, u8){ .0 => _5, .1 => _6, .2 => _7, };
+          let mut _1: bool;
+          let mut _2: bool;
+          let mut _3: u8;
+          let mut _4: !;
+      }
   
       bb0: {
+          StorageLive(_5);
+          StorageLive(_6);
+          _5 = const ();
+          _6 = const 0_u8;
+          _7 = const 0_u8;
+          StorageLive(_1);
           StorageLive(_2);
-          _2 = (const (), const 0_u8, const 0_u8);
-          _1 = encode(move _2) -> [return: bb1, unwind unreachable];
+-         _2 = Eq(_7, const 0_u8);
+-         _1 = Not(move _2);
++         _2 = const true;
++         _1 = const false;
+          StorageDead(_2);
+-         switchInt(move _1) -> [0: bb2, otherwise: bb1];
++         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-          StorageDead(_2);
+          _4 = core::panicking::panic(const "assertion failed: this.2 == 0") -> unwind unreachable;
+      }
+  
+      bb2: {
+          StorageDead(_1);
+          StorageDead(_5);
+          StorageDead(_6);
           return;
       }
   }

--- a/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-unwind.diff
@@ -3,17 +3,42 @@
   
   fn main() -> () {
       let mut _0: ();
-      let _1: ();
-      let mut _2: ((), u8, u8);
+      let mut _5: ();
+      let mut _6: u8;
+      let mut _7: u8;
+      scope 1 (inlined encode) {
+          debug this => ((), u8, u8){ .0 => _5, .1 => _6, .2 => _7, };
+          let mut _1: bool;
+          let mut _2: bool;
+          let mut _3: u8;
+          let mut _4: !;
+      }
   
       bb0: {
+          StorageLive(_5);
+          StorageLive(_6);
+          _5 = const ();
+          _6 = const 0_u8;
+          _7 = const 0_u8;
+          StorageLive(_1);
           StorageLive(_2);
-          _2 = (const (), const 0_u8, const 0_u8);
-          _1 = encode(move _2) -> bb1;
+-         _2 = Eq(_7, const 0_u8);
+-         _1 = Not(move _2);
++         _2 = const true;
++         _1 = const false;
+          StorageDead(_2);
+-         switchInt(move _1) -> [0: bb2, otherwise: bb1];
++         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-          StorageDead(_2);
+          _4 = core::panicking::panic(const "assertion failed: this.2 == 0");
+      }
+  
+      bb2: {
+          StorageDead(_1);
+          StorageDead(_5);
+          StorageDead(_6);
           return;
       }
   }

--- a/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-abort.diff
@@ -3,22 +3,38 @@
   
   fn main() -> () {
       let mut _0: ();
-      let _1: ();
-      let mut _2: ((u8, u8),);
-      let mut _3: (u8, u8);
+      let mut _5: u8;
+      let mut _6: u8;
+      let mut _7: u8;
+      let mut _8: u8;
+      scope 1 (inlined test) {
+          debug this => ((u8, u8),){ .0.0 => _7, .0.1 => _8, };
+          let mut _1: bool;
+          let mut _2: bool;
+          let mut _3: u8;
+          let mut _4: !;
+      }
   
       bb0: {
+          _7 = const 1_u8;
+          _8 = const 2_u8;
+          StorageLive(_1);
           StorageLive(_2);
-          StorageLive(_3);
--         _3 = (const 1_u8, const 2_u8);
-+         _3 = const (1_u8, 2_u8);
-          _2 = (move _3,);
-          StorageDead(_3);
-          _1 = test(move _2) -> [return: bb1, unwind unreachable];
+-         _2 = Eq(_7, const 1_u8);
+-         _1 = Not(move _2);
++         _2 = const true;
++         _1 = const false;
+          StorageDead(_2);
+-         switchInt(move _1) -> [0: bb2, otherwise: bb1];
++         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-          StorageDead(_2);
+          _4 = core::panicking::panic(const "assertion failed: (this.0).0 == 1") -> unwind unreachable;
+      }
+  
+      bb2: {
+          StorageDead(_1);
           return;
       }
   }

--- a/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-unwind.diff
@@ -3,22 +3,38 @@
   
   fn main() -> () {
       let mut _0: ();
-      let _1: ();
-      let mut _2: ((u8, u8),);
-      let mut _3: (u8, u8);
+      let mut _5: u8;
+      let mut _6: u8;
+      let mut _7: u8;
+      let mut _8: u8;
+      scope 1 (inlined test) {
+          debug this => ((u8, u8),){ .0.0 => _7, .0.1 => _8, };
+          let mut _1: bool;
+          let mut _2: bool;
+          let mut _3: u8;
+          let mut _4: !;
+      }
   
       bb0: {
+          _7 = const 1_u8;
+          _8 = const 2_u8;
+          StorageLive(_1);
           StorageLive(_2);
-          StorageLive(_3);
--         _3 = (const 1_u8, const 2_u8);
-+         _3 = const (1_u8, 2_u8);
-          _2 = (move _3,);
-          StorageDead(_3);
-          _1 = test(move _2) -> bb1;
+-         _2 = Eq(_7, const 1_u8);
+-         _1 = Not(move _2);
++         _2 = const true;
++         _1 = const false;
+          StorageDead(_2);
+-         switchInt(move _1) -> [0: bb2, otherwise: bb1];
++         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-          StorageDead(_2);
+          _4 = core::panicking::panic(const "assertion failed: (this.0).0 == 1");
+      }
+  
+      bb2: {
+          StorageDead(_1);
           return;
       }
   }

--- a/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-abort.diff
+++ b/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-abort.diff
@@ -4,27 +4,19 @@
   fn main() -> () {
       let mut _0: ();
       let _1: main::Un;
-      let mut _2: u32;
-      let mut _3: u32;
       scope 1 {
           debug un => _1;
           scope 2 {
           }
-          scope 3 (inlined std::mem::drop::<u32>) {
-              debug _x => _3;
+          scope 4 (inlined std::mem::drop::<u32>) {
+              debug _x => const 1_u32;
           }
+      }
+      scope 3 (inlined val) {
       }
   
       bb0: {
           StorageLive(_1);
-          StorageLive(_2);
-          _2 = val() -> [return: bb1, unwind unreachable];
-      }
-  
-      bb1: {
-          StorageDead(_2);
-          StorageLive(_3);
-          StorageDead(_3);
           StorageDead(_1);
           return;
       }

--- a/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-unwind.diff
@@ -4,27 +4,19 @@
   fn main() -> () {
       let mut _0: ();
       let _1: main::Un;
-      let mut _2: u32;
-      let mut _3: u32;
       scope 1 {
           debug un => _1;
           scope 2 {
           }
-          scope 3 (inlined std::mem::drop::<u32>) {
-              debug _x => _3;
+          scope 4 (inlined std::mem::drop::<u32>) {
+              debug _x => const 1_u32;
           }
+      }
+      scope 3 (inlined val) {
       }
   
       bb0: {
           StorageLive(_1);
-          StorageLive(_2);
-          _2 = val() -> bb1;
-      }
-  
-      bb1: {
-          StorageDead(_2);
-          StorageLive(_3);
-          StorageDead(_3);
           StorageDead(_1);
           return;
       }

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.panic-abort.diff
@@ -4,13 +4,13 @@
   fn outer() -> usize {
       let mut _0: usize;
 +     scope 1 (inlined inner) {
-+         let mut _1: &[bool; 1];
-+         let mut _2: bool;
-+         let mut _3: bool;
 +         scope 2 {
 +             debug buffer => const _;
++             let _1: usize;
 +             scope 3 {
-+                 debug index => _0;
++                 debug index => _1;
++             }
++             scope 4 (inlined index) {
 +             }
 +         }
 +     }
@@ -18,30 +18,12 @@
       bb0: {
 -         _0 = inner() -> [return: bb1, unwind unreachable];
 +         StorageLive(_1);
-+         _1 = const _;
-+         _0 = index() -> [return: bb1, unwind unreachable];
++         goto -> bb1;
       }
   
       bb1: {
-+         StorageLive(_3);
-+         _2 = Lt(_0, const 1_usize);
-+         assert(move _2, "index out of bounds: the length is {} but the index is {}", const 1_usize, _0) -> [success: bb2, unwind unreachable];
-+     }
-+ 
-+     bb2: {
-+         _3 = (*_1)[_0];
-+         switchInt(move _3) -> [0: bb3, otherwise: bb4];
-+     }
-+ 
-+     bb3: {
-+         _0 = const 0_usize;
-+         goto -> bb4;
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_3);
-+         StorageDead(_1);
-          return;
+-         return;
++         goto -> bb1;
       }
   }
   

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
@@ -4,13 +4,13 @@
   fn outer() -> usize {
       let mut _0: usize;
 +     scope 1 (inlined inner) {
-+         let mut _1: &[bool; 1];
-+         let mut _2: bool;
-+         let mut _3: bool;
 +         scope 2 {
 +             debug buffer => const _;
++             let _1: usize;
 +             scope 3 {
-+                 debug index => _0;
++                 debug index => _1;
++             }
++             scope 4 (inlined index) {
 +             }
 +         }
 +     }
@@ -18,30 +18,12 @@
       bb0: {
 -         _0 = inner() -> bb1;
 +         StorageLive(_1);
-+         _1 = const _;
-+         _0 = index() -> bb1;
++         goto -> bb1;
       }
   
       bb1: {
-+         StorageLive(_3);
-+         _2 = Lt(_0, const 1_usize);
-+         assert(move _2, "index out of bounds: the length is {} but the index is {}", const 1_usize, _0) -> bb2;
-+     }
-+ 
-+     bb2: {
-+         _3 = (*_1)[_0];
-+         switchInt(move _3) -> [0: bb3, otherwise: bb4];
-+     }
-+ 
-+     bb3: {
-+         _0 = const 0_usize;
-+         goto -> bb4;
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_3);
-+         StorageDead(_1);
-          return;
+-         return;
++         goto -> bb1;
       }
   }
   

--- a/tests/mir-opt/inline/issue_78442.bar.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/issue_78442.bar.Inline.panic-abort.diff
@@ -8,40 +8,40 @@
       let mut _3: &fn() {foo};
       let _4: fn() {foo};
       let mut _5: ();
-+     scope 1 (inlined <fn() {foo} as Fn<()>>::call - shim(fn() {foo})) {
++     scope 1 (inlined hide_foo) {
++     }
++     scope 2 (inlined <fn() {foo} as Fn<()>>::call - shim(fn() {foo})) {
++         scope 3 (inlined foo) {
++         }
 +     }
   
       bb0: {
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _4 = hide_foo() -> [return: bb1, unwind unreachable];
-      }
-  
-      bb1: {
+-         _4 = hide_foo() -> [return: bb1, unwind unreachable];
+-     }
+- 
+-     bb1: {
           _3 = &_4;
           StorageLive(_5);
           _5 = ();
 -         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind unreachable];
-+         _2 = move (*_3)() -> [return: bb3, unwind unreachable];
-      }
-  
-      bb2: {
-+         return;
-+     }
-+ 
-+     bb3: {
+-     }
+- 
+-     bb2: {
           StorageDead(_5);
           StorageDead(_3);
           StorageDead(_4);
           StorageDead(_2);
           _0 = const ();
 -         drop(_1) -> [return: bb3, unwind unreachable];
--     }
-- 
++         drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
 -     bb3: {
--         return;
-+         drop(_1) -> [return: bb2, unwind unreachable];
++     bb1: {
+          return;
       }
   }
   

--- a/tests/mir-opt/inline/issue_78442.bar.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_78442.bar.Inline.panic-unwind.diff
@@ -8,7 +8,11 @@
       let mut _3: &fn() {foo};
       let _4: fn() {foo};
       let mut _5: ();
-+     scope 1 (inlined <fn() {foo} as Fn<()>>::call - shim(fn() {foo})) {
++     scope 1 (inlined hide_foo) {
++     }
++     scope 2 (inlined <fn() {foo} as Fn<()>>::call - shim(fn() {foo})) {
++         scope 3 (inlined foo) {
++         }
 +     }
   
       bb0: {
@@ -16,47 +20,37 @@
           StorageLive(_3);
           StorageLive(_4);
 -         _4 = hide_foo() -> [return: bb1, unwind: bb4];
-+         _4 = hide_foo() -> [return: bb1, unwind: bb3];
-      }
-  
-      bb1: {
+-     }
+- 
+-     bb1: {
           _3 = &_4;
           StorageLive(_5);
           _5 = ();
 -         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4];
-+         _2 = move (*_3)() -> [return: bb5, unwind: bb3];
-      }
-  
-      bb2: {
--         StorageDead(_5);
--         StorageDead(_3);
--         StorageDead(_4);
--         StorageDead(_2);
--         _0 = const ();
+-     }
+- 
+-     bb2: {
+          StorageDead(_5);
+          StorageDead(_3);
+          StorageDead(_4);
+          StorageDead(_2);
+          _0 = const ();
 -         drop(_1) -> [return: bb3, unwind: bb5];
-+         return;
++         drop(_1) -> [return: bb1, unwind: bb2];
       }
   
 -     bb3: {
--         return;
-+     bb3 (cleanup): {
-+         drop(_1) -> [return: bb4, unwind terminate];
++     bb1: {
+          return;
       }
   
-      bb4 (cleanup): {
+-     bb4 (cleanup): {
 -         drop(_1) -> [return: bb5, unwind terminate];
-+         resume;
-      }
-  
+-     }
+- 
 -     bb5 (cleanup): {
--         resume;
-+     bb5: {
-+         StorageDead(_5);
-+         StorageDead(_3);
-+         StorageDead(_4);
-+         StorageDead(_2);
-+         _0 = const ();
-+         drop(_1) -> [return: bb2, unwind: bb4];
++     bb2 (cleanup): {
+          resume;
       }
   }
   

--- a/tests/mir-opt/inline/private_helper.outer.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/private_helper.outer.Inline.panic-abort.diff
@@ -1,0 +1,18 @@
+- // MIR for `outer` before Inline
++ // MIR for `outer` after Inline
+  
+  fn outer() -> u8 {
+      let mut _0: u8;
+- 
+-     bb0: {
+-         _0 = helper() -> [return: bb1, unwind unreachable];
++     scope 1 (inlined helper) {
+      }
+  
+-     bb1: {
++     bb0: {
++         _0 = const 123_u8;
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/inline/private_helper.outer.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/private_helper.outer.Inline.panic-unwind.diff
@@ -1,0 +1,18 @@
+- // MIR for `outer` before Inline
++ // MIR for `outer` after Inline
+  
+  fn outer() -> u8 {
+      let mut _0: u8;
+- 
+-     bb0: {
+-         _0 = helper() -> bb1;
++     scope 1 (inlined helper) {
+      }
+  
+-     bb1: {
++     bb0: {
++         _0 = const 123_u8;
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/inline/private_helper.rs
+++ b/tests/mir-opt/inline/private_helper.rs
@@ -1,0 +1,13 @@
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+// compile-flags: -Zmir-opt-level=2 -Zinline-mir
+
+#![crate_type = "lib"]
+
+// EMIT_MIR private_helper.outer.Inline.diff
+pub fn outer() -> u8 {
+    helper()
+}
+
+fn helper() -> u8 {
+    123
+}

--- a/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-abort.mir
@@ -3,17 +3,12 @@
 fn outer(_1: u8) -> u8 {
     debug v => _1;                       // in scope 0 at $DIR/spans.rs:10:14: 10:15
     let mut _0: u8;                      // return place in scope 0 at $DIR/spans.rs:10:24: 10:26
-    let _2: &u8;                         // in scope 0 at $DIR/spans.rs:11:11: 11:13
-
-    bb0: {
-        _2 = &_1;                        // scope 0 at $DIR/spans.rs:11:11: 11:13
-        _0 = inner(_2) -> [return: bb1, unwind unreachable]; // scope 0 at $DIR/spans.rs:11:5: 11:14
-                                         // mir::Constant
-                                         // + span: $DIR/spans.rs:11:5: 11:10
-                                         // + literal: Const { ty: for<'a> fn(&'a u8) -> u8 {inner}, val: Value(<ZST>) }
+    scope 1 (inlined inner) {            // at $DIR/spans.rs:11:5: 11:14
+        debug x => &_1;                  // in scope 1 at $DIR/spans.rs:14:14: 14:15
     }
 
-    bb1: {
+    bb0: {
+        _0 = _1;                         // scope 1 at $DIR/spans.rs:15:5: 15:7
         return;                          // scope 0 at $DIR/spans.rs:12:2: 12:2
     }
 }

--- a/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-unwind.mir
@@ -3,17 +3,12 @@
 fn outer(_1: u8) -> u8 {
     debug v => _1;                       // in scope 0 at $DIR/spans.rs:10:14: 10:15
     let mut _0: u8;                      // return place in scope 0 at $DIR/spans.rs:10:24: 10:26
-    let _2: &u8;                         // in scope 0 at $DIR/spans.rs:11:11: 11:13
-
-    bb0: {
-        _2 = &_1;                        // scope 0 at $DIR/spans.rs:11:11: 11:13
-        _0 = inner(_2) -> bb1;           // scope 0 at $DIR/spans.rs:11:5: 11:14
-                                         // mir::Constant
-                                         // + span: $DIR/spans.rs:11:5: 11:10
-                                         // + literal: Const { ty: for<'a> fn(&'a u8) -> u8 {inner}, val: Value(<ZST>) }
+    scope 1 (inlined inner) {            // at $DIR/spans.rs:11:5: 11:14
+        debug x => &_1;                  // in scope 1 at $DIR/spans.rs:14:14: 14:15
     }
 
-    bb1: {
+    bb0: {
+        _0 = _1;                         // scope 1 at $DIR/spans.rs:15:5: 15:7
         return;                          // scope 0 at $DIR/spans.rs:12:2: 12:2
     }
 }

--- a/tests/mir-opt/while_storage.while_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/while_storage.while_loop.PreCodegen.after.panic-abort.mir
@@ -3,44 +3,26 @@
 fn while_loop(_1: bool) -> () {
     debug c => _1;
     let mut _0: ();
-    let mut _2: bool;
-    let mut _3: bool;
+    scope 1 (inlined get_bool) {
+        debug c => _1;
+    }
+    scope 2 (inlined get_bool) {
+        debug c => _1;
+    }
 
     bb0: {
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_2);
-        _2 = get_bool(_1) -> [return: bb2, unwind unreachable];
+        switchInt(_1) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
-        switchInt(move _2) -> [0: bb7, otherwise: bb3];
+        switchInt(_1) -> [0: bb1, otherwise: bb3];
     }
 
     bb3: {
-        StorageLive(_3);
-        _3 = get_bool(_1) -> [return: bb4, unwind unreachable];
-    }
-
-    bb4: {
-        switchInt(move _3) -> [0: bb5, otherwise: bb6];
-    }
-
-    bb5: {
-        StorageDead(_3);
-        StorageDead(_2);
-        goto -> bb1;
-    }
-
-    bb6: {
-        StorageDead(_3);
-        goto -> bb7;
-    }
-
-    bb7: {
-        StorageDead(_2);
         return;
     }
 }

--- a/tests/mir-opt/while_storage.while_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/while_storage.while_loop.PreCodegen.after.panic-unwind.mir
@@ -3,44 +3,26 @@
 fn while_loop(_1: bool) -> () {
     debug c => _1;
     let mut _0: ();
-    let mut _2: bool;
-    let mut _3: bool;
+    scope 1 (inlined get_bool) {
+        debug c => _1;
+    }
+    scope 2 (inlined get_bool) {
+        debug c => _1;
+    }
 
     bb0: {
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_2);
-        _2 = get_bool(_1) -> bb2;
+        switchInt(_1) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
-        switchInt(move _2) -> [0: bb7, otherwise: bb3];
+        switchInt(_1) -> [0: bb1, otherwise: bb3];
     }
 
     bb3: {
-        StorageLive(_3);
-        _3 = get_bool(_1) -> bb4;
-    }
-
-    bb4: {
-        switchInt(move _3) -> [0: bb5, otherwise: bb6];
-    }
-
-    bb5: {
-        StorageDead(_3);
-        StorageDead(_2);
-        goto -> bb1;
-    }
-
-    bb6: {
-        StorageDead(_3);
-        goto -> bb7;
-    }
-
-    bb7: {
-        StorageDead(_2);
         return;
     }
 }

--- a/tests/ui/mir/auxiliary/tricky_mir.rs
+++ b/tests/ui/mir/auxiliary/tricky_mir.rs
@@ -1,0 +1,48 @@
+// compile-flags: -Zmir-opt-level=2 -Zinline-mir
+
+#![crate_type = "lib"]
+
+// get_static is a good inlining candidate.
+// But it calls a private function that is a good inlining candidate, which also accesses a private
+// static.
+// If we naivelly inline all of this away in MIR, we will reference a private static from this
+// crate while compiling another crate, which will produce a linker error.
+
+#[inline]
+pub fn get_static() -> &'static u8 {
+    get_static_impl()
+}
+
+fn get_static_impl() -> &'static u8 {
+    static THING: u8 = 0;
+    &THING
+}
+
+// This is the same as the get_static test, except that here we reference a local function. If we
+// mishandle this we will ICE or get a linker error because the private non-exported function will
+// get pulled into the other crate.
+
+#[inline]
+pub fn get_fn_ptr() -> u8 {
+    wrapper()()
+}
+
+fn wrapper() -> fn() -> u8 {
+    inner
+}
+
+fn inner() -> u8 {
+    123
+}
+
+// Same as the get_static test, but with a promoted const. In this case, we can just generate MIR
+// for all promoted consts, and permit the inlining to happen.
+
+#[inline]
+pub fn get_promoted_const() -> &'static u8 {
+   inner_promoted_const()
+}
+
+fn inner_promoted_const() -> &'static u8 {
+    &0
+}

--- a/tests/ui/mir/private-const.rs
+++ b/tests/ui/mir/private-const.rs
@@ -1,0 +1,9 @@
+// run-pass
+// compile-flags: -Zmir-opt-level=2 -Zinline-mir
+// aux-build:tricky_mir.rs
+
+extern crate tricky_mir;
+
+fn main() {
+    println!("{:?}", tricky_mir::get_promoted_const());
+}

--- a/tests/ui/mir/private-fn-ptr.rs
+++ b/tests/ui/mir/private-fn-ptr.rs
@@ -1,0 +1,9 @@
+// run-pass
+// compile-flags: -Zmir-opt-level=2 -Zinline-mir
+// aux-build:tricky_mir.rs
+
+extern crate tricky_mir;
+
+fn main() {
+    println!("{}", tricky_mir::get_fn_ptr());
+}

--- a/tests/ui/mir/private-static.rs
+++ b/tests/ui/mir/private-static.rs
@@ -1,0 +1,9 @@
+// run-pass
+// compile-flags: -Zmir-opt-level=2 -Zinline-mir
+// aux-build:tricky_mir.rs
+
+extern crate tricky_mir;
+
+fn main() {
+    println!("{}", *tricky_mir::get_static());
+}


### PR DESCRIPTION
Before this PR, MIR inlining only inlines across crates or within a crate if the callee is a constructor, `#[inline]`, or generic. This misses some inlining opportunities within a crate; trivial helper functions are not always given `#[inline]` (and maybe that's a good thing).

The reason we were so conservative before is that the MIR inliner needs to not drag MIR which mentions items that we did not generate MIR for, or items that we have given internal linkage, into bodies that we must generate MIR for. If we get this heuristic wrong, we see ICEs (for promoted consts without MIR) or linker errors (for private functions and statics now mentioned in exported MIR). So this PR adds more fine-grained analysis to detect callee bodies that contain MIR we must not export.

Perhaps even better, this PR removes any prohibition on inlining not-exported bodies into other not-exported bodies.