### PR TITLE
cg_llvm: use index-based loop in write_operand_repeatedly

### DIFF
--- a/tests/codegen/issues/issue-111603.rs
+++ b/tests/codegen/issues/issue-111603.rs
@@ -5,6 +5,18 @@
 
 use std::sync::Arc;
 
+// CHECK-LABEL: @new_from_array
+#[no_mangle]
+pub fn new_from_array(x: u64) -> Arc<[u64]> {
+    // Ensure that we only generate one alloca for the array.
+
+    // CHECK: alloca
+    // CHECK-SAME: [1000 x i64]
+    // CHECK-NOT: alloca
+    let array = [x; 1000];
+    Arc::new(array)
+}
+
 // CHECK-LABEL: @new_uninit
 #[no_mangle]
 pub fn new_uninit(x: u64) -> Arc<[u64; 1000]> {


### PR DESCRIPTION
This should be easier for LLVM to analyze.

Fixes #111603

This needs a perf run.

[cc](https://github.com/rust-lang/rust/issues/111603#issuecomment-1567531178) @caojoshua