### PR TITLE
bootstrap: Don't override `debuginfo-level = 1` to mean `line-tables-only`

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1649,12 +1649,7 @@ impl<'a> Builder<'a> {
                 self.config.rust_debuginfo_level_tools
             }
         };
-        if debuginfo_level == 1 {
-            // Use less debuginfo than the default to save on disk space.
-            cargo.env(profile_var("DEBUG"), "line-tables-only");
-        } else {
-            cargo.env(profile_var("DEBUG"), debuginfo_level.to_string());
-        };
+        cargo.env(profile_var("DEBUG"), debuginfo_level.to_string());
         if self.cc[&target].args().iter().any(|arg| arg == "-gz") {
             rustflags.arg("-Clink-arg=-gz");
         }


### PR DESCRIPTION
This has real differences in the effective debuginfo: in particular, it omits the module-level information and makes perf less useful (it can't distinguish "self" from "child" time anymore).

Allow passing `line-tables-only` directly in config.toml instead.

See https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/debuginfo.20in.20try.20builds/near/365090631 and https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bsteering.5D.202023-06-09/near/364883519 for more discussion. This effectively reverts the cargo half of https://github.com/rust-lang/rust/pull/110221 to avoid regressing https://github.com/rust-lang/rust/issues/60020 again in 1.72.