### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -510,6 +510,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ..
                 } = self.type_var_origin(expected)? else { return None; };
 
+                let Some(rpit_local_def_id) = rpit_def_id.as_local() else { return None; };
+                if !matches!(
+                    self.tcx.hir().expect_item(rpit_local_def_id).expect_opaque_ty().origin,
+                    hir::OpaqueTyOrigin::FnReturn(..)
+                ) {
+                    return None;
+                }
+
                 let sig = self.body_fn_sig()?;
 
                 let substs = sig.output().walk().find_map(|arg| {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1649,12 +1649,7 @@ impl<'a> Builder<'a> {
                 self.config.rust_debuginfo_level_tools
             }
         };
-        if debuginfo_level == 1 {
-            // Use less debuginfo than the default to save on disk space.
-            cargo.env(profile_var("DEBUG"), "line-tables-only");
-        } else {
-            cargo.env(profile_var("DEBUG"), debuginfo_level.to_string());
-        };
+        cargo.env(profile_var("DEBUG"), debuginfo_level.to_string());
         if self.cc[&target].args().iter().any(|arg| arg == "-gz") {
             rustflags.arg("-Clink-arg=-gz");
         }

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -9,6 +9,8 @@ debug-logging = true
 incremental = true
 # Download rustc from CI instead of building it from source.
 # This cuts compile times by almost 60x, but means you can't modify the compiler.
+# Using these defaults will download the stage2 compiler (see `download-rustc`
+# setting) and the stage2 toolchain should therefore be used for these defaults.
 download-rustc = "if-unchanged"
 
 [build]

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -176,6 +176,14 @@ pub fn setup(config: &Config, profile: Profile) {
         );
     }
 
+    if profile == Profile::Tools {
+        eprintln!();
+        eprintln!(
+            "note: the `tools` profile sets up the `stage2` toolchain (use \
+            `rustup toolchain link 'name' host/build/stage2` to use rustc)"
+        )
+    }
+
     let path = &config.config.clone().unwrap_or(PathBuf::from("config.toml"));
     setup_config_toml(path, profile, config);
 }

--- a/tests/ui/impl-trait/dont-suggest-box-on-empty-else-arm.rs
+++ b/tests/ui/impl-trait/dont-suggest-box-on-empty-else-arm.rs
@@ -1,0 +1,9 @@
+fn test() -> impl std::fmt::Debug {
+    if true {
+        "boo2"
+    } else {
+        //~^ ERROR `if` and `else` have incompatible types
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/dont-suggest-box-on-empty-else-arm.stderr
+++ b/tests/ui/impl-trait/dont-suggest-box-on-empty-else-arm.stderr
@@ -1,0 +1,16 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/dont-suggest-box-on-empty-else-arm.rs:4:12
+   |
+LL |       if true {
+   |       ------- `if` and `else` have incompatible types
+LL |           "boo2"
+   |           ------ expected because of this
+LL |       } else {
+   |  ____________^
+LL | |
+LL | |     }
+   | |_____^ expected `&str`, found `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #112487 (Update documentation for `tools` defaults)
 - #112513 (Dont compute `opt_suggest_box_span` span for TAIT)
 - #112528 (bootstrap: Don't override `debuginfo-level = 1` to mean `line-tables-only`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112487,112513,112528)
<!-- homu-ignore:end -->