### PR TITLE
Rename Error::provide to Error::provide_context

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2966,7 +2966,7 @@ impl<T: core::error::Error + ?Sized> core::error::Error for Arc<T> {
         core::error::Error::source(&**self)
     }
 
-    fn provide<'a>(&'a self, req: &mut core::any::Demand<'a>) {
-        core::error::Error::provide(&**self, req);
+    fn provide_context<'a>(&'a self, req: &mut core::any::Demand<'a>) {
+        core::error::Error::provide_context(&**self, req);
     }
 }

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -172,7 +172,7 @@ pub trait Error: Debug + Display {
     /// }
     ///
     /// impl std::error::Error for Error {
-    ///     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+    ///     fn provide_context<'a>(&'a self, demand: &mut Demand<'a>) {
     ///         demand
     ///             .provide_ref::<MyBacktrace>(&self.backtrace)
     ///             .provide_ref::<dyn std::error::Error + 'static>(&self.source);
@@ -191,7 +191,7 @@ pub trait Error: Debug + Display {
     /// ```
     #[unstable(feature = "error_generic_member_access", issue = "99301")]
     #[allow(unused_variables)]
-    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {}
+    fn provide_context<'a>(&'a self, demand: &mut Demand<'a>) {}
 }
 
 #[unstable(feature = "error_generic_member_access", issue = "99301")]
@@ -200,7 +200,7 @@ where
     E: Error + ?Sized,
 {
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        self.provide(demand)
+        self.provide_context(demand)
     }
 }
 
@@ -449,8 +449,8 @@ impl<'a, T: Error + ?Sized> Error for &'a T {
         Error::source(&**self)
     }
 
-    fn provide<'b>(&'b self, demand: &mut Demand<'b>) {
-        Error::provide(&**self, demand);
+    fn provide_context<'b>(&'b self, demand: &mut Demand<'b>) {
+        Error::provide_context(&**self, demand);
     }
 }
 

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -404,7 +404,7 @@ impl<E> Report<E> {
     /// }
     ///
     /// impl Error for SuperErrorSideKick {
-    ///     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+    ///     fn provide_context<'a>(&'a self, demand: &mut Demand<'a>) {
     ///         demand.provide_ref::<Backtrace>(&self.backtrace);
     ///     }
     /// }

--- a/library/std/src/error/tests.rs
+++ b/library/std/src/error/tests.rs
@@ -199,7 +199,7 @@ where
         self.source.as_deref()
     }
 
-    fn provide<'a>(&'a self, req: &mut Demand<'a>) {
+    fn provide_context<'a>(&'a self, req: &mut Demand<'a>) {
         self.backtrace.as_ref().map(|bt| req.provide_ref::<Backtrace>(bt));
     }
 }


### PR DESCRIPTION
Resolves the [deref/autoref method name conflict](https://github.com/rust-lang/rust/issues/99301#issuecomment-1237530400) between `Error::provide` and `Provider::provide` mentioned in the tracking issue for `error_generic_member_access` https://github.com/rust-lang/rust/issues/99301.

Note: `provide_context` is the method name that was originally proposed in the [RFC](https://github.com/yaahc/rfcs/blob/master/text/0000-dyn-error-generic-member-access.md).

[This comment](https://github.com/rust-lang/rust/issues/96024#issuecomment-1554773172) suggests removing the provider API, which would also resolve the name conflict as a side effect. However, even if it is indeed removed, there's still a small chance it'll be brought back later, I guess. Plus, [some users](https://github.com/rust-lang/rust/issues/99301#issuecomment-1525795789) (including myself) feel like the name `provide_context` provides a clearer indication _what_ should be provided.