### PR TITLE
Removed unnecessary &String -> &str, now that &String implements StableOrd as well

### DIFF
--- a/compiler/rustc_data_structures/src/unord.rs
+++ b/compiler/rustc_data_structures/src/unord.rs
@@ -107,6 +107,10 @@ impl<T, I: Iterator<Item = T>> UnordItems<T, I> {
     {
         UnordItems(self.0.flat_map(f))
     }
+
+    pub fn collect<C: From<UnordItems<T, I>>>(self) -> C {
+        self.into()
+    }
 }
 
 impl<T> UnordItems<T, std::iter::Empty<T>> {
@@ -160,10 +164,6 @@ impl<T: Ord, I: Iterator<Item = T>> UnordItems<T, I> {
         let mut items: SmallVec<[T; LEN]> = self.0.collect();
         items.sort_by_cached_key(|x| x.to_stable_hash_key(hcx));
         items
-    }
-
-    pub fn collect<C: From<UnordItems<T, I>>>(self) -> C {
-        self.into()
     }
 }
 

--- a/compiler/rustc_incremental/src/persist/dirty_clean.rs
+++ b/compiler/rustc_incremental/src/persist/dirty_clean.rs
@@ -198,7 +198,7 @@ impl<'tcx> DirtyCleanVisitor<'tcx> {
         let (name, mut auto) = self.auto_labels(item_id, attr);
         let except = self.except(attr);
         let loaded_from_disk = self.loaded_from_disk(attr);
-        for e in except.items().map(|x| x.as_str()).into_sorted_stable_ord() {
+        for e in except.items().into_sorted_stable_ord() {
             if !auto.remove(e) {
                 self.tcx.sess.emit_fatal(errors::AssertionAuto { span: attr.span, name, e });
             }
@@ -377,17 +377,15 @@ impl<'tcx> DirtyCleanVisitor<'tcx> {
                 continue;
             };
             self.checked_attrs.insert(attr.id);
-            for label in assertion.clean.items().map(|x| x.as_str()).into_sorted_stable_ord() {
+            for label in assertion.clean.items().into_sorted_stable_ord() {
                 let dep_node = DepNode::from_label_string(self.tcx, &label, def_path_hash).unwrap();
                 self.assert_clean(item_span, dep_node);
             }
-            for label in assertion.dirty.items().map(|x| x.as_str()).into_sorted_stable_ord() {
+            for label in assertion.dirty.items().into_sorted_stable_ord() {
                 let dep_node = DepNode::from_label_string(self.tcx, &label, def_path_hash).unwrap();
                 self.assert_dirty(item_span, dep_node);
             }
-            for label in
-                assertion.loaded_from_disk.items().map(|x| x.as_str()).into_sorted_stable_ord()
-            {
+            for label in assertion.loaded_from_disk.items().into_sorted_stable_ord() {
                 let dep_node = DepNode::from_label_string(self.tcx, &label, def_path_hash).unwrap();
                 self.assert_loaded_from_disk(item_span, dep_node);
             }

--- a/compiler/rustc_incremental/src/persist/fs.rs
+++ b/compiler/rustc_incremental/src/persist/fs.rs
@@ -855,12 +855,11 @@ fn all_except_most_recent(
     let most_recent = deletion_candidates.items().map(|(&(timestamp, _), _)| timestamp).max();
 
     if let Some(most_recent) = most_recent {
-        UnordMap::from(
-            deletion_candidates
-                .into_items()
-                .filter(|&((timestamp, _), _)| timestamp != most_recent)
-                .map(|((_, path), lock)| (path, lock)),
-        )
+        deletion_candidates
+            .into_items()
+            .filter(|&((timestamp, _), _)| timestamp != most_recent)
+            .map(|((_, path), lock)| (path, lock))
+            .collect()
     } else {
         UnordMap::default()
     }


### PR DESCRIPTION
Applied a few nits suggested by lcnr to PR #110040 (nits can be found [here](https://github.com/rust-lang/rust/pull/110040#pullrequestreview-1469452191).)

Making a new PR because the old one was already merged, and given that this just applies changes that were already suggested, reviewing it should be fairly open-and-shut.