### PR TITLE
[doc]  [library/core/src/fmt/mod.rs]  modify the example code of trait Debug

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -570,10 +570,7 @@ pub trait Debug {
     /// let position = Position { longitude: 1.987, latitude: 2.983 };
     /// assert_eq!(format!("{position:?}"), "(1.987, 2.983)");
     ///
-    /// assert_eq!(format!("{position:#?}"), "(
-    ///     1.987,
-    ///     2.983,
-    /// )");
+    /// assert_eq!(format!("{position:#?}"), "(\n    1.987,\n    2.983,\n)");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result;


### PR DESCRIPTION
![image](https://github.com/rust-lang/rust/assets/31559413/ceda00f9-a6cf-4faf-9066-ab2ebe67b852)
In line 23 - 26,  if there are some indentation before the code, the assertion will fail. So I think it is not good writing style. 