### PR TITLE
implement stdout streaming in `render_tests::Renderer`

### DIFF
--- a/src/bootstrap/render_tests.rs
+++ b/src/bootstrap/render_tests.rs
@@ -7,7 +7,7 @@
 //! to reimplement all the rendering logic in this module because of that.
 
 use crate::builder::Builder;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{ChildStdout, Command, Stdio};
 use std::time::Duration;
 use termcolor::{Color, ColorSpec, WriteColor};
@@ -20,15 +20,15 @@ pub(crate) fn add_flags_and_try_run_tests(builder: &Builder<'_>, cmd: &mut Comma
     }
     cmd.args(&["-Z", "unstable-options", "--format", "json"]);
 
-    try_run_tests(builder, cmd)
+    try_run_tests(builder, cmd, false)
 }
 
-pub(crate) fn try_run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
+pub(crate) fn try_run_tests(builder: &Builder<'_>, cmd: &mut Command, stream: bool) -> bool {
     if builder.config.dry_run() {
         return true;
     }
 
-    if !run_tests(builder, cmd) {
+    if !run_tests(builder, cmd, stream) {
         if builder.fail_fast {
             crate::detail_exit_macro!(1);
         } else {
@@ -41,7 +41,7 @@ pub(crate) fn try_run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
     }
 }
 
-fn run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
+fn run_tests(builder: &Builder<'_>, cmd: &mut Command, stream: bool) -> bool {
     cmd.stdout(Stdio::piped());
 
     builder.verbose(&format!("running: {cmd:?}"));
@@ -50,7 +50,12 @@ fn run_tests(builder: &Builder<'_>, cmd: &mut Command) -> bool {
 
     // This runs until the stdout of the child is closed, which means the child exited. We don't
     // run this on another thread since the builder is not Sync.
-    Renderer::new(process.stdout.take().unwrap(), builder).render_all();
+    let renderer = Renderer::new(process.stdout.take().unwrap(), builder);
+    if stream {
+        renderer.stream_all();
+    } else {
+        renderer.render_all();
+    }
 
     let result = process.wait_with_output().unwrap();
     if !result.status.success() && builder.is_verbose() {
@@ -108,6 +113,23 @@ impl<'a> Renderer<'a> {
                     stdout.write_all(&line).unwrap();
                     let _ = stdout.flush();
                 }
+            }
+        }
+    }
+
+    /// Renders the stdout characters one by one
+    fn stream_all(mut self) {
+        let mut buffer = [0; 1];
+        loop {
+            match self.stdout.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(_) => {
+                    let mut stdout = std::io::stdout();
+                    stdout.write_all(&buffer).unwrap();
+                    let _ = stdout.flush();
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(err) => panic!("failed to read output of test runner: {err}"),
             }
         }
     }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1035,7 +1035,7 @@ impl Step for RustdocGUI {
         }
 
         let _time = util::timeit(&builder);
-        crate::render_tests::try_run_tests(builder, &mut cmd);
+        crate::render_tests::try_run_tests(builder, &mut cmd, true);
     }
 }
 
@@ -1732,7 +1732,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             suite, mode, &compiler.host, target
         ));
         let _time = util::timeit(&builder);
-        crate::render_tests::try_run_tests(builder, &mut cmd);
+        crate::render_tests::try_run_tests(builder, &mut cmd, false);
 
         if let Some(compare_mode) = compare_mode {
             cmd.arg("--compare-mode").arg(compare_mode);
@@ -1755,7 +1755,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
                 suite, mode, compare_mode, &compiler.host, target
             ));
             let _time = util::timeit(&builder);
-            crate::render_tests::try_run_tests(builder, &mut cmd);
+            crate::render_tests::try_run_tests(builder, &mut cmd, false);
         }
     }
 }


### PR DESCRIPTION
This way, we can show the test dot characters on the console immediately, without having to wait for the entire line to finish.

cc @GuillaumeGomez 