### PR TITLE
Adjust UI tests for `unit_bindings` lint

### DIFF
--- a/tests/ui/assign-assign.rs
+++ b/tests/ui/assign-assign.rs
@@ -6,7 +6,7 @@ fn test_assign() {
     let y: () = x = 10;
     assert_eq!(x, 10);
     assert_eq!(y, ());
-    let mut z = x = 11;
+    let mut z: () = x = 11;
     assert_eq!(x, 11);
     assert_eq!(z, ());
     z = x = 12;
@@ -19,7 +19,7 @@ fn test_assign_op() {
     let y: () = x += 10;
     assert_eq!(x, 10);
     assert_eq!(y, ());
-    let mut z = x += 11;
+    let mut z: () = x += 11;
     assert_eq!(x, 21);
     assert_eq!(z, ());
     z = x += 12;

--- a/tests/ui/associated-type-bounds/dyn-impl-trait-type.rs
+++ b/tests/ui/associated-type-bounds/dyn-impl-trait-type.rs
@@ -59,8 +59,8 @@ fn def_et4() -> Et4 {
 pub fn use_et4() { assert_forall_tr2(def_et4().mk()); }
 
 fn main() {
-    let _ = use_et1();
-    let _ = use_et2();
-    let _ = use_et3();
-    let _ = use_et4();
+    use_et1();
+    use_et2();
+    use_et3();
+    use_et4();
 }

--- a/tests/ui/associated-type-bounds/dyn-rpit-and-let.rs
+++ b/tests/ui/associated-type-bounds/dyn-rpit-and-let.rs
@@ -66,8 +66,8 @@ fn def_et4() -> Box<dyn Tr1<As1: for<'a> Tr2<'a>>> {
 pub fn use_et4() { assert_forall_tr2(def_et4().mk()); }
 
 fn main() {
-    let _ = use_et1();
-    let _ = use_et2();
-    let _ = use_et3();
-    let _ = use_et4();
+    use_et1();
+    use_et2();
+    use_et3();
+    use_et4();
 }

--- a/tests/ui/associated-type-bounds/rpit.rs
+++ b/tests/ui/associated-type-bounds/rpit.rs
@@ -57,8 +57,8 @@ fn def_et4() -> impl Tr1<As1: for<'a> Tr2<'a>> {
 pub fn use_et4() { assert_forall_tr2(def_et4().mk()); }
 
 fn main() {
-    let _ = use_et1();
-    let _ = use_et2();
-    let _ = use_et3();
-    let _ = use_et4();
+    use_et1();
+    use_et2();
+    use_et3();
+    use_et4();
 }

--- a/tests/ui/associated-type-bounds/trait-alias-impl-trait.rs
+++ b/tests/ui/associated-type-bounds/trait-alias-impl-trait.rs
@@ -89,8 +89,8 @@ pub fn use_et4() {
 }
 
 fn main() {
-    let _ = use_et1();
-    let _ = use_et2();
-    let _ = use_et3();
-    let _ = use_et4();
+    use_et1();
+    use_et2();
+    use_et3();
+    use_et4();
 }

--- a/tests/ui/associated-types/normalization-debruijn-3.rs
+++ b/tests/ui/associated-types/normalization-debruijn-3.rs
@@ -6,10 +6,10 @@
 
 use std::future::{Future, Ready};
 async fn read() {
-    let _ = connect(&()).await;
+    connect(&()).await;
 }
 async fn connect<A: ToSocketAddr>(addr: A) {
-    let _ = addr.to_socket_addr().await;
+    addr.to_socket_addr().await;
 }
 pub trait ToSocketAddr {
     type Future: Future<Output = ()>;

--- a/tests/ui/async-await/drop-track-field-assign.rs
+++ b/tests/ui/async-await/drop-track-field-assign.rs
@@ -21,7 +21,7 @@ impl Agent {
         let mut info = self.info_result.clone();
         info.node = Some("bar".into());
         let element = parse_info(info);
-        let _ = send_element(element).await;
+        send_element(element).await;
     }
 }
 

--- a/tests/ui/async-await/field-assign.rs
+++ b/tests/ui/async-await/field-assign.rs
@@ -21,7 +21,7 @@ impl Agent {
         let mut info = self.info_result.clone();
         info.node = Some("bar".into());
         let element = parse_info(info);
-        let _ = send_element(element).await;
+        send_element(element).await;
     }
 }
 

--- a/tests/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
@@ -6,13 +6,13 @@ LL | pub fn foo() -> impl Future + Send {
    |
    = help: the trait `Sync` is not implemented for `(dyn Any + Send + 'static)`
 note: future is not `Send` as this value is used across an await
-  --> $DIR/issue-64130-4-async-move.rs:27:32
+  --> $DIR/issue-64130-4-async-move.rs:27:23
    |
 LL |         match client.status() {
    |               ------ has type `&Client` which is not `Send`
 LL |             200 => {
-LL |                 let _x = get().await;
-   |                                ^^^^^ await occurs here, with `client` maybe used later
+LL |                 get().await;
+   |                       ^^^^^ await occurs here, with `client` maybe used later
 ...
 LL |     }
    |     - `client` is later dropped here

--- a/tests/ui/async-await/issue-64130-4-async-move.rs
+++ b/tests/ui/async-await/issue-64130-4-async-move.rs
@@ -24,7 +24,7 @@ pub fn foo() -> impl Future + Send {
     async move {
         match client.status() {
             200 => {
-                let _x = get().await;
+                get().await;
             }
             _ => (),
         }

--- a/tests/ui/async-await/non-trivial-drop.rs
+++ b/tests/ui/async-await/non-trivial-drop.rs
@@ -7,7 +7,7 @@
 #![feature(generators)]
 
 fn main() {
-    let _ = foo();
+    foo();
 }
 
 fn foo() {

--- a/tests/ui/cfg/cfg_stmt_expr.rs
+++ b/tests/ui/cfg/cfg_stmt_expr.rs
@@ -81,7 +81,7 @@ fn main() {
     // check that lints work
 
     #[allow(non_snake_case)]
-    let FOOBAR = {
+    let FOOBAR: () = {
         fn SYLADEX() {}
     };
 

--- a/tests/ui/closures/2229_closure_analysis/run_pass/disjoint-capture-in-same-closure.rs
+++ b/tests/ui/closures/2229_closure_analysis/run_pass/disjoint-capture-in-same-closure.rs
@@ -15,7 +15,7 @@ struct Struct {
 fn main() {
     let mut s = Struct { x: 10, y: 10, s: String::new() };
 
-    let mut c = {
+    let mut c = || {
         s.x += 10;
         s.y += 42;
         s.s = String::from("new");

--- a/tests/ui/const-generics/generic_const_exprs/issue-86710.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-86710.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 
 fn main() {
     let x = FooImpl::<BarImpl<1>> { phantom: PhantomData };
-    let _ = x.foo::<BarImpl<1>>();
+    x.foo::<BarImpl<1>>();
 }
 
 trait Foo<T>

--- a/tests/ui/const-generics/issues/issue-70273-assoc-fn.rs
+++ b/tests/ui/const-generics/issues/issue-70273-assoc-fn.rs
@@ -10,5 +10,5 @@ impl T<0usize> for S {
 }
 
 fn main() {
-    let _err = <S as T<0usize>>::f();
+    <S as T<0usize>>::f();
 }

--- a/tests/ui/consts/assoc_const_generic_impl.rs
+++ b/tests/ui/consts/assoc_const_generic_impl.rs
@@ -8,7 +8,7 @@ trait ZeroSized: Sized {
 impl<T: Sized> ZeroSized for T {
     const I_AM_ZERO_SIZED: ()  = [()][std::mem::size_of::<Self>()]; //~ ERROR evaluation of `<u32 as ZeroSized>::I_AM_ZERO_SIZED` failed
     fn requires_zero_size(self) {
-        let () = Self::I_AM_ZERO_SIZED;
+        Self::I_AM_ZERO_SIZED;
         println!("requires_zero_size called");
     }
 }

--- a/tests/ui/consts/const-eval/erroneous-const.rs
+++ b/tests/ui/consts/const-eval/erroneous-const.rs
@@ -10,7 +10,7 @@ const fn no_codegen<T>() {
     if false {
         // This bad constant is only used in dead code in a no-codegen function... and yet we still
         // must make sure that the build fails.
-        let _ = PrintName::<T>::VOID; //~ constant
+            PrintName::<T>::VOID; //~ constant
     }
 }
 

--- a/tests/ui/consts/const-eval/erroneous-const.stderr
+++ b/tests/ui/consts/const-eval/erroneous-const.stderr
@@ -5,10 +5,10 @@ LL |     const VOID: () = [()][2];
    |                      ^^^^^^^ index out of bounds: the length is 1 but the index is 2
 
 note: erroneous constant used
-  --> $DIR/erroneous-const.rs:13:17
+  --> $DIR/erroneous-const.rs:13:13
    |
-LL |         let _ = PrintName::<T>::VOID;
-   |                 ^^^^^^^^^^^^^^^^^^^^
+LL |             PrintName::<T>::VOID;
+   |             ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/consts/const-eval/erroneous-const2.rs
+++ b/tests/ui/consts/const-eval/erroneous-const2.rs
@@ -10,7 +10,7 @@ pub static FOO: () = {
     if false {
         // This bad constant is only used in dead code in a static initializer... and yet we still
         // must make sure that the build fails.
-        let _ = PrintName::<i32>::VOID; //~ constant
+        PrintName::<i32>::VOID; //~ constant
     }
 };
 

--- a/tests/ui/consts/const-eval/erroneous-const2.stderr
+++ b/tests/ui/consts/const-eval/erroneous-const2.stderr
@@ -5,10 +5,10 @@ LL |     const VOID: () = [()][2];
    |                      ^^^^^^^ index out of bounds: the length is 1 but the index is 2
 
 note: erroneous constant used
-  --> $DIR/erroneous-const2.rs:13:17
+  --> $DIR/erroneous-const2.rs:13:9
    |
-LL |         let _ = PrintName::<i32>::VOID;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^
+LL |         PrintName::<i32>::VOID;
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/consts/const-eval/promoted_errors.rs
+++ b/tests/ui/consts/const-eval/promoted_errors.rs
@@ -48,5 +48,5 @@ const Y: () = {
 };
 
 fn main() {
-    let _y = Y;
+    Y;
 }

--- a/tests/ui/consts/const-eval/unwind-abort.rs
+++ b/tests/ui/consts/const-eval/unwind-abort.rs
@@ -8,5 +8,5 @@ const _: () = foo();
 // Ensure that the CTFE engine handles calls to `extern "C"` aborting gracefully
 
 fn main() {
-    let _ = foo();
+    foo();
 }

--- a/tests/ui/consts/large_const_alloc.rs
+++ b/tests/ui/consts/large_const_alloc.rs
@@ -13,6 +13,6 @@ static FOO2: () = {
 };
 
 fn main() {
-    let _ = FOO;
-    let _ = FOO2;
+    FOO;
+    FOO2;
 }

--- a/tests/ui/empty-allocation-rvalue-non-null.rs
+++ b/tests/ui/empty-allocation-rvalue-non-null.rs
@@ -4,5 +4,5 @@
 // pretty-expanded FIXME #23616
 
 pub fn main() {
-    let x = *Box::new(());
+    let x: () = *Box::new(());
 }

--- a/tests/ui/feature-gates/feature-gate-generic_arg_infer.rs
+++ b/tests/ui/feature-gates/feature-gate-generic_arg_infer.rs
@@ -19,5 +19,5 @@ fn bar() {
 fn main() {
     let _x = foo::<_>([1,2]);
     //[normal]~^ ERROR: type provided when a constant was expected
-    let _y = bar();
+    bar();
 }

--- a/tests/ui/for-loop-while/loop-break-value.rs
+++ b/tests/ui/for-loop-while/loop-break-value.rs
@@ -64,7 +64,7 @@ pub fn main() {
     };
     assert_eq!(trait_unified_3, ["Yes"]);
 
-    let regular_break = loop {
+    let regular_break: () = loop {
         if true {
             break;
         } else {
@@ -73,7 +73,7 @@ pub fn main() {
     };
     assert_eq!(regular_break, ());
 
-    let regular_break_2 = loop {
+    let regular_break_2: () = loop {
         if true {
             break Default::default();
         } else {
@@ -82,7 +82,7 @@ pub fn main() {
     };
     assert_eq!(regular_break_2, ());
 
-    let regular_break_3 = loop {
+    let regular_break_3: () = loop {
         break if true {
             Default::default()
         } else {
@@ -91,13 +91,13 @@ pub fn main() {
     };
     assert_eq!(regular_break_3, ());
 
-    let regular_break_4 = loop {
+    let regular_break_4: () = loop {
         break ();
         break;
     };
     assert_eq!(regular_break_4, ());
 
-    let regular_break_5 = loop {
+    let regular_break_5: () = loop {
         break;
         break ();
     };

--- a/tests/ui/generics/post_monomorphization_error_backtrace.rs
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.rs
@@ -11,7 +11,7 @@ fn assert_zst<T>() {
         //~| NOTE: in this expansion of assert!
         //~| NOTE: the evaluated program panicked
     }
-    let _ = F::<T>::V;
+    F::<T>::V;
 }
 
 fn foo<U>() {

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-6.rs
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-6.rs
@@ -71,7 +71,7 @@ impl<'a, 'b, U: Unpack<'b>> Backed<'a, U> {
     where
         F: for<'f> FnOnce(<U as Unpack<'f>>::Unpacked) -> (),
     {
-        let result = f(self.1.unpack());
+        let result: () = f(self.1.unpack());
         Backed(self.0, result)
     }
 }

--- a/tests/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/tests/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -391,7 +391,7 @@ fn main() {
         let _val = mem::zeroed::<ZeroIsValid>();
         let _val = mem::uninitialized::<MaybeUninit<bool>>();
         let _val = mem::uninitialized::<[!; 0]>();
-        let _val = mem::uninitialized::<()>();
+        let _val: () = mem::uninitialized::<()>();
         let _val = mem::uninitialized::<ZeroSized>();
     }
 }

--- a/tests/ui/issues/issue-11047.rs
+++ b/tests/ui/issues/issue-11047.rs
@@ -18,8 +18,8 @@ pub mod foo {
 fn main() {
 
     type Ham = foo::bar::baz::Qux;
-    let foo = foo::bar::baz::Qux::new();  // invoke directly
-    let bar = Ham::new();                 // invoke via type alias
+    let foo: () = foo::bar::baz::Qux::new();  // invoke directly
+    let bar: () = Ham::new();                 // invoke via type alias
 
     type StringVec = Vec<String>;
     let sv = StringVec::new();

--- a/tests/ui/issues/issue-11709.rs
+++ b/tests/ui/issues/issue-11709.rs
@@ -10,7 +10,7 @@ struct S {x:()}
 
 fn test(slot: &mut Option<Box<dyn FnMut() -> Box<dyn FnMut()>>>) -> () {
   let a = slot.take();
-  let _a = match a {
+  let _a: () = match a {
     // `{let .. a(); }` would break
     Some(mut a) => { let _a = a(); },
     None => (),
@@ -28,7 +28,7 @@ fn not(b: bool) -> bool {
 
 pub fn main() {
     // {} would break
-    let _r = {};
+    let _r: () = {};
     let mut slot = None;
     // `{ test(...); }` would break
     let _s : S  = S{ x: { test(&mut slot); } };

--- a/tests/ui/issues/issue-11740.rs
+++ b/tests/ui/issues/issue-11740.rs
@@ -24,5 +24,5 @@ impl Element {
 
 fn main() {
     let element = Element { attrs: Vec::new() };
-    let _ = unsafe { element.get_attr("foo") };
+    unsafe { let () = element.get_attr("foo"); };
 }

--- a/tests/ui/issues/issue-20644.rs
+++ b/tests/ui/issues/issue-20644.rs
@@ -26,7 +26,7 @@ fn foo() {
     let cwd = env::current_dir().unwrap();
     let src = cwd.clone();
     let summary = File::open(&src.join("SUMMARY.md")).unwrap();
-    let _ = parse_summary(summary, &src);
+    parse_summary(summary, &src);
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-23808.rs
+++ b/tests/ui/issues/issue-23808.rs
@@ -45,14 +45,14 @@ impl_Const!(ConstStruct, ConstEnum, AliasedConstStruct, AliasedConstEnum);
 impl_StaticFn!(StaticFnStruct, StaticFnEnum, AliasedStaticFnStruct, AliasedStaticFnEnum);
 
 fn main() {
-    let _ = ConstStruct::C;
-    let _ = ConstEnum::C;
+    let () = ConstStruct::C;
+    let () = ConstEnum::C;
 
     StaticFnStruct::sfn();
     StaticFnEnum::sfn();
 
-    let _ = AliasConstStruct::C;
-    let _ = AliasConstEnum::C;
+    let () = AliasConstStruct::C;
+    let () = AliasConstEnum::C;
 
     AliasStaticFnStruct::sfn();
     AliasStaticFnEnum::sfn();

--- a/tests/ui/lint/lint-attr-everywhere-early.rs
+++ b/tests/ui/lint/lint-attr-everywhere-early.rs
@@ -147,7 +147,7 @@ fn expressions() {
         #![deny(unsafe_code)]
         unsafe {} //~ ERROR usage of an `unsafe` block
     }
-    let block_tail = {
+    let block_tail: () = {
         #[deny(unsafe_code)]
         unsafe {} //~ ERROR usage of an `unsafe` block
     };

--- a/tests/ui/lint/lint-attr-everywhere-late.rs
+++ b/tests/ui/lint/lint-attr-everywhere-late.rs
@@ -172,7 +172,7 @@ fn expressions() {
         #![deny(enum_intrinsics_non_enums)]
         discriminant::<i32>(&123); //~ ERROR the return value of
     }
-    let block_tail = {
+    let block_tail: () = {
         #[deny(enum_intrinsics_non_enums)]
         discriminant::<i32>(&123); //~ ERROR the return value of
     };

--- a/tests/ui/lint/unused/lint-unused-extern-crate.rs
+++ b/tests/ui/lint/unused/lint-unused-extern-crate.rs
@@ -31,5 +31,5 @@ mod foo {
 
 fn main() {
     lint_unused_extern_crate3::foo();
-    let y = foo();
+    foo();
 }

--- a/tests/ui/lint/unused/lint-unused-imports.rs
+++ b/tests/ui/lint/unused/lint-unused-imports.rs
@@ -86,5 +86,5 @@ fn main() {
     let mut b = 4;
     swap(&mut a, &mut b);
     test::C.b();
-    let _a = foo();
+    foo();
 }

--- a/tests/ui/lint/unused/lint-unused-variables.rs
+++ b/tests/ui/lint/unused/lint-unused-variables.rs
@@ -74,6 +74,6 @@ fn main() {
         b: i32,
         //~^ ERROR unused variable: `b`
     | {};
-    let _ = a(1, 2);
-    let _ = b(1, 2);
+    a(1, 2);
+    b(1, 2);
 }

--- a/tests/ui/lint/unused_import_warning_issue_45268.rs
+++ b/tests/ui/lint/unused_import_warning_issue_45268.rs
@@ -31,15 +31,15 @@ use test::B;        // This is used by the test2::func() through import of super
 mod test2 {
     use super::*;
     pub fn func() {
-        let _ = <()>::a();
-        let _ = ().b();
+        <()>::a();
+        ().b();
         test3::inner_func();
     }
     mod test3 {
         use super::*;
         pub fn inner_func() {
-            let _ = <()>::a();
-            let _ = ().b();
+            <()>::a();
+            ().b();
         }
     }
 }

--- a/tests/ui/macros/format-args-temporaries.rs
+++ b/tests/ui/macros/format-args-temporaries.rs
@@ -27,27 +27,27 @@ impl<'a> Display for MutexGuard<'a> {
 }
 
 fn main() {
-    let _print = {
+    let _print: () = {
         let mutex = Mutex;
         print!("{}", mutex.lock()) /* no semicolon */
     };
 
-    let _println = {
+    let _println: () = {
         let mutex = Mutex;
         println!("{}", mutex.lock()) /* no semicolon */
     };
 
-    let _eprint = {
+    let _eprint: () = {
         let mutex = Mutex;
         eprint!("{}", mutex.lock()) /* no semicolon */
     };
 
-    let _eprintln = {
+    let _eprintln: () = {
         let mutex = Mutex;
         eprintln!("{}", mutex.lock()) /* no semicolon */
     };
 
-    let _panic = {
+    let _panic: () = {
         let mutex = Mutex;
         panic!("{}", mutex.lock()) /* no semicolon */
     };

--- a/tests/ui/macros/macro-comma-support-rpass.rs
+++ b/tests/ui/macros/macro-comma-support-rpass.rs
@@ -170,8 +170,8 @@ fn format_args() {
 
 #[test]
 fn include() {
-    let _ = include!("auxiliary/macro-comma-support.rs");
-    let _ = include!("auxiliary/macro-comma-support.rs",);
+    include!("auxiliary/macro-comma-support.rs");
+    include!("auxiliary/macro-comma-support.rs",);
 }
 
 #[test]

--- a/tests/ui/mir/issue-101844.rs
+++ b/tests/ui/mir/issue-101844.rs
@@ -67,7 +67,7 @@ where
     MS::Item: Into<()>,
 {
     // Error: Apparently Balance::new doesn't exist during MIR validation
-    let _ = ImplShoulExist::<MS, ()>::access_fn(ms);
+    ImplShoulExist::<MS, ()>::access_fn(ms);
 }
 
 fn main() {}

--- a/tests/ui/mir/issue-80949.rs
+++ b/tests/ui/mir/issue-80949.rs
@@ -28,7 +28,7 @@ fn may_panic<X>(_: X) { }
 fn main() {
     let dyn_trait = make_dyn_trait(&());
     let storage = vec![()];
-    let _x = may_panic(());
+    may_panic(());
     let storage_ref = &storage;
     diff(dyn_trait, storage_ref);
 }

--- a/tests/ui/mir/issue66339.rs
+++ b/tests/ui/mir/issue66339.rs
@@ -5,7 +5,7 @@
 
 fn foo() {
     let bar = |_| { };
-    let _ = bar("a");
+    bar("a");
 }
 
 fn main() {

--- a/tests/ui/never_type/diverging-fallback-control-flow.rs
+++ b/tests/ui/never_type/diverging-fallback-control-flow.rs
@@ -48,7 +48,7 @@ fn assignment_rev() {
 }
 
 fn if_then_else() {
-    let _x = if true {
+    let _x: () = if true {
         UnitDefault::default()
     } else {
         return;
@@ -56,7 +56,7 @@ fn if_then_else() {
 }
 
 fn if_then_else_rev() {
-    let _x = if true {
+    let _x: () = if true {
         return;
     } else {
         UnitDefault::default()
@@ -64,21 +64,21 @@ fn if_then_else_rev() {
 }
 
 fn match_arm() {
-    let _x = match Ok(UnitDefault::default()) {
+    let _x: () = match Ok(UnitDefault::default()) {
         Ok(v) => v,
         Err(()) => return,
     };
 }
 
 fn match_arm_rev() {
-    let _x = match Ok(UnitDefault::default()) {
+    let _x: () = match Ok(UnitDefault::default()) {
         Err(()) => return,
         Ok(v) => v,
     };
 }
 
 fn loop_break() {
-    let _x = loop {
+    let _x: () = loop {
         if false {
             break return;
         } else {
@@ -88,7 +88,7 @@ fn loop_break() {
 }
 
 fn loop_break_rev() {
-    let _x = loop {
+    let _x: () = loop {
         if false {
             break return;
         } else {

--- a/tests/ui/nll/assign-while-to-immutable.rs
+++ b/tests/ui/nll/assign-while-to-immutable.rs
@@ -4,8 +4,8 @@
 // check-pass
 
 fn main() {
-    let x = while false {
+    let x: () = while false {
         break;
     };
-    let y = 'l: while break 'l {};
+    let y: () = 'l: while break 'l {};
 }

--- a/tests/ui/nll/issue-54943-3.rs
+++ b/tests/ui/nll/issue-54943-3.rs
@@ -13,7 +13,7 @@ fn foo<T: 'static + Debug>(_: T) { }
 fn bar<'a>() {
     return;
 
-    let _x = foo::<Vec<_>>(Vec::<&'a u32>::new());
+    foo::<Vec<_>>(Vec::<&'a u32>::new());
 }
 
 fn main() {}

--- a/tests/ui/polymorphization/drop_shims/simple.rs
+++ b/tests/ui/polymorphization/drop_shims/simple.rs
@@ -14,7 +14,7 @@ fn foo<R, S: FnOnce()>(
     let bar = || {
         let _ = OnDrop(|| ());
     };
-    let _ = bar();
+    bar();
 }
 
 fn main() {

--- a/tests/ui/polymorphization/drop_shims/transitive.rs
+++ b/tests/ui/polymorphization/drop_shims/transitive.rs
@@ -19,7 +19,7 @@ fn foo<R, S: FnOnce()>(
     let bar = || {
         bar(|| {})
     };
-    let _ = bar();
+    bar();
 }
 
 fn main() {

--- a/tests/ui/reachable/expr_return.rs
+++ b/tests/ui/reachable/expr_return.rs
@@ -7,7 +7,7 @@
 fn a() {
     // Here we issue that the "2nd-innermost" return is unreachable,
     // but we stop there.
-    let x = {return {return {return;}}}; //~ ERROR unreachable
+    let x: () = {return {return {return;}}}; //~ ERROR unreachable
 }
 
 fn main() { }

--- a/tests/ui/reachable/expr_return.stderr
+++ b/tests/ui/reachable/expr_return.stderr
@@ -1,11 +1,11 @@
 error: unreachable expression
-  --> $DIR/expr_return.rs:10:22
+  --> $DIR/expr_return.rs:10:26
    |
-LL |     let x = {return {return {return;}}};
-   |                      ^^^^^^^^------^^
-   |                      |       |
-   |                      |       any code following this expression is unreachable
-   |                      unreachable expression
+LL |     let x: () = {return {return {return;}}};
+   |                          ^^^^^^^^------^^
+   |                          |       |
+   |                          |       any code following this expression is unreachable
+   |                          unreachable expression
    |
 note: the lint level is defined here
   --> $DIR/expr_return.rs:4:9

--- a/tests/ui/resolve/extern-prelude.rs
+++ b/tests/ui/resolve/extern-prelude.rs
@@ -25,7 +25,7 @@ fn shadow_mod() {
 
 fn shadow_prelude() {
     // Extern prelude shadows standard library prelude
-    let x = Vec::new(0f32, ()); // OK
+    let x: () = Vec::new(0f32, ()); // OK
 }
 
 fn main() {}

--- a/tests/ui/resolve/resolve-pseudo-shadowing.rs
+++ b/tests/ui/resolve/resolve-pseudo-shadowing.rs
@@ -3,7 +3,7 @@
 
 fn check<Clone>(_c: Clone) {
     fn check2() {
-        let _ = <() as std::clone::Clone>::clone(&());
+        let () = <() as std::clone::Clone>::clone(&());
     }
     check2();
 }

--- a/tests/ui/return-nil.rs
+++ b/tests/ui/return-nil.rs
@@ -1,6 +1,6 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-fn f() { let x: () = (); return x; }
+fn f() { let x = (); return x; }
 
-pub fn main() { let _x = f(); }
+pub fn main() { f(); }

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-allowed.rs
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-allowed.rs
@@ -97,5 +97,5 @@ fn main() {
         #[cfg_attr(something, cfg(nothing))]
         #[deny(unused_mut)] c: i32,
     | {};
-    let _ = c(1, 2);
+    c(1, 2);
 }

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-cfg.rs
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-cfg.rs
@@ -116,6 +116,6 @@ fn main() {
         //~^ ERROR unused variable: `c`
         #[cfg_attr(something, cfg(nothing))] d: i32,
     | {};
-    let _ = a(1);
-    let _ = c(1, 2);
+    a(1);
+    c(1, 2);
 }

--- a/tests/ui/traits/bound/generic_trait.rs
+++ b/tests/ui/traits/bound/generic_trait.rs
@@ -24,7 +24,7 @@ impl connection_factory<my_connection> for my_connection_factory {
 
 pub fn main() {
     let factory = ();
-    let connection = factory.create();
+    let connection: () = factory.create();
     let result = connection.read();
     assert_eq!(result, 43);
 }

--- a/tests/ui/try-block/issue-45124.rs
+++ b/tests/ui/try-block/issue-45124.rs
@@ -8,7 +8,7 @@ fn main() {
     let mut a = 0;
     let () = {
         let _: Result<(), ()> = try {
-            let _ = Err(())?;
+            let () = Err(())?;
             return
         };
         a += 1;

--- a/tests/ui/tuple/index-float.rs
+++ b/tests/ui/tuple/index-float.rs
@@ -3,8 +3,8 @@
 fn main() {
     let tuple = (((),),);
 
-    let _ = tuple. 0.0; // OK, whitespace
-    let _ = tuple.0. 0; // OK, whitespace
+    let () = tuple. 0.0; // OK, whitespace
+    let () = tuple.0. 0; // OK, whitespace
 
-    let _ = tuple./*special cases*/0.0; // OK, comment
+    let () = tuple./*special cases*/0.0; // OK, comment
 }

--- a/tests/ui/weird-exprs.rs
+++ b/tests/ui/weird-exprs.rs
@@ -81,7 +81,7 @@ fn angrydome() {
       break; }
 }
 
-fn evil_lincoln() { let _evil = println!("lincoln"); }
+fn evil_lincoln() { let _evil: () = println!("lincoln"); }
 
 fn dots() {
     assert_eq!(String::from(".................................................."),
@@ -137,7 +137,7 @@ fn punch_card() -> impl std::fmt::Debug {
 }
 
 fn r#match() {
-    let val = match match match match match () {
+    let val: () = match match match match match () {
         () => ()
     } {
         () => ()
@@ -166,7 +166,7 @@ fn match_nested_if() {
 }
 
 fn monkey_barrel() {
-    let val = ()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=();
+    let val: () = ()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=();
     assert_eq!(val, ());
 }
 


### PR DESCRIPTION
- Explicitly annotate `let x: () = expr;` where `x` has unit type, or remove the unit binding to leave only `expr;` instead.
- Use `let () = init;` or `let pat = ();` where appropriate.
- Fix disjoint-capture-in-same-closure test which wasn't actually testing a closure: `tests/ui/closures/2229_closure_analysis/run_pass/disjoint-capture-in-same-closure.rs`.

Note that unfortunately there's *a lot* of UI tests, there are a couple of places where I may have left something like `let (): ()` (this is not needed but is left over from an ealier version of the lint) which is bad style.

This PR is to help with the `unit_bindings` lint at #112380.