### PR TITLE
riscv: Make ELF flags RVE-aware

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -273,6 +273,11 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
                 e_flags |= elf::EF_RISCV_RVC;
             }
 
+            // Check if embedded is enabled
+            if features.contains("+e") {
+                e_flags |= elf::EF_RISCV_RVE;
+            }
+
             // Select the appropriate floating-point ABI
             if features.contains("+d") {
                 e_flags |= elf::EF_RISCV_FLOAT_ABI_DOUBLE;


### PR DESCRIPTION
This fixes the ELF header flags when targetting embedded RISC-V (rv32e and rv64e).

I think this is the only fix required for when LLVM merges D70401 and RVE targets can be added.