### PR TITLE
Fix building libstd documentation on FreeBSD.

### DIFF
--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -17,6 +17,7 @@ mod libc {
     pub use libc::c_int;
     pub struct ucred;
     pub struct cmsghdr;
+    pub struct sockcred2;
     pub type pid_t = i32;
     pub type gid_t = u32;
     pub type uid_t = u32;


### PR DESCRIPTION
It fixes the following error:
```
error[E0412]: cannot find type `sockcred2` in module `libc`
   --> library/std/src/os/unix/net/ancillary.rs:211:29
    |
211 | pub struct SocketCred(libc::sockcred2);
    |                             ^^^^^^^^^ not found in `libc`
```