### PR TITLE
[rustdoc] Fix URL encoding of % sign

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1940,8 +1940,6 @@ pub(crate) fn small_url_encode(s: String) -> String {
             // While the same is not true for hashes, rustdoc only needs to be
             // consistent with itself when encoding them.
             st += "+";
-        } else if b == b'%' {
-            st += "%%";
         } else {
             write!(st, "%{:02X}", b).unwrap();
         }


### PR DESCRIPTION
Fix #112580

The % is encoded as %%, but the correct encoding is %25.