### PR TITLE
Correctly display whitespace characters in search error

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2062,7 +2062,7 @@ function initSearch(rawSearchIndex) {
             error.forEach((value, index) => {
                 value = value.split("<").join("&lt;").split(">").join("&gt;");
                 if (index % 2 !== 0) {
-                    error[index] = `<code>${value}</code>`;
+                    error[index] = `<code>${value.replaceAll(" ", "&nbsp;")}</code>`;
                 } else {
                     error[index] = value;
                 }


### PR DESCRIPTION
If `<code>` only contains whitespace character, it won't be visible. To fix this, I replaced them with non breaking space.

I took this commit from https://github.com/rust-lang/rust/pull/108537.

r? @notriddle 