### PR TITLE
loongarch64-none*: Remove environment component from llvm target

### DIFF
--- a/compiler/rustc_target/src/spec/loongarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/loongarch64_unknown_none_softfloat.rs
@@ -3,7 +3,7 @@ use super::{Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
-        llvm_target: "loongarch64-unknown-none-softfloat".into(),
+        llvm_target: "loongarch64-unknown-none".into(),
         pointer_width: 64,
         data_layout: "e-m:e-p:64:64-i64:64-i128:128-n64-S128".into(),
         arch: "loongarch64".into(),


### PR DESCRIPTION
A warning is reported when the LLVM triple-implied ABI conflicts with the provided target-abi.

```
warning: triple-implied ABI conflicts with provided target-abi ‘lp64s', using target-abi
```

Specifically, the ABI hint comes from the environment component of the triple. When only the target-abi is provided and no environment, there is no conflict. This PR removes the environment component from the LLVM target name of the `loongarch64-unknown-none-softfloat` target.