### PR TITLE
Bencher: pass closure through black_box

### DIFF
--- a/library/test/src/bench.rs
+++ b/library/test/src/bench.rs
@@ -114,7 +114,7 @@ where
 {
     let start = Instant::now();
     for _ in 0..k {
-        black_box(inner());
+        black_box(black_box(&mut *inner)());
     }
     start.elapsed().as_nanos() as u64
 }


### PR DESCRIPTION
This pattern:
```rust
#[bench]
fn bench(b: &mut Bencher) {
    let bench_data = include_bytes!("...");
    b.iter(|| deserialize(&bench_data));
}
```
should probably pass `bench_data` through `std::hint::black_box` to avoid it being propagated and `deserialize` potentially being specialised.

This PR makes a change to `Bencher` that should mitigate this by ensuring the closure's whole captured environment is passed through `black_box`.
