### PR TITLE
Better diagnostics for dlltool errors.

### DIFF
--- a/compiler/rustc_codegen_llvm/messages.ftl
+++ b/compiler/rustc_codegen_llvm/messages.ftl
@@ -1,7 +1,8 @@
 codegen_llvm_copy_bitcode = failed to copy bitcode to object file: {$err}
 
 codegen_llvm_dlltool_fail_import_library =
-    Dlltool could not create import library: {$stdout}
+    Dlltool could not create import library with {$dlltool_path} {$dlltool_args}:
+    {$stdout}
     {$stderr}
 
 codegen_llvm_dynamic_linking_with_lto =

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -81,6 +81,8 @@ pub(crate) struct ErrorCallingDllTool<'a> {
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_dlltool_fail_import_library)]
 pub(crate) struct DlltoolFailImportLibrary<'a> {
+    pub dlltool_path: Cow<'a, str>,
+    pub dlltool_args: String,
     pub stdout: Cow<'a, str>,
     pub stderr: Cow<'a, str>,
 }

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/dlltool-failed.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/dlltool-failed.rs
@@ -6,6 +6,10 @@
 // compile-flags: --crate-type lib --emit link
 // normalize-stderr-test: "[^ ']*/dlltool.exe" -> "$$DLLTOOL"
 // normalize-stderr-test: "[^ ]*/foo.def" -> "$$DEF_FILE"
+// normalize-stderr-test: "[^ ]*/foo.lib" -> "$$LIB_FILE"
+// normalize-stderr-test: "-m [^ ]*" -> "$$TARGET_MACHINE"
+// normalize-stderr-test: "-f [^ ]*" -> "$$ASM_FLAGS"
+// normalize-stderr-test: "--temp-prefix [^ ]*/foo.dll" -> "$$TEMP_PREFIX"
 #[link(name = "foo", kind = "raw-dylib")]
 extern "C" {
     // `@1` is an invalid name to export, as it usually indicates that something

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/dlltool-failed.stderr
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/dlltool-failed.stderr
@@ -1,4 +1,5 @@
-error: Dlltool could not create import library: 
+error: Dlltool could not create import library with $DLLTOOL -d $DEF_FILE -D foo.dll -l $LIB_FILE $TARGET_MACHINE $ASM_FLAGS --no-leading-underscore $TEMP_PREFIX:
+       
        $DLLTOOL: Syntax error in def file $DEF_FILE:1
 
 error: aborting due to previous error


### PR DESCRIPTION
When dlltool fails, show the full command that was executed. In particular, llvm-dlltool is not very helpful, printing a generic usage message rather than what actually went wrong, so stdout and stderr aren't of much use when troubleshooting.