### PR TITLE
Suggest correct signature on missing fn returning RPITIT/AFIT

### DIFF
--- a/tests/ui/impl-trait/in-trait/suggest-missing-item.fixed
+++ b/tests/ui/impl-trait/in-trait/suggest-missing-item.fixed
@@ -1,0 +1,22 @@
+// edition:2021
+// run-rustfix
+
+#![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
+
+trait Trait {
+    async fn foo();
+
+    async fn bar() -> i32;
+
+    fn test(&self) -> impl Sized + '_;
+}
+
+struct S;
+
+impl Trait for S {fn test(&self) -> impl Sized + '_ { todo!() }
+async fn bar() -> i32 { todo!() }
+async fn foo() { todo!() }
+}
+//~^ ERROR not all trait items implemented
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/suggest-missing-item.rs
+++ b/tests/ui/impl-trait/in-trait/suggest-missing-item.rs
@@ -1,0 +1,19 @@
+// edition:2021
+// run-rustfix
+
+#![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
+
+trait Trait {
+    async fn foo();
+
+    async fn bar() -> i32;
+
+    fn test(&self) -> impl Sized + '_;
+}
+
+struct S;
+
+impl Trait for S {}
+//~^ ERROR not all trait items implemented
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/suggest-missing-item.stderr
+++ b/tests/ui/impl-trait/in-trait/suggest-missing-item.stderr
@@ -1,0 +1,18 @@
+error[E0046]: not all trait items implemented, missing: `foo`, `bar`, `test`
+  --> $DIR/suggest-missing-item.rs:16:1
+   |
+LL |     async fn foo();
+   |     --------------- `foo` from trait
+LL |
+LL |     async fn bar() -> i32;
+   |     ---------------------- `bar` from trait
+LL |
+LL |     fn test(&self) -> impl Sized + '_;
+   |     ---------------------------------- `test` from trait
+...
+LL | impl Trait for S {}
+   | ^^^^^^^^^^^^^^^^ missing `foo`, `bar`, `test` in implementation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0046`.


### PR DESCRIPTION
Add `async` and unpeel the future's output type if the function is async

Fixes #108195