### PR TITLE
Launch a non-unwinding panic for misaligned pointer deref

### DIFF
--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -9,7 +9,6 @@ use rustc_middle::mir::{
 };
 use rustc_middle::ty::{Ty, TyCtxt, TypeAndMut};
 use rustc_session::Session;
-use rustc_target::spec::PanicStrategy;
 
 pub struct CheckAlignment;
 
@@ -237,11 +236,10 @@ fn insert_alignment_check<'tcx>(
                 required: Operand::Copy(alignment),
                 found: Operand::Copy(addr),
             }),
-            unwind: if tcx.sess.panic_strategy() == PanicStrategy::Unwind {
-                UnwindAction::Terminate
-            } else {
-                UnwindAction::Unreachable
-            },
+            // The panic symbol that this calls is #[rustc_nounwind]. We never want to insert an
+            // unwind into unsafe code, because unwinding could make a failing UB check turn into
+            // much worse UB when we start unwinding.
+            unwind: UnwindAction::Unreachable,
         },
     });
 }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -166,14 +166,15 @@ fn panic_bounds_check(index: usize, len: usize) -> ! {
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never))]
 #[track_caller]
 #[lang = "panic_misaligned_pointer_dereference"] // needed by codegen for panic on misaligned pointer deref
+#[rustc_nounwind] // `CheckAlignment` MIR pass requires this function to never unwind
 fn panic_misaligned_pointer_dereference(required: usize, found: usize) -> ! {
     if cfg!(feature = "panic_immediate_abort") {
         super::intrinsics::abort()
     }
 
-    panic!(
+    panic_nounwind_fmt(format_args!(
         "misaligned pointer dereference: address must be a multiple of {required:#x} but is {found:#x}"
-    )
+    ))
 }
 
 /// Panic because we cannot unwind out of a function.


### PR DESCRIPTION
This panic already never unwinds, but that's only because it always hits the unwind guard that's created by our `UnwindAction::Terminate`. Hitting the unwind guard generates a huge double-panic backtrace. Now we generate a normal-looking panic message when this check is hit.

r? @thomcc