### PR TITLE
Update cargo

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -16,6 +16,9 @@ const LICENSES: &[&str] = &[
     "Apache-2.0 OR MIT",
     "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT", // wasi license
     "Apache-2.0/MIT",
+    "BSD-2-Clause",                                        // arrayref from Cargo
+    "CC0-1.0 OR Apache-2.0",                               // blake3 from Cargo
+    "CC0-1.0 OR MIT-0 OR Apache-2.0",                      // constant_time_eq from cargo
     "ISC",
     "MIT / Apache-2.0",
     "MIT OR Apache-2.0 OR Zlib",                           // tinyvec_macros
@@ -54,7 +57,7 @@ const EXCEPTIONS_CARGO: &[(&str, &str)] = &[
     // tidy-alphabetical-start
     ("bitmaps", "MPL-2.0+"),
     ("bytesize", "Apache-2.0"),
-    ("dunce", "CC0-1.0 OR MIT-0"),
+    ("dunce", "CC0-1.0 OR MIT-0 OR Apache-2.0"),
     ("fiat-crypto", "MIT OR Apache-2.0 OR BSD-1-Clause"),
     ("im-rc", "MPL-2.0+"),
     ("imara-diff", "Apache-2.0"),


### PR DESCRIPTION
11 commits in 49b6d9e179a91cf7645142541c9563443f64bf2b..0c14026aa84ee2ec4c67460c0a18abc8519ca6b2
2023-06-09 17:21:19 +0000 to 2023-06-14 18:43:05 +0000
- fix(embedded): Don't append hash to bin names (rust-lang/cargo#12269)
- Fix version requirement example in Dependency Resolution, SemVer compatibility section (rust-lang/cargo#12267)
- Update triagebot links. (rust-lang/cargo#12265)
- Show a better error when container tests fail. (rust-lang/cargo#12264)
- chore: update dependencies (rust-lang/cargo#12261)
- refactor(embedded) (rust-lang/cargo#12262)
- docs: clarify the use of `default` branch instead of `main` by default (rust-lang/cargo#12251)
- docs: update changelog for 1.71 backport and 1.72 (rust-lang/cargo#12256)
- feat: Initial support for single-file packages (rust-lang/cargo#12245)
- test(z-flags): Verify `-Z` flags list is sorted (rust-lang/cargo#12224)
- refactor: registry data kinds cleanup (rust-lang/cargo#12248)


---

This commit also update LICENSE exceptions, as Cargo introduced a newer version of `dunce` and `blake3` as dependencies.

r? @ghost