### PR TITLE
Fix explicit-outlives-requirements lint span

### DIFF
--- a/tests/ui/rust-2018/edition-lint-infer-outlives.fixed
+++ b/tests/ui/rust-2018/edition-lint-infer-outlives.fixed
@@ -801,4 +801,10 @@ where
     yoo: &'a U
 }
 
+// https://github.com/rust-lang/rust/issues/105150
+struct InferredWhereBoundWithInlineBound<'a, T: ?Sized>
+{
+    data: &'a T,
+}
+
 fn main() {}

--- a/tests/ui/rust-2018/edition-lint-infer-outlives.rs
+++ b/tests/ui/rust-2018/edition-lint-infer-outlives.rs
@@ -801,4 +801,12 @@ where
     yoo: &'a U
 }
 
+// https://github.com/rust-lang/rust/issues/105150
+struct InferredWhereBoundWithInlineBound<'a, T: ?Sized>
+//~^ ERROR outlives requirements can be inferred
+    where T: 'a,
+{
+    data: &'a T,
+}
+
 fn main() {}

--- a/tests/ui/rust-2018/edition-lint-infer-outlives.stderr
+++ b/tests/ui/rust-2018/edition-lint-infer-outlives.stderr
@@ -11,6 +11,15 @@ LL | #![deny(explicit_outlives_requirements)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:805:56
+   |
+LL |   struct InferredWhereBoundWithInlineBound<'a, T: ?Sized>
+   |  ________________________________________________________^
+LL | |
+LL | |     where T: 'a,
+   | |________________^ help: remove this bound
+
+error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives.rs:26:31
    |
 LL |     struct TeeOutlivesAy<'a, T: 'a> {
@@ -922,5 +931,5 @@ error: outlives requirements can be inferred
 LL |     union BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where 'b: 'a, T: Debug {
    |                                                            ^^^^^^^^ help: remove this bound
 
-error: aborting due to 153 previous errors
+error: aborting due to 154 previous errors
 


### PR DESCRIPTION
Fixes #105150 which caused the span reported by the explicit-outlives-requirements lint to be incorrect when
1) the lint should suggest the entire where clause to be removed and
2) there are inline bounds present that are not inferable outlives requirements

In particular, this would cause rustfix to leave a dangling empty where clause.