### PR TITLE
tweak suggestion for argument-position `impl ?Sized`

### DIFF
--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -252,13 +252,10 @@ pub fn suggest_constraining_type_params<'a>(
         {
             let mut sized_constraints =
                 constraints.extract_if(|(_, def_id)| *def_id == tcx.lang_items().sized_trait());
-            if let Some((constraint, def_id)) = sized_constraints.next() {
+            if let Some((_, def_id)) = sized_constraints.next() {
                 applicability = Applicability::MaybeIncorrect;
 
-                err.span_label(
-                    param.span,
-                    format!("this type parameter needs to be `{}`", constraint),
-                );
+                err.span_label(param.span, "this type parameter needs to be `Sized`");
                 suggest_changing_unsized_bound(generics, &mut suggestions, param, def_id);
             }
         }

--- a/tests/ui/const-generics/const-argument-if-length.full.stderr
+++ b/tests/ui/const-generics/const-argument-if-length.full.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/const-argument-if-length.rs:15:12
    |
 LL | pub struct AtLeastByte<T: ?Sized> {
-   |                        - this type parameter needs to be `std::marker::Sized`
+   |                        - this type parameter needs to be `Sized`
 LL |     value: T,
    |            ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/const-generics/const-argument-if-length.min.stderr
+++ b/tests/ui/const-generics/const-argument-if-length.min.stderr
@@ -11,7 +11,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/const-argument-if-length.rs:15:12
    |
 LL | pub struct AtLeastByte<T: ?Sized> {
-   |                        - this type parameter needs to be `std::marker::Sized`
+   |                        - this type parameter needs to be `Sized`
 LL |     value: T,
    |            ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/dst/dst-object-from-unsized-type.stderr
+++ b/tests/ui/dst/dst-object-from-unsized-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/dst-object-from-unsized-type.rs:8:23
    |
 LL | fn test1<T: ?Sized + Foo>(t: &T) {
-   |          - this type parameter needs to be `std::marker::Sized`
+   |          - this type parameter needs to be `Sized`
 LL |     let u: &dyn Foo = t;
    |                       ^ doesn't have a size known at compile-time
    |
@@ -17,7 +17,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/dst-object-from-unsized-type.rs:13:23
    |
 LL | fn test2<T: ?Sized + Foo>(t: &T) {
-   |          - this type parameter needs to be `std::marker::Sized`
+   |          - this type parameter needs to be `Sized`
 LL |     let v: &dyn Foo = t as &dyn Foo;
    |                       ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/generic-associated-types/issue-88287.stderr
+++ b/tests/ui/generic-associated-types/issue-88287.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/issue-88287.rs:34:9
    |
 LL | type SearchFutureTy<'f, A, B: 'f>
-   |                         - this type parameter needs to be `std::marker::Sized`
+   |                         - this type parameter needs to be `Sized`
 ...
 LL |         async move { todo!() }
    |         ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/tests/ui/offset-of/offset-of-dst-field.stderr
+++ b/tests/ui/offset-of/offset-of-dst-field.stderr
@@ -70,7 +70,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/offset-of-dst-field.rs:50:5
    |
 LL | fn generic_with_maybe_sized<T: ?Sized>() -> usize {
-   |                             - this type parameter needs to be `std::marker::Sized`
+   |                             - this type parameter needs to be `Sized`
 LL |     offset_of!(Delta<T>, z)
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |

--- a/tests/ui/packed/issue-27060-2.stderr
+++ b/tests/ui/packed/issue-27060-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/issue-27060-2.rs:3:11
    |
 LL | pub struct Bad<T: ?Sized> {
-   |                - this type parameter needs to be `std::marker::Sized`
+   |                - this type parameter needs to be `Sized`
 LL |     data: T,
    |           ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/adt-param-with-implicit-sized-bound.rs:25:9
    |
 LL | struct Struct5<T: ?Sized>{
-   |                - this type parameter needs to be `std::marker::Sized`
+   |                - this type parameter needs to be `Sized`
 LL |     _t: X<T>,
    |         ^^^^ doesn't have a size known at compile-time
    |

--- a/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
+++ b/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn foo<T>(foo: Wrapper<T>)
    |        -       ^^^^^^^^^^ doesn't have a size known at compile-time
    |        |
-   |        this type parameter needs to be `std::marker::Sized`
+   |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
@@ -33,7 +33,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn bar<T>(foo: Wrapper<T>)
    |        -       ^^^^^^^^^^ doesn't have a size known at compile-time
    |        |
-   |        this type parameter needs to be `std::marker::Sized`
+   |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
@@ -58,7 +58,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn qux<T>(foo: Wrapper<T>)
    |        -       ^^^^^^^^^^ doesn't have a size known at compile-time
    |        |
-   |        this type parameter needs to be `std::marker::Sized`
+   |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16

--- a/tests/ui/trait-bounds/apit-unsized.rs
+++ b/tests/ui/trait-bounds/apit-unsized.rs
@@ -1,0 +1,4 @@
+fn foo(_: impl Iterator<Item = i32> + ?Sized) {} //~ ERROR [E0277]
+fn bar(_: impl ?Sized) {} //~ ERROR [E0277]
+
+fn main() {}

--- a/tests/ui/trait-bounds/apit-unsized.stderr
+++ b/tests/ui/trait-bounds/apit-unsized.stderr
@@ -1,0 +1,41 @@
+error[E0277]: the size for values of type `impl Iterator<Item = i32> + ?Sized` cannot be known at compilation time
+  --> $DIR/apit-unsized.rs:1:8
+   |
+LL | fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
+   |        ^  ---------------------------------- this type parameter needs to be `std::marker::Sized`
+   |        |
+   |        doesn't have a size known at compile-time
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
+LL + fn foo(_: impl Iterator<Item = i32>) {}
+   |
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn foo(_: &impl Iterator<Item = i32> + ?Sized) {}
+   |           +
+
+error[E0277]: the size for values of type `impl ?Sized` cannot be known at compilation time
+  --> $DIR/apit-unsized.rs:2:8
+   |
+LL | fn bar(_: impl ?Sized) {}
+   |        ^  ----------- this type parameter needs to be `std::marker::Sized`
+   |        |
+   |        doesn't have a size known at compile-time
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: consider replacing `?Sized` with `Sized`
+   |
+LL - fn bar(_: impl ?Sized) {}
+LL + fn bar(_: impl Sized) {}
+   |
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn bar(_: &impl ?Sized) {}
+   |           +
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/trait-bounds/apit-unsized.stderr
+++ b/tests/ui/trait-bounds/apit-unsized.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `impl Iterator<Item = i32> + ?Sized` c
   --> $DIR/apit-unsized.rs:1:8
    |
 LL | fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
-   |        ^  ---------------------------------- this type parameter needs to be `std::marker::Sized`
+   |        ^  ---------------------------------- this type parameter needs to be `Sized`
    |        |
    |        doesn't have a size known at compile-time
    |
@@ -21,7 +21,7 @@ error[E0277]: the size for values of type `impl ?Sized` cannot be known at compi
   --> $DIR/apit-unsized.rs:2:8
    |
 LL | fn bar(_: impl ?Sized) {}
-   |        ^  ----------- this type parameter needs to be `std::marker::Sized`
+   |        ^  ----------- this type parameter needs to be `Sized`
    |        |
    |        doesn't have a size known at compile-time
    |

--- a/tests/ui/trait-bounds/unsized-bound.stderr
+++ b/tests/ui/trait-bounds/unsized-bound.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `B` cannot be known at compilation tim
 LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
    |         -                    ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B)`
 note: required by a bound in `Trait`
@@ -28,7 +28,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
    |      -                       ^^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -43,7 +43,7 @@ error[E0277]: the size for values of type `C` cannot be known at compilation tim
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
    |                    -                               ^^^^^^^^^ doesn't have a size known at compile-time
    |                    |
-   |                    this type parameter needs to be `std::marker::Sized`
+   |                    this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B, C)`
 note: required by a bound in `Trait`
@@ -65,9 +65,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/unsized-bound.rs:5:52
    |
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |      -                                             ^^^^^^^^^ doesn't have a size known at compile-time
-   |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      - this type parameter needs to be `Sized`     ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -80,9 +78,7 @@ error[E0277]: the size for values of type `B` cannot be known at compilation tim
   --> $DIR/unsized-bound.rs:5:52
    |
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |         -                                          ^^^^^^^^^ doesn't have a size known at compile-time
-   |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         - this type parameter needs to be `Sized`  ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -97,7 +93,7 @@ error[E0277]: the size for values of type `B` cannot be known at compilation tim
 LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
    |                 -                             ^^^^^^ doesn't have a size known at compile-time
    |                 |
-   |                 this type parameter needs to be `std::marker::Sized`
+   |                 this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B)`
 note: required by a bound in `Trait2`
@@ -121,7 +117,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
    |      -                                        ^^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -136,7 +132,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL | impl<A> Trait3<A> for A where A: ?Sized {}
    |      -                ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait3`
   --> $DIR/unsized-bound.rs:13:14
@@ -159,7 +155,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL | impl<A: ?Sized> Trait4<A> for A {}
    |      -                        ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait4`
   --> $DIR/unsized-bound.rs:16:14
@@ -182,7 +178,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
    |      -                      ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait5`
   --> $DIR/unsized-bound.rs:19:14
@@ -205,7 +201,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized, Y> Trait6<X, Y> for X {}
    |      -                              ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait6`
   --> $DIR/unsized-bound.rs:22:14
@@ -228,7 +224,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
 LL | impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
    |         -  ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait7`
   --> $DIR/unsized-bound.rs:25:17
@@ -251,7 +247,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
 LL | impl<X, Y: ?Sized> Trait8<X, Y> for X {}
    |         -          ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait8`
   --> $DIR/unsized-bound.rs:28:17

--- a/tests/ui/traits/suggest-where-clause.stderr
+++ b/tests/ui/traits/suggest-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `U` cannot be known at compilation tim
   --> $DIR/suggest-where-clause.rs:7:20
    |
 LL | fn check<T: Iterator, U: ?Sized>() {
-   |                       - this type parameter needs to be `std::marker::Sized`
+   |                       - this type parameter needs to be `Sized`
 LL |     // suggest a where-clause, if needed
 LL |     mem::size_of::<U>();
    |                    ^ doesn't have a size known at compile-time
@@ -19,7 +19,7 @@ error[E0277]: the size for values of type `U` cannot be known at compilation tim
   --> $DIR/suggest-where-clause.rs:10:20
    |
 LL | fn check<T: Iterator, U: ?Sized>() {
-   |                       - this type parameter needs to be `std::marker::Sized`
+   |                       - this type parameter needs to be `Sized`
 ...
 LL |     mem::size_of::<Misc<U>>();
    |                    ^^^^^^^ doesn't have a size known at compile-time

--- a/tests/ui/union/union-sized-field.stderr
+++ b/tests/ui/union/union-sized-field.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:4:12
    |
 LL | union Foo<T: ?Sized> {
-   |           - this type parameter needs to be `std::marker::Sized`
+   |           - this type parameter needs to be `Sized`
 LL |     value: ManuallyDrop<T>,
    |            ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -28,7 +28,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:9:12
    |
 LL | struct Foo2<T: ?Sized> {
-   |             - this type parameter needs to be `std::marker::Sized`
+   |             - this type parameter needs to be `Sized`
 LL |     value: ManuallyDrop<T>,
    |            ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -54,7 +54,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:15:11
    |
 LL | enum Foo3<T: ?Sized> {
-   |           - this type parameter needs to be `std::marker::Sized`
+   |           - this type parameter needs to be `Sized`
 LL |     Value(ManuallyDrop<T>),
    |           ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |

--- a/tests/ui/unsized/unsized-bare-typaram.stderr
+++ b/tests/ui/unsized/unsized-bare-typaram.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn foo<T: ?Sized>() { bar::<T>() }
    |        -                    ^ doesn't have a size known at compile-time
    |        |
-   |        this type parameter needs to be `std::marker::Sized`
+   |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `bar`
   --> $DIR/unsized-bare-typaram.rs:1:8

--- a/tests/ui/unsized/unsized-enum.stderr
+++ b/tests/ui/unsized/unsized-enum.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required by a bound in `Foo`
   --> $DIR/unsized-enum.rs:4:10

--- a/tests/ui/unsized/unsized-enum2.stderr
+++ b/tests/ui/unsized/unsized-enum2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `W` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:23:8
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     // parameter
 LL |     VA(W),
    |        ^ doesn't have a size known at compile-time
@@ -27,7 +27,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:25:11
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                   - this type parameter needs to be `std::marker::Sized`
+   |                   - this type parameter needs to be `Sized`
 ...
 LL |     VB{x: X},
    |           ^ doesn't have a size known at compile-time
@@ -52,7 +52,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:27:15
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                              - this type parameter needs to be `std::marker::Sized`
+   |                              - this type parameter needs to be `Sized`
 ...
 LL |     VC(isize, Y),
    |               ^ doesn't have a size known at compile-time
@@ -77,7 +77,7 @@ error[E0277]: the size for values of type `Z` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:29:21
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                                         - this type parameter needs to be `std::marker::Sized`
+   |                                         - this type parameter needs to be `Sized`
 ...
 LL |     VD{u: isize, x: Z},
    |                     ^ doesn't have a size known at compile-time

--- a/tests/ui/unsized/unsized-fn-arg.stderr
+++ b/tests/ui/unsized/unsized-fn-arg.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn f<T: ?Sized>(t: T) {}
    |      -          ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider removing the `?Sized` bound to make the type parameter `Sized`

--- a/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized> S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `S5`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11

--- a/tests/ui/unsized/unsized-struct.stderr
+++ b/tests/ui/unsized/unsized-struct.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required by a bound in `Foo`
   --> $DIR/unsized-struct.rs:4:12
@@ -30,7 +30,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
    |         -                         ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required because it appears within the type `Bar<T>`
   --> $DIR/unsized-struct.rs:11:8

--- a/tests/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      -                    ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `S5`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized> T2<X> for S4<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `T2`
   --> $DIR/unsized-trait-impl-trait-arg.rs:4:10

--- a/tests/ui/unsized/unsized3.stderr
+++ b/tests/ui/unsized/unsized3.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:7:13
    |
 LL | fn f1<X: ?Sized>(x: &X) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     f2::<X>(x);
    |     ------- ^ doesn't have a size known at compile-time
    |     |
@@ -27,7 +27,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:18:13
    |
 LL | fn f3<X: ?Sized + T>(x: &X) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     f4::<X>(x);
    |     ------- ^ doesn't have a size known at compile-time
    |     |
@@ -52,7 +52,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:33:8
    |
 LL | fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     f5(x1);
    |     -- ^^ doesn't have a size known at compile-time
    |     |
@@ -82,7 +82,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:40:5
    |
 LL | fn f9<X: ?Sized>(x1: Box<S<X>>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     f5(&(*x1, 34));
    |     ^^ doesn't have a size known at compile-time
    |
@@ -102,7 +102,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:45:9
    |
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     f5(&(32, *x1));
    |         ^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -123,7 +123,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:45:8
    |
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     f5(&(32, *x1));
    |     -- ^^^^^^^^^^ doesn't have a size known at compile-time
    |     |

--- a/tests/ui/unsized/unsized5.stderr
+++ b/tests/ui/unsized/unsized5.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:4:9
    |
 LL | struct S1<X: ?Sized> {
-   |           - this type parameter needs to be `std::marker::Sized`
+   |           - this type parameter needs to be `Sized`
 LL |     f1: X,
    |         ^ doesn't have a size known at compile-time
    |
@@ -26,7 +26,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:10:8
    |
 LL | struct S2<X: ?Sized> {
-   |           - this type parameter needs to be `std::marker::Sized`
+   |           - this type parameter needs to be `Sized`
 LL |     f: isize,
 LL |     g: X,
    |        ^ doesn't have a size known at compile-time
@@ -87,7 +87,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:25:8
    |
 LL | enum E<X: ?Sized> {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     V1(X, isize),
    |        ^ doesn't have a size known at compile-time
    |
@@ -111,7 +111,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:29:12
    |
 LL | enum F<X: ?Sized> {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     V2{f1: X, f: isize},
    |            ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/unsized/unsized6.stderr
+++ b/tests/ui/unsized/unsized6.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized6.rs:9:9
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                             - this type parameter needs to be `std::marker::Sized`
+   |                             - this type parameter needs to be `Sized`
 ...
 LL |     let y: Y;
    |         ^ doesn't have a size known at compile-time
@@ -23,7 +23,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:7:12
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                  - this type parameter needs to be `std::marker::Sized`
+   |                  - this type parameter needs to be `Sized`
 LL |     let _: W; // <-- this is OK, no bindings created, no initializer.
 LL |     let _: (isize, (X, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -39,7 +39,7 @@ error[E0277]: the size for values of type `Z` cannot be known at compilation tim
   --> $DIR/unsized6.rs:11:12
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                                        - this type parameter needs to be `std::marker::Sized`
+   |                                        - this type parameter needs to be `Sized`
 ...
 LL |     let y: (isize, (Z, usize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -55,7 +55,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:15:9
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     let y: X;
    |         ^ doesn't have a size known at compile-time
    |
@@ -75,7 +75,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized6.rs:17:12
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
-   |                  - this type parameter needs to be `std::marker::Sized`
+   |                  - this type parameter needs to be `Sized`
 ...
 LL |     let y: (isize, (Y, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -91,7 +91,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:22:9
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
@@ -111,7 +111,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:24:9
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 ...
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
@@ -128,7 +128,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:26:10
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
@@ -145,7 +145,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:30:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
@@ -165,7 +165,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:32:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 ...
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
@@ -182,7 +182,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:34:10
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
@@ -201,7 +201,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn g1<X: ?Sized>(x: X) {}
    |       -          ^ doesn't have a size known at compile-time
    |       |
-   |       this type parameter needs to be `std::marker::Sized`
+   |       this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -220,7 +220,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn g2<X: ?Sized + T>(x: X) {}
    |       -              ^ doesn't have a size known at compile-time
    |       |
-   |       this type parameter needs to be `std::marker::Sized`
+   |       this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider removing the `?Sized` bound to make the type parameter `Sized`

--- a/tests/ui/unsized/unsized7.stderr
+++ b/tests/ui/unsized/unsized7.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |      -              ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `T1`
   --> $DIR/unsized7.rs:7:10


### PR DESCRIPTION
fixes this invalid suggestion:
```text
help: consider removing the `?Sized` bound to make the type parameter `Sized`
  |
1 - fn foo(_: impl ?Sized) {}
1 + fn foo(_: impl ) {}
  |
```