### PR TITLE
Improve tests on targets without unwinding

### DIFF
--- a/tests/codegen/naked-nocoverage.rs
+++ b/tests/codegen/naked-nocoverage.rs
@@ -11,7 +11,7 @@ use std::arch::asm;
 #[naked]
 #[no_mangle]
 pub unsafe extern "C" fn f() {
-    // CHECK:       define void @f()
+    // CHECK:       define {{(dso_local )?}}void @f()
     // CHECK-NEXT:  start:
     // CHECK-NEXT:    call void asm
     // CHECK-NEXT:    unreachable

--- a/tests/ui/asm/aarch64/may_unwind.rs
+++ b/tests/ui/asm/aarch64/may_unwind.rs
@@ -1,6 +1,7 @@
 // only-aarch64
 // run-pass
 // needs-asm-support
+// needs-unwind
 
 #![feature(asm_unwind)]
 

--- a/tests/ui/test-attrs/test-panic-abort-disabled.rs
+++ b/tests/ui/test-attrs/test-panic-abort-disabled.rs
@@ -3,6 +3,7 @@
 // compile-flags: --test -Cpanic=abort -Zpanic-abort-tests=no
 // run-flags: --test-threads=1
 
+// needs-unwind
 // ignore-wasm no panic or subprocess support
 // ignore-emscripten no panic or subprocess support
 

--- a/tests/ui/test-attrs/test-type.rs
+++ b/tests/ui/test-attrs/test-type.rs
@@ -1,4 +1,4 @@
-// compile-flags: --test
+// compile-flags: --test -Zpanic-abort-tests
 // run-flags: --test-threads=1
 // check-run-results
 // normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"

--- a/tests/ui/test-attrs/test-type.rs
+++ b/tests/ui/test-attrs/test-type.rs
@@ -3,7 +3,6 @@
 // check-run-results
 // normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // ignore-emscripten no threads support
-// needs-unwind
 // run-pass
 
 #[test]


### PR DESCRIPTION
This PR makes more miscellaneous changes to tests, to make it work on targets without unwinding support.