### PR TITLE
Suggest bumping download-ci-llvm-stamp if the build config for llvm changes

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -477,6 +477,13 @@ message = "This PR changes src/bootstrap/defaults/config.compiler.toml. If appro
 [mentions."src/bootstrap/defaults/config.codegen.toml"]
 message = "This PR changes src/bootstrap/defaults/config.codegen.toml. If appropriate, please also update `config.compiler.toml` so the defaults are in sync."
 
+[mentions."src/bootstrap/llvm.rs"]
+message = "This PR changes how LLVM is built. Consider updating src/bootstrap/download-ci-llvm-stamp."
+[mentions."compiler/rustc_llvm/build.rs"]
+message = "This PR changes how LLVM is built. Consider updating src/bootstrap/download-ci-llvm-stamp."
+[mentions."compiler/rustc_llvm/llvm-wrapper"]
+message = "This PR changes how LLVM is built. Consider updating src/bootstrap/download-ci-llvm-stamp."
+
 [mentions."tests/ui/deriving/deriving-all-codegen.stdout"]
 message = "Changes to the code generated for builtin derived traits."
 cc = ["@nnethercote"]


### PR DESCRIPTION
This will hopefully avoid issues like https://github.com/rust-lang/rust/issues/110474 where the uploaded `rust-dev` component doesn't match the one you'd get if you built LLVM from source.

cc https://github.com/rust-lang/rust/issues/110474#issuecomment-1516403887