### PR TITLE
Fix small typo

### DIFF
--- a/library/core/src/iter/sources/successors.rs
+++ b/library/core/src/iter/sources/successors.rs
@@ -22,7 +22,7 @@ where
     Successors { next: first, succ }
 }
 
-/// An new iterator where each successive item is computed based on the preceding one.
+/// A new iterator where each successive item is computed based on the preceding one.
 ///
 /// This `struct` is created by the [`iter::successors()`] function.
 /// See its documentation for more.


### PR DESCRIPTION
Fixes a small typo in the [`Successors`](https://doc.rust-lang.org/std/iter/struct.Successors.html) documentation.