### PR TITLE
Mention `env!` in `option_env!`'s docs

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -960,6 +960,8 @@ pub(crate) mod builtin {
     ///
     /// A compile time error is never emitted when using this macro regardless
     /// of whether the environment variable is present or not.
+    /// To emit a compile error if the environment variable is not present,
+    /// use the [`env!`] macro instead.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
`env!` mentions that there is an alternative that returns an `Option<...>` instead of emitting a compile error.

Now `option_env!` also mentions that there is an alternative that emits a compile error instead of returning an `Option<...>`.