### PR TITLE
Make associated type bounds in supertrait position implied

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -9,11 +9,11 @@ use rustc_span::symbol::Ident;
 use rustc_span::{ErrorGuaranteed, Span};
 use rustc_trait_selection::traits;
 
-use crate::astconv::{AstConv, ConvertedBinding, ConvertedBindingKind};
+use crate::astconv::{
+    AstConv, ConvertedBinding, ConvertedBindingKind, OnlySelfBounds, PredicateFilter,
+};
 use crate::bounds::Bounds;
 use crate::errors::{MultipleRelaxedDefaultBounds, ValueOfAssociatedStructAlreadySpecified};
-
-use super::OnlySelfBounds;
 
 impl<'tcx> dyn AstConv<'tcx> + '_ {
     /// Sets `implicitly_sized` to true on `Bounds` if necessary
@@ -176,47 +176,39 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
         &self,
         param_ty: Ty<'tcx>,
         ast_bounds: &[hir::GenericBound<'_>],
-        only_self_bounds: OnlySelfBounds,
+        filter: PredicateFilter,
     ) -> Bounds<'tcx> {
         let mut bounds = Bounds::default();
+
+        let only_self_bounds = match filter {
+            PredicateFilter::All | PredicateFilter::SelfAndAssociatedTypeBounds => {
+                OnlySelfBounds(false)
+            }
+            PredicateFilter::SelfOnly | PredicateFilter::SelfThatDefines(_) => OnlySelfBounds(true),
+        };
+
         self.add_bounds(
             param_ty,
-            ast_bounds.iter(),
+            ast_bounds.iter().filter(|bound| {
+                match filter {
+                PredicateFilter::All
+                | PredicateFilter::SelfOnly
+                | PredicateFilter::SelfAndAssociatedTypeBounds => true,
+                PredicateFilter::SelfThatDefines(assoc_name) => {
+                    if let Some(trait_ref) = bound.trait_ref()
+                        && let Some(trait_did) = trait_ref.trait_def_id()
+                        && self.tcx().trait_may_define_assoc_item(trait_did, assoc_name)
+                    {
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+            }),
             &mut bounds,
             ty::List::empty(),
             only_self_bounds,
-        );
-        debug!(?bounds);
-
-        bounds
-    }
-
-    /// Convert the bounds in `ast_bounds` that refer to traits which define an associated type
-    /// named `assoc_name` into ty::Bounds. Ignore the rest.
-    pub(crate) fn compute_bounds_that_match_assoc_item(
-        &self,
-        param_ty: Ty<'tcx>,
-        ast_bounds: &[hir::GenericBound<'_>],
-        assoc_name: Ident,
-    ) -> Bounds<'tcx> {
-        let mut result = Vec::new();
-
-        for ast_bound in ast_bounds {
-            if let Some(trait_ref) = ast_bound.trait_ref()
-                && let Some(trait_did) = trait_ref.trait_def_id()
-                && self.tcx().trait_may_define_assoc_item(trait_did, assoc_name)
-            {
-                result.push(ast_bound.clone());
-            }
-        }
-
-        let mut bounds = Bounds::default();
-        self.add_bounds(
-            param_ty,
-            result.iter(),
-            &mut bounds,
-            ty::List::empty(),
-            OnlySelfBounds(true),
         );
         debug!(?bounds);
 

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -58,6 +58,24 @@ pub struct PathSeg(pub DefId, pub usize);
 #[derive(Copy, Clone, Debug)]
 pub struct OnlySelfBounds(pub bool);
 
+#[derive(Copy, Clone, Debug)]
+pub enum PredicateFilter {
+    /// All predicates may be implied by the trait.
+    All,
+
+    /// Only traits that reference `Self: ..` are implied by the trait.
+    SelfOnly,
+
+    /// Only traits that reference `Self: ..` and define an associated type
+    /// with the given ident are implied by the trait.
+    SelfThatDefines(Ident),
+
+    /// Only traits that reference `Self: ..` and their associated type bounds.
+    /// For example, given `Self: Tr<A: B>`, this would expand to `Self: Tr`
+    /// and `<Self as Tr>::A: B`.
+    SelfAndAssociatedTypeBounds,
+}
+
 pub trait AstConv<'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx>;
 

--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -1,5 +1,5 @@
 use super::ItemCtxt;
-use crate::astconv::{AstConv, OnlySelfBounds};
+use crate::astconv::{AstConv, PredicateFilter};
 use rustc_hir as hir;
 use rustc_infer::traits::util;
 use rustc_middle::ty::subst::InternalSubsts;
@@ -26,7 +26,7 @@ fn associated_type_bounds<'tcx>(
     );
 
     let icx = ItemCtxt::new(tcx, assoc_item_def_id);
-    let mut bounds = icx.astconv().compute_bounds(item_ty, ast_bounds, OnlySelfBounds(false));
+    let mut bounds = icx.astconv().compute_bounds(item_ty, ast_bounds, PredicateFilter::All);
     // Associated types are implicitly sized unless a `?Sized` bound is found
     icx.astconv().add_implicitly_sized(&mut bounds, item_ty, ast_bounds, None, span);
 
@@ -68,7 +68,7 @@ fn opaque_type_bounds<'tcx>(
 ) -> &'tcx [(ty::Clause<'tcx>, Span)] {
     ty::print::with_no_queries!({
         let icx = ItemCtxt::new(tcx, opaque_def_id);
-        let mut bounds = icx.astconv().compute_bounds(item_ty, ast_bounds, OnlySelfBounds(false));
+        let mut bounds = icx.astconv().compute_bounds(item_ty, ast_bounds, PredicateFilter::All);
         // Opaque types are implicitly sized unless a `?Sized` bound is found
         icx.astconv().add_implicitly_sized(&mut bounds, item_ty, ast_bounds, None, span);
         debug!(?bounds);

--- a/tests/ui/associated-type-bounds/implied-in-supertrait.rs
+++ b/tests/ui/associated-type-bounds/implied-in-supertrait.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![feature(associated_type_bounds)]
+
+trait Trait: Super<Assoc: Bound> {}
+
+trait Super {
+    type Assoc;
+}
+
+trait Bound {}
+
+fn foo<T>(x: T)
+where
+    T: Trait,
+{
+}
+
+fn main() {}

--- a/tests/ui/async-await/return-type-notation/rtn-implied-in-supertrait.rs
+++ b/tests/ui/async-await/return-type-notation/rtn-implied-in-supertrait.rs
@@ -1,0 +1,28 @@
+// edition:2021
+// check-pass
+
+#![feature(async_fn_in_trait, return_position_impl_trait_in_trait, return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+use std::future::Future;
+
+struct JoinHandle<T>(fn() -> T);
+
+fn spawn<T>(_: impl Future<Output = T>) -> JoinHandle<T> {
+    todo!()
+}
+
+trait Foo {
+    async fn bar(&self) -> i32;
+}
+
+trait SendFoo: Foo<bar(): Send> + Send {}
+
+fn foobar(foo: impl SendFoo) -> JoinHandle<i32> {
+    spawn(async move {
+        let future = foo.bar();
+        future.await
+    })
+}
+
+fn main() {}

--- a/tests/ui/async-await/return-type-notation/rtn-implied-in-supertrait.stderr
+++ b/tests/ui/async-await/return-type-notation/rtn-implied-in-supertrait.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/rtn-implied-in-supertrait.rs:4:68
+   |
+LL | #![feature(async_fn_in_trait, return_position_impl_trait_in_trait, return_type_notation)]
+   |                                                                    ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
`trait A: B<Assoc: C> {}` should be able to imply both `Self: B` and `<Self as B>::Assoc: C`. Adjust the way that we collect implied predicates to do so.

Fixes #112573
Fixes #112568