### PR TITLE
CI: merge `msvc` test CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,25 +383,15 @@ jobs:
               DIST_REQUIRE_ALL_TOOLS: 1
               JEMALLOC_SYS_WITH_LG_PAGE: 14
             os: macos-latest
-          - name: x86_64-msvc-1
+          - name: x86_64-msvc
             env:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-profiler"
-              SCRIPT: make ci-subset-1
+              SCRIPT: make ci-msvc
             os: windows-2019-8core-32gb
-          - name: x86_64-msvc-2
-            env:
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-profiler"
-              SCRIPT: make ci-subset-2
-            os: windows-2019-8core-32gb
-          - name: i686-msvc-1
+          - name: i686-msvc
             env:
               RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-msvc"
-              SCRIPT: make ci-subset-1
-            os: windows-2019-8core-32gb
-          - name: i686-msvc-2
-            env:
-              RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-msvc"
-              SCRIPT: make ci-subset-2
+              SCRIPT: make ci-msvc
             os: windows-2019-8core-32gb
           - name: x86_64-msvc-cargo
             env:

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -57,17 +57,11 @@ tidy:
 prepare:
 	$(Q)$(BOOTSTRAP) build --stage 2 nonexistent/path/to/trigger/cargo/metadata
 
-TESTS_IN_2 := \
-	tests/ui \
-	src/tools/linkchecker
-
 ## MSVC native builders
 
-# these intentionally don't use `$(BOOTSTRAP)` so we can test the shebang on Windows
-ci-subset-1:
-	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2 $(TESTS_IN_2:%=--exclude %)
-ci-subset-2:
-	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 $(TESTS_IN_2)
+# this intentionally doesn't use `$(BOOTSTRAP)` so we can test the shebang on Windows
+ci-msvc:
+	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2
 
 ## MingW native builders
 

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -582,28 +582,16 @@ jobs:
           #  Windows Builders  #
           ######################
 
-          - name: x86_64-msvc-1
+          - name: x86_64-msvc
             env:
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
-              SCRIPT: make ci-subset-1
+              SCRIPT: make ci-msvc
             <<: *job-windows-8c
 
-          - name: x86_64-msvc-2
-            env:
-              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
-              SCRIPT: make ci-subset-2
-            <<: *job-windows-8c
-
-          - name: i686-msvc-1
+          - name: i686-msvc
             env:
               RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
-              SCRIPT: make ci-subset-1
-            <<: *job-windows-8c
-
-          - name: i686-msvc-2
-            env:
-              RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
-              SCRIPT: make ci-subset-2
+              SCRIPT: make ci-msvc
             <<: *job-windows-8c
 
           - name: x86_64-msvc-cargo


### PR DESCRIPTION
Merges `msvc` jobs together to save CI time. Currently, both runners take about 1h 15 minutes, but nowadays it should be possible to just run everything in a single job.

CI run: https://github.com/rust-lang/rust/actions/runs/5272144087/jobs/9534015536?pr=112633 (both finish under ~1h 35 minutes)

After this change, we no longer test both `x.py` and `x.ps1`, but I don't suppose that it's worth it to spend 1.5 hours of additional CI time just for that. I suggest to run all tests using e.g. `x.py` and then run just `x.ps1 test --stage 2 --force-rerun tests/<single-quick-test>`.
Also I'm not sure if it's worth it to keep using the Makefile for this.
