### PR TITLE
Don't capture `&[T; N]` when contents isn't read

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -443,7 +443,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                         if matches!((lhs, wild, rhs), (&[], Some(_), &[]))
                             // Arrays have a statically known size, so
                             // there is no need to read their length
-                            || discr_place.place.base_ty.is_array()
+                            || place.place.ty().peel_refs().is_array()
                         {
                         } else {
                             needs_to_be_read = true;

--- a/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.rs
+++ b/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.rs
@@ -87,6 +87,31 @@ fn test_4_should_not_capture_array() {
         }
     };
     c();
+
+    // We also do not need to capture an array
+    // behind a reference (#112607)
+    let array: &[i32; 3] = &[0; 3];
+    let c = #[rustc_capture_analysis]
+    || {
+    //~^ First Pass analysis includes:
+        match array {
+            [_, _, _] => {}
+        }
+    };
+    c();
+
+    // We should still not insert a read if the array is inside an
+    // irrefutable pattern
+    struct Foo<T>(T);
+    let f = &Foo(&[10; 3]);
+    let c = #[rustc_capture_analysis]
+    || {
+    //~^ First Pass analysis includes:
+        match f {
+            Foo([_, _, _]) => ()
+        }
+    };
+    c();
 }
 
 // Testing MultiVariant patterns

--- a/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.stderr
@@ -109,7 +109,29 @@ LL | |     };
    | |_____^
 
 error: First Pass analysis includes:
-  --> $DIR/patterns-capture-analysis.rs:105:5
+  --> $DIR/patterns-capture-analysis.rs:95:5
+   |
+LL | /     || {
+LL | |
+LL | |         match array {
+LL | |             [_, _, _] => {}
+LL | |         }
+LL | |     };
+   | |_____^
+
+error: First Pass analysis includes:
+  --> $DIR/patterns-capture-analysis.rs:108:5
+   |
+LL | /     || {
+LL | |
+LL | |         match f {
+LL | |             Foo([_, _, _]) => ()
+LL | |         }
+LL | |     };
+   | |_____^
+
+error: First Pass analysis includes:
+  --> $DIR/patterns-capture-analysis.rs:130:5
    |
 LL | /     || {
 LL | |
@@ -121,13 +143,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing variant[] -> ImmBorrow
-  --> $DIR/patterns-capture-analysis.rs:108:15
+  --> $DIR/patterns-capture-analysis.rs:133:15
    |
 LL |         match variant {
    |               ^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/patterns-capture-analysis.rs:105:5
+  --> $DIR/patterns-capture-analysis.rs:130:5
    |
 LL | /     || {
 LL | |
@@ -139,13 +161,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture variant[] -> ImmBorrow
-  --> $DIR/patterns-capture-analysis.rs:108:15
+  --> $DIR/patterns-capture-analysis.rs:133:15
    |
 LL |         match variant {
    |               ^^^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/patterns-capture-analysis.rs:123:5
+  --> $DIR/patterns-capture-analysis.rs:148:5
    |
 LL | /     || {
 LL | |
@@ -157,13 +179,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing slice[] -> ImmBorrow
-  --> $DIR/patterns-capture-analysis.rs:126:15
+  --> $DIR/patterns-capture-analysis.rs:151:15
    |
 LL |         match slice {
    |               ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/patterns-capture-analysis.rs:123:5
+  --> $DIR/patterns-capture-analysis.rs:148:5
    |
 LL | /     || {
 LL | |
@@ -175,13 +197,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture slice[] -> ImmBorrow
-  --> $DIR/patterns-capture-analysis.rs:126:15
+  --> $DIR/patterns-capture-analysis.rs:151:15
    |
 LL |         match slice {
    |               ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/patterns-capture-analysis.rs:135:5
+  --> $DIR/patterns-capture-analysis.rs:160:5
    |
 LL | /     || {
 LL | |
@@ -193,13 +215,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing slice[] -> ImmBorrow
-  --> $DIR/patterns-capture-analysis.rs:138:15
+  --> $DIR/patterns-capture-analysis.rs:163:15
    |
 LL |         match slice {
    |               ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/patterns-capture-analysis.rs:135:5
+  --> $DIR/patterns-capture-analysis.rs:160:5
    |
 LL | /     || {
 LL | |
@@ -211,13 +233,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture slice[] -> ImmBorrow
-  --> $DIR/patterns-capture-analysis.rs:138:15
+  --> $DIR/patterns-capture-analysis.rs:163:15
    |
 LL |         match slice {
    |               ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/patterns-capture-analysis.rs:147:5
+  --> $DIR/patterns-capture-analysis.rs:172:5
    |
 LL | /     || {
 LL | |
@@ -229,13 +251,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing slice[] -> ImmBorrow
-  --> $DIR/patterns-capture-analysis.rs:150:15
+  --> $DIR/patterns-capture-analysis.rs:175:15
    |
 LL |         match slice {
    |               ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/patterns-capture-analysis.rs:147:5
+  --> $DIR/patterns-capture-analysis.rs:172:5
    |
 LL | /     || {
 LL | |
@@ -247,13 +269,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture slice[] -> ImmBorrow
-  --> $DIR/patterns-capture-analysis.rs:150:15
+  --> $DIR/patterns-capture-analysis.rs:175:15
    |
 LL |         match slice {
    |               ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/patterns-capture-analysis.rs:164:5
+  --> $DIR/patterns-capture-analysis.rs:189:5
    |
 LL | /     || {
 LL | |
@@ -264,5 +286,5 @@ LL | |         }
 LL | |     };
    | |_____^
 
-error: aborting due to 16 previous errors
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Fixes the check in #111831
Fixes #112607, although I decided to test the root cause rather than including the example in the issue as a test.
cc @BoxyUwU 