### PR TITLE
Always register sized obligation for argument

### DIFF
--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -92,10 +92,7 @@ pub(super) fn check_fn<'a, 'tcx>(
         fcx.check_pat_top(&param.pat, param_ty, ty_span, None);
 
         // Check that argument is Sized.
-        // The check for a non-trivial pattern is a hack to avoid duplicate warnings
-        // for simple cases like `fn foo(x: Trait)`,
-        // where we would error once on the parameter as a whole, and once on the binding `x`.
-        if param.pat.simple_ident().is_none() && !params_can_be_unsized {
+        if !params_can_be_unsized {
             fcx.require_type_is_sized(
                 param_ty,
                 param.pat.span,

--- a/tests/ui/closures/cannot-call-unsized-via-ptr-2.rs
+++ b/tests/ui/closures/cannot-call-unsized-via-ptr-2.rs
@@ -1,0 +1,11 @@
+#![feature(unsized_fn_params)]
+
+fn main() {
+    // CoerceMany "LUB"
+    let f = if true { |_a| {} } else { |_b| {} };
+    //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+    //~| ERROR the size for values of type `[u8]` cannot be known at compilation time
+
+    let slice: Box<[u8]> = Box::new([1; 8]);
+    f(*slice);
+}

--- a/tests/ui/closures/cannot-call-unsized-via-ptr-2.stderr
+++ b/tests/ui/closures/cannot-call-unsized-via-ptr-2.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/cannot-call-unsized-via-ptr-2.rs:5:24
+   |
+LL |     let f = if true { |_a| {} } else { |_b| {} };
+   |                        ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all function arguments must have a statically known size
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/cannot-call-unsized-via-ptr-2.rs:5:41
+   |
+LL |     let f = if true { |_a| {} } else { |_b| {} };
+   |                                         ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all function arguments must have a statically known size
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/closures/cannot-call-unsized-via-ptr.rs
+++ b/tests/ui/closures/cannot-call-unsized-via-ptr.rs
@@ -1,0 +1,10 @@
+#![feature(unsized_fn_params)]
+
+fn main() {
+    // Simple coercion
+    let f: fn([u8]) = |_result| {};
+    //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+
+    let slice: Box<[u8]> = Box::new([1; 8]);
+    f(*slice);
+}

--- a/tests/ui/closures/cannot-call-unsized-via-ptr.stderr
+++ b/tests/ui/closures/cannot-call-unsized-via-ptr.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/cannot-call-unsized-via-ptr.rs:5:24
+   |
+LL |     let f: fn([u8]) = |_result| {};
+   |                        ^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all function arguments must have a statically known size
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/issues/issue-5883.rs
+++ b/tests/ui/issues/issue-5883.rs
@@ -6,7 +6,7 @@ struct Struct {
 
 fn new_struct(
     r: dyn A + 'static //~ ERROR the size for values of type
-) -> Struct {          //~ ERROR the size for values of type
+) -> Struct {
     Struct { r: r }
 }
 

--- a/tests/ui/issues/issue-5883.stderr
+++ b/tests/ui/issues/issue-5883.stderr
@@ -15,22 +15,6 @@ help: function arguments must have a statically known size, borrowed types alway
 LL |     r: &dyn A + 'static
    |        +
 
-error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
-  --> $DIR/issue-5883.rs:9:6
-   |
-LL | ) -> Struct {
-   |      ^^^^^^ doesn't have a size known at compile-time
-LL |     Struct { r: r }
-   |     --------------- this returned value is of type `Struct`
-   |
-   = help: within `Struct`, the trait `Sized` is not implemented for `(dyn A + 'static)`
-note: required because it appears within the type `Struct`
-  --> $DIR/issue-5883.rs:3:8
-   |
-LL | struct Struct {
-   |        ^^^^^^
-   = note: the return type of a function must have a statically known size
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Removes a "hack" that skips registering sized obligations for parameters that are simple identifiers. This doesn't seem to affect diagnostics because we're probably already being smart enough about deduplicating identical error messages anyways.

Fixes #112608