### PR TITLE
CI: merge `mingw` test CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,30 +414,16 @@ jobs:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstate/toolstates.json"
               DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
             os: windows-2019-8core-32gb
-          - name: i686-mingw-1
+          - name: i686-mingw
             env:
               RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-gnu"
-              SCRIPT: make ci-mingw-subset-1
+              SCRIPT: make ci-mingw
               NO_DOWNLOAD_CI_LLVM: 1
               CUSTOM_MINGW: 1
             os: windows-2019-8core-32gb
-          - name: i686-mingw-2
+          - name: x86_64-mingw
             env:
-              RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-gnu"
-              SCRIPT: make ci-mingw-subset-2
-              NO_DOWNLOAD_CI_LLVM: 1
-              CUSTOM_MINGW: 1
-            os: windows-2019-8core-32gb
-          - name: x86_64-mingw-1
-            env:
-              SCRIPT: make ci-mingw-subset-1
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-profiler"
-              NO_DOWNLOAD_CI_LLVM: 1
-              CUSTOM_MINGW: 1
-            os: windows-2019-8core-32gb
-          - name: x86_64-mingw-2
-            env:
-              SCRIPT: make ci-mingw-subset-2
+              SCRIPT: make ci-mingw
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-profiler"
               NO_DOWNLOAD_CI_LLVM: 1
               CUSTOM_MINGW: 1

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -71,13 +71,11 @@ ci-subset-2:
 
 ## MingW native builders
 
-TESTS_IN_MINGW_2 := \
-	tests/ui
-
-ci-mingw-subset-1:
-	$(Q)$(CFG_SRC_DIR)/x test --stage 2 $(TESTS_IN_MINGW_2:%=--exclude %)
-ci-mingw-subset-2:
-	$(Q)$(BOOTSTRAP) test --stage 2 $(TESTS_IN_MINGW_2)
-
+# test both x and bootstrap entrypoints
+ci-mingw-x:
+	$(Q)$(CFG_SRC_DIR)/x test --stage 2 tidy
+ci-mingw-bootstrap:
+	$(Q)$(BOOTSTRAP) test --stage 2 --exclude tidy
+ci-mingw: ci-mingw-x ci-mingw-bootstrap
 
 .PHONY: dist

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -635,41 +635,19 @@ jobs:
           # came from the mingw-w64 SourceForge download site. Unfortunately
           # SourceForge is notoriously flaky, so we mirror it on our own infrastructure.
 
-          - name: i686-mingw-1
+          - name: i686-mingw
             env:
               RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
-              SCRIPT: make ci-mingw-subset-1
+              SCRIPT: make ci-mingw
               # We are intentionally allowing an old toolchain on this builder (and that's
               # incompatible with LLVM downloads today).
               NO_DOWNLOAD_CI_LLVM: 1
               CUSTOM_MINGW: 1
             <<: *job-windows-8c
 
-          - name: i686-mingw-2
+          - name: x86_64-mingw
             env:
-              RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
-              SCRIPT: make ci-mingw-subset-2
-              # We are intentionally allowing an old toolchain on this builder (and that's
-              # incompatible with LLVM downloads today).
-              NO_DOWNLOAD_CI_LLVM: 1
-              CUSTOM_MINGW: 1
-            <<: *job-windows-8c
-
-          - name: x86_64-mingw-1
-            env:
-              SCRIPT: make ci-mingw-subset-1
-              RUST_CONFIGURE_ARGS: >-
-                --build=x86_64-pc-windows-gnu
-                --enable-profiler
-              # We are intentionally allowing an old toolchain on this builder (and that's
-              # incompatible with LLVM downloads today).
-              NO_DOWNLOAD_CI_LLVM: 1
-              CUSTOM_MINGW: 1
-            <<: *job-windows-8c
-
-          - name: x86_64-mingw-2
-            env:
-              SCRIPT: make ci-mingw-subset-2
+              SCRIPT: make ci-mingw
               RUST_CONFIGURE_ARGS: >-
                 --build=x86_64-pc-windows-gnu
                 --enable-profiler


### PR DESCRIPTION
Same as https://github.com/rust-lang/rust/pull/112633, but for `mingw`. From the logs it looks like the runner spends 40 minutes compiling `rustc`, and then `10`/`20` minutes running tests. It seems wasteful to split that into two jobs.

CI run: https://github.com/rust-lang/rust/actions/runs/5275702134/jobs/9541479343?pr=112645

r? @jyn514