### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -67,7 +67,7 @@ struct ArenaChunk<T = u8> {
 
 unsafe impl<#[may_dangle] T> Drop for ArenaChunk<T> {
     fn drop(&mut self) {
-        unsafe { Box::from_raw(self.storage.as_mut()) };
+        unsafe { drop(Box::from_raw(self.storage.as_mut())) }
     }
 }
 

--- a/compiler/rustc_borrowck/src/type_check/input_output.rs
+++ b/compiler/rustc_borrowck/src/type_check/input_output.rs
@@ -124,21 +124,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         // Return types are a bit more complex. They may contain opaque `impl Trait` types.
         let mir_output_ty = body.local_decls[RETURN_PLACE].ty;
         let output_span = body.local_decls[RETURN_PLACE].source_info.span;
-        if let Err(terr) = self.eq_types(
-            normalized_output_ty,
-            mir_output_ty,
-            Locations::All(output_span),
-            ConstraintCategory::BoringNoLocation,
-        ) {
-            span_mirbug!(
-                self,
-                Location::START,
-                "equate_inputs_and_outputs: `{:?}=={:?}` failed with `{:?}`",
-                normalized_output_ty,
-                mir_output_ty,
-                terr
-            );
-        };
+        self.equate_normalized_input_or_output(normalized_output_ty, mir_output_ty, output_span);
     }
 
     #[instrument(skip(self), level = "debug")]

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -616,7 +616,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             AssertKind::MisalignedPointerDereference { ref required, ref found } => {
                 let required = self.codegen_operand(bx, required).immediate();
                 let found = self.codegen_operand(bx, found).immediate();
-                // It's `fn panic_bounds_check(index: usize, len: usize)`,
+                // It's `fn panic_misaligned_pointer_dereference(required: usize, found: usize)`,
                 // and `#[track_caller]` adds an implicit third argument.
                 (LangItem::PanicMisalignedPointerDereference, vec![required, found, location])
             }

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -478,13 +478,11 @@ lint_requested_level = requested on the command line with `{$level} {$lint_name}
 lint_supertrait_as_deref_target = `{$t}` implements `Deref` with supertrait `{$target_principal}` as target
     .label = target type is set here
 
-lint_suspicious_double_ref_op =
-    using `.{$call}()` on a double reference, which returns `{$ty}` instead of {$op ->
-        *[should_not_happen] [{$op}]
-        [deref] dereferencing
-        [borrow] borrowing
-        [clone] cloning
-    } the inner type
+lint_suspicious_double_ref_clone =
+    using `.clone()` on a double reference, which returns `{$ty}` instead of cloning the inner type
+
+lint_suspicious_double_ref_deref =
+    using `.deref()` on a double reference, which returns `{$ty}` instead of dereferencing the inner type
 
 lint_trivial_untranslatable_diag = diagnostic with static strings only
 

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1231,11 +1231,15 @@ pub struct NoopMethodCallDiag<'a> {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(lint_suspicious_double_ref_op)]
-pub struct SuspiciousDoubleRefDiag<'a> {
-    pub call: Symbol,
+#[diag(lint_suspicious_double_ref_deref)]
+pub struct SuspiciousDoubleRefDerefDiag<'a> {
     pub ty: Ty<'a>,
-    pub op: &'static str,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(lint_suspicious_double_ref_clone)]
+pub struct SuspiciousDoubleRefCloneDiag<'a> {
+    pub ty: Ty<'a>,
 }
 
 // pass_by_value.rs

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1534,8 +1534,29 @@ pub struct UnusedOp<'a> {
     pub op: &'a str,
     #[label]
     pub label: Span,
-    #[suggestion(style = "verbose", code = "let _ = ", applicability = "maybe-incorrect")]
-    pub suggestion: Span,
+    #[subdiagnostic]
+    pub suggestion: UnusedOpSuggestion,
+}
+
+#[derive(Subdiagnostic)]
+pub enum UnusedOpSuggestion {
+    #[suggestion(
+        lint_suggestion,
+        style = "verbose",
+        code = "let _ = ",
+        applicability = "maybe-incorrect"
+    )]
+    NormalExpr {
+        #[primary_span]
+        span: Span,
+    },
+    #[multipart_suggestion(lint_suggestion, style = "verbose", applicability = "maybe-incorrect")]
+    BlockTailExpr {
+        #[suggestion_part(code = "let _ = ")]
+        before_span: Span,
+        #[suggestion_part(code = ";")]
+        after_span: Span,
+    },
 }
 
 #[derive(LintDiagnostic)]
@@ -1578,15 +1599,25 @@ pub struct UnusedDef<'a, 'b> {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(
-    lint_suggestion,
-    style = "verbose",
-    code = "let _ = ",
-    applicability = "maybe-incorrect"
-)]
-pub struct UnusedDefSuggestion {
-    #[primary_span]
-    pub span: Span,
+
+pub enum UnusedDefSuggestion {
+    #[suggestion(
+        lint_suggestion,
+        style = "verbose",
+        code = "let _ = ",
+        applicability = "maybe-incorrect"
+    )]
+    NormalExpr {
+        #[primary_span]
+        span: Span,
+    },
+    #[multipart_suggestion(lint_suggestion, style = "verbose", applicability = "maybe-incorrect")]
+    BlockTailExpr {
+        #[suggestion_part(code = "let _ = ")]
+        before_span: Span,
+        #[suggestion_part(code = ";")]
+        after_span: Span,
+    },
 }
 
 // Needed because of def_path_str

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -252,13 +252,10 @@ pub fn suggest_constraining_type_params<'a>(
         {
             let mut sized_constraints =
                 constraints.extract_if(|(_, def_id)| *def_id == tcx.lang_items().sized_trait());
-            if let Some((constraint, def_id)) = sized_constraints.next() {
+            if let Some((_, def_id)) = sized_constraints.next() {
                 applicability = Applicability::MaybeIncorrect;
 
-                err.span_label(
-                    param.span,
-                    format!("this type parameter needs to be `{}`", constraint),
-                );
+                err.span_label(param.span, "this type parameter needs to be `Sized`");
                 suggest_changing_unsized_bound(generics, &mut suggestions, param, def_id);
             }
         }

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -9,6 +9,7 @@ use rustc_middle::mir::{
 };
 use rustc_middle::ty::{Ty, TyCtxt, TypeAndMut};
 use rustc_session::Session;
+use rustc_target::spec::PanicStrategy;
 
 pub struct CheckAlignment;
 
@@ -236,7 +237,11 @@ fn insert_alignment_check<'tcx>(
                 required: Operand::Copy(alignment),
                 found: Operand::Copy(addr),
             }),
-            unwind: UnwindAction::Terminate,
+            unwind: if tcx.sess.panic_strategy() == PanicStrategy::Unwind {
+                UnwindAction::Terminate
+            } else {
+                UnwindAction::Unreachable
+            },
         },
     });
 }

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -308,7 +308,7 @@ mod prim_never {}
 ///
 /// ```no_run
 /// // Undefined behaviour
-/// unsafe { char::from_u32_unchecked(0x110000) };
+/// let _ = unsafe { char::from_u32_unchecked(0x110000) };
 /// ```
 ///
 /// USVs are also the exact set of values that may be encoded in UTF-8. Because

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -1001,7 +1001,7 @@ fn nonnull_tagged_pointer_with_provenance() {
     assert_eq!(p.tag(), 3);
     assert_eq!(unsafe { *p.pointer().as_ptr() }, 10);
 
-    unsafe { Box::from_raw(p.pointer().as_ptr()) };
+    unsafe { drop(Box::from_raw(p.pointer().as_ptr())) };
 
     /// A non-null pointer type which carries several bits of metadata and maintains provenance.
     #[repr(transparent)]

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -308,7 +308,7 @@ mod prim_never {}
 ///
 /// ```no_run
 /// // Undefined behaviour
-/// unsafe { char::from_u32_unchecked(0x110000) };
+/// let _ = unsafe { char::from_u32_unchecked(0x110000) };
 /// ```
 ///
 /// USVs are also the exact set of values that may be encoded in UTF-8. Because

--- a/src/ci/docker/scripts/fuchsia-test-runner.py
+++ b/src/ci/docker/scripts/fuchsia-test-runner.py
@@ -171,7 +171,6 @@ class TestEnvironment:
     def home_dir(self):
         return os.path.join(self.tmp_dir(), "user-home")
 
-
     def start_ffx_isolation(self):
         # Most of this is translated directly from ffx's isolate library
         os.mkdir(self.ffx_isolate_dir())
@@ -424,7 +423,7 @@ class TestEnvironment:
         )
 
         # Create lockfiles
-        open(self.pm_lockfile_path(), 'a').close()
+        open(self.pm_lockfile_path(), "a").close()
 
         # Write to file
         self.write_to_file()
@@ -458,6 +457,7 @@ class TestEnvironment:
         ],
         use: [
             {{ storage: "data", path: "/data" }},
+            {{ storage: "tmp", path: "/tmp" }},
             {{ protocol: [ "fuchsia.process.Launcher" ] }},
             {{ protocol: [ "fuchsia.posix.socket.Provider" ] }}
         ],
@@ -571,6 +571,9 @@ class TestEnvironment:
                 if os.getenv("RUST_BACKTRACE") == None:
                     env_vars += f'\n            "RUST_BACKTRACE=0",'
 
+                # Use /tmp as the test temporary directory
+                env_vars += f'\n            "RUST_TEST_TMPDIR=/tmp",'
+
                 cml.write(
                     self.CML_TEMPLATE.format(env_vars=env_vars, exe_name=exe_name)
                 )
@@ -642,7 +645,7 @@ class TestEnvironment:
             log("Publishing package to repo...")
 
             # Publish package to repo
-            with open(self.pm_lockfile_path(), 'w') as pm_lockfile:
+            with open(self.pm_lockfile_path(), "w") as pm_lockfile:
                 fcntl.lockf(pm_lockfile.fileno(), fcntl.LOCK_EX)
                 subprocess.check_call(
                     [
@@ -1045,9 +1048,7 @@ def main():
     )
     debug_parser.set_defaults(func=debug)
 
-    syslog_parser = subparsers.add_parser(
-        "syslog", help="prints the device syslog"
-    )
+    syslog_parser = subparsers.add_parser("syslog", help="prints the device syslog")
     syslog_parser.set_defaults(func=syslog)
 
     args = parser.parse_args()

--- a/src/tools/clippy/tests/ui/transmute_ptr_to_ref.fixed
+++ b/src/tools/clippy/tests/ui/transmute_ptr_to_ref.fixed
@@ -2,6 +2,7 @@
 
 #![warn(clippy::transmute_ptr_to_ref)]
 #![allow(clippy::match_single_binding)]
+#![allow(unused_must_use)]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
     let _: &T = &*p;
@@ -38,7 +39,7 @@ fn _issue1231() {
 
     type Bar<'a> = &'a u8;
     let raw = 42 as *const i32;
-    unsafe { &*(raw as *const u8) };
+    let _ = unsafe { &*(raw as *const u8) };
 }
 
 unsafe fn _issue8924<'a, 'b, 'c>(x: *const &'a u32, y: *const &'b u32) -> &'c &'b u32 {

--- a/src/tools/clippy/tests/ui/transmute_ptr_to_ref.rs
+++ b/src/tools/clippy/tests/ui/transmute_ptr_to_ref.rs
@@ -2,6 +2,7 @@
 
 #![warn(clippy::transmute_ptr_to_ref)]
 #![allow(clippy::match_single_binding)]
+#![allow(unused_must_use)]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
     let _: &T = std::mem::transmute(p);
@@ -38,7 +39,7 @@ fn _issue1231() {
 
     type Bar<'a> = &'a u8;
     let raw = 42 as *const i32;
-    unsafe { std::mem::transmute::<_, Bar>(raw) };
+    let _ = unsafe { std::mem::transmute::<_, Bar>(raw) };
 }
 
 unsafe fn _issue8924<'a, 'b, 'c>(x: *const &'a u32, y: *const &'b u32) -> &'c &'b u32 {

--- a/src/tools/clippy/tests/ui/transmute_ptr_to_ref.stderr
+++ b/src/tools/clippy/tests/ui/transmute_ptr_to_ref.stderr
@@ -1,5 +1,5 @@
 error: transmute from a pointer type (`*const T`) to a reference type (`&T`)
-  --> $DIR/transmute_ptr_to_ref.rs:7:17
+  --> $DIR/transmute_ptr_to_ref.rs:8:17
    |
 LL |     let _: &T = std::mem::transmute(p);
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*p`
@@ -7,127 +7,127 @@ LL |     let _: &T = std::mem::transmute(p);
    = note: `-D clippy::transmute-ptr-to-ref` implied by `-D warnings`
 
 error: transmute from a pointer type (`*mut T`) to a reference type (`&mut T`)
-  --> $DIR/transmute_ptr_to_ref.rs:10:21
+  --> $DIR/transmute_ptr_to_ref.rs:11:21
    |
 LL |     let _: &mut T = std::mem::transmute(m);
    |                     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *m`
 
 error: transmute from a pointer type (`*mut T`) to a reference type (`&T`)
-  --> $DIR/transmute_ptr_to_ref.rs:13:17
+  --> $DIR/transmute_ptr_to_ref.rs:14:17
    |
 LL |     let _: &T = std::mem::transmute(m);
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*m`
 
 error: transmute from a pointer type (`*mut T`) to a reference type (`&mut T`)
-  --> $DIR/transmute_ptr_to_ref.rs:16:21
+  --> $DIR/transmute_ptr_to_ref.rs:17:21
    |
 LL |     let _: &mut T = std::mem::transmute(p as *mut T);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *(p as *mut T)`
 
 error: transmute from a pointer type (`*const U`) to a reference type (`&T`)
-  --> $DIR/transmute_ptr_to_ref.rs:19:17
+  --> $DIR/transmute_ptr_to_ref.rs:20:17
    |
 LL |     let _: &T = std::mem::transmute(o);
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(o as *const T)`
 
 error: transmute from a pointer type (`*mut U`) to a reference type (`&mut T`)
-  --> $DIR/transmute_ptr_to_ref.rs:22:21
+  --> $DIR/transmute_ptr_to_ref.rs:23:21
    |
 LL |     let _: &mut T = std::mem::transmute(om);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *(om as *mut T)`
 
 error: transmute from a pointer type (`*mut U`) to a reference type (`&T`)
-  --> $DIR/transmute_ptr_to_ref.rs:25:17
+  --> $DIR/transmute_ptr_to_ref.rs:26:17
    |
 LL |     let _: &T = std::mem::transmute(om);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(om as *const T)`
 
 error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<'_, u8>`)
-  --> $DIR/transmute_ptr_to_ref.rs:35:32
+  --> $DIR/transmute_ptr_to_ref.rs:36:32
    |
 LL |     let _: &Foo<u8> = unsafe { std::mem::transmute::<_, &Foo<_>>(raw) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*raw.cast::<Foo<_>>()`
 
 error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<'_, &u8>`)
-  --> $DIR/transmute_ptr_to_ref.rs:37:33
+  --> $DIR/transmute_ptr_to_ref.rs:38:33
    |
 LL |     let _: &Foo<&u8> = unsafe { std::mem::transmute::<_, &Foo<&_>>(raw) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*raw.cast::<Foo<&_>>()`
 
 error: transmute from a pointer type (`*const i32`) to a reference type (`&u8`)
-  --> $DIR/transmute_ptr_to_ref.rs:41:14
+  --> $DIR/transmute_ptr_to_ref.rs:42:22
    |
-LL |     unsafe { std::mem::transmute::<_, Bar>(raw) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(raw as *const u8)`
+LL |     let _ = unsafe { std::mem::transmute::<_, Bar>(raw) };
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(raw as *const u8)`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:46:14
+  --> $DIR/transmute_ptr_to_ref.rs:47:14
    |
 LL |         0 => std::mem::transmute(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:47:14
+  --> $DIR/transmute_ptr_to_ref.rs:48:14
    |
 LL |         1 => std::mem::transmute(y),
    |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*y.cast::<&u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:48:14
+  --> $DIR/transmute_ptr_to_ref.rs:49:14
    |
 LL |         2 => std::mem::transmute::<_, &&'b u32>(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&'b u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:49:14
+  --> $DIR/transmute_ptr_to_ref.rs:50:14
    |
 LL |         _ => std::mem::transmute::<_, &&'b u32>(y),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*y.cast::<&'b u32>()`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:57:19
+  --> $DIR/transmute_ptr_to_ref.rs:58:19
    |
 LL |     let _: &u32 = std::mem::transmute(a);
    |                   ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:58:19
+  --> $DIR/transmute_ptr_to_ref.rs:59:19
    |
 LL |     let _: &u32 = std::mem::transmute::<_, &u32>(a);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a.cast::<u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:60:14
+  --> $DIR/transmute_ptr_to_ref.rs:61:14
    |
 LL |         0 => std::mem::transmute(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:61:14
+  --> $DIR/transmute_ptr_to_ref.rs:62:14
    |
 LL |         _ => std::mem::transmute::<_, &&'b u32>(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&'b u32>()`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:69:19
+  --> $DIR/transmute_ptr_to_ref.rs:70:19
    |
 LL |     let _: &u32 = std::mem::transmute(a);
    |                   ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:70:19
+  --> $DIR/transmute_ptr_to_ref.rs:71:19
    |
 LL |     let _: &u32 = std::mem::transmute::<_, &u32>(a);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(a as *const u32)`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:72:14
+  --> $DIR/transmute_ptr_to_ref.rs:73:14
    |
 LL |         0 => std::mem::transmute(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(x as *const () as *const &u32)`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> $DIR/transmute_ptr_to_ref.rs:73:14
+  --> $DIR/transmute_ptr_to_ref.rs:74:14
    |
 LL |         _ => std::mem::transmute::<_, &&'b u32>(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(x as *const () as *const &'b u32)`

--- a/src/tools/miri/tests/fail/dangling_pointers/storage_dead_dangling.rs
+++ b/src/tools/miri/tests/fail/dangling_pointers/storage_dead_dangling.rs
@@ -10,7 +10,7 @@ fn fill(v: &mut i32) {
 }
 
 fn evil() {
-    unsafe { &mut *(LEAK as *mut i32) }; //~ ERROR: is a dangling pointer
+    let _ = unsafe { &mut *(LEAK as *mut i32) }; //~ ERROR: is a dangling pointer
 }
 
 fn main() {

--- a/src/tools/miri/tests/fail/dangling_pointers/storage_dead_dangling.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/storage_dead_dangling.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: dereferencing pointer failed: $HEX[noalloc] is a dangling pointer (it has no provenance)
   --> $DIR/storage_dead_dangling.rs:LL:CC
    |
-LL |     unsafe { &mut *(LEAK as *mut i32) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ dereferencing pointer failed: $HEX[noalloc] is a dangling pointer (it has no provenance)
+LL |     let _ = unsafe { &mut *(LEAK as *mut i32) };
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ dereferencing pointer failed: $HEX[noalloc] is a dangling pointer (it has no provenance)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/intrinsics/uninit_uninhabited_type.rs
+++ b/src/tools/miri/tests/fail/intrinsics/uninit_uninhabited_type.rs
@@ -2,6 +2,6 @@
 
 #[allow(deprecated, invalid_value)]
 fn main() {
-    unsafe { std::mem::uninitialized::<!>() };
+    let _ = unsafe { std::mem::uninitialized::<!>() };
     //~^ ERROR: attempted to instantiate uninhabited type `!`
 }

--- a/src/tools/miri/tests/fail/intrinsics/uninit_uninhabited_type.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/uninit_uninhabited_type.stderr
@@ -1,8 +1,8 @@
 error: abnormal termination: aborted execution: attempted to instantiate uninhabited type `!`
   --> $DIR/uninit_uninhabited_type.rs:LL:CC
    |
-LL |     unsafe { std::mem::uninitialized::<!>() };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to instantiate uninhabited type `!`
+LL |     let _ = unsafe { std::mem::uninitialized::<!>() };
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to instantiate uninhabited type `!`
    |
    = note: inside `main` at $DIR/uninit_uninhabited_type.rs:LL:CC
 

--- a/src/tools/miri/tests/fail/intrinsics/zero_fn_ptr.rs
+++ b/src/tools/miri/tests/fail/intrinsics/zero_fn_ptr.rs
@@ -1,5 +1,5 @@
 #[allow(deprecated, invalid_value)]
 fn main() {
-    unsafe { std::mem::zeroed::<fn()>() };
+    let _ = unsafe { std::mem::zeroed::<fn()>() };
     //~^ ERROR: attempted to zero-initialize type `fn()`, which is invalid
 }

--- a/src/tools/miri/tests/fail/intrinsics/zero_fn_ptr.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/zero_fn_ptr.stderr
@@ -1,8 +1,8 @@
 error: abnormal termination: aborted execution: attempted to zero-initialize type `fn()`, which is invalid
   --> $DIR/zero_fn_ptr.rs:LL:CC
    |
-LL |     unsafe { std::mem::zeroed::<fn()>() };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to zero-initialize type `fn()`, which is invalid
+LL |     let _ = unsafe { std::mem::zeroed::<fn()>() };
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to zero-initialize type `fn()`, which is invalid
    |
    = note: inside `main` at $DIR/zero_fn_ptr.rs:LL:CC
 

--- a/tests/run-make/panic-abort-eh_frame/Makefile
+++ b/tests/run-make/panic-abort-eh_frame/Makefile
@@ -1,0 +1,10 @@
+# only-linux
+#
+# This test ensures that `panic=abort` code (without `C-unwind`, that is) should not have any
+# unwinding related `.eh_frame` sections emitted.
+
+include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs --crate-type=lib --emit=obj=$(TMPDIR)/foo.o -Cpanic=abort
+	objdump --dwarf=frames $(TMPDIR)/foo.o | $(CGREP) -v 'DW_CFA'

--- a/tests/run-make/panic-abort-eh_frame/foo.rs
+++ b/tests/run-make/panic-abort-eh_frame/foo.rs
@@ -1,0 +1,10 @@
+#![no_std]
+
+#[panic_handler]
+fn handler(_: &core::panic::PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+pub unsafe fn oops(x: *const u32) -> u32 {
+    *x
+}

--- a/tests/rustdoc-gui/headers-color.goml
+++ b/tests/rustdoc-gui/headers-color.goml
@@ -42,29 +42,29 @@ call-function: (
     "check-colors",
     {
         "theme": "ayu",
-        "color": "rgb(197, 197, 197)",
-        "code_header_color": "rgb(230, 225, 207)",
+        "color": "#c5c5c5",
+        "code_header_color": "#e6e1cf",
         "focus_background_color": "rgba(255, 236, 164, 0.06)",
-        "headings_color": "rgb(57, 175, 215)",
+        "headings_color": "#39afd7",
     },
 )
 call-function: (
     "check-colors",
     {
         "theme": "dark",
-        "color": "rgb(221, 221, 221)",
-        "code_header_color": "rgb(221, 221, 221)",
-        "focus_background_color": "rgb(73, 74, 61)",
-        "headings_color": "rgb(210, 153, 29)",
+        "color": "#ddd",
+        "code_header_color": "#ddd",
+        "focus_background_color": "#494a3d",
+        "headings_color": "#d2991d",
     },
 )
 call-function: (
     "check-colors",
     {
         "theme": "light",
-        "color": "rgb(0, 0, 0)",
-        "code_header_color": "rgb(0, 0, 0)",
-        "focus_background_color": "rgb(253, 255, 211)",
-        "headings_color": "rgb(56, 115, 173)",
+        "color": "black",
+        "code_header_color": "black",
+        "focus_background_color": "#fdffd3",
+        "headings_color": "#3873ad",
     },
 )

--- a/tests/ui/const-generics/const-argument-if-length.full.stderr
+++ b/tests/ui/const-generics/const-argument-if-length.full.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/const-argument-if-length.rs:15:12
    |
 LL | pub struct AtLeastByte<T: ?Sized> {
-   |                        - this type parameter needs to be `std::marker::Sized`
+   |                        - this type parameter needs to be `Sized`
 LL |     value: T,
    |            ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/const-generics/const-argument-if-length.min.stderr
+++ b/tests/ui/const-generics/const-argument-if-length.min.stderr
@@ -11,7 +11,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/const-argument-if-length.rs:15:12
    |
 LL | pub struct AtLeastByte<T: ?Sized> {
-   |                        - this type parameter needs to be `std::marker::Sized`
+   |                        - this type parameter needs to be `Sized`
 LL |     value: T,
    |            ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/dst/dst-object-from-unsized-type.stderr
+++ b/tests/ui/dst/dst-object-from-unsized-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/dst-object-from-unsized-type.rs:8:23
    |
 LL | fn test1<T: ?Sized + Foo>(t: &T) {
-   |          - this type parameter needs to be `std::marker::Sized`
+   |          - this type parameter needs to be `Sized`
 LL |     let u: &dyn Foo = t;
    |                       ^ doesn't have a size known at compile-time
    |
@@ -17,7 +17,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/dst-object-from-unsized-type.rs:13:23
    |
 LL | fn test2<T: ?Sized + Foo>(t: &T) {
-   |          - this type parameter needs to be `std::marker::Sized`
+   |          - this type parameter needs to be `Sized`
 LL |     let v: &dyn Foo = t as &dyn Foo;
    |                       ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/generic-associated-types/issue-88287.stderr
+++ b/tests/ui/generic-associated-types/issue-88287.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/issue-88287.rs:34:9
    |
 LL | type SearchFutureTy<'f, A, B: 'f>
-   |                         - this type parameter needs to be `std::marker::Sized`
+   |                         - this type parameter needs to be `Sized`
 ...
 LL |         async move { todo!() }
    |         ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/tests/ui/issues/issue-1460.stderr
+++ b/tests/ui/issues/issue-1460.stderr
@@ -1,8 +1,8 @@
 warning: unused closure that must be used
-  --> $DIR/issue-1460.rs:6:5
+  --> $DIR/issue-1460.rs:6:6
    |
 LL |     {|i: u32| if 1 == i { }};
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: closures are lazy and do nothing unless called
    = note: `#[warn(unused_must_use)]` on by default

--- a/tests/ui/lint/issue-112489.rs
+++ b/tests/ui/lint/issue-112489.rs
@@ -1,0 +1,17 @@
+// check-pass
+use std::borrow::Borrow;
+
+struct S;
+
+trait T: Sized {
+    fn foo(self) {}
+}
+
+impl T for S {}
+impl T for &S {}
+
+fn main() {
+    let s = S;
+    s.borrow().foo();
+    s.foo();
+}

--- a/tests/ui/lint/unused/must-use-block-expr.fixed
+++ b/tests/ui/lint/unused/must-use-block-expr.fixed
@@ -1,0 +1,36 @@
+// run-rustfix
+// check-pass
+
+#![warn(unused_must_use)]
+
+#[must_use]
+fn foo() -> i32 {
+    42
+}
+
+fn bar() {
+    {
+        let _ = foo();
+        //~^ WARN unused return value
+    }
+}
+
+fn baz() {
+    {
+        let _ = foo();
+        //~^ WARN unused return value
+    };
+}
+
+fn main() {
+    bar();
+    baz();
+    {
+        let _ = 1 + 2;
+        //~^ WARN unused arithmetic operation
+    }
+    {
+        let _ = 1 + 2;
+        //~^ WARN unused arithmetic operation
+    };
+}

--- a/tests/ui/lint/unused/must-use-block-expr.rs
+++ b/tests/ui/lint/unused/must-use-block-expr.rs
@@ -1,0 +1,36 @@
+// run-rustfix
+// check-pass
+
+#![warn(unused_must_use)]
+
+#[must_use]
+fn foo() -> i32 {
+    42
+}
+
+fn bar() {
+    {
+        foo();
+        //~^ WARN unused return value
+    }
+}
+
+fn baz() {
+    {
+        foo()
+        //~^ WARN unused return value
+    };
+}
+
+fn main() {
+    bar();
+    baz();
+    {
+        1 + 2;
+        //~^ WARN unused arithmetic operation
+    }
+    {
+        1 + 2
+        //~^ WARN unused arithmetic operation
+    };
+}

--- a/tests/ui/lint/unused/must-use-block-expr.stderr
+++ b/tests/ui/lint/unused/must-use-block-expr.stderr
@@ -1,0 +1,51 @@
+warning: unused return value of `foo` that must be used
+  --> $DIR/must-use-block-expr.rs:13:9
+   |
+LL |         foo();
+   |         ^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/must-use-block-expr.rs:4:9
+   |
+LL | #![warn(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = foo();
+   |         +++++++
+
+warning: unused return value of `foo` that must be used
+  --> $DIR/must-use-block-expr.rs:20:9
+   |
+LL |         foo()
+   |         ^^^^^
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = foo();
+   |         +++++++      +
+
+warning: unused arithmetic operation that must be used
+  --> $DIR/must-use-block-expr.rs:29:9
+   |
+LL |         1 + 2;
+   |         ^^^^^ the arithmetic operation produces a value
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = 1 + 2;
+   |         +++++++
+
+warning: unused arithmetic operation that must be used
+  --> $DIR/must-use-block-expr.rs:33:9
+   |
+LL |         1 + 2
+   |         ^^^^^ the arithmetic operation produces a value
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = 1 + 2;
+   |         +++++++      +
+
+warning: 4 warnings emitted
+

--- a/tests/ui/nll/issue-112604-closure-output-normalize.rs
+++ b/tests/ui/nll/issue-112604-closure-output-normalize.rs
@@ -1,0 +1,49 @@
+//check-pass
+
+use higher_kinded_types::*;
+mod higher_kinded_types {
+    pub(crate) trait HKT {
+        type Of<'lt>;
+    }
+
+    pub(crate) trait WithLifetime<'lt> {
+        type T;
+    }
+
+    impl<T: ?Sized + for<'any> WithLifetime<'any>> HKT for T {
+        type Of<'lt> = <T as WithLifetime<'lt>>::T;
+    }
+}
+
+trait Trait {
+    type Gat<'lt>;
+}
+
+impl Trait for () {
+    type Gat<'lt> = ();
+}
+
+/// Same as `Trait`, but using HKTs rather than GATs
+trait HTrait {
+    type Hat: ?Sized + HKT;
+}
+
+impl<T: Trait> HTrait for T {
+    type Hat = dyn for<'lt> WithLifetime<'lt, T = T::Gat<'lt>>;
+}
+
+impl<Hat: ?Sized + HKT> Trait for Box<dyn '_ + HTrait<Hat = Hat>> {
+    type Gat<'lt> = Hat::Of<'lt>;
+}
+
+fn existential() -> impl for<'a> Trait<Gat<'a> = ()> {}
+
+fn dyn_hoops<T: Trait>(
+    _: T,
+) -> Box<dyn HTrait<Hat = dyn for<'a> WithLifetime<'a, T = T::Gat<'a>>>> {
+    loop {}
+}
+
+fn main() {
+    let _ = || -> _ { dyn_hoops(existential()) };
+}

--- a/tests/ui/offset-of/offset-of-dst-field.stderr
+++ b/tests/ui/offset-of/offset-of-dst-field.stderr
@@ -70,7 +70,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/offset-of-dst-field.rs:50:5
    |
 LL | fn generic_with_maybe_sized<T: ?Sized>() -> usize {
-   |                             - this type parameter needs to be `std::marker::Sized`
+   |                             - this type parameter needs to be `Sized`
 LL |     offset_of!(Delta<T>, z)
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |

--- a/tests/ui/packed/issue-27060-2.stderr
+++ b/tests/ui/packed/issue-27060-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/issue-27060-2.rs:3:11
    |
 LL | pub struct Bad<T: ?Sized> {
-   |                - this type parameter needs to be `std::marker::Sized`
+   |                - this type parameter needs to be `Sized`
 LL |     data: T,
    |           ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/adt-param-with-implicit-sized-bound.rs:25:9
    |
 LL | struct Struct5<T: ?Sized>{
-   |                - this type parameter needs to be `std::marker::Sized`
+   |                - this type parameter needs to be `Sized`
 LL |     _t: X<T>,
    |         ^^^^ doesn't have a size known at compile-time
    |

--- a/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
+++ b/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn foo<T>(foo: Wrapper<T>)
    |        -       ^^^^^^^^^^ doesn't have a size known at compile-time
    |        |
-   |        this type parameter needs to be `std::marker::Sized`
+   |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
@@ -33,7 +33,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn bar<T>(foo: Wrapper<T>)
    |        -       ^^^^^^^^^^ doesn't have a size known at compile-time
    |        |
-   |        this type parameter needs to be `std::marker::Sized`
+   |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
@@ -58,7 +58,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn qux<T>(foo: Wrapper<T>)
    |        -       ^^^^^^^^^^ doesn't have a size known at compile-time
    |        |
-   |        this type parameter needs to be `std::marker::Sized`
+   |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16

--- a/tests/ui/trait-bounds/apit-unsized.rs
+++ b/tests/ui/trait-bounds/apit-unsized.rs
@@ -1,0 +1,4 @@
+fn foo(_: impl Iterator<Item = i32> + ?Sized) {} //~ ERROR [E0277]
+fn bar(_: impl ?Sized) {} //~ ERROR [E0277]
+
+fn main() {}

--- a/tests/ui/trait-bounds/apit-unsized.stderr
+++ b/tests/ui/trait-bounds/apit-unsized.stderr
@@ -1,0 +1,41 @@
+error[E0277]: the size for values of type `impl Iterator<Item = i32> + ?Sized` cannot be known at compilation time
+  --> $DIR/apit-unsized.rs:1:8
+   |
+LL | fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
+   |        ^  ---------------------------------- this type parameter needs to be `std::marker::Sized`
+   |        |
+   |        doesn't have a size known at compile-time
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
+LL + fn foo(_: impl Iterator<Item = i32>) {}
+   |
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn foo(_: &impl Iterator<Item = i32> + ?Sized) {}
+   |           +
+
+error[E0277]: the size for values of type `impl ?Sized` cannot be known at compilation time
+  --> $DIR/apit-unsized.rs:2:8
+   |
+LL | fn bar(_: impl ?Sized) {}
+   |        ^  ----------- this type parameter needs to be `std::marker::Sized`
+   |        |
+   |        doesn't have a size known at compile-time
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: consider replacing `?Sized` with `Sized`
+   |
+LL - fn bar(_: impl ?Sized) {}
+LL + fn bar(_: impl Sized) {}
+   |
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn bar(_: &impl ?Sized) {}
+   |           +
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/trait-bounds/apit-unsized.stderr
+++ b/tests/ui/trait-bounds/apit-unsized.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `impl Iterator<Item = i32> + ?Sized` c
   --> $DIR/apit-unsized.rs:1:8
    |
 LL | fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
-   |        ^  ---------------------------------- this type parameter needs to be `std::marker::Sized`
+   |        ^  ---------------------------------- this type parameter needs to be `Sized`
    |        |
    |        doesn't have a size known at compile-time
    |
@@ -21,7 +21,7 @@ error[E0277]: the size for values of type `impl ?Sized` cannot be known at compi
   --> $DIR/apit-unsized.rs:2:8
    |
 LL | fn bar(_: impl ?Sized) {}
-   |        ^  ----------- this type parameter needs to be `std::marker::Sized`
+   |        ^  ----------- this type parameter needs to be `Sized`
    |        |
    |        doesn't have a size known at compile-time
    |

--- a/tests/ui/trait-bounds/unsized-bound.stderr
+++ b/tests/ui/trait-bounds/unsized-bound.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `B` cannot be known at compilation tim
 LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
    |         -                    ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B)`
 note: required by a bound in `Trait`
@@ -28,7 +28,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
    |      -                       ^^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -43,7 +43,7 @@ error[E0277]: the size for values of type `C` cannot be known at compilation tim
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
    |                    -                               ^^^^^^^^^ doesn't have a size known at compile-time
    |                    |
-   |                    this type parameter needs to be `std::marker::Sized`
+   |                    this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B, C)`
 note: required by a bound in `Trait`
@@ -65,9 +65,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/unsized-bound.rs:5:52
    |
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |      -                                             ^^^^^^^^^ doesn't have a size known at compile-time
-   |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      - this type parameter needs to be `Sized`     ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -80,9 +78,7 @@ error[E0277]: the size for values of type `B` cannot be known at compilation tim
   --> $DIR/unsized-bound.rs:5:52
    |
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |         -                                          ^^^^^^^^^ doesn't have a size known at compile-time
-   |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         - this type parameter needs to be `Sized`  ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -97,7 +93,7 @@ error[E0277]: the size for values of type `B` cannot be known at compilation tim
 LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
    |                 -                             ^^^^^^ doesn't have a size known at compile-time
    |                 |
-   |                 this type parameter needs to be `std::marker::Sized`
+   |                 this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B)`
 note: required by a bound in `Trait2`
@@ -121,7 +117,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
    |      -                                        ^^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -136,7 +132,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL | impl<A> Trait3<A> for A where A: ?Sized {}
    |      -                ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait3`
   --> $DIR/unsized-bound.rs:13:14
@@ -159,7 +155,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL | impl<A: ?Sized> Trait4<A> for A {}
    |      -                        ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait4`
   --> $DIR/unsized-bound.rs:16:14
@@ -182,7 +178,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
    |      -                      ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait5`
   --> $DIR/unsized-bound.rs:19:14
@@ -205,7 +201,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized, Y> Trait6<X, Y> for X {}
    |      -                              ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait6`
   --> $DIR/unsized-bound.rs:22:14
@@ -228,7 +224,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
 LL | impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
    |         -  ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait7`
   --> $DIR/unsized-bound.rs:25:17
@@ -251,7 +247,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
 LL | impl<X, Y: ?Sized> Trait8<X, Y> for X {}
    |         -          ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required by a bound in `Trait8`
   --> $DIR/unsized-bound.rs:28:17

--- a/tests/ui/traits/suggest-where-clause.stderr
+++ b/tests/ui/traits/suggest-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `U` cannot be known at compilation tim
   --> $DIR/suggest-where-clause.rs:7:20
    |
 LL | fn check<T: Iterator, U: ?Sized>() {
-   |                       - this type parameter needs to be `std::marker::Sized`
+   |                       - this type parameter needs to be `Sized`
 LL |     // suggest a where-clause, if needed
 LL |     mem::size_of::<U>();
    |                    ^ doesn't have a size known at compile-time
@@ -19,7 +19,7 @@ error[E0277]: the size for values of type `U` cannot be known at compilation tim
   --> $DIR/suggest-where-clause.rs:10:20
    |
 LL | fn check<T: Iterator, U: ?Sized>() {
-   |                       - this type parameter needs to be `std::marker::Sized`
+   |                       - this type parameter needs to be `Sized`
 ...
 LL |     mem::size_of::<Misc<U>>();
    |                    ^^^^^^^ doesn't have a size known at compile-time

--- a/tests/ui/union/union-sized-field.stderr
+++ b/tests/ui/union/union-sized-field.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:4:12
    |
 LL | union Foo<T: ?Sized> {
-   |           - this type parameter needs to be `std::marker::Sized`
+   |           - this type parameter needs to be `Sized`
 LL |     value: ManuallyDrop<T>,
    |            ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -28,7 +28,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:9:12
    |
 LL | struct Foo2<T: ?Sized> {
-   |             - this type parameter needs to be `std::marker::Sized`
+   |             - this type parameter needs to be `Sized`
 LL |     value: ManuallyDrop<T>,
    |            ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -54,7 +54,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:15:11
    |
 LL | enum Foo3<T: ?Sized> {
-   |           - this type parameter needs to be `std::marker::Sized`
+   |           - this type parameter needs to be `Sized`
 LL |     Value(ManuallyDrop<T>),
    |           ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |

--- a/tests/ui/unsized/unsized-bare-typaram.stderr
+++ b/tests/ui/unsized/unsized-bare-typaram.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn foo<T: ?Sized>() { bar::<T>() }
    |        -                    ^ doesn't have a size known at compile-time
    |        |
-   |        this type parameter needs to be `std::marker::Sized`
+   |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `bar`
   --> $DIR/unsized-bare-typaram.rs:1:8

--- a/tests/ui/unsized/unsized-enum.stderr
+++ b/tests/ui/unsized/unsized-enum.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required by a bound in `Foo`
   --> $DIR/unsized-enum.rs:4:10

--- a/tests/ui/unsized/unsized-enum2.stderr
+++ b/tests/ui/unsized/unsized-enum2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `W` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:23:8
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     // parameter
 LL |     VA(W),
    |        ^ doesn't have a size known at compile-time
@@ -27,7 +27,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:25:11
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                   - this type parameter needs to be `std::marker::Sized`
+   |                   - this type parameter needs to be `Sized`
 ...
 LL |     VB{x: X},
    |           ^ doesn't have a size known at compile-time
@@ -52,7 +52,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:27:15
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                              - this type parameter needs to be `std::marker::Sized`
+   |                              - this type parameter needs to be `Sized`
 ...
 LL |     VC(isize, Y),
    |               ^ doesn't have a size known at compile-time
@@ -77,7 +77,7 @@ error[E0277]: the size for values of type `Z` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:29:21
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                                         - this type parameter needs to be `std::marker::Sized`
+   |                                         - this type parameter needs to be `Sized`
 ...
 LL |     VD{u: isize, x: Z},
    |                     ^ doesn't have a size known at compile-time

--- a/tests/ui/unsized/unsized-fn-arg.stderr
+++ b/tests/ui/unsized/unsized-fn-arg.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn f<T: ?Sized>(t: T) {}
    |      -          ^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider removing the `?Sized` bound to make the type parameter `Sized`

--- a/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized> S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `S5`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11

--- a/tests/ui/unsized/unsized-struct.stderr
+++ b/tests/ui/unsized/unsized-struct.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required by a bound in `Foo`
   --> $DIR/unsized-struct.rs:4:12
@@ -30,7 +30,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
    |         -                         ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `std::marker::Sized`
+   |         this type parameter needs to be `Sized`
    |
 note: required because it appears within the type `Bar<T>`
   --> $DIR/unsized-struct.rs:11:8

--- a/tests/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      -                    ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `S5`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized> T2<X> for S4<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `T2`
   --> $DIR/unsized-trait-impl-trait-arg.rs:4:10

--- a/tests/ui/unsized/unsized3.stderr
+++ b/tests/ui/unsized/unsized3.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:7:13
    |
 LL | fn f1<X: ?Sized>(x: &X) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     f2::<X>(x);
    |     ------- ^ doesn't have a size known at compile-time
    |     |
@@ -27,7 +27,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:18:13
    |
 LL | fn f3<X: ?Sized + T>(x: &X) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     f4::<X>(x);
    |     ------- ^ doesn't have a size known at compile-time
    |     |
@@ -52,7 +52,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:33:8
    |
 LL | fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     f5(x1);
    |     -- ^^ doesn't have a size known at compile-time
    |     |
@@ -82,7 +82,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:40:5
    |
 LL | fn f9<X: ?Sized>(x1: Box<S<X>>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     f5(&(*x1, 34));
    |     ^^ doesn't have a size known at compile-time
    |
@@ -102,7 +102,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:45:9
    |
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     f5(&(32, *x1));
    |         ^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -123,7 +123,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:45:8
    |
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     f5(&(32, *x1));
    |     -- ^^^^^^^^^^ doesn't have a size known at compile-time
    |     |

--- a/tests/ui/unsized/unsized5.stderr
+++ b/tests/ui/unsized/unsized5.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:4:9
    |
 LL | struct S1<X: ?Sized> {
-   |           - this type parameter needs to be `std::marker::Sized`
+   |           - this type parameter needs to be `Sized`
 LL |     f1: X,
    |         ^ doesn't have a size known at compile-time
    |
@@ -26,7 +26,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:10:8
    |
 LL | struct S2<X: ?Sized> {
-   |           - this type parameter needs to be `std::marker::Sized`
+   |           - this type parameter needs to be `Sized`
 LL |     f: isize,
 LL |     g: X,
    |        ^ doesn't have a size known at compile-time
@@ -87,7 +87,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:25:8
    |
 LL | enum E<X: ?Sized> {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     V1(X, isize),
    |        ^ doesn't have a size known at compile-time
    |
@@ -111,7 +111,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:29:12
    |
 LL | enum F<X: ?Sized> {
-   |        - this type parameter needs to be `std::marker::Sized`
+   |        - this type parameter needs to be `Sized`
 LL |     V2{f1: X, f: isize},
    |            ^ doesn't have a size known at compile-time
    |

--- a/tests/ui/unsized/unsized6.stderr
+++ b/tests/ui/unsized/unsized6.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized6.rs:9:9
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                             - this type parameter needs to be `std::marker::Sized`
+   |                             - this type parameter needs to be `Sized`
 ...
 LL |     let y: Y;
    |         ^ doesn't have a size known at compile-time
@@ -23,7 +23,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:7:12
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                  - this type parameter needs to be `std::marker::Sized`
+   |                  - this type parameter needs to be `Sized`
 LL |     let _: W; // <-- this is OK, no bindings created, no initializer.
 LL |     let _: (isize, (X, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -39,7 +39,7 @@ error[E0277]: the size for values of type `Z` cannot be known at compilation tim
   --> $DIR/unsized6.rs:11:12
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                                        - this type parameter needs to be `std::marker::Sized`
+   |                                        - this type parameter needs to be `Sized`
 ...
 LL |     let y: (isize, (Z, usize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -55,7 +55,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:15:9
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     let y: X;
    |         ^ doesn't have a size known at compile-time
    |
@@ -75,7 +75,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized6.rs:17:12
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
-   |                  - this type parameter needs to be `std::marker::Sized`
+   |                  - this type parameter needs to be `Sized`
 ...
 LL |     let y: (isize, (Y, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -91,7 +91,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:22:9
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
@@ -111,7 +111,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:24:9
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 ...
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
@@ -128,7 +128,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:26:10
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
@@ -145,7 +145,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:30:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
@@ -165,7 +165,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:32:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 ...
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
@@ -182,7 +182,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:34:10
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `std::marker::Sized`
+   |       - this type parameter needs to be `Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
@@ -201,7 +201,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn g1<X: ?Sized>(x: X) {}
    |       -          ^ doesn't have a size known at compile-time
    |       |
-   |       this type parameter needs to be `std::marker::Sized`
+   |       this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -220,7 +220,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn g2<X: ?Sized + T>(x: X) {}
    |       -              ^ doesn't have a size known at compile-time
    |       |
-   |       this type parameter needs to be `std::marker::Sized`
+   |       this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider removing the `?Sized` bound to make the type parameter `Sized`

--- a/tests/ui/unsized/unsized7.stderr
+++ b/tests/ui/unsized/unsized7.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |      -              ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `std::marker::Sized`
+   |      this type parameter needs to be `Sized`
    |
 note: required by a bound in `T1`
   --> $DIR/unsized7.rs:7:10


### PR DESCRIPTION
Successful merges:

 - #112403 (Prevent `.eh_frame` from being emitted for `-C panic=abort`)
 - #112517 (`suspicious_double_ref_op`: don't lint on `.borrow()`)
 - #112529 (Extend `unused_must_use` to cover block exprs)
 - #112614 (tweak suggestion for argument-position `impl ?Sized`)
 - #112654 (normalize closure output in equate_inputs_and_outputs)
 - #112660 (Migrate GUI colors test to original CSS color format)
 - #112664 (Add support for test tmpdir to fuchsia test runner)
 - #112669 (Fix comment for ptr alignment checks in codegen)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112403,112517,112529,112614,112654,112660,112664,112669)
<!-- homu-ignore:end -->