### PR TITLE
Disable alignment checks on i686-pc-windows-msvc

### DIFF
--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -15,6 +15,9 @@ pub struct CheckAlignment;
 
 impl<'tcx> MirPass<'tcx> for CheckAlignment {
     fn is_enabled(&self, sess: &Session) -> bool {
+        if sess.target.llvm_target == "i686-pc-windows-msvc" {
+            return false;
+        }
         sess.opts.debug_assertions
     }
 

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -15,6 +15,7 @@ pub struct CheckAlignment;
 
 impl<'tcx> MirPass<'tcx> for CheckAlignment {
     fn is_enabled(&self, sess: &Session) -> bool {
+        // FIXME(#112480) MSVC and rustc disagree on minimum stack alignment on x86 Windows
         if sess.target.llvm_target == "i686-pc-windows-msvc" {
             return false;
         }

--- a/tests/ui/mir/mir_alignment_check.rs
+++ b/tests/ui/mir/mir_alignment_check.rs
@@ -1,5 +1,6 @@
 // run-fail
 // ignore-wasm32-bare: No panic messages
+// ignore-i686-pc-windows-msvc: #112480
 // compile-flags: -C debug-assertions
 // error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
 

--- a/tests/ui/mir/mir_alignment_check_i686-pc-windows-msvc.rs
+++ b/tests/ui/mir/mir_alignment_check_i686-pc-windows-msvc.rs
@@ -1,0 +1,21 @@
+// run-pass
+// only-i686-pc-windows-msvc
+// compile-flags: -Copt-level=0 -Cdebug-assertions=yes
+
+// MSVC isn't sure if on 32-bit Windows its u64 type is 8-byte-aligned or 4-byte-aligned.
+// So this test ensures that on i686-pc-windows-msvc, we do not insert a runtime check
+// that will fail on dereferencing of a pointer to u64 which is not 8-byte-aligned but is
+// 4-byte-aligned.
+
+#![feature(strict_provenance)]
+
+fn main() {
+    let mut x = [0u64; 2];
+    let ptr: *mut u8 = x.as_mut_ptr().cast::<u8>();
+    unsafe {
+        let misaligned = ptr.add(4).cast::<u64>();
+        assert!(misaligned.addr() % 8 != 0);
+        assert!(misaligned.addr() % 4 == 0);
+        *misaligned = 42;
+    }
+}


### PR DESCRIPTION
r? @wesleywiser Because you were in the Zulip discussion of this: https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202023-06-15

cc #112480