### PR TITLE
Account for sealed traits in privacy and trait bound errors

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1831,6 +1831,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                 path,
                                 accessible: true,
                                 note: None,
+                                via_import: false,
                             },
                         ));
                     } else {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -689,10 +689,13 @@ impl<'a> NameBindingKind<'a> {
     }
 }
 
+#[derive(Debug)]
 struct PrivacyError<'a> {
     ident: Ident,
     binding: &'a NameBinding<'a>,
     dedup_span: Span,
+    outermost_res: Option<(Res, Ident)>,
+    parent_scope: ParentScope<'a>,
 }
 
 #[derive(Debug)]

--- a/tests/ui/extern/extern-crate-visibility.stderr
+++ b/tests/ui/extern/extern-crate-visibility.stderr
@@ -9,6 +9,10 @@ note: the crate import `core` is defined here
    |
 LL |     extern crate core;
    |     ^^^^^^^^^^^^^^^^^^
+help: consider importing this module instead
+   |
+LL | use std::cell;
+   |     ~~~~~~~~~
 
 error[E0603]: crate import `core` is private
   --> $DIR/extern-crate-visibility.rs:9:10
@@ -21,6 +25,10 @@ note: the crate import `core` is defined here
    |
 LL |     extern crate core;
    |     ^^^^^^^^^^^^^^^^^^
+help: consider importing this struct instead
+   |
+LL |     std::cell::Cell::new(0);
+   |     ~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-11680.stderr
+++ b/tests/ui/issues/issue-11680.stderr
@@ -2,7 +2,9 @@ error[E0603]: enum `Foo` is private
   --> $DIR/issue-11680.rs:6:21
    |
 LL |     let _b = other::Foo::Bar(1);
-   |                     ^^^ private enum
+   |                     ^^^  --- tuple variant `Bar` is not publicly re-exported
+   |                     |
+   |                     private enum
    |
 note: the enum `Foo` is defined here
   --> $DIR/auxiliary/issue-11680.rs:1:1
@@ -14,7 +16,9 @@ error[E0603]: enum `Foo` is private
   --> $DIR/issue-11680.rs:9:27
    |
 LL |     let _b = other::test::Foo::Bar(1);
-   |                           ^^^ private enum
+   |                           ^^^  --- tuple variant `Bar` is not publicly re-exported
+   |                           |
+   |                           private enum
    |
 note: the enum `Foo` is defined here
   --> $DIR/auxiliary/issue-11680.rs:6:5

--- a/tests/ui/macros/issue-88228.stderr
+++ b/tests/ui/macros/issue-88228.stderr
@@ -4,7 +4,7 @@ error: cannot find macro `bla` in this scope
 LL |     bla!();
    |     ^^^
    |
-help: consider importing this macro
+help: consider importing this macro through its public re-export
    |
 LL + use crate::hey::bla;
    |
@@ -23,7 +23,7 @@ error: cannot find derive macro `Bla` in this scope
 LL | #[derive(Bla)]
    |          ^^^
    |
-help: consider importing this derive macro
+help: consider importing this derive macro through its public re-export
    |
 LL + use crate::hey::Bla;
    |

--- a/tests/ui/privacy/export-tag-variant.stderr
+++ b/tests/ui/privacy/export-tag-variant.stderr
@@ -2,7 +2,9 @@ error[E0603]: enum `Y` is private
   --> $DIR/export-tag-variant.rs:7:26
    |
 LL | fn main() { let z = foo::Y::Y1; }
-   |                          ^ private enum
+   |                          ^  -- unit variant `Y1` is not publicly re-exported
+   |                          |
+   |                          private enum
    |
 note: the enum `Y` is defined here
   --> $DIR/export-tag-variant.rs:4:5

--- a/tests/ui/privacy/privacy-in-paths.stderr
+++ b/tests/ui/privacy/privacy-in-paths.stderr
@@ -2,7 +2,9 @@ error[E0603]: module `bar` is private
   --> $DIR/privacy-in-paths.rs:24:16
    |
 LL |         ::foo::bar::baz::f();
-   |                ^^^ private module
+   |                ^^^       - function `f` is not publicly re-exported
+   |                |
+   |                private module
    |
 note: the module `bar` is defined here
   --> $DIR/privacy-in-paths.rs:3:5
@@ -21,12 +23,18 @@ note: the module `bar` is defined here
    |
 LL |     mod bar {
    |     ^^^^^^^
+help: consider importing this struct through its public re-export instead
+   |
+LL |         foo::S::f();
+   |         ~~~~~~
 
 error[E0603]: trait `T` is private
   --> $DIR/privacy-in-paths.rs:26:23
    |
 LL |         <() as ::foo::T>::Assoc::f();
-   |                       ^ private trait
+   |                       ^   ----- associated type `Assoc` is not publicly re-exported
+   |                       |
+   |                       private trait
    |
 note: the trait `T` is defined here
   --> $DIR/privacy-in-paths.rs:8:5

--- a/tests/ui/privacy/privacy-ufcs.stderr
+++ b/tests/ui/privacy/privacy-ufcs.stderr
@@ -2,7 +2,9 @@ error[E0603]: trait `Bar` is private
   --> $DIR/privacy-ufcs.rs:12:20
    |
 LL |     <i32 as ::foo::Bar>::baz();
-   |                    ^^^ private trait
+   |                    ^^^   --- associated function `baz` is not publicly re-exported
+   |                    |
+   |                    private trait
    |
 note: the trait `Bar` is defined here
   --> $DIR/privacy-ufcs.rs:4:5

--- a/tests/ui/privacy/privacy1.stderr
+++ b/tests/ui/privacy/privacy1.stderr
@@ -50,7 +50,9 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:104:16
    |
 LL |         ::bar::baz::A::foo();
-   |                ^^^ private module
+   |                ^^^  - struct `A` is not publicly re-exported
+   |                |
+   |                private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -62,7 +64,9 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:105:16
    |
 LL |         ::bar::baz::A::bar();
-   |                ^^^ private module
+   |                ^^^  - struct `A` is not publicly re-exported
+   |                |
+   |                private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -74,7 +78,9 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:107:16
    |
 LL |         ::bar::baz::A.foo2();
-   |                ^^^ private module
+   |                ^^^  - unit struct `A` is not publicly re-exported
+   |                |
+   |                private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -86,7 +92,9 @@ error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:108:16
    |
 LL |         ::bar::baz::A.bar2();
-   |                ^^^ private module
+   |                ^^^  - unit struct `A` is not publicly re-exported
+   |                |
+   |                private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -98,7 +106,9 @@ error[E0603]: trait `B` is private
   --> $DIR/privacy1.rs:112:16
    |
 LL |         ::bar::B::foo();
-   |                ^ private trait
+   |                ^  --- associated function `foo` is not publicly re-exported
+   |                |
+   |                private trait
    |
 note: the trait `B` is defined here
   --> $DIR/privacy1.rs:40:5
@@ -129,6 +139,10 @@ note: the module `baz` is defined here
    |
 LL |     mod baz {
    |     ^^^^^^^
+help: consider importing this function through its public re-export instead
+   |
+LL |         bar::foo();
+   |         ~~~~~~~~
 
 error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:128:16
@@ -141,6 +155,10 @@ note: the module `baz` is defined here
    |
 LL |     mod baz {
    |     ^^^^^^^
+help: consider importing this function through its public re-export instead
+   |
+LL |         bar::bar();
+   |         ~~~~~~~~
 
 error[E0603]: trait `B` is private
   --> $DIR/privacy1.rs:157:17

--- a/tests/ui/privacy/sealed-traits/private-trait-non-local.rs
+++ b/tests/ui/privacy/sealed-traits/private-trait-non-local.rs
@@ -1,0 +1,4 @@
+extern crate core;
+use core::slice::index::private_slice_index::Sealed; //~ ERROR module `index` is private
+fn main() {
+}

--- a/tests/ui/privacy/sealed-traits/private-trait-non-local.stderr
+++ b/tests/ui/privacy/sealed-traits/private-trait-non-local.stderr
@@ -1,0 +1,12 @@
+error[E0603]: module `index` is private
+  --> $DIR/private-trait-non-local.rs:2:18
+   |
+LL | use core::slice::index::private_slice_index::Sealed;
+   |                  ^^^^^ private module        ------ trait `Sealed` is not publicly re-exported
+   |
+note: the module `index` is defined here
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0603`.

--- a/tests/ui/privacy/sealed-traits/private-trait.rs
+++ b/tests/ui/privacy/sealed-traits/private-trait.rs
@@ -1,0 +1,10 @@
+pub mod a {
+    mod b {
+        pub trait Hidden {}
+    }
+}
+
+struct S;
+impl a::b::Hidden for S {} //~ ERROR module `b` is private
+
+fn main() {}

--- a/tests/ui/privacy/sealed-traits/private-trait.stderr
+++ b/tests/ui/privacy/sealed-traits/private-trait.stderr
@@ -1,0 +1,17 @@
+error[E0603]: module `b` is private
+  --> $DIR/private-trait.rs:8:9
+   |
+LL | impl a::b::Hidden for S {}
+   |         ^  ------ trait `Hidden` is not publicly re-exported
+   |         |
+   |         private module
+   |
+note: the module `b` is defined here
+  --> $DIR/private-trait.rs:2:5
+   |
+LL |     mod b {
+   |     ^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0603`.

--- a/tests/ui/privacy/sealed-traits/re-exported-trait.fixed
+++ b/tests/ui/privacy/sealed-traits/re-exported-trait.fixed
@@ -1,0 +1,13 @@
+// run-rustfix
+
+pub mod a {
+    pub use self::b::Trait;
+    mod b {
+        pub trait Trait {}
+    }
+}
+
+struct S;
+impl a::Trait for S {} //~ ERROR module `b` is private
+
+fn main() {}

--- a/tests/ui/privacy/sealed-traits/re-exported-trait.rs
+++ b/tests/ui/privacy/sealed-traits/re-exported-trait.rs
@@ -1,0 +1,13 @@
+// run-rustfix
+
+pub mod a {
+    pub use self::b::Trait;
+    mod b {
+        pub trait Trait {}
+    }
+}
+
+struct S;
+impl a::b::Trait for S {} //~ ERROR module `b` is private
+
+fn main() {}

--- a/tests/ui/privacy/sealed-traits/re-exported-trait.stderr
+++ b/tests/ui/privacy/sealed-traits/re-exported-trait.stderr
@@ -1,0 +1,19 @@
+error[E0603]: module `b` is private
+  --> $DIR/re-exported-trait.rs:11:9
+   |
+LL | impl a::b::Trait for S {}
+   |         ^ private module
+   |
+note: the module `b` is defined here
+  --> $DIR/re-exported-trait.rs:5:5
+   |
+LL |     mod b {
+   |     ^^^^^
+help: consider importing this trait through its public re-export instead
+   |
+LL | impl a::Trait for S {}
+   |      ~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0603`.

--- a/tests/ui/privacy/sealed-traits/sealed-trait-local.rs
+++ b/tests/ui/privacy/sealed-traits/sealed-trait-local.rs
@@ -1,0 +1,19 @@
+// provide custom privacy error for sealed traits
+pub mod a {
+    pub trait Sealed: self::b::Hidden {
+        fn foo() {}
+    }
+
+    struct X;
+    impl Sealed for X {}
+    impl self::b::Hidden for X {}
+
+    mod b {
+        pub trait Hidden {}
+    }
+}
+
+struct S;
+impl a::Sealed for S {} //~ ERROR the trait bound `S: Hidden` is not satisfied
+
+fn main() {}

--- a/tests/ui/privacy/sealed-traits/sealed-trait-local.stderr
+++ b/tests/ui/privacy/sealed-traits/sealed-trait-local.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the trait bound `S: Hidden` is not satisfied
+  --> $DIR/sealed-trait-local.rs:17:20
+   |
+LL | impl a::Sealed for S {}
+   |                    ^ the trait `Hidden` is not implemented for `S`
+   |
+note: required by a bound in `Sealed`
+  --> $DIR/sealed-trait-local.rs:3:23
+   |
+LL |     pub trait Sealed: self::b::Hidden {
+   |                       ^^^^^^^^^^^^^^^ required by this bound in `Sealed`
+   = note: `Sealed` is a "sealed trait", because to implement it you also need to implelement `a::b::Hidden`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/tests/ui/proc-macro/derive-helper-shadowing.stderr
@@ -17,7 +17,7 @@ LL |             #[derive(GenHelperUse)]
    |                      ^^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `GenHelperUse` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this attribute macro
+help: consider importing this attribute macro through its public re-export
    |
 LL +             use empty_helper;
    |
@@ -32,7 +32,7 @@ LL |             gen_helper_use!();
    |             ----------------- in this macro invocation
    |
    = note: this error originates in the macro `gen_helper_use` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this attribute macro
+help: consider importing this attribute macro through its public re-export
    |
 LL +             use crate::empty_helper;
    |

--- a/tests/ui/reachable/unreachable-variant.stderr
+++ b/tests/ui/reachable/unreachable-variant.stderr
@@ -2,7 +2,7 @@ error[E0603]: module `super_sekrit` is private
   --> $DIR/unreachable-variant.rs:6:21
    |
 LL |     let _x = other::super_sekrit::sooper_sekrit::baz;
-   |                     ^^^^^^^^^^^^ private module
+   |                     ^^^^^^^^^^^^ private module  --- unit variant `baz` is not publicly re-exported
    |
 note: the module `super_sekrit` is defined here
   --> $DIR/auxiliary/unreachable_variant.rs:1:1

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -228,7 +228,9 @@ error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:61:22
    |
 LL |     let _: Z = m::n::Z::Fn;
-   |                      ^ private enum
+   |                      ^  -- tuple variant `Fn` is not publicly re-exported
+   |                      |
+   |                      private enum
    |
 note: the enum `Z` is defined here
   --> $DIR/privacy-enum-ctor.rs:11:9
@@ -252,7 +254,9 @@ error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:68:22
    |
 LL |     let _: Z = m::n::Z::Unit {};
-   |                      ^ private enum
+   |                      ^  ---- variant `Unit` is not publicly re-exported
+   |                      |
+   |                      private enum
    |
 note: the enum `Z` is defined here
   --> $DIR/privacy-enum-ctor.rs:11:9

--- a/tests/ui/stability-attribute/stability-in-private-module.stderr
+++ b/tests/ui/stability-attribute/stability-in-private-module.stderr
@@ -2,7 +2,9 @@ error[E0603]: module `thread_info` is private
   --> $DIR/stability-in-private-module.rs:2:26
    |
 LL |     let _ = std::thread::thread_info::current_thread();
-   |                          ^^^^^^^^^^^ private module
+   |                          ^^^^^^^^^^^  -------------- function `current_thread` is not publicly re-exported
+   |                          |
+   |                          private module
    |
 note: the module `thread_info` is defined here
   --> $SRC_DIR/std/src/thread/mod.rs:LL:COL

--- a/tests/ui/structs/struct-variant-privacy-xc.stderr
+++ b/tests/ui/structs/struct-variant-privacy-xc.stderr
@@ -14,7 +14,9 @@ error[E0603]: enum `Bar` is private
   --> $DIR/struct-variant-privacy-xc.rs:7:33
    |
 LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
-   |                                 ^^^ private enum
+   |                                 ^^^  --- variant `Baz` is not publicly re-exported
+   |                                 |
+   |                                 private enum
    |
 note: the enum `Bar` is defined here
   --> $DIR/auxiliary/struct_variant_privacy.rs:1:1

--- a/tests/ui/structs/struct-variant-privacy.stderr
+++ b/tests/ui/structs/struct-variant-privacy.stderr
@@ -14,7 +14,9 @@ error[E0603]: enum `Bar` is private
   --> $DIR/struct-variant-privacy.rs:10:14
    |
 LL |         foo::Bar::Baz { a: _a } => {}
-   |              ^^^ private enum
+   |              ^^^  --- variant `Baz` is not publicly re-exported
+   |              |
+   |              private enum
    |
 note: the enum `Bar` is defined here
   --> $DIR/struct-variant-privacy.rs:2:5

--- a/tests/ui/xcrate/xcrate-private-by-default.stderr
+++ b/tests/ui/xcrate/xcrate-private-by-default.stderr
@@ -62,7 +62,9 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:35:29
    |
 LL |     static_priv_by_default::foo::a;
-   |                             ^^^ private module
+   |                             ^^^  - static `a` is not publicly re-exported
+   |                             |
+   |                             private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1
@@ -74,7 +76,9 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:37:29
    |
 LL |     static_priv_by_default::foo::b;
-   |                             ^^^ private module
+   |                             ^^^  - function `b` is not publicly re-exported
+   |                             |
+   |                             private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1
@@ -86,7 +90,9 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:39:29
    |
 LL |     static_priv_by_default::foo::c;
-   |                             ^^^ private module
+   |                             ^^^  - unit struct `c` is not publicly re-exported
+   |                             |
+   |                             private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1
@@ -98,7 +104,9 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:41:35
    |
 LL |     foo::<static_priv_by_default::foo::d>();
-   |                                   ^^^ private module
+   |                                   ^^^  - enum `d` is not publicly re-exported
+   |                                   |
+   |                                   private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1
@@ -110,7 +118,9 @@ error[E0603]: module `foo` is private
   --> $DIR/xcrate-private-by-default.rs:43:35
    |
 LL |     foo::<static_priv_by_default::foo::e>();
-   |                                   ^^^ private module
+   |                                   ^^^  - type alias `e` is not publicly re-exported
+   |                                   |
+   |                                   private module
    |
 note: the module `foo` is defined here
   --> $DIR/auxiliary/static_priv_by_default.rs:12:1


### PR DESCRIPTION
On trait bound errors caused by super-traits, identify if the super-trait is publicly accessibly and if not, explain "sealed traits".

```
error[E0277]: the trait bound `S: Hidden` is not satisfied
  --> $DIR/sealed-trait-local.rs:17:20
   |
LL | impl a::Sealed for S {}
   |                    ^ the trait `Hidden` is not implemented for `S`
   |
note: required by a bound in `Sealed`
  --> $DIR/sealed-trait-local.rs:3:23
   |
LL |     pub trait Sealed: self::b::Hidden {
   |                       ^^^^^^^^^^^^^^^ required by this bound in `Sealed`
   = note: `Sealed` is a "sealed trait", because to implement it you also need to implelement `a::b::Hidden`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
```

Deduplicate privacy errors that point to the same path segment even if their deduplication span are different.

When encountering a path that is not reachable due to privacy constraints path segments other than the last, keep metadata for the last path segment's `Res` in order to look for alternative import paths for that item to suggest. If there are none, be explicit that the item is not accessible.

```
error[E0603]: module `b` is private
  --> $DIR/re-exported-trait.rs:11:9
   |
LL | impl a::b::Trait for S {}
   |         ^ private module
   |
note: the module `b` is defined here
  --> $DIR/re-exported-trait.rs:5:5
   |
LL |     mod b {
   |     ^^^^^
help: consider importing this trait through its public re-export instead
   |
LL | impl a::Trait for S {}
   |      ~~~~~~~~
```

```
error[E0603]: module `b` is private
  --> $DIR/private-trait.rs:8:9
   |
LL | impl a::b::Hidden for S {}
   |         ^  ------ trait `b` is not publicly reachable
   |         |
   |         private module
   |
note: the module `b` is defined here
  --> $DIR/private-trait.rs:2:5
   |
LL |     mod b {
   |     ^^^^^
```