### PR TITLE
[-Ztrait-solver=next, mir-typeck] instantiate hidden types in the root universe

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -50,7 +50,6 @@ use rustc_mir_dataflow::impls::MaybeInitializedPlaces;
 use rustc_mir_dataflow::move_paths::MoveData;
 use rustc_mir_dataflow::ResultsCursor;
 
-use crate::renumber::RegionCtxt;
 use crate::session_diagnostics::MoveUnsized;
 use crate::{
     borrow_set::BorrowSet,
@@ -1041,9 +1040,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             .collect();
 
         let renumbered_opaques = self.infcx.tcx.fold_regions(opaques, |_, _| {
-            self.infcx.next_nll_region_var(
+            self.infcx.next_nll_region_var_in_universe(
                 NllRegionVariableOrigin::Existential { from_forall: false },
-                || RegionCtxt::Unknown,
+                ty::UniverseIndex::ROOT,
             )
         });
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1474,6 +1474,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// universes. Updates `self.universe` to that new universe.
     pub fn create_next_universe(&self) -> ty::UniverseIndex {
         let u = self.universe.get().next_universe();
+        debug!("create_next_universe {u:?}");
         self.universe.set(u);
         u
     }

--- a/tests/ui/traits/new-solver/member-constraints-in-root-universe.rs
+++ b/tests/ui/traits/new-solver/member-constraints-in-root-universe.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+trait Trait {
+    type Ty;
+}
+
+impl Trait for for<'a> fn(&'a u8, &'a u8) {
+    type Ty = ();
+}
+
+// argument is necessary to create universes before registering the hidden type.
+fn test<'a>(_: <fn(&u8, &u8) as Trait>::Ty) -> impl Sized {
+    "hidden type is `&'?0 str` with '?0 member of ['static,]"
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/normalize-hidden-types.current.stderr
+++ b/tests/ui/type-alias-impl-trait/normalize-hidden-types.current.stderr
@@ -1,0 +1,55 @@
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/normalize-hidden-types.rs:25:20
+   |
+LL |     fn define() -> Opaque {
+   |                    ^^^^^^ expected `*const (dyn FnOnce(()) + 'static)`, got `*const dyn for<'a> FnOnce(<u8 as Trait>::Gat<'a>)`
+   |
+note: previous use here
+  --> $DIR/normalize-hidden-types.rs:27:9
+   |
+LL |         dyn_hoops::<_>(0)
+   |         ^^^^^^^^^^^^^^^^^
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/normalize-hidden-types.rs:34:22
+   |
+LL |     fn define_1() -> Opaque { dyn_hoops::<_>(0) }
+   |                      ^^^^^^ expected `*const (dyn FnOnce(()) + 'static)`, got `*const dyn for<'a> FnOnce(<u8 as Trait>::Gat<'a>)`
+   |
+note: previous use here
+  --> $DIR/normalize-hidden-types.rs:34:31
+   |
+LL |     fn define_1() -> Opaque { dyn_hoops::<_>(0) }
+   |                               ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/normalize-hidden-types.rs:44:25
+   |
+LL |     type Opaque = impl Sized;
+   |                   ---------- the expected opaque type
+...
+LL |         let _: Opaque = dyn_hoops::<u8>(0);
+   |                ------   ^^^^^^^^^^^^^^^^^^ expected opaque type, found `*const dyn FnOnce(())`
+   |                |
+   |                expected due to this
+   |
+   = note: expected opaque type `typeck::Opaque`
+              found raw pointer `*const (dyn FnOnce(()) + 'static)`
+   = help: consider constraining the associated type `<u8 as Trait>::Gat<'_>` to `()` or calling a method that returns `<u8 as Trait>::Gat<'_>`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/normalize-hidden-types.rs:54:25
+   |
+LL |         let _: Opaque = dyn_hoops::<_>(0);
+   |                         ^^^^^^^^^^^^^^^^^ expected `*const (dyn FnOnce(()) + 'static)`, got `*const dyn for<'a> FnOnce(<u8 as Trait>::Gat<'a>)`
+   |
+note: previous use here
+  --> $DIR/normalize-hidden-types.rs:56:9
+   |
+LL |         None
+   |         ^^^^
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/normalize-hidden-types.rs
+++ b/tests/ui/type-alias-impl-trait/normalize-hidden-types.rs
@@ -1,0 +1,60 @@
+// Regression test for #112691
+//
+// revisions: current next
+// [next] compile-flags: -Ztrait-solver=next
+// [next] check-pass
+// [current]: known-bug: #112691
+
+#![feature(type_alias_impl_trait)]
+
+trait Trait {
+    type Gat<'lt>;
+}
+
+impl Trait for u8 {
+    type Gat<'lt> = ();
+}
+
+fn dyn_hoops<T: Trait>(_: T) -> *const dyn FnOnce(T::Gat<'_>) {
+    loop {}
+}
+
+mod typeof_1 {
+    use super::*;
+    type Opaque = impl Sized;
+    fn define() -> Opaque {
+        //[current]~^ ERROR concrete type differs
+        dyn_hoops::<_>(0)
+    }
+}
+
+mod typeof_2 {
+    use super::*;
+    type Opaque = impl Sized;
+    fn define_1() -> Opaque { dyn_hoops::<_>(0) }
+    //[current]~^ ERROR concrete type differs
+    fn define_2() -> Opaque { dyn_hoops::<u8>(0) }
+}
+
+mod typeck {
+    use super::*;
+    type Opaque = impl Sized;
+    fn define() -> Option<Opaque> {
+        let _: Opaque = dyn_hoops::<_>(0);
+        let _: Opaque = dyn_hoops::<u8>(0);
+        //[current]~^ ERROR mismatched types
+        None
+    }
+}
+
+mod borrowck {
+    use super::*;
+    type Opaque = impl Sized;
+    fn define() -> Option<Opaque> {
+        let _: Opaque = dyn_hoops::<_>(0);
+        //[current]~^ ERROR concrete type differs
+        None
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes an ICE in the test `member-constraints-in-root-universe`.

Main motivation is to make #112691 pass under the new solver.

r? @compiler-errors 