### PR TITLE
Avoid calling queries during query stack printing

### DIFF
--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -349,7 +349,12 @@ pub fn try_print_query_stack(handler: &Handler, num_frames: Option<usize>) {
     // state if it was responsible for triggering the panic.
     let i = ty::tls::with_context_opt(|icx| {
         if let Some(icx) = icx {
-            print_query_stack(QueryCtxt::new(icx.tcx), icx.query, handler, num_frames)
+            ty::print::with_no_queries!(print_query_stack(
+                QueryCtxt::new(icx.tcx),
+                icx.query,
+                handler,
+                num_frames
+            ))
         } else {
             0
         }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -94,6 +94,10 @@ macro_rules! define_helper {
                     $tl.with(|c| c.set(self.0))
                 }
             }
+
+            pub fn $name() -> bool {
+                $tl.with(|c| c.get())
+            }
         )+
     }
 }
@@ -676,7 +680,7 @@ pub trait PrettyPrinter<'tcx>:
                 p!(")")
             }
             ty::FnDef(def_id, substs) => {
-                if NO_QUERIES.with(|q| q.get()) {
+                if with_no_queries() {
                     p!(print_def_path(def_id, substs));
                 } else {
                     let sig = self.tcx().fn_sig(def_id).subst(self.tcx(), substs);
@@ -732,7 +736,7 @@ pub trait PrettyPrinter<'tcx>:
                 p!(print_def_path(def_id, &[]));
             }
             ty::Alias(ty::Projection | ty::Inherent | ty::Weak, ref data) => {
-                if !(self.should_print_verbose() || NO_QUERIES.with(|q| q.get()))
+                if !(self.should_print_verbose() || with_no_queries())
                     && self.tcx().is_impl_trait_in_trait(data.def_id)
                 {
                     return self.pretty_print_opaque_impl_type(data.def_id, data.substs);
@@ -779,7 +783,7 @@ pub trait PrettyPrinter<'tcx>:
                         return Ok(self);
                     }
                     _ => {
-                        if NO_QUERIES.with(|q| q.get()) {
+                        if with_no_queries() {
                             p!(print_def_path(def_id, &[]));
                             return Ok(self);
                         } else {
@@ -1746,7 +1750,8 @@ impl DerefMut for FmtPrinter<'_, '_> {
 
 impl<'a, 'tcx> FmtPrinter<'a, 'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>, ns: Namespace) -> Self {
-        Self::new_with_limit(tcx, ns, tcx.type_length_limit())
+        let limit = if with_no_queries() { Limit::new(1048576) } else { tcx.type_length_limit() };
+        Self::new_with_limit(tcx, ns, limit)
     }
 
     pub fn new_with_limit(tcx: TyCtxt<'tcx>, ns: Namespace, type_length_limit: Limit) -> Self {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3004,7 +3004,7 @@ fn for_each_def(tcx: TyCtxt<'_>, mut collect_fn: impl for<'b> FnMut(&'b Ident, N
 ///
 /// The implementation uses similar import discovery logic to that of 'use' suggestions.
 ///
-/// See also [`DelayDm`](rustc_error_messages::DelayDm) and [`with_no_trimmed_paths`].
+/// See also [`DelayDm`](rustc_error_messages::DelayDm) and [`with_no_trimmed_paths!`].
 fn trimmed_def_paths(tcx: TyCtxt<'_>, (): ()) -> FxHashMap<DefId, Symbol> {
     let mut map: FxHashMap<DefId, Symbol> = FxHashMap::default();
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -16,7 +16,7 @@ use rustc_middle::query::on_disk_cache::AbsoluteBytePos;
 use rustc_middle::query::on_disk_cache::{CacheDecoder, CacheEncoder, EncodedDepNodeIndex};
 use rustc_middle::query::Key;
 use rustc_middle::ty::tls::{self, ImplicitCtxt};
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_middle::ty::{self, print::with_no_queries, TyCtxt};
 use rustc_query_system::dep_graph::{DepNodeParams, HasDepContext};
 use rustc_query_system::ich::StableHashingContext;
 use rustc_query_system::query::{
@@ -312,7 +312,7 @@ pub(crate) fn create_query_frame<
     );
     let description =
         if tcx.sess.verbose() { format!("{description} [{name:?}]") } else { description };
-    let span = if kind == dep_graph::DepKind::def_span {
+    let span = if kind == dep_graph::DepKind::def_span || with_no_queries() {
         // The `def_span` query is used to calculate `default_span`,
         // so exit to avoid infinite recursion.
         None
@@ -320,7 +320,7 @@ pub(crate) fn create_query_frame<
         Some(key.default_span(tcx))
     };
     let def_id = key.key_as_def_id();
-    let def_kind = if kind == dep_graph::DepKind::opt_def_kind {
+    let def_kind = if kind == dep_graph::DepKind::opt_def_kind || with_no_queries() {
         // Try to avoid infinite recursion.
         None
     } else {

--- a/tests/ui/treat-err-as-bug/panic-causes-oom-112708.rs
+++ b/tests/ui/treat-err-as-bug/panic-causes-oom-112708.rs
@@ -1,0 +1,11 @@
+// compile-flags: -Ztreat-err-as-bug
+// dont-check-failure-status
+// error-pattern: aborting due to `-Z treat-err-as-bug=1`
+// normalize-stderr-test "note: .*\n\n" -> ""
+// normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+// rustc-env:RUST_BACKTRACE=0
+
+fn main() {
+    #[deny(while_true)]
+    while true {}
+}

--- a/tests/ui/treat-err-as-bug/panic-causes-oom-112708.rs
+++ b/tests/ui/treat-err-as-bug/panic-causes-oom-112708.rs
@@ -1,8 +1,7 @@
 // compile-flags: -Ztreat-err-as-bug
 // dont-check-failure-status
 // error-pattern: aborting due to `-Z treat-err-as-bug=1`
-// normalize-stderr-test "note: .*\n\n" -> ""
-// normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+// dont-check-compiler-stderr
 // rustc-env:RUST_BACKTRACE=0
 
 fn main() {

--- a/tests/ui/treat-err-as-bug/panic-causes-oom-112708.stderr
+++ b/tests/ui/treat-err-as-bug/panic-causes-oom-112708.stderr
@@ -1,0 +1,16 @@
+error: denote infinite loops with `loop { ... }`
+  --> $DIR/panic-causes-oom-112708.rs:10:5
+   |
+LL |     while true {}
+   |     ^^^^^^^^^^ help: use `loop`
+   |
+note: the lint level is defined here
+  --> $DIR/panic-causes-oom-112708.rs:9:12
+   |
+LL |     #[deny(while_true)]
+   |            ^^^^^^^^^^
+
+error: the compiler unexpectedly panicked. this is a bug.
+
+query stack during panic:
+thread panicked while processing panic. aborting.

--- a/tests/ui/treat-err-as-bug/panic-causes-oom-112708.stderr
+++ b/tests/ui/treat-err-as-bug/panic-causes-oom-112708.stderr
@@ -1,16 +1,32 @@
 error: denote infinite loops with `loop { ... }`
-  --> $DIR/panic-causes-oom-112708.rs:10:5
+  --> $DIR/panic-causes-oom-112708.rs:13:5
    |
 LL |     while true {}
    |     ^^^^^^^^^^ help: use `loop`
    |
 note: the lint level is defined here
-  --> $DIR/panic-causes-oom-112708.rs:9:12
+  --> $DIR/panic-causes-oom-112708.rs:12:12
    |
 LL |     #[deny(while_true)]
    |            ^^^^^^^^^^
 
+
+query stack during panic:
+#0 [early_lint_checks] perform lints prior to macro expansion
+#1 [hir_crate] getting the crate HIR
+end of query stack
+
 error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
-thread panicked while processing panic. aborting.
+#0 [early_lint_checks] perform lints prior to macro expansion
+#1 [hir_crate] getting the crate HIR
+end of query stack
+
+error: the compiler unexpectedly panicked. this is a bug.
+
+query stack during panic:
+#0 [early_lint_checks] perform lints prior to macro expansion
+#1 [hir_crate] getting the crate HIR
+end of query stack
+thread caused non-unwinding panic. aborting.


### PR DESCRIPTION
This has the side effect, that when Clippy should ICE (during an EarlyPass?) it will fill up the RAM with 2 GB/s and then freezes my Laptop. This is blocking the Clippy sync and might give some people really bad experiences, so this should be merged ASAP.

r? @cjgillot
cc @Zoxc 

I only commented this on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/.60try_print_query_stack.60.20has.20.60ImplicitCtx.60.20during.20.60EarlyPass.60/near/363926180). I should've left a comment on the PR as well. My bad.