### PR TITLE
implement Literal::byte_character

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1337,6 +1337,13 @@ impl Literal {
         Literal::new(bridge::LitKind::Char, symbol, None)
     }
 
+    /// Byte character literal.
+    #[unstable(feature = "proc_macro_byte_character", issue = "115268")]
+    pub fn byte_character(byte: u8) -> Literal {
+        let string = [byte].escape_ascii().to_string();
+        Literal::new(bridge::LitKind::Byte, &string, None)
+    }
+
     /// Byte string literal.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn byte_string(bytes: &[u8]) -> Literal {

--- a/tests/ui/feature-gates/feature-gate-proc_macro_byte_character.rs
+++ b/tests/ui/feature-gates/feature-gate-proc_macro_byte_character.rs
@@ -1,0 +1,10 @@
+// force-host
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::Literal;
+
+fn test() {
+    Literal::byte_character(b'a'); //~ ERROR use of unstable library feature 'proc_macro_byte_character'
+}

--- a/tests/ui/feature-gates/feature-gate-proc_macro_byte_character.stderr
+++ b/tests/ui/feature-gates/feature-gate-proc_macro_byte_character.stderr
@@ -1,0 +1,12 @@
+error[E0658]: use of unstable library feature 'proc_macro_byte_character'
+  --> $DIR/feature-gate-proc_macro_byte_character.rs:9:5
+   |
+LL |     Literal::byte_character(b'a');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #115268 <https://github.com/rust-lang/rust/issues/115268> for more information
+   = help: add `#![feature(proc_macro_byte_character)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/proc-macro/auxiliary/api/mod.rs
+++ b/tests/ui/proc-macro/auxiliary/api/mod.rs
@@ -4,6 +4,7 @@
 #![crate_type = "proc-macro"]
 #![crate_name = "proc_macro_api_tests"]
 #![feature(proc_macro_span)]
+#![feature(proc_macro_byte_character)]
 #![deny(dead_code)] // catch if a test function is never called
 
 extern crate proc_macro;

--- a/tests/ui/proc-macro/auxiliary/api/parse.rs
+++ b/tests/ui/proc-macro/auxiliary/api/parse.rs
@@ -29,12 +29,16 @@ fn test_display_literal() {
     assert_eq!(Literal::character('\'').to_string(), "'\\''");
     assert_eq!(Literal::character('"').to_string(), "'\"'");
     assert_eq!(Literal::character('\u{1}').to_string(), "'\\u{1}'");
+
+    assert_eq!(Literal::byte_character(b'a').to_string(), "b'a'");
+    assert_eq!(Literal::byte_character(0).to_string(), "b'\\x00'");
 }
 
 fn test_parse_literal() {
     assert_eq!("1".parse::<Literal>().unwrap().to_string(), "1");
     assert_eq!("1.0".parse::<Literal>().unwrap().to_string(), "1.0");
     assert_eq!("'a'".parse::<Literal>().unwrap().to_string(), "'a'");
+    assert_eq!("b'a'".parse::<Literal>().unwrap().to_string(), "b'a'");
     assert_eq!("\"\n\"".parse::<Literal>().unwrap().to_string(), "\"\n\"");
     assert_eq!("b\"\"".parse::<Literal>().unwrap().to_string(), "b\"\"");
     assert_eq!("r##\"\"##".parse::<Literal>().unwrap().to_string(), "r##\"\"##");


### PR DESCRIPTION
without this, the only way to create a `LitKind::Byte` is by
doing `"b'a'".parse::<Literal>()`, this solves that by enabling
`Literal::byte_character(b'a')`

cc #71358

The tracking issue is #115268