### PR TITLE
bootstrap: check for dry run when copying env vars for msvc

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1766,7 +1766,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
         //
         // Note that if we encounter `PATH` we make sure to append to our own `PATH`
         // rather than stomp over it.
-        if target.contains("msvc") {
+        if !builder.config.dry_run() && target.contains("msvc") {
             for &(ref k, ref v) in builder.cc.borrow()[&target].env() {
                 if k != "PATH" {
                     cmd.env(k, v);


### PR DESCRIPTION
The new synthetic targets for mir-opt blessing aren't added to `builder.cc` during dry runs, causing `x.py test tests/mir-opt --bless`  to crash on MSVC when it tries to copy env vars to the C compiler invocation. This PR adds a check for dry run to fix the panic.