### PR TITLE
Implement SpecFromElem for bool

### DIFF
--- a/library/alloc/src/vec/spec_from_elem.rs
+++ b/library/alloc/src/vec/spec_from_elem.rs
@@ -68,7 +68,7 @@ impl SpecFromElem for bool {
         }
         unsafe {
             let mut v = Vec::with_capacity_in(n, alloc);
-            ptr::write_bytes(v.as_mut_ptr(), 1u8, n);
+            ptr::write_bytes(v.as_mut_ptr(), elem as u8, n);
             v.set_len(n);
             v
         }

--- a/library/alloc/src/vec/spec_from_elem.rs
+++ b/library/alloc/src/vec/spec_from_elem.rs
@@ -59,3 +59,18 @@ impl SpecFromElem for u8 {
         }
     }
 }
+
+impl SpecFromElem for bool {
+    #[inline]
+    fn from_elem<A: Allocator>(elem: bool, n: usize, alloc: A) -> Vec<bool, A> {
+        if elem == false {
+            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
+        }
+        unsafe {
+            let mut v = Vec::with_capacity_in(n, alloc);
+            ptr::write_bytes(v.as_mut_ptr(), 1u8, n);
+            v.set_len(n);
+            v
+        }
+    }
+}

--- a/tests/codegen/vec-calloc.rs
+++ b/tests/codegen/vec-calloc.rs
@@ -42,6 +42,43 @@ pub fn vec_one_bytes(n: usize) -> Vec<u8> {
     vec![1; n]
 }
 
+// CHECK-LABEL: @vec_false
+#[no_mangle]
+pub fn vec_false(n: usize) -> Vec<bool> {
+    // CHECK-NOT: call {{.*}}alloc::vec::from_elem
+    // CHECK-NOT: call {{.*}}reserve
+    // CHECK-NOT: call {{.*}}__rust_alloc(
+    // CHECK-NOT: call {{.*}}llvm.memset
+
+    // CHECK: call {{.*}}__rust_alloc_zeroed(
+
+    // CHECK-NOT: call {{.*}}alloc::vec::from_elem
+    // CHECK-NOT: call {{.*}}reserve
+    // CHECK-NOT: call {{.*}}__rust_alloc(
+    // CHECK-NOT: call {{.*}}llvm.memset
+
+    // CHECK: ret void
+    vec![false; n]
+}
+
+// CHECK-LABEL: @vec_true
+#[no_mangle]
+pub fn vec_true(n: usize) -> Vec<bool> {
+    // CHECK-NOT: call {{.*}}alloc::vec::from_elem
+    // CHECK-NOT: call {{.*}}reserve
+    // CHECK-NOT: call {{.*}}__rust_alloc_zeroed(
+
+    // CHECK: call {{.*}}__rust_alloc(
+    // CHECK: call {{.*}}llvm.memset
+
+    // CHECK-NOT: call {{.*}}alloc::vec::from_elem
+    // CHECK-NOT: call {{.*}}reserve
+    // CHECK-NOT: call {{.*}}__rust_alloc_zeroed(
+
+    // CHECK: ret void
+    vec![true; n]
+}
+
 // CHECK-LABEL: @vec_zero_scalar
 #[no_mangle]
 pub fn vec_zero_scalar(n: usize) -> Vec<i32> {


### PR DESCRIPTION
On my machine, this sped `vec![true; n]`up by 4-5 times in debug mode.

This can also be done for other types of size 1, such as `NonZero{i,u}8`, `Option<bool>`, `Option<NonZero{i,u}8>` and `Option<ZST>`. I can try to do these in this PR as well if there is interest; I figured these options may be more contentious than bools.