### PR TITLE
Add `<meta charset="utf-8">` to `-Zdump-mir-spanview` output

### DIFF
--- a/compiler/rustc_middle/src/mir/spanview.rs
+++ b/compiler/rustc_middle/src/mir/spanview.rs
@@ -15,8 +15,9 @@ const ANNOTATION_LEFT_BRACKET: char = '\u{298a}'; // Unicode `Z NOTATION RIGHT B
 const ANNOTATION_RIGHT_BRACKET: char = '\u{2989}'; // Unicode `Z NOTATION LEFT BINDING BRACKET`
 const NEW_LINE_SPAN: &str = "</span>\n<span class=\"line\">";
 const HEADER: &str = r#"<!DOCTYPE html>
-<html>
-<head>"#;
+<html lang="en">
+<head>
+<meta charset="utf-8">"#;
 const START_BODY: &str = r#"</head>
 <body>"#;
 const FOOTER: &str = r#"</body>

--- a/tests/mir-opt/spanview_block.main.built.after.html
+++ b/tests/mir-opt/spanview_block.main.built.after.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>spanview_block.main.built.after</title>
 <style>
     .line {

--- a/tests/mir-opt/spanview_statement.main.built.after.html
+++ b/tests/mir-opt/spanview_statement.main.built.after.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>spanview_statement.main.built.after</title>
 <style>
     .line {

--- a/tests/mir-opt/spanview_terminator.main.built.after.html
+++ b/tests/mir-opt/spanview_terminator.main.built.after.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>spanview_terminator.main.built.after</title>
 <style>
     .line {


### PR DESCRIPTION
Without an explicit `<meta charset>` declaration, some browsers (e.g. Safari) won't detect the page encoding as UTF-8, causing unicode characters in the dump output to display incorrectly.