### PR TITLE
Add machine-applicable suggestion for `unused_qualifications` lint

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -956,6 +956,14 @@ pub trait LintContext: Sized {
                     db.span_note(glob_reexport_span, format!("the name `{}` in the {} namespace is supposed to be publicly re-exported here", name, namespace));
                     db.span_note(private_item_span, "but the private item here shadows it".to_owned());
                 }
+                BuiltinLintDiagnostics::UnusedQualifications { path_span, unqualified_path } => {
+                    db.span_suggestion_verbose(
+                        path_span,
+                        "replace it with the unqualified path",
+                        unqualified_path,
+                        Applicability::MachineApplicable
+                    );
+                }
             }
             // Rewrap `db`, and pass control to the user.
             decorate(db)

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -550,6 +550,12 @@ pub enum BuiltinLintDiagnostics {
         /// The local binding that shadows the glob reexport.
         private_item_span: Span,
     },
+    UnusedQualifications {
+        /// The span of the unnecessarily-qualified path.
+        path_span: Span,
+        /// The replacement unqualified path.
+        unqualified_path: Ident,
+    },
 }
 
 /// Lints that are buffered up early on in the `Session` before the

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3917,11 +3917,15 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
             };
             if res == unqualified_result {
                 let lint = lint::builtin::UNUSED_QUALIFICATIONS;
-                self.r.lint_buffer.buffer_lint(
+                self.r.lint_buffer.buffer_lint_with_diagnostic(
                     lint,
                     finalize.node_id,
                     finalize.path_span,
                     "unnecessary qualification",
+                    lint::BuiltinLintDiagnostics::UnusedQualifications {
+                        path_span: finalize.path_span,
+                        unqualified_path: path.last().unwrap().ident
+                    }
                 )
             }
         }

--- a/tests/ui/lint/lint-qualification.stderr
+++ b/tests/ui/lint/lint-qualification.stderr
@@ -9,6 +9,10 @@ note: the lint level is defined here
    |
 LL | #![deny(unused_qualifications)]
    |         ^^^^^^^^^^^^^^^^^^^^^
+help: replace it with the unqualified path
+   |
+LL |     bar();
+   |     ~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/resolve/unused-qualifications-suggestion.fixed
+++ b/tests/ui/resolve/unused-qualifications-suggestion.fixed
@@ -1,0 +1,23 @@
+// run-rustfix
+
+#![deny(unused_qualifications)]
+
+mod foo {
+    pub fn bar() {}
+}
+
+mod baz {
+    pub mod qux {
+        pub fn quux() {}
+    }
+}
+
+fn main() {
+    use foo::bar;
+    bar();
+    //~^ ERROR unnecessary qualification
+
+    use baz::qux::quux;
+    quux();
+    //~^ ERROR unnecessary qualification
+}

--- a/tests/ui/resolve/unused-qualifications-suggestion.rs
+++ b/tests/ui/resolve/unused-qualifications-suggestion.rs
@@ -1,0 +1,23 @@
+// run-rustfix
+
+#![deny(unused_qualifications)]
+
+mod foo {
+    pub fn bar() {}
+}
+
+mod baz {
+    pub mod qux {
+        pub fn quux() {}
+    }
+}
+
+fn main() {
+    use foo::bar;
+    foo::bar();
+    //~^ ERROR unnecessary qualification
+
+    use baz::qux::quux;
+    baz::qux::quux();
+    //~^ ERROR unnecessary qualification
+}

--- a/tests/ui/resolve/unused-qualifications-suggestion.stderr
+++ b/tests/ui/resolve/unused-qualifications-suggestion.stderr
@@ -1,0 +1,29 @@
+error: unnecessary qualification
+  --> $DIR/unused-qualifications-suggestion.rs:17:5
+   |
+LL |     foo::bar();
+   |     ^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-qualifications-suggestion.rs:3:9
+   |
+LL | #![deny(unused_qualifications)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+help: replace it with the unqualified path
+   |
+LL |     bar();
+   |     ~~~
+
+error: unnecessary qualification
+  --> $DIR/unused-qualifications-suggestion.rs:21:5
+   |
+LL |     baz::qux::quux();
+   |     ^^^^^^^^^^^^^^
+   |
+help: replace it with the unqualified path
+   |
+LL |     quux();
+   |     ~~~~
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
```
error: unnecessary qualification
  --> $DIR/unused-qualifications-suggestion.rs:17:5
   |
LL |     foo::bar();
   |     ^^^^^^^^
   |
note: the lint level is defined here
  --> $DIR/unused-qualifications-suggestion.rs:3:9
   |
LL | #![deny(unused_qualifications)]
   |         ^^^^^^^^^^^^^^^^^^^^^
help: replace it with the unqualified path
   |
LL |     bar();
   |     ~~~
```

Closes #92198.