### PR TITLE
fix(resolve): update the ambiguity glob binding recursively

### DIFF
--- a/tests/ui/imports/duplicate.rs
+++ b/tests/ui/imports/duplicate.rs
@@ -33,7 +33,7 @@ mod g {
 fn main() {
     e::foo();
     f::foo(); //~ ERROR `foo` is ambiguous
-    g::foo();
+    g::foo(); //~ ERROR `foo` is ambiguous
 }
 
 mod ambiguous_module_errors {

--- a/tests/ui/imports/duplicate.stderr
+++ b/tests/ui/imports/duplicate.stderr
@@ -49,6 +49,26 @@ LL |     pub use b::*;
    = help: consider adding an explicit import of `foo` to disambiguate
 
 error[E0659]: `foo` is ambiguous
+  --> $DIR/duplicate.rs:36:8
+   |
+LL |     g::foo();
+   |        ^^^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `foo` could refer to the function imported here
+  --> $DIR/duplicate.rs:24:13
+   |
+LL |     pub use a::*;
+   |             ^^^^
+   = help: consider adding an explicit import of `foo` to disambiguate
+note: `foo` could also refer to the function imported here
+  --> $DIR/duplicate.rs:25:13
+   |
+LL |     pub use b::*;
+   |             ^^^^
+   = help: consider adding an explicit import of `foo` to disambiguate
+
+error[E0659]: `foo` is ambiguous
   --> $DIR/duplicate.rs:49:9
    |
 LL |         foo::bar();
@@ -68,7 +88,7 @@ LL |     use self::m2::*;
    |         ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0252, E0659.
 For more information about an error, try `rustc --explain E0252`.

--- a/tests/ui/resolve/issue-105235.rs
+++ b/tests/ui/resolve/issue-105235.rs
@@ -1,0 +1,30 @@
+// edition: 2021
+// check-pass
+
+mod abc {
+    pub struct Beeblebrox;
+    pub struct Zaphod;
+}
+
+mod foo {
+    pub mod bar {
+        use crate::abc::*;
+
+        #[derive(Debug)]
+        pub enum Zaphod {
+            Whale,
+            President,
+        }
+    }
+    pub use bar::*;
+}
+
+mod baz {
+    pub fn do_something() {
+        println!("{:?}", crate::foo::Zaphod::Whale);
+    }
+}
+
+fn main() {
+    baz::do_something();
+}

--- a/tests/ui/resolve/issue-112713.rs
+++ b/tests/ui/resolve/issue-112713.rs
@@ -1,0 +1,16 @@
+// edition: 2021
+
+pub fn foo() -> u32 {
+    use sub::*;
+    C //~ERROR `C` is ambiguous
+}
+
+mod sub {
+    mod mod1 { pub const C: u32 = 1; }
+    mod mod2 { pub const C: u32 = 2; }
+
+    pub use mod1::*;
+    pub use mod2::*;
+}
+
+fn main() {}

--- a/tests/ui/resolve/issue-112713.stderr
+++ b/tests/ui/resolve/issue-112713.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `C` is ambiguous
+  --> $DIR/issue-112713.rs:5:5
+   |
+LL |     C
+   |     ^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `C` could refer to the constant imported here
+  --> $DIR/issue-112713.rs:12:13
+   |
+LL |     pub use mod1::*;
+   |             ^^^^^^^
+   = help: consider adding an explicit import of `C` to disambiguate
+note: `C` could also refer to the constant imported here
+  --> $DIR/issue-112713.rs:13:13
+   |
+LL |     pub use mod2::*;
+   |             ^^^^^^^
+   = help: consider adding an explicit import of `C` to disambiguate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/resolve/issue-112743.rs
+++ b/tests/ui/resolve/issue-112743.rs
@@ -1,0 +1,25 @@
+// https://github.com/rust-lang/rust/pull/112743#issuecomment-1601986883
+
+macro_rules! m {
+    () => {
+      pub fn EVP_PKEY_id() {}
+    };
+}
+
+mod openssl {
+    pub use self::evp::*;
+    pub use self::handwritten::*;
+
+    mod evp {
+      m!();
+    }
+
+    mod handwritten {
+      m!();
+    }
+}
+use openssl::*;
+
+fn main() {
+    EVP_PKEY_id(); //~ ERROR `EVP_PKEY_id` is ambiguous
+}

--- a/tests/ui/resolve/issue-112743.stderr
+++ b/tests/ui/resolve/issue-112743.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `EVP_PKEY_id` is ambiguous
+  --> $DIR/issue-112743.rs:24:5
+   |
+LL |     EVP_PKEY_id();
+   |     ^^^^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `EVP_PKEY_id` could refer to the function imported here
+  --> $DIR/issue-112743.rs:10:13
+   |
+LL |     pub use self::evp::*;
+   |             ^^^^^^^^^^^^
+   = help: consider adding an explicit import of `EVP_PKEY_id` to disambiguate
+note: `EVP_PKEY_id` could also refer to the function imported here
+  --> $DIR/issue-112743.rs:11:13
+   |
+LL |     pub use self::handwritten::*;
+   |             ^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `EVP_PKEY_id` to disambiguate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/resolve/issue-56593-0.rs
+++ b/tests/ui/resolve/issue-56593-0.rs
@@ -1,0 +1,21 @@
+// check-pass
+
+mod a {
+    pub trait P {}
+}
+pub use a::*;
+
+mod b {
+    #[derive(Clone)]
+    pub enum P {
+        A
+    }
+}
+pub use b::P;
+
+mod c {
+    use crate::*;
+    pub struct S(Vec<P>);
+}
+
+fn main() {}

--- a/tests/ui/resolve/issue-56593-1.rs
+++ b/tests/ui/resolve/issue-56593-1.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+struct Foo;
+
+mod foo {
+    use super::*;
+
+    #[derive(Debug)]
+    pub struct Foo;
+}
+
+mod bar {
+    use super::foo::*;
+
+    fn bar(_: Foo) {}
+}
+
+fn main() {}

--- a/tests/ui/resolve/issue-56593-2.rs
+++ b/tests/ui/resolve/issue-56593-2.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+use thing::*;
+
+#[derive(Debug)]
+pub enum Thing {
+    Foo,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_thing() {
+        let thing = Thing::Foo;
+    }
+}
+
+mod thing {
+    pub enum Thing {
+        Bar,
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #112713

The error was not reported for #112713 because the `ambiguity` in the binding of `root::sub::C` was lost.

The `resolve_imports` process is shown below:

|Iter| `importer` | `module` | `resolve_glob_import` |
| -  | - | - | - |
| 0  | `use sub::*`| `root::sub`         | Since no bindings had been added, nothing was defined|
| 1  | `use mod1::*` | `root::sub::mod1` | 1. `(root::sub, C) -> root::sub::mod1::C` by `try_define`; <br/>2. `(block_module, C) -> NameBinding { kind: Import { binding: root::sub::mod1::C }, .. }` by `try_define` recursively for `module.glob_importers`  |
| 2  | `use mod2::*` | `root::sub::mod2` | `(root::sub, C) -> root::sub::mod1::C` with  ambiguity  |

However, the ambiguity binding generated by iteration 2 points to a different value than the one generated by iteration 1. Therefore, the binding to ﻿`root::sub::mod::C` in iteration 1 does not have ambiguity, and no error is thrown in the end.

In this PR, I had made update the ambiguity glob binding recursively.

Perhaps changing `﻿&'a NameBinding<'a>` to ﻿`&'a mut NameBinding<'a>` in `﻿NameResolution` would be a better choice.

r? @petrochenkov 
