### PR TITLE
rustdoc: Fixes with --test-run-directory and relative paths.

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -463,7 +463,9 @@ fn run_test(
     // Run the code!
     let mut cmd;
 
+    let output_file = make_maybe_absolute_path(output_file);
     if let Some(tool) = runtool {
+        let tool = make_maybe_absolute_path(tool.into());
         cmd = Command::new(tool);
         cmd.args(runtool_args);
         cmd.arg(output_file);
@@ -495,6 +497,20 @@ fn run_test(
     }
 
     Ok(())
+}
+
+/// Converts a path intended to use as a command to absolute if it is
+/// relative, and not a single component.
+///
+/// This is needed to deal with relative paths interacting with
+/// `Command::current_dir` in a platform-specific way.
+fn make_maybe_absolute_path(path: PathBuf) -> PathBuf {
+    if path.components().count() == 1 {
+        // Look up process via PATH.
+        path
+    } else {
+        std::env::current_dir().map(|c| c.join(&path)).unwrap_or_else(|_| path)
+    }
 }
 
 /// Transforms a test into code that can be compiled into a Rust binary, and returns the number of

--- a/tests/run-make/doctests-keep-binaries/Makefile
+++ b/tests/run-make/doctests-keep-binaries/Makefile
@@ -3,7 +3,9 @@ include ../tools.mk
 
 # Check that valid binaries are persisted by running them, regardless of whether the --run or --no-run option is used.
 
-all: run no_run
+MY_SRC_DIR := ${CURDIR}
+
+all: run no_run test_run_directory
 
 run:
 	mkdir -p $(TMPDIR)/doctests
@@ -20,3 +22,12 @@ no_run:
 	$(TMPDIR)/doctests/t_rs_2_0/rust_out
 	$(TMPDIR)/doctests/t_rs_8_0/rust_out
 	rm -rf $(TMPDIR)/doctests
+
+# Behavior with --test-run-directory with relative paths.
+test_run_directory:
+	mkdir -p $(TMPDIR)/doctests
+	mkdir -p $(TMPDIR)/rundir
+	$(RUSTC) --crate-type rlib t.rs
+	( cd $(TMPDIR); \
+		$(RUSTDOC) -Zunstable-options --test --persist-doctests doctests --test-run-directory rundir --extern t=libt.rlib $(MY_SRC_DIR)/t.rs )
+	rm -rf $(TMPDIR)/doctests $(TMPDIR)/rundir

--- a/tests/run-make/doctests-runtool/Makefile
+++ b/tests/run-make/doctests-runtool/Makefile
@@ -1,0 +1,20 @@
+# ignore-cross-compile
+include ../tools.mk
+
+# Tests behavior of rustdoc --runtool
+
+MY_SRC_DIR := ${CURDIR}
+
+all: with_test_run_directory
+
+# Behavior with --runtool with relative paths and --test-run-directory.
+with_test_run_directory:
+	mkdir -p $(TMPDIR)/rundir
+	mkdir -p $(TMPDIR)/runtool
+	$(RUSTC) --crate-type rlib t.rs
+	$(RUSTC) runtool.rs -o $(TMPDIR)/runtool/runtool
+	( cd $(TMPDIR); \
+		$(RUSTDOC) -Zunstable-options --test --test-run-directory rundir \
+			--runtool runtool/runtool --extern t=libt.rlib $(MY_SRC_DIR)/t.rs \
+	)
+	rm -rf $(TMPDIR)/rundir $(TMPDIR)/runtool

--- a/tests/run-make/doctests-runtool/runtool.rs
+++ b/tests/run-make/doctests-runtool/runtool.rs
@@ -1,0 +1,3 @@
+fn main() {
+    eprintln!("{:?}", std::env::args().collect::<Vec<_>>());
+}

--- a/tests/run-make/doctests-runtool/t.rs
+++ b/tests/run-make/doctests-runtool/t.rs
@@ -1,0 +1,11 @@
+/// Fungle the foople.
+/// ```
+/// t::foople();
+/// ```
+pub fn foople() {}
+
+/// Flomble the florp
+/// ```
+/// t::florp();
+/// ```
+pub fn florp() {}


### PR DESCRIPTION
Fixes #112191
Fixes #112210

This fixes some issues with `--test-run-directory` and its interaction with `--runtool` and `--persist-doctests`. Relative directories don't work with `Command::current_dir` very well because it has platform-specific behavior with relative paths. This fixes it by avoiding the use of relative paths.

This is needed because cargo is switching to use `--test-run-directory`, and it uses relative paths when interacting with rustdoc/rustc.
