### PR TITLE
Sort the errors from arguments checking so that suggestions are handled properly

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/arg_matrix.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/arg_matrix.rs
@@ -34,14 +34,14 @@ enum Issue {
     Permutation(Vec<Option<usize>>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Compatibility<'tcx> {
     Compatible,
     Incompatible(Option<TypeError<'tcx>>),
 }
 
 /// Similar to `Issue`, but contains some extra information
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Error<'tcx> {
     /// The provided argument is the invalid type for the expected input
     Invalid(ProvidedIdx, ExpectedIdx, Compatibility<'tcx>),
@@ -53,6 +53,34 @@ pub(crate) enum Error<'tcx> {
     Swap(ProvidedIdx, ProvidedIdx, ExpectedIdx, ExpectedIdx),
     /// Several arguments should be reordered
     Permutation(Vec<(ExpectedIdx, ProvidedIdx)>),
+}
+
+impl Ord for Error<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let key = |error: &Error<'_>| -> usize {
+            match error {
+                Error::Invalid(..) => 0,
+                Error::Extra(_) => 1,
+                Error::Missing(_) => 2,
+                Error::Swap(..) => 3,
+                Error::Permutation(..) => 4,
+            }
+        };
+        match (self, other) {
+            (Error::Invalid(a, _, _), Error::Invalid(b, _, _)) => a.cmp(b),
+            (Error::Extra(a), Error::Extra(b)) => a.cmp(b),
+            (Error::Missing(a), Error::Missing(b)) => a.cmp(b),
+            (Error::Swap(a, b, ..), Error::Swap(c, d, ..)) => a.cmp(c).then(b.cmp(d)),
+            (Error::Permutation(a), Error::Permutation(b)) => a.cmp(b),
+            _ => key(self).cmp(&key(other)),
+        }
+    }
+}
+
+impl PartialOrd for Error<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 pub(crate) struct ArgMatrix<'tcx> {
@@ -378,11 +406,7 @@ impl<'tcx> ArgMatrix<'tcx> {
 
         // sort errors with same type by the order they appear in the source
         // so that suggestion will be handled properly, see #112507
-        errors.sort_by(|a, b| match (a, b) {
-            (Error::Missing(i), Error::Missing(j)) => i.cmp(j),
-            (Error::Extra(i), Error::Extra(j)) => i.cmp(j),
-            _ => Ordering::Equal,
-        });
+        errors.sort();
         return (errors, matched_inputs);
     }
 }

--- a/tests/ui/argument-suggestions/issue-112507.rs
+++ b/tests/ui/argument-suggestions/issue-112507.rs
@@ -1,0 +1,12 @@
+pub enum Value {
+    Float(Option<f64>),
+}
+
+fn main() {
+    let _a = Value::Float( //~ ERROR this enum variant takes 1 argument but 4 arguments were supplied
+        0,
+        None,
+        None,
+        0,
+    );
+}

--- a/tests/ui/argument-suggestions/issue-112507.stderr
+++ b/tests/ui/argument-suggestions/issue-112507.stderr
@@ -1,0 +1,27 @@
+error[E0061]: this enum variant takes 1 argument but 4 arguments were supplied
+  --> $DIR/issue-112507.rs:6:14
+   |
+LL |     let _a = Value::Float(
+   |              ^^^^^^^^^^^^
+LL |         0,
+   |         - unexpected argument of type `{integer}`
+LL |         None,
+LL |         None,
+   |         ---- unexpected argument of type `Option<_>`
+LL |         0,
+   |         - unexpected argument of type `{integer}`
+   |
+note: tuple variant defined here
+  --> $DIR/issue-112507.rs:2:5
+   |
+LL |     Float(Option<f64>),
+   |     ^^^^^
+help: remove the extra arguments
+   |
+LL ~         ,
+LL ~         None);
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
Fixes #112507

The algorithm of `find_issue` does not make sure the index comes out in order, which will make suggesting `remove` or `add` arguments broken in some cases.

Modifying the algorithm to obey order involves much more trivial change, so it's better to order the `errors` after iterations.
