### PR TITLE
Bump compiler_builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.92"
+version = "0.1.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64518f1ae689f74db058bbfb3238dfe6eb53f59f4ae712f1ff4348628522e190"
+checksum = "76630810d973ecea3dbf611e1b7aecfb1012751ef1ff8de3998f89014a166781"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
 libc = { version = "0.2.146", default-features = false, features = ['rustc-dep-of-std'], public = true }
-compiler_builtins = { version = "0.1.92" }
+compiler_builtins = { version = "0.1.93" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = ['rustc-dep-of-std'] }


### PR DESCRIPTION
Actually closes https://github.com/rust-lang/rust/issues/108489.

Note that the example code given [in compiler_builtins](https://github.com/rust-lang/compiler-builtins/pull/527) doesn't compile on current rustc since we're still waiting for https://reviews.llvm.org/D153197 (aka `LLVM ERROR: Expected a constant shift amount!`), but it's a step forward anyway.