### PR TITLE
Accept `"{:}<"` in format macro parser

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -626,6 +626,13 @@ impl<'a> Parser<'a> {
 
         // fill character
         if let Some(&(_, c)) = self.cur.peek() {
+            // The following case should be compiled successfully.
+            // ```
+            // format!("foo {:}<", 2);
+            // ```
+            if c == '}' {
+                return spec;
+            }
             if let Some((_, '>' | '<' | '^')) = self.cur.clone().nth(1) {
                 spec.fill = Some(c);
                 self.cur.next();

--- a/tests/ui/fmt/format-args-issue-112732.rs
+++ b/tests/ui/fmt/format-args-issue-112732.rs
@@ -1,0 +1,5 @@
+// check-pass
+
+fn main() {
+    println!("Hello, world! {0:}<3", 2);
+}


### PR DESCRIPTION
I think this should also be compiled successfully.

Fixes #112732

https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=5a69e2326988b6150c62087ef60ecf2f