### PR TITLE
Add gha problem matcher

### DIFF
--- a/src/ci/github-actions/problem_matchers.json
+++ b/src/ci/github-actions/problem_matchers.json
@@ -10,6 +10,46 @@
                     "message": 3
                 }
             ]
+        },
+        {
+            "owner": "cargo-common",
+            "pattern": [
+                {
+                    "regexp": "^(warning|warn|error)(\\[(\\S*)\\])?: (.*)$",
+                    "severity": 1,
+                    "message": 4,
+                    "code": 3
+                },
+                {
+                    "regexp": "^\\s+-->\\s(\\S+):(\\d+):(\\d+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3
+                }
+            ]
+        },
+        {
+            "owner": "compiler-panic",
+            "pattern": [
+                {
+                    "regexp": "error: internal compiler error: (.*):(\\d+):(\\d+): (.*)$",
+                    "message": 4,
+                    "file": 1,
+                    "line": 2,
+                    "column": 3
+                }
+            ]
+        },
+        {
+            "owner": "cargo-fmt",
+            "pattern": [
+                {
+                    "regexp": "^(Diff in (\\S+)) at line (\\d+):",
+                    "message": 1,
+                    "file": 2,
+                    "line": 3
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
These regexes capture rustfmt errors, panics and regular Rust errors in CI and automatically add messages in the diff view. This should make it simpler to quickly see what went wrong without having to scroll through CI logs.

We can fine tune the regexes or add more matchers after having a look at how it actually works in practice

The relevant documentation can be found at https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md

r? @jyn514 