### PR TITLE
CI: merge msvc cargo and tools jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,15 +406,10 @@ jobs:
               RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-msvc"
               SCRIPT: make ci-msvc
             os: windows-2019-8core-32gb
-          - name: x86_64-msvc-cargo
+          - name: x86_64-msvc-ext
             env:
-              SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-lld"
-            os: windows-2019-8core-32gb
-          - name: x86_64-msvc-tools
-            env:
-              SCRIPT: src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstate/toolstates.json windows
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstate/toolstates.json"
+              SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo && src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstate/toolstates.json windows
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-lld --save-toolstates=/tmp/toolstate/toolstates.json"
               DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
             os: windows-2019-8core-32gb
           - name: i686-mingw

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -610,16 +610,10 @@ jobs:
               SCRIPT: make ci-msvc
             <<: *job-windows-8c
 
-          - name: x86_64-msvc-cargo
+          - name: x86_64-msvc-ext
             env:
-              SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo
-              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
-            <<: *job-windows-8c
-
-          - name: x86_64-msvc-tools
-            env:
-              SCRIPT: src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstate/toolstates.json windows
-              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstate/toolstates.json
+              SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo && src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstate/toolstates.json windows
+              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld --save-toolstates=/tmp/toolstate/toolstates.json
               DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
             <<: *job-windows-8c
 


### PR DESCRIPTION
The `x86_64-msvc-cargo` and `x86_64-msvc-tools` jobs both run for ~1 hour, but most of that time is actually spent in building LLVM and `rustc`, so I want to try merging them.
![image](https://github.com/rust-lang/rust/assets/4539057/8652fa2a-b8b7-41d0-8f16-555d31acd9a5)
