### PR TITLE
Format the examples directory of cg_clif

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -38,6 +38,5 @@ ignore = [
 
     # these are ignored by a standard cargo fmt run
     "compiler/rustc_codegen_cranelift/y.rs", # running rustfmt breaks this file
-    "compiler/rustc_codegen_cranelift/example",
     "compiler/rustc_codegen_cranelift/scripts",
 ]


### PR DESCRIPTION
Formatting has been enforced in cg_clif's CI for a while now.