### PR TITLE
Migrate `rustdoc` diagnostics to translatable diagnostics

### DIFF
--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -439,7 +439,7 @@ impl<'a> fmt::Display for Display<'a> {
                             write!(fmt, "`{}`", feat)?;
                         }
                     } else {
-                        write_with_opt_paren(fmt, !sub_cfg.is_all(), Display(sub_cfg, self.1))?;
+                        write_with_opt_paren(fmt, !sub_cfg.is_all(), Display(&sub_cfg, self.1))?;
                     }
                 }
                 Ok(())
@@ -476,7 +476,7 @@ impl<'a> fmt::Display for Display<'a> {
                             write!(fmt, "`{}`", feat)?;
                         }
                     } else {
-                        write_with_opt_paren(fmt, !sub_cfg.is_simple(), Display(sub_cfg, self.1))?;
+                        write_with_opt_paren(fmt, !sub_cfg.is_simple(), Display(&sub_cfg, self.1))?;
                     }
                 }
                 Ok(())

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -298,6 +298,8 @@ pub(crate) fn create_config(
     }
 }
 
+#[allow(rustc::untranslatable_diagnostic)]
+#[allow(rustc::diagnostic_outside_of_impl)]
 pub(crate) fn run_global_ctxt(
     tcx: TyCtxt<'_>,
     show_coverage: bool,

--- a/src/librustdoc/errors.rs
+++ b/src/librustdoc/errors.rs
@@ -1,34 +1,163 @@
-use crate::fluent_generated as fluent;
-use rustc_errors::IntoDiagnostic;
-use rustc_macros::Diagnostic;
-use rustc_span::ErrorGuaranteed;
+use std::{io, path::Path};
+
+use rustc_macros::{Diagnostic, Subdiagnostic};
 
 #[derive(Diagnostic)]
-#[diag(rustdoc_main_error)]
-pub(crate) struct MainError {
-    pub(crate) error: String,
-}
-
+#[diag(rustdoc_couldnt_generate_documentation)]
 pub(crate) struct CouldntGenerateDocumentation {
     pub(crate) error: String,
-    pub(crate) file: String,
+    #[subdiagnostic]
+    pub(crate) file: Option<FailedToCreateOrModifyFile>,
 }
 
-impl IntoDiagnostic<'_> for CouldntGenerateDocumentation {
-    fn into_diagnostic(
-        self,
-        handler: &'_ rustc_errors::Handler,
-    ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = handler.struct_err(fluent::rustdoc_couldnt_generate_documentation);
-        diag.set_arg("error", self.error);
-        if !self.file.is_empty() {
-            diag.note(fluent::_subdiag::note);
-        }
-
-        diag
-    }
+#[derive(Subdiagnostic)]
+#[note(rustdoc_failed_to_create_or_modify_file)]
+pub(crate) struct FailedToCreateOrModifyFile {
+    pub(crate) file: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(rustdoc_compilation_failed)]
 pub(crate) struct CompilationFailed;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_load_string_error_read_fail)]
+pub(crate) struct LoadStringErrorReadFail<'a> {
+    pub(crate) file_path: &'a Path,
+    pub(crate) err: io::Error,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_load_string_error_bad_utf8)]
+pub(crate) struct LoadStringErrorBadUtf8<'a> {
+    pub(crate) file_path: &'a Path,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_scrape_examples_must_use_output_path_and_target_crate_together)]
+pub(crate) struct ScrapeExamplesMustUseOutputPathAndTargetCrateTogether;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_scrape_examples_must_use_output_path_and_target_crate_with_scrape_tests)]
+pub(crate) struct ScrapeExamplesMustUseOutputPathAndTargetCrateWithScrapeTests;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_load_examples_failed)]
+pub(crate) struct LoadExamplesFailed {
+    pub(crate) err: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_arguments_to_theme_must_be_files)]
+#[help]
+pub(crate) struct ArgumentsToThemeMustBeFiles {
+    pub(crate) theme: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_arguments_to_theme_must_have_a_css_extension)]
+#[help]
+pub(crate) struct ArgumentsToThemeMustHaveACssExtension {
+    pub(crate) theme: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_error_loading_theme_file)]
+pub(crate) struct ErrorLoadingThemeFile {
+    pub(crate) theme: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_theme_file_missing_css_rules_from_default_theme)]
+#[warning]
+#[help]
+pub(crate) struct ThemeFileMissingCssRulesFromDefaultTheme {
+    pub(crate) theme: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_unrecognized_emission_type)]
+pub(crate) struct UnrecognizedEmissionType<'a> {
+    pub(crate) kind: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_missing_file_operand)]
+pub(crate) struct MissingFileOperand;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_too_many_file_operands)]
+pub(crate) struct TooManyFileOperands;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_test_flag_must_be_passed_to_enable_no_run)]
+pub(crate) struct TestFlagMustBePassedToEnableNoRun;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_extend_css_arg_must_be_a_file)]
+pub(crate) struct ExtendCssArgMustBeAFile;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_cannot_use_both_out_dir_and_output_at_once)]
+pub(crate) struct CannotUseBothOutDirAndOutputAtOnce;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_unknown_input_format)]
+pub(crate) struct UnknownInputFormat<'a> {
+    pub(crate) format: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_index_page_arg_must_be_a_file)]
+pub(crate) struct IndexPageArgMustBeAFile;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_unknown_crate_type)]
+pub(crate) struct UnknownCrateType {
+    pub(crate) err: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_html_output_format_unsupported_for_show_coverage_option)]
+pub(crate) struct HtmlOutputFormatUnsupportedForShowCoverageOption;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_generate_link_to_definition_option_can_only_be_used_with_html_output_format)]
+pub(crate) struct GenerateLinkToDefinitionOptionCanOnlyBeUsedWithHtmlOutputFormat;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_flag_is_deprecated)]
+#[note]
+pub(crate) struct FlagIsDeprecated<'a> {
+    pub(crate) flag: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_flag_no_longer_functions)]
+#[note]
+pub(crate) struct FlagNoLongerFunctions<'a> {
+    flag: &'a str,
+    #[subdiagnostic]
+    help: Option<MayWantToUseDocumentPrivateItems>,
+    #[subdiagnostic]
+    warning: Option<SeeCve20181000622>,
+}
+
+#[derive(Subdiagnostic)]
+#[help(rustdoc_may_want_to_use_document_private_items)]
+pub(crate) struct MayWantToUseDocumentPrivateItems;
+
+#[derive(Subdiagnostic)]
+#[warning(rustdoc_see_cve_2018_1000622)]
+pub(crate) struct SeeCve20181000622;
+
+impl<'a> FlagNoLongerFunctions<'a> {
+    pub(crate) fn new(flag: &'a str) -> Self {
+        let (help, warning) = match flag {
+            "no-defaults" | "passes" => (Some(MayWantToUseDocumentPrivateItems), None),
+            "plugins" | "plugin-path" => (None, Some(SeeCve20181000622)),
+            _ => (None, None),
+        };
+        Self { flag, help, warning }
+    }
+}

--- a/src/librustdoc/errors.rs
+++ b/src/librustdoc/errors.rs
@@ -1,0 +1,34 @@
+use crate::fluent_generated as fluent;
+use rustc_errors::IntoDiagnostic;
+use rustc_macros::Diagnostic;
+use rustc_span::ErrorGuaranteed;
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_main_error)]
+pub(crate) struct MainError {
+    pub(crate) error: String,
+}
+
+pub(crate) struct CouldntGenerateDocumentation {
+    pub(crate) error: String,
+    pub(crate) file: String,
+}
+
+impl IntoDiagnostic<'_> for CouldntGenerateDocumentation {
+    fn into_diagnostic(
+        self,
+        handler: &'_ rustc_errors::Handler,
+    ) -> rustc_errors::DiagnosticBuilder<'_, ErrorGuaranteed> {
+        let mut diag = handler.struct_err(fluent::rustdoc_couldnt_generate_documentation);
+        diag.set_arg("error", self.error);
+        if !self.file.is_empty() {
+            diag.note(fluent::_subdiag::note);
+        }
+
+        diag
+    }
+}
+
+#[derive(Diagnostic)]
+#[diag(rustdoc_compilation_failed)]
+pub(crate) struct CompilationFailed;

--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -1,3 +1,4 @@
+use crate::errors::{LoadStringErrorBadUtf8, LoadStringErrorReadFail};
 use crate::html::markdown::{ErrorCodes, HeadingOffset, IdMap, Markdown, Playground};
 use crate::rustc_span::edition::Edition;
 use std::fs;
@@ -83,14 +84,14 @@ pub(crate) fn load_string<P: AsRef<Path>>(
     let contents = match fs::read(file_path) {
         Ok(bytes) => bytes,
         Err(e) => {
-            diag.struct_err(format!("error reading `{}`: {}", file_path.display(), e)).emit();
+            diag.emit_err(LoadStringErrorReadFail { file_path, err: e });
             return Err(LoadStringError::ReadFail);
         }
     };
     match str::from_utf8(&contents) {
         Ok(s) => Ok(s.to_string()),
         Err(_) => {
-            diag.struct_err(format!("error reading `{}`: not UTF-8", file_path.display())).emit();
+            diag.emit_err(LoadStringErrorBadUtf8 { file_path });
             Err(LoadStringError::BadUtf8)
         }
     }

--- a/src/librustdoc/messages.ftl
+++ b/src/librustdoc/messages.ftl
@@ -1,7 +1,64 @@
-rustdoc_main_error = {$error}
-
 rustdoc_couldnt_generate_documentation =
     couldn't generate documentation: {$error}
-    .note = failed to create or modify "{$file}"
+
+rustdoc_failed_to_create_or_modify_file = failed to create or modify "{$file}"
 
 rustdoc_compilation_failed = compilation failed, aborting rustdoc
+
+rustdoc_load_string_error_read_fail = error reading `{$file_path}`: {$err}
+
+rustdoc_load_string_error_bad_utf8 = error reading `{$file_path}`: not UTF-8
+
+rustdoc_arguments_to_theme_must_be_files = invalid argument: "{$theme}"
+    .help = arguments to --theme must be files
+
+rustdoc_arguments_to_theme_must_have_a_css_extension = invalid argument: "{$theme}"
+    .help = arguments to --theme must have a .css extension
+
+rustdoc_error_loading_theme_file = error loading theme file: "{$theme}"
+
+rustdoc_theme_file_missing_css_rules_from_default_theme = theme file "{$theme}" is missing CSS rules from the default theme
+    .warn = the theme may appear incorrect when loaded
+    .help = to see what rules are missing, call `rustdoc --check-theme "{$theme}"`
+
+rustdoc_scrape_examples_must_use_output_path_and_target_crate_together = must use --scrape-examples-output-path and --scrape-examples-target-crate together
+
+rustdoc_scrape_examples_must_use_output_path_and_target_crate_with_scrape_tests = must use --scrape-examples-output-path and --scrape-examples-target-crate with --scrape-tests
+
+rustdoc_load_examples_failed = failed to load examples: {$err}
+
+rustdoc_unrecognized_emission_type = unrecognized emission type: {$kind}
+
+rustdoc_missing_file_operand = missing file operand
+
+rustdoc_too_many_file_operands = too many file operands
+
+rustdoc_test_flag_must_be_passed_to_enable_no_run = the `--test` flag must be passed to enable `--no-run`
+
+rustdoc_cannot_use_both_out_dir_and_output_at_once = cannot use both 'out-dir' and 'output' at once
+
+rustdoc_extend_css_arg_must_be_a_file = option --extend-css argument must be a file
+
+rustdoc_unknown_input_format = unknown input format: {$format}
+
+rustdoc_index_page_arg_must_be_a_file = option `--index-page` argument must be a file
+
+rustdoc_unknown_crate_type = unknown crate type: {$err}
+
+rustdoc_html_output_format_unsupported_for_show_coverage_option = html output format isn't supported for the --show-coverage option
+
+rustdoc_generate_link_to_definition_option_can_only_be_used_with_html_output_format = --generate-link-to-definition option can only be used with HTML output format
+
+rustdoc_flag_is_deprecated = the `{$flag}` flag is deprecated
+    .note =
+        see issue #44136 <https://github.com/rust-lang/rust/issues/44136>
+        for more information,
+
+rustdoc_flag_no_longer_functions = the `{$flag}` flag no longer functions
+    .note =
+        see issue #44136 <https://github.com/rust-lang/rust/issues/44136>
+        for more information,
+
+rustdoc_may_want_to_use_document_private_items = you may want to use --document-private-items
+
+rustdoc_see_cve_2018_1000622 = see CVE-2018-1000622

--- a/src/librustdoc/messages.ftl
+++ b/src/librustdoc/messages.ftl
@@ -1,0 +1,7 @@
+rustdoc_main_error = {$error}
+
+rustdoc_couldnt_generate_documentation =
+    couldn't generate documentation: {$error}
+    .note = failed to create or modify "{$file}"
+
+rustdoc_compilation_failed = Compilation failed, aborting rustdoc

--- a/src/librustdoc/messages.ftl
+++ b/src/librustdoc/messages.ftl
@@ -4,4 +4,4 @@ rustdoc_couldnt_generate_documentation =
     couldn't generate documentation: {$error}
     .note = failed to create or modify "{$file}"
 
-rustdoc_compilation_failed = Compilation failed, aborting rustdoc
+rustdoc_compilation_failed = compilation failed, aborting rustdoc

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -2,6 +2,9 @@
 
 use crate::clean;
 use crate::config;
+use crate::errors::LoadExamplesFailed;
+use crate::errors::ScrapeExamplesMustUseOutputPathAndTargetCrateTogether;
+use crate::errors::ScrapeExamplesMustUseOutputPathAndTargetCrateWithScrapeTests;
 use crate::formats;
 use crate::formats::renderer::FormatRenderer;
 use crate::html::render::Context;
@@ -52,11 +55,11 @@ impl ScrapeExamplesOptions {
                 scrape_tests,
             })),
             (Some(_), false, _) | (None, true, _) => {
-                diag.err("must use --scrape-examples-output-path and --scrape-examples-target-crate together");
+                diag.emit_err(ScrapeExamplesMustUseOutputPathAndTargetCrateTogether);
                 Err(1)
             }
             (None, false, true) => {
-                diag.err("must use --scrape-examples-output-path and --scrape-examples-target-crate with --scrape-tests");
+                diag.emit_err(ScrapeExamplesMustUseOutputPathAndTargetCrateWithScrapeTests);
                 Err(1)
             }
             (None, false, false) => Ok(None),
@@ -272,6 +275,8 @@ where
     }
 }
 
+#[allow(rustc::untranslatable_diagnostic)]
+#[allow(rustc::diagnostic_outside_of_impl)]
 pub(crate) fn run(
     krate: clean::Crate,
     mut renderopts: config::RenderOptions,
@@ -358,7 +363,7 @@ pub(crate) fn load_call_locations(
     };
 
     inner().map_err(|e: String| {
-        diag.err(format!("failed to load examples: {}", e));
+        diag.emit_err(LoadExamplesFailed { err: e });
         1
     })
 }

--- a/src/librustdoc/theme.rs
+++ b/src/librustdoc/theme.rs
@@ -230,6 +230,8 @@ pub(crate) fn get_differences(
     }
 }
 
+#[allow(rustc::untranslatable_diagnostic)]
+#[allow(rustc::diagnostic_outside_of_impl)]
 pub(crate) fn test_theme_against<P: AsRef<Path>>(
     f: &P,
     origin: &FxHashMap<String, CssPath>,

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -183,8 +183,10 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     .unwrap_or(&[])
                     .iter()
                     .filter_map(|attr| {
+                        #[allow(rustc::untranslatable_diagnostic)]
+                        #[allow(rustc::diagnostic_outside_of_impl)]
                         Cfg::parse(attr.meta_item()?)
-                            .map_err(|e| self.cx.sess().diagnostic().span_err(e.span, e.msg))
+                            .map_err(|e| self.cx.sess().span_err(e.span, e.msg))
                             .ok()
                     })
                     .collect::<Vec<_>>()

--- a/tests/ui/issues/issue-21763.stderr
+++ b/tests/ui/issues/issue-21763.stderr
@@ -9,9 +9,6 @@ LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    = note: required for `hashbrown::raw::RawTable<(Rc<()>, Rc<()>)>` to implement `Send`
 note: required because it appears within the type `HashMap<Rc<()>, Rc<()>, RandomState>`
   --> $HASHBROWN_SRC_LOCATION
-   |
-LL | pub struct HashMap<K, V, S = DefaultHashBuilder, A: Allocator + Clone = Global> {
-   |            ^^^^^^^
 note: required because it appears within the type `HashMap<Rc<()>, Rc<()>>`
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
 note: required by a bound in `foo`

--- a/tests/ui/mismatched_types/issue-36053-2.stderr
+++ b/tests/ui/mismatched_types/issue-36053-2.stderr
@@ -27,6 +27,7 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
    |
    = note: doesn't satisfy `_: Iterator`
    |
+   = note: the full type name has been written to '$TEST_BUILD_DIR/mismatched_types/issue-36053-2/issue-36053-2.long-type-15876109348482306250.txt'
    = note: the following trait bounds were not satisfied:
            `<[closure@$DIR/issue-36053-2.rs:7:39: 7:48] as FnOnce<(&&str,)>>::Output = bool`
            which is required by `Filter<Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:48]>: Iterator`

--- a/tests/ui/recursion/issue-83150.stderr
+++ b/tests/ui/recursion/issue-83150.stderr
@@ -12,7 +12,8 @@ LL |     func(&mut iter.map(|x| x + 1))
 error[E0275]: overflow evaluating the requirement `Map<&mut std::ops::Range<u8>, [closure@$DIR/issue-83150.rs:13:24: 13:27]>: Iterator`
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_83150`)
-   = note: required for `&mut Map<&mut std::ops::Range<u8>, [closure@$DIR/issue-83150.rs:13:24: 13:27]>` to implement `Iterator`
+   = note: required for `&mut Map<&mut Range<u8>, [closure@issue-83150.rs:13:24]>` to implement `Iterator`
+   = note: the full type name has been written to '$TEST_BUILD_DIR/recursion/issue-83150/issue-83150.long-type-hash.txt'
    = note: 65 redundant requirements hidden
    = note: required for `&mut Map<&mut Map<&mut Map<&mut Map<&mut Map<&mut Map<&mut Map<..., ...>, ...>, ...>, ...>, ...>, ...>, ...>` to implement `Iterator`
    = note: the full type name has been written to '$TEST_BUILD_DIR/recursion/issue-83150/issue-83150.long-type-hash.txt'

--- a/tests/ui/typeck/issue-31173.stderr
+++ b/tests/ui/typeck/issue-31173.stderr
@@ -42,6 +42,7 @@ LL | |         .collect();
    |
    = note: doesn't satisfy `_: Iterator`
    |
+   = note: the full type name has been written to '$TEST_BUILD_DIR/typeck/issue-31173/issue-31173.long-type-16947039427408058100.txt'
    = note: the following trait bounds were not satisfied:
            `<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:7:21: 7:25]> as Iterator>::Item = &_`
            which is required by `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:7:21: 7:25]>>: Iterator`


### PR DESCRIPTION
Diagnostic translation tracking issue: https://github.com/rust-lang/rust/issues/100717