### PR TITLE
bootstrap: Add and use -Z absolute-file-paths

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -657,6 +657,7 @@ fn test_unstable_options_tracking_hash() {
 
     // Make sure that changing an [UNTRACKED] option leaves the hash unchanged.
     // tidy-alphabetical-start
+    untracked!(absolute_file_paths, true);
     untracked!(assert_incr_state, Some(String::from("loaded")));
     untracked!(deduplicate_diagnostics, false);
     untracked!(dep_tasks, true);

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1352,6 +1352,8 @@ options! {
     // - src/doc/unstable-book/src/compiler-flags
 
     // tidy-alphabetical-start
+    absolute_file_paths: bool = (false, parse_bool, [UNTRACKED],
+        "use absolute file paths in diagnostics, not relative paths (default: no)"),
     allow_features: Option<Vec<String>> = (None, parse_opt_comma_list, [TRACKED],
         "only allow the listed language features to be enabled in code (comma separated)"),
     always_encode_mir: bool = (false, parse_bool, [TRACKED],

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1392,6 +1392,11 @@ impl<'a> Builder<'a> {
         // cargo would implicitly add it, it was discover that sometimes bootstrap only use
         // `rustflags` without `cargo` making it required.
         rustflags.arg("-Zunstable-options");
+        // Make ctrl+click, etc. work with workspaces other than the root workspace.
+        // cfg(bootstrap)
+        if stage > 0 {
+            rustflags.arg("-Zabsolute-file-paths");
+        }
         for (restricted_mode, name, values) in EXTRA_CHECK_CFGS {
             if *restricted_mode == None || *restricted_mode == Some(mode) {
                 // Creating a string of the values by concatenating each value:

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -36,7 +36,7 @@ use once_cell::sync::OnceCell;
 use crate::builder::Kind;
 use crate::config::{LlvmLibunwind, TargetSelection};
 use crate::util::{
-    exe, libdir, mtime, output, run, run_suppressed, symlink_dir, try_run_suppressed,
+    absolute, exe, libdir, mtime, output, run, run_suppressed, symlink_dir, try_run_suppressed,
 };
 
 mod bolt;
@@ -426,8 +426,9 @@ impl Build {
         }
 
         let mut build = Build {
-            initial_rustc: config.initial_rustc.clone(),
-            initial_cargo: config.initial_cargo.clone(),
+            // Use absolute paths for these to allow setting them to e.g. build/host/stage1
+            initial_rustc: absolute(&config.initial_rustc),
+            initial_cargo: absolute(&config.initial_cargo),
             initial_lld,
             initial_libdir,
             initial_sysroot: initial_sysroot.into(),

--- a/src/doc/unstable-book/src/compiler-flags/absolute-file-paths.md
+++ b/src/doc/unstable-book/src/compiler-flags/absolute-file-paths.md
@@ -1,0 +1,9 @@
+# `absolute-file-paths`
+
+This features is currently perma-unstable, with no tracking issue.
+
+------------------------
+
+This feature allows you to configure rustc to print diagnostics and other output using absolute file paths, not relative file paths.
+
+Set `-Zabsolute-file-paths` to enable this feature.


### PR DESCRIPTION
It's unfortunate that this hack is necessary. A short summary of the background here:
- Rust-Analyzer uses `x check --json-output` to show red underlines in the editor.
- There are several different Cargo workspaces in rust-lang/rust, including src/bootstrap and src/tools/miri.
- Cargo runs each invocation of rustc relative to the *workspace*, not to the current working directory of cargo itself.
- Rustc prints file paths relative to its current working directory. As a result, it would print things like `config.rs:43:14` instead of `src/bootstrap/config.rs`.

This adds a new flag to rustc to print the files as an absolute path instead of a relative path. I went with this approach instead of one of the wrapping tools for the following reasons:
1. Cargo considers changing the working directory to be a breaking change:
   https://github.com/rust-lang/cargo/issues/11007#issuecomment-1290294388. They have open feature
   requests for adding a flag to print absolute paths, but none have been implemented.
2. Bootstrap would potentially be able to parse and rewrite the paths that cargo emits, but I don't
   want to hard-code Cargo's JSON output format in both bootstrap.py and rustbuild; unlike rustbuild,
   bootstrap.py can't use `cargo_metadata` as a library.
3. Rust-Analyzer could potentially rewrite this output, but that wouldn't fix ctrl+click on the relative path when someone runs `cargo check`.

In addition to adding and using the new flag, this also adds `local_rebuild` detection to bootstrap.py, so that I could test the change.

Before:
```
error[E0425]: cannot find value `MIRI_DEFAULT_ARGS` in crate `miri`
   --> src/bin/miri.rs:269:33
    |
269 |         args.splice(1..1, miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
    |                                 ^^^^^^^^^^^^^^^^^ help: a constant with a similar name exists: `MIRI_DEFLT_ARGS`
    |
   ::: src/lib.rs:128:1
    |
128 | pub const MIRI_DEFLT_ARGS: &[&str] = &[
    | ---------------------------------- similarly named constant `MIRI_DEFLT_ARGS` defined here
```

After:
```
error[E0425]: cannot find value `MIRI_DEFAULT_ARGS` in crate `miri`
   --> /home/jyn/src/rust/src/tools/miri/src/bin/miri.rs:269:33
    |
269 |         args.splice(1..1, miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
    |                                 ^^^^^^^^^^^^^^^^^ help: a constant with a similar name exists: `MIRI_DEFLT_ARGS`
    |
   ::: /home/jyn/src/rust/src/tools/miri/src/lib.rs:128:1
    |
128 | pub const MIRI_DEFLT_ARGS: &[&str] = &[
    | ---------------------------------- similarly named constant `MIRI_DEFLT_ARGS` defined here
```

Fixes https://github.com/rust-lang/rust/issues/80541 and https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/missing.20errors.20for.20bootstrap.20itself.

---

I am not convinced this is the right approach; i could be convinced to make the change in cargo instead, but it was easier to do this than to wait the 6 weeks.