### PR TITLE
Add --llvm-targets option to bootstrap configure script

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -148,6 +148,7 @@ v("qemu-aarch64-rootfs", "target.aarch64-unknown-linux-gnu.qemu-rootfs",
   "rootfs in qemu testing, you probably don't want to use this")
 v("qemu-riscv64-rootfs", "target.riscv64gc-unknown-linux-gnu.qemu-rootfs",
   "rootfs in qemu testing, you probably don't want to use this")
+v("llvm-targets", "llvm.targets", "LLVM targets to build")
 v("experimental-targets", "llvm.experimental-targets",
   "experimental LLVM targets to build")
 v("release-channel", "rust.channel", "the name of the release channel to build")


### PR DESCRIPTION
There's already an option for enabling experimental LLVM targets.  It would be useful to also be able to override the default target list to disable ones that you don't need.