### PR TITLE
Experimental : Time docker commands for CI build

### DIFF
--- a/src/ci/scripts/run-build-from-ci.sh
+++ b/src/ci/scripts/run-build-from-ci.sh
@@ -19,5 +19,6 @@ rustup self uninstall -y || true
 if [ -z "${IMAGE+x}" ]; then
     src/ci/run.sh
 else
-    src/ci/docker/run.sh "${IMAGE}"
+    TIME_TAKEN=$( { time src/ci/docker/run.sh "${IMAGE}"; } 2>&1 )
+    echo "Time taken for image ${IMAGE}: $TIME_TAKEN"
 fi


### PR DESCRIPTION
This PR is experimental and is aimed to time the docker image builds, in an effort to notice blockages or analyze results and publish them to `metrics.json`. 