### PR TITLE
More codegen cleanups

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -424,7 +424,7 @@ fn run_compiler(
                 return early_exit();
             }
 
-            queries.ongoing_codegen()?;
+            let ongoing_codegen = queries.ongoing_codegen()?;
 
             if sess.opts.unstable_opts.print_type_sizes {
                 sess.code_stats.print_type_sizes();
@@ -437,7 +437,7 @@ fn run_compiler(
                 sess.code_stats.print_vtable_sizes(crate_name);
             }
 
-            let linker = queries.linker()?;
+            let linker = queries.linker(ongoing_codegen)?;
             Ok(Some(linker))
         })?;
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -740,8 +740,8 @@ pub fn create_global_ctxt<'tcx>(
     })
 }
 
-/// Runs the resolution, type-checking, region checking and other
-/// miscellaneous analysis passes on the crate.
+/// Runs the type-checking, region checking and other miscellaneous analysis
+/// passes on the crate.
 fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
     rustc_passes::hir_id_validator::check_crate(tcx);
 

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -93,7 +93,6 @@ pub struct Queries<'tcx> {
     dep_graph: Query<DepGraph>,
     // This just points to what's in `gcx_cell`.
     gcx: Query<&'tcx GlobalCtxt<'tcx>>,
-    ongoing_codegen: Query<Box<dyn Any>>,
 }
 
 impl<'tcx> Queries<'tcx> {
@@ -110,7 +109,6 @@ impl<'tcx> Queries<'tcx> {
             register_plugins: Default::default(),
             dep_graph: Default::default(),
             gcx: Default::default(),
-            ongoing_codegen: Default::default(),
         }
     }
 
@@ -249,23 +247,19 @@ impl<'tcx> Queries<'tcx> {
         })
     }
 
-    pub fn ongoing_codegen(&'tcx self) -> Result<QueryResult<'_, Box<dyn Any>>> {
-        self.ongoing_codegen.compute(|| {
-            self.global_ctxt()?.enter(|tcx| {
-                tcx.analysis(()).ok();
+    pub fn ongoing_codegen(&'tcx self) -> Result<Box<dyn Any>> {
+        self.global_ctxt()?.enter(|tcx| {
+            // Don't do code generation if there were any errors
+            self.session().compile_status()?;
 
-                // Don't do code generation if there were any errors
-                self.session().compile_status()?;
+            // If we have any delayed bugs, for example because we created TyKind::Error earlier,
+            // it's likely that codegen will only cause more ICEs, obscuring the original problem
+            self.session().diagnostic().flush_delayed();
 
-                // If we have any delayed bugs, for example because we created TyKind::Error earlier,
-                // it's likely that codegen will only cause more ICEs, obscuring the original problem
-                self.session().diagnostic().flush_delayed();
+            // Hook for UI tests.
+            Self::check_for_rustc_errors_attr(tcx);
 
-                // Hook for UI tests.
-                Self::check_for_rustc_errors_attr(tcx);
-
-                Ok(passes::start_codegen(&***self.codegen_backend(), tcx))
-            })
+            Ok(passes::start_codegen(&***self.codegen_backend(), tcx))
         })
     }
 
@@ -303,7 +297,7 @@ impl<'tcx> Queries<'tcx> {
         }
     }
 
-    pub fn linker(&'tcx self) -> Result<Linker> {
+    pub fn linker(&'tcx self, ongoing_codegen: Box<dyn Any>) -> Result<Linker> {
         let sess = self.session().clone();
         let codegen_backend = self.codegen_backend().clone();
 
@@ -314,7 +308,6 @@ impl<'tcx> Queries<'tcx> {
                 tcx.dep_graph.clone(),
             )
         });
-        let ongoing_codegen = self.ongoing_codegen()?.steal();
 
         Ok(Linker {
             sess,


### PR DESCRIPTION
Some additional cleanups I found while looking closely at this code, following up from #112827.

r= @oli-obk 