### PR TITLE
add wrapping_offset_from which allows wrapping but still requires ptrs to be for the same allocation

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -355,7 +355,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
                 tcx.mk_unit(),
             ),
 
-            sym::ptr_offset_from => {
+            sym::ptr_offset_from | sym::ptr_wrapping_offset_from => {
                 (1, vec![tcx.mk_imm_ptr(param(0)), tcx.mk_imm_ptr(param(0))], tcx.types.isize)
             }
             sym::ptr_offset_from_unsigned => {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1156,6 +1156,7 @@ symbols! {
         ptr_offset_from,
         ptr_offset_from_unsigned,
         ptr_unique,
+        ptr_wrapping_offset_from,
         pub_macro_rules,
         pub_restricted,
         public,

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2337,6 +2337,12 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn ptr_offset_from_unsigned<T>(ptr: *const T, base: *const T) -> usize;
 
+    /// See documentation of `<*const T>::wrapping_offset_from` for details.
+    #[rustc_const_unstable(feature = "ptr_wrapping_offset_from", issue = "none")]
+    #[rustc_nounwind]
+    #[cfg(not(bootstrap))]
+    pub fn ptr_wrapping_offset_from<T>(ptr: *const T, base: *const T) -> isize;
+
     /// See documentation of `<*const T>::guaranteed_eq` for details.
     /// Returns `2` if the result is unknown.
     /// Returns `1` if the pointers are guaranteed equal

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -99,6 +99,7 @@
 //
 // Library features:
 // tidy-alphabetical-start
+#![cfg_attr(not(bootstrap), feature(ptr_wrapping_offset_from))]
 #![feature(char_indices_offset)]
 #![feature(const_align_of_val)]
 #![feature(const_align_of_val_raw)]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -605,7 +605,9 @@ impl<T: ?Sized> *const T {
     /// Calculates the distance between two pointers. The returned value is in
     /// units of T: the distance in bytes divided by `mem::size_of::<T>()`.
     ///
-    /// This function is the inverse of [`offset`].
+    /// This function is the inverse of [`offset`]: it is valid to call if and only if
+    /// `self` could have been computed as `origin.offset(n)` for some `n`, and it will
+    /// then return that `n`.
     ///
     /// [`offset`]: #method.offset
     ///
@@ -643,6 +645,12 @@ impl<T: ?Sized> *const T {
     /// mapped files *may* be too large to handle with this function.
     /// (Note that [`offset`] and [`add`] also have a similar limitation and hence cannot be used on
     /// such large allocations either.)
+    ///
+    /// The requirement for pointers to be derived from the same allocated object is primarily
+    /// needed for `const`-compatibility: at compile-time, pointers into *different* allocated
+    /// object do not have a known distance to each other. However, the requirement also exists at
+    /// runtime, and may be exploited by optimizations. You can use `(self as usize).sub(origin as
+    /// usize) / mem::size_of::<T>()` to avoid this requirement.
     ///
     /// [`add`]: #method.add
     /// [allocated object]: crate::ptr#allocated-object
@@ -701,7 +709,7 @@ impl<T: ?Sized> *const T {
     /// units of **bytes**.
     ///
     /// This is purely a convenience for casting to a `u8` pointer and
-    /// using [offset_from][pointer::offset_from] on it. See that method for
+    /// using [`offset_from`][pointer::offset_from] on it. See that method for
     /// documentation and safety requirements.
     ///
     /// For non-`Sized` pointees this operation considers only the data pointers,
@@ -797,6 +805,108 @@ impl<T: ?Sized> *const T {
         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
         // SAFETY: the caller must uphold the safety contract for `ptr_offset_from_unsigned`.
         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
+    }
+
+    /// Calculates the distance between two pointers using wrapping arithmetic. The returned value
+    /// is in units of T: the distance in bytes divided by `mem::size_of::<T>()`.
+    ///
+    /// This function is the inverse of [`wrapping_offset`]: it is valid to call if and only if
+    /// `self` could have been computed as `origin.wrapping_offset(n)` for some `n`, and it will
+    /// then return that `n`.
+    ///
+    /// [`wrapping_offset`]: #method.wrapping_offset
+    ///
+    /// # Safety
+    ///
+    /// If any of the following conditions are violated, the result is Undefined
+    /// Behavior:
+    ///
+    /// * Both pointers must be *derived from* a pointer to the same [allocated object].
+    ///   (See below for an example.)
+    ///
+    /// * The distance between the pointers, in bytes, must be an exact multiple
+    ///   of the size of `T`.
+    ///
+    /// Unlike [`offset_from`][pointer::offset_from], this method does *not* require the pointers to
+    /// be in-bounds of the object they are derived from, nor does it impose any restrictions
+    /// regarding the maximum distance or wrapping around the address space.
+    ///
+    /// The requirement for pointers to be derived from the same allocated object is primarily
+    /// needed for `const`-compatibility: at compile-time, pointers into *different* allocated
+    /// object do not have a known distance to each other. However, the requirement also exists at
+    /// runtime, and may be exploited by optimizations. You can use `(self as usize).sub(origin as
+    /// usize) / mem::size_of::<T>()` to avoid this requirement.
+    ///
+    /// [allocated object]: crate::ptr#allocated-object
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `T` is a Zero-Sized Type ("ZST").
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(ptr_wrapping_offset_from)]
+    /// let a = [0; 2];
+    /// let ptr1: *const i32 = &a[1];
+    /// let ptr2: *const i32 = a.as_ptr().wrapping_offset(3); // out-of-bounds!
+    /// unsafe {
+    ///     assert_eq!(ptr2.wrapping_offset_from(ptr1), 2);
+    ///     assert_eq!(ptr1.wrapping_offset_from(ptr2), -2);
+    ///     assert_eq!(ptr1.wrapping_offset(2), ptr2);
+    ///     assert_eq!(ptr2.wrapping_offset(-2), ptr1);
+    /// }
+    /// ```
+    ///
+    /// *Incorrect* usage:
+    ///
+    /// ```rust,no_run
+    /// #![feature(ptr_wrapping_offset_from)]
+    /// let ptr1 = Box::into_raw(Box::new(0u8)) as *const u8;
+    /// let ptr2 = Box::into_raw(Box::new(1u8)) as *const u8;
+    /// let diff = (ptr2 as isize).wrapping_sub(ptr1 as isize);
+    /// // Make ptr2_other an "alias" of ptr2, but derived from ptr1.
+    /// let ptr2_other = (ptr1 as *const u8).wrapping_offset(diff);
+    /// assert_eq!(ptr2 as usize, ptr2_other as usize);
+    /// // Since ptr2_other and ptr2 are derived from pointers to different objects,
+    /// // computing their offset is undefined behavior, even though
+    /// // they point to the same address!
+    /// unsafe {
+    ///     let zero = ptr2_other.wrapping_offset_from(ptr2); // Undefined Behavior
+    /// }
+    /// ```
+    #[unstable(feature = "ptr_wrapping_offset_from", issue = "none")]
+    #[rustc_const_unstable(feature = "ptr_wrapping_offset_from", issue = "none")]
+    #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(bootstrap))]
+    pub const unsafe fn wrapping_offset_from(self, origin: *const T) -> isize
+    where
+        T: Sized,
+    {
+        // SAFETY: the caller must uphold the safety contract for `ptr_offset_from`.
+        unsafe { intrinsics::ptr_wrapping_offset_from(self, origin) }
+    }
+
+    /// Calculates the distance between two pointers using wrapping arithmetic. The returned value
+    /// is in units of **bytes**.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and using
+    /// [`wrapping_offset_from`][pointer::wrapping_offset_from] on it. See that method for
+    /// documentation and safety requirements.
+    ///
+    /// For non-`Sized` pointees this operation considers only the data pointers,
+    /// ignoring the metadata.
+    #[inline(always)]
+    #[unstable(feature = "ptr_wrapping_offset_from", issue = "none")]
+    #[rustc_const_unstable(feature = "ptr_wrapping_offset_from", issue = "none")]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(bootstrap))]
+    pub const unsafe fn wrapping_byte_offset_from<U: ?Sized>(self, origin: *const U) -> isize {
+        // SAFETY: the caller must uphold the safety contract for `wrapping_offset_from`.
+        unsafe { self.cast::<u8>().wrapping_offset_from(origin.cast::<u8>()) }
     }
 
     /// Returns whether two pointers are guaranteed to be equal.

--- a/src/tools/miri/tests/pass/ptr_offset.rs
+++ b/src/tools/miri/tests/pass/ptr_offset.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -Zmiri-permissive-provenance
-#![feature(ptr_sub_ptr)]
+#![feature(ptr_sub_ptr, ptr_wrapping_offset_from)]
 use std::{mem, ptr};
 
 fn main() {
@@ -37,11 +37,16 @@ fn test_offset_from() {
         assert_eq!(x.offset_from(y), -12);
         assert_eq!((y as *const u32).offset_from(x as *const u32), 12 / 4);
         assert_eq!((x as *const u32).offset_from(y as *const u32), -12 / 4);
+        assert_eq!(y.wrapping_add(12).wrapping_offset_from(x), 24);
+        assert_eq!(x.wrapping_sub(12).wrapping_offset_from(y), -24);
 
-        let x = (((x as usize) * 2) / 2) as *const u8;
+        let x = (((x as usize) * 2) / 2) as *const u8; // lose track of provenance
         assert_eq!(y.offset_from(x), 12);
         assert_eq!(y.sub_ptr(x), 12);
         assert_eq!(x.offset_from(y), -12);
+        assert_eq!(y.wrapping_add(12).wrapping_offset_from(x), 24);
+        //FIXME: this doesn't work yet as exposed ptrs are not handled correctly
+        //assert_eq!(x.wrapping_sub(12).wrapping_offset_from(y), -24);
     }
 }
 

--- a/tests/codegen/intrinsics/offset_from.rs
+++ b/tests/codegen/intrinsics/offset_from.rs
@@ -34,3 +34,15 @@ pub unsafe fn offset_from_unsigned_odd_size(a: *const RGB, b: *const RGB) -> usi
     // CHECK-NEXT: ret i64
     ptr_offset_from_unsigned(a, b)
 }
+
+// CHECK-LABEL: @wrapping_offset_from_odd_size
+#[no_mangle]
+pub unsafe fn wrapping_offset_from_odd_size(a: *const RGB, b: *const RGB) -> isize {
+    // CHECK: start
+    // CHECK-NEXT: ptrtoint
+    // CHECK-NEXT: ptrtoint
+    // CHECK-NEXT: sub i64
+    // CHECK-NEXT: sdiv exact i64 %{{[0-9]+}}, 3
+    // CHECK-NEXT: ret i64
+    ptr_wrapping_offset_from(a, b)
+}

--- a/tests/ui/consts/offset_from_ub.stderr
+++ b/tests/ui/consts/offset_from_ub.stderr
@@ -109,6 +109,18 @@ note: inside `OFFSET_VERY_FAR2`
 LL |     unsafe { ptr1.offset_from(ptr2.wrapping_offset(1)) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 15 previous errors
+error[E0080]: evaluation of constant value failed
+  --> $DIR/offset_from_ub.rs:131:14
+   |
+LL |     unsafe { ptr_wrapping_offset_from(field_ptr, base_ptr) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_wrapping_offset_from` called on pointers into different allocations
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/offset_from_ub.rs:139:14
+   |
+LL |     unsafe { ptr_wrapping_offset_from(field_ptr, base_ptr as *const u16) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ exact_div: 1_isize cannot be divided by 2_isize without remainder
+
+error: aborting due to 17 previous errors
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/92512: currently, we have `wrapping_offset` as a `const fn`, but there is no way inside `const` to perform a subtraction that would tell how much a pointer has been wrapping-offset. This is an unfortunate lack of symmetry, and an issue for some approaches to implementing slice iterators -- those tend to handle zero-sized types by doing `wrapping_offset` and then they need a `wrapping_offset_from` to compute the remaining length of the iterator.

So I propose we add a new `wrapping_offset_from` that is able to always invert `wrapping_offset`: `wrapping_offset_from` is valid if and only if `origin` could have been produced from `self` via `wrapping_offset`. Correspondingly, the requirement for both pointers to be derived from the same allocated object remains (it is also required to make the function `const`), as does the requirement of being an exact multiple (hoping that it aids LLVM in its codegen). `byte_wrapping_offset_from` can be used in case the exact-multiple requirement might be violated.