### PR TITLE
doc: loongarch: Update maintainers

### DIFF
--- a/src/doc/rustc/src/platform-support/loongarch-linux.md
+++ b/src/doc/rustc/src/platform-support/loongarch-linux.md
@@ -28,9 +28,9 @@ While the integer base ABI is implied by the machine field, the floating po
 
 ## Target maintainers
 
-- [ZHAI Xiaojuan](https://github.com/zhaixiaojuan) `zhaixiaojuan@loongson.cn`
 - [WANG Rui](https://github.com/heiher) `wangrui@loongson.cn`
 - [ZHAI Xiang](https://github.com/xiangzhai) `zhaixiang@loongson.cn`
+- [ZHAI Xiaojuan](https://github.com/zhaixiaojuan) `zhaixiaojuan@loongson.cn`
 - [WANG Xuerui](https://github.com/xen0n) `git@xen0n.name`
 
 ## Requirements


### PR DESCRIPTION
My colleague, @zhaixiaojuan, has been completely occupied with other matters and is no longer in charge of Rust. Consequently, I intend to update the maintainers in the platform documentation to avoid causing any disruptions for her and to ensure that relevant notifications regarding LoongArch are promptly directed to the appropriate developers.

Thanks your for contributions!