### PR TITLE
Add retag in MIR transform: `Adt` for `Unique` may contain a reference

### DIFF
--- a/compiler/rustc_mir_transform/src/add_retag.rs
+++ b/compiler/rustc_mir_transform/src/add_retag.rs
@@ -28,6 +28,7 @@ fn may_contain_reference<'tcx>(ty: Ty<'tcx>, depth: u32, tcx: TyCtxt<'tcx>) -> b
         // References
         ty::Ref(..) => true,
         ty::Adt(..) if ty.is_box() => true,
+        ty::Adt(adt, _) if Some(adt.did()) == tcx.lang_items().ptr_unique() => true,
         // Compound types: recurse
         ty::Array(ty, _) | ty::Slice(ty) => {
             // This does not branch so we keep the depth the same.


### PR DESCRIPTION
Following #112662 , `may_contain_reference` in `rustc_mir_transform::add_retag` underapproximates too much the types that require retagging.

r? @RalfJung 