### PR TITLE
Add `lazy_type_alias` feature gate

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -440,6 +440,8 @@ declare_features! (
     (active, intra_doc_pointers, "1.51.0", Some(80896), None),
     // Allows setting the threshold for the `large_assignments` lint.
     (active, large_assignments, "1.52.0", Some(83518), None),
+    /// Allow to have type alias types for inter-crate use.
+    (active, lazy_type_alias, "CURRENT_RUSTC_VERSION", Some(112792), None),
     /// Allows `if/while p && let q = r && ...` chains.
     (active, let_chains, "1.37.0", Some(53667), None),
     /// Allows using `reason` in lint attributes and the `#[expect(lint)]` lint check.

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -896,7 +896,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let ty = self.tcx().at(span).type_of(did);
 
         if matches!(self.tcx().def_kind(did), DefKind::TyAlias)
-            && ty.skip_binder().has_opaque_types()
+            && (ty.skip_binder().has_opaque_types() || self.tcx().features().lazy_type_alias)
         {
             // Type aliases referring to types that contain opaque types (but aren't just directly
             // referencing a single opaque type) get encoded as a type alias that normalization will

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -870,6 +870,7 @@ symbols! {
         large_assignments,
         lateout,
         lazy_normalization_consts,
+        lazy_type_alias,
         le,
         len,
         let_chains,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2024,8 +2024,8 @@ pub(crate) fn clean_middle_ty<'tcx>(
             Tuple(t.iter().map(|t| clean_middle_ty(bound_ty.rebind(t), cx, None, None)).collect())
         }
 
-        ty::Alias(ty::Projection, ref data) => {
-            clean_projection(bound_ty.rebind(*data), cx, parent_def_id)
+        ty::Alias(ty::Projection, data) => {
+            clean_projection(bound_ty.rebind(data), cx, parent_def_id)
         }
 
         ty::Alias(ty::Inherent, alias_ty) => {
@@ -2053,8 +2053,21 @@ pub(crate) fn clean_middle_ty<'tcx>(
         }
 
         ty::Alias(ty::Weak, data) => {
-            let ty = cx.tcx.type_of(data.def_id).subst(cx.tcx, data.substs);
-            clean_middle_ty(bound_ty.rebind(ty), cx, None, None)
+            if cx.tcx.features().lazy_type_alias {
+                // Weak type alias `data` represents the `type X` in `type X = Y`. If we need `Y`,
+                // we need to use `type_of`.
+                let path = external_path(
+                    cx,
+                    data.def_id,
+                    false,
+                    ThinVec::new(),
+                    bound_ty.rebind(data.substs),
+                );
+                Type::Path { path }
+            } else {
+                let ty = cx.tcx.type_of(data.def_id).subst(cx.tcx, data.substs);
+                clean_middle_ty(bound_ty.rebind(ty), cx, None, None)
+            }
         }
 
         ty::Param(ref p) => {

--- a/tests/rustdoc/alias-reexport.rs
+++ b/tests/rustdoc/alias-reexport.rs
@@ -7,11 +7,9 @@
 extern crate alias_reexport2;
 
 // @has 'foo/reexport/fn.foo.html'
-// FIXME: should be 'pub fn foo() -> Reexport'
-// @has - '//*[@class="rust item-decl"]' 'pub fn foo() -> u8'
+// @has - '//*[@class="rust item-decl"]' 'pub fn foo() -> Reexported'
 // @has 'foo/reexport/fn.foo2.html'
-// FIXME: should be 'pub fn foo2() -> Result<Reexport, ()>'
-// @has - '//*[@class="rust item-decl"]' 'pub fn foo2() -> Result<u8, ()>'
+// @has - '//*[@class="rust item-decl"]' 'pub fn foo2() -> Result<Reexported, ()>'
 // @has 'foo/reexport/type.Reexported.html'
 // @has - '//*[@class="rust item-decl"]' 'pub type Reexported = u8;'
 #[doc(inline)]

--- a/tests/rustdoc/alias-reexport.rs
+++ b/tests/rustdoc/alias-reexport.rs
@@ -1,0 +1,18 @@
+// aux-build:alias-reexport.rs
+// aux-build:alias-reexport2.rs
+
+#![crate_name = "foo"]
+#![feature(lazy_type_alias)]
+
+extern crate alias_reexport2;
+
+// @has 'foo/reexport/fn.foo.html'
+// FIXME: should be 'pub fn foo() -> Reexport'
+// @has - '//*[@class="rust item-decl"]' 'pub fn foo() -> u8'
+// @has 'foo/reexport/fn.foo2.html'
+// FIXME: should be 'pub fn foo2() -> Result<Reexport, ()>'
+// @has - '//*[@class="rust item-decl"]' 'pub fn foo2() -> Result<u8, ()>'
+// @has 'foo/reexport/type.Reexported.html'
+// @has - '//*[@class="rust item-decl"]' 'pub type Reexported = u8;'
+#[doc(inline)]
+pub use alias_reexport2 as reexport;

--- a/tests/rustdoc/alias-reexport2.rs
+++ b/tests/rustdoc/alias-reexport2.rs
@@ -1,0 +1,16 @@
+// gate-test-lazy_type_alias
+// aux-build:alias-reexport.rs
+
+#![crate_name = "foo"]
+#![feature(lazy_type_alias)]
+
+extern crate alias_reexport;
+
+use alias_reexport::Reexported;
+
+// @has 'foo/fn.foo.html'
+// @has - '//*[@class="rust item-decl"]' 'pub fn foo() -> Reexported'
+pub fn foo() -> Reexported { 0 }
+// @has 'foo/fn.foo2.html'
+// @has - '//*[@class="rust item-decl"]' 'pub fn foo2() -> Result<Reexported, ()>'
+pub fn foo2() -> Result<Reexported, ()> { Ok(0) }

--- a/tests/rustdoc/auxiliary/alias-reexport.rs
+++ b/tests/rustdoc/auxiliary/alias-reexport.rs
@@ -1,0 +1,3 @@
+#![feature(lazy_type_alias)]
+
+pub type Reexported = u8;

--- a/tests/rustdoc/auxiliary/alias-reexport2.rs
+++ b/tests/rustdoc/auxiliary/alias-reexport2.rs
@@ -1,0 +1,12 @@
+#![feature(lazy_type_alias)]
+
+extern crate alias_reexport;
+
+pub use alias_reexport::Reexported;
+
+// @has 'foo/fn.foo.html'
+// @has - '//*[@class="docblock item-decl"]' 'pub fn foo() -> Reexported'
+pub fn foo() -> Reexported { 0 }
+// @has 'foo/fn.foo2.html'
+// @has - '//*[@class="docblock item-decl"]' 'pub fn foo2() -> Result<Reexported, ()>'
+pub fn foo2() -> Result<Reexported, ()> { Ok(0) }


### PR DESCRIPTION
Add the `type_alias_type` to be able to have the weak alias used without restrictions.

Part of #112792.

cc @compiler-errors 
r? @oli-obk 