### PR TITLE
Update cargo

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -16,9 +16,6 @@ const LICENSES: &[&str] = &[
     "Apache-2.0 OR MIT",
     "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT", // wasi license
     "Apache-2.0/MIT",
-    "BSD-2-Clause",                                        // arrayref from Cargo
-    "CC0-1.0 OR Apache-2.0",                               // blake3 from Cargo
-    "CC0-1.0 OR MIT-0 OR Apache-2.0",                      // constant_time_eq from cargo
     "ISC",
     "MIT / Apache-2.0",
     "MIT OR Apache-2.0 OR Zlib",                           // tinyvec_macros


### PR DESCRIPTION
12 commits in 0c14026aa84ee2ec4c67460c0a18abc8519ca6b2..dead4b8740c4b6a8ed5211e37c99cf81d01c3b1c
2023-06-14 18:43:05 +0000 to 2023-06-20 20:07:17 +0000
- Convert valid feature name warning to an error. (rust-lang/cargo#12291)
- fix(embedded): Don't pollute script dir with lockfile (rust-lang/cargo#12284)
- fix: remove `-Zjobserver-per-rustc` again (rust-lang/cargo#12285)
- docs: some tweaks around `cargo test` (rust-lang/cargo#12288)
- Enable `doctest-in-workspace` by default (rust-lang/cargo#12221)
- fix(embedded): Don't auto-discover build.rs files (rust-lang/cargo#12283)
- fix(embeded): Don't pollute the scripts dir with `target/` (rust-lang/cargo#12282)
- feat: prepare for the next lockfile bump (rust-lang/cargo#12279)
- fix(embedded): Don't create an intermediate manifest (rust-lang/cargo#12268)
- refactor(embedded): Switch to `syn` for parsing doc comments (rust-lang/cargo#12258)
- fix(embedded): Align package name sanitization with cargo-new (rust-lang/cargo#12255)
- Clarify the default behavior of cargo-install. (rust-lang/cargo#12276)

r? @ghost