### PR TITLE
rust-installer: migrate to clap 4.2, change to 2021 edition and fix few clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,29 +482,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive 3.2.18",
- "clap_lex 0.2.2",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
 dependencies = [
  "clap_builder",
- "clap_derive 4.2.0",
+ "clap_derive",
  "once_cell",
 ]
 
@@ -517,7 +500,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "bitflags",
- "clap_lex 0.4.1",
+ "clap_lex",
  "once_cell",
  "strsim",
  "terminal_size",
@@ -529,20 +512,7 @@ version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10861370d2ba66b0f5989f83ebf35db6421713fd92351790e7fdd6c36774c56b"
 dependencies = [
- "clap 4.2.1",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.102",
+ "clap",
 ]
 
 [[package]]
@@ -559,15 +529,6 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
@@ -576,7 +537,7 @@ checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 name = "clippy"
 version = "0.1.72"
 dependencies = [
- "clap 4.2.1",
+ "clap",
  "clippy_lints",
  "clippy_utils",
  "compiletest_rs",
@@ -605,7 +566,7 @@ name = "clippy_dev"
 version = "0.0.1"
 dependencies = [
  "aho-corasick",
- "clap 4.2.1",
+ "clap",
  "indoc",
  "itertools",
  "opener",
@@ -1749,7 +1710,7 @@ name = "installer"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 3.2.20",
+ "clap",
  "flate2",
  "num_cpus",
  "rayon",
@@ -1869,7 +1830,7 @@ name = "jsondoclint"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.2.1",
+ "clap",
  "fs-err",
  "rustc-hash",
  "rustdoc-json-types",
@@ -2086,7 +2047,7 @@ dependencies = [
  "ammonia",
  "anyhow",
  "chrono",
- "clap 4.2.1",
+ "clap",
  "clap_complete",
  "elasticlunr-rs",
  "env_logger 0.10.0",
@@ -2371,12 +2332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-
-[[package]]
 name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,30 +2571,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.102",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro-hack"
@@ -2897,7 +2828,7 @@ dependencies = [
 name = "rustbook"
 version = "0.1.0"
 dependencies = [
- "clap 4.2.1",
+ "clap",
  "env_logger 0.10.0",
  "mdbook",
 ]
@@ -4346,7 +4277,7 @@ dependencies = [
  "anyhow",
  "bytecount",
  "cargo_metadata",
- "clap 4.2.1",
+ "clap",
  "diff",
  "dirs",
  "env_logger 0.10.0",
@@ -4873,12 +4804,6 @@ dependencies = [
  "num_cpus",
  "term",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thin-vec"

--- a/src/tools/rust-installer/Cargo.toml
+++ b/src/tools/rust-installer/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "installer"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 doc = false

--- a/src/tools/rust-installer/Cargo.toml
+++ b/src/tools/rust-installer/Cargo.toml
@@ -20,4 +20,4 @@ num_cpus = "1"
 
 [dependencies.clap]
 features = ["derive"]
-version = "3.1"
+version = "4.2"

--- a/src/tools/rust-installer/src/combiner.rs
+++ b/src/tools/rust-installer/src/combiner.rs
@@ -13,47 +13,47 @@ actor! {
     #[derive(Debug)]
     pub struct Combiner {
         /// The name of the product, for display.
-        #[clap(value_name = "NAME")]
+        #[arg(value_name = "NAME")]
         product_name: String = "Product",
 
         /// The name of the package  tarball.
-        #[clap(value_name = "NAME")]
+        #[arg(value_name = "NAME")]
         package_name: String = "package",
 
         /// The directory under lib/ where the manifest lives.
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         rel_manifest_dir: String = "packagelib",
 
         /// The string to print after successful installation.
-        #[clap(value_name = "MESSAGE")]
+        #[arg(value_name = "MESSAGE")]
         success_message: String = "Installed.",
 
         /// Places to look for legacy manifests to uninstall.
-        #[clap(value_name = "DIRS")]
+        #[arg(value_name = "DIRS")]
         legacy_manifest_dirs: String = "",
 
         /// Installers to combine.
-        #[clap(value_name = "FILE,FILE")]
+        #[arg(value_name = "FILE,FILE")]
         input_tarballs: String = "",
 
         /// Directory containing files that should not be installed.
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         non_installed_overlay: String = "",
 
         /// The directory to do temporary work.
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         work_dir: String = "./workdir",
 
         /// The location to put the final image and tarball.
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         output_dir: String = "./dist",
 
         /// The profile used to compress the tarball.
-        #[clap(value_name = "FORMAT", default_value_t)]
+        #[arg(value_name = "FORMAT", default_value_t)]
         compression_profile: CompressionProfile,
 
         /// The formats used to compress the tarball
-        #[clap(value_name = "FORMAT", default_value_t)]
+        #[arg(value_name = "FORMAT", default_value_t)]
         compression_formats: CompressionFormats,
     }
 }

--- a/src/tools/rust-installer/src/combiner.rs
+++ b/src/tools/rust-installer/src/combiner.rs
@@ -94,7 +94,7 @@ impl Combiner {
             let pkg_name =
                 input_tarball.trim_end_matches(&format!(".tar.{}", compression.extension()));
             let pkg_name = Path::new(pkg_name).file_name().unwrap();
-            let pkg_dir = Path::new(&self.work_dir).join(&pkg_name);
+            let pkg_dir = Path::new(&self.work_dir).join(pkg_name);
 
             // Verify the version number.
             let mut version = String::new();
@@ -114,9 +114,9 @@ impl Combiner {
                 // All we need to do is copy the component directory. We could
                 // move it, but rustbuild wants to reuse the unpacked package
                 // dir for OS-specific installers on macOS and Windows.
-                let component_dir = package_dir.join(&component);
+                let component_dir = package_dir.join(component);
                 create_dir(&component_dir)?;
-                copy_recursive(&pkg_dir.join(&component), &component_dir)?;
+                copy_recursive(&pkg_dir.join(component), &component_dir)?;
 
                 // Merge the component name.
                 writeln!(&components, "{}", component).context("failed to write new components")?;
@@ -158,7 +158,7 @@ impl Combiner {
             .input(self.package_name)
             .output(path_to_str(&output)?.into())
             .compression_profile(self.compression_profile)
-            .compression_formats(self.compression_formats.clone());
+            .compression_formats(self.compression_formats);
         tarballer.run()?;
 
         Ok(())

--- a/src/tools/rust-installer/src/compression.rs
+++ b/src/tools/rust-installer/src/compression.rs
@@ -166,7 +166,7 @@ impl Default for CompressionFormats {
 
 impl CompressionFormats {
     pub(crate) fn iter(&self) -> impl Iterator<Item = CompressionFormat> + '_ {
-        self.0.iter().map(|i| *i)
+        self.0.iter().copied()
     }
 }
 

--- a/src/tools/rust-installer/src/generator.rs
+++ b/src/tools/rust-installer/src/generator.rs
@@ -118,7 +118,7 @@ impl Generator {
             .input(self.package_name)
             .output(path_to_str(&output)?.into())
             .compression_profile(self.compression_profile)
-            .compression_formats(self.compression_formats.clone());
+            .compression_formats(self.compression_formats);
         tarballer.run()?;
 
         Ok(())

--- a/src/tools/rust-installer/src/generator.rs
+++ b/src/tools/rust-installer/src/generator.rs
@@ -11,55 +11,55 @@ actor! {
     #[derive(Debug)]
     pub struct Generator {
         /// The name of the product, for display
-        #[clap(value_name = "NAME")]
+        #[arg(value_name = "NAME")]
         product_name: String = "Product",
 
         /// The name of the component, distinct from other installed components
-        #[clap(value_name = "NAME")]
+        #[arg(value_name = "NAME")]
         component_name: String = "component",
 
         /// The name of the package, tarball
-        #[clap(value_name = "NAME")]
+        #[arg(value_name = "NAME")]
         package_name: String = "package",
 
         /// The directory under lib/ where the manifest lives
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         rel_manifest_dir: String = "packagelib",
 
         /// The string to print after successful installation
-        #[clap(value_name = "MESSAGE")]
+        #[arg(value_name = "MESSAGE")]
         success_message: String = "Installed.",
 
         /// Places to look for legacy manifests to uninstall
-        #[clap(value_name = "DIRS")]
+        #[arg(value_name = "DIRS")]
         legacy_manifest_dirs: String = "",
 
         /// Directory containing files that should not be installed
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         non_installed_overlay: String = "",
 
         /// Path prefixes of directories that should be installed/uninstalled in bulk
-        #[clap(value_name = "DIRS")]
+        #[arg(value_name = "DIRS")]
         bulk_dirs: String = "",
 
         /// The directory containing the installation medium
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         image_dir: String = "./install_image",
 
         /// The directory to do temporary work
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         work_dir: String = "./workdir",
 
         /// The location to put the final image and tarball
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         output_dir: String = "./dist",
 
         /// The profile used to compress the tarball.
-        #[clap(value_name = "FORMAT", default_value_t)]
+        #[arg(value_name = "FORMAT", default_value_t)]
         compression_profile: CompressionProfile,
 
         /// The formats used to compress the tarball
-        #[clap(value_name = "FORMAT", default_value_t)]
+        #[arg(value_name = "FORMAT", default_value_t)]
         compression_formats: CompressionFormats,
     }
 }

--- a/src/tools/rust-installer/src/scripter.rs
+++ b/src/tools/rust-installer/src/scripter.rs
@@ -2,7 +2,7 @@ use crate::util::*;
 use anyhow::{Context, Result};
 use std::io::Write;
 
-const TEMPLATE: &'static str = include_str!("../install-template.sh");
+const TEMPLATE: &str = include_str!("../install-template.sh");
 
 actor! {
     #[derive(Debug)]

--- a/src/tools/rust-installer/src/scripter.rs
+++ b/src/tools/rust-installer/src/scripter.rs
@@ -8,23 +8,23 @@ actor! {
     #[derive(Debug)]
     pub struct Scripter {
         /// The name of the product, for display
-        #[clap(value_name = "NAME")]
+        #[arg(value_name = "NAME")]
         product_name: String = "Product",
 
         /// The directory under lib/ where the manifest lives
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         rel_manifest_dir: String = "manifestlib",
 
         /// The string to print after successful installation
-        #[clap(value_name = "MESSAGE")]
+        #[arg(value_name = "MESSAGE")]
         success_message: String = "Installed.",
 
         /// Places to look for legacy manifests to uninstall
-        #[clap(value_name = "DIRS")]
+        #[arg(value_name = "DIRS")]
         legacy_manifest_dirs: String = "",
 
         /// The name of the output script
-        #[clap(value_name = "FILE")]
+        #[arg(value_name = "FILE")]
         output_script: String = "install.sh",
     }
 }

--- a/src/tools/rust-installer/src/tarballer.rs
+++ b/src/tools/rust-installer/src/tarballer.rs
@@ -14,23 +14,23 @@ actor! {
     #[derive(Debug)]
     pub struct Tarballer {
         /// The input folder to be compressed.
-        #[clap(value_name = "NAME")]
+        #[arg(value_name = "NAME")]
         input: String = "package",
 
         /// The prefix of the tarballs.
-        #[clap(value_name = "PATH")]
+        #[arg(value_name = "PATH")]
         output: String = "./dist",
 
         /// The folder in which the input is to be found.
-        #[clap(value_name = "DIR")]
+        #[arg(value_name = "DIR")]
         work_dir: String = "./workdir",
 
         /// The profile used to compress the tarball.
-        #[clap(value_name = "FORMAT", default_value_t)]
+        #[arg(value_name = "FORMAT", default_value_t)]
         compression_profile: CompressionProfile,
 
         /// The formats used to compress the tarball.
-        #[clap(value_name = "FORMAT", default_value_t)]
+        #[arg(value_name = "FORMAT", default_value_t)]
         compression_formats: CompressionFormats,
     }
 }

--- a/src/tools/rust-installer/src/tarballer.rs
+++ b/src/tools/rust-installer/src/tarballer.rs
@@ -98,7 +98,7 @@ fn append_path<W: Write>(builder: &mut Builder<W>, src: &Path, path: &String) ->
         if cfg!(windows) {
             // Windows doesn't really have a mode, so `tar` never marks files executable.
             // Use an extension whitelist to update files that usually should be so.
-            const EXECUTABLES: [&'static str; 4] = ["exe", "dll", "py", "sh"];
+            const EXECUTABLES: [&str; 4] = ["exe", "dll", "py", "sh"];
             if let Some(ext) = src.extension().and_then(|s| s.to_str()) {
                 if EXECUTABLES.contains(&ext) {
                     let mode = header.mode()?;
@@ -134,7 +134,7 @@ where
     for entry in WalkDir::new(root.join(name)) {
         let entry = entry?;
         let path = entry.path().strip_prefix(root)?;
-        let path = path_to_str(&path)?;
+        let path = path_to_str(path)?;
 
         if entry.file_type().is_dir() {
             dirs.push(path.to_owned());

--- a/src/tools/rust-installer/src/util.rs
+++ b/src/tools/rust-installer/src/util.rs
@@ -135,7 +135,7 @@ macro_rules! actor {
         $( #[ $attr ] )+
         #[derive(clap::Args)]
         pub struct $name {
-            $( $( #[ $field_attr ] )+ #[clap(long, $(default_value = $default)*)] $field : $type, )*
+            $( $( #[ $field_attr ] )+ #[arg(long, $(default_value = $default)*)] $field : $type, )*
         }
 
         impl Default for $name {

--- a/src/tools/rust-installer/src/util.rs
+++ b/src/tools/rust-installer/src/util.rs
@@ -117,7 +117,7 @@ where
         } else {
             copy(entry.path(), dst)?;
         }
-        callback(&path, file_type)?;
+        callback(path, file_type)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Updated rust-installer to clap 4.2, dropping last user of clap v3; changes to 2021 edition, fixes few clippy warns.