### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -535,7 +535,7 @@ pub fn compile_declarative_macro(
                     .pop()
                     .unwrap();
                 }
-                sess.parse_sess.span_diagnostic.span_bug(def.span, "wrong-structured lhs")
+                sess.parse_sess.span_diagnostic.span_bug(def.span, "wrong-structured rhs")
             })
             .collect::<Vec<mbe::TokenTree>>(),
         _ => sess.parse_sess.span_diagnostic.span_bug(def.span, "wrong-structured rhs"),

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -154,7 +154,7 @@ macro_rules! println {
 ///
 /// Panics if writing to `io::stderr` fails.
 ///
-/// Writing to non-blocking stdout can cause an error, which will lead
+/// Writing to non-blocking stderr can cause an error, which will lead
 /// this macro to panic.
 ///
 /// # Examples
@@ -189,7 +189,7 @@ macro_rules! eprint {
 ///
 /// Panics if writing to `io::stderr` fails.
 ///
-/// Writing to non-blocking stdout can cause an error, which will lead
+/// Writing to non-blocking stderr can cause an error, which will lead
 /// this macro to panic.
 ///
 /// # Examples

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -891,8 +891,8 @@ pub fn sleep(dur: Duration) {
 /// performs the corresponding `Acquire` operation. Calls to `unpark` for the same
 /// thread form a [release sequence].
 ///
-/// Note that being unblocked does not imply synchronization with a call to `unpark`,
-/// the wakeup could also be spurious. For example, a valid, but inefficient,
+/// Note that being unblocked does not imply a call was made to `unpark`, because
+/// wakeups can also be spurious. For example, a valid, but inefficient,
 /// implementation could have `park` and `unpark` return immediately without doing anything.
 ///
 /// # Examples

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -880,7 +880,7 @@ pub fn sleep(dur: Duration) {
 /// * It can be implemented very efficiently on many platforms.
 ///
 /// # Memory Orderings
-/// 
+///
 /// Calls to `park` _synchronize-with_ calls to `unpark`, meaning that memory
 /// operations performed before a call to `unpark` are made visible to the thread that
 /// consumes the token and returns from `park`. Note that all `park` and `unpark`
@@ -890,7 +890,7 @@ pub fn sleep(dur: Duration) {
 /// In atomic ordering terms, `unpark` performs a `Release` operation and `park`
 /// performs the corresponding `Acquire` operation. Calls to `unpark` for the same
 /// thread form a [release sequence].
-/// 
+///
 /// Notice that being unblocked does not imply any synchronization with someone that
 /// unparked this thread, it could also be spurious. For example, it would be a valid,
 /// but inefficient, implementation to make both park and unpark return immediately

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -891,10 +891,9 @@ pub fn sleep(dur: Duration) {
 /// performs the corresponding `Acquire` operation. Calls to `unpark` for the same
 /// thread form a [release sequence].
 ///
-/// Notice that being unblocked does not imply any synchronization with someone that
-/// unparked this thread, it could also be spurious. For example, it would be a valid,
-/// but inefficient, implementation to make both park and unpark return immediately
-/// without doing anything.
+/// Note that being unblocked does not imply synchronization with a call to `unpark`,
+/// the wakeup could also be spurious. For example, a valid, but inefficient,
+/// implementation could have `park` and `unpark` return immediately without doing anything.
 ///
 /// # Examples
 ///

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -893,7 +893,8 @@ pub fn sleep(dur: Duration) {
 ///
 /// Note that being unblocked does not imply a call was made to `unpark`, because
 /// wakeups can also be spurious. For example, a valid, but inefficient,
-/// implementation could have `park` and `unpark` return immediately without doing anything.
+/// implementation could have `park` and `unpark` return immediately without doing anything,
+/// making *all* wakeups spurious.
 ///
 /// # Examples
 ///
@@ -908,7 +909,7 @@ pub fn sleep(dur: Duration) {
 /// let parked_thread = thread::spawn(move || {
 ///     // We want to wait until the flag is set. We *could* just spin, but using
 ///     // park/unpark is more efficient.
-///     while !flag2.load(Ordering::Acquire) {
+///     while !flag2.load(Ordering::Relaxed) {
 ///         println!("Parking thread");
 ///         thread::park();
 ///         // We *could* get here spuriously, i.e., way before the 10ms below are over!
@@ -925,7 +926,7 @@ pub fn sleep(dur: Duration) {
 /// // There is no race condition here, if `unpark`
 /// // happens first, `park` will return immediately.
 /// // Hence there is no risk of a deadlock.
-/// flag.store(true, Ordering::Release);
+/// flag.store(true, Ordering::Relaxed);
 /// println!("Unpark the thread");
 /// parked_thread.thread().unpark();
 ///

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -879,7 +879,7 @@ pub fn sleep(dur: Duration) {
 ///
 /// * It can be implemented very efficiently on many platforms.
 ///
-/// # Memory Orderings
+/// # Memory Ordering
 ///
 /// Calls to `park` _synchronize-with_ calls to `unpark`, meaning that memory
 /// operations performed before a call to `unpark` are made visible to the thread that

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -20,7 +20,7 @@ pub enum Profile {
     Codegen,
     Library,
     Tools,
-    Dist,
+    User,
     None,
 }
 
@@ -43,7 +43,7 @@ impl Profile {
     pub fn all() -> impl Iterator<Item = Self> {
         use Profile::*;
         // N.B. these are ordered by how they are displayed, not alphabetically
-        [Library, Compiler, Codegen, Tools, Dist, None].iter().copied()
+        [Library, Compiler, Codegen, Tools, User, None].iter().copied()
     }
 
     pub fn purpose(&self) -> String {
@@ -53,7 +53,7 @@ impl Profile {
             Compiler => "Contribute to the compiler itself",
             Codegen => "Contribute to the compiler, and also modify LLVM or codegen",
             Tools => "Contribute to tools which depend on the compiler, but do not modify it directly (e.g. rustdoc, clippy, miri)",
-            Dist => "Install Rust from source",
+            User => "Install Rust from source",
             None => "Do not modify `config.toml`"
         }
         .to_string()
@@ -73,7 +73,7 @@ impl Profile {
             Profile::Codegen => "codegen",
             Profile::Library => "library",
             Profile::Tools => "tools",
-            Profile::Dist => "dist",
+            Profile::User => "user",
             Profile::None => "none",
         }
     }
@@ -87,7 +87,7 @@ impl FromStr for Profile {
             "lib" | "library" => Ok(Profile::Library),
             "compiler" => Ok(Profile::Compiler),
             "llvm" | "codegen" => Ok(Profile::Codegen),
-            "maintainer" | "dist" => Ok(Profile::Dist),
+            "maintainer" | "user" => Ok(Profile::User),
             "tools" | "tool" | "rustdoc" | "clippy" | "miri" | "rustfmt" | "rls" => {
                 Ok(Profile::Tools)
             }
@@ -160,7 +160,7 @@ pub fn setup(config: &Config, profile: Profile) {
             "test src/tools/rustfmt",
         ],
         Profile::Library => &["check", "build", "test library/std", "doc"],
-        Profile::Dist => &["dist", "build"],
+        Profile::User => &["dist", "build"],
     };
 
     println!();
@@ -170,7 +170,7 @@ pub fn setup(config: &Config, profile: Profile) {
         println!("- `x.py {}`", cmd);
     }
 
-    if profile != Profile::Dist {
+    if profile != Profile::User {
         println!(
             "For more suggestions, see https://rustc-dev-guide.rust-lang.org/building/suggested.html"
         );

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -358,15 +358,15 @@ fn is_field_vis_inherited(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 
 impl Item {
     pub(crate) fn stability<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Stability> {
-        self.item_id.as_def_id().and_then(|did| tcx.lookup_stability(did))
+        self.def_id().and_then(|did| tcx.lookup_stability(did))
     }
 
     pub(crate) fn const_stability<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<ConstStability> {
-        self.item_id.as_def_id().and_then(|did| tcx.lookup_const_stability(did))
+        self.def_id().and_then(|did| tcx.lookup_const_stability(did))
     }
 
     pub(crate) fn deprecation(&self, tcx: TyCtxt<'_>) -> Option<Deprecation> {
-        self.item_id.as_def_id().and_then(|did| tcx.lookup_deprecation(did))
+        self.def_id().and_then(|did| tcx.lookup_deprecation(did))
     }
 
     pub(crate) fn inner_docs(&self, tcx: TyCtxt<'_>) -> bool {
@@ -391,7 +391,7 @@ impl Item {
                     panic!("blanket impl item has non-blanket ID")
                 }
             }
-            _ => self.item_id.as_def_id().map(|did| rustc_span(did, tcx)),
+            _ => self.def_id().map(|did| rustc_span(did, tcx)),
         }
     }
 
@@ -501,7 +501,7 @@ impl Item {
     }
 
     pub(crate) fn is_crate(&self) -> bool {
-        self.is_mod() && self.item_id.as_def_id().map_or(false, |did| did.is_crate_root())
+        self.is_mod() && self.def_id().map_or(false, |did| did.is_crate_root())
     }
     pub(crate) fn is_mod(&self) -> bool {
         self.type_() == ItemType::Module
@@ -638,11 +638,11 @@ impl Item {
         }
         let header = match *self.kind {
             ItemKind::ForeignFunctionItem(_) => {
-                let def_id = self.item_id.as_def_id().unwrap();
+                let def_id = self.def_id().unwrap();
                 let abi = tcx.fn_sig(def_id).skip_binder().abi();
                 hir::FnHeader {
                     unsafety: if abi == Abi::RustIntrinsic {
-                        intrinsic_operation_unsafety(tcx, self.item_id.as_def_id().unwrap())
+                        intrinsic_operation_unsafety(tcx, self.def_id().unwrap())
                     } else {
                         hir::Unsafety::Unsafe
                     },
@@ -659,7 +659,7 @@ impl Item {
                 }
             }
             ItemKind::FunctionItem(_) | ItemKind::MethodItem(_, _) | ItemKind::TyMethodItem(_) => {
-                let def_id = self.item_id.as_def_id().unwrap();
+                let def_id = self.def_id().unwrap();
                 build_fn_header(def_id, tcx, tcx.asyncness(def_id))
             }
             _ => return None,
@@ -738,7 +738,7 @@ impl Item {
                 }
             })
             .collect();
-        if let Some(def_id) = self.item_id.as_def_id() &&
+        if let Some(def_id) = self.def_id() &&
             !def_id.is_local() &&
             // This check is needed because `adt_def` will panic if not a compatible type otherwise...
             matches!(self.type_(), ItemType::Struct | ItemType::Enum | ItemType::Union)
@@ -786,6 +786,10 @@ impl Item {
 
     pub fn is_doc_hidden(&self) -> bool {
         self.attrs.is_doc_hidden()
+    }
+
+    pub fn def_id(&self) -> Option<DefId> {
+        self.item_id.as_def_id()
     }
 }
 

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -121,6 +121,11 @@ pub(crate) struct Cache {
     pub(crate) intra_doc_links: FxHashMap<ItemId, FxIndexSet<clean::ItemLink>>,
     /// Cfg that have been hidden via #![doc(cfg_hide(...))]
     pub(crate) hidden_cfg: FxHashSet<clean::cfg::Cfg>,
+
+    /// Contains the list of `DefId`s which have been inlined. It is used when generating files
+    /// to check if a stripped item should get its file generated or not: if it's inside a
+    /// `#[doc(hidden)]` item or a private one and not inlined, it shouldn't get a file.
+    pub(crate) inlined_items: DefIdSet,
 }
 
 /// This struct is used to wrap the `cache` and `tcx` in order to run `DocFolder`.

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -313,7 +313,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             return false;
         }
 
-        let ret = match tcx.hir().get_by_def_id(res_did) {
+        let inlined = match tcx.hir().get_by_def_id(res_did) {
             // Bang macros are handled a bit on their because of how they are handled by the
             // compiler. If they have `#[doc(hidden)]` and the re-export doesn't have
             // `#[doc(inline)]`, then we don't inline it.
@@ -344,7 +344,10 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             _ => false,
         };
         self.view_item_stack.remove(&res_did);
-        ret
+        if inlined {
+            self.cx.cache.inlined_items.insert(res_did.to_def_id());
+        }
+        inlined
     }
 
     /// Returns `true` if the item is visible, meaning it's not `#[doc(hidden)]` or private.

--- a/tests/rustdoc/files-creation-hidden.rs
+++ b/tests/rustdoc/files-creation-hidden.rs
@@ -1,0 +1,23 @@
+#![crate_name="foo"]
+
+// @!has "foo/struct.Foo.html"
+#[doc(hidden)]
+pub struct Foo;
+
+// @!has "foo/struct.Bar.html"
+pub use crate::Foo as Bar;
+
+// @!has "foo/struct.Baz.html"
+#[doc(hidden)]
+pub use crate::Foo as Baz;
+
+// @!has "foo/foo/index.html"
+#[doc(hidden)]
+pub mod foo {}
+
+// @!has "foo/bar/index.html"
+pub use crate::foo as bar;
+
+// @!has "foo/baz/index.html"
+#[doc(hidden)]
+pub use crate::foo as baz;

--- a/tests/rustdoc/files-creation-private.rs
+++ b/tests/rustdoc/files-creation-private.rs
@@ -1,0 +1,18 @@
+#![crate_name="foo"]
+
+// @!has "foo/priv/index.html"
+// @!has "foo/priv/struct.Foo.html"
+mod private {
+    pub struct Foo;
+}
+
+// @has "foo/struct.Bar.html"
+pub use crate::private::Foo as Bar;
+
+// @!has "foo/foo/index.html"
+mod foo {
+    pub mod subfoo {}
+}
+
+// @has "foo/bar/index.html"
+pub use crate::foo::subfoo as bar;

--- a/tests/rustdoc/issue-111249-file-creation.rs
+++ b/tests/rustdoc/issue-111249-file-creation.rs
@@ -1,18 +1,23 @@
+#![crate_name = "foo"]
 #![feature(no_core)]
 #![no_core]
-#![crate_name = "foo"]
 
+// The following five should not fail!
 // @!has 'foo/hidden/index.html'
 // @!has 'foo/hidden/inner/index.html'
 // FIXME: Should be `@!has`: https://github.com/rust-lang/rust/issues/111249
 // @has 'foo/hidden/inner/trait.Foo.html'
 // @matchesraw - '<meta http-equiv="refresh" content="0;URL=../../../foo/visible/trait.Foo.html">'
+// @!has 'foo/hidden/inner/inner_hidden/index.html'
+// @!has 'foo/hidden/inner/inner_hidden/trait.HiddenFoo.html'
 #[doc(hidden)]
 pub mod hidden {
     pub mod inner {
-        pub trait Foo {
-            /// Hello, world!
-            fn test();
+        pub trait Foo {}
+
+        #[doc(hidden)]
+        pub mod inner_hidden {
+            pub trait HiddenFoo {}
         }
     }
 }
@@ -26,6 +31,4 @@ pub use hidden::inner as visible;
 // @count - '//*[@id="impl-Foo-for-Bar"]' 1
 pub struct Bar;
 
-impl visible::Foo for Bar {
-    fn test() {}
-}
+impl visible::Foo for Bar {}

--- a/tests/rustdoc/redirect.rs
+++ b/tests/rustdoc/redirect.rs
@@ -10,7 +10,9 @@ pub trait Foo {}
 // @has - '//code' 'pub use reexp_stripped::Bar'
 // @has - '//code/a' 'Bar'
 // @has - '//a[@href="../reexp_stripped/hidden/struct.Bar.html"]' 'Bar'
+// FIXME: Should be `@!has`: https://github.com/rust-lang/rust/issues/111249
 // @has reexp_stripped/hidden/struct.Bar.html
+// @matchesraw - '<meta http-equiv="refresh" content="0;URL=../../reexp_stripped/struct.Bar.html">'
 // @has 'reexp_stripped/struct.Bar.html'
 // @has - '//a[@href="struct.Bar.html"]' 'Bar'
 #[doc(no_inline)]


### PR DESCRIPTION
Successful merges:

 - #99587 (Document memory orderings of `thread::{park, unpark}`)
 - #112836 ([rustdoc] partially fix invalid files creation)
 - #112863 (Fix copy-paste typo in `eprint(ln)` docs)
 - #112883 (Make queries traceable again)
 - #112885 (Fix msg passed to span_bug)
 - #112886 (Revert 'Rename profile=user to profile=dist')

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=99587,112836,112863,112883,112885,112886)
<!-- homu-ignore:end -->