### PR TITLE
Fix union fields display

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -421,11 +421,10 @@ fn document<'a, 'cx: 'a>(
     display_fn(move |f| {
         document_item_info(cx, item, parent).render_into(f).unwrap();
         if parent.is_none() {
-            write!(f, "{}", document_full_collapsible(item, cx, heading_offset))?;
+            write!(f, "{}", document_full_collapsible(item, cx, heading_offset))
         } else {
-            write!(f, "{}", document_full(item, cx, heading_offset))?;
+            write!(f, "{}", document_full(item, cx, heading_offset))
         }
-        Ok(())
     })
 }
 

--- a/src/librustdoc/html/templates/item_info.html
+++ b/src/librustdoc/html/templates/item_info.html
@@ -1,5 +1,5 @@
 {% if !items.is_empty() %}
-    <span class="item-info"> {# #}
+    <span class="item-info">
         {% for item in items %}
             {{item|safe}} {# #}
         {% endfor %}

--- a/src/librustdoc/html/templates/item_union.html
+++ b/src/librustdoc/html/templates/item_union.html
@@ -4,14 +4,15 @@
 </code></pre>
 {{ self.document() | safe }}
 {% if self.fields_iter().peek().is_some() %}
-    <h2 id="fields" class="fields small-section-header">
-        Fields<a href="#fields" class="anchor">§</a>
+    <h2 id="fields" class="fields small-section-header"> {# #}
+        Fields<a href="#fields" class="anchor">§</a> {# #}
     </h2>
     {% for (field, ty) in self.fields_iter() %}
         {% let name = field.name.expect("union field name") %}
-        <span id="structfield.{{ name }}" class="{{ ItemType::StructField }} small-section-header">
-            <a href="#structfield.{{ name }}" class="anchor field">§</a>
-            <code>{{ name }}: {{ self.print_ty(ty) | safe }}</code>
+        <span id="structfield.{{ name }}" {#+ #}
+            class="{{ ItemType::StructField +}} small-section-header"> {# #}
+            <a href="#structfield.{{ name }}" class="anchor field">§</a> {# #}
+            <code>{{ name }}: {{+ self.print_ty(ty) | safe }}</code> {# #}
         </span>
         {% if let Some(stability_class) = self.stability_field(field) %}
             <span class="stab {{ stability_class }}"></span>

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -1,5 +1,5 @@
 <div class="main-heading"> {# #}
-    <h1> {# #}
+    <h1>
         {{typ}}
         {# The breadcrumbs of the item path, like std::string #}
         {% for component in path_components %}
@@ -12,7 +12,7 @@
                 alt="Copy item path"> {# #}
         </button> {# #}
     </h1> {# #}
-    <span class="out-of-band"> {# #}
+    <span class="out-of-band">
         {% if !stability_since_raw.is_empty() %}
         {{ stability_since_raw|safe +}} · {#+ #}
         {% endif %}

--- a/tests/rustdoc-gui/fields.goml
+++ b/tests/rustdoc-gui/fields.goml
@@ -1,0 +1,18 @@
+// This test checks that fields are displayed as expected (one by line).
+go-to: "file://" + |DOC_PATH| + "/test_docs/fields/struct.Struct.html"
+store-position: ("#structfield\.a", {"y": a_y})
+store-position: ("#structfield\.b", {"y": b_y})
+assert: |a_y| < |b_y|
+
+go-to: "file://" + |DOC_PATH| + "/test_docs/fields/union.Union.html"
+store-position: ("#structfield\.a", {"y": a_y})
+store-position: ("#structfield\.b", {"y": b_y})
+assert: |a_y| < |b_y|
+
+go-to: "file://" + |DOC_PATH| + "/test_docs/fields/enum.Enum.html"
+store-position: ("#variant\.A\.field\.a", {"y": a_y})
+store-position: ("#variant\.A\.field\.b", {"y": b_y})
+assert: |a_y| < |b_y|
+store-position: ("#variant\.B\.field\.a", {"y": a_y})
+store-position: ("#variant\.B\.field\.b", {"y": b_y})
+assert: |a_y| < |b_y|

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -486,3 +486,24 @@ pub mod search_results {
     }
 
 }
+
+pub mod fields {
+    pub struct Struct {
+        pub a: u8,
+        pub b: u32,
+    }
+    pub union Union {
+        pub a: u8,
+        pub b: u32,
+    }
+    pub enum Enum {
+        A {
+            a: u8,
+            b: u32,
+        },
+        B {
+            a: u8,
+            b: u32,
+        },
+    }
+}

--- a/tests/rustdoc/union-fields-html.rs
+++ b/tests/rustdoc/union-fields-html.rs
@@ -1,0 +1,11 @@
+#![crate_name = "foo"]
+
+// @has 'foo/union.Union.html'
+// Checking that there is a whitespace after `:`.
+// @has - '//*[@id="structfield.a"]/code' 'a: u8'
+// @has - '//*[@id="structfield.b"]/code' 'b: u32'
+pub union Union {
+    pub a: u8,
+    /// tadam
+    pub b: u32,
+}


### PR DESCRIPTION
![Screenshot from 2023-06-21 16-47-24](https://github.com/rust-lang/rust/assets/3050060/833b0fe6-7fb6-4371-86c3-d82fa0c3fe49)

So two bugs in this screenshot: no whitespace between field name and type name, both fields are on the same line. Both problems come from issues in the templates because all whitespace are removed if a askama "command" follows.

r? @notriddle 