### PR TITLE
Add more context to `quit_if_file_exists` in `configure.py` & delete config.toml in CI

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -180,7 +180,7 @@ def p(msg):
 
 
 def err(msg):
-    print("configure: error: " + msg)
+    print("\nconfigure: ERROR: " + msg + "\n")
     sys.exit(1)
 
 def is_value_list(key):
@@ -544,7 +544,14 @@ def write_config_toml(writer, section_order, targets, sections):
 
 def quit_if_file_exists(file):
     if os.path.isfile(file):
-        err("Existing '" + file + "' detected.")
+        msg = "Existing '{}' detected. Exiting".format(file)
+
+        # If the output object directory isn't empty, we can get these errors
+        host_objdir = os.environ.get("OBJDIR_ON_HOST")
+        if host_objdir is not None:
+            msg += "\nIs objdir '{}' clean?".format(host_objdir)
+
+        err(msg)
 
 if __name__ == "__main__":
     # If 'config.toml' already exists, exit the script at this point

--- a/src/ci/docker/README.md
+++ b/src/ci/docker/README.md
@@ -14,7 +14,8 @@ for example:
 ./src/ci/docker/run.sh x86_64-gnu
 ```
 
-Images will output artifacts in an `obj` dir at the root of a repository.
+Images will output artifacts in an `obj` dir at the root of a repository. Note
+that the script will overwrite the contents of this directory.
 
 To match conditions in rusts CI, also set the environment variable `DEPLOY=1`, e.g.:
 ```

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -266,6 +266,7 @@ docker \
   --env BASE_COMMIT="$BASE_COMMIT" \
   --env DIST_TRY_BUILD \
   --env PR_CI_JOB \
+  --env OBJDIR_ON_HOST="$objdir" \
   --init \
   --rm \
   rust-ci \

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -171,6 +171,9 @@ trap datecheck EXIT
 # sccache server at the start of the build, but no need to worry if this fails.
 SCCACHE_IDLE_TIMEOUT=10800 sccache --start-server || true
 
+# Our build may overwrite config.toml, so we remove it here
+rm -f config.toml
+
 $SRC/configure $RUST_CONFIGURE_ARGS
 
 retry make prepare


### PR DESCRIPTION
If the `obj` directory isn't empty, the error message is subtle and not very helpful:

```
== clock drift check ==
  local time: Sun Jul  2 00:57:06 UTC 2023
  network time: Sun, 02 Jul 2023 00:57:06 GMT
== end clock drift check ==
sccache: Starting the server...
configure: error: Existing 'config.toml' detected.
== clock drift check ==
  local time: Sun Jul  2 00:57:06 UTC 2023
  network time: Sun, 02 Jul 2023 00:57:06 GMT
== end clock drift check ==
```

This makes it stand out and suggests how to resolve the issue:

```
== clock drift check ==
  local time: Sun Jul  2 02:11:30 UTC 2023
  network time: Sun, 02 Jul 2023 02:11:31 GMT
== end clock drift check ==
sccache: Starting the server...

configure: ERROR: Existing 'config.toml' detected. Exiting
Is objdir '/home/tmgross/projects/rust/obj' clean?

== clock drift check ==
  local time: Sun Jul  2 02:11:31 UTC 2023
  network time: Sun, 02 Jul 2023 02:11:31 GMT
== end clock drift check ==
```