### PR TITLE
Fix indentation for where clause in rustdoc pages

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -347,13 +347,19 @@ pub(crate) fn print_where_clause<'a, 'tcx: 'a>(
             }
         } else {
             let mut br_with_padding = String::with_capacity(6 * indent + 28);
-            br_with_padding.push_str("\n");
+            br_with_padding.push('\n');
 
-            let padding_amount =
-                if ending == Ending::Newline { indent + 4 } else { indent + "fn where ".len() };
+            let where_indent = 3;
+            let padding_amount = if ending == Ending::Newline {
+                indent + 4
+            } else if indent == 0 {
+                4
+            } else {
+                indent + where_indent + "where ".len()
+            };
 
             for _ in 0..padding_amount {
-                br_with_padding.push_str(" ");
+                br_with_padding.push(' ');
             }
             let where_preds = where_preds.to_string().replace('\n', &br_with_padding);
 
@@ -370,7 +376,8 @@ pub(crate) fn print_where_clause<'a, 'tcx: 'a>(
                     let where_preds = where_preds.replacen(&br_with_padding, " ", 1);
 
                     let mut clause = br_with_padding;
-                    clause.truncate(clause.len() - "where ".len());
+                    // +1 is for `\n`.
+                    clause.truncate(indent + 1 + where_indent);
 
                     write!(clause, "<span class=\"where\">where{where_preds}</span>")?;
                     clause

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -859,8 +859,8 @@ fn assoc_method(
     w.reserve(header_len + "<a href=\"\" class=\"fn\">{".len() + "</a>".len());
     write!(
         w,
-        "{indent}{vis}{constness}{asyncness}{unsafety}{defaultness}{abi}fn <a{href} class=\"fn\">{name}</a>\
-         {generics}{decl}{notable_traits}{where_clause}",
+        "{indent}{vis}{constness}{asyncness}{unsafety}{defaultness}{abi}fn \
+         <a{href} class=\"fn\">{name}</a>{generics}{decl}{notable_traits}{where_clause}",
         indent = indent_str,
         vis = vis,
         constness = constness,

--- a/tests/rustdoc/where.SWhere_Echo_impl.html
+++ b/tests/rustdoc/where.SWhere_Echo_impl.html
@@ -1,0 +1,2 @@
+<h3 class="code-header">impl&lt;D&gt; <a class="struct" href="struct.Delta.html" title="struct foo::Delta">Delta</a>&lt;D&gt;<span class="where fmt-newline">where
+    D: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a>,</span></h3>

--- a/tests/rustdoc/where.SWhere_Simd_item-decl.html
+++ b/tests/rustdoc/where.SWhere_Simd_item-decl.html
@@ -1,3 +1,3 @@
 <pre class="rust item-decl"><code>pub struct Simd&lt;T&gt;(_)
 <span class="where">where
-         T: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a></span>;</code></pre>
+    T: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a></span>;</code></pre>

--- a/tests/rustdoc/where.alpha_trait_decl.html
+++ b/tests/rustdoc/where.alpha_trait_decl.html
@@ -1,0 +1,3 @@
+<code>pub struct Alpha&lt;A&gt;(_)
+<span class="where">where
+    A: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a></span>;</code>

--- a/tests/rustdoc/where.bravo_trait_decl.html
+++ b/tests/rustdoc/where.bravo_trait_decl.html
@@ -1,0 +1,5 @@
+<code>pub trait Bravo&lt;B&gt;<span class="where fmt-newline">where
+    B: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a>,</span>{
+    // Required method
+    fn <a href="#tymethod.get" class="fn">get</a>(&amp;self, B: B);
+}</code>

--- a/tests/rustdoc/where.charlie_fn_decl.html
+++ b/tests/rustdoc/where.charlie_fn_decl.html
@@ -1,0 +1,2 @@
+<code>pub fn charlie&lt;C&gt;()<span class="where fmt-newline">where
+    C: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a>,</span></code>

--- a/tests/rustdoc/where.golf_type_alias_decl.html
+++ b/tests/rustdoc/where.golf_type_alias_decl.html
@@ -1,0 +1,2 @@
+<code>pub type Golf&lt;T&gt;<span class="where fmt-newline">where
+    T: <a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>,</span> = <a class="primitive" href="{{channel}}/std/primitive.tuple.html">(T, T)</a>;</code>

--- a/tests/rustdoc/where.rs
+++ b/tests/rustdoc/where.rs
@@ -5,16 +5,20 @@ use std::io::Lines;
 pub trait MyTrait { fn dummy(&self) { } }
 
 // @has foo/struct.Alpha.html '//pre' "pub struct Alpha<A>(_) where A: MyTrait"
+// @snapshot alpha_trait_decl - '//*[@class="rust item-decl"]/code'
 pub struct Alpha<A>(A) where A: MyTrait;
 // @has foo/trait.Bravo.html '//pre' "pub trait Bravo<B>where B: MyTrait"
+// @snapshot bravo_trait_decl - '//*[@class="rust item-decl"]/code'
 pub trait Bravo<B> where B: MyTrait { fn get(&self, B: B); }
 // @has foo/fn.charlie.html '//pre' "pub fn charlie<C>()where C: MyTrait"
+// @snapshot charlie_fn_decl - '//*[@class="rust item-decl"]/code'
 pub fn charlie<C>() where C: MyTrait {}
 
 pub struct Delta<D>(D);
 
 // @has foo/struct.Delta.html '//*[@class="impl"]//h3[@class="code-header"]' \
 //          "impl<D> Delta<D>where D: MyTrait"
+// @snapshot SWhere_Echo_impl - '//*[@id="impl-Delta%3CD%3E"]/h3[@class="code-header"]'
 impl<D> Delta<D> where D: MyTrait {
     pub fn delta() {}
 }
@@ -65,4 +69,5 @@ impl<F> MyTrait for Foxtrot<F>where F: MyTrait {}
 
 // @has foo/type.Golf.html '//pre[@class="rust item-decl"]' \
 //          "type Golf<T>where T: Clone, = (T, T)"
+// @snapshot golf_type_alias_decl - '//*[@class="rust item-decl"]/code'
 pub type Golf<T> where T: Clone = (T, T);


### PR DESCRIPTION
Screenshot of the bug:

![image](https://github.com/rust-lang/rust/assets/3050060/090cfeaa-0edc-46c7-9ea0-e26ac865b2c2)

I used this opportunity to clarify the code a bit because some weird things were going on.

r? @notriddle 