### PR TITLE
Enable zlib in LLVM on aarch64-apple-darwin

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/96971
+Last change is for: https://github.com/rust-lang/rust/pull/112931

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -352,7 +352,7 @@ impl Step for Llvm {
         // Disable zstd to avoid a dependency on libzstd.so.
         cfg.define("LLVM_ENABLE_ZSTD", "OFF");
 
-        if target != "aarch64-apple-darwin" && !target.contains("windows") {
+        if !target.contains("windows") {
             cfg.define("LLVM_ENABLE_ZLIB", "ON");
         } else {
             cfg.define("LLVM_ENABLE_ZLIB", "OFF");


### PR DESCRIPTION
Works on macOS 13.4, Xcode version 14.3.1.0.1.1683849156

This was disabled in #75500 on Apple Silicon Developer Transition Kit, but Apple appears to have fixed their zlib now