### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3743,6 +3743,29 @@ impl<'hir> Node<'hir> {
         }
     }
 
+    /// Get the type for constants, assoc types, type aliases and statics.
+    pub fn ty(self) -> Option<&'hir Ty<'hir>> {
+        match self {
+            Node::Item(it) => match it.kind {
+                ItemKind::TyAlias(ty, _) | ItemKind::Static(ty, _, _) | ItemKind::Const(ty, _) => {
+                    Some(ty)
+                }
+                _ => None,
+            },
+            Node::TraitItem(it) => match it.kind {
+                TraitItemKind::Const(ty, _) => Some(ty),
+                TraitItemKind::Type(_, ty) => ty,
+                _ => None,
+            },
+            Node::ImplItem(it) => match it.kind {
+                ImplItemKind::Const(ty, _) => Some(ty),
+                ImplItemKind::Type(ty) => Some(ty),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     pub fn alias_ty(self) -> Option<&'hir Ty<'hir>> {
         match self {
             Node::Item(Item { kind: ItemKind::TyAlias(ty, ..), .. }) => Some(ty),

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -563,8 +563,8 @@ fn check_item_type(tcx: TyCtxt<'_>, id: hir::ItemId) {
             check_union(tcx, id.owner_id.def_id);
         }
         DefKind::OpaqueTy => {
-            let opaque = tcx.hir().expect_item(id.owner_id.def_id).expect_opaque_ty();
-            if let hir::OpaqueTyOrigin::FnReturn(fn_def_id) | hir::OpaqueTyOrigin::AsyncFn(fn_def_id) = opaque.origin
+            let origin = tcx.opaque_type_origin(id.owner_id.def_id);
+            if let hir::OpaqueTyOrigin::FnReturn(fn_def_id) | hir::OpaqueTyOrigin::AsyncFn(fn_def_id) = origin
                 && let hir::Node::TraitItem(trait_item) = tcx.hir().get_by_def_id(fn_def_id)
                 && let (_, hir::TraitFn::Required(..)) = trait_item.expect_fn()
             {

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1543,8 +1543,8 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
         if let ty::Alias(ty::Opaque, unshifted_opaque_ty) = *ty.kind()
             && self.seen.insert(unshifted_opaque_ty.def_id)
             && let Some(opaque_def_id) = unshifted_opaque_ty.def_id.as_local()
-            && let opaque = tcx.hir().expect_item(opaque_def_id).expect_opaque_ty()
-            && let hir::OpaqueTyOrigin::FnReturn(source) | hir::OpaqueTyOrigin::AsyncFn(source) = opaque.origin
+            && let origin = tcx.opaque_type_origin(opaque_def_id)
+            && let hir::OpaqueTyOrigin::FnReturn(source) | hir::OpaqueTyOrigin::AsyncFn(source) = origin
             && source == self.fn_def_id
         {
             let opaque_ty = tcx.fold_regions(unshifted_opaque_ty, |re, _depth| {

--- a/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
@@ -260,7 +260,8 @@ impl<T> Trait<T> for X {
                     (ty::Alias(ty::Opaque, alias), _) | (_, ty::Alias(ty::Opaque, alias)) if alias.def_id.is_local() && matches!(tcx.def_kind(body_owner_def_id), DefKind::AssocFn | DefKind::AssocConst) => {
                         if tcx.is_type_alias_impl_trait(alias.def_id) {
                             if !tcx.opaque_types_defined_by(body_owner_def_id.expect_local()).contains(&alias.def_id.expect_local()) {
-                                diag.span_note(tcx.def_span(body_owner_def_id), "\
+                                let sp = tcx.def_ident_span(body_owner_def_id).unwrap_or_else(|| tcx.def_span(body_owner_def_id));
+                                diag.span_note(sp, "\
                                     this item must have the opaque type in its signature \
                                     in order to be able to register hidden types");
                             }

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -378,7 +378,7 @@ impl<'tcx> InferCtxt<'tcx> {
             DefiningAnchor::Bind(bind) => bind,
         };
 
-        let origin = self.opaque_type_origin_unchecked(def_id);
+        let origin = self.tcx.opaque_type_origin(def_id);
         let in_definition_scope = match origin {
             // Async `impl Trait`
             hir::OpaqueTyOrigin::AsyncFn(parent) => parent == parent_def_id,
@@ -394,13 +394,6 @@ impl<'tcx> InferCtxt<'tcx> {
             }
         };
         in_definition_scope.then_some(origin)
-    }
-
-    /// Returns the origin of the opaque type `def_id` even if we are not in its
-    /// defining scope.
-    #[instrument(skip(self), level = "trace", ret)]
-    fn opaque_type_origin_unchecked(&self, def_id: LocalDefId) -> OpaqueTyOrigin {
-        self.tcx.hir().expect_item(def_id).expect_opaque_ty().origin
     }
 }
 

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3464,7 +3464,8 @@ declare_lint! {
     /// out an update in your own time.
     pub LONG_RUNNING_CONST_EVAL,
     Deny,
-    "detects long const eval operations"
+    "detects long const eval operations",
+    report_in_external_macro
 }
 
 declare_lint! {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1138,8 +1138,8 @@ fn should_encode_type(tcx: TyCtxt<'_>, def_id: LocalDefId, def_kind: DefKind) ->
         | DefKind::InlineConst => true,
 
         DefKind::OpaqueTy => {
-            let opaque = tcx.hir().expect_item(def_id).expect_opaque_ty();
-            if let hir::OpaqueTyOrigin::FnReturn(fn_def_id) | hir::OpaqueTyOrigin::AsyncFn(fn_def_id) = opaque.origin
+            let origin = tcx.opaque_type_origin(def_id);
+            if let hir::OpaqueTyOrigin::FnReturn(fn_def_id) | hir::OpaqueTyOrigin::AsyncFn(fn_def_id) = origin
                 && let hir::Node::TraitItem(trait_item) = tcx.hir().get_by_def_id(fn_def_id)
                 && let (_, hir::TraitFn::Required(..)) = trait_item.expect_fn()
             {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1189,6 +1189,12 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn local_visibility(self, def_id: LocalDefId) -> Visibility {
         self.visibility(def_id).expect_local()
     }
+
+    /// Returns the origin of the opaque type `def_id`.
+    #[instrument(skip(self), level = "trace", ret)]
+    pub fn opaque_type_origin(self, def_id: LocalDefId) -> hir::OpaqueTyOrigin {
+        self.hir().expect_item(def_id).expect_opaque_ty().origin
+    }
 }
 
 /// A trait implemented for all `X<'a>` types that can be safely and

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -69,8 +69,6 @@ where
         make_query: fn(Qcx, K) -> QueryStackFrame<D>,
         jobs: &mut QueryMap<D>,
     ) -> Option<()> {
-        let mut active = Vec::new();
-
         #[cfg(parallel_compiler)]
         {
             // We use try_lock_shards here since we are called from the
@@ -79,7 +77,8 @@ where
             for shard in shards.iter() {
                 for (k, v) in shard.iter() {
                     if let QueryResult::Started(ref job) = *v {
-                        active.push((*k, job.clone()));
+                        let query = make_query(qcx, *k);
+                        jobs.insert(job.id, QueryJobInfo { query, job: job.clone() });
                     }
                 }
             }
@@ -92,16 +91,10 @@ where
             // really hurt much.)
             for (k, v) in self.active.try_lock()?.iter() {
                 if let QueryResult::Started(ref job) = *v {
-                    active.push((*k, job.clone()));
+                    let query = make_query(qcx, *k);
+                    jobs.insert(job.id, QueryJobInfo { query, job: job.clone() });
                 }
             }
-        }
-
-        // Call `make_query` while we're not holding a `self.active` lock as `make_query` may call
-        // queries leading to a deadlock.
-        for (key, job) in active {
-            let query = make_query(qcx, key);
-            jobs.insert(job.id, QueryJobInfo { query, job });
         }
 
         Some(())

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -259,7 +259,7 @@ fn associated_type_for_impl_trait_in_trait(
     opaque_ty_def_id: LocalDefId,
 ) -> LocalDefId {
     let (hir::OpaqueTyOrigin::FnReturn(fn_def_id) | hir::OpaqueTyOrigin::AsyncFn(fn_def_id)) =
-        tcx.hir().expect_item(opaque_ty_def_id).expect_opaque_ty().origin
+        tcx.opaque_type_origin(opaque_ty_def_id)
     else {
         bug!("expected opaque for {opaque_ty_def_id:?}");
     };

--- a/compiler/rustc_ty_utils/src/errors.rs
+++ b/compiler/rustc_ty_utils/src/errors.rs
@@ -113,7 +113,7 @@ pub struct DuplicateArg<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(ty_utils_impl_trait_not_param)]
+#[diag(ty_utils_impl_trait_not_param, code = "E0792")]
 pub struct NotParam<'tcx> {
     pub arg: GenericArg<'tcx>,
     #[primary_span]

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -72,13 +72,14 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for OpaqueTypeCollector<'tcx> {
                 if !self.seen.insert(alias_ty.def_id.expect_local()) {
                     return ControlFlow::Continue(());
                 }
+
+                self.opaques.push(alias_ty.def_id.expect_local());
+
                 match self.tcx.uses_unique_generic_params(alias_ty.substs, CheckRegions::Bound) {
                     Ok(()) => {
                         // FIXME: implement higher kinded lifetime bounds on nested opaque types. They are not
                         // supported at all, so this is sound to do, but once we want to support them, you'll
                         // start seeing the error below.
-
-                        self.opaques.push(alias_ty.def_id.expect_local());
 
                         // Collect opaque types nested within the associated type bounds of this opaque type.
                         for (pred, span) in self

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -217,7 +217,9 @@ fn opaque_types_defined_by<'tcx>(tcx: TyCtxt<'tcx>, item: LocalDefId) -> &'tcx [
         | DefKind::GlobalAsm
         | DefKind::Impl { .. }
         | DefKind::Closure
-        | DefKind::Generator => &[],
+        | DefKind::Generator => {
+            span_bug!(tcx.def_span(item), "{kind:?} is type checked as part of its parent")
+        }
     }
 }
 

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -177,13 +177,9 @@ fn opaque_types_defined_by<'tcx>(tcx: TyCtxt<'tcx>, item: LocalDefId) -> &'tcx [
                     }
                 }
                 DefKind::AssocTy | DefKind::AssocConst => {
-                    let span = match tcx.hir().get_by_def_id(item) {
-                        rustc_hir::Node::ImplItem(it) => match it.kind {
-                            rustc_hir::ImplItemKind::Const(ty, _) => ty.span,
-                            rustc_hir::ImplItemKind::Type(ty) => ty.span,
-                            other => span_bug!(tcx.def_span(item), "{other:#?}"),
-                        },
-                        other => span_bug!(tcx.def_span(item), "{other:#?}"),
+                    let span = match tcx.hir().get_by_def_id(item).ty() {
+                        Some(ty) => ty.span,
+                        _ => tcx.def_span(item),
                     };
                     collector.visit_spanned(span, tcx.type_of(item).subst_identity());
                 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -347,13 +347,19 @@ pub(crate) fn print_where_clause<'a, 'tcx: 'a>(
             }
         } else {
             let mut br_with_padding = String::with_capacity(6 * indent + 28);
-            br_with_padding.push_str("\n");
+            br_with_padding.push('\n');
 
-            let padding_amount =
-                if ending == Ending::Newline { indent + 4 } else { indent + "fn where ".len() };
+            let where_indent = 3;
+            let padding_amount = if ending == Ending::Newline {
+                indent + 4
+            } else if indent == 0 {
+                4
+            } else {
+                indent + where_indent + "where ".len()
+            };
 
             for _ in 0..padding_amount {
-                br_with_padding.push_str(" ");
+                br_with_padding.push(' ');
             }
             let where_preds = where_preds.to_string().replace('\n', &br_with_padding);
 
@@ -370,7 +376,8 @@ pub(crate) fn print_where_clause<'a, 'tcx: 'a>(
                     let where_preds = where_preds.replacen(&br_with_padding, " ", 1);
 
                     let mut clause = br_with_padding;
-                    clause.truncate(clause.len() - "where ".len());
+                    // +1 is for `\n`.
+                    clause.truncate(indent + 1 + where_indent);
 
                     write!(clause, "<span class=\"where\">where{where_preds}</span>")?;
                     clause

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -859,8 +859,8 @@ fn assoc_method(
     w.reserve(header_len + "<a href=\"\" class=\"fn\">{".len() + "</a>".len());
     write!(
         w,
-        "{indent}{vis}{constness}{asyncness}{unsafety}{defaultness}{abi}fn <a{href} class=\"fn\">{name}</a>\
-         {generics}{decl}{notable_traits}{where_clause}",
+        "{indent}{vis}{constness}{asyncness}{unsafety}{defaultness}{abi}fn \
+         <a{href} class=\"fn\">{name}</a>{generics}{decl}{notable_traits}{where_clause}",
         indent = indent_str,
         vis = vis,
         constness = constness,

--- a/tests/codegen/sanitizer-cfi-emit-type-metadata-id-itanium-cxx-abi.rs
+++ b/tests/codegen/sanitizer-cfi-emit-type-metadata-id-itanium-cxx-abi.rs
@@ -61,7 +61,19 @@ pub type Type9 = impl Send;
 pub type Type10 = impl Send;
 pub type Type11 = impl Send;
 
-pub fn fn1<'a>() {
+pub fn fn1<'a>() where
+    Type1: 'static,
+    Type2: 'static,
+    Type3: 'static,
+    Type4: 'static,
+    Type5: 'static,
+    Type6: 'static,
+    Type7: 'static,
+    Type8: 'static,
+    Type9: 'static,
+    Type10: 'static,
+    Type11: 'static,
+{
     // Closure
     let closure1 = || { };
     let _: Type1 = closure1;

--- a/tests/rustdoc/where.SWhere_Echo_impl.html
+++ b/tests/rustdoc/where.SWhere_Echo_impl.html
@@ -1,0 +1,2 @@
+<h3 class="code-header">impl&lt;D&gt; <a class="struct" href="struct.Delta.html" title="struct foo::Delta">Delta</a>&lt;D&gt;<span class="where fmt-newline">where
+    D: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a>,</span></h3>

--- a/tests/rustdoc/where.SWhere_Simd_item-decl.html
+++ b/tests/rustdoc/where.SWhere_Simd_item-decl.html
@@ -1,3 +1,3 @@
 <pre class="rust item-decl"><code>pub struct Simd&lt;T&gt;(_)
 <span class="where">where
-         T: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a></span>;</code></pre>
+    T: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a></span>;</code></pre>

--- a/tests/rustdoc/where.alpha_trait_decl.html
+++ b/tests/rustdoc/where.alpha_trait_decl.html
@@ -1,0 +1,3 @@
+<code>pub struct Alpha&lt;A&gt;(_)
+<span class="where">where
+    A: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a></span>;</code>

--- a/tests/rustdoc/where.bravo_trait_decl.html
+++ b/tests/rustdoc/where.bravo_trait_decl.html
@@ -1,0 +1,5 @@
+<code>pub trait Bravo&lt;B&gt;<span class="where fmt-newline">where
+    B: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a>,</span>{
+    // Required method
+    fn <a href="#tymethod.get" class="fn">get</a>(&amp;self, B: B);
+}</code>

--- a/tests/rustdoc/where.charlie_fn_decl.html
+++ b/tests/rustdoc/where.charlie_fn_decl.html
@@ -1,0 +1,2 @@
+<code>pub fn charlie&lt;C&gt;()<span class="where fmt-newline">where
+    C: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a>,</span></code>

--- a/tests/rustdoc/where.golf_type_alias_decl.html
+++ b/tests/rustdoc/where.golf_type_alias_decl.html
@@ -1,0 +1,2 @@
+<code>pub type Golf&lt;T&gt;<span class="where fmt-newline">where
+    T: <a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>,</span> = <a class="primitive" href="{{channel}}/std/primitive.tuple.html">(T, T)</a>;</code>

--- a/tests/rustdoc/where.rs
+++ b/tests/rustdoc/where.rs
@@ -5,16 +5,20 @@ use std::io::Lines;
 pub trait MyTrait { fn dummy(&self) { } }
 
 // @has foo/struct.Alpha.html '//pre' "pub struct Alpha<A>(_) where A: MyTrait"
+// @snapshot alpha_trait_decl - '//*[@class="rust item-decl"]/code'
 pub struct Alpha<A>(A) where A: MyTrait;
 // @has foo/trait.Bravo.html '//pre' "pub trait Bravo<B>where B: MyTrait"
+// @snapshot bravo_trait_decl - '//*[@class="rust item-decl"]/code'
 pub trait Bravo<B> where B: MyTrait { fn get(&self, B: B); }
 // @has foo/fn.charlie.html '//pre' "pub fn charlie<C>()where C: MyTrait"
+// @snapshot charlie_fn_decl - '//*[@class="rust item-decl"]/code'
 pub fn charlie<C>() where C: MyTrait {}
 
 pub struct Delta<D>(D);
 
 // @has foo/struct.Delta.html '//*[@class="impl"]//h3[@class="code-header"]' \
 //          "impl<D> Delta<D>where D: MyTrait"
+// @snapshot SWhere_Echo_impl - '//*[@id="impl-Delta%3CD%3E"]/h3[@class="code-header"]'
 impl<D> Delta<D> where D: MyTrait {
     pub fn delta() {}
 }
@@ -65,4 +69,5 @@ impl<F> MyTrait for Foxtrot<F>where F: MyTrait {}
 
 // @has foo/type.Golf.html '//pre[@class="rust item-decl"]' \
 //          "type Golf<T>where T: Clone, = (T, T)"
+// @snapshot golf_type_alias_decl - '//*[@class="rust item-decl"]/code'
 pub type Golf<T> where T: Clone = (T, T);

--- a/tests/ui/consts/timeout.rs
+++ b/tests/ui/consts/timeout.rs
@@ -1,0 +1,25 @@
+//! This test checks that external macros don't hide
+//! the const eval timeout lint and then subsequently
+//! ICE.
+
+// compile-flags: --crate-type=lib -Ztiny-const-eval-limit
+// error-pattern: constant evaluation is taking a long time
+
+static ROOK_ATTACKS_TABLE: () = {
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+    0_u64.count_ones();
+};

--- a/tests/ui/consts/timeout.stderr
+++ b/tests/ui/consts/timeout.stderr
@@ -1,0 +1,15 @@
+error: constant evaluation is taking a long time
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+   |
+   = note: this lint makes sure the compiler doesn't get stuck due to infinite loops in const eval.
+           If your compilation actually takes a long time, you can safely allow the lint.
+help: the constant being evaluated
+  --> $DIR/timeout.rs:8:1
+   |
+LL | static ROOK_ATTACKS_TABLE: () = {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(long_running_const_eval)]` on by default
+   = note: this error originates in the macro `uint_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/tests/ui/generic-associated-types/issue-88595.rs
+++ b/tests/ui/generic-associated-types/issue-88595.rs
@@ -19,5 +19,4 @@ impl<'a> A<'a> for C {
     type B<'b> = impl Clone;
 
     fn a(&'a self) -> Self::B<'a> {} //~ ERROR: non-defining opaque type use in defining scope
-    //~^ ERROR: mismatched types
 }

--- a/tests/ui/generic-associated-types/issue-88595.stderr
+++ b/tests/ui/generic-associated-types/issue-88595.stderr
@@ -1,8 +1,8 @@
 error: non-defining opaque type use in defining scope
-  --> $DIR/issue-88595.rs:21:5
+  --> $DIR/issue-88595.rs:21:23
    |
 LL |     fn a(&'a self) -> Self::B<'a> {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ generic argument `'a` used twice
+   |                       ^^^^^^^^^^^ generic argument `'a` used twice
    |
 note: for this opaque type
   --> $DIR/issue-88595.rs:19:18
@@ -24,10 +24,10 @@ LL |     fn a(&'a self) -> Self::B<'a> {}
    = note: expected opaque type `<C as A<'a>>::B<'a>`
                 found unit type `()`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/issue-88595.rs:21:5
+  --> $DIR/issue-88595.rs:21:8
    |
 LL |     fn a(&'a self) -> Self::B<'a> {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generic-associated-types/issue-88595.stderr
+++ b/tests/ui/generic-associated-types/issue-88595.stderr
@@ -10,25 +10,5 @@ note: for this opaque type
 LL |     type B<'b> = impl Clone;
    |                  ^^^^^^^^^^
 
-error[E0308]: mismatched types
-  --> $DIR/issue-88595.rs:21:23
-   |
-LL |     type B<'b> = impl Clone;
-   |                  ---------- the expected opaque type
-LL |
-LL |     fn a(&'a self) -> Self::B<'a> {}
-   |        -              ^^^^^^^^^^^ expected opaque type, found `()`
-   |        |
-   |        implicitly returns `()` as its body has no tail or `return` expression
-   |
-   = note: expected opaque type `<C as A<'a>>::B<'a>`
-                found unit type `()`
-note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/issue-88595.rs:21:8
-   |
-LL |     fn a(&'a self) -> Self::B<'a> {}
-   |        ^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/in-assoc-type-unconstrained.stderr
+++ b/tests/ui/impl-trait/in-assoc-type-unconstrained.stderr
@@ -40,10 +40,10 @@ LL |         fn method() -> Self::Ty;
    = note: expected signature `fn() -> <() as compare_method::Trait>::Ty`
               found signature `fn()`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/in-assoc-type-unconstrained.rs:22:9
+  --> $DIR/in-assoc-type-unconstrained.rs:22:12
    |
 LL |         fn method() -> () {}
-   |         ^^^^^^^^^^^^^^^^^
+   |            ^^^^^^
 
 error: unconstrained opaque type
   --> $DIR/in-assoc-type-unconstrained.rs:20:19

--- a/tests/ui/impl-trait/in-assoc-type.stderr
+++ b/tests/ui/impl-trait/in-assoc-type.stderr
@@ -12,10 +12,10 @@ LL |     fn foo(&self) -> <Self as Foo<()>>::Bar {}
    = note: expected opaque type `<() as Foo<()>>::Bar`
                 found unit type `()`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/in-assoc-type.rs:17:5
+  --> $DIR/in-assoc-type.rs:17:8
    |
 LL |     fn foo(&self) -> <Self as Foo<()>>::Bar {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
@@ -20,11 +20,6 @@ LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
    |
    = note: expected signature `fn(&a::Bar, &(a::Bar, i32)) -> _`
               found signature `fn(&a::Bar, &(a::Foo, i32)) -> _`
-note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:10:12
-   |
-LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
-   |            ^^
 
 error: unconstrained opaque type
   --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:18:16

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
@@ -21,10 +21,10 @@ LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
    = note: expected signature `fn(&a::Bar, &(a::Bar, i32)) -> _`
               found signature `fn(&a::Bar, &(a::Foo, i32)) -> _`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:10:9
+  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:10:12
    |
 LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^
 
 error: unconstrained opaque type
   --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:18:16
@@ -49,10 +49,10 @@ LL |         fn eq(&self, _other: &(Bar, i32)) -> bool {
    = note: expected signature `fn(&b::Bar, &(b::Foo, i32)) -> _`
               found signature `fn(&b::Bar, &(b::Bar, i32)) -> _`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:24:9
+  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:24:12
    |
 LL |         fn eq(&self, _other: &(Bar, i32)) -> bool {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/treat-err-as-bug/panic-causes-oom-112708.rs
+++ b/tests/ui/treat-err-as-bug/panic-causes-oom-112708.rs
@@ -1,0 +1,11 @@
+// compile-flags: -Ztreat-err-as-bug
+// dont-check-failure-status
+// error-pattern: aborting due to `-Z treat-err-as-bug=1`
+// normalize-stderr-test "note: .*\n\n" -> ""
+// normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+// rustc-env:RUST_BACKTRACE=0
+
+fn main() {
+    #[deny(while_true)]
+    while true {}
+}

--- a/tests/ui/treat-err-as-bug/panic-causes-oom-112708.stderr
+++ b/tests/ui/treat-err-as-bug/panic-causes-oom-112708.stderr
@@ -1,0 +1,16 @@
+error: denote infinite loops with `loop { ... }`
+  --> $DIR/panic-causes-oom-112708.rs:10:5
+   |
+LL |     while true {}
+   |     ^^^^^^^^^^ help: use `loop`
+   |
+note: the lint level is defined here
+  --> $DIR/panic-causes-oom-112708.rs:9:12
+   |
+LL |     #[deny(while_true)]
+   |            ^^^^^^^^^^
+
+error: the compiler unexpectedly panicked. this is a bug.
+
+query stack during panic:
+thread panicked while processing panic. aborting.

--- a/tests/ui/type-alias-impl-trait/hidden_behind_projection_behind_struct_field.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_projection_behind_struct_field.rs
@@ -1,0 +1,28 @@
+//! This test shows that a field type that is a projection that resolves to an opaque,
+//! is not a defining use. While we could substitute the struct generics, that would
+//! mean we would have to walk all substitutions of an `Foo`, which can quickly
+//! degenerate into looking at an exponential number of types depending on the complexity
+//! of a program.
+
+#![feature(impl_trait_in_assoc_type)]
+
+struct Bar;
+
+trait Trait: Sized {
+    type Assoc;
+    fn foo() -> Foo<Self>;
+}
+
+impl Trait for Bar {
+    type Assoc = impl std::fmt::Debug;
+    fn foo() -> Foo<Bar> {
+        Foo { field: () }
+        //~^ ERROR: mismatched types
+    }
+}
+
+struct Foo<T: Trait> {
+    field: <T as Trait>::Assoc,
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/hidden_behind_projection_behind_struct_field.stderr
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_projection_behind_struct_field.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/hidden_behind_projection_behind_struct_field.rs:19:22
+   |
+LL |     type Assoc = impl std::fmt::Debug;
+   |                  -------------------- the expected opaque type
+LL |     fn foo() -> Foo<Bar> {
+LL |         Foo { field: () }
+   |                      ^^ expected opaque type, found `()`
+   |
+   = note: expected opaque type `<Bar as Trait>::Assoc`
+                found unit type `()`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
+  --> $DIR/hidden_behind_projection_behind_struct_field.rs:18:8
+   |
+LL |     fn foo() -> Foo<Bar> {
+   |        ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field.rs
@@ -1,0 +1,30 @@
+//! This test shows that the appearance of an opaque type
+//! in the substs of a struct are enough to make it count
+//! for making the function a defining use. It doesn't matter
+//! if the opaque type is actually used in the field.
+
+#![feature(impl_trait_in_assoc_type)]
+// check-pass
+
+use std::marker::PhantomData;
+
+struct Bar;
+
+trait Trait: Sized {
+    type Assoc;
+    fn foo() -> Foo<Self::Assoc>;
+}
+
+impl Trait for Bar {
+    type Assoc = impl std::fmt::Debug;
+    fn foo() -> Foo<Self::Assoc> {
+        let foo: Foo<()> = Foo { field: PhantomData };
+        foo
+    }
+}
+
+struct Foo<T> {
+    field: PhantomData<T>,
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field2.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field2.rs
@@ -1,0 +1,26 @@
+//! This test shows that we can even follow projections
+//! into associated types of the same impl if they are
+//! indirectly mentioned in a struct field.
+
+#![feature(impl_trait_in_assoc_type)]
+// check-pass
+
+struct Bar;
+
+trait Trait: Sized {
+    type Assoc;
+    fn foo() -> Foo;
+}
+
+impl Trait for Bar {
+    type Assoc = impl std::fmt::Debug;
+    fn foo() -> Foo {
+        Foo { field: () }
+    }
+}
+
+struct Foo {
+    field: <Bar as Trait>::Assoc,
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/higher_kinded_params3.rs
+++ b/tests/ui/type-alias-impl-trait/higher_kinded_params3.rs
@@ -1,0 +1,35 @@
+//! This test checks that we can't actually have an opaque type behind
+//! a binder that references variables from that binder.
+
+// edition: 2021
+
+#![feature(type_alias_impl_trait)]
+
+trait B {
+    type C;
+}
+
+struct A;
+
+impl<'a> B for &'a A {
+    type C = Tait<'a>;
+}
+
+type Tait<'a> = impl std::fmt::Debug + 'a;
+
+struct Terminator;
+
+type Successors<'a> = impl std::fmt::Debug + 'a;
+
+impl Terminator {
+    fn successors(&self, mut f: for<'x> fn(&'x ()) -> <&'x A as B>::C) -> Successors<'_> {
+        f = g;
+        //~^ ERROR: mismatched types
+    }
+}
+
+fn g(x: &()) -> &() {
+    x
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/higher_kinded_params3.stderr
+++ b/tests/ui/type-alias-impl-trait/higher_kinded_params3.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/higher_kinded_params3.rs:26:9
+   |
+LL | type Tait<'a> = impl std::fmt::Debug + 'a;
+   |                 ------------------------- the expected opaque type
+...
+LL |         f = g;
+   |         ^^^^^ one type is more general than the other
+   |
+   = note: expected fn pointer `for<'x> fn(&'x ()) -> Tait<'x>`
+              found fn pointer `for<'a> fn(&'a ()) -> &'a ()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/invalid_impl_trait_in_assoc_ty.stderr
+++ b/tests/ui/type-alias-impl-trait/invalid_impl_trait_in_assoc_ty.stderr
@@ -12,10 +12,10 @@ LL |         let x: Self::Foo = ();
    = note: expected opaque type `<() as Foo>::Foo`
                 found unit type `()`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/invalid_impl_trait_in_assoc_ty.rs:10:5
+  --> $DIR/invalid_impl_trait_in_assoc_ty.rs:10:8
    |
 LL |     fn bar() {
-   |     ^^^^^^^^
+   |        ^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/type-alias-impl-trait/multi-error.rs
+++ b/tests/ui/type-alias-impl-trait/multi-error.rs
@@ -18,7 +18,6 @@ impl Foo for () {
         //~^ ERROR non-defining opaque type use
         ((), ())
         //~^ ERROR mismatched types
-        //~| ERROR mismatched types
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/multi-error.rs
+++ b/tests/ui/type-alias-impl-trait/multi-error.rs
@@ -17,7 +17,6 @@ impl Foo for () {
     fn foo() -> (Self::Bar<u32>, Self::Baz) {
         //~^ ERROR non-defining opaque type use
         ((), ())
-        //~^ ERROR mismatched types
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/multi-error.rs
+++ b/tests/ui/type-alias-impl-trait/multi-error.rs
@@ -1,0 +1,25 @@
+//! This test checks that we don't follow up
+//! with type mismatch errors of opaque types
+//! with their hidden types if we failed the
+//! defining scope check at the signature level.
+
+#![feature(impl_trait_in_assoc_type)]
+
+trait Foo {
+    type Bar<T>;
+    type Baz;
+    fn foo() -> (Self::Bar<u32>, Self::Baz);
+}
+
+impl Foo for () {
+    type Bar<T> = impl Sized;
+    type Baz = impl Sized;
+    fn foo() -> (Self::Bar<u32>, Self::Baz) {
+        //~^ ERROR non-defining opaque type use
+        ((), ())
+        //~^ ERROR mismatched types
+        //~| ERROR mismatched types
+    }
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/multi-error.stderr
+++ b/tests/ui/type-alias-impl-trait/multi-error.stderr
@@ -10,23 +10,5 @@ note: for this opaque type
 LL |     type Bar<T> = impl Sized;
    |                   ^^^^^^^^^^
 
-error[E0308]: mismatched types
-  --> $DIR/multi-error.rs:19:10
-   |
-LL |     type Bar<T> = impl Sized;
-   |                   ---------- the expected opaque type
-...
-LL |         ((), ())
-   |          ^^ expected opaque type, found `()`
-   |
-   = note: expected opaque type `<() as Foo>::Bar<u32>`
-                found unit type `()`
-note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/multi-error.rs:17:8
-   |
-LL |     fn foo() -> (Self::Bar<u32>, Self::Baz) {
-   |        ^^^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/multi-error.stderr
+++ b/tests/ui/type-alias-impl-trait/multi-error.stderr
@@ -1,4 +1,4 @@
-error: non-defining opaque type use in defining scope
+error[E0792]: non-defining opaque type use in defining scope
   --> $DIR/multi-error.rs:17:17
    |
 LL |     fn foo() -> (Self::Bar<u32>, Self::Baz) {
@@ -12,3 +12,4 @@ LL |     type Bar<T> = impl Sized;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/multi-error.stderr
+++ b/tests/ui/type-alias-impl-trait/multi-error.stderr
@@ -27,23 +27,6 @@ note: this item must have the opaque type in its signature in order to be able t
 LL |     fn foo() -> (Self::Bar<u32>, Self::Baz) {
    |        ^^^
 
-error[E0308]: mismatched types
-  --> $DIR/multi-error.rs:19:14
-   |
-LL |     type Baz = impl Sized;
-   |                ---------- the expected opaque type
-...
-LL |         ((), ())
-   |              ^^ expected opaque type, found `()`
-   |
-   = note: expected opaque type `<() as Foo>::Baz`
-                found unit type `()`
-note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/multi-error.rs:17:8
-   |
-LL |     fn foo() -> (Self::Bar<u32>, Self::Baz) {
-   |        ^^^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/multi-error.stderr
+++ b/tests/ui/type-alias-impl-trait/multi-error.stderr
@@ -1,0 +1,49 @@
+error: non-defining opaque type use in defining scope
+  --> $DIR/multi-error.rs:17:17
+   |
+LL |     fn foo() -> (Self::Bar<u32>, Self::Baz) {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument `u32` is not a generic parameter
+   |
+note: for this opaque type
+  --> $DIR/multi-error.rs:15:19
+   |
+LL |     type Bar<T> = impl Sized;
+   |                   ^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/multi-error.rs:19:10
+   |
+LL |     type Bar<T> = impl Sized;
+   |                   ---------- the expected opaque type
+...
+LL |         ((), ())
+   |          ^^ expected opaque type, found `()`
+   |
+   = note: expected opaque type `<() as Foo>::Bar<u32>`
+                found unit type `()`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
+  --> $DIR/multi-error.rs:17:8
+   |
+LL |     fn foo() -> (Self::Bar<u32>, Self::Baz) {
+   |        ^^^
+
+error[E0308]: mismatched types
+  --> $DIR/multi-error.rs:19:14
+   |
+LL |     type Baz = impl Sized;
+   |                ---------- the expected opaque type
+...
+LL |         ((), ())
+   |              ^^ expected opaque type, found `()`
+   |
+   = note: expected opaque type `<() as Foo>::Baz`
+                found unit type `()`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
+  --> $DIR/multi-error.rs:17:8
+   |
+LL |     fn foo() -> (Self::Bar<u32>, Self::Baz) {
+   |        ^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/non-defining-method.rs
+++ b/tests/ui/type-alias-impl-trait/non-defining-method.rs
@@ -15,7 +15,6 @@ impl Foo for () {
     type Bar<T> = impl Sized;
     fn foo() -> Self::Bar<u32> {}
     //~^ ERROR non-defining opaque type use
-    //~| ERROR mismatched types
     fn bar<T>() -> Self::Bar<T> {}
 }
 

--- a/tests/ui/type-alias-impl-trait/non-defining-method.rs
+++ b/tests/ui/type-alias-impl-trait/non-defining-method.rs
@@ -1,0 +1,22 @@
+//! This test checks that we don't follow up
+//! with type mismatch errors of opaque types
+//! with their hidden types if we failed the
+//! defining scope check at the signature level.
+
+#![feature(impl_trait_in_assoc_type)]
+
+trait Foo {
+    type Bar<T>;
+    fn foo() -> Self::Bar<u32>;
+    fn bar<T>() -> Self::Bar<T>;
+}
+
+impl Foo for () {
+    type Bar<T> = impl Sized;
+    fn foo() -> Self::Bar<u32> {}
+    //~^ ERROR non-defining opaque type use
+    //~| ERROR mismatched types
+    fn bar<T>() -> Self::Bar<T> {}
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/non-defining-method.stderr
+++ b/tests/ui/type-alias-impl-trait/non-defining-method.stderr
@@ -1,0 +1,33 @@
+error: non-defining opaque type use in defining scope
+  --> $DIR/non-defining-method.rs:16:17
+   |
+LL |     fn foo() -> Self::Bar<u32> {}
+   |                 ^^^^^^^^^^^^^^ argument `u32` is not a generic parameter
+   |
+note: for this opaque type
+  --> $DIR/non-defining-method.rs:15:19
+   |
+LL |     type Bar<T> = impl Sized;
+   |                   ^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/non-defining-method.rs:16:17
+   |
+LL |     type Bar<T> = impl Sized;
+   |                   ---------- the expected opaque type
+LL |     fn foo() -> Self::Bar<u32> {}
+   |        ---      ^^^^^^^^^^^^^^ expected opaque type, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note: expected opaque type `<() as Foo>::Bar<u32>`
+                found unit type `()`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
+  --> $DIR/non-defining-method.rs:16:8
+   |
+LL |     fn foo() -> Self::Bar<u32> {}
+   |        ^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/non-defining-method.stderr
+++ b/tests/ui/type-alias-impl-trait/non-defining-method.stderr
@@ -10,24 +10,5 @@ note: for this opaque type
 LL |     type Bar<T> = impl Sized;
    |                   ^^^^^^^^^^
 
-error[E0308]: mismatched types
-  --> $DIR/non-defining-method.rs:16:17
-   |
-LL |     type Bar<T> = impl Sized;
-   |                   ---------- the expected opaque type
-LL |     fn foo() -> Self::Bar<u32> {}
-   |        ---      ^^^^^^^^^^^^^^ expected opaque type, found `()`
-   |        |
-   |        implicitly returns `()` as its body has no tail or `return` expression
-   |
-   = note: expected opaque type `<() as Foo>::Bar<u32>`
-                found unit type `()`
-note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/non-defining-method.rs:16:8
-   |
-LL |     fn foo() -> Self::Bar<u32> {}
-   |        ^^^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/non-defining-method.stderr
+++ b/tests/ui/type-alias-impl-trait/non-defining-method.stderr
@@ -1,4 +1,4 @@
-error: non-defining opaque type use in defining scope
+error[E0792]: non-defining opaque type use in defining scope
   --> $DIR/non-defining-method.rs:16:17
    |
 LL |     fn foo() -> Self::Bar<u32> {}
@@ -12,3 +12,4 @@ LL |     type Bar<T> = impl Sized;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/not-matching-trait-refs-isnt-defining.stderr
+++ b/tests/ui/type-alias-impl-trait/not-matching-trait-refs-isnt-defining.stderr
@@ -12,10 +12,10 @@ LL |         let _: <Self as Foo<DefinesOpaque>>::Assoc = "";
    = note: expected opaque type `<() as Foo<DefinesOpaque>>::Assoc`
                 found reference `&'static str`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/not-matching-trait-refs-isnt-defining.rs:16:5
+  --> $DIR/not-matching-trait-refs-isnt-defining.rs:16:8
    |
 LL |     fn test() -> <() as Foo<NoOpaques>>::Assoc {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/type-alias-impl-trait/unnameable_type.stderr
+++ b/tests/ui/type-alias-impl-trait/unnameable_type.stderr
@@ -25,11 +25,6 @@ LL |         fn dont_define_this(_private: Private) {}
    |                                       ^^^^^^^
    = note: expected signature `fn(Private)`
               found signature `fn(MyPrivate)`
-note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/unnameable_type.rs:20:8
-   |
-LL |     fn dont_define_this(_private: MyPrivate) {}
-   |        ^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/unnameable_type.stderr
+++ b/tests/ui/type-alias-impl-trait/unnameable_type.stderr
@@ -26,10 +26,10 @@ LL |         fn dont_define_this(_private: Private) {}
    = note: expected signature `fn(Private)`
               found signature `fn(MyPrivate)`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/unnameable_type.rs:20:5
+  --> $DIR/unnameable_type.rs:20:8
    |
 LL |     fn dont_define_this(_private: MyPrivate) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #112708 (Revert "Don't hold the active queries lock while calling `make_query`")
 - #112891 (Various impl trait in assoc tys cleanups)
 - #112925 (Stop hiding const eval limit in external macros)
 - #112927 (Fix indentation for where clause in rustdoc pages)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112708,112891,112925,112927)
<!-- homu-ignore:end -->