### PR TITLE
Add illumos aarch64 target for rust.

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_illumos.rs
@@ -1,0 +1,19 @@
+use crate::spec::{Cc, LinkerFlavor, SanitizerSet, Target};
+
+pub fn target() -> Target {
+    let mut base = super::illumos_base::opts();
+    base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-std=c99"]);
+    base.cpu = "aarch64".into();
+    base.max_atomic_width = Some(128);
+    base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI;
+
+    Target {
+        // LLVM does not currently have a separate illumos target,
+        // so we still pass Solaris to it
+        llvm_target: "aarch64-unknown-solaris2.11".into(),
+        pointer_width: 64,
+        data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
+        arch: "aarch64".into(),
+        options: base,
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1586,6 +1586,7 @@ supported_targets! {
     ("sparcv9-sun-solaris", sparcv9_sun_solaris),
 
     ("x86_64-unknown-illumos", x86_64_unknown_illumos),
+    ("aarch64-unknown-illumos", aarch64_unknown_illumos),
 
     ("x86_64-pc-windows-gnu", x86_64_pc_windows_gnu),
     ("i686-pc-windows-gnu", i686_pc_windows_gnu),

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_illumos.rs
@@ -1,7 +1,7 @@
-use crate::spec::{Cc, LinkerFlavor, SanitizerSet, Target};
+use crate::spec::{base, Cc, LinkerFlavor, SanitizerSet, Target};
 
 pub fn target() -> Target {
-    let mut base = super::illumos_base::opts();
+    let mut base = base::illumos::opts();
     base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-std=c99"]);
     base.cpu = "aarch64".into();
     base.max_atomic_width = Some(128);

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_illumos.rs
@@ -3,9 +3,9 @@ use crate::spec::{base, Cc, LinkerFlavor, SanitizerSet, Target};
 pub fn target() -> Target {
     let mut base = base::illumos::opts();
     base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-std=c99"]);
-    base.cpu = "aarch64".into();
     base.max_atomic_width = Some(128);
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI;
+    base.features = "+v8a".into();
 
     Target {
         // LLVM does not currently have a separate illumos target,

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -229,6 +229,7 @@ target | std | host | notes
 [`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS |
 `aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
 [`aarch64-unknown-hermit`](platform-support/hermit.md) | ✓ |  | ARM64 Hermit
+`aarch64-unknown-illumos` | ✓ | ✓ | ARM64 illumos
 `aarch64-unknown-linux-gnu_ilp32` | ✓ | ✓ | ARM64 Linux (ILP32 ABI)
 [`aarch64-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | ARM64 NetBSD
 [`aarch64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | ARM64 OpenBSD


### PR DESCRIPTION
This adds the newly being developed illumos aarch64 target to the rust compiler. 

@rmustacc @citrus-it @richlowe As promissed before my hiatus :)