### PR TITLE
(re-)tighten sourceinfo span of adjustments in MIR

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1121,7 +1121,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                             err.eager_subdiagnostic(
                                 &self.infcx.tcx.sess.parse_sess.span_diagnostic,
                                 CaptureReasonSuggest::FreshReborrow {
-                                    span: fn_call_span.shrink_to_lo(),
+                                    span: move_span.shrink_to_hi(),
                                 });
                         }
                         if let Some(clone_trait) = tcx.lang_items().clone_trait()

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1135,10 +1135,10 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                             && self.infcx.predicate_must_hold_modulo_regions(&o)
                         {
                             err.span_suggestion_verbose(
-                                fn_call_span.shrink_to_lo(),
+                                move_span.shrink_to_hi(),
                                 "you can `clone` the value and consume it, but this might not be \
                                  your desired behavior",
-                                "clone().".to_string(),
+                                ".clone()".to_string(),
                                 Applicability::MaybeIncorrect,
                             );
                         }

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -398,7 +398,7 @@ pub(crate) enum CaptureReasonSuggest<'tcx> {
     #[suggestion(
         borrowck_suggest_create_freash_reborrow,
         applicability = "maybe-incorrect",
-        code = "as_mut().",
+        code = ".as_mut()",
         style = "verbose"
     )]
     FreshReborrow {

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -16,7 +16,6 @@ use rustc_hir::Node;
 use rustc_middle::middle::region;
 use rustc_middle::thir::*;
 use rustc_middle::ty::{self, RvalueScopes, Ty, TyCtxt};
-use rustc_span::Span;
 
 pub(crate) fn thir_body(
     tcx: TyCtxt<'_>,
@@ -62,14 +61,6 @@ struct Cx<'tcx> {
     typeck_results: &'tcx ty::TypeckResults<'tcx>,
     rvalue_scopes: &'tcx RvalueScopes,
 
-    /// When applying adjustments to the expression
-    /// with the given `HirId`, use the given `Span`,
-    /// instead of the usual span. This is used to
-    /// assign the span of an overall method call
-    /// (e.g. `my_val.foo()`) to the adjustment expressions
-    /// for the receiver.
-    adjustment_span: Option<(HirId, Span)>,
-
     /// False to indicate that adjustments should not be applied. Only used for `custom_mir`
     apply_adjustments: bool,
 
@@ -110,7 +101,6 @@ impl<'tcx> Cx<'tcx> {
             typeck_results,
             rvalue_scopes: &typeck_results.rvalue_scopes,
             body_owner: def.to_def_id(),
-            adjustment_span: None,
             apply_adjustments: hir
                 .attrs(hir_id)
                 .iter()

--- a/src/tools/miri/tests/fail/box-cell-alias.stderr
+++ b/src/tools/miri/tests/fail/box-cell-alias.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permis
   --> $DIR/box-cell-alias.rs:LL:CC
    |
 LL |     unsafe { (*ptr).set(20) };
-   |              ^^^^^^^^^^^^^^
+   |              ^^^^^^
    |              |
    |              trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |              this error occurs as part of retag at ALLOC[0x0..0x1]

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_read7.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_read7.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permis
   --> $DIR/illegal_read7.rs:LL:CC
    |
 LL |         let _val = *x.get_mut();
-   |                     ^^^^^^^^^^^
+   |                     ^
    |                     |
    |                     trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                     this error occurs as part of two-phase retag at ALLOC[0x0..0x4]

--- a/src/tools/miri/tests/fail/stacked_borrows/interior_mut1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/interior_mut1.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permis
   --> $DIR/interior_mut1.rs:LL:CC
    |
 LL |         let _val = *inner_shr.get();
-   |                     ^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^
    |                     |
    |                     trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                     this error occurs as part of retag at ALLOC[0x0..0x4]

--- a/src/tools/miri/tests/fail/stacked_borrows/interior_mut2.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/interior_mut2.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permis
   --> $DIR/interior_mut2.rs:LL:CC
    |
 LL |         let _val = *inner_shr.get();
-   |                     ^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^
    |                     |
    |                     trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                     this error occurs as part of retag at ALLOC[0x0..0x4]

--- a/src/tools/miri/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to retag from <TAG> for SharedReadWrite permis
   --> $DIR/shared_rw_borrows_are_weak1.rs:LL:CC
    |
 LL |         y.get_mut();
-   |         ^^^^^^^^^^^
+   |         ^
    |         |
    |         trying to retag from <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of two-phase retag at ALLOC[0x0..0x4]

--- a/src/tools/miri/tests/fail/tree_borrows/fnentry_invalidation.stderr
+++ b/src/tools/miri/tests/fail/tree_borrows/fnentry_invalidation.stderr
@@ -21,7 +21,7 @@ help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (act
   --> $DIR/fnentry_invalidation.rs:LL:CC
    |
 LL |     x.do_bad();
-   |     ^^^^^^^^^^
+   |     ^
    = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fnentry_invalidation.rs:LL:CC

--- a/src/tools/miri/tests/fail/tree_borrows/write-during-2phase.stderr
+++ b/src/tools/miri/tests/fail/tree_borrows/write-during-2phase.stderr
@@ -9,15 +9,8 @@ LL |     fn add(&mut self, n: u64) -> u64 {
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> $DIR/write-during-2phase.rs:LL:CC
    |
-LL |       let _res = f.add(unsafe {
-   |  ________________^
-LL | |         let n = f.0;
-LL | |         // This is the access at fault, but it's not immediately apparent because
-LL | |         // the reference that got invalidated is not under a Protector.
-LL | |         *inner = 42;
-LL | |         n
-LL | |     });
-   | |______^
+LL |     let _res = f.add(unsafe {
+   |                ^
 help: the accessed tag <TAG> later transitioned to Disabled due to a foreign write access at offsets [0x0..0x8]
   --> $DIR/write-during-2phase.rs:LL:CC
    |

--- a/tests/ui/array-slice-vec/vec-mut-iter-borrow.stderr
+++ b/tests/ui/array-slice-vec/vec-mut-iter-borrow.stderr
@@ -7,7 +7,7 @@ LL |     for x in &mut xs {
    |              first mutable borrow occurs here
    |              first borrow later used here
 LL |         xs.push(1)
-   |         ^^^^^^^^^^ second mutable borrow occurs here
+   |         ^^ second mutable borrow occurs here
 
 error: aborting due to previous error
 

--- a/tests/ui/async-await/clone-suggestion.stderr
+++ b/tests/ui/async-await/clone-suggestion.stderr
@@ -13,7 +13,7 @@ note: `into_future` takes ownership of the receiver `self`, which moves `f`
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     f.clone().await;
-   |       ++++++++
+   |      ++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/async-await/issue-61452.stderr
+++ b/tests/ui/async-await/issue-61452.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/issue-61452.rs:4:5
    |
 LL |     x.take();
-   |     ^^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/async-await/issues/issue-61187.stderr
+++ b/tests/ui/async-await/issues/issue-61187.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `data` as mutable, as it is not declared as mutable
   --> $DIR/issue-61187.rs:6:5
    |
 LL |     data.reverse();
-   |     ^^^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/binop/binop-move-semantics.stderr
+++ b/tests/ui/binop/binop-move-semantics.stderr
@@ -27,7 +27,7 @@ LL |     x
    |     - value moved here
 LL |     +
 LL |     x.clone();
-   |     ^^^^^^^^^ value borrowed here after move
+   |     ^ value borrowed here after move
    |
 help: consider cloning the value if the performance cost is acceptable
    |

--- a/tests/ui/borrowck/borrow-tuple-fields.stderr
+++ b/tests/ui/borrowck/borrow-tuple-fields.stderr
@@ -9,7 +9,7 @@ LL |     let y = x;
    |             ^ move out of `x` occurs here
 LL |
 LL |     r.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0502]: cannot borrow `x.0` as mutable because it is also borrowed as immutable
   --> $DIR/borrow-tuple-fields.rs:18:13
@@ -19,7 +19,7 @@ LL |     let a = &x.0;
 LL |     let b = &mut x.0;
    |             ^^^^^^^^ mutable borrow occurs here
 LL |     a.use_ref();
-   |     ----------- immutable borrow later used here
+   |     - immutable borrow later used here
 
 error[E0499]: cannot borrow `x.0` as mutable more than once at a time
   --> $DIR/borrow-tuple-fields.rs:23:13
@@ -29,7 +29,7 @@ LL |     let a = &mut x.0;
 LL |     let b = &mut x.0;
    |             ^^^^^^^^ second mutable borrow occurs here
 LL |     a.use_ref();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/borrow-tuple-fields.rs:28:13
@@ -41,7 +41,7 @@ LL |     let r = &x.0;
 LL |     let y = x;
    |             ^ move out of `x` occurs here
 LL |     r.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0502]: cannot borrow `x.0` as mutable because it is also borrowed as immutable
   --> $DIR/borrow-tuple-fields.rs:33:13
@@ -51,7 +51,7 @@ LL |     let a = &x.0;
 LL |     let b = &mut x.0;
    |             ^^^^^^^^ mutable borrow occurs here
 LL |     a.use_ref();
-   |     ----------- immutable borrow later used here
+   |     - immutable borrow later used here
 
 error[E0499]: cannot borrow `x.0` as mutable more than once at a time
   --> $DIR/borrow-tuple-fields.rs:38:13
@@ -61,7 +61,7 @@ LL |     let a = &mut x.0;
 LL |     let b = &mut x.0;
    |             ^^^^^^^^ second mutable borrow occurs here
 LL |     a.use_mut();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/borrowck/borrowck-argument.stderr
+++ b/tests/ui/borrowck/borrowck-argument.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-argument.rs:10:5
    |
 LL |     arg.mutate();
-   |     ^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-argument.rs:15:9
    |
 LL |         arg.mutate();
-   |         ^^^^^^^^^^^^ cannot borrow as mutable
+   |         ^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-argument.rs:21:9
    |
 LL |         arg.mutate();
-   |         ^^^^^^^^^^^^ cannot borrow as mutable
+   |         ^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-argument.rs:32:17
    |
 LL |     (|arg: S| { arg.mutate() })(s);
-   |                 ^^^^^^^^^^^^ cannot borrow as mutable
+   |                 ^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/borrowck/borrowck-auto-mut-ref-to-immut-var.stderr
+++ b/tests/ui/borrowck/borrowck-auto-mut-ref-to-immut-var.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-auto-mut-ref-to-immut-var.rs:15:5
    |
 LL |     x.printme();
-   |     ^^^^^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*a` as mutable, as `a` is not declared as mutable
   --> $DIR/borrowck-borrow-immut-deref-of-box-as-mut.rs:12:5
    |
 LL |     a.foo();
-   |     ^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/borrowck/borrowck-borrow-mut-object-twice.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-mut-object-twice.stderr
@@ -2,11 +2,11 @@ error[E0499]: cannot borrow `*x` as mutable more than once at a time
   --> $DIR/borrowck-borrow-mut-object-twice.rs:13:5
    |
 LL |     let y = x.f1();
-   |             ------ first mutable borrow occurs here
+   |             - first mutable borrow occurs here
 LL |     x.f2();
-   |     ^^^^^^ second mutable borrow occurs here
+   |     ^ second mutable borrow occurs here
 LL |     y.use_ref();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-borrow-overloaded-auto-deref.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-overloaded-auto-deref.stderr
@@ -58,7 +58,7 @@ error[E0596]: cannot borrow data in an `Rc` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref.rs:72:5
    |
 LL |     x.set(0, 0);
-   |     ^^^^^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Rc<Point>`
 
@@ -66,7 +66,7 @@ error[E0596]: cannot borrow data in an `Rc` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref.rs:76:5
    |
 LL |     x.set(0, 0);
-   |     ^^^^^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Rc<Point>`
 
@@ -74,7 +74,7 @@ error[E0596]: cannot borrow data in an `Rc` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref.rs:84:5
    |
 LL |     x.y_mut()
-   |     ^^^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Rc<Point>`
 
@@ -82,7 +82,7 @@ error[E0596]: cannot borrow data in an `Rc` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref.rs:88:5
    |
 LL |     x.y_mut()
-   |     ^^^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Rc<Point>`
 
@@ -90,7 +90,7 @@ error[E0596]: cannot borrow data in an `Rc` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref.rs:92:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^^^^^^^^^ cannot borrow as mutable
+   |      ^ cannot borrow as mutable
    |
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Rc<Point>`
 
@@ -98,7 +98,7 @@ error[E0596]: cannot borrow data in an `Rc` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref.rs:96:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^^^^^^^^^ cannot borrow as mutable
+   |      ^ cannot borrow as mutable
    |
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Rc<Point>`
 
@@ -106,7 +106,7 @@ error[E0596]: cannot borrow data in an `Rc` as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref.rs:100:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^^^^^^^^^ cannot borrow as mutable
+   |      ^ cannot borrow as mutable
    |
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Rc<Point>`
 

--- a/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue.stderr
+++ b/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue.stderr
@@ -7,7 +7,7 @@ LL |     buggy_map.insert(42, &*Box::new(1));
    |                            creates a temporary value which is freed while still in use
 ...
 LL |     buggy_map.insert(43, &*tmp);
-   |     --------------------------- borrow later used here
+   |     --------- borrow later used here
    |
 help: consider using a `let` binding to create a longer lived value
    |

--- a/tests/ui/borrowck/borrowck-closures-unique-imm.stderr
+++ b/tests/ui/borrowck/borrowck-closures-unique-imm.stderr
@@ -6,7 +6,7 @@ LL |         let p = &this.x;
 LL |         &mut this.x;
    |         ^^^^^^^^^^^ mutable borrow occurs here
 LL |         p.use_ref();
-   |         ----------- immutable borrow later used here
+   |         - immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-describe-lvalue.stderr
+++ b/tests/ui/borrowck/borrowck-describe-lvalue.stderr
@@ -45,7 +45,7 @@ error[E0503]: cannot use `f.x` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:37:9
    |
 LL |         let x = f.x();
-   |                 ----- `f` is borrowed here
+   |                 - `f` is borrowed here
 LL |         f.x;
    |         ^^^ use of borrowed `f`
 LL |         drop(x);
@@ -55,7 +55,7 @@ error[E0503]: cannot use `g.0` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:44:9
    |
 LL |         let x = g.x();
-   |                 ----- `g` is borrowed here
+   |                 - `g` is borrowed here
 LL |         g.0;
    |         ^^^ use of borrowed `g`
 LL |         drop(x);
@@ -75,7 +75,7 @@ error[E0503]: cannot use `e.0` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:59:20
    |
 LL |         let x = e.x();
-   |                 ----- `e` is borrowed here
+   |                 - `e` is borrowed here
 LL |         match e {
 LL |             Baz::X(value) => value
    |                    ^^^^^ use of borrowed `e`
@@ -97,7 +97,7 @@ error[E0503]: cannot use `f.x` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:74:9
    |
 LL |         let x = f.x();
-   |                 ----- `*f` is borrowed here
+   |                 - `*f` is borrowed here
 LL |         f.x;
    |         ^^^ use of borrowed `*f`
 LL |         drop(x);
@@ -107,7 +107,7 @@ error[E0503]: cannot use `g.0` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:81:9
    |
 LL |         let x = g.x();
-   |                 ----- `*g` is borrowed here
+   |                 - `*g` is borrowed here
 LL |         g.0;
    |         ^^^ use of borrowed `*g`
 LL |         drop(x);
@@ -127,7 +127,7 @@ error[E0503]: cannot use `e.0` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:96:20
    |
 LL |         let x = e.x();
-   |                 ----- `*e` is borrowed here
+   |                 - `*e` is borrowed here
 LL |         match *e {
 LL |             Baz::X(value) => value
    |                    ^^^^^ use of borrowed `*e`

--- a/tests/ui/borrowck/borrowck-insert-during-each.stderr
+++ b/tests/ui/borrowck/borrowck-insert-during-each.stderr
@@ -16,17 +16,15 @@ LL | |         })
 error[E0500]: closure requires unique access to `f` but it is already borrowed
   --> $DIR/borrowck-insert-during-each.rs:18:9
    |
-LL |       f.foo(
-   |       - --- first borrow later used by call
-   |  _____|
-   | |
-LL | |
-LL | |         |a| {
-   | |         ^^^ closure construction occurs here
-LL | |             f.n.insert(*a);
-   | |             --- second borrow occurs due to use of `f` in closure
-LL | |         })
-   | |__________- borrow occurs here
+LL |     f.foo(
+   |     - --- first borrow later used by call
+   |     |
+   |     borrow occurs here
+LL |
+LL |         |a| {
+   |         ^^^ closure construction occurs here
+LL |             f.n.insert(*a);
+   |             --- second borrow occurs due to use of `f` in closure
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-issue-2657-1.stderr
+++ b/tests/ui/borrowck/borrowck-issue-2657-1.stderr
@@ -6,7 +6,7 @@ LL |       Some(ref _y) => {
 LL |         let _a = x;
    |                  ^ move out of `x` occurs here
 LL |         _y.use_ref();
-   |         ------------ borrow later used here
+   |         -- borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-lend-flow-if.stderr
+++ b/tests/ui/borrowck/borrowck-lend-flow-if.stderr
@@ -7,7 +7,7 @@ LL |     }
 LL |     borrow_mut(&mut *v);
    |                ^^^^^^^ mutable borrow occurs here
 LL |     _w.use_ref();
-   |     ------------ immutable borrow later used here
+   |     -- immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-lend-flow.stderr
+++ b/tests/ui/borrowck/borrowck-lend-flow.stderr
@@ -6,7 +6,7 @@ LL |     let _w = &v;
 LL |     borrow_mut(&mut *v);
    |                ^^^^^^^ mutable borrow occurs here
 LL |     _w.use_ref();
-   |     ------------ immutable borrow later used here
+   |     -- immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-loan-blocks-move-cc.stderr
+++ b/tests/ui/borrowck/borrowck-loan-blocks-move-cc.stderr
@@ -12,7 +12,7 @@ LL |         println!("v={}", *v);
    |                          -- move occurs due to use in closure
 LL |     });
 LL |     w.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0505]: cannot move out of `v` because it is borrowed
   --> $DIR/borrowck-loan-blocks-move-cc.rs:24:19
@@ -28,7 +28,7 @@ LL |         println!("v={}", *v);
    |                          -- move occurs due to use in closure
 LL |     });
 LL |     w.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-loan-blocks-move.stderr
+++ b/tests/ui/borrowck/borrowck-loan-blocks-move.stderr
@@ -8,7 +8,7 @@ LL |     let w = &v;
 LL |     take(v);
    |          ^ move out of `v` occurs here
 LL |     w.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-loan-in-overloaded-op.stderr
+++ b/tests/ui/borrowck/borrowck-loan-in-overloaded-op.stderr
@@ -4,7 +4,7 @@ error[E0382]: borrow of moved value: `x`
 LL |     let x = Foo(Box::new(3));
    |         - move occurs because `x` has type `Foo`, which does not implement the `Copy` trait
 LL |     let _y = {x} + x.clone(); // the `{x}` forces a move to occur
-   |               -    ^^^^^^^^^ value borrowed here after move
+   |               -    ^ value borrowed here after move
    |               |
    |               value moved here
    |

--- a/tests/ui/borrowck/borrowck-loan-rcvr-overloaded-op.stderr
+++ b/tests/ui/borrowck/borrowck-loan-rcvr-overloaded-op.stderr
@@ -17,7 +17,7 @@ LL |     let q = &mut p;
    |             ------ mutable borrow occurs here
 ...
 LL |     p.times(3);
-   |     ^^^^^^^^^^ immutable borrow occurs here
+   |     ^ immutable borrow occurs here
 LL |
 LL |     *q + 3; // OK to use the new alias `q`
    |     -- mutable borrow later used here

--- a/tests/ui/borrowck/borrowck-loan-rcvr.stderr
+++ b/tests/ui/borrowck/borrowck-loan-rcvr.stderr
@@ -1,15 +1,13 @@
 error[E0502]: cannot borrow `p` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-loan-rcvr.rs:23:14
    |
-LL |       p.blockm(|| {
-   |       - ------ ^^ mutable borrow occurs here
-   |       | |
-   |  _____| immutable borrow later used by call
-   | |
-LL | |         p.x = 10;
-   | |         --- second borrow occurs due to use of `p` in closure
-LL | |     })
-   | |______- immutable borrow occurs here
+LL |     p.blockm(|| {
+   |     - ------ ^^ mutable borrow occurs here
+   |     | |
+   |     | immutable borrow later used by call
+   |     immutable borrow occurs here
+LL |         p.x = 10;
+   |         --- second borrow occurs due to use of `p` in closure
 
 error[E0502]: cannot borrow `p` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-loan-rcvr.rs:34:5
@@ -17,7 +15,7 @@ error[E0502]: cannot borrow `p` as immutable because it is also borrowed as muta
 LL |     let l = &mut p;
    |             ------ mutable borrow occurs here
 LL |     p.impurem();
-   |     ^^^^^^^^^^^ immutable borrow occurs here
+   |     ^ immutable borrow occurs here
 LL |
 LL |     l.x += 1;
    |     -------- mutable borrow later used here

--- a/tests/ui/borrowck/borrowck-move-from-subpath-of-borrowed-path.stderr
+++ b/tests/ui/borrowck/borrowck-move-from-subpath-of-borrowed-path.stderr
@@ -9,7 +9,7 @@ LL |
 LL |     let z = *a;
    |             ^^ move out of `*a` occurs here
 LL |     b.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-move-mut-base-ptr.stderr
+++ b/tests/ui/borrowck/borrowck-move-mut-base-ptr.stderr
@@ -9,7 +9,7 @@ LL |     let t1 = t0;
    |              ^^ move out of `t0` occurs here
 LL |     *t1 = 22;
 LL |     p.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
+++ b/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
@@ -11,7 +11,7 @@ note: `into_iter` takes ownership of the receiver `self`, which moves value
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     let _x = Rc::new(vec![1, 2]).clone().into_iter();
-   |                                  ++++++++
+   |                                 ++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
+++ b/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
@@ -2,9 +2,8 @@ error[E0507]: cannot move out of an `Rc`
   --> $DIR/borrowck-move-out-of-overloaded-auto-deref.rs:4:14
    |
 LL |     let _x = Rc::new(vec![1, 2]).into_iter();
-   |              ^^^^^^^^^^^^^^^^^^^^-----------
-   |              |                   |
-   |              |                   value moved due to this method call
+   |              ^^^^^^^^^^^^^^^^^^^ ----------- value moved due to this method call
+   |              |
    |              move occurs because value has type `Vec<i32>`, which does not implement the `Copy` trait
    |
 note: `into_iter` takes ownership of the receiver `self`, which moves value

--- a/tests/ui/borrowck/borrowck-mut-borrow-linear-errors.stderr
+++ b/tests/ui/borrowck/borrowck-mut-borrow-linear-errors.stderr
@@ -5,9 +5,8 @@ LL |             1 => { addr.push(&mut x); }
    |                              ^^^^^^ second mutable borrow occurs here
 LL |             2 => { addr.push(&mut x); }
 LL |             _ => { addr.push(&mut x); }
-   |                    -----------------
-   |                    |         |
-   |                    |         first mutable borrow occurs here
+   |                    ----      ------ first mutable borrow occurs here
+   |                    |
    |                    first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
@@ -16,18 +15,16 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
 LL |             2 => { addr.push(&mut x); }
    |                              ^^^^^^ second mutable borrow occurs here
 LL |             _ => { addr.push(&mut x); }
-   |                    -----------------
-   |                    |         |
-   |                    |         first mutable borrow occurs here
+   |                    ----      ------ first mutable borrow occurs here
+   |                    |
    |                    first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-mut-borrow-linear-errors.rs:12:30
    |
 LL |             _ => { addr.push(&mut x); }
-   |                    ----------^^^^^^-
-   |                    |         |
-   |                    |         `x` was mutably borrowed here in the previous iteration of the loop
+   |                    ----      ^^^^^^ `x` was mutably borrowed here in the previous iteration of the loop
+   |                    |
    |                    first borrow used here, in later iteration of loop
 
 error: aborting due to 3 previous errors

--- a/tests/ui/borrowck/borrowck-mut-borrow-of-mut-base-ptr.stderr
+++ b/tests/ui/borrowck/borrowck-mut-borrow-of-mut-base-ptr.stderr
@@ -7,7 +7,7 @@ LL |     let mut t2 = &mut t0;
    |                  ^^^^^^^ mutable borrow occurs here
 LL |     **t2 += 1;              // Mutates `*t0`
 LL |     p.use_ref();
-   |     ----------- immutable borrow later used here
+   |     - immutable borrow later used here
 
 error[E0499]: cannot borrow `t0` as mutable more than once at a time
   --> $DIR/borrowck-mut-borrow-of-mut-base-ptr.rs:19:18
@@ -18,7 +18,7 @@ LL |     let mut t2 = &mut t0;
    |                  ^^^^^^^ second mutable borrow occurs here
 LL |     **t2 += 1;                  // Mutates `*t0` but not through `*p`
 LL |     p.use_mut();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-object-lifetime.stderr
+++ b/tests/ui/borrowck/borrowck-object-lifetime.stderr
@@ -2,21 +2,21 @@ error[E0502]: cannot borrow `*x` as mutable because it is also borrowed as immut
   --> $DIR/borrowck-object-lifetime.rs:20:13
    |
 LL |     let y = x.borrowed();
-   |             ------------ immutable borrow occurs here
+   |             - immutable borrow occurs here
 LL |     let z = x.mut_borrowed();
    |             ^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     y.use_ref();
-   |     ----------- immutable borrow later used here
+   |     - immutable borrow later used here
 
 error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-object-lifetime.rs:26:13
    |
 LL |     let y = x.borrowed();
-   |             ------------ immutable borrow occurs here
+   |             - immutable borrow occurs here
 LL |     let z = &mut x;
    |             ^^^^^^ mutable borrow occurs here
 LL |     y.use_ref();
-   |     ----------- immutable borrow later used here
+   |     - immutable borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-overloaded-index-autoderef.stderr
+++ b/tests/ui/borrowck/borrowck-overloaded-index-autoderef.stderr
@@ -6,7 +6,7 @@ LL |     let p = &mut f[&s];
 LL |     let q = &f[&s];
    |              ^ immutable borrow occurs here
 LL |     p.use_mut();
-   |     ----------- mutable borrow later used here
+   |     - mutable borrow later used here
 
 error[E0499]: cannot borrow `*f` as mutable more than once at a time
   --> $DIR/borrowck-overloaded-index-autoderef.rs:43:18
@@ -16,7 +16,7 @@ LL |     let p = &mut f[&s];
 LL |     let q = &mut f[&s];
    |                  ^ second mutable borrow occurs here
 LL |     p.use_mut();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error[E0499]: cannot borrow `f.foo` as mutable more than once at a time
   --> $DIR/borrowck-overloaded-index-autoderef.rs:53:18
@@ -26,7 +26,7 @@ LL |     let p = &mut f.foo[&s];
 LL |     let q = &mut f.foo[&s];
    |                  ^^^^^ second mutable borrow occurs here
 LL |     p.use_mut();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error[E0502]: cannot borrow `f.foo` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-overloaded-index-autoderef.rs:65:18
@@ -36,7 +36,7 @@ LL |     let p = &f.foo[&s];
 LL |     let q = &mut f.foo[&s];
    |                  ^^^^^ mutable borrow occurs here
 LL |     p.use_ref();
-   |     ----------- immutable borrow later used here
+   |     - immutable borrow later used here
 
 error[E0506]: cannot assign to `f.foo` because it is borrowed
   --> $DIR/borrowck-overloaded-index-autoderef.rs:71:5
@@ -46,7 +46,7 @@ LL |     let p = &f.foo[&s];
 LL |     f.foo = g;
    |     ^^^^^^^^^ `f.foo` is assigned to here but it was already borrowed
 LL |     p.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0506]: cannot assign to `*f` because it is borrowed
   --> $DIR/borrowck-overloaded-index-autoderef.rs:77:5
@@ -56,7 +56,7 @@ LL |     let p = &f.foo[&s];
 LL |     *f = g;
    |     ^^^^^^ `*f` is assigned to here but it was already borrowed
 LL |     p.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0506]: cannot assign to `f.foo` because it is borrowed
   --> $DIR/borrowck-overloaded-index-autoderef.rs:83:5
@@ -66,7 +66,7 @@ LL |     let p = &mut f.foo[&s];
 LL |     f.foo = g;
    |     ^^^^^^^^^ `f.foo` is assigned to here but it was already borrowed
 LL |     p.use_mut();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0506]: cannot assign to `*f` because it is borrowed
   --> $DIR/borrowck-overloaded-index-autoderef.rs:89:5
@@ -76,7 +76,7 @@ LL |     let p = &mut f.foo[&s];
 LL |     *f = g;
    |     ^^^^^^ `*f` is assigned to here but it was already borrowed
 LL |     p.use_mut();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/borrowck/borrowck-report-with-custom-diagnostic.stderr
+++ b/tests/ui/borrowck/borrowck-report-with-custom-diagnostic.stderr
@@ -8,7 +8,7 @@ LL |     let z = &x;
    |             ^^ immutable borrow occurs here
 ...
 LL |     y.use_mut();
-   |     ----------- mutable borrow later used here
+   |     - mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-report-with-custom-diagnostic.rs:21:21
@@ -20,7 +20,7 @@ LL |             let z = &mut x;
    |                     ^^^^^^ mutable borrow occurs here
 ...
 LL |             y.use_ref();
-   |             ----------- immutable borrow later used here
+   |             - immutable borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-report-with-custom-diagnostic.rs:36:17
@@ -32,7 +32,7 @@ LL |         let z = &mut x;
    |                 ^^^^^^ second mutable borrow occurs here
 ...
 LL |         y.use_mut();
-   |         ----------- first borrow later used here
+   |         - first borrow later used here
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/borrowck/borrowck-swap-mut-base-ptr.stderr
+++ b/tests/ui/borrowck/borrowck-swap-mut-base-ptr.stderr
@@ -7,7 +7,7 @@ LL |     swap(&mut t0, &mut t1);
    |          ^^^^^^^ mutable borrow occurs here
 LL |     *t1 = 22;
 LL |     p.use_ref();
-   |     ----------- immutable borrow later used here
+   |     - immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-union-borrow-nested.stderr
+++ b/tests/ui/borrowck/borrowck-union-borrow-nested.stderr
@@ -6,7 +6,7 @@ LL |             let ra = &mut u.s.a;
 LL |             let b = u.c;
    |                     ^^^ use of borrowed `u.s.a`
 LL |             ra.use_mut();
-   |             ------------ borrow later used here
+   |             -- borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/borrowck-uniq-via-lend.stderr
+++ b/tests/ui/borrowck/borrowck-uniq-via-lend.stderr
@@ -6,7 +6,7 @@ LL |     let w = &mut v;
 LL |     borrow(&*v);
    |            ^^^ immutable borrow occurs here
 LL |     w.use_mut();
-   |     ----------- mutable borrow later used here
+   |     - mutable borrow later used here
 
 error[E0502]: cannot borrow `*v` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-uniq-via-lend.rs:53:12
@@ -16,7 +16,7 @@ LL |     x = &mut v;
 LL |     borrow(&*v);
    |            ^^^ immutable borrow occurs here
 LL |     x.use_mut();
-   |     ----------- mutable borrow later used here
+   |     - mutable borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-vec-pattern-loan-from-mut.stderr
+++ b/tests/ui/borrowck/borrowck-vec-pattern-loan-from-mut.stderr
@@ -5,9 +5,8 @@ LL |     let vb: &mut [isize] = &mut v;
    |                            ------ first mutable borrow occurs here
 ...
 LL |             v.push(tail[0] + tail[1]);
-   |             ^^^^^^^-------^^^^^^^^^^^
-   |             |      |
-   |             |      first borrow later used here
+   |             ^      ------- first borrow later used here
+   |             |
    |             second mutable borrow occurs here
 
 error: aborting due to previous error

--- a/tests/ui/borrowck/borrowck-vec-pattern-nesting.stderr
+++ b/tests/ui/borrowck/borrowck-vec-pattern-nesting.stderr
@@ -8,7 +8,7 @@ LL |             vec[0] = Box::new(4);
    |             ^^^^^^ `vec[_]` is assigned to here but it was already borrowed
 LL |
 LL |             _a.use_ref();
-   |             ------------ borrow later used here
+   |             -- borrow later used here
 
 error[E0506]: cannot assign to `vec[_]` because it is borrowed
   --> $DIR/borrowck-vec-pattern-nesting.rs:23:13
@@ -20,7 +20,7 @@ LL |             vec[0] = Box::new(4);
    |             ^^^^^^ `vec[_]` is assigned to here but it was already borrowed
 LL |
 LL |             _b.use_ref();
-   |             ------------ borrow later used here
+   |             -- borrow later used here
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
   --> $DIR/borrowck-vec-pattern-nesting.rs:34:11

--- a/tests/ui/borrowck/clone-span-on-try-operator.fixed
+++ b/tests/ui/borrowck/clone-span-on-try-operator.fixed
@@ -1,0 +1,11 @@
+// run-rustfix
+
+#[derive(Clone)]
+struct Foo;
+impl Foo {
+    fn foo(self) {}
+}
+fn main() {
+    let foo = &Foo;
+    (*foo).clone().foo(); //~ ERROR cannot move out
+}

--- a/tests/ui/borrowck/clone-span-on-try-operator.rs
+++ b/tests/ui/borrowck/clone-span-on-try-operator.rs
@@ -1,0 +1,11 @@
+// run-rustfix
+
+#[derive(Clone)]
+struct Foo;
+impl Foo {
+    fn foo(self) {}
+}
+fn main() {
+    let foo = &Foo;
+    (*foo).foo(); //~ ERROR cannot move out
+}

--- a/tests/ui/borrowck/clone-span-on-try-operator.stderr
+++ b/tests/ui/borrowck/clone-span-on-try-operator.stderr
@@ -1,20 +1,20 @@
 error[E0507]: cannot move out of `*foo` which is behind a shared reference
-  --> $DIR/suggest-clone.rs:10:5
+  --> $DIR/clone-span-on-try-operator.rs:10:5
    |
-LL |     foo.foo();
-   |     ^^^ ----- `*foo` moved due to this method call
+LL |     (*foo).foo();
+   |     ^^^^^^ ----- `*foo` moved due to this method call
    |     |
    |     move occurs because `*foo` has type `Foo`, which does not implement the `Copy` trait
    |
 note: `Foo::foo` takes ownership of the receiver `self`, which moves `*foo`
-  --> $DIR/suggest-clone.rs:6:12
+  --> $DIR/clone-span-on-try-operator.rs:6:12
    |
 LL |     fn foo(self) {}
    |            ^^^^
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
-LL |     foo.clone().foo();
-   |        ++++++++
+LL |     (*foo).clone().foo();
+   |           ++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/copy-suggestion-region-vid.stderr
+++ b/tests/ui/borrowck/copy-suggestion-region-vid.stderr
@@ -5,7 +5,7 @@ LL |         let helpers = [vec![], vec![]];
    |             ------- move occurs because `helpers` has type `[Vec<&i64>; 2]`, which does not implement the `Copy` trait
 LL |
 LL |         HelperStruct { helpers, is_empty: helpers[0].is_empty() }
-   |                        -------            ^^^^^^^^^^^^^^^^^^^^^ value borrowed here after move
+   |                        -------            ^^^^^^^^^^ value borrowed here after move
    |                        |
    |                        value moved here
 

--- a/tests/ui/borrowck/index-mut-help-with-impl.stderr
+++ b/tests/ui/borrowck/index-mut-help-with-impl.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/index-mut-help-with-impl.rs:9:5
    |
 LL |     Index::index(&v, 1..2).make_ascii_uppercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/index-mut-help.stderr
+++ b/tests/ui/borrowck/index-mut-help.stderr
@@ -2,13 +2,10 @@ error[E0596]: cannot borrow data in an index of `HashMap<&str, String>` as mutab
   --> $DIR/index-mut-help.rs:10:5
    |
 LL |     map["peter"].clear();
-   |     ^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^^^^^^^^^^ cannot borrow as mutable
    |
    = help: trait `IndexMut` is required to modify indexed content, but it is not implemented for `HashMap<&str, String>`
-help: to modify a `HashMap<&str, String>` use `.get_mut()`
-   |
-LL |     map.get_mut("peter").map(|val| val.clear());
-   |        ~~~~~~~~~       ~~~~~~~~~~~~~~~        +
+   = help: to modify a `HashMap<&str, String>`, use `.get_mut()`, `.insert()` or the entry API
 
 error[E0594]: cannot assign to data in an index of `HashMap<&str, String>`
   --> $DIR/index-mut-help.rs:11:5

--- a/tests/ui/borrowck/issue-109271-pass-self-into-closure.stderr
+++ b/tests/ui/borrowck/issue-109271-pass-self-into-closure.stderr
@@ -26,9 +26,8 @@ error[E0499]: cannot borrow `v` as mutable more than once at a time
   --> $DIR/issue-109271-pass-self-into-closure.rs:21:12
    |
 LL |     v.call(|(), this: &mut S| v.set());
-   |     -------^^^^^^^^^^^^^^^^^^---------
-   |     | |    |                  |
-   |     | |    |                  second borrow occurs due to use of `v` in closure
+   |     - ---- ^^^^^^^^^^^^^^^^^^ - second borrow occurs due to use of `v` in closure
+   |     | |    |
    |     | |    second mutable borrow occurs here
    |     | first borrow later used by call
    |     first mutable borrow occurs here
@@ -63,21 +62,14 @@ LL ~         S::get(&this);
 error[E0499]: cannot borrow `v` as mutable more than once at a time
   --> $DIR/issue-109271-pass-self-into-closure.rs:25:12
    |
-LL |       v.call(|(), this: &mut S| {
-   |       - ---- ^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
-   |       | |
-   |  _____| first borrow later used by call
-   | |
-LL | |
-LL | |
-LL | |
-LL | |         _ = v;
-LL | |         v.set();
-   | |         - second borrow occurs due to use of `v` in closure
-...  |
-LL | |         _ = v.add(3);
-LL | |     });
-   | |______- first mutable borrow occurs here
+LL |     v.call(|(), this: &mut S| {
+   |     - ---- ^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     | |
+   |     | first borrow later used by call
+   |     first mutable borrow occurs here
+...
+LL |         v.set();
+   |         - second borrow occurs due to use of `v` in closure
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/borrowck/issue-42344.stderr
+++ b/tests/ui/borrowck/issue-42344.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*TAB[_]` as mutable, as `TAB` is an immutable stati
   --> $DIR/issue-42344.rs:4:5
    |
 LL |     TAB[0].iter_mut();
-   |     ^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^^^^ cannot borrow as mutable
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-47646.stderr
+++ b/tests/ui/borrowck/issue-47646.stderr
@@ -2,7 +2,7 @@ error[E0502]: cannot borrow `heap` as immutable because it is also borrowed as m
   --> $DIR/issue-47646.rs:9:30
    |
 LL |     let borrow = heap.peek_mut();
-   |                  --------------- mutable borrow occurs here
+   |                  ---- mutable borrow occurs here
 LL |
 LL |     match (borrow, ()) {
    |           ------------ a temporary with access to the mutable borrow is created here ...

--- a/tests/ui/borrowck/issue-51117.stderr
+++ b/tests/ui/borrowck/issue-51117.stderr
@@ -4,7 +4,7 @@ error[E0499]: cannot borrow `*bar` as mutable more than once at a time
 LL |         Some(baz) => {
    |              --- first mutable borrow occurs here
 LL |             bar.take();
-   |             ^^^^^^^^^^ second mutable borrow occurs here
+   |             ^^^ second mutable borrow occurs here
 LL |             drop(baz);
    |                  --- first borrow later used here
 

--- a/tests/ui/borrowck/issue-81365-10.stderr
+++ b/tests/ui/borrowck/issue-81365-10.stderr
@@ -2,7 +2,7 @@ error[E0506]: cannot assign to `self.container_field` because it is borrowed
   --> $DIR/issue-81365-10.rs:21:9
    |
 LL |         let first = &self.deref().target_field;
-   |                      ------------ `self.container_field` is borrowed here
+   |                      ---- `self.container_field` is borrowed here
 LL |         self.container_field = true;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `self.container_field` is assigned to here but it was already borrowed
 LL |         first;

--- a/tests/ui/borrowck/issue-81365-5.stderr
+++ b/tests/ui/borrowck/issue-81365-5.stderr
@@ -2,7 +2,7 @@ error[E0506]: cannot assign to `self.container_field` because it is borrowed
   --> $DIR/issue-81365-5.rs:28:9
    |
 LL |         let first = self.get();
-   |                     ---------- `self.container_field` is borrowed here
+   |                     ---- `self.container_field` is borrowed here
 LL |         self.container_field = true;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `self.container_field` is assigned to here but it was already borrowed
 LL |         first;

--- a/tests/ui/borrowck/issue-82032.stderr
+++ b/tests/ui/borrowck/issue-82032.stderr
@@ -7,7 +7,7 @@ LL |         for v in self.0.values() {
    |                  |      help: use mutable method: `values_mut()`
    |                  this iterator yields `&` references
 LL |             v.flush();
-   |             ^^^^^^^^^ `v` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^ `v` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-85581.stderr
+++ b/tests/ui/borrowck/issue-85581.stderr
@@ -7,7 +7,7 @@ LL |     match heap.peek_mut() {
    |           first mutable borrow occurs here
    |           a temporary with access to the first borrow is created here ...
 LL |         Some(_) => { heap.pop(); },
-   |                      ^^^^^^^^^^ second mutable borrow occurs here
+   |                      ^^^^ second mutable borrow occurs here
 ...
 LL | }
    | - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<PeekMut<'_, i32>>`

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765.rs:5:5
    |
 LL |     rofl.push(Vec::new());
-   |     ^^^^^^^^^^^^^^^^^^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-91206.stderr
+++ b/tests/ui/borrowck/issue-91206.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
   --> $DIR/issue-91206.rs:13:5
    |
 LL |     inner.clear();
-   |     ^^^^^^^^^^^^^ `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^ `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-93078.stderr
+++ b/tests/ui/borrowck/issue-93078.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-93078.rs:11:9
    |
 LL |         self.modify();
-   |         ^^^^^^^^^^^^^ cannot borrow as mutable
+   |         ^^^^ cannot borrow as mutable
    |
    = note: as `Self` may be unsized, this call attempts to take `&mut &mut self`
    = note: however, `&mut self` expands to `self: &mut Self`, therefore `self` cannot be borrowed mutably

--- a/tests/ui/borrowck/many-mutable-borrows.stderr
+++ b/tests/ui/borrowck/many-mutable-borrows.stderr
@@ -4,23 +4,23 @@ error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
 LL |     let v = Vec::new();
    |         ^ not mutable
 LL |     v.push(0);
-   |     --------- cannot borrow as mutable
+   |     - cannot borrow as mutable
 LL |     v.push(0);
-   |     --------- cannot borrow as mutable
+   |     - cannot borrow as mutable
 LL |     v.push(0);
-   |     --------- cannot borrow as mutable
+   |     - cannot borrow as mutable
 LL |     v.push(0);
-   |     --------- cannot borrow as mutable
+   |     - cannot borrow as mutable
 LL |     v.push(0);
-   |     --------- cannot borrow as mutable
+   |     - cannot borrow as mutable
 LL |     v.push(0);
-   |     --------- cannot borrow as mutable
+   |     - cannot borrow as mutable
 LL |     v.push(0);
-   |     --------- cannot borrow as mutable
+   |     - cannot borrow as mutable
 LL |     v.push(0);
-   |     --------- cannot borrow as mutable
+   |     - cannot borrow as mutable
 LL |     v.push(0);
-   |     --------- cannot borrow as mutable
+   |     - cannot borrow as mutable
    |
    = note: ...and 5 other attempted mutable borrows
 help: consider changing this to be mutable

--- a/tests/ui/borrowck/mut-borrow-of-mut-ref.stderr
+++ b/tests/ui/borrowck/mut-borrow-of-mut-ref.stderr
@@ -47,7 +47,7 @@ error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:34:5
    |
 LL |     f.bar();
-   |     ^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
 help: consider making the binding mutable
    |

--- a/tests/ui/borrowck/mut-borrow-outside-loop.stderr
+++ b/tests/ui/borrowck/mut-borrow-outside-loop.stderr
@@ -6,7 +6,7 @@ LL |     let first = &mut void;
 LL |     let second = &mut void;
    |                  ^^^^^^^^^ second mutable borrow occurs here
 LL |     first.use_mut();
-   |     --------------- first borrow later used here
+   |     ----- first borrow later used here
 
 error[E0499]: cannot borrow `inner_void` as mutable more than once at a time
   --> $DIR/mut-borrow-outside-loop.rs:15:28
@@ -17,7 +17,7 @@ LL |         let inner_second = &mut inner_void;
    |                            ^^^^^^^^^^^^^^^ second mutable borrow occurs here
 LL |         inner_second.use_mut();
 LL |         inner_first.use_mut();
-   |         --------------------- first borrow later used here
+   |         ----------- first borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
@@ -2,9 +2,8 @@ error[E0507]: cannot move out of `*cb` which is behind a mutable reference
   --> $DIR/suggest-as-ref-on-mut-closure.rs:7:5
    |
 LL |     cb.map(|cb| cb());
-   |     ^^^--------------
-   |     |  |
-   |     |  `*cb` moved due to this method call
+   |     ^^ -------------- `*cb` moved due to this method call
+   |     |
    |     help: consider calling `.as_ref()` or `.as_mut()` to borrow the type's contents
    |     move occurs because `*cb` has type `Option<&mut dyn FnMut()>`, which does not implement the `Copy` trait
    |

--- a/tests/ui/borrowck/suggest-local-var-double-mut.stderr
+++ b/tests/ui/borrowck/suggest-local-var-double-mut.stderr
@@ -2,9 +2,8 @@ error[E0499]: cannot borrow `*self` as mutable more than once at a time
   --> $DIR/suggest-local-var-double-mut.rs:12:22
    |
 LL |             self.foo(self.bar());
-   |             ---------^^^^^^^^^^-
-   |             |    |   |
-   |             |    |   second mutable borrow occurs here
+   |             ---- --- ^^^^ second mutable borrow occurs here
+   |             |    |
    |             |    first borrow later used by call
    |             first mutable borrow occurs here
    |

--- a/tests/ui/borrowck/suggest-local-var-for-vector.stderr
+++ b/tests/ui/borrowck/suggest-local-var-for-vector.stderr
@@ -2,7 +2,7 @@ error[E0502]: cannot borrow `vec` as immutable because it is also borrowed as mu
   --> $DIR/suggest-local-var-for-vector.rs:3:9
    |
 LL |     vec[vec.len() - 1] = 123;
-   |     ----^^^^^^^^^-----
+   |     ----^^^-----------
    |     |   |
    |     |   immutable borrow occurs here
    |     mutable borrow occurs here

--- a/tests/ui/borrowck/suggest-local-var-imm-and-mut.stderr
+++ b/tests/ui/borrowck/suggest-local-var-imm-and-mut.stderr
@@ -2,9 +2,8 @@ error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as im
   --> $DIR/suggest-local-var-imm-and-mut.rs:12:22
    |
 LL |             self.foo(self.bar());
-   |             ---------^^^^^^^^^^-
-   |             |    |   |
-   |             |    |   mutable borrow occurs here
+   |             ---- --- ^^^^^^^^^^ mutable borrow occurs here
+   |             |    |
    |             |    immutable borrow later used by call
    |             immutable borrow occurs here
 

--- a/tests/ui/borrowck/suggest-storing-local-var-for-vector.stderr
+++ b/tests/ui/borrowck/suggest-storing-local-var-for-vector.stderr
@@ -2,7 +2,7 @@ error[E0502]: cannot borrow `vec` as immutable because it is also borrowed as mu
   --> $DIR/suggest-storing-local-var-for-vector.rs:3:9
    |
 LL |     vec[vec.len() - 1] = 123;
-   |     ----^^^^^^^^^-----
+   |     ----^^^-----------
    |     |   |
    |     |   immutable borrow occurs here
    |     mutable borrow occurs here

--- a/tests/ui/borrowck/two-phase-across-loop.stderr
+++ b/tests/ui/borrowck/two-phase-across-loop.stderr
@@ -2,9 +2,8 @@ error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/two-phase-across-loop.rs:17:22
    |
 LL |         strings.push(foo.get_string());
-   |         -------------^^^^^^^^^^^^^^^^-
-   |         |            |
-   |         |            `foo` was mutably borrowed here in the previous iteration of the loop
+   |         -------      ^^^ `foo` was mutably borrowed here in the previous iteration of the loop
+   |         |
    |         first borrow used here, in later iteration of loop
 
 error: aborting due to previous error

--- a/tests/ui/borrowck/two-phase-cannot-nest-mut-self-calls.stderr
+++ b/tests/ui/borrowck/two-phase-cannot-nest-mut-self-calls.stderr
@@ -1,18 +1,13 @@
 error[E0502]: cannot borrow `vec` as mutable because it is also borrowed as immutable
   --> $DIR/two-phase-cannot-nest-mut-self-calls.rs:14:9
    |
-LL |       vec.get({
-   |       -   --- immutable borrow later used by call
-   |  _____|
-   | |
-LL | |
-LL | |         vec.push(2);
-   | |         ^^^^^^^^^^^ mutable borrow occurs here
-LL | |
-LL | |
-LL | |         0
-LL | |     });
-   | |______- immutable borrow occurs here
+LL |     vec.get({
+   |     --- --- immutable borrow later used by call
+   |     |
+   |     immutable borrow occurs here
+LL |
+LL |         vec.push(2);
+   |         ^^^^^^^^^^^ mutable borrow occurs here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/two-phase-multi-mut.stderr
+++ b/tests/ui/borrowck/two-phase-multi-mut.stderr
@@ -12,9 +12,8 @@ error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/two-phase-multi-mut.rs:11:16
    |
 LL |     foo.method(&mut foo);
-   |     -----------^^^^^^^^-
-   |     |   |      |
-   |     |   |      second mutable borrow occurs here
+   |     --- ------ ^^^^^^^^ second mutable borrow occurs here
+   |     |   |
    |     |   first borrow later used by call
    |     first mutable borrow occurs here
 

--- a/tests/ui/borrowck/two-phase-sneaky.stderr
+++ b/tests/ui/borrowck/two-phase-sneaky.stderr
@@ -7,7 +7,7 @@ LL |     v[0].push_str({
    |     first mutable borrow occurs here
 LL |
 LL |         v.push(format!("foo"));
-   |         ^^^^^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |         ^ second mutable borrow occurs here
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/two-phase-surprise-no-conflict.stderr
+++ b/tests/ui/borrowck/two-phase-surprise-no-conflict.stderr
@@ -13,7 +13,7 @@ error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as im
   --> $DIR/two-phase-surprise-no-conflict.rs:57:17
    |
 LL |                 self.hash_expr(&self.cx_mut.body(eid).value);
-   |                 ^^^^^---------^^---------------------^^^^^^^
+   |                 ^^^^^---------^^-----------^^^^^^^^^^^^^^^^^
    |                 |    |          |
    |                 |    |          immutable borrow occurs here
    |                 |    immutable borrow later used by call
@@ -23,9 +23,8 @@ error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:119:51
    |
 LL |     reg.register_static(Box::new(TrivialPass::new(&mut reg.sess_mut)));
-   |     ----------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |   |                                         |
-   |     |   |                                         second mutable borrow occurs here
+   |     --- ---------------                           ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
    |     |   first borrow later used by call
    |     first mutable borrow occurs here
 
@@ -33,9 +32,8 @@ error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:122:54
    |
 LL |     reg.register_bound(Box::new(TrivialPass::new_mut(&mut reg.sess_mut)));
-   |     -------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |   |                                            |
-   |     |   |                                            second mutable borrow occurs here
+   |     --- --------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
    |     |   first borrow later used by call
    |     first mutable borrow occurs here
 
@@ -43,9 +41,8 @@ error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:125:53
    |
 LL |     reg.register_univ(Box::new(TrivialPass::new_mut(&mut reg.sess_mut)));
-   |     ------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |   |                                           |
-   |     |   |                                           second mutable borrow occurs here
+   |     --- -------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
    |     |   first borrow later used by call
    |     first mutable borrow occurs here
 
@@ -53,9 +50,8 @@ error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:128:44
    |
 LL |     reg.register_ref(&TrivialPass::new_mut(&mut reg.sess_mut));
-   |     ---------------------------------------^^^^^^^^^^^^^^^^^--
-   |     |   |                                  |
-   |     |   |                                  second mutable borrow occurs here
+   |     --- ------------                       ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
    |     |   first borrow later used by call
    |     first mutable borrow occurs here
 
@@ -106,9 +102,8 @@ error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:154:54
    |
 LL |     reg.register_bound(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
-   |     -------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |   |                                            |
-   |     |   |                                            second mutable borrow occurs here
+   |     --- --------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
    |     |   first borrow later used by call
    |     first mutable borrow occurs here
 
@@ -129,9 +124,8 @@ error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:158:53
    |
 LL |     reg.register_univ(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
-   |     ------------------------------------------------^^^^^^^^^^^^^^^^^---
-   |     |   |                                           |
-   |     |   |                                           second mutable borrow occurs here
+   |     --- -------------                               ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
    |     |   first borrow later used by call
    |     first mutable borrow occurs here
 
@@ -149,9 +143,8 @@ error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:162:44
    |
 LL |     reg.register_ref(&CapturePass::new_mut(&mut reg.sess_mut));
-   |     ---------------------------------------^^^^^^^^^^^^^^^^^--
-   |     |   |                                  |
-   |     |   |                                  second mutable borrow occurs here
+   |     --- ------------                       ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     |   |
    |     |   first borrow later used by call
    |     first mutable borrow occurs here
 

--- a/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
+++ b/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
@@ -15,7 +15,7 @@ note: `into_iter` takes ownership of the receiver `self`, which moves `y`
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |         y.clone().into_iter();
-   |           ++++++++
+   |          ++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/box/leak-alloc.stderr
+++ b/tests/ui/box/leak-alloc.stderr
@@ -4,7 +4,7 @@ error[E0505]: cannot move out of `alloc` because it is borrowed
 LL |     let alloc = Alloc {};
    |         ----- binding `alloc` declared here
 LL |     let boxed = Box::new_in(10, alloc.by_ref());
-   |                                 -------------- borrow of `alloc` occurs here
+   |                                 ----- borrow of `alloc` occurs here
 LL |     let theref = Box::leak(boxed);
 LL |     drop(alloc);
    |          ^^^^^ move out of `alloc` occurs here

--- a/tests/ui/cannot-mutate-captured-non-mut-var.stderr
+++ b/tests/ui/cannot-mutate-captured-non-mut-var.stderr
@@ -12,7 +12,7 @@ error[E0596]: cannot borrow `s` as mutable, as it is not declared as mutable
 LL |     let s = std::io::stdin();
    |         - help: consider changing this to be mutable: `mut s`
 LL |     to_fn_once(move|| { s.read_to_end(&mut Vec::new()); });
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |                         ^ cannot borrow as mutable
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/codemap_tests/issue-11715.stderr
+++ b/tests/ui/codemap_tests/issue-11715.stderr
@@ -7,7 +7,7 @@ LL |     let z = &mut x;
    |             ^^^^^^ second mutable borrow occurs here
 LL |     z.use_mut();
 LL |     y.use_mut();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/codemap_tests/one_line.stderr
+++ b/tests/ui/codemap_tests/one_line.stderr
@@ -2,9 +2,8 @@ error[E0499]: cannot borrow `v` as mutable more than once at a time
   --> $DIR/one_line.rs:3:12
    |
 LL |     v.push(v.pop().unwrap());
-   |     -------^^^^^^^----------
-   |     | |    |
-   |     | |    second mutable borrow occurs here
+   |     - ---- ^ second mutable borrow occurs here
+   |     | |
    |     | first borrow later used by call
    |     first mutable borrow occurs here
    |

--- a/tests/ui/codemap_tests/tab_3.stderr
+++ b/tests/ui/codemap_tests/tab_3.stderr
@@ -15,7 +15,7 @@ note: `into_iter` takes ownership of the receiver `self`, which moves `some_vec`
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     some_vec.clone().into_iter();
-   |              ++++++++
+   |             ++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/const-generic-default-wont-borrowck.stderr
+++ b/tests/ui/const-generics/const-generic-default-wont-borrowck.stderr
@@ -2,7 +2,7 @@ error[E0381]: used binding `s` isn't initialized
   --> $DIR/const-generic-default-wont-borrowck.rs:2:26
    |
 LL |     let s: &'static str; s.len()
-   |         -                ^^^^^^^ `*s` used here but it isn't initialized
+   |         -                ^ `*s` used here but it isn't initialized
    |         |
    |         binding declared here but left uninitialized
    |

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*self.0` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-109141.rs:6:9
    |
 LL |         self.0.iter_mut()
-   |         ^^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/const-generics/issues/issue-67375.full.stderr
+++ b/tests/ui/const-generics/issues/issue-67375.full.stderr
@@ -2,7 +2,7 @@ error: overly complex generic constant
   --> $DIR/issue-67375.rs:7:17
    |
 LL |     inner: [(); { [|_: &T| {}; 0].len() }],
-   |                 ^^---------------------^^
+   |                 ^^---------------^^^^^^^^
    |                   |
    |                   pointer casts are not allowed in generic constants
    |

--- a/tests/ui/consts/const_let_assign3.stderr
+++ b/tests/ui/consts/const_let_assign3.stderr
@@ -11,7 +11,7 @@ error[E0658]: mutable references are not allowed in constants
   --> $DIR/const_let_assign3.rs:14:5
    |
 LL |     s.foo(3);
-   |     ^^^^^^^^
+   |     ^
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable

--- a/tests/ui/did_you_mean/issue-34126.stderr
+++ b/tests/ui/did_you_mean/issue-34126.stderr
@@ -19,9 +19,8 @@ error[E0502]: cannot borrow `self` as mutable because it is also borrowed as imm
   --> $DIR/issue-34126.rs:6:18
    |
 LL |         self.run(&mut self);
-   |         ---------^^^^^^^^^-
-   |         |    |   |
-   |         |    |   mutable borrow occurs here
+   |         ---- --- ^^^^^^^^^ mutable borrow occurs here
+   |         |    |
    |         |    immutable borrow later used by call
    |         immutable borrow occurs here
 

--- a/tests/ui/did_you_mean/issue-35937.stderr
+++ b/tests/ui/did_you_mean/issue-35937.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `f.v` as mutable, as `f` is not declared as mutable
   --> $DIR/issue-35937.rs:7:5
    |
 LL |     f.v.push("cat".to_string());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/did_you_mean/issue-38147-1.stderr
+++ b/tests/ui/did_you_mean/issue-38147-1.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-38147-1.rs:17:9
    |
 LL |         self.s.push('x');
-   |         ^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-38147-2.stderr
+++ b/tests/ui/did_you_mean/issue-38147-2.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-38147-2.rs:9:9
    |
 LL |         self.s.push('x');
-   |         ^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |         ^^^^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*self.longer_name` as mutable, as it is behind a `&
   --> $DIR/issue-38147-2.rs:12:9
    |
 LL |         self.longer_name.push(13);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |         ^^^^^^^^^^^^^^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/did_you_mean/issue-38147-3.stderr
+++ b/tests/ui/did_you_mean/issue-38147-3.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-38147-3.rs:7:9
    |
 LL |         self.s.push('x');
-   |         ^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |         ^^^^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/did_you_mean/issue-38147-4.stderr
+++ b/tests/ui/did_you_mean/issue-38147-4.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*f.s` as mutable, as it is behind a `&` reference
   --> $DIR/issue-38147-4.rs:6:5
    |
 LL |     f.s.push('x');
-   |     ^^^^^^^^^^^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-40823.stderr
+++ b/tests/ui/did_you_mean/issue-40823.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*buf` as mutable, as it is behind a `&` reference
   --> $DIR/issue-40823.rs:3:5
    |
 LL |     buf.iter_mut();
-   |     ^^^^^^^^^^^^^^ `buf` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `buf` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/dropck/drop-with-active-borrows-1.stderr
+++ b/tests/ui/dropck/drop-with-active-borrows-1.stderr
@@ -4,7 +4,7 @@ error[E0505]: cannot move out of `a` because it is borrowed
 LL |     let a = "".to_string();
    |         - binding `a` declared here
 LL |     let b: Vec<&str> = a.lines().collect();
-   |                        --------- borrow of `a` occurs here
+   |                        - borrow of `a` occurs here
 LL |     drop(a);
    |          ^ move out of `a` occurs here
 LL |     for s in &b {

--- a/tests/ui/dropck/drop-with-active-borrows-2.stderr
+++ b/tests/ui/dropck/drop-with-active-borrows-2.stderr
@@ -2,7 +2,7 @@ error[E0515]: cannot return value referencing local variable `raw_lines`
   --> $DIR/drop-with-active-borrows-2.rs:3:5
    |
 LL |     raw_lines.iter().map(|l| l.trim()).collect()
-   |     ----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     returns a value referencing data owned by the current function
    |     `raw_lines` is borrowed here

--- a/tests/ui/error-codes/E0161.base.stderr
+++ b/tests/ui/error-codes/E0161.base.stderr
@@ -2,7 +2,7 @@ error[E0161]: cannot move a value of type `dyn Bar`
   --> $DIR/E0161.rs:16:5
    |
 LL |     x.f();
-   |     ^^^^^ the size of `dyn Bar` cannot be statically determined
+   |     ^ the size of `dyn Bar` cannot be statically determined
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0499.stderr
+++ b/tests/ui/error-codes/E0499.stderr
@@ -7,7 +7,7 @@ LL |     let mut a = &mut i;
    |                 ^^^^^^ second mutable borrow occurs here
 LL |     a.use_mut();
 LL |     x.use_mut();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0502.stderr
+++ b/tests/ui/error-codes/E0502.stderr
@@ -6,7 +6,7 @@ LL |     let ref y = a;
 LL |     bar(a);
    |     ^^^^^^ mutable borrow occurs here
 LL |     y.use_ref();
-   |     ----------- immutable borrow later used here
+   |     - immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0503.stderr
+++ b/tests/ui/error-codes/E0503.stderr
@@ -6,7 +6,7 @@ LL |     let _borrow = &mut value;
 LL |     let _sum = value + 1;
    |                ^^^^^ use of borrowed `value`
 LL |     _borrow.use_mut();
-   |     ----------------- borrow later used here
+   |     ------- borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0505.stderr
+++ b/tests/ui/error-codes/E0505.stderr
@@ -9,7 +9,7 @@ LL |         let _ref_to_val: &Value = &x;
 LL |         eat(x);
    |             ^ move out of `x` occurs here
 LL |         _ref_to_val.use_ref();
-   |         --------------------- borrow later used here
+   |         ----------- borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0507.stderr
+++ b/tests/ui/error-codes/E0507.stderr
@@ -2,9 +2,8 @@ error[E0507]: cannot move out of dereference of `Ref<'_, TheDarkKnight>`
   --> $DIR/E0507.rs:12:5
    |
 LL |     x.borrow().nothing_is_true();
-   |     ^^^^^^^^^^^-----------------
-   |     |          |
-   |     |          value moved due to this method call
+   |     ^^^^^^^^^^ ----------------- value moved due to this method call
+   |     |
    |     move occurs because value has type `TheDarkKnight`, which does not implement the `Copy` trait
    |
 note: `TheDarkKnight::nothing_is_true` takes ownership of the receiver `self`, which moves value

--- a/tests/ui/generator/dropck-resume.stderr
+++ b/tests/ui/generator/dropck-resume.stderr
@@ -5,7 +5,7 @@ LL |     let z = &mut y;
    |             ------ mutable borrow occurs here
 ...
 LL |         r = y.as_ref().unwrap();
-   |             ^^^^^^^^^^ immutable borrow occurs here
+   |             ^ immutable borrow occurs here
 LL |
 LL |     }
    |     - mutable borrow might be used here, when `g` is dropped and runs the destructor for generator

--- a/tests/ui/generator/dropck.stderr
+++ b/tests/ui/generator/dropck.stderr
@@ -5,7 +5,7 @@ LL |     let (mut gen, cell);
    |                   ---- binding `cell` declared here
 LL |     cell = Box::new(RefCell::new(0));
 LL |     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
-   |                                        ^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                                        ^^^^ borrowed value does not live long enough
 ...
 LL | }
    | -

--- a/tests/ui/hashmap/hashmap-iter-value-lifetime.stderr
+++ b/tests/ui/hashmap/hashmap-iter-value-lifetime.stderr
@@ -2,7 +2,7 @@ error[E0502]: cannot borrow `my_stuff` as mutable because it is also borrowed as
   --> $DIR/hashmap-iter-value-lifetime.rs:7:5
    |
 LL |     let (_, thing) = my_stuff.iter().next().unwrap();
-   |                      --------------- immutable borrow occurs here
+   |                      -------- immutable borrow occurs here
 LL |
 LL |     my_stuff.clear();
    |     ^^^^^^^^^^^^^^^^ mutable borrow occurs here

--- a/tests/ui/hashmap/hashmap-lifetimes.stderr
+++ b/tests/ui/hashmap/hashmap-lifetimes.stderr
@@ -2,7 +2,7 @@ error[E0502]: cannot borrow `my_stuff` as mutable because it is also borrowed as
   --> $DIR/hashmap-lifetimes.rs:6:5
    |
 LL |     let mut it = my_stuff.iter();
-   |                  --------------- immutable borrow occurs here
+   |                  -------- immutable borrow occurs here
 LL |     my_stuff.insert(1, 43);
    |     ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     it;

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-debruijn-in-receiver.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-debruijn-in-receiver.stderr
@@ -2,9 +2,9 @@ error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/hrtb-debruijn-in-receiver.rs:17:5
    |
 LL |     foo.insert();
-   |     ------------ first mutable borrow occurs here
+   |     --- first mutable borrow occurs here
 LL |     foo.insert();
-   |     ^^^^^^^^^^^^
+   |     ^^^
    |     |
    |     second mutable borrow occurs here
    |     first borrow later used here

--- a/tests/ui/hygiene/fields-numeric-borrowck.stderr
+++ b/tests/ui/hygiene/fields-numeric-borrowck.stderr
@@ -7,7 +7,7 @@ LL |     let S { 0: ref mut borrow2 } = s;
    |                ^^^^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 LL |     borrow1.use_mut();
-   |     ----------------- first borrow later used here
+   |     ------- first borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-13497-2.stderr
+++ b/tests/ui/issues/issue-13497-2.stderr
@@ -1,11 +1,13 @@
 error[E0515]: cannot return value referencing local variable `rawLines`
   --> $DIR/issue-13497-2.rs:3:5
    |
-LL | //     rawLines
-LL | ||         .iter().map(|l| l.trim()).collect()
-   | ||_______________-___________________________^ returns a value referencing data owned by the current function
-   |  |_______________|
-   |                  `rawLines` is borrowed here
+LL |       rawLines
+   |       ^-------
+   |       |
+   |  _____`rawLines` is borrowed here
+   | |
+LL | |         .iter().map(|l| l.trim()).collect()
+   | |___________________________________________^ returns a value referencing data owned by the current function
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-21600.stderr
+++ b/tests/ui/issues/issue-21600.stderr
@@ -5,7 +5,7 @@ LL | fn call_it<F>(f: F) where F: Fn() { f(); }
    |                  - change this to accept `FnMut` instead of `Fn`
 ...
 LL |         call_it(|| x.gen_mut());
-   |         ------- -- ^^^^^^^^^^^ cannot borrow as mutable
+   |         ------- -- ^ cannot borrow as mutable
    |         |       |
    |         |       in this closure
    |         expects `Fn` instead of `FnMut`

--- a/tests/ui/issues/issue-41726.stderr
+++ b/tests/ui/issues/issue-41726.stderr
@@ -2,13 +2,10 @@ error[E0596]: cannot borrow data in an index of `HashMap<String, Vec<String>>` a
   --> $DIR/issue-41726.rs:5:9
    |
 LL |         things[src.as_str()].sort();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |         ^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
    |
    = help: trait `IndexMut` is required to modify indexed content, but it is not implemented for `HashMap<String, Vec<String>>`
-help: to modify a `HashMap<String, Vec<String>>` use `.get_mut()`
-   |
-LL |         things.get_mut(src.as_str()).map(|val| val.sort());
-   |               ~~~~~~~~~            ~~~~~~~~~~~~~~~       +
+   = help: to modify a `HashMap<String, Vec<String>>`, use `.get_mut()`, `.insert()` or the entry API
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-42106.stderr
+++ b/tests/ui/issues/issue-42106.stderr
@@ -4,9 +4,9 @@ error[E0502]: cannot borrow `*collection` as mutable because it is also borrowed
 LL |     let _a = &collection;
    |              ----------- immutable borrow occurs here
 LL |     collection.swap(1, 2);
-   |     ^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+   |     ^^^^^^^^^^ mutable borrow occurs here
 LL |     _a.use_ref();
-   |     ------------ immutable borrow later used here
+   |     -- immutable borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-44405.stderr
+++ b/tests/ui/issues/issue-44405.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow data in an index of `Container` as mutable
   --> $DIR/issue-44405.rs:21:5
    |
 LL |     container[&mut val].test();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
    |
    = help: trait `IndexMut` is required to modify indexed content, but it is not implemented for `Container`
 

--- a/tests/ui/issues/issue-52126-assign-op-invariance.stderr
+++ b/tests/ui/issues/issue-52126-assign-op-invariance.stderr
@@ -4,7 +4,7 @@ error[E0597]: `line` does not live long enough
 LL |     for line in vec!["123456789".to_string(), "12345678".to_string()] {
    |         ---- binding `line` declared here
 LL |         let v: Vec<&str> = line.split_whitespace().collect();
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                            ^^^^ borrowed value does not live long enough
 ...
 LL |         acc += cnt2;
    |         --- borrow later used here

--- a/tests/ui/issues/issue-61108.stderr
+++ b/tests/ui/issues/issue-61108.stderr
@@ -7,7 +7,7 @@ LL |     for l in bad_letters {
    |              ----------- `bad_letters` moved due to this implicit call to `.into_iter()`
 ...
 LL |     bad_letters.push('s');
-   |     ^^^^^^^^^^^^^^^^^^^^^ value borrowed here after move
+   |     ^^^^^^^^^^^ value borrowed here after move
    |
 note: `into_iter` takes ownership of the receiver `self`, which moves `bad_letters`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL

--- a/tests/ui/issues/issue-81584.stderr
+++ b/tests/ui/issues/issue-81584.stderr
@@ -2,7 +2,7 @@ error[E0515]: cannot return value referencing function parameter `y`
   --> $DIR/issue-81584.rs:5:22
    |
 LL |             .map(|y| y.iter().map(|x| x + 1))
-   |                      --------^^^^^^^^^^^^^^^
+   |                      -^^^^^^^^^^^^^^^^^^^^^^
    |                      |
    |                      returns a value referencing data owned by the current function
    |                      `y` is borrowed here

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -7,7 +7,7 @@ LL |     let mut x = vec![1].iter();
    |                 creates a temporary value which is freed while still in use
 LL |
 LL |     x.use_mut();
-   |     ----------- borrow later used here
+   |     - borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
@@ -1,3 +1,14 @@
+error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
+  --> $DIR/ex3-both-anon-regions-using-fn-items.rs:2:3
+   |
+LL |   y.push(z);
+   |   ^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | fn foo(x:fn(&u8, &u8), mut y: Vec<&u8>, z: &u8) {
+   |                        +++
+
 error: lifetime may not live long enough
   --> $DIR/ex3-both-anon-regions-using-fn-items.rs:2:3
    |
@@ -12,17 +23,6 @@ help: consider introducing a named lifetime parameter
    |
 LL | fn foo<'a>(x:fn(&u8, &u8), y: Vec<&'a u8>, z: &'a u8) {
    |       ++++                         ++          ++
-
-error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
-  --> $DIR/ex3-both-anon-regions-using-fn-items.rs:2:3
-   |
-LL |   y.push(z);
-   |   ^^^^^^^^^ cannot borrow as mutable
-   |
-help: consider changing this to be mutable
-   |
-LL | fn foo(x:fn(&u8, &u8), mut y: Vec<&u8>, z: &u8) {
-   |                        +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
@@ -1,3 +1,14 @@
+error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
+  --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:2:3
+   |
+LL |   y.push(z);
+   |   ^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | fn foo(x:Box<dyn Fn(&u8, &u8)> , mut y: Vec<&u8>, z: &u8) {
+   |                                  +++
+
 error: lifetime may not live long enough
   --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:2:3
    |
@@ -12,17 +23,6 @@ help: consider introducing a named lifetime parameter
    |
 LL | fn foo<'a>(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&'a u8>, z: &'a u8) {
    |       ++++                                   ++          ++
-
-error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
-  --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:2:3
-   |
-LL |   y.push(z);
-   |   ^^^^^^^^^ cannot borrow as mutable
-   |
-help: consider changing this to be mutable
-   |
-LL | fn foo(x:Box<dyn Fn(&u8, &u8)> , mut y: Vec<&u8>, z: &u8) {
-   |                                  +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/unaligned_references.stderr
+++ b/tests/ui/lint/unaligned_references.stderr
@@ -52,7 +52,7 @@ error[E0793]: reference to packed field is unaligned
   --> $DIR/unaligned_references.rs:40:17
    |
 LL |         let _ = good.data.clone();
-   |                 ^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^
    |
    = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)

--- a/tests/ui/macros/format-args-temporaries-in-write.stderr
+++ b/tests/ui/macros/format-args-temporaries-in-write.stderr
@@ -4,7 +4,7 @@ error[E0597]: `mutex` does not live long enough
 LL |         let mutex = Mutex;
    |             ----- binding `mutex` declared here
 LL |         write!(Out, "{}", mutex.lock()) /* no semicolon */
-   |                           ^^^^^^^^^^^^
+   |                           ^^^^^-------
    |                           |
    |                           borrowed value does not live long enough
    |                           a temporary with access to the borrow is created here ...
@@ -21,7 +21,7 @@ error[E0597]: `mutex` does not live long enough
 LL |         let mutex = Mutex;
    |             ----- binding `mutex` declared here
 LL |         writeln!(Out, "{}", mutex.lock()) /* no semicolon */
-   |                             ^^^^^^^^^^^^
+   |                             ^^^^^-------
    |                             |
    |                             borrowed value does not live long enough
    |                             a temporary with access to the borrow is created here ...

--- a/tests/ui/macros/issue-19163.stderr
+++ b/tests/ui/macros/issue-19163.stderr
@@ -1,10 +1,8 @@
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/issue-19163.rs:9:5
+  --> $DIR/issue-19163.rs:9:14
    |
 LL |     mywrite!(&v, "Hello world");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
-   |
-   = note: this error originates in the macro `mywrite` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |              ^^ cannot borrow as mutable
 
 error: aborting due to previous error
 

--- a/tests/ui/match/issue-74050-end-span.stderr
+++ b/tests/ui/match/issue-74050-end-span.stderr
@@ -6,7 +6,7 @@ LL |     let _arg = match args.next() {
 LL |         Some(arg) => {
    |              --- binding `arg` declared here
 LL |             match arg.to_str() {
-   |                   ^^^^^^^^^^^^ borrowed value does not live long enough
+   |                   ^^^ borrowed value does not live long enough
 ...
 LL |         }
    |         - `arg` dropped here while still borrowed

--- a/tests/ui/methods/method-self-arg-2.stderr
+++ b/tests/ui/methods/method-self-arg-2.stderr
@@ -6,7 +6,7 @@ LL |     let y = &mut x;
 LL |     Foo::bar(&x);
    |              ^^ immutable borrow occurs here
 LL |     y.use_mut();
-   |     ----------- mutable borrow later used here
+   |     - mutable borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/method-self-arg-2.rs:20:14
@@ -16,7 +16,7 @@ LL |     let y = &mut x;
 LL |     Foo::baz(&mut x);
    |              ^^^^^^ second mutable borrow occurs here
 LL |     y.use_mut();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/moves/move-fn-self-receiver.stderr
+++ b/tests/ui/moves/move-fn-self-receiver.stderr
@@ -78,7 +78,7 @@ error[E0505]: cannot move out of `mut_foo` because it is borrowed
 LL |     let mut mut_foo = Foo;
    |         ----------- binding `mut_foo` declared here
 LL |     let ret = mut_foo.use_mut_self();
-   |               ---------------------- borrow of `mut_foo` occurs here
+   |               ------- borrow of `mut_foo` occurs here
 LL |     mut_foo;
    |     ^^^^^^^ move out of `mut_foo` occurs here
 LL |     ret;

--- a/tests/ui/moves/move-fn-self-receiver.stderr
+++ b/tests/ui/moves/move-fn-self-receiver.stderr
@@ -12,7 +12,7 @@ note: `into_iter` takes ownership of the receiver `self`, which moves `val.0`
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     val.0.clone().into_iter().next();
-   |           ++++++++
+   |          ++++++++
 
 error[E0382]: use of moved value: `foo`
   --> $DIR/move-fn-self-receiver.rs:34:5
@@ -102,7 +102,7 @@ LL |     fn use_rc_self(self: Rc<Self>) {}
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     rc_foo.clone().use_rc_self();
-   |            ++++++++
+   |           ++++++++
 
 error[E0382]: use of moved value: `foo_add`
   --> $DIR/move-fn-self-receiver.rs:59:5
@@ -145,7 +145,7 @@ LL |     explicit_into_iter;
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     for _val in explicit_into_iter.clone().into_iter() {}
-   |                                    ++++++++
+   |                                   ++++++++
 
 error[E0382]: use of moved value: `container`
   --> $DIR/move-fn-self-receiver.rs:71:5

--- a/tests/ui/moves/moves-based-on-type-access-to-field.stderr
+++ b/tests/ui/moves/moves-based-on-type-access-to-field.stderr
@@ -13,7 +13,7 @@ note: `into_iter` takes ownership of the receiver `self`, which moves `x`
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     consume(x.clone().into_iter().next().unwrap());
-   |               ++++++++
+   |              ++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/moves/moves-based-on-type-exprs.stderr
+++ b/tests/ui/moves/moves-based-on-type-exprs.stderr
@@ -165,7 +165,7 @@ note: `into_iter` takes ownership of the receiver `self`, which moves `x`
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     let _y = x.clone().into_iter().next().unwrap();
-   |                ++++++++
+   |               ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:83:11
@@ -182,7 +182,7 @@ note: `into_iter` takes ownership of the receiver `self`, which moves `x`
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     let _y = [x.clone().into_iter().next().unwrap(); 1];
-   |                 ++++++++
+   |                ++++++++
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/moves/pin-mut-reborrow-infer-var-issue-107419.stderr
+++ b/tests/ui/moves/pin-mut-reborrow-infer-var-issue-107419.stderr
@@ -13,7 +13,7 @@ note: `Pin::<&'a mut T>::get_mut` takes ownership of the receiver `self`, which 
 help: consider reborrowing the `Pin` instead of moving it
    |
 LL |     foo(r.as_mut().get_mut());
-   |           +++++++++
+   |          +++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/moves/pin-mut-reborrow.stderr
+++ b/tests/ui/moves/pin-mut-reborrow.stderr
@@ -16,7 +16,7 @@ LL |     fn foo(self: Pin<&mut Self>) {}
 help: consider reborrowing the `Pin` instead of moving it
    |
 LL |     foo.as_mut().foo();
-   |         +++++++++
+   |        +++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/moves/suggest-clone.stderr
+++ b/tests/ui/moves/suggest-clone.stderr
@@ -2,9 +2,8 @@ error[E0507]: cannot move out of `*foo` which is behind a shared reference
   --> $DIR/suggest-clone.rs:10:5
    |
 LL |     foo.foo();
-   |     ^^^^-----
-   |     |   |
-   |     |   `*foo` moved due to this method call
+   |     ^^^ ----- `*foo` moved due to this method call
+   |     |
    |     move occurs because `*foo` has type `Foo`, which does not implement the `Copy` trait
    |
 note: `Foo::foo` takes ownership of the receiver `self`, which moves `*foo`

--- a/tests/ui/mut/mut-cant-alias.stderr
+++ b/tests/ui/mut/mut-cant-alias.stderr
@@ -6,7 +6,7 @@ LL |     let b1 = &mut *b;
 LL |     let b2 = &mut *b;
    |                    ^ second mutable borrow occurs here
 LL |     b1.use_mut();
-   |     ------------ first borrow later used here
+   |     -- first borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/mut/mut-suggestion.stderr
+++ b/tests/ui/mut/mut-suggestion.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
   --> $DIR/mut-suggestion.rs:12:5
    |
 LL |     arg.mutate();
-   |     ^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `local` as mutable, as it is not declared as mutable
   --> $DIR/mut-suggestion.rs:20:5
    |
 LL |     local.mutate();
-   |     ^^^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^^^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/nll/closure-access-spans.stderr
+++ b/tests/ui/nll/closure-access-spans.stderr
@@ -8,7 +8,7 @@ LL |     || x;
    |     |
    |     immutable borrow occurs here
 LL |     r.use_mut();
-   |     ----------- mutable borrow later used here
+   |     - mutable borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/closure-access-spans.rs:11:5
@@ -20,7 +20,7 @@ LL |     || x = 2;
    |     |
    |     second mutable borrow occurs here
 LL |     r.use_mut();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error[E0500]: closure requires unique access to `x` but it is already borrowed
   --> $DIR/closure-access-spans.rs:17:5
@@ -32,7 +32,7 @@ LL |     || *x = 2;
    |     |
    |     closure construction occurs here
 LL |     r.use_mut();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/closure-access-spans.rs:23:13
@@ -42,7 +42,7 @@ LL |     let r = &mut x;
 LL |     move || x;
    |             ^ use of borrowed `x`
 LL |     r.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/closure-access-spans.rs:29:5
@@ -56,7 +56,7 @@ LL |     || x;
    |     |
    |     move out of `x` occurs here
 LL |     r.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/closure-access-spans.rs:35:5

--- a/tests/ui/nll/closure-borrow-spans.stderr
+++ b/tests/ui/nll/closure-borrow-spans.stderr
@@ -8,7 +8,7 @@ LL |     let f = || x.len();
 LL |     let y = x;
    |             ^ move out of `x` occurs here
 LL |     f.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
   --> $DIR/closure-borrow-spans.rs:11:13
@@ -20,7 +20,7 @@ LL |     let f = || x;
 LL |     let y = &mut x;
    |             ^^^^^^ mutable borrow occurs here
 LL |     f.use_ref();
-   |     ----------- immutable borrow later used here
+   |     - immutable borrow later used here
 
 error[E0597]: `x` does not live long enough
   --> $DIR/closure-borrow-spans.rs:19:16
@@ -32,7 +32,7 @@ LL |         f = || x;
 LL |     }
    |     - `x` dropped here while still borrowed
 LL |     f.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0506]: cannot assign to `x` because it is borrowed
   --> $DIR/closure-borrow-spans.rs:26:5
@@ -44,7 +44,7 @@ LL |     let f = || x;
 LL |     x = 1;
    |     ^^^^^ `x` is assigned to here but it was already borrowed
 LL |     f.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/closure-borrow-spans.rs:32:13
@@ -56,7 +56,7 @@ LL |     let f = || x = 0;
 LL |     let y = x;
    |             ^ use of borrowed `x`
 LL |     f.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/closure-borrow-spans.rs:38:13
@@ -68,7 +68,7 @@ LL |     let f = || x = 0;
 LL |     let y = &x;
    |             ^^ immutable borrow occurs here
 LL |     f.use_ref();
-   |     ----------- mutable borrow later used here
+   |     - mutable borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/closure-borrow-spans.rs:44:13
@@ -80,7 +80,7 @@ LL |     let f = || x = 0;
 LL |     let y = &mut x;
    |             ^^^^^^ second mutable borrow occurs here
 LL |     f.use_ref();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error[E0597]: `x` does not live long enough
   --> $DIR/closure-borrow-spans.rs:52:16
@@ -92,7 +92,7 @@ LL |         f = || x = 0;
 LL |     }
    |     - `x` dropped here while still borrowed
 LL |     f.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0506]: cannot assign to `x` because it is borrowed
   --> $DIR/closure-borrow-spans.rs:59:5
@@ -104,7 +104,7 @@ LL |     let f = || x = 0;
 LL |     x = 1;
    |     ^^^^^ `x` is assigned to here but it was already borrowed
 LL |     f.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/closure-borrow-spans.rs:65:13
@@ -116,7 +116,7 @@ LL |     let f = || *x = 0;
 LL |     let y = x;
    |             ^ move out of `x` occurs here
 LL |     f.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0501]: cannot borrow `x` as immutable because previous closure requires unique access
   --> $DIR/closure-borrow-spans.rs:71:13
@@ -128,7 +128,7 @@ LL |     let f = || *x = 0;
 LL |     let y = &x;
    |             ^^ second borrow occurs here
 LL |     f.use_ref();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error[E0501]: cannot borrow `x` as mutable because previous closure requires unique access
   --> $DIR/closure-borrow-spans.rs:77:13
@@ -140,7 +140,7 @@ LL |     let f = || *x = 0;
 LL |     let y = &mut x;
    |             ^^^^^^ second borrow occurs here
 LL |     f.use_ref();
-   |     ----------- first borrow later used here
+   |     - first borrow later used here
 
 error[E0597]: `x` does not live long enough
   --> $DIR/closure-borrow-spans.rs:86:16
@@ -152,7 +152,7 @@ LL |         f = || *x = 0;
 LL |     }
    |     - `x` dropped here while still borrowed
 LL |     f.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/closure-borrow-spans.rs:93:5
@@ -164,7 +164,7 @@ LL |     let f = || *x = 0;
 LL |     *x = 1;
    |     ^^^^^^ `*x` is assigned to here but it was already borrowed
 LL |     f.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/nll/closures-in-loops.stderr
+++ b/tests/ui/nll/closures-in-loops.stderr
@@ -13,9 +13,8 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/closures-in-loops.rs:13:16
    |
 LL |         v.push(|| x = String::new());
-   |         -------^^-------------------
-   |         |      |  |
-   |         |      |  borrows occur due to use of `x` in closure
+   |         -      ^^ - borrows occur due to use of `x` in closure
+   |         |      |
    |         |      `x` was mutably borrowed here in the previous iteration of the loop
    |         first borrow used here, in later iteration of loop
 
@@ -23,9 +22,8 @@ error[E0524]: two closures require unique access to `x` at the same time
   --> $DIR/closures-in-loops.rs:20:16
    |
 LL |         v.push(|| *x = String::new());
-   |         -------^^--------------------
-   |         |      |  |
-   |         |      |  borrows occur due to use of `x` in closure
+   |         -      ^^ -- borrows occur due to use of `x` in closure
+   |         |      |
    |         |      closures are constructed here in different iterations of loop
    |         first borrow used here, in later iteration of loop
 

--- a/tests/ui/nll/get_default.stderr
+++ b/tests/ui/nll/get_default.stderr
@@ -5,7 +5,7 @@ LL | fn ok(map: &mut Map) -> &String {
    |            - let's call the lifetime of this reference `'1`
 LL |     loop {
 LL |         match map.get() {
-   |               --------- immutable borrow occurs here
+   |               --- immutable borrow occurs here
 LL |             Some(v) => {
 LL |                 return v;
    |                        - returning this value requires that `*map` is borrowed for `'1`
@@ -20,7 +20,7 @@ LL | fn err(map: &mut Map) -> &String {
    |             - let's call the lifetime of this reference `'1`
 LL |     loop {
 LL |         match map.get() {
-   |               --------- immutable borrow occurs here
+   |               --- immutable borrow occurs here
 LL |             Some(v) => {
 LL |                 map.set(String::new()); // Both AST and MIR error here
    |                 ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
@@ -35,7 +35,7 @@ LL | fn err(map: &mut Map) -> &String {
    |             - let's call the lifetime of this reference `'1`
 LL |     loop {
 LL |         match map.get() {
-   |               --------- immutable borrow occurs here
+   |               --- immutable borrow occurs here
 ...
 LL |                 return v;
    |                        - returning this value requires that `*map` is borrowed for `'1`

--- a/tests/ui/nll/issue-46589.stderr
+++ b/tests/ui/nll/issue-46589.stderr
@@ -2,10 +2,10 @@ error[E0499]: cannot borrow `**other` as mutable more than once at a time
   --> $DIR/issue-46589.rs:23:21
    |
 LL |         *other = match (*other).get_self() {
-   |                        ------------------- first mutable borrow occurs here
+   |                        -------- first mutable borrow occurs here
 LL |             Some(s) => s,
 LL |             None => (*other).new_self()
-   |                     ^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^
    |                     |
    |                     second mutable borrow occurs here
    |                     first borrow later used here

--- a/tests/ui/nll/issue-51191.stderr
+++ b/tests/ui/nll/issue-51191.stderr
@@ -48,7 +48,7 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/issue-51191.rs:22:9
    |
 LL |         (&mut self).bar();
-   |         ^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |         ^^^^^^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-51191.rs:28:9

--- a/tests/ui/nll/issue-52669.stderr
+++ b/tests/ui/nll/issue-52669.stderr
@@ -7,7 +7,7 @@ LL |     a.b = B;
 LL |     foo(a);
    |         - value moved here
 LL |     a.b.clone()
-   |     ^^^^^^^^^^^ value borrowed here after move
+   |     ^^^ value borrowed here after move
 
 error: aborting due to previous error
 

--- a/tests/ui/nll/issue-53773.stderr
+++ b/tests/ui/nll/issue-53773.stderr
@@ -2,7 +2,9 @@ error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-53773.rs:41:22
    |
 LL |         members.push(child.raw);
-   |         -------------^^^^^^^^^- borrow later used here
+   |         -------      ^^^^^^^^^
+   |         |
+   |         borrow later used here
 LL |
 LL |     }
    |     - here, drop of `child` needs exclusive access to `*child.raw`, because the type `C<'_>` implements the `Drop` trait

--- a/tests/ui/nll/issue-54556-niconii.stderr
+++ b/tests/ui/nll/issue-54556-niconii.stderr
@@ -5,7 +5,7 @@ LL |     let counter = Mutex;
    |         ------- binding `counter` declared here
 LL |
 LL |     if let Ok(_) = counter.lock() { }
-   |                    ^^^^^^^^^^^^^^
+   |                    ^^^^^^^-------
    |                    |
    |                    borrowed value does not live long enough
    |                    a temporary with access to the borrow is created here ...

--- a/tests/ui/nll/issue-62007-assign-const-index.stderr
+++ b/tests/ui/nll/issue-62007-assign-const-index.stderr
@@ -17,7 +17,7 @@ LL | fn to_refs<T>(mut list: [&mut List<T>; 2]) -> Vec<&mut T> {
    |                          - let's call the lifetime of this reference `'1`
 ...
 LL |         if let Some(n) = list[0].next.as_mut() {
-   |                          ^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^---------
    |                          |
    |                          `list[_].next` was mutably borrowed here in the previous iteration of the loop
    |                          argument requires that `list[_].next` is borrowed for `'1`

--- a/tests/ui/nll/issue-62007-assign-differing-fields.stderr
+++ b/tests/ui/nll/issue-62007-assign-differing-fields.stderr
@@ -17,7 +17,7 @@ LL | fn to_refs<'a, T>(mut list: (&'a mut List<T>, &'a mut List<T>)) -> Vec<&'a 
    |            -- lifetime `'a` defined here
 ...
 LL |         if let Some(n) = (list.0).next.as_mut() {
-   |                          ^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^---------
    |                          |
    |                          `list.0.next` was mutably borrowed here in the previous iteration of the loop
    |                          argument requires that `list.0.next` is borrowed for `'a`

--- a/tests/ui/nll/loan_ends_mid_block_vec.stderr
+++ b/tests/ui/nll/loan_ends_mid_block_vec.stderr
@@ -5,7 +5,7 @@ LL |     let slice = &mut data;
    |                 --------- first mutable borrow occurs here
 LL |     capitalize(slice);
 LL |     data.push('d');
-   |     ^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     ^^^^ second mutable borrow occurs here
 ...
 LL |     capitalize(slice);
    |                ----- first borrow later used here
@@ -17,7 +17,7 @@ LL |     let slice = &mut data;
    |                 --------- first mutable borrow occurs here
 ...
 LL |     data.push('e');
-   |     ^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     ^^^^ second mutable borrow occurs here
 ...
 LL |     capitalize(slice);
    |                ----- first borrow later used here
@@ -29,7 +29,7 @@ LL |     let slice = &mut data;
    |                 --------- first mutable borrow occurs here
 ...
 LL |     data.push('f');
-   |     ^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |     ^^^^ second mutable borrow occurs here
 LL |
 LL |     capitalize(slice);
    |                ----- first borrow later used here

--- a/tests/ui/nll/polonius/assignment-to-differing-field.stderr
+++ b/tests/ui/nll/polonius/assignment-to-differing-field.stderr
@@ -17,7 +17,7 @@ LL | fn assignment_to_field_projection<'a, T>(
    |                                   -- lifetime `'a` defined here
 ...
 LL |         if let Some(n) = (list.0).next.as_mut() {
-   |                          ^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^---------
    |                          |
    |                          `list.0.next` was mutably borrowed here in the previous iteration of the loop
    |                          argument requires that `list.0.next` is borrowed for `'a`
@@ -41,7 +41,7 @@ LL | fn assignment_through_projection_chain<'a, T>(
    |                                        -- lifetime `'a` defined here
 ...
 LL |         if let Some(n) = ((((list.0).0).0).0).0.next.as_mut() {
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^---------
    |                          |
    |                          `list.0.0.0.0.0.next` was mutably borrowed here in the previous iteration of the loop
    |                          argument requires that `list.0.0.0.0.0.next` is borrowed for `'a`

--- a/tests/ui/nll/return_from_loop.stderr
+++ b/tests/ui/nll/return_from_loop.stderr
@@ -5,10 +5,10 @@ LL |     let value = &mut my_struct.field;
    |                 -------------------- first mutable borrow occurs here
 LL |     loop {
 LL |         my_struct.field.push_str("Hello, world!");
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |         ^^^^^^^^^^^^^^^ second mutable borrow occurs here
 LL |
 LL |         value.len();
-   |         ----------- first borrow later used here
+   |         ----- first borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/object-safety/object-safety-by-value-self-use.stderr
+++ b/tests/ui/object-safety/object-safety-by-value-self-use.stderr
@@ -2,7 +2,7 @@ error[E0161]: cannot move a value of type `dyn Bar`
   --> $DIR/object-safety-by-value-self-use.rs:15:5
    |
 LL |     t.bar()
-   |     ^^^^^^^ the size of `dyn Bar` cannot be statically determined
+   |     ^ the size of `dyn Bar` cannot be statically determined
 
 error: aborting due to previous error
 

--- a/tests/ui/regions/region-object-lifetime-5.rs
+++ b/tests/ui/regions/region-object-lifetime-5.rs
@@ -8,7 +8,7 @@ trait Foo {
 // Here, the object is bounded by an anonymous lifetime and returned
 // as `&'static`, so you get an error.
 fn owned_receiver(x: Box<dyn Foo>) -> &'static () {
-    x.borrowed() //~ ERROR cannot return reference to local data `*x`
+    x.borrowed() //~ ERROR cannot return value referencing local data `*x`
 }
 
 fn main() {}

--- a/tests/ui/regions/region-object-lifetime-5.stderr
+++ b/tests/ui/regions/region-object-lifetime-5.stderr
@@ -1,8 +1,11 @@
-error[E0515]: cannot return reference to local data `*x`
+error[E0515]: cannot return value referencing local data `*x`
   --> $DIR/region-object-lifetime-5.rs:11:5
    |
 LL |     x.borrowed()
-   |     ^^^^^^^^^^^^ returns a reference to data owned by the current function
+   |     -^^^^^^^^^^^
+   |     |
+   |     returns a value referencing data owned by the current function
+   |     `*x` is borrowed here
 
 error: aborting due to previous error
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/borrowck-issue-49631.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/borrowck-issue-49631.stderr
@@ -2,7 +2,7 @@ error[E0502]: cannot borrow `foo` as mutable because it is also borrowed as immu
   --> $DIR/borrowck-issue-49631.rs:20:9
    |
 LL |     while let Some(Ok(string)) = foo.get() {
-   |                                  --------- immutable borrow occurs here
+   |                                  --- immutable borrow occurs here
 LL |         foo.mutate();
    |         ^^^^^^^^^^^^ mutable borrow occurs here
 LL |

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -66,7 +66,7 @@ error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:109:5
    |
 LL |     x.set(0, 0);
-   |     ^^^^^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |
@@ -77,7 +77,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:121:5
    |
 LL |     x.y_mut()
-   |     ^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -88,7 +88,7 @@ error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:129:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^^^^^^^^^ cannot borrow as mutable
+   |      ^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |
@@ -99,7 +99,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:133:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -25,7 +25,7 @@ error[E0596]: cannot borrow `f.f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:34:5
    |
 LL |     f.f.call_mut(())
-   |     ^^^^^^^^^^^^^^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
+++ b/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-method-from-mut-aliasable.rs:17:5
    |
 LL |     x.h();
-   |     ^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-fn-in-const-b.stderr
+++ b/tests/ui/span/borrowck-fn-in-const-b.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-fn-in-const-b.rs:7:9
    |
 LL |         x.push(format!("this is broken"));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-let-suggestion-suffixes.stderr
+++ b/tests/ui/span/borrowck-let-suggestion-suffixes.stderr
@@ -39,7 +39,7 @@ LL |         v4.push(&id('y'));
    |                  creates a temporary value which is freed while still in use
 ...
 LL |         v4.use_ref();
-   |         ------------ borrow later used here
+   |         -- borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
 

--- a/tests/ui/span/borrowck-object-mutability.stderr
+++ b/tests/ui/span/borrowck-object-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-object-mutability.rs:8:5
    |
 LL |     x.borrowed_mut();
-   |     ^^^^^^^^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as `x` is not declared as mutable
   --> $DIR/borrowck-object-mutability.rs:18:5
    |
 LL |     x.borrowed_mut();
-   |     ^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^ cannot borrow as mutable
    |
 help: consider changing this to be mutable
    |

--- a/tests/ui/span/destructor-restrictions.stderr
+++ b/tests/ui/span/destructor-restrictions.stderr
@@ -4,7 +4,7 @@ error[E0597]: `*a` does not live long enough
 LL |         let a = Box::new(RefCell::new(4));
    |             - binding `a` declared here
 LL |         *a.borrow() + 1
-   |          ^^^^^^^^^^
+   |          ^---------
    |          |
    |          borrowed value does not live long enough
    |          a temporary with access to the borrow is created here ...

--- a/tests/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
+++ b/tests/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
@@ -4,7 +4,7 @@ error[E0597]: `y` does not live long enough
 LL |     let y = x;
    |         - binding `y` declared here
 LL |     y.borrow().clone()
-   |     ^^^^^^^^^^
+   |     ^---------
    |     |
    |     borrowed value does not live long enough
    |     a temporary with access to the borrow is created here ...
@@ -27,7 +27,7 @@ error[E0597]: `y` does not live long enough
 LL |         let y = x;
    |             - binding `y` declared here
 LL |         y.borrow().clone()
-   |         ^^^^^^^^^^
+   |         ^---------
    |         |
    |         borrowed value does not live long enough
    |         a temporary with access to the borrow is created here ...

--- a/tests/ui/span/issue-36537.stderr
+++ b/tests/ui/span/issue-36537.stderr
@@ -9,7 +9,7 @@ LL |         p = &a;
 LL |     }
    |     - `a` dropped here while still borrowed
 LL |     p.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/span/issue-40157.stderr
+++ b/tests/ui/span/issue-40157.stderr
@@ -2,7 +2,7 @@ error[E0597]: `foo` does not live long enough
   --> $DIR/issue-40157.rs:2:53
    |
 LL |     {println!("{:?}", match { let foo = vec![1, 2]; foo.get(1) } { x => x });}
-   |                                   ---               ^^^^^^^^^^ - `foo` dropped here while still borrowed
+   |                                   ---               ^^^        - `foo` dropped here while still borrowed
    |                                   |                 |
    |                                   |                 borrowed value does not live long enough
    |                                   binding `foo` declared here

--- a/tests/ui/span/mut-arg-hint.stderr
+++ b/tests/ui/span/mut-arg-hint.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:3:9
    |
 LL |         a.push_str("bar");
-   |         ^^^^^^^^^^^^^^^^^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:8:5
    |
 LL |     a.push_str("foo");
-   |     ^^^^^^^^^^^^^^^^^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:15:9
    |
 LL |         a.push_str("foo");
-   |         ^^^^^^^^^^^^^^^^^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/mut-ptr-cant-outlive-ref.stderr
+++ b/tests/ui/span/mut-ptr-cant-outlive-ref.stderr
@@ -9,7 +9,7 @@ LL |     }
    |     - `b` dropped here while still borrowed
 LL |
 LL |     p.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/span/regionck-unboxed-closure-lifetimes.stderr
+++ b/tests/ui/span/regionck-unboxed-closure-lifetimes.stderr
@@ -9,7 +9,7 @@ LL |         let c_ref = &c;
 LL |     }
    |     - `c` dropped here while still borrowed
 LL |     f.use_mut();
-   |     ----------- borrow later used here
+   |     - borrow later used here
 
 error: aborting due to previous error
 

--- a/tests/ui/span/regions-escape-loop-via-vec.stderr
+++ b/tests/ui/span/regions-escape-loop-via-vec.stderr
@@ -7,7 +7,7 @@ LL |     while x < 10 {
    |           ^ use of borrowed `x`
 LL |         let mut z = x;
 LL |         _y.push(&mut z);
-   |         --------------- borrow later used here
+   |         -- borrow later used here
 
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/regions-escape-loop-via-vec.rs:6:21
@@ -18,7 +18,7 @@ LL |     while x < 10 {
 LL |         let mut z = x;
    |                     ^ use of borrowed `x`
 LL |         _y.push(&mut z);
-   |         --------------- borrow later used here
+   |         -- borrow later used here
 
 error[E0597]: `z` does not live long enough
   --> $DIR/regions-escape-loop-via-vec.rs:7:17
@@ -26,7 +26,9 @@ error[E0597]: `z` does not live long enough
 LL |         let mut z = x;
    |             ----- binding `z` declared here
 LL |         _y.push(&mut z);
-   |                 ^^^^^^ borrowed value does not live long enough
+   |         --      ^^^^^^ borrowed value does not live long enough
+   |         |
+   |         borrow later used here
 ...
 LL |     }
    |     - `z` dropped here while still borrowed
@@ -38,7 +40,7 @@ LL |     let mut _y = vec![&mut x];
    |                       ------ `x` is borrowed here
 ...
 LL |         _y.push(&mut z);
-   |         --------------- borrow later used here
+   |         -- borrow later used here
 LL |
 LL |         x += 1;
    |         ^^^^^^ use of borrowed `x`

--- a/tests/ui/span/send-is-not-static-std-sync.stderr
+++ b/tests/ui/span/send-is-not-static-std-sync.stderr
@@ -10,7 +10,7 @@ LL |     drop(y);
    |          ^ move out of `y` occurs here
 ...
 LL |         *lock.lock().unwrap() = &z;
-   |          ----------- borrow later used here
+   |          ---- borrow later used here
 
 error[E0597]: `z` does not live long enough
   --> $DIR/send-is-not-static-std-sync.rs:16:33
@@ -23,7 +23,7 @@ LL |     }
    |     - `z` dropped here while still borrowed
 LL |
 LL |     lock.use_ref(); // (Mutex is #[may_dangle] so its dtor does not use `z` => needs explicit use)
-   |     -------------- borrow later used here
+   |     ---- borrow later used here
 
 error[E0505]: cannot move out of `y` because it is borrowed
   --> $DIR/send-is-not-static-std-sync.rs:27:10
@@ -37,7 +37,7 @@ LL |     drop(y);
    |          ^ move out of `y` occurs here
 ...
 LL |         *lock.write().unwrap() = &z;
-   |          ------------ borrow later used here
+   |          ---- borrow later used here
 
 error[E0597]: `z` does not live long enough
   --> $DIR/send-is-not-static-std-sync.rs:30:34
@@ -50,7 +50,7 @@ LL |     }
    |     - `z` dropped here while still borrowed
 LL |
 LL |     lock.use_ref(); // (RwLock is #[may_dangle] so its dtor does not use `z` => needs explicit use)
-   |     -------------- borrow later used here
+   |     ---- borrow later used here
 
 error[E0505]: cannot move out of `y` because it is borrowed
   --> $DIR/send-is-not-static-std-sync.rs:43:10
@@ -64,7 +64,7 @@ LL |     drop(y);
    |          ^ move out of `y` occurs here
 ...
 LL |         tx.send(&z).unwrap();
-   |         ----------- borrow later used here
+   |         -- borrow later used here
 
 error[E0597]: `z` does not live long enough
   --> $DIR/send-is-not-static-std-sync.rs:46:17

--- a/tests/ui/span/slice-borrow.stderr
+++ b/tests/ui/span/slice-borrow.stderr
@@ -7,7 +7,7 @@ LL |         let x: &[isize] = &vec![1, 2, 3, 4, 5];
 LL |     }
    |     - temporary value is freed at the end of this statement
 LL |     y.use_ref();
-   |     ----------- borrow later used here
+   |     - borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs
@@ -18,7 +18,7 @@ mod bav {
     impl Bar for i32 {}
 
     fn use_it<'a>(val: Box<dyn ObjectTrait<Assoc = i32>>) -> impl OtherTrait<'a> {
-        val.use_self() //~ ERROR cannot return reference to function parameter
+        val.use_self() //~ ERROR cannot return value referencing function parameter
     }
 }
 

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
@@ -1,20 +1,29 @@
-error[E0515]: cannot return reference to function parameter `val`
+error[E0515]: cannot return value referencing function parameter `val`
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:21:9
    |
 LL |         val.use_self()
-   |         ^^^^^^^^^^^^^^ returns a reference to data owned by the current function
+   |         ---^^^^^^^^^^^
+   |         |
+   |         returns a value referencing data owned by the current function
+   |         `val` is borrowed here
 
-error[E0515]: cannot return reference to function parameter `val`
+error[E0515]: cannot return value referencing function parameter `val`
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:43:9
    |
 LL |         val.use_self()
-   |         ^^^^^^^^^^^^^^ returns a reference to data owned by the current function
+   |         ---^^^^^^^^^^^
+   |         |
+   |         returns a value referencing data owned by the current function
+   |         `val` is borrowed here
 
-error[E0515]: cannot return reference to function parameter `val`
+error[E0515]: cannot return value referencing function parameter `val`
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:109:9
    |
 LL |         val.use_self()
-   |         ^^^^^^^^^^^^^^ returns a reference to data owned by the current function
+   |         ---^^^^^^^^^^^
+   |         |
+   |         returns a value referencing data owned by the current function
+   |         `val` is borrowed here
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/issue-102972.stderr
+++ b/tests/ui/suggestions/issue-102972.stderr
@@ -7,10 +7,7 @@ LL |     for _c in chars.by_ref() {
    |               first mutable borrow occurs here
    |               first borrow later used here
 LL |         chars.next();
-   |         ^^^^^^^^^^^^ second mutable borrow occurs here
-   |
-   = note: a for loop advances the iterator for you, the result is stored in `_c`.
-   = help: if you want to call `next` on a iterator within the loop, consider using `while let`.
+   |         ^^^^^ second mutable borrow occurs here
 
 error[E0382]: borrow of moved value: `iter`
   --> $DIR/issue-102972.rs:12:9
@@ -20,10 +17,8 @@ LL |     let mut iter = v.iter();
 LL |     for _i in iter {
    |               ---- `iter` moved due to this implicit call to `.into_iter()`
 LL |         iter.next();
-   |         ^^^^^^^^^^^ value borrowed here after move
+   |         ^^^^ value borrowed here after move
    |
-   = note: a for loop advances the iterator for you, the result is stored in `_i`.
-   = help: if you want to call `next` on a iterator within the loop, consider using `while let`.
 note: `into_iter` takes ownership of the receiver `self`, which moves `iter`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 

--- a/tests/ui/suggestions/option-content-move.stderr
+++ b/tests/ui/suggestions/option-content-move.stderr
@@ -12,7 +12,7 @@ note: `Option::<T>::unwrap` takes ownership of the receiver `self`, which moves 
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |                 if selection.1.clone().unwrap().contains(selection.0) {
-   |                                ++++++++
+   |                               ++++++++
 
 error[E0507]: cannot move out of `selection.1` which is behind a shared reference
   --> $DIR/option-content-move.rs:27:20
@@ -28,7 +28,7 @@ note: `Result::<T, E>::unwrap` takes ownership of the receiver `self`, which mov
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |                 if selection.1.clone().unwrap().contains(selection.0) {
-   |                                ++++++++
+   |                               ++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/unop-move-semantics.stderr
+++ b/tests/ui/unop-move-semantics.stderr
@@ -7,7 +7,7 @@ LL |     !x;
    |     -- `x` moved due to usage in operator
 LL |
 LL |     x.clone();
-   |     ^^^^^^^^^ value borrowed here after move
+   |     ^ value borrowed here after move
    |
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL

--- a/tests/ui/use/use-after-move-implicity-coerced-object.stderr
+++ b/tests/ui/use/use-after-move-implicity-coerced-object.stderr
@@ -8,7 +8,7 @@ LL |     l.push(n);
    |            - value moved here
 LL |
 LL |     let x = n.to_string();
-   |             ^^^^^^^^^^^^^ value borrowed here after move
+   |             ^ value borrowed here after move
    |
 note: consider changing this parameter type in method `push` to borrow instead if owning the value isn't necessary
   --> $DIR/use-after-move-implicity-coerced-object.rs:17:27


### PR DESCRIPTION
Diagnostics rely on the spans of MIR statements being (approximately) correct in order to give suggestions relative to that span (i.e. `shrink_to_hi` and `shrink_to_lo`).

I discovered that we're *intentionally* lowering THIR exprs with their parent expr's span if they come from adjustments that are due to a parent expression. While I understand why that may be desirable to demonstrate the relationship of an adjustment and the expression that requires it, it leads to

1. very verbose borrowck output
2. incorrect spans for suggestions

Some diagnostics get around that by giving suggestions relative to other spans we've collected during MIR lowering, such as the span of the method's identifier (e.g. `name` in `.name()`), but this doesn't work too well when things come from desugaring.

I assume it also has lead to numerous tweaks and complications to diagnostics code down the road, which this PR doesn't necessarily aim to fix but may open the gates to fixing later... The last three commits are simplifications due to the fact that we can assume that the move span actually points to what is being moved (and a test).

This regressed in #89110, which was debated somewhat in #90286. cc @Aaron1011 who originally made this change.

r? diagnostics

Fixes #113547
Fixes #111016