### PR TITLE
Avoid guessing unknown trait implementation in suggestions

### DIFF
--- a/tests/ui/error-codes/E0283.stderr
+++ b/tests/ui/error-codes/E0283.stderr
@@ -9,8 +9,8 @@ LL |     let cont: u32 = Generator::create();
    |
 help: use a fully-qualified path to a specific available implementation (2 found)
    |
-LL |     let cont: u32 = <Impl as Generator>::create();
-   |                     ++++++++          +
+LL |     let cont: u32 = </* self type */ as Generator>::create();
+   |                     +++++++++++++++++++          +
 
 error[E0283]: type annotations needed
   --> $DIR/E0283.rs:35:24

--- a/tests/ui/error-codes/E0790.stderr
+++ b/tests/ui/error-codes/E0790.stderr
@@ -65,8 +65,8 @@ LL |     MyTrait2::my_fn();
    |
 help: use a fully-qualified path to a specific available implementation (2 found)
    |
-LL |     <Impl1 as MyTrait2>::my_fn();
-   |     +++++++++         +
+LL |     </* self type */ as MyTrait2>::my_fn();
+   |     +++++++++++++++++++         +
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
When a trait is used without specifying the implementation (e.g. calling a non-member associated function without fully-qualified syntax) and there are multiple implementations available, use a placeholder comment for the implementation type in the suggestion instead of picking a random implementation.

Example:

```
fn main() {
    let _ = Default::default();
}
```

Previous output:

```
error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
 --> test.rs:2:13
  |
2 |     let _ = Default::default();
  |             ^^^^^^^^^^^^^^^^ cannot call associated function of trait
  |
help: use a fully-qualified path to a specific available implementation (273 found)
  |
2 |     let _ = <FileTimes as Default>::default();
  |             +++++++++++++        +
```

New output:

```
error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
 --> test.rs:2:13
  |
2 |     let _ = Default::default();
  |             ^^^^^^^^^^^^^^^^ cannot call associated function of trait
  |
help: use a fully-qualified path to a specific available implementation (273 found)
  |
2 |     let _ = </* self type */ as Default>::default();
  |             +++++++++++++++++++        +
```

Fixes #112897