### PR TITLE
fix: add deref suggestion for type mismatch binary op

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -1417,6 +1417,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         }
                     }
 
+                    if let Some(hir::Node::Expr(hir::Expr {
+                        kind: hir::ExprKind::Binary(_, left, right),
+                        ..
+                    })) = self.tcx.hir().find_parent(expr.hir_id) && mutability.is_mut() {
+                        let deref_expr = if expr.hir_id == left.hir_id { right } else { left };
+                        let sugg = vec![(deref_expr.span.shrink_to_lo(), "*".to_string())];
+                        return Some((
+                            sugg,
+                            format!("consider dereferencing here"),
+                            Applicability::MachineApplicable,
+                            true,
+                            false
+                        ))
+                    }
+
                     let sugg = mutability.ref_prefix_str();
                     let (sugg, verbose) = if needs_parens {
                         (

--- a/tests/ui/suggestions/issue-112958.rs
+++ b/tests/ui/suggestions/issue-112958.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let a = &mut 0;
+    let b = 1;
+    let _ = a < b;
+    //~^ ERROR mismatched types
+    //~| HELP consider dereferencing here
+    //~| SUGGESTION *
+}

--- a/tests/ui/suggestions/issue-112958.stderr
+++ b/tests/ui/suggestions/issue-112958.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-112958.rs:4:17
+   |
+LL |     let _ = a < b;
+   |                 ^ expected `&mut _`, found integer
+   |
+   = note: expected mutable reference `&mut _`
+                           found type `{integer}`
+help: consider dereferencing here
+   |
+LL |     let _ = *a < b;
+   |             +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #112958

Find the mutable expression in binary operation and add * suggestion before it