### PR TITLE
Stop bubbling out hidden types from the eval obligation queries

### DIFF
--- a/compiler/rustc_traits/src/evaluate_obligation.rs
+++ b/compiler/rustc_traits/src/evaluate_obligation.rs
@@ -1,6 +1,5 @@
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::query::Providers;
-use rustc_middle::traits::DefiningAnchor;
 use rustc_middle::ty::{ParamEnvAnd, TyCtxt};
 use rustc_span::source_map::DUMMY_SP;
 use rustc_trait_selection::traits::query::CanonicalPredicateGoal;
@@ -18,12 +17,8 @@ fn evaluate_obligation<'tcx>(
 ) -> Result<EvaluationResult, OverflowError> {
     assert!(!tcx.next_trait_solver_globally());
     debug!("evaluate_obligation(canonical_goal={:#?})", canonical_goal);
-    // HACK This bubble is required for this tests to pass:
-    // impl-trait/issue99642.rs
-    let (ref infcx, goal, _canonical_inference_vars) = tcx
-        .infer_ctxt()
-        .with_opaque_type_inference(DefiningAnchor::Bubble)
-        .build_with_canonical(DUMMY_SP, &canonical_goal);
+    let (ref infcx, goal, _canonical_inference_vars) =
+        tcx.infer_ctxt().build_with_canonical(DUMMY_SP, &canonical_goal);
     debug!("evaluate_obligation: goal={:#?}", goal);
     let ParamEnvAnd { param_env, value: predicate } = goal;
 


### PR DESCRIPTION
r? @compiler-errors 

I don't know why these were added, but they are not needed anymore. The relevant test is unaffected and I didn't see anything interesting in logging that would have justified it.

This PR has no effect on the new solver behaviour of https://github.com/rust-lang/rust/blob/cf2dff2b1e3fa55fa5415d524200070d0d7aacfe/tests/ui/impl-trait/issue-99642.rs (which is overflow) and https://github.com/rust-lang/rust/blob/cf2dff2b1e3fa55fa5415d524200070d0d7aacfe/tests/ui/impl-trait/issue-99642-2.rs (which is "unstable certainty ICE")