### PR TITLE
Don't emit same goal as input during `wf::unnormalized_obligations`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1049,6 +1049,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     }
 
                     ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(ty)) => {
+                        let ty = self.resolve_vars_if_possible(ty);
                         match self.tcx.sess.opts.unstable_opts.trait_solver {
                             TraitSolver::Classic => {
                                 // WF predicates cannot themselves make

--- a/tests/ui/for/issue-20605.next.stderr
+++ b/tests/ui/for/issue-20605.next.stderr
@@ -14,7 +14,7 @@ LL |     for item in *things { *item = 0 }
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
 
-error: the type `<_ as IntoIterator>::IntoIter` is not well-formed
+error: the type `<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
   --> $DIR/issue-20605.rs:5:17
    |
 LL |     for item in *things { *item = 0 }

--- a/tests/ui/for/issue-20605.rs
+++ b/tests/ui/for/issue-20605.rs
@@ -4,7 +4,7 @@
 fn changer<'a>(mut things: Box<dyn Iterator<Item=&'a mut u8>>) {
     for item in *things { *item = 0 }
     //~^ ERROR the size for values of type
-    //[next]~^^ ERROR the type `<_ as IntoIterator>::IntoIter` is not well-formed
+    //[next]~^^ ERROR the type `<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
     //[next]~| ERROR the trait bound `dyn Iterator<Item = &'a mut u8>: IntoIterator` is not satisfied
 }
 

--- a/tests/ui/traits/new-solver/alias-bound-unsound.rs
+++ b/tests/ui/traits/new-solver/alias-bound-unsound.rs
@@ -23,5 +23,7 @@ fn main() {
     drop(<() as Foo>::copy_me(&x));
     //~^ ERROR `<() as Foo>::Item: Copy` is not satisfied
     //~| ERROR `<() as Foo>::Item` is not well-formed
+    //~| ERROR `_` is not well-formed
+    //~| ERROR `_` is not well-formed
     println!("{x}");
 }

--- a/tests/ui/traits/new-solver/alias-bound-unsound.rs
+++ b/tests/ui/traits/new-solver/alias-bound-unsound.rs
@@ -23,7 +23,7 @@ fn main() {
     drop(<() as Foo>::copy_me(&x));
     //~^ ERROR `<() as Foo>::Item: Copy` is not satisfied
     //~| ERROR `<() as Foo>::Item` is not well-formed
-    //~| ERROR `_` is not well-formed
-    //~| ERROR `_` is not well-formed
+    //~| ERROR `<() as Foo>::Item` is not well-formed
+    //~| ERROR `<() as Foo>::Item` is not well-formed
     println!("{x}");
 }

--- a/tests/ui/traits/new-solver/alias-bound-unsound.stderr
+++ b/tests/ui/traits/new-solver/alias-bound-unsound.stderr
@@ -19,6 +19,18 @@ error: the type `<() as Foo>::Item` is not well-formed
 LL |     drop(<() as Foo>::copy_me(&x));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: the type `_` is not well-formed
+  --> $DIR/alias-bound-unsound.rs:23:5
+   |
+LL |     drop(<() as Foo>::copy_me(&x));
+   |     ^^^^
+
+error: the type `_` is not well-formed
+  --> $DIR/alias-bound-unsound.rs:23:10
+   |
+LL |     drop(<() as Foo>::copy_me(&x));
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/new-solver/alias-bound-unsound.stderr
+++ b/tests/ui/traits/new-solver/alias-bound-unsound.stderr
@@ -19,13 +19,13 @@ error: the type `<() as Foo>::Item` is not well-formed
 LL |     drop(<() as Foo>::copy_me(&x));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the type `_` is not well-formed
+error: the type `<() as Foo>::Item` is not well-formed
   --> $DIR/alias-bound-unsound.rs:23:5
    |
 LL |     drop(<() as Foo>::copy_me(&x));
    |     ^^^^
 
-error: the type `_` is not well-formed
+error: the type `<() as Foo>::Item` is not well-formed
   --> $DIR/alias-bound-unsound.rs:23:10
    |
 LL |     drop(<() as Foo>::copy_me(&x));


### PR DESCRIPTION
r? @aliemjay cc @lcnr 

I accidentally pruned the logic to handle `WF(?0)` when writing `wf::unnormalized_obligations`.

idk if you wanted to construct a test first, but this is an obvious fix. Copied the comment from above.

Fixes rust-lang/trait-system-refactor-initiative#36