### PR TITLE
Make `UnwindAction::Continue` explicit in MIR dump

### DIFF
--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -272,7 +272,8 @@ impl<'tcx> Debug for TerminatorKind<'tcx> {
 
         let unwind = match self.unwind() {
             // Not needed or included in successors
-            None | Some(UnwindAction::Continue) | Some(UnwindAction::Cleanup(_)) => None,
+            None | Some(UnwindAction::Cleanup(_)) => None,
+            Some(UnwindAction::Continue) => Some("unwind continue"),
             Some(UnwindAction::Unreachable) => Some("unwind unreachable"),
             Some(UnwindAction::Terminate) => Some("unwind terminate"),
         };

--- a/tests/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -36,7 +36,7 @@ fn main() -> () {
         StorageLive(_5);
         StorageLive(_6);
         _6 = _3;
-        _5 = foo(move _6) -> bb1;
+        _5 = foo(move _6) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -45,7 +45,7 @@ fn main() -> () {
         _7 = _2;
         _8 = Len(_1);
         _9 = Lt(_7, _8);
-        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2;
+        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> [success: bb2, unwind continue];
     }
 
     bb2: {

--- a/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
+++ b/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
@@ -58,7 +58,7 @@
   
       bb4: {
           StorageDead(_5);
--         drop(_4) -> bb5;
+-         drop(_4) -> [return: bb5, unwind continue];
 +         goto -> bb5;
       }
   

--- a/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-unwind.mir
@@ -19,7 +19,7 @@ fn main() -> () {
         StorageLive(_1);
         _2 = SizeOf(S);
         _3 = AlignOf(S);
-        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1;
+        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -30,7 +30,7 @@ fn main() -> () {
 
     bb2: {
         _1 = move _5;
-        drop(_5) -> bb3;
+        drop(_5) -> [return: bb3, unwind continue];
     }
 
     bb3: {
@@ -45,7 +45,7 @@ fn main() -> () {
         StorageDead(_7);
         StorageDead(_6);
         _0 = const ();
-        drop(_1) -> bb5;
+        drop(_1) -> [return: bb5, unwind continue];
     }
 
     bb5: {

--- a/tests/mir-opt/building/async_await.a-{closure#0}.generator_resume.0.mir
+++ b/tests/mir-opt/building/async_await.a-{closure#0}.generator_resume.0.mir
@@ -30,7 +30,7 @@ fn a::{closure#0}(_1: Pin<&mut [async fn body@$DIR/async_await.rs:11:14: 11:16]>
     }
 
     bb2: {
-        assert(const false, "`async fn` resumed after completion") -> bb2;
+        assert(const false, "`async fn` resumed after completion") -> [success: bb2, unwind continue];
     }
 
     bb3: {

--- a/tests/mir-opt/building/async_await.b-{closure#0}.generator_resume.0.mir
+++ b/tests/mir-opt/building/async_await.b-{closure#0}.generator_resume.0.mir
@@ -310,7 +310,7 @@ fn b::{closure#0}(_1: Pin<&mut [async fn body@$DIR/async_await.rs:14:18: 17:2]>,
     }
 
     bb28: {
-        assert(const false, "`async fn` resumed after completion") -> bb28;
+        assert(const false, "`async fn` resumed after completion") -> [success: bb28, unwind continue];
     }
 
     bb29: {

--- a/tests/mir-opt/building/custom/terminators.direct_call.built.after.mir
+++ b/tests/mir-opt/building/custom/terminators.direct_call.built.after.mir
@@ -4,7 +4,7 @@ fn direct_call(_1: i32) -> i32 {
     let mut _0: i32;
 
     bb0: {
-        _0 = ident::<i32>(_1) -> bb1;
+        _0 = ident::<i32>(_1) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/building/custom/terminators.drop_first.built.after.mir
+++ b/tests/mir-opt/building/custom/terminators.drop_first.built.after.mir
@@ -4,7 +4,7 @@ fn drop_first(_1: WriteOnDrop<'_>, _2: WriteOnDrop<'_>) -> () {
     let mut _0: ();
 
     bb0: {
-        drop(_1) -> bb1;
+        drop(_1) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/building/custom/terminators.drop_second.built.after.mir
+++ b/tests/mir-opt/building/custom/terminators.drop_second.built.after.mir
@@ -4,7 +4,7 @@ fn drop_second(_1: WriteOnDrop<'_>, _2: WriteOnDrop<'_>) -> () {
     let mut _0: ();
 
     bb0: {
-        drop(_2) -> bb1;
+        drop(_2) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/building/custom/terminators.indirect_call.built.after.mir
+++ b/tests/mir-opt/building/custom/terminators.indirect_call.built.after.mir
@@ -4,7 +4,7 @@ fn indirect_call(_1: i32, _2: fn(i32) -> i32) -> i32 {
     let mut _0: i32;
 
     bb0: {
-        _0 = _2(_1) -> bb1;
+        _0 = _2(_1) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/combine_array_len.norm2.InstSimplify.panic-unwind.diff
+++ b/tests/mir-opt/combine_array_len.norm2.InstSimplify.panic-unwind.diff
@@ -32,7 +32,7 @@
 -         _4 = Len(_1);
 +         _4 = const 2_usize;
           _5 = Lt(_3, _4);
-          assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1;
+          assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
       }
   
       bb1: {
@@ -44,7 +44,7 @@
 -         _8 = Len(_1);
 +         _8 = const 2_usize;
           _9 = Lt(_7, _8);
-          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2;
+          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> [success: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstSimplify.panic-unwind.diff
+++ b/tests/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstSimplify.panic-unwind.diff
@@ -21,7 +21,7 @@
           _4 = &((*_1).0: T);
 -         _3 = &(*_4);
 +         _3 = _4;
-          _2 = <T as Clone>::clone(move _3) -> bb1;
+          _2 = <T as Clone>::clone(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/aggregate.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/aggregate.main.ConstProp.panic-unwind.diff
@@ -27,7 +27,7 @@
           StorageLive(_5);
 -         _5 = _1;
 +         _5 = const 1_u8;
-          _4 = foo(move _5) -> bb1;
+          _4 = foo(move _5) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/aggregate.main.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/const_prop/aggregate.main.PreCodegen.after.panic-unwind.mir
@@ -23,7 +23,7 @@ fn main() -> () {
         StorageLive(_4);
         StorageLive(_5);
         _5 = const 1_u8;
-        _4 = foo(move _5) -> bb1;
+        _4 = foo(move _5) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/const_prop/array_index.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/array_index.main.ConstProp.32bit.panic-unwind.diff
@@ -20,10 +20,10 @@
           _3 = const 2_usize;
 -         _4 = Len(_2);
 -         _5 = Lt(_3, _4);
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1;
+-         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
 +         _4 = const 4_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/array_index.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/array_index.main.ConstProp.64bit.panic-unwind.diff
@@ -20,10 +20,10 @@
           _3 = const 2_usize;
 -         _4 = Len(_2);
 -         _5 = Lt(_3, _4);
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1;
+-         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
 +         _4 = const 4_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.panic-unwind.diff
@@ -24,21 +24,21 @@
           StorageLive(_3);
 -         _3 = _1;
 -         _4 = Eq(_3, const 0_i32);
--         assert(!move _4, "attempt to divide `{}` by zero", const 1_i32) -> bb1;
+-         assert(!move _4, "attempt to divide `{}` by zero", const 1_i32) -> [success: bb1, unwind continue];
 +         _3 = const 0_i32;
 +         _4 = const true;
-+         assert(!const true, "attempt to divide `{}` by zero", const 1_i32) -> bb1;
++         assert(!const true, "attempt to divide `{}` by zero", const 1_i32) -> [success: bb1, unwind continue];
       }
   
       bb1: {
 -         _5 = Eq(_3, const -1_i32);
 -         _6 = Eq(const 1_i32, const i32::MIN);
 -         _7 = BitAnd(move _5, move _6);
--         assert(!move _7, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> bb2;
+-         assert(!move _7, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> [success: bb2, unwind continue];
 +         _5 = const false;
 +         _6 = const false;
 +         _7 = const false;
-+         assert(!const false, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> bb2;
++         assert(!const false, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> [success: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.panic-unwind.diff
@@ -24,21 +24,21 @@
           StorageLive(_3);
 -         _3 = _1;
 -         _4 = Eq(_3, const 0_i32);
--         assert(!move _4, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1;
+-         assert(!move _4, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> [success: bb1, unwind continue];
 +         _3 = const 0_i32;
 +         _4 = const true;
-+         assert(!const true, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1;
++         assert(!const true, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> [success: bb1, unwind continue];
       }
   
       bb1: {
 -         _5 = Eq(_3, const -1_i32);
 -         _6 = Eq(const 1_i32, const i32::MIN);
 -         _7 = BitAnd(move _5, move _6);
--         assert(!move _7, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> bb2;
+-         assert(!move _7, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> [success: bb2, unwind continue];
 +         _5 = const false;
 +         _6 = const false;
 +         _7 = const false;
-+         assert(!const false, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> bb2;
++         assert(!const false, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> [success: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.panic-unwind.diff
@@ -36,9 +36,9 @@
           _6 = const 3_usize;
           _7 = const 3_usize;
 -         _8 = Lt(_6, _7);
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1;
+-         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
 +         _8 = const false;
-+         assert(const false, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1;
++         assert(const false, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.panic-unwind.diff
@@ -36,9 +36,9 @@
           _6 = const 3_usize;
           _7 = const 3_usize;
 -         _8 = Lt(_6, _7);
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1;
+-         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
 +         _8 = const false;
-+         assert(const false, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1;
++         assert(const false, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/boxes.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/boxes.main.ConstProp.panic-unwind.diff
@@ -26,7 +26,7 @@
 -         _5 = AlignOf(i32);
 +         _4 = const 4_usize;
 +         _5 = const 4_usize;
-          _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> bb1;
+          _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/checked_add.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/checked_add.main.ConstProp.panic-unwind.diff
@@ -12,9 +12,9 @@
       bb0: {
           StorageLive(_1);
 -         _2 = CheckedAdd(const 1_u32, const 1_u32);
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1;
+-         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> [success: bb1, unwind continue];
 +         _2 = const (2_u32, false);
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1;
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.panic-unwind.diff
@@ -24,7 +24,7 @@
           StorageLive(_4);
           StorageLive(_5);
           _5 = _1;
-          _4 = read(move _5) -> bb1;
+          _4 = read(move _5) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.panic-unwind.diff
@@ -14,7 +14,7 @@
       }
   
       bb1: {
-          _2 = begin_panic::<&str>(const "explicit panic");
+          _2 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
       }
   
       bb2: {

--- a/tests/mir-opt/const_prop/indirect.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/indirect.main.ConstProp.panic-unwind.diff
@@ -15,10 +15,10 @@
           StorageLive(_2);
 -         _2 = const 2_u32 as u8 (IntToInt);
 -         _3 = CheckedAdd(_2, const 1_u8);
--         assert(!move (_3.1: bool), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1;
+-         assert(!move (_3.1: bool), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> [success: bb1, unwind continue];
 +         _2 = const 2_u8;
 +         _3 = const (3_u8, false);
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> bb1;
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-unwind.diff
@@ -21,9 +21,9 @@
           StorageLive(_3);
           _3 = const 1_u8;
 -         _4 = CheckedAdd(_2, _3);
--         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> bb1;
+-         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind continue];
 +         _4 = const (0_u8, true);
-+         assert(!const true, "attempt to compute `{} + {}`, which would overflow", _2, _3) -> bb1;
++         assert(!const true, "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-unwind.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_2);
           _2 = (const (), const 0_u8, const 0_u8);
-          _1 = encode(move _2) -> bb1;
+          _1 = encode(move _2) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-unwind.diff
@@ -14,7 +14,7 @@
 +         _3 = const (1_u8, 2_u8);
           _2 = (move _3,);
           StorageDead(_3);
-          _1 = test(move _2) -> bb1;
+          _1 = test(move _2) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.panic-unwind.diff
@@ -20,10 +20,10 @@
           _3 = const 2_usize;
 -         _4 = Len(_2);
 -         _5 = Lt(_3, _4);
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1;
+-         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
 +         _4 = const 5000_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.panic-unwind.diff
@@ -20,10 +20,10 @@
           _3 = const 2_usize;
 -         _4 = Len(_2);
 -         _5 = Lt(_3, _4);
--         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1;
+-         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
 +         _4 = const 5000_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.panic-unwind.diff
@@ -14,7 +14,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = foo() -> bb1;
+          _1 = foo() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.panic-unwind.diff
@@ -23,7 +23,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = foo() -> bb1;
+          _1 = foo() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-unwind.diff
@@ -29,7 +29,7 @@
           StorageLive(_2);
 -         _2 = OffsetOf(Alpha, [0]);
 +         _2 = const 4_usize;
-          _1 = must_use::<usize>(move _2) -> bb1;
+          _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -38,7 +38,7 @@
           StorageLive(_4);
 -         _4 = OffsetOf(Alpha, [1]);
 +         _4 = const 0_usize;
-          _3 = must_use::<usize>(move _4) -> bb2;
+          _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -47,7 +47,7 @@
           StorageLive(_6);
 -         _6 = OffsetOf(Alpha, [2, 0]);
 +         _6 = const 2_usize;
-          _5 = must_use::<usize>(move _6) -> bb3;
+          _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
       }
   
       bb3: {
@@ -56,7 +56,7 @@
           StorageLive(_8);
 -         _8 = OffsetOf(Alpha, [2, 1]);
 +         _8 = const 3_usize;
-          _7 = must_use::<usize>(move _8) -> bb4;
+          _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
       }
   
       bb4: {

--- a/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-unwind.diff
@@ -28,7 +28,7 @@
           StorageLive(_1);
           StorageLive(_2);
           _2 = OffsetOf(Gamma<T>, [0]);
-          _1 = must_use::<usize>(move _2) -> bb1;
+          _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -36,7 +36,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = OffsetOf(Gamma<T>, [1]);
-          _3 = must_use::<usize>(move _4) -> bb2;
+          _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -44,7 +44,7 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = OffsetOf(Delta<T>, [1]);
-          _5 = must_use::<usize>(move _6) -> bb3;
+          _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
       }
   
       bb3: {
@@ -52,7 +52,7 @@
           StorageLive(_7);
           StorageLive(_8);
           _8 = OffsetOf(Delta<T>, [2]);
-          _7 = must_use::<usize>(move _8) -> bb4;
+          _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
       }
   
       bb4: {

--- a/tests/mir-opt/const_prop/repeat.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/repeat.main.ConstProp.32bit.panic-unwind.diff
@@ -22,10 +22,10 @@
           _4 = const 2_usize;
 -         _5 = Len(_3);
 -         _6 = Lt(_4, _5);
--         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1;
+-         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind continue];
 +         _5 = const 8_usize;
 +         _6 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/repeat.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/repeat.main.ConstProp.64bit.panic-unwind.diff
@@ -22,10 +22,10 @@
           _4 = const 2_usize;
 -         _5 = Len(_3);
 -         _6 = Lt(_4, _5);
--         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1;
+-         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind continue];
 +         _5 = const 8_usize;
 +         _6 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> bb1;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/return_place.add.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/return_place.add.ConstProp.panic-unwind.diff
@@ -7,9 +7,9 @@
   
       bb0: {
 -         _1 = CheckedAdd(const 2_u32, const 2_u32);
--         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1;
+-         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> [success: bb1, unwind continue];
 +         _1 = const (4_u32, false);
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1;
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/return_place.add.PreCodegen.before.panic-unwind.mir
+++ b/tests/mir-opt/const_prop/return_place.add.PreCodegen.before.panic-unwind.mir
@@ -6,7 +6,7 @@ fn add() -> u32 {
 
     bb0: {
         _1 = const (4_u32, false);
-        assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1;
+        assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> [success: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.panic-unwind.diff
@@ -17,7 +17,7 @@
           StorageLive(_3);
 -         _3 = _1;
 +         _3 = const 1_u32;
-          _2 = consume(move _3) -> bb1;
+          _2 = consume(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/slice_len.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.ConstProp.32bit.panic-unwind.diff
@@ -27,10 +27,10 @@
           _6 = const 1_usize;
 -         _7 = Len((*_2));
 -         _8 = Lt(_6, _7);
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1;
+-         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
 +         _7 = const 3_usize;
 +         _8 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/slice_len.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.ConstProp.64bit.panic-unwind.diff
@@ -27,10 +27,10 @@
           _6 = const 1_usize;
 -         _7 = Len((*_2));
 -         _8 = Lt(_6, _7);
--         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1;
+-         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
 +         _7 = const 3_usize;
 +         _8 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb1;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/switch_int.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/switch_int.main.ConstProp.panic-unwind.diff
@@ -13,11 +13,11 @@
       }
   
       bb1: {
-          _0 = foo(const -1_i32) -> bb3;
+          _0 = foo(const -1_i32) -> [return: bb3, unwind continue];
       }
   
       bb2: {
-          _0 = foo(const 0_i32) -> bb3;
+          _0 = foo(const 0_i32) -> [return: bb3, unwind continue];
       }
   
       bb3: {

--- a/tests/mir-opt/const_prop/switch_int.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/switch_int.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
@@ -13,11 +13,11 @@
       }
   
       bb1: {
-          _0 = foo(const -1_i32) -> bb3;
+          _0 = foo(const -1_i32) -> [return: bb3, unwind continue];
       }
   
       bb2: {
-          _0 = foo(const 0_i32) -> bb3;
+          _0 = foo(const 0_i32) -> [return: bb3, unwind continue];
       }
   
       bb3: {

--- a/tests/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.panic-unwind.diff
@@ -18,7 +18,7 @@
           StorageLive(_3);
 -         _3 = _1;
 +         _3 = const (1_u32, 2_u32);
-          _2 = consume(move _3) -> bb1;
+          _2 = consume(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/copy-prop/borrowed_local.f.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/borrowed_local.f.CopyProp.panic-unwind.diff
@@ -13,11 +13,11 @@
           _2 = &_1;
           _3 = _1;
           _4 = &_3;
-          _0 = cmp_ref(_2, _4) -> bb1;
+          _0 = cmp_ref(_2, _4) -> [return: bb1, unwind continue];
       }
   
       bb1: {
-          _0 = opaque::<u8>(_3) -> bb2;
+          _0 = opaque::<u8>(_3) -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/copy-prop/branch.foo.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/branch.foo.CopyProp.panic-unwind.diff
@@ -16,13 +16,13 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = val() -> bb1;
+          _1 = val() -> [return: bb1, unwind continue];
       }
   
       bb1: {
           StorageLive(_2);
           StorageLive(_3);
-          _3 = cond() -> bb2;
+          _3 = cond() -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -36,7 +36,7 @@
   
       bb4: {
           StorageLive(_4);
-          _4 = val() -> bb5;
+          _4 = val() -> [return: bb5, unwind continue];
       }
   
       bb5: {

--- a/tests/mir-opt/copy-prop/copy_propagation_arg.bar.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/copy_propagation_arg.bar.CopyProp.panic-unwind.diff
@@ -11,7 +11,7 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = _1;
-          _2 = dummy(move _3) -> bb1;
+          _2 = dummy(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/copy-prop/copy_propagation_arg.foo.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/copy_propagation_arg.foo.CopyProp.panic-unwind.diff
@@ -11,7 +11,7 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = _1;
-          _2 = dummy(move _3) -> bb1;
+          _2 = dummy(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/copy-prop/custom_move_arg.f.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/custom_move_arg.f.CopyProp.panic-unwind.diff
@@ -8,14 +8,14 @@
   
       bb0: {
 -         _2 = _1;
--         _0 = opaque::<NotCopy>(move _1) -> bb1;
-+         _0 = opaque::<NotCopy>(_1) -> bb1;
+-         _0 = opaque::<NotCopy>(move _1) -> [return: bb1, unwind continue];
++         _0 = opaque::<NotCopy>(_1) -> [return: bb1, unwind continue];
       }
   
       bb1: {
 -         _3 = move _2;
--         _0 = opaque::<NotCopy>(_3) -> bb2;
-+         _0 = opaque::<NotCopy>(_1) -> bb2;
+-         _0 = opaque::<NotCopy>(_3) -> [return: bb2, unwind continue];
++         _0 = opaque::<NotCopy>(_1) -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/copy-prop/cycle.main.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/cycle.main.CopyProp.panic-unwind.diff
@@ -22,7 +22,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = val() -> bb1;
+          _1 = val() -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -38,7 +38,7 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = _1;
-          _5 = std::mem::drop::<i32>(move _6) -> bb2;
+          _5 = std::mem::drop::<i32>(move _6) -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/copy-prop/dead_stores_79191.f.CopyProp.after.panic-unwind.mir
+++ b/tests/mir-opt/copy-prop/dead_stores_79191.f.CopyProp.after.panic-unwind.mir
@@ -16,7 +16,7 @@ fn f(_1: usize) -> usize {
         _1 = _2;
         StorageLive(_4);
         _4 = _1;
-        _0 = id::<usize>(move _4) -> bb1;
+        _0 = id::<usize>(move _4) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/copy-prop/dead_stores_better.f.CopyProp.after.panic-unwind.mir
+++ b/tests/mir-opt/copy-prop/dead_stores_better.f.CopyProp.after.panic-unwind.mir
@@ -16,7 +16,7 @@ fn f(_1: usize) -> usize {
         _1 = _2;
         StorageLive(_4);
         _4 = _1;
-        _0 = id::<usize>(move _4) -> bb1;
+        _0 = id::<usize>(move _4) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.panic-unwind.diff
@@ -49,14 +49,14 @@
           _7 = &_2;
           _6 = move _7 as &[i32] (Pointer(Unsize));
           StorageDead(_7);
-          _5 = core::slice::<impl [i32]>::len(move _6) -> bb1;
+          _5 = core::slice::<impl [i32]>::len(move _6) -> [return: bb1, unwind continue];
       }
   
       bb1: {
           StorageDead(_6);
           _4 = std::ops::Range::<usize> { start: const 0_usize, end: move _5 };
           StorageDead(_5);
-          _3 = <std::ops::Range<usize> as IntoIterator>::into_iter(move _4) -> bb2;
+          _3 = <std::ops::Range<usize> as IntoIterator>::into_iter(move _4) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -73,7 +73,7 @@
           StorageLive(_13);
           _13 = &mut _8;
           _12 = &mut (*_13);
-          _11 = <std::ops::Range<usize> as Iterator>::next(move _12) -> bb4;
+          _11 = <std::ops::Range<usize> as Iterator>::next(move _12) -> [return: bb4, unwind continue];
       }
   
       bb4: {
@@ -90,9 +90,9 @@
 -         _18 = _16;
           _19 = Len(_2);
 -         _20 = Lt(_18, _19);
--         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _18) -> bb8;
+-         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _18) -> [success: bb8, unwind continue];
 +         _20 = Lt(_16, _19);
-+         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _16) -> bb8;
++         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _16) -> [success: bb8, unwind continue];
       }
   
       bb6: {

--- a/tests/mir-opt/copy-prop/move_arg.f.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/move_arg.f.CopyProp.panic-unwind.diff
@@ -21,8 +21,8 @@
 -         _4 = _1;
 -         StorageLive(_5);
 -         _5 = _2;
--         _3 = g::<T>(move _4, move _5) -> bb1;
-+         _3 = g::<T>(_1, _1) -> bb1;
+-         _3 = g::<T>(move _4, move _5) -> [return: bb1, unwind continue];
++         _3 = g::<T>(_1, _1) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/copy-prop/move_projection.f.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/move_projection.f.CopyProp.panic-unwind.diff
@@ -9,13 +9,13 @@
       bb0: {
 -         _2 = _1;
 -         _3 = move (_2.0: u8);
--         _0 = opaque::<Foo>(move _1) -> bb1;
+-         _0 = opaque::<Foo>(move _1) -> [return: bb1, unwind continue];
 +         _3 = (_1.0: u8);
-+         _0 = opaque::<Foo>(_1) -> bb1;
++         _0 = opaque::<Foo>(_1) -> [return: bb1, unwind continue];
       }
   
       bb1: {
-          _0 = opaque::<u8>(move _3) -> bb2;
+          _0 = opaque::<u8>(move _3) -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/copy-prop/reborrow.demiraw.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/reborrow.demiraw.CopyProp.panic-unwind.diff
@@ -36,8 +36,8 @@
           StorageLive(_6);
 -         StorageLive(_7);
 -         _7 = _5;
--         _6 = opaque::<*mut u8>(move _7) -> bb1;
-+         _6 = opaque::<*mut u8>(_2) -> bb1;
+-         _6 = opaque::<*mut u8>(move _7) -> [return: bb1, unwind continue];
++         _6 = opaque::<*mut u8>(_2) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/copy-prop/reborrow.miraw.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/reborrow.miraw.CopyProp.panic-unwind.diff
@@ -32,8 +32,8 @@
           StorageLive(_5);
 -         StorageLive(_6);
 -         _6 = _4;
--         _5 = opaque::<*mut u8>(move _6) -> bb1;
-+         _5 = opaque::<*mut u8>(_2) -> bb1;
+-         _5 = opaque::<*mut u8>(move _6) -> [return: bb1, unwind continue];
++         _5 = opaque::<*mut u8>(_2) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/copy-prop/reborrow.remut.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/reborrow.remut.CopyProp.panic-unwind.diff
@@ -30,8 +30,8 @@
           StorageLive(_5);
 -         StorageLive(_6);
 -         _6 = move _4;
--         _5 = opaque::<&mut u8>(move _6) -> bb1;
-+         _5 = opaque::<&mut u8>(move _2) -> bb1;
+-         _5 = opaque::<&mut u8>(move _6) -> [return: bb1, unwind continue];
++         _5 = opaque::<&mut u8>(move _2) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/copy-prop/reborrow.reraw.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/reborrow.reraw.CopyProp.panic-unwind.diff
@@ -30,8 +30,8 @@
           StorageLive(_5);
 -         StorageLive(_6);
 -         _6 = move _4;
--         _5 = opaque::<&mut u8>(move _6) -> bb1;
-+         _5 = opaque::<&mut u8>(move _2) -> bb1;
+-         _5 = opaque::<&mut u8>(move _6) -> [return: bb1, unwind continue];
++         _5 = opaque::<&mut u8>(move _2) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
@@ -41,10 +41,10 @@
           StorageLive(_5);
 -         _5 = _2;
 -         _6 = CheckedAdd(_4, _5);
--         assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", move _4, move _5) -> bb1;
+-         assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", move _4, move _5) -> [success: bb1, unwind continue];
 +         _5 = const 2_i32;
 +         _6 = CheckedAdd(const 1_i32, const 2_i32);
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_i32, const 2_i32) -> bb1;
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_i32, const 2_i32) -> [success: bb1, unwind continue];
       }
   
       bb1: {
@@ -58,10 +58,10 @@
           StorageLive(_9);
 -         _9 = _7;
 -         _10 = CheckedAdd(_9, const 1_i32);
--         assert(!move (_10.1: bool), "attempt to compute `{} + {}`, which would overflow", move _9, const 1_i32) -> bb2;
+-         assert(!move (_10.1: bool), "attempt to compute `{} + {}`, which would overflow", move _9, const 1_i32) -> [success: bb2, unwind continue];
 +         _9 = const i32::MAX;
 +         _10 = CheckedAdd(const i32::MAX, const 1_i32);
-+         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const i32::MAX, const 1_i32) -> bb2;
++         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const i32::MAX, const 1_i32) -> [success: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
@@ -21,9 +21,9 @@
           StorageLive(_3);
           _3 = const 1_u8;
 -         _4 = CheckedAdd(_2, _3);
--         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> bb1;
+-         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind continue];
 +         _4 = CheckedAdd(const u8::MAX, const 1_u8);
-+         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> bb1;
++         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/dataflow-const-prop/ref_without_sb.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/ref_without_sb.main.DataflowConstProp.panic-unwind.diff
@@ -24,7 +24,7 @@
           StorageLive(_4);
           _4 = &_1;
           _3 = &(*_4);
-          _2 = escape::<i32>(move _3) -> bb1;
+          _2 = escape::<i32>(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -33,7 +33,7 @@
           StorageDead(_2);
           _1 = const 1_i32;
           StorageLive(_5);
-          _5 = some_function() -> bb2;
+          _5 = some_function() -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/dataflow-const-prop/sibling_ptr.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/sibling_ptr.main.DataflowConstProp.panic-unwind.diff
@@ -30,7 +30,7 @@
           StorageLive(_4);
           StorageLive(_5);
           _5 = _3;
-          _4 = ptr::mut_ptr::<impl *mut u8>::add(move _5, const 1_usize) -> bb1;
+          _4 = ptr::mut_ptr::<impl *mut u8>::add(move _5, const 1_usize) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/dataflow-const-prop/terminator.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/terminator.main.DataflowConstProp.panic-unwind.diff
@@ -22,8 +22,8 @@
 +         _4 = const 1_i32;
 +         _3 = const 2_i32;
           StorageDead(_4);
--         _2 = foo(move _3) -> bb1;
-+         _2 = foo(const 2_i32) -> bb1;
+-         _2 = foo(move _3) -> [return: bb1, unwind continue];
++         _2 = foo(const 2_i32) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.panic-unwind.diff
+++ b/tests/mir-opt/dead-store-elimination/cycle.cycle.DeadStoreElimination.panic-unwind.diff
@@ -28,9 +28,9 @@
   
       bb1: {
 -         StorageLive(_5);
--         _5 = cond() -> bb2;
+-         _5 = cond() -> [return: bb2, unwind continue];
 +         StorageLive(_4);
-+         _4 = cond() -> bb2;
++         _4 = cond() -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-unwind.diff
+++ b/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-unwind.diff
@@ -17,7 +17,7 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = &(*_1);
-          _2 = core::str::<impl str>::as_bytes(move _3) -> bb1;
+          _2 = core::str::<impl str>::as_bytes(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/derefer_complex_case.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_complex_case.main.Derefer.panic-unwind.diff
@@ -30,7 +30,7 @@
           StorageLive(_2);
           _14 = const _;
           _2 = &(*_14);
-          _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> bb1;
+          _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -47,7 +47,7 @@
           StorageLive(_9);
           _9 = &mut _4;
           _8 = &mut (*_9);
-          _7 = <std::slice::Iter<'_, i32> as Iterator>::next(move _8) -> bb3;
+          _7 = <std::slice::Iter<'_, i32> as Iterator>::next(move _8) -> [return: bb3, unwind continue];
       }
   
       bb3: {
@@ -63,7 +63,7 @@
 +         _12 = (*_15);
           StorageLive(_13);
           _13 = _12;
-          _6 = std::mem::drop::<i32>(move _13) -> bb7;
+          _6 = std::mem::drop::<i32>(move _13) -> [return: bb7, unwind continue];
       }
   
       bb5: {

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = f() -> bb1;
+          _2 = f() -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -18,7 +18,7 @@
   
       bb2: {
           StorageDead(_2);
-          drop(_1) -> bb3;
+          drop(_1) -> [return: bb3, unwind continue];
       }
   
       bb3: {

--- a/tests/mir-opt/derefer_terminator_test.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_terminator_test.main.Derefer.panic-unwind.diff
@@ -30,12 +30,12 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = foo() -> bb1;
+          _1 = foo() -> [return: bb1, unwind continue];
       }
   
       bb1: {
           StorageLive(_2);
-          _2 = foo() -> bb2;
+          _2 = foo() -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/dest-prop/branch.foo.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/branch.foo.DestinationPropagation.panic-unwind.diff
@@ -18,16 +18,16 @@
   
       bb0: {
 -         StorageLive(_1);
--         _1 = val() -> bb1;
+-         _1 = val() -> [return: bb1, unwind continue];
 +         nop;
-+         _0 = val() -> bb1;
++         _0 = val() -> [return: bb1, unwind continue];
       }
   
       bb1: {
 -         StorageLive(_2);
 +         nop;
           StorageLive(_3);
-          _3 = cond() -> bb2;
+          _3 = cond() -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -42,7 +42,7 @@
   
       bb4: {
           StorageLive(_4);
-          _4 = val() -> bb5;
+          _4 = val() -> [return: bb5, unwind continue];
       }
   
       bb5: {

--- a/tests/mir-opt/dest-prop/copy_propagation_arg.bar.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/copy_propagation_arg.bar.DestinationPropagation.panic-unwind.diff
@@ -11,10 +11,10 @@
           StorageLive(_2);
 -         StorageLive(_3);
 -         _3 = _1;
--         _2 = dummy(move _3) -> bb1;
+-         _2 = dummy(move _3) -> [return: bb1, unwind continue];
 +         nop;
 +         nop;
-+         _2 = dummy(move _1) -> bb1;
++         _2 = dummy(move _1) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.panic-unwind.diff
@@ -12,8 +12,8 @@
 +         nop;
           StorageLive(_3);
           _3 = _1;
--         _2 = dummy(move _3) -> bb1;
-+         _1 = dummy(move _3) -> bb1;
+-         _2 = dummy(move _3) -> [return: bb1, unwind continue];
++         _1 = dummy(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-unwind.diff
@@ -24,9 +24,9 @@
   
       bb0: {
 -         StorageLive(_1);
--         _1 = val() -> bb1;
+-         _1 = val() -> [return: bb1, unwind continue];
 +         nop;
-+         _6 = val() -> bb1;
++         _6 = val() -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -51,7 +51,7 @@
 -         _6 = _1;
 +         nop;
 +         nop;
-          _5 = std::mem::drop::<i32>(move _6) -> bb2;
+          _5 = std::mem::drop::<i32>(move _6) -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/dest-prop/dead_stores_79191.f.DestinationPropagation.after.panic-unwind.mir
+++ b/tests/mir-opt/dest-prop/dead_stores_79191.f.DestinationPropagation.after.panic-unwind.mir
@@ -20,7 +20,7 @@ fn f(_1: usize) -> usize {
         nop;
         nop;
         nop;
-        _0 = id::<usize>(move _1) -> bb1;
+        _0 = id::<usize>(move _1) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/dest-prop/dead_stores_better.f.DestinationPropagation.after.panic-unwind.mir
+++ b/tests/mir-opt/dest-prop/dead_stores_better.f.DestinationPropagation.after.panic-unwind.mir
@@ -19,7 +19,7 @@ fn f(_1: usize) -> usize {
         nop;
         nop;
         nop;
-        _0 = id::<usize>(move _1) -> bb1;
+        _0 = id::<usize>(move _1) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.panic-unwind.diff
@@ -25,8 +25,8 @@
           StorageLive(_6);
           _6 = &mut _2;
           _5 = &mut (*_6);
--         _3 = move _4(move _5) -> bb1;
-+         _3 = move _1(move _5) -> bb1;
+-         _3 = move _4(move _5) -> [return: bb1, unwind continue];
++         _3 = move _1(move _5) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-unwind.diff
@@ -18,7 +18,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = val() -> bb1;
+          _2 = val() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/dest-prop/unreachable.f.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/unreachable.f.DestinationPropagation.panic-unwind.diff
@@ -34,7 +34,7 @@
 -         _5 = _1;
 -         StorageLive(_6);
 -         _6 = _2;
--         _4 = g::<T>(move _5, move _6) -> bb2;
+-         _4 = g::<T>(move _5, move _6) -> [return: bb2, unwind continue];
 -     }
 - 
 -     bb2: {
@@ -53,9 +53,9 @@
 +         nop;
           StorageLive(_9);
 -         _9 = _2;
--         _7 = g::<T>(move _8, move _9) -> bb4;
+-         _7 = g::<T>(move _8, move _9) -> [return: bb4, unwind continue];
 +         _9 = _1;
-+         _7 = g::<T>(move _1, move _9) -> bb2;
++         _7 = g::<T>(move _1, move _9) -> [return: bb2, unwind continue];
       }
   
 -     bb4: {

--- a/tests/mir-opt/fn_ptr_shim.core.ops-function-Fn-call.AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/fn_ptr_shim.core.ops-function-Fn-call.AddMovesForPackedDrops.before.mir
@@ -4,7 +4,7 @@ fn std::ops::Fn::call(_1: *const fn(), _2: ()) -> <fn() as FnOnce<()>>::Output {
     let mut _0: <fn() as std::ops::FnOnce<()>>::Output;
 
     bb0: {
-        _0 = move (*_1)() -> bb1;
+        _0 = move (*_1)() -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.ConstProp.panic-unwind.diff
@@ -38,7 +38,7 @@
           StorageLive(_4);
           StorageLive(_5);
           _5 = &(*_1);
-          _4 = Formatter::<'_>::sign_plus(move _5) -> bb1;
+          _4 = Formatter::<'_>::sign_plus(move _5) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -63,7 +63,7 @@
           StorageLive(_7);
           StorageLive(_8);
           _8 = &(*_1);
-          _7 = Formatter::<'_>::precision(move _8) -> bb5;
+          _7 = Formatter::<'_>::precision(move _8) -> [return: bb5, unwind continue];
       }
   
       bb5: {
@@ -81,7 +81,7 @@
           _15 = _10 as u32 (IntToInt);
           _14 = Add(move _15, const 1_u32);
           StorageDead(_15);
-          _0 = float_to_exponential_common_exact::<T>(_1, _2, move _13, move _14, _3) -> bb7;
+          _0 = float_to_exponential_common_exact::<T>(_1, _2, move _13, move _14, _3) -> [return: bb7, unwind continue];
       }
   
       bb7: {
@@ -93,7 +93,7 @@
       bb8: {
           StorageLive(_20);
           _20 = _6;
-          _0 = float_to_exponential_common_shortest::<T>(_1, _2, move _20, _3) -> bb9;
+          _0 = float_to_exponential_common_shortest::<T>(_1, _2, move _20, _3) -> [return: bb9, unwind continue];
       }
   
       bb9: {

--- a/tests/mir-opt/inline/asm_unwind.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/asm_unwind.main.Inline.panic-unwind.diff
@@ -15,7 +15,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = foo() -> bb1;
+-         _1 = foo() -> [return: bb1, unwind continue];
 +         StorageLive(_2);
 +         asm!("", options(MAY_UNWIND)) -> [return: bb2, unwind: bb3];
       }
@@ -28,7 +28,7 @@
 +     }
 + 
 +     bb2: {
-+         drop(_2) -> bb1;
++         drop(_2) -> [return: bb1, unwind continue];
 +     }
 + 
 +     bb3 (cleanup): {

--- a/tests/mir-opt/inline/caller_with_trivial_bound.foo.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/caller_with_trivial_bound.foo.Inline.panic-unwind.diff
@@ -10,7 +10,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = bar::<T>() -> bb1;
+          _1 = bar::<T>() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/cycle.g.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.g.Inline.panic-unwind.diff
@@ -16,7 +16,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = f::<fn() {main}>(main) -> bb1;
+-         _1 = f::<fn() {main}>(main) -> [return: bb1, unwind continue];
 +         StorageLive(_2);
 +         _2 = main;
 +         StorageLive(_4);
@@ -46,7 +46,7 @@
 +     bb4: {
 +         StorageDead(_5);
 +         StorageDead(_3);
-+         drop(_2) -> bb1;
++         drop(_2) -> [return: bb1, unwind continue];
       }
   }
   

--- a/tests/mir-opt/inline/cycle.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.main.Inline.panic-unwind.diff
@@ -24,7 +24,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = f::<fn() {g}>(g) -> bb1;
+-         _1 = f::<fn() {g}>(g) -> [return: bb1, unwind continue];
 +         StorageLive(_2);
 +         _2 = g;
 +         StorageLive(_4);
@@ -56,7 +56,7 @@
 +         StorageDead(_6);
 +         StorageDead(_5);
 +         StorageDead(_3);
-+         drop(_2) -> bb1;
++         drop(_2) -> [return: bb1, unwind continue];
       }
   }
   

--- a/tests/mir-opt/inline/dyn_trait.get_query.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/dyn_trait.get_query.Inline.panic-unwind.diff
@@ -22,17 +22,17 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = &(*_1);
-          _2 = <Q as Query>::cache::<T>(move _3) -> bb1;
+          _2 = <Q as Query>::cache::<T>(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {
           StorageDead(_3);
           StorageLive(_4);
           _4 = &(*_2);
--         _0 = try_execute_query::<<Q as Query>::C>(move _4) -> bb2;
+-         _0 = try_execute_query::<<Q as Query>::C>(move _4) -> [return: bb2, unwind continue];
 +         StorageLive(_5);
 +         _5 = _4 as &dyn Cache<V = <Q as Query>::V> (Pointer(Unsize));
-+         _0 = <dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache(_5) -> bb2;
++         _0 = <dyn Cache<V = <Q as Query>::V> as Cache>::store_nocache(_5) -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/inline/dyn_trait.mk_cycle.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/dyn_trait.mk_cycle.Inline.panic-unwind.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_2);
           _2 = &(*_1);
-          _0 = <dyn Cache<V = V> as Cache>::store_nocache(move _2) -> bb1;
+          _0 = <dyn Cache<V = V> as Cache>::store_nocache(move _2) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/dyn_trait.try_execute_query.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/dyn_trait.try_execute_query.Inline.panic-unwind.diff
@@ -16,8 +16,8 @@
           _3 = &(*_1);
           _2 = move _3 as &dyn Cache<V = <C as Cache>::V> (Pointer(Unsize));
           StorageDead(_3);
--         _0 = mk_cycle::<<C as Cache>::V>(move _2) -> bb1;
-+         _0 = <dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache(_2) -> bb1;
+-         _0 = mk_cycle::<<C as Cache>::V>(move _2) -> [return: bb1, unwind continue];
++         _0 = <dyn Cache<V = <C as Cache>::V> as Cache>::store_nocache(_2) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/exponential_runtime.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/exponential_runtime.main.Inline.panic-unwind.diff
@@ -37,7 +37,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = <() as G>::call() -> bb1;
+-         _1 = <() as G>::call() -> [return: bb1, unwind continue];
 +         StorageLive(_2);
 +         StorageLive(_3);
 +         StorageLive(_4);
@@ -56,7 +56,7 @@
 +         StorageLive(_17);
 +         StorageLive(_18);
 +         StorageLive(_19);
-+         _17 = <() as A>::call() -> bb12;
++         _17 = <() as A>::call() -> [return: bb12, unwind continue];
       }
   
       bb1: {
@@ -72,63 +72,63 @@
 +         StorageDead(_7);
 +         StorageDead(_6);
 +         StorageDead(_5);
-+         _3 = <() as F>::call() -> bb3;
++         _3 = <() as F>::call() -> [return: bb3, unwind continue];
 +     }
 + 
 +     bb3: {
-+         _4 = <() as F>::call() -> bb1;
++         _4 = <() as F>::call() -> [return: bb1, unwind continue];
 +     }
 + 
 +     bb4: {
 +         StorageDead(_10);
 +         StorageDead(_9);
 +         StorageDead(_8);
-+         _6 = <() as E>::call() -> bb5;
++         _6 = <() as E>::call() -> [return: bb5, unwind continue];
 +     }
 + 
 +     bb5: {
-+         _7 = <() as E>::call() -> bb2;
++         _7 = <() as E>::call() -> [return: bb2, unwind continue];
 +     }
 + 
 +     bb6: {
 +         StorageDead(_13);
 +         StorageDead(_12);
 +         StorageDead(_11);
-+         _9 = <() as D>::call() -> bb7;
++         _9 = <() as D>::call() -> [return: bb7, unwind continue];
 +     }
 + 
 +     bb7: {
-+         _10 = <() as D>::call() -> bb4;
++         _10 = <() as D>::call() -> [return: bb4, unwind continue];
 +     }
 + 
 +     bb8: {
 +         StorageDead(_16);
 +         StorageDead(_15);
 +         StorageDead(_14);
-+         _12 = <() as C>::call() -> bb9;
++         _12 = <() as C>::call() -> [return: bb9, unwind continue];
 +     }
 + 
 +     bb9: {
-+         _13 = <() as C>::call() -> bb6;
++         _13 = <() as C>::call() -> [return: bb6, unwind continue];
 +     }
 + 
 +     bb10: {
 +         StorageDead(_19);
 +         StorageDead(_18);
 +         StorageDead(_17);
-+         _15 = <() as B>::call() -> bb11;
++         _15 = <() as B>::call() -> [return: bb11, unwind continue];
 +     }
 + 
 +     bb11: {
-+         _16 = <() as B>::call() -> bb8;
++         _16 = <() as B>::call() -> [return: bb8, unwind continue];
 +     }
 + 
 +     bb12: {
-+         _18 = <() as A>::call() -> bb13;
++         _18 = <() as A>::call() -> [return: bb13, unwind continue];
 +     }
 + 
 +     bb13: {
-+         _19 = <() as A>::call() -> bb10;
++         _19 = <() as A>::call() -> [return: bb10, unwind continue];
       }
   }
   

--- a/tests/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.panic-unwind.diff
@@ -9,7 +9,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = no_sanitize() -> bb1;
+-         _1 = no_sanitize() -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.panic-unwind.diff
@@ -9,7 +9,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = target_feature() -> bb1;
+-         _1 = target_feature() -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/inline_compatibility.not_inlined_c_variadic.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_compatibility.not_inlined_c_variadic.Inline.panic-unwind.diff
@@ -10,7 +10,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = sum(const 4_u32, const 4_u32, const 30_u32, const 200_u32, const 1000_u32) -> bb1;
+          _1 = sum(const 4_u32, const 4_u32, const 30_u32, const 200_u32, const 1000_u32) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_compatibility.not_inlined_no_sanitize.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_compatibility.not_inlined_no_sanitize.Inline.panic-unwind.diff
@@ -7,7 +7,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = no_sanitize() -> bb1;
+          _1 = no_sanitize() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_compatibility.not_inlined_target_feature.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_compatibility.not_inlined_target_feature.Inline.panic-unwind.diff
@@ -7,7 +7,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = target_feature() -> bb1;
+          _1 = target_feature() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_cycle.one.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_cycle.one.Inline.panic-unwind.diff
@@ -13,7 +13,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = <C as Call>::call() -> bb1;
+          _1 = <C as Call>::call() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_cycle.two.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_cycle.two.Inline.panic-unwind.diff
@@ -23,14 +23,14 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = call::<fn() {f}>(f) -> bb1;
+-         _1 = call::<fn() {f}>(f) -> [return: bb1, unwind continue];
 +         StorageLive(_2);
 +         _2 = f;
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         _4 = const ();
 +         StorageLive(_5);
-+         _5 = f() -> bb1;
++         _5 = f() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_cycle_generic.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_cycle_generic.main.Inline.panic-unwind.diff
@@ -13,8 +13,8 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = <C as Call>::call() -> bb1;
-+         _1 = <B<C> as Call>::call() -> bb1;
+-         _1 = <C as Call>::call() -> [return: bb1, unwind continue];
++         _1 = <B<C> as Call>::call() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_diverging.f.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_diverging.f.Inline.panic-unwind.diff
@@ -10,7 +10,7 @@
   
       bb0: {
           StorageLive(_2);
--         _2 = sleep();
+-         _2 = sleep() -> unwind continue;
 +         goto -> bb1;
 +     }
 + 

--- a/tests/mir-opt/inline/inline_diverging.g.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_diverging.g.Inline.panic-unwind.diff
@@ -33,9 +33,9 @@
   
       bb2: {
           StorageLive(_6);
--         _6 = panic();
+-         _6 = panic() -> unwind continue;
 +         StorageLive(_7);
-+         _7 = begin_panic::<&str>(const "explicit panic");
++         _7 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
       }
   }
   

--- a/tests/mir-opt/inline/inline_diverging.h.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_diverging.h.Inline.panic-unwind.diff
@@ -27,7 +27,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = call_twice::<!, fn() -> ! {sleep}>(sleep);
+-         _1 = call_twice::<!, fn() -> ! {sleep}>(sleep) -> unwind continue;
 +         StorageLive(_2);
 +         _2 = sleep;
 +         StorageLive(_6);

--- a/tests/mir-opt/inline/inline_generator.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_generator.main.Inline.panic-unwind.diff
@@ -35,7 +35,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
--         _4 = g() -> bb1;
+-         _4 = g() -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
@@ -117,7 +117,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
--         _2 = Vec::<u32>::new() -> bb1;
+-         _2 = Vec::<u32>::new() -> [return: bb1, unwind continue];
 +         StorageLive(_3);
 +         _3 = const _;
 +         _2 = Vec::<u32> { buf: move _3, len: const 0_usize };

--- a/tests/mir-opt/inline/inline_options.main.Inline.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/inline_options.main.Inline.after.panic-unwind.mir
@@ -12,7 +12,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);
-        _1 = not_inlined() -> bb1;
+        _1 = not_inlined() -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -21,7 +21,7 @@ fn main() -> () {
         StorageLive(_3);
         StorageLive(_4);
         StorageLive(_5);
-        _3 = g() -> bb3;
+        _3 = g() -> [return: bb3, unwind continue];
     }
 
     bb2: {
@@ -34,10 +34,10 @@ fn main() -> () {
     }
 
     bb3: {
-        _4 = g() -> bb4;
+        _4 = g() -> [return: bb4, unwind continue];
     }
 
     bb4: {
-        _5 = g() -> bb2;
+        _5 = g() -> [return: bb2, unwind continue];
     }
 }

--- a/tests/mir-opt/inline/inline_shims.clone.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_shims.clone.Inline.panic-unwind.diff
@@ -11,7 +11,7 @@
       bb0: {
           StorageLive(_2);
           _2 = &_1;
--         _0 = <fn(A, B) as Clone>::clone(move _2) -> bb1;
+-         _0 = <fn(A, B) as Clone>::clone(move _2) -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-unwind.diff
@@ -21,7 +21,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = _1;
-          _3 = std::ptr::drop_in_place::<Vec<A>>(move _4) -> bb1;
+          _3 = std::ptr::drop_in_place::<Vec<A>>(move _4) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -29,7 +29,7 @@
           StorageDead(_3);
           StorageLive(_5);
           _5 = _2;
--         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> bb2;
+-         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind continue];
 +         StorageLive(_6);
 +         StorageLive(_7);
 +         _6 = discriminant((*_5));
@@ -44,7 +44,7 @@
 +     }
 + 
 +     bb3: {
-+         drop((((*_5) as Some).0: B)) -> bb2;
++         drop((((*_5) as Some).0: B)) -> [return: bb2, unwind continue];
       }
   }
   

--- a/tests/mir-opt/inline/inline_specialization.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_specialization.main.Inline.panic-unwind.diff
@@ -12,7 +12,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = <Vec<()> as Foo>::bar() -> bb1;
+-         _1 = <Vec<()> as Foo>::bar() -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/inline_trait_method.test.Inline.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/inline_trait_method.test.Inline.after.panic-unwind.mir
@@ -8,7 +8,7 @@ fn test(_1: &dyn X) -> u32 {
     bb0: {
         StorageLive(_2);
         _2 = &(*_1);
-        _0 = <dyn X as X>::y(move _2) -> bb1;
+        _0 = <dyn X as X>::y(move _2) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/inline/inline_trait_method_2.test2.Inline.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/inline_trait_method_2.test2.Inline.after.panic-unwind.mir
@@ -15,7 +15,7 @@ fn test2(_1: &dyn X) -> bool {
         _3 = &(*_1);
         _2 = move _3 as &dyn X (Pointer(Unsize));
         StorageDead(_3);
-        _0 = <dyn X as X>::y(_2) -> bb1;
+        _0 = <dyn X as X>::y(_2) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
@@ -16,16 +16,16 @@
 +     }
   
       bb0: {
--         _0 = inner() -> bb1;
+-         _0 = inner() -> [return: bb1, unwind continue];
 +         StorageLive(_1);
 +         _1 = const _;
-+         _0 = index() -> bb1;
++         _0 = index() -> [return: bb1, unwind continue];
       }
   
       bb1: {
 +         StorageLive(_3);
 +         _2 = Lt(_0, const 1_usize);
-+         assert(move _2, "index out of bounds: the length is {} but the index is {}", const 1_usize, _0) -> bb2;
++         assert(move _2, "index out of bounds: the length is {} but the index is {}", const 1_usize, _0) -> [success: bb2, unwind continue];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.Inline.panic-unwind.diff
@@ -20,7 +20,7 @@
           _3 = _1;
           StorageLive(_4);
           _4 = _2;
--         _0 = core::num::<impl u64>::unchecked_shl(move _3, move _4) -> bb1;
+-         _0 = core::num::<impl u64>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
@@ -22,7 +22,7 @@
           _3 = _1;
           StorageLive(_4);
           _4 = _2;
--         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> bb1;
+-         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
@@ -20,7 +20,7 @@
           _3 = _1;
           StorageLive(_4);
           _4 = _2;
--         _0 = core::num::<impl i64>::unchecked_shr(move _3, move _4) -> bb1;
+-         _0 = core::num::<impl i64>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-unwind.diff
@@ -22,7 +22,7 @@
           _3 = _1;
           StorageLive(_4);
           _4 = _2;
--         _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> bb1;
+-         _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/issue_101973.inner.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/issue_101973.inner.ConstProp.panic-unwind.diff
@@ -45,10 +45,10 @@
           StorageLive(_8);
 -         _10 = const 8_i32 as u32 (IntToInt);
 -         _11 = Lt(move _10, const 32_u32);
--         assert(move _11, "attempt to shift right by `{}`, which would overflow", const 8_i32) -> bb1;
+-         assert(move _11, "attempt to shift right by `{}`, which would overflow", const 8_i32) -> [success: bb1, unwind continue];
 +         _10 = const 8_u32;
 +         _11 = const true;
-+         assert(const true, "attempt to shift right by `{}`, which would overflow", const 8_i32) -> bb1;
++         assert(const true, "attempt to shift right by `{}`, which would overflow", const 8_i32) -> [success: bb1, unwind continue];
       }
   
       bb1: {
@@ -57,10 +57,10 @@
           StorageDead(_8);
 -         _12 = const 1_i32 as u32 (IntToInt);
 -         _13 = Lt(move _12, const 32_u32);
--         assert(move _13, "attempt to shift left by `{}`, which would overflow", const 1_i32) -> bb2;
+-         assert(move _13, "attempt to shift left by `{}`, which would overflow", const 1_i32) -> [success: bb2, unwind continue];
 +         _12 = const 1_u32;
 +         _13 = const true;
-+         assert(const true, "attempt to shift left by `{}`, which would overflow", const 1_i32) -> bb2;
++         assert(const true, "attempt to shift left by `{}`, which would overflow", const 1_i32) -> [success: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/issue_104451_unwindable_intrinsics.main.AbortUnwindingCalls.after.panic-unwind.mir
+++ b/tests/mir-opt/issue_104451_unwindable_intrinsics.main.AbortUnwindingCalls.after.panic-unwind.mir
@@ -11,6 +11,6 @@ fn main() -> () {
         StorageLive(_1);
         StorageLive(_2);
         _2 = ();
-        _1 = const_eval_select::<(), fn() -> ! {ow_ct}, fn() -> ! {ow_ct}, !>(move _2, ow_ct, ow_ct);
+        _1 = const_eval_select::<(), fn() -> ! {ow_ct}, fn() -> ! {ow_ct}, !>(move _2, ow_ct, ow_ct) -> unwind continue;
     }
 }

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
@@ -58,7 +58,7 @@
   
       bb5: {
           StorageDead(_2);
--         drop(_1) -> bb6;
+-         drop(_1) -> [return: bb6, unwind continue];
 +         goto -> bb6;
       }
   

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
@@ -85,7 +85,7 @@
   
       bb9: {
           StorageDead(_2);
--         drop(_1) -> bb10;
+-         drop(_1) -> [return: bb10, unwind continue];
 +         goto -> bb19;
       }
   

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
@@ -31,7 +31,7 @@ fn test() -> Option<Box<u32>> {
         StorageLive(_1);
         _2 = SizeOf(u32);
         _3 = AlignOf(u32);
-        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1;
+        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -73,13 +73,13 @@ fn test() -> Option<Box<u32>> {
     bb6: {
         StorageDead(_11);
         StorageDead(_9);
-        drop(_5) -> bb9;
+        drop(_5) -> [return: bb9, unwind continue];
     }
 
     bb7: {
         StorageDead(_5);
         _0 = Option::<Box<u32>>::Some(move _1);
-        drop(_1) -> bb8;
+        drop(_1) -> [return: bb8, unwind continue];
     }
 
     bb8: {

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
@@ -42,7 +42,7 @@
       }
   
       bb1: {
-          _15 = core::panicking::panic(const "internal error: entered unreachable code");
+          _15 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind continue;
       }
   
       bb2: {

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
@@ -26,7 +26,7 @@ fn num_to_digit(_1: char) -> u32 {
     bb0: {
         StorageLive(_3);
         StorageLive(_2);
-        _2 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb1;
+        _2 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -39,7 +39,7 @@ fn num_to_digit(_1: char) -> u32 {
 
     bb2: {
         StorageLive(_5);
-        _5 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> bb3;
+        _5 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> [return: bb3, unwind continue];
     }
 
     bb3: {
@@ -48,7 +48,7 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb4: {
-        _7 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value");
+        _7 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value") -> unwind continue;
     }
 
     bb5: {

--- a/tests/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.panic-unwind.diff
+++ b/tests/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.panic-unwind.diff
@@ -42,7 +42,7 @@
           _8 = _1;
           _9 = Len((*_2));
           _10 = Lt(_8, _9);
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3;
+          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> [success: bb3, unwind continue];
       }
   
       bb3: {

--- a/tests/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.panic-unwind.diff
+++ b/tests/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.panic-unwind.diff
@@ -45,7 +45,7 @@
           _8 = _1;
           _9 = Len((*_2));
           _10 = Lt(_8, _9);
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3;
+          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> [success: bb3, unwind continue];
       }
   
       bb3: {
@@ -59,7 +59,7 @@
           _11 = const 0_usize;
           _12 = Len((*_2));
           _13 = Lt(_11, _12);
-          assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> bb5;
+          assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> [success: bb5, unwind continue];
       }
   
       bb5: {

--- a/tests/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.panic-unwind.diff
+++ b/tests/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.panic-unwind.diff
@@ -20,7 +20,7 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = &(*_2);
--         _5 = core::slice::<impl [u8]>::len(move _6) -> bb1;
+-         _5 = core::slice::<impl [u8]>::len(move _6) -> [return: bb1, unwind continue];
 +         _5 = Len((*_6));
 +         goto -> bb1;
       }
@@ -38,7 +38,7 @@
           _7 = _1;
           _8 = Len((*_2));
           _9 = Lt(_7, _8);
-          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb3;
+          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> [success: bb3, unwind continue];
       }
   
       bb3: {

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
@@ -14,7 +14,7 @@ fn main() -> () {
         StorageLive(_4);
         _4 = const "";
         _3 = &(*_4);
-        _2 = <str as ToString>::to_string(move _3) -> bb1;
+        _2 = <str as ToString>::to_string(move _3) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.panic-unwind.diff
+++ b/tests/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.panic-unwind.diff
@@ -26,7 +26,7 @@
 -         _6 = &mut _2;
 +         _6 = &mut _0;
           _5 = &mut (*_6);
-          _3 = move _4(move _5) -> bb1;
+          _3 = move _4(move _5) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.mir
@@ -31,7 +31,7 @@ fn step_forward(_1: u32, _2: usize) -> u32 {
         StorageLive(_7);
         StorageLive(_4);
         StorageLive(_3);
-        _3 = <u32 as Step>::forward_checked(_1, _2) -> bb1;
+        _3 = <u32 as Step>::forward_checked(_1, _2) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -47,7 +47,7 @@ fn step_forward(_1: u32, _2: usize) -> u32 {
     }
 
     bb2: {
-        assert(!const true, "attempt to compute `{} + {}`, which would overflow", const _, const 1_u32) -> bb3;
+        assert(!const true, "attempt to compute `{} + {}`, which would overflow", const _, const 1_u32) -> [success: bb3, unwind continue];
     }
 
     bb3: {

--- a/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
@@ -30,7 +30,7 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
     bb0: {
         StorageLive(_4);
         StorageLive(_3);
-        _3 = <impl Iterator<Item = T> as Iterator>::filter_map::<U, impl Fn(T) -> Option<U>>(move _1, move _2) -> bb1;
+        _3 = <impl Iterator<Item = T> as Iterator>::filter_map::<U, impl Fn(T) -> Option<U>>(move _1, move _2) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -60,7 +60,7 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
 
     bb4: {
         StorageDead(_9);
-        drop(_5) -> bb5;
+        drop(_5) -> [return: bb5, unwind continue];
     }
 
     bb5: {

--- a/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
@@ -79,7 +79,7 @@ fn int_range(_1: usize, _2: usize) -> () {
     bb3: {
         _12 = ((*_5).0: usize);
         StorageLive(_13);
-        _13 = <usize as Step>::forward_unchecked(_12, const 1_usize) -> bb4;
+        _13 = <usize as Step>::forward_unchecked(_12, const 1_usize) -> [return: bb4, unwind continue];
     }
 
     bb4: {
@@ -104,7 +104,7 @@ fn int_range(_1: usize, _2: usize) -> () {
 
     bb7: {
         _15 = ((_11 as Some).0: usize);
-        _16 = opaque::<usize>(_15) -> bb8;
+        _16 = opaque::<usize>(_15) -> [return: bb8, unwind continue];
     }
 
     bb8: {

--- a/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
@@ -25,7 +25,7 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
     bb0: {
         StorageLive(_4);
         StorageLive(_3);
-        _3 = <impl Iterator<Item = T> as Iterator>::map::<U, impl Fn(T) -> U>(move _1, move _2) -> bb1;
+        _3 = <impl Iterator<Item = T> as Iterator>::map::<U, impl Fn(T) -> U>(move _1, move _2) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -49,7 +49,7 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
 
     bb4: {
         StorageDead(_7);
-        drop(_5) -> bb5;
+        drop(_5) -> [return: bb5, unwind continue];
     }
 
     bb5: {

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -19,7 +19,7 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
 
     bb0: {
         StorageLive(_2);
-        _2 = <Vec<impl Sized> as IntoIterator>::into_iter(move _1) -> bb1;
+        _2 = <Vec<impl Sized> as IntoIterator>::into_iter(move _1) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -41,7 +41,7 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
 
     bb4: {
         StorageDead(_5);
-        drop(_3) -> bb5;
+        drop(_3) -> [return: bb5, unwind continue];
     }
 
     bb5: {

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ConstProp.32bit.panic-unwind.diff
@@ -25,9 +25,9 @@
       bb0: {
           StorageLive(_1);
 -         _2 = CheckedAdd(const 2_i32, const 2_i32);
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1;
+-         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> [success: bb1, unwind continue];
 +         _2 = const (4_i32, false);
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1;
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> [success: bb1, unwind continue];
       }
   
       bb1: {
@@ -40,9 +40,9 @@
           _5 = const 3_usize;
           _6 = const 6_usize;
 -         _7 = Lt(_5, _6);
--         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2;
+-         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> [success: bb2, unwind continue];
 +         _7 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> [success: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ConstProp.64bit.panic-unwind.diff
@@ -25,9 +25,9 @@
       bb0: {
           StorageLive(_1);
 -         _2 = CheckedAdd(const 2_i32, const 2_i32);
--         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1;
+-         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> [success: bb1, unwind continue];
 +         _2 = const (4_i32, false);
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1;
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> [success: bb1, unwind continue];
       }
   
       bb1: {
@@ -40,9 +40,9 @@
           _5 = const 3_usize;
           _6 = const 6_usize;
 -         _7 = Lt(_5, _6);
--         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2;
+-         assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> [success: bb2, unwind continue];
 +         _7 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2;
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> [success: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-unwind.diff
@@ -27,7 +27,7 @@
       bb0: {
           StorageLive(_1);
           _2 = CheckedAdd(const 2_i32, const 2_i32);
-          assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1;
+          assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> [success: bb1, unwind continue];
       }
   
       bb1: {
@@ -39,7 +39,7 @@
           _5 = const 3_usize;
           _6 = Len(_4);
           _7 = Lt(_5, _6);
-          assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2;
+          assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> [success: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-unwind.diff
@@ -27,7 +27,7 @@
       bb0: {
           StorageLive(_1);
           _2 = CheckedAdd(const 2_i32, const 2_i32);
-          assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1;
+          assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> [success: bb1, unwind continue];
       }
   
       bb1: {
@@ -39,7 +39,7 @@
           _5 = const 3_usize;
           _6 = Len(_4);
           _7 = Lt(_5, _6);
-          assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> bb2;
+          assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> [success: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -102,7 +102,7 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     bb6: {
         StorageDead(_12);
         StorageDead(_5);
-        drop(_3) -> bb7;
+        drop(_3) -> [return: bb7, unwind continue];
     }
 
     bb7: {

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
@@ -52,7 +52,7 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     bb3: {
         StorageDead(_7);
         StorageDead(_5);
-        drop(_3) -> bb4;
+        drop(_3) -> [return: bb4, unwind continue];
     }
 
     bb4: {

--- a/tests/mir-opt/pre-codegen/range_iter.range_inclusive_iter_next.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_inclusive_iter_next.PreCodegen.after.panic-unwind.mir
@@ -8,7 +8,7 @@ fn range_inclusive_iter_next(_1: &mut RangeInclusive<u32>) -> Option<u32> {
     }
 
     bb0: {
-        _0 = <RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(_1) -> bb1;
+        _0 = <RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(_1) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
@@ -53,7 +53,7 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
     bb2: {
         _7 = ((*_1).0: u32);
         StorageLive(_8);
-        _8 = <u32 as Step>::forward_unchecked(_7, const 1_usize) -> bb3;
+        _8 = <u32 as Step>::forward_unchecked(_7, const 1_usize) -> [return: bb3, unwind continue];
     }
 
     bb3: {

--- a/tests/mir-opt/pre-codegen/slice_index.slice_index_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_index_range.PreCodegen.after.panic-unwind.mir
@@ -12,7 +12,7 @@ fn slice_index_range(_1: &[u32], _2: std::ops::Range<usize>) -> &[u32] {
 
     bb0: {
         StorageLive(_3);
-        _3 = <std::ops::Range<usize> as SliceIndex<[u32]>>::index(move _2, _1) -> bb1;
+        _3 = <std::ops::Range<usize> as SliceIndex<[u32]>>::index(move _2, _1) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/slice_index.slice_index_usize.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_index_usize.PreCodegen.after.panic-unwind.mir
@@ -10,7 +10,7 @@ fn slice_index_usize(_1: &[u32], _2: usize) -> u32 {
     bb0: {
         _3 = Len((*_1));
         _4 = Lt(_2, _3);
-        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> bb1;
+        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -164,7 +164,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     bb6: {
         StorageDead(_17);
         StorageDead(_15);
-        drop(_2) -> bb7;
+        drop(_2) -> [return: bb7, unwind continue];
     }
 
     bb7: {

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -152,7 +152,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     bb6: {
         StorageDead(_16);
         StorageDead(_14);
-        drop(_2) -> bb7;
+        drop(_2) -> [return: bb7, unwind continue];
     }
 
     bb7: {

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
@@ -111,7 +111,7 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     bb6: {
         StorageDead(_12);
         StorageDead(_5);
-        drop(_2) -> bb7;
+        drop(_2) -> [return: bb7, unwind continue];
     }
 
     bb7: {

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -169,7 +169,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     bb6: {
         StorageDead(_18);
         StorageDead(_15);
-        drop(_2) -> bb7;
+        drop(_2) -> [return: bb7, unwind continue];
     }
 
     bb7: {

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_mut_next_back.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_mut_next_back.PreCodegen.after.panic-unwind.mir
@@ -5,7 +5,7 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
     let mut _0: std::option::Option<&mut T>;
 
     bb0: {
-        _0 = <std::slice::IterMut<'_, T> as DoubleEndedIterator>::next_back(_1) -> bb1;
+        _0 = <std::slice::IterMut<'_, T> as DoubleEndedIterator>::next_back(_1) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-unwind.mir
@@ -5,7 +5,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     let mut _0: std::option::Option<&T>;
 
     bb0: {
-        _0 = <std::slice::Iter<'_, T> as Iterator>::next(_1) -> bb1;
+        _0 = <std::slice::Iter<'_, T> as Iterator>::next(_1) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-unwind.mir
@@ -7,7 +7,7 @@ fn outer(_1: u8) -> u8 {
 
     bb0: {
         _2 = &_1;                        // scope 0 at $DIR/spans.rs:11:11: 11:13
-        _0 = inner(_2) -> bb1;           // scope 0 at $DIR/spans.rs:11:5: 11:14
+        _0 = inner(_2) -> [return: bb1, unwind continue]; // scope 0 at $DIR/spans.rs:11:5: 11:14
                                          // mir::Constant
                                          // + span: $DIR/spans.rs:11:5: 11:10
                                          // + literal: Const { ty: for<'a> fn(&'a u8) -> u8 {inner}, val: Value(<ZST>) }

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -104,7 +104,7 @@
           _13 = &(*_26);
           StorageLive(_15);
           _15 = RangeFull;
-          _12 = <[i32; 10] as Index<RangeFull>>::index(move _13, move _15) -> bb5;
+          _12 = <[i32; 10] as Index<RangeFull>>::index(move _13, move _15) -> [return: bb5, unwind continue];
       }
   
       bb5: {

--- a/tests/mir-opt/reference_prop.dominate_storage.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.dominate_storage.ReferencePropagation.diff
@@ -22,7 +22,7 @@
   
       bb2: {
           _5 = (*_2);
-          _0 = opaque::<i32>(_5) -> bb3;
+          _0 = opaque::<i32>(_5) -> [return: bb3, unwind continue];
       }
   
       bb3: {

--- a/tests/mir-opt/reference_prop.maybe_dead.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.maybe_dead.ReferencePropagation.diff
@@ -27,17 +27,17 @@
       bb1: {
           StorageDead(_2);
           StorageDead(_3);
-          _0 = opaque::<i32>(_6) -> bb2;
+          _0 = opaque::<i32>(_6) -> [return: bb2, unwind continue];
       }
   
       bb2: {
           _7 = (*_4);
-          _0 = opaque::<i32>(_7) -> bb3;
+          _0 = opaque::<i32>(_7) -> [return: bb3, unwind continue];
       }
   
       bb3: {
           _8 = (*_5);
-          _0 = opaque::<i32>(_8) -> bb4;
+          _0 = opaque::<i32>(_8) -> [return: bb4, unwind continue];
       }
   
       bb4: {

--- a/tests/mir-opt/reference_prop.multiple_storage.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.multiple_storage.ReferencePropagation.diff
@@ -14,7 +14,7 @@
           StorageDead(_1);
           StorageLive(_1);
           _3 = (*_2);
-          _0 = opaque::<i32>(_3) -> bb1;
+          _0 = opaque::<i32>(_3) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
@@ -201,7 +201,7 @@
           StorageLive(_7);
           StorageLive(_8);
           _8 = ();
-          _7 = opaque::<()>(move _8) -> bb1;
+          _7 = opaque::<()>(move _8) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -232,7 +232,7 @@
           StorageLive(_16);
           StorageLive(_17);
           _17 = ();
-          _16 = opaque::<()>(move _17) -> bb2;
+          _16 = opaque::<()>(move _17) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -256,7 +256,7 @@
           StorageLive(_23);
           StorageLive(_24);
           _24 = _21;
-          _23 = opaque::<&&usize>(move _24) -> bb3;
+          _23 = opaque::<&&usize>(move _24) -> [return: bb3, unwind continue];
       }
   
       bb3: {
@@ -280,7 +280,7 @@
           StorageLive(_30);
           StorageLive(_31);
           _31 = _28;
-          _30 = opaque::<*mut &usize>(move _31) -> bb4;
+          _30 = opaque::<*mut &usize>(move _31) -> [return: bb4, unwind continue];
       }
   
       bb4: {
@@ -303,7 +303,7 @@
           StorageLive(_36);
           StorageLive(_37);
           _37 = _34;
-          _36 = opaque::<&usize>(move _37) -> bb5;
+          _36 = opaque::<&usize>(move _37) -> [return: bb5, unwind continue];
       }
   
       bb5: {
@@ -332,7 +332,7 @@
           StorageLive(_45);
           StorageLive(_46);
           _46 = _44;
-          _45 = opaque::<&usize>(move _46) -> bb6;
+          _45 = opaque::<&usize>(move _46) -> [return: bb6, unwind continue];
       }
   
       bb6: {
@@ -355,7 +355,7 @@
           StorageLive(_50);
           StorageLive(_51);
           _51 = ();
-          _50 = opaque::<()>(move _51) -> bb7;
+          _50 = opaque::<()>(move _51) -> [return: bb7, unwind continue];
       }
   
       bb7: {
@@ -381,7 +381,7 @@
           StorageLive(_57);
           StorageLive(_58);
           _58 = ();
-          _57 = opaque::<()>(move _58) -> bb8;
+          _57 = opaque::<()>(move _58) -> [return: bb8, unwind continue];
       }
   
       bb8: {
@@ -404,7 +404,7 @@
           StorageLive(_64);
           StorageLive(_65);
           _65 = ();
-          _64 = opaque::<()>(move _65) -> bb9;
+          _64 = opaque::<()>(move _65) -> [return: bb9, unwind continue];
       }
   
       bb9: {
@@ -428,7 +428,7 @@
           StorageLive(_70);
           StorageLive(_71);
           _71 = ();
-          _70 = opaque::<()>(move _71) -> bb10;
+          _70 = opaque::<()>(move _71) -> [return: bb10, unwind continue];
       }
   
       bb10: {

--- a/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
@@ -242,7 +242,7 @@
           StorageLive(_7);
           StorageLive(_8);
           _8 = ();
-          _7 = opaque::<()>(move _8) -> bb1;
+          _7 = opaque::<()>(move _8) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -269,7 +269,7 @@
           StorageLive(_15);
           StorageLive(_16);
           _16 = ();
-          _15 = opaque::<()>(move _16) -> bb2;
+          _15 = opaque::<()>(move _16) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -293,7 +293,7 @@
           StorageLive(_22);
           StorageLive(_23);
           _23 = _20;
-          _22 = opaque::<&*const usize>(move _23) -> bb3;
+          _22 = opaque::<&*const usize>(move _23) -> [return: bb3, unwind continue];
       }
   
       bb3: {
@@ -317,7 +317,7 @@
           StorageLive(_29);
           StorageLive(_30);
           _30 = _27;
-          _29 = opaque::<*mut *const usize>(move _30) -> bb4;
+          _29 = opaque::<*mut *const usize>(move _30) -> [return: bb4, unwind continue];
       }
   
       bb4: {
@@ -340,7 +340,7 @@
           StorageLive(_35);
           StorageLive(_36);
           _36 = _33;
-          _35 = opaque::<*const usize>(move _36) -> bb5;
+          _35 = opaque::<*const usize>(move _36) -> [return: bb5, unwind continue];
       }
   
       bb5: {
@@ -369,7 +369,7 @@
           StorageLive(_44);
           StorageLive(_45);
           _45 = _43;
-          _44 = opaque::<*const usize>(move _45) -> bb6;
+          _44 = opaque::<*const usize>(move _45) -> [return: bb6, unwind continue];
       }
   
       bb6: {
@@ -392,7 +392,7 @@
           StorageLive(_49);
           StorageLive(_50);
           _50 = ();
-          _49 = opaque::<()>(move _50) -> bb7;
+          _49 = opaque::<()>(move _50) -> [return: bb7, unwind continue];
       }
   
       bb7: {
@@ -414,7 +414,7 @@
           StorageLive(_55);
           StorageLive(_56);
           _56 = ();
-          _55 = opaque::<()>(move _56) -> bb8;
+          _55 = opaque::<()>(move _56) -> [return: bb8, unwind continue];
       }
   
       bb8: {
@@ -437,7 +437,7 @@
           StorageLive(_62);
           StorageLive(_63);
           _63 = ();
-          _62 = opaque::<()>(move _63) -> bb9;
+          _62 = opaque::<()>(move _63) -> [return: bb9, unwind continue];
       }
   
       bb9: {
@@ -462,7 +462,7 @@
           StorageLive(_69);
           StorageLive(_70);
           _70 = ();
-          _69 = opaque::<()>(move _70) -> bb10;
+          _69 = opaque::<()>(move _70) -> [return: bb10, unwind continue];
       }
   
       bb10: {
@@ -486,7 +486,7 @@
           StorageLive(_75);
           StorageLive(_76);
           _76 = ();
-          _75 = opaque::<()>(move _76) -> bb11;
+          _75 = opaque::<()>(move _76) -> [return: bb11, unwind continue];
       }
   
       bb11: {

--- a/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
@@ -201,7 +201,7 @@
           StorageLive(_7);
           StorageLive(_8);
           _8 = ();
-          _7 = opaque::<()>(move _8) -> bb1;
+          _7 = opaque::<()>(move _8) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -232,7 +232,7 @@
           StorageLive(_16);
           StorageLive(_17);
           _17 = ();
-          _16 = opaque::<()>(move _17) -> bb2;
+          _16 = opaque::<()>(move _17) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -256,7 +256,7 @@
           StorageLive(_23);
           StorageLive(_24);
           _24 = _21;
-          _23 = opaque::<&&mut usize>(move _24) -> bb3;
+          _23 = opaque::<&&mut usize>(move _24) -> [return: bb3, unwind continue];
       }
   
       bb3: {
@@ -280,7 +280,7 @@
           StorageLive(_30);
           StorageLive(_31);
           _31 = _28;
-          _30 = opaque::<*mut &mut usize>(move _31) -> bb4;
+          _30 = opaque::<*mut &mut usize>(move _31) -> [return: bb4, unwind continue];
       }
   
       bb4: {
@@ -302,7 +302,7 @@
           StorageLive(_36);
           StorageLive(_37);
           _37 = move _34;
-          _36 = opaque::<&mut usize>(move _37) -> bb5;
+          _36 = opaque::<&mut usize>(move _37) -> [return: bb5, unwind continue];
       }
   
       bb5: {
@@ -329,7 +329,7 @@
           StorageLive(_45);
           StorageLive(_46);
           _46 = move _44;
-          _45 = opaque::<&mut usize>(move _46) -> bb6;
+          _45 = opaque::<&mut usize>(move _46) -> [return: bb6, unwind continue];
       }
   
       bb6: {
@@ -352,7 +352,7 @@
           StorageLive(_50);
           StorageLive(_51);
           _51 = ();
-          _50 = opaque::<()>(move _51) -> bb7;
+          _50 = opaque::<()>(move _51) -> [return: bb7, unwind continue];
       }
   
       bb7: {
@@ -378,7 +378,7 @@
           StorageLive(_57);
           StorageLive(_58);
           _58 = ();
-          _57 = opaque::<()>(move _58) -> bb8;
+          _57 = opaque::<()>(move _58) -> [return: bb8, unwind continue];
       }
   
       bb8: {
@@ -401,7 +401,7 @@
           StorageLive(_64);
           StorageLive(_65);
           _65 = ();
-          _64 = opaque::<()>(move _65) -> bb9;
+          _64 = opaque::<()>(move _65) -> [return: bb9, unwind continue];
       }
   
       bb9: {
@@ -425,7 +425,7 @@
           StorageLive(_70);
           StorageLive(_71);
           _71 = ();
-          _70 = opaque::<()>(move _71) -> bb10;
+          _70 = opaque::<()>(move _71) -> [return: bb10, unwind continue];
       }
   
       bb10: {

--- a/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
@@ -219,7 +219,7 @@
           StorageLive(_7);
           StorageLive(_8);
           _8 = ();
-          _7 = opaque::<()>(move _8) -> bb1;
+          _7 = opaque::<()>(move _8) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -246,7 +246,7 @@
           StorageLive(_15);
           StorageLive(_16);
           _16 = ();
-          _15 = opaque::<()>(move _16) -> bb2;
+          _15 = opaque::<()>(move _16) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -270,7 +270,7 @@
           StorageLive(_22);
           StorageLive(_23);
           _23 = _20;
-          _22 = opaque::<&*mut usize>(move _23) -> bb3;
+          _22 = opaque::<&*mut usize>(move _23) -> [return: bb3, unwind continue];
       }
   
       bb3: {
@@ -294,7 +294,7 @@
           StorageLive(_29);
           StorageLive(_30);
           _30 = _27;
-          _29 = opaque::<*mut *mut usize>(move _30) -> bb4;
+          _29 = opaque::<*mut *mut usize>(move _30) -> [return: bb4, unwind continue];
       }
   
       bb4: {
@@ -316,7 +316,7 @@
           StorageLive(_35);
           StorageLive(_36);
           _36 = _33;
-          _35 = opaque::<*mut usize>(move _36) -> bb5;
+          _35 = opaque::<*mut usize>(move _36) -> [return: bb5, unwind continue];
       }
   
       bb5: {
@@ -343,7 +343,7 @@
           StorageLive(_44);
           StorageLive(_45);
           _45 = _43;
-          _44 = opaque::<*mut usize>(move _45) -> bb6;
+          _44 = opaque::<*mut usize>(move _45) -> [return: bb6, unwind continue];
       }
   
       bb6: {
@@ -366,7 +366,7 @@
           StorageLive(_49);
           StorageLive(_50);
           _50 = ();
-          _49 = opaque::<()>(move _50) -> bb7;
+          _49 = opaque::<()>(move _50) -> [return: bb7, unwind continue];
       }
   
       bb7: {
@@ -388,7 +388,7 @@
           StorageLive(_55);
           StorageLive(_56);
           _56 = ();
-          _55 = opaque::<()>(move _56) -> bb8;
+          _55 = opaque::<()>(move _56) -> [return: bb8, unwind continue];
       }
   
       bb8: {
@@ -411,7 +411,7 @@
           StorageLive(_62);
           StorageLive(_63);
           _63 = ();
-          _62 = opaque::<()>(move _63) -> bb9;
+          _62 = opaque::<()>(move _63) -> [return: bb9, unwind continue];
       }
   
       bb9: {
@@ -435,7 +435,7 @@
           StorageLive(_68);
           StorageLive(_69);
           _69 = ();
-          _68 = opaque::<()>(move _69) -> bb10;
+          _68 = opaque::<()>(move _69) -> [return: bb10, unwind continue];
       }
   
       bb10: {

--- a/tests/mir-opt/reference_prop.unique_with_copies.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.unique_with_copies.ReferencePropagation.diff
@@ -34,7 +34,7 @@
           StorageLive(_4);
           StorageLive(_5);
           _5 = (*_3);
-          _4 = opaque::<i32>(move _5) -> bb1;
+          _4 = opaque::<i32>(move _5) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -47,7 +47,7 @@
           StorageLive(_7);
 -         _7 = (*_1);
 +         _7 = (*_3);
-          _6 = opaque::<i32>(move _7) -> bb2;
+          _6 = opaque::<i32>(move _7) -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.panic-unwind.diff
+++ b/tests/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.panic-unwind.diff
@@ -32,7 +32,7 @@
 -         StorageLive(_2);
 -         StorageLive(_3);
           _3 = std::ops::Range::<i32> { start: const 0_i32, end: const 10_i32 };
-          _2 = <std::ops::Range<i32> as IntoIterator>::into_iter(move _3) -> bb1;
+          _2 = <std::ops::Range<i32> as IntoIterator>::into_iter(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -49,7 +49,7 @@
 -         StorageLive(_9);
           _9 = &mut _4;
           _8 = &mut (*_9);
-          _7 = <std::ops::Range<i32> as Iterator>::next(move _8) -> bb3;
+          _7 = <std::ops::Range<i32> as Iterator>::next(move _8) -> [return: bb3, unwind continue];
       }
   
       bb3: {

--- a/tests/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.panic-unwind.diff
+++ b/tests/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.panic-unwind.diff
@@ -14,7 +14,7 @@
 -         nop;
           StorageLive(_3);
           _3 = _1;
--         drop(_3) -> bb1;
+-         drop(_3) -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.panic-unwind.diff
+++ b/tests/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.panic-unwind.diff
@@ -14,7 +14,7 @@
 -         nop;
           StorageLive(_3);
           _3 = _1;
--         drop(_3) -> bb1;
+-         drop(_3) -> [return: bb1, unwind continue];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -76,7 +76,7 @@ fn array_casts() -> () {
         StorageLive(_6);
         StorageLive(_7);
         _7 = _2;
-        _6 = ptr::mut_ptr::<impl *mut usize>::add(move _7, const 1_usize) -> bb1;
+        _6 = ptr::mut_ptr::<impl *mut usize>::add(move _7, const 1_usize) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -102,7 +102,7 @@ fn array_casts() -> () {
         StorageLive(_16);
         StorageLive(_17);
         _17 = _9;
-        _16 = ptr::const_ptr::<impl *const usize>::add(move _17, const 1_usize) -> bb2;
+        _16 = ptr::const_ptr::<impl *const usize>::add(move _17, const 1_usize) -> [return: bb2, unwind continue];
     }
 
     bb2: {
@@ -154,7 +154,7 @@ fn array_casts() -> () {
         StorageLive(_34);
         _34 = Option::<Arguments<'_>>::None;
         Retag(_34);
-        _28 = core::panicking::assert_failed::<usize, usize>(move _29, move _30, move _32, move _34);
+        _28 = core::panicking::assert_failed::<usize, usize>(move _29, move _30, move _32, move _34) -> unwind continue;
     }
 
     bb4: {

--- a/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-unwind.mir
@@ -10,7 +10,7 @@ fn std::ptr::drop_in_place(_1: *mut Test) -> () {
         _2 = &mut (*_1);
         Retag([fn entry] _2);
         _3 = &mut (*_2);
-        _4 = <Test as Drop>::drop(move _3) -> bb1;
+        _4 = <Test as Drop>::drop(move _3) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -114,7 +114,7 @@ fn main() -> () {
         StorageLive(_18);
         _18 = &_1;
         _17 = &(*_18);
-        _15 = move _16(move _17) -> bb3;
+        _15 = move _16(move _17) -> [return: bb3, unwind continue];
     }
 
     bb3: {
@@ -153,7 +153,7 @@ fn main() -> () {
         _25 = _26;
         StorageDead(_26);
         StorageLive(_27);
-        _27 = array_casts() -> bb6;
+        _27 = array_casts() -> [return: bb6, unwind continue];
     }
 
     bb6: {

--- a/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
+++ b/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
@@ -14,7 +14,7 @@
       }
   
       bb1: {
-          _2 = noop() -> bb2;
+          _2 = noop() -> [return: bb2, unwind continue];
       }
   
       bb2: {

--- a/tests/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals-final.panic-unwind.diff
+++ b/tests/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals-final.panic-unwind.diff
@@ -39,7 +39,7 @@
       }
   
       bb3: {
-          drop(_1) -> bb4;
+          drop(_1) -> [return: bb4, unwind continue];
       }
   
       bb4: {

--- a/tests/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals-before-const-prop.panic-unwind.diff
+++ b/tests/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals-before-const-prop.panic-unwind.diff
@@ -36,7 +36,7 @@
 +         _2 = (move _3, move _4);
 +         StorageDead(_4);
           StorageDead(_3);
-+         _1 = use_zst(move _2) -> bb1;
++         _1 = use_zst(move _2) -> [return: bb1, unwind continue];
 +     }
 + 
 +     bb1: {
@@ -55,8 +55,8 @@
 +         _6 = Add(move _7, const 2_u8);
           StorageDead(_7);
 -         StorageDead(_6);
--         _4 = use_zst(move _5) -> bb1;
-+         _5 = use_u8(move _6) -> bb2;
+-         _4 = use_zst(move _5) -> [return: bb1, unwind continue];
++         _5 = use_u8(move _6) -> [return: bb2, unwind continue];
       }
   
 -     bb1: {
@@ -70,7 +70,7 @@
 -         _10 = (_11.0: u8);
 -         _9 = Add(move _10, const 2_u8);
 -         StorageDead(_10);
--         _8 = use_u8(move _9) -> bb2;
+-         _8 = use_u8(move _9) -> [return: bb2, unwind continue];
 -     }
 - 
       bb2: {

--- a/tests/mir-opt/simplify_match.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/simplify_match.main.ConstProp.panic-unwind.diff
@@ -20,7 +20,7 @@
       }
   
       bb2: {
-          _0 = noop() -> bb3;
+          _0 = noop() -> [return: bb3, unwind continue];
       }
   
       bb3: {

--- a/tests/mir-opt/unreachable.main.UnreachablePropagation.panic-unwind.diff
+++ b/tests/mir-opt/unreachable.main.UnreachablePropagation.panic-unwind.diff
@@ -19,7 +19,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = empty() -> bb1;
+          _1 = empty() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/unreachable_diverging.main.UnreachablePropagation.panic-unwind.diff
+++ b/tests/mir-opt/unreachable_diverging.main.UnreachablePropagation.panic-unwind.diff
@@ -21,7 +21,7 @@
           StorageLive(_1);
           _1 = const true;
           StorageLive(_2);
-          _2 = empty() -> bb1;
+          _2 = empty() -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -39,7 +39,7 @@
       }
   
       bb3: {
-          _5 = loop_forever() -> bb5;
+          _5 = loop_forever() -> [return: bb5, unwind continue];
       }
   
       bb4: {

--- a/tests/mir-opt/while_storage.while_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/while_storage.while_loop.PreCodegen.after.panic-unwind.mir
@@ -12,7 +12,7 @@ fn while_loop(_1: bool) -> () {
 
     bb1: {
         StorageLive(_2);
-        _2 = get_bool(_1) -> bb2;
+        _2 = get_bool(_1) -> [return: bb2, unwind continue];
     }
 
     bb2: {
@@ -21,7 +21,7 @@ fn while_loop(_1: bool) -> () {
 
     bb3: {
         StorageLive(_3);
-        _3 = get_bool(_1) -> bb4;
+        _3 = get_bool(_1) -> [return: bb4, unwind continue];
     }
 
     bb4: {

--- a/tests/run-make/const_fn_mir/dump.mir
+++ b/tests/run-make/const_fn_mir/dump.mir
@@ -6,7 +6,7 @@ fn foo() -> i32 {
 
     bb0: {
         _1 = CheckedAdd(const 5_i32, const 6_i32);
-        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 5_i32, const 6_i32) -> bb1;
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 5_i32, const 6_i32) -> [success: bb1, unwind continue];
     }
 
     bb1: {
@@ -22,7 +22,7 @@ fn foo() -> i32 {
 
     bb0: {
         _1 = CheckedAdd(const 5_i32, const 6_i32);
-        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 5_i32, const 6_i32) -> bb1;
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 5_i32, const 6_i32) -> [success: bb1, unwind continue];
     }
 
     bb1: {
@@ -36,7 +36,7 @@ fn main() -> () {
     let _1: i32;
 
     bb0: {
-        _1 = foo() -> bb1;
+        _1 = foo() -> [return: bb1, unwind continue];
     }
 
     bb1: {


### PR DESCRIPTION
Makes it easier to spot unwinding related issues in MIR by making `UnwindAction::Continue` explicit, just like all other `UnwindAction`s.