### PR TITLE
Add test for futures with HRTB

### DIFF
--- a/tests/ui/higher-ranked/trait-bounds/future.classic.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/future.classic.stderr
@@ -1,0 +1,6 @@
+error: the compiler unexpectedly panicked. this is a bug.
+
+query stack during panic:
+#0 [evaluate_obligation] evaluating trait selection obligation `for<'a> [async fn body@$DIR/future.rs:32:35: 34:2]: core::future::future::Future`
+#1 [codegen_select_candidate] computing candidate for `<strlen as Trait>`
+end of query stack

--- a/tests/ui/higher-ranked/trait-bounds/future.rs
+++ b/tests/ui/higher-ranked/trait-bounds/future.rs
@@ -1,0 +1,38 @@
+// ignore-tidy-linelength
+// edition:2021
+// revisions: classic next
+//[next] compile-flags: -Ztrait-solver=next
+//[next] check-pass
+//[classic] known-bug: #112347
+//[classic] build-fail
+//[classic] failure-status: 101
+//[classic] normalize-stderr-test "note: .*\n\n" -> ""
+//[classic] normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+//[classic] normalize-stderr-test "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//[classic] rustc-env:RUST_BACKTRACE=0
+
+#![feature(unboxed_closures)]
+
+use std::future::Future;
+
+trait Trait {
+    fn func(&self, _: &str);
+}
+
+impl<T> Trait for T
+where
+    for<'a> T: Fn<(&'a str,)> + Send + Sync,
+    for<'a> <T as FnOnce<(&'a str,)>>::Output: Future<Output = usize> + Send,
+{
+    fn func(&self, _: &str) {
+        println!("hello!");
+    }
+}
+
+async fn strlen(x: &str) -> usize {
+    x.len()
+}
+
+fn main() {
+    strlen.func("hi");
+}


### PR DESCRIPTION
Part of #112347 

This PR adds test for ice when resolving for `Futures` with HRTB.