### PR TITLE
Fix return type notation errors with -Zlower-impl-trait-in-trait-to-assoc-ty

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -412,7 +412,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
             // an RPITIT (return-position impl trait in trait) or AFIT (async fn in trait).
             let output = tcx.fn_sig(assoc_item.def_id).skip_binder().output();
             let output = if let ty::Alias(ty::Projection, alias_ty) = *output.skip_binder().kind()
-                && tcx.def_kind(alias_ty.def_id) == DefKind::ImplTraitPlaceholder
+                && tcx.is_impl_trait_in_trait(alias_ty.def_id)
             {
                 alias_ty
             } else {

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.current.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.current.stderr
@@ -1,11 +1,11 @@
 error: return type notation uses `()` instead of `(..)` for elided arguments
-  --> $DIR/bad-inputs-and-output.rs:18:24
+  --> $DIR/bad-inputs-and-output.rs:20:24
    |
 LL | fn baz<T: Trait<method(..): Send>>() {}
    |                        ^^ help: remove the `..`
 
 error[E0658]: associated type bounds are unstable
-  --> $DIR/bad-inputs-and-output.rs:10:17
+  --> $DIR/bad-inputs-and-output.rs:12:17
    |
 LL | fn foo<T: Trait<method(i32): Send>>() {}
    |                 ^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL | fn foo<T: Trait<method(i32): Send>>() {}
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
-  --> $DIR/bad-inputs-and-output.rs:14:17
+  --> $DIR/bad-inputs-and-output.rs:16:17
    |
 LL | fn bar<T: Trait<method() -> (): Send>>() {}
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | fn bar<T: Trait<method() -> (): Send>>() {}
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/bad-inputs-and-output.rs:3:12
+  --> $DIR/bad-inputs-and-output.rs:5:12
    |
 LL | #![feature(return_type_notation, async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -32,13 +32,13 @@ LL | #![feature(return_type_notation, async_fn_in_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: argument types not allowed with return type notation
-  --> $DIR/bad-inputs-and-output.rs:10:23
+  --> $DIR/bad-inputs-and-output.rs:12:23
    |
 LL | fn foo<T: Trait<method(i32): Send>>() {}
    |                       ^^^^^ help: remove the input types: `()`
 
 error: return type not allowed with return type notation
-  --> $DIR/bad-inputs-and-output.rs:14:25
+  --> $DIR/bad-inputs-and-output.rs:16:25
    |
 LL | fn bar<T: Trait<method() -> (): Send>>() {}
    |                         ^^^^^^ help: remove the return type

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.next.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.next.stderr
@@ -1,0 +1,48 @@
+error: return type notation uses `()` instead of `(..)` for elided arguments
+  --> $DIR/bad-inputs-and-output.rs:20:24
+   |
+LL | fn baz<T: Trait<method(..): Send>>() {}
+   |                        ^^ help: remove the `..`
+
+error[E0658]: associated type bounds are unstable
+  --> $DIR/bad-inputs-and-output.rs:12:17
+   |
+LL | fn foo<T: Trait<method(i32): Send>>() {}
+   |                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+
+error[E0658]: associated type bounds are unstable
+  --> $DIR/bad-inputs-and-output.rs:16:17
+   |
+LL | fn bar<T: Trait<method() -> (): Send>>() {}
+   |                 ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/bad-inputs-and-output.rs:5:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: argument types not allowed with return type notation
+  --> $DIR/bad-inputs-and-output.rs:12:23
+   |
+LL | fn foo<T: Trait<method(i32): Send>>() {}
+   |                       ^^^^^ help: remove the input types: `()`
+
+error: return type not allowed with return type notation
+  --> $DIR/bad-inputs-and-output.rs:16:25
+   |
+LL | fn bar<T: Trait<method() -> (): Send>>() {}
+   |                         ^^^^^^ help: remove the return type
+
+error: aborting due to 5 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
@@ -1,4 +1,6 @@
 // edition: 2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_type_notation, async_fn_in_trait)]
 //~^ WARN the feature `return_type_notation` is incomplete

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.current_with.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.current_with.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/equality.rs:3:12
+  --> $DIR/basic.rs:8:12
    |
 LL | #![feature(return_type_notation, async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -7,11 +7,5 @@ LL | #![feature(return_type_notation, async_fn_in_trait)]
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error: return type notation is not allowed to use type equality
-  --> $DIR/equality.rs:12:18
-   |
-LL | fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to previous error; 1 warning emitted
+warning: 1 warning emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.current_without.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.current_without.stderr
@@ -1,0 +1,29 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/basic.rs:8:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: future cannot be sent between threads safely
+  --> $DIR/basic.rs:26:13
+   |
+LL |     is_send(foo::<T>());
+   |             ^^^^^^^^^^ future returned by `foo` is not `Send`
+   |
+   = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>>`
+note: future is not `Send` as it awaits another future which is not `Send`
+  --> $DIR/basic.rs:16:5
+   |
+LL |     T::method().await?;
+   |     ^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), ()>>`, which is not `Send`
+note: required by a bound in `is_send`
+  --> $DIR/basic.rs:20:20
+   |
+LL | fn is_send(_: impl Send) {}
+   |                    ^^^^ required by this bound in `is_send`
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.next_with.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.next_with.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/basic.rs:8:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.next_without.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.next_without.stderr
@@ -1,0 +1,29 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/basic.rs:8:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: future cannot be sent between threads safely
+  --> $DIR/basic.rs:26:13
+   |
+LL |     is_send(foo::<T>());
+   |             ^^^^^^^^^^ future returned by `foo` is not `Send`
+   |
+   = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>>`
+note: future is not `Send` as it awaits another future which is not `Send`
+  --> $DIR/basic.rs:16:5
+   |
+LL |     T::method().await?;
+   |     ^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), ()>>`, which is not `Send`
+note: required by a bound in `is_send`
+  --> $DIR/basic.rs:20:20
+   |
+LL | fn is_send(_: impl Send) {}
+   |                    ^^^^ required by this bound in `is_send`
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.rs
@@ -1,6 +1,9 @@
-// revisions: with without
+// revisions: current_with current_without next_with next_without
+// [next_with] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// [next_without] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
 // edition: 2021
-//[with] check-pass
+// [current_with] check-pass
+// [next_with] check-pass
 
 #![feature(return_type_notation, async_fn_in_trait)]
 //~^ WARN the feature `return_type_notation` is incomplete
@@ -17,11 +20,12 @@ async fn foo<T: Foo>() -> Result<(), ()> {
 fn is_send(_: impl Send) {}
 
 fn test<
-    #[cfg(with)] T: Foo<method(): Send>,
-    #[cfg(without)] T: Foo,
+    #[cfg(any(current_with, next_with))] T: Foo<method(): Send>,
+    #[cfg(any(current_without, next_without))] T: Foo,
 >() {
     is_send(foo::<T>());
-    //[without]~^ ERROR future cannot be sent between threads safely
+    //[current_without]~^ ERROR future cannot be sent between threads safely
+    //[next_without]~^^ ERROR future cannot be sent between threads safely
 }
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.current.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.current.stderr
@@ -1,0 +1,17 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/equality.rs:5:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation is not allowed to use type equality
+  --> $DIR/equality.rs:14:18
+   |
+LL | fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.next.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.next.stderr
@@ -1,0 +1,17 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/equality.rs:5:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation is not allowed to use type equality
+  --> $DIR/equality.rs:14:18
+   |
+LL | fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.rs
@@ -1,4 +1,6 @@
 // edition: 2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_type_notation, async_fn_in_trait)]
 //~^ WARN the feature `return_type_notation` is incomplete

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.current.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/issue-110963-early.rs:4:12
+  --> $DIR/issue-110963-early.rs:6:12
    |
 LL | #![feature(return_type_notation)]
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![feature(return_type_notation)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: higher-ranked lifetime error
-  --> $DIR/issue-110963-early.rs:15:5
+  --> $DIR/issue-110963-early.rs:17:5
    |
 LL | /     spawn(async move {
 LL | |         let mut hc = hc;
@@ -18,10 +18,10 @@ LL | |         }
 LL | |     });
    | |______^
    |
-   = note: could not prove `[async block@$DIR/issue-110963-early.rs:15:11: 20:6]: Send`
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:17:11: 22:6]: Send`
 
 error: higher-ranked lifetime error
-  --> $DIR/issue-110963-early.rs:15:5
+  --> $DIR/issue-110963-early.rs:17:5
    |
 LL | /     spawn(async move {
 LL | |         let mut hc = hc;
@@ -31,7 +31,7 @@ LL | |         }
 LL | |     });
    | |______^
    |
-   = note: could not prove `[async block@$DIR/issue-110963-early.rs:15:11: 20:6]: Send`
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:17:11: 22:6]: Send`
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.next.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.next.stderr
@@ -1,0 +1,37 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-110963-early.rs:6:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: higher-ranked lifetime error
+  --> $DIR/issue-110963-early.rs:17:5
+   |
+LL | /     spawn(async move {
+LL | |         let mut hc = hc;
+LL | |         if !hc.check().await {
+LL | |             log_health_check_failure().await;
+LL | |         }
+LL | |     });
+   | |______^
+   |
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:17:11: 22:6]: Send`
+
+error: higher-ranked lifetime error
+  --> $DIR/issue-110963-early.rs:17:5
+   |
+LL | /     spawn(async move {
+LL | |         let mut hc = hc;
+LL | |         if !hc.check().await {
+LL | |             log_health_check_failure().await;
+LL | |         }
+LL | |     });
+   | |______^
+   |
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:17:11: 22:6]: Send`
+
+error: aborting due to 2 previous errors; 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.rs
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.rs
@@ -1,5 +1,7 @@
 // edition: 2021
 // known-bug: #110963
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_type_notation)]
 #![feature(async_fn_in_trait)]

--- a/tests/ui/async-await/return-type-notation/issue-110963-late.current.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-late.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/issue-110963-late.rs:4:12
+  --> $DIR/issue-110963-late.rs:6:12
    |
 LL | #![feature(return_type_notation)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/return-type-notation/issue-110963-late.next.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-late.next.stderr
@@ -1,8 +1,8 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/super-method-bound.rs:4:31
+  --> $DIR/issue-110963-late.rs:6:12
    |
-LL | #![feature(async_fn_in_trait, return_type_notation)]
-   |                               ^^^^^^^^^^^^^^^^^^^^
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = note: `#[warn(incomplete_features)]` on by default

--- a/tests/ui/async-await/return-type-notation/issue-110963-late.rs
+++ b/tests/ui/async-await/return-type-notation/issue-110963-late.rs
@@ -1,5 +1,7 @@
 // edition: 2021
 // check-pass
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_type_notation)]
 //~^ WARN the feature `return_type_notation` is incomplete

--- a/tests/ui/async-await/return-type-notation/super-method-bound.current.stderr
+++ b/tests/ui/async-await/return-type-notation/super-method-bound.current.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/super-method-bound.rs:6:31
+   |
+LL | #![feature(async_fn_in_trait, return_type_notation)]
+   |                               ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/super-method-bound.next.stderr
+++ b/tests/ui/async-await/return-type-notation/super-method-bound.next.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/super-method-bound.rs:6:31
+   |
+LL | #![feature(async_fn_in_trait, return_type_notation)]
+   |                               ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/super-method-bound.rs
+++ b/tests/ui/async-await/return-type-notation/super-method-bound.rs
@@ -1,5 +1,7 @@
 // edition:2021
 // check-pass
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(async_fn_in_trait, return_type_notation)]
 //~^ WARN the feature `return_type_notation` is incomplete

--- a/tests/ui/async-await/return-type-notation/supertrait-bound.current.stderr
+++ b/tests/ui/async-await/return-type-notation/supertrait-bound.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/supertrait-bound.rs:3:49
+  --> $DIR/supertrait-bound.rs:5:49
    |
 LL | #![feature(return_position_impl_trait_in_trait, return_type_notation)]
    |                                                 ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/return-type-notation/supertrait-bound.next.stderr
+++ b/tests/ui/async-await/return-type-notation/supertrait-bound.next.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/supertrait-bound.rs:5:49
+   |
+LL | #![feature(return_position_impl_trait_in_trait, return_type_notation)]
+   |                                                 ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/supertrait-bound.rs
+++ b/tests/ui/async-await/return-type-notation/supertrait-bound.rs
@@ -1,4 +1,6 @@
 // check-pass
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_position_impl_trait_in_trait, return_type_notation)]
 //~^ WARN the feature `return_type_notation` is incomplete and may not be safe to use

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.current.stderr
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/ty-or-ct-params.rs:3:31
+  --> $DIR/ty-or-ct-params.rs:5:31
    |
 LL | #![feature(async_fn_in_trait, return_type_notation)]
    |                               ^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![feature(async_fn_in_trait, return_type_notation)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: return type notation is not allowed for functions that have type parameters
-  --> $DIR/ty-or-ct-params.rs:14:12
+  --> $DIR/ty-or-ct-params.rs:16:12
    |
 LL |     async fn bar<T>() {}
    |                  - type parameter declared here
@@ -17,7 +17,7 @@ LL |     T: Foo<bar(): Send, baz(): Send>,
    |            ^^^^^^^^^^^
 
 error: return type notation is not allowed for functions that have const parameters
-  --> $DIR/ty-or-ct-params.rs:14:25
+  --> $DIR/ty-or-ct-params.rs:16:25
    |
 LL |     async fn baz<const N: usize>() {}
    |                  -------------- const parameter declared here

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.next.stderr
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.next.stderr
@@ -1,0 +1,29 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/ty-or-ct-params.rs:5:31
+   |
+LL | #![feature(async_fn_in_trait, return_type_notation)]
+   |                               ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation is not allowed for functions that have type parameters
+  --> $DIR/ty-or-ct-params.rs:16:12
+   |
+LL |     async fn bar<T>() {}
+   |                  - type parameter declared here
+...
+LL |     T: Foo<bar(): Send, baz(): Send>,
+   |            ^^^^^^^^^^^
+
+error: return type notation is not allowed for functions that have const parameters
+  --> $DIR/ty-or-ct-params.rs:16:25
+   |
+LL |     async fn baz<const N: usize>() {}
+   |                  -------------- const parameter declared here
+...
+LL |     T: Foo<bar(): Send, baz(): Send>,
+   |                         ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.rs
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.rs
@@ -1,4 +1,6 @@
 // edition: 2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(async_fn_in_trait, return_type_notation)]
 //~^ WARN the feature `return_type_notation` is incomplete


### PR DESCRIPTION
This just adjust the way we check for RPITITs and uses the new helper method to do the "old" and "new" check at once.

r? @compiler-errors 