### PR TITLE
Fix return type notation associated type suggestion when -Zlower-impl-trait-in-trait-to-assoc-ty

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -122,9 +122,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         let all_candidate_names: Vec<_> = all_candidates()
             .flat_map(|r| self.tcx().associated_items(r.def_id()).in_definition_order())
-            .filter_map(
-                |item| if item.kind == ty::AssocKind::Type { Some(item.name) } else { None },
-            )
+            .filter_map(|item| {
+                if item.opt_rpitit_info.is_none() && item.kind == ty::AssocKind::Type {
+                    Some(item.name)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         if let (Some(suggested_name), true) = (
@@ -159,9 +163,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             .flat_map(|trait_def_id| {
                 self.tcx().associated_items(*trait_def_id).in_definition_order()
             })
-            .filter_map(
-                |item| if item.kind == ty::AssocKind::Type { Some(item.name) } else { None },
-            )
+            .filter_map(|item| {
+                if item.opt_rpitit_info.is_none() && item.kind == ty::AssocKind::Type {
+                    Some(item.name)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         if let (Some(suggested_name), true) = (

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.cfg_current.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.cfg_current.stderr
@@ -1,0 +1,27 @@
+error[E0658]: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+
+error: parenthesized generic arguments cannot be used in associated type constraints
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^--
+   |                  |
+   |                  help: remove these parentheses
+
+error[E0220]: associated type `m` not found for `Trait`
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^ associated type `m` not found
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0220, E0658.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.cfg_next.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.cfg_next.stderr
@@ -1,0 +1,27 @@
+error[E0658]: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+
+error: parenthesized generic arguments cannot be used in associated type constraints
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^--
+   |                  |
+   |                  help: remove these parentheses
+
+error[E0220]: associated type `m` not found for `Trait`
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^ associated type `m` not found
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0220, E0658.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.no_current.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.no_current.stderr
@@ -1,0 +1,13 @@
+warning: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+   = warning: unstable syntax can change at any point in the future, causing a hard error!
+   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+
+warning: 1 warning emitted
+

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.no_next.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.no_next.stderr
@@ -1,0 +1,13 @@
+warning: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+   = warning: unstable syntax can change at any point in the future, causing a hard error!
+   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+
+warning: 1 warning emitted
+

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.rs
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.rs
@@ -1,7 +1,10 @@
 // edition: 2021
-// revisions: cfg no
+// revisions: cfg_current cfg_next no_current no_next
+// [cfg_next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// [no_next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
 
-//[no] check-pass
+// [no_current] check-pass
+// [no_next] check-pass
 // Since we're not adding new syntax, `cfg`'d out RTN must pass.
 
 #![feature(async_fn_in_trait)]
@@ -10,12 +13,17 @@ trait Trait {
     async fn m();
 }
 
-#[cfg(cfg)]
+#[cfg(any(cfg_current, cfg_next))]
 fn foo<T: Trait<m(): Send>>() {}
-//[cfg]~^ ERROR return type notation is experimental
-//[cfg]~| ERROR parenthesized generic arguments cannot be used in associated type constraints
-//[cfg]~| ERROR associated type `m` not found for `Trait`
-//[no]~^^^^ WARN return type notation is experimental
-//[no]~| WARN unstable syntax can change at any point in the future, causing a hard error!
+//[cfg_current]~^ ERROR return type notation is experimental
+//[cfg_current]~| ERROR parenthesized generic arguments cannot be used in associated type constraints
+//[cfg_current]~| ERROR associated type `m` not found for `Trait`
+//[cfg_next]~^^^^ ERROR return type notation is experimental
+//[cfg_next]~| ERROR parenthesized generic arguments cannot be used in associated type constraints
+//[cfg_next]~| ERROR associated type `m` not found for `Trait`
+//[no_current]~^^^^^^^ WARN return type notation is experimental
+//[no_current]~| WARN unstable syntax can change at any point in the future, causing a hard error!
+//[no_next]~^^^^^^^^^ WARN return type notation is experimental
+//[no_next]~| WARN unstable syntax can change at any point in the future, causing a hard error!
 
 fn main() {}


### PR DESCRIPTION
This avoid suggesting the associated types generated for RPITITs when the one the code refers to doesn't exist and rustc looks for a suggestion.

r? @compiler-errors 