### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.92"
+version = "0.1.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64518f1ae689f74db058bbfb3238dfe6eb53f59f4ae712f1ff4348628522e190"
+checksum = "76630810d973ecea3dbf611e1b7aecfb1012751ef1ff8de3998f89014a166781"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -97,6 +97,7 @@ pub static DEFAULT_LOCALE_RESOURCES: &[&str] = &[
     rustc_codegen_ssa::DEFAULT_LOCALE_RESOURCE,
     rustc_const_eval::DEFAULT_LOCALE_RESOURCE,
     rustc_error_messages::DEFAULT_LOCALE_RESOURCE,
+    rustc_errors::DEFAULT_LOCALE_RESOURCE,
     rustc_expand::DEFAULT_LOCALE_RESOURCE,
     rustc_hir_analysis::DEFAULT_LOCALE_RESOURCE,
     rustc_hir_typeck::DEFAULT_LOCALE_RESOURCE,

--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -412,7 +412,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
             // an RPITIT (return-position impl trait in trait) or AFIT (async fn in trait).
             let output = tcx.fn_sig(assoc_item.def_id).skip_binder().output();
             let output = if let ty::Alias(ty::Projection, alias_ty) = *output.skip_binder().kind()
-                && tcx.def_kind(alias_ty.def_id) == DefKind::ImplTraitPlaceholder
+                && tcx.is_impl_trait_in_trait(alias_ty.def_id)
             {
                 alias_ty
             } else {

--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -122,9 +122,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         let all_candidate_names: Vec<_> = all_candidates()
             .flat_map(|r| self.tcx().associated_items(r.def_id()).in_definition_order())
-            .filter_map(
-                |item| if item.kind == ty::AssocKind::Type { Some(item.name) } else { None },
-            )
+            .filter_map(|item| {
+                if item.opt_rpitit_info.is_none() && item.kind == ty::AssocKind::Type {
+                    Some(item.name)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         if let (Some(suggested_name), true) = (
@@ -159,9 +163,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             .flat_map(|trait_def_id| {
                 self.tcx().associated_items(*trait_def_id).in_definition_order()
             })
-            .filter_map(
-                |item| if item.kind == ty::AssocKind::Type { Some(item.name) } else { None },
-            )
+            .filter_map(|item| {
+                if item.opt_rpitit_info.is_none() && item.kind == ty::AssocKind::Type {
+                    Some(item.name)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         if let (Some(suggested_name), true) = (

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1049,6 +1049,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     }
 
                     ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(ty)) => {
+                        let ty = self.resolve_vars_if_possible(ty);
                         match self.tcx.sess.opts.unstable_opts.trait_solver {
                             TraitSolver::Classic => {
                                 // WF predicates cannot themselves make

--- a/compiler/rustc_traits/src/evaluate_obligation.rs
+++ b/compiler/rustc_traits/src/evaluate_obligation.rs
@@ -1,6 +1,5 @@
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::query::Providers;
-use rustc_middle::traits::DefiningAnchor;
 use rustc_middle::ty::{ParamEnvAnd, TyCtxt};
 use rustc_span::source_map::DUMMY_SP;
 use rustc_trait_selection::traits::query::CanonicalPredicateGoal;
@@ -18,12 +17,8 @@ fn evaluate_obligation<'tcx>(
 ) -> Result<EvaluationResult, OverflowError> {
     assert!(!tcx.next_trait_solver_globally());
     debug!("evaluate_obligation(canonical_goal={:#?})", canonical_goal);
-    // HACK This bubble is required for this tests to pass:
-    // impl-trait/issue99642.rs
-    let (ref infcx, goal, _canonical_inference_vars) = tcx
-        .infer_ctxt()
-        .with_opaque_type_inference(DefiningAnchor::Bubble)
-        .build_with_canonical(DUMMY_SP, &canonical_goal);
+    let (ref infcx, goal, _canonical_inference_vars) =
+        tcx.infer_ctxt().build_with_canonical(DUMMY_SP, &canonical_goal);
     debug!("evaluate_obligation: goal={:#?}", goal);
     let ParamEnvAnd { param_env, value: predicate } = goal;
 

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
 libc = { version = "0.2.146", default-features = false, features = ['rustc-dep-of-std'], public = true }
-compiler_builtins = { version = "0.1.92" }
+compiler_builtins = { version = "0.1.93" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = ['rustc-dep-of-std'] }

--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -347,8 +347,8 @@ pub struct Sender<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for Sender<T> {}
 
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<T> !Sync for Sender<T> {}
+#[stable(feature = "mpsc_sender_sync", since = "CURRENT_RUSTC_VERSION")]
+unsafe impl<T: Send> Sync for Sender<T> {}
 
 /// The sending-half of Rust's synchronous [`sync_channel`] type.
 ///

--- a/tests/run-make/target-specs/Makefile
+++ b/tests/run-make/target-specs/Makefile
@@ -8,4 +8,5 @@ all:
 	RUST_TARGET_PATH=. $(RUSTC) foo.rs --target=my-x86_64-unknown-linux-gnu-platform --crate-type=lib --emit=asm
 	$(RUSTC) -Z unstable-options --target=my-awesome-platform.json --print target-spec-json > $(TMPDIR)/test-platform.json && $(RUSTC) -Z unstable-options --target=$(TMPDIR)/test-platform.json --print target-spec-json | diff -q $(TMPDIR)/test-platform.json -
 	$(RUSTC) foo.rs --target=definitely-not-builtin-target 2>&1 | $(CGREP) 'may not set is_builtin'
+	$(RUSTC) foo.rs --target=endianness-mismatch 2>&1 | $(CGREP) '"data-layout" claims architecture is little-endian'
 	$(RUSTC) foo.rs --target=mismatching-data-layout --crate-type=lib

--- a/tests/run-make/target-specs/endianness-mismatch.json
+++ b/tests/run-make/target-specs/endianness-mismatch.json
@@ -1,0 +1,11 @@
+{
+    "pre-link-args": {"gcc": ["-m64"]},
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "linker-flavor": "gcc",
+    "llvm-target": "x86_64-unknown-linux-gnu",
+    "target-endian": "big",
+    "target-pointer-width": "64",
+    "target-c-int-width": "32",
+    "arch": "x86_64",
+    "os": "linux"
+}

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.current.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.current.stderr
@@ -1,11 +1,11 @@
 error: return type notation uses `()` instead of `(..)` for elided arguments
-  --> $DIR/bad-inputs-and-output.rs:18:24
+  --> $DIR/bad-inputs-and-output.rs:20:24
    |
 LL | fn baz<T: Trait<method(..): Send>>() {}
    |                        ^^ help: remove the `..`
 
 error[E0658]: associated type bounds are unstable
-  --> $DIR/bad-inputs-and-output.rs:10:17
+  --> $DIR/bad-inputs-and-output.rs:12:17
    |
 LL | fn foo<T: Trait<method(i32): Send>>() {}
    |                 ^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL | fn foo<T: Trait<method(i32): Send>>() {}
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
-  --> $DIR/bad-inputs-and-output.rs:14:17
+  --> $DIR/bad-inputs-and-output.rs:16:17
    |
 LL | fn bar<T: Trait<method() -> (): Send>>() {}
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | fn bar<T: Trait<method() -> (): Send>>() {}
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/bad-inputs-and-output.rs:3:12
+  --> $DIR/bad-inputs-and-output.rs:5:12
    |
 LL | #![feature(return_type_notation, async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -32,13 +32,13 @@ LL | #![feature(return_type_notation, async_fn_in_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: argument types not allowed with return type notation
-  --> $DIR/bad-inputs-and-output.rs:10:23
+  --> $DIR/bad-inputs-and-output.rs:12:23
    |
 LL | fn foo<T: Trait<method(i32): Send>>() {}
    |                       ^^^^^ help: remove the input types: `()`
 
 error: return type not allowed with return type notation
-  --> $DIR/bad-inputs-and-output.rs:14:25
+  --> $DIR/bad-inputs-and-output.rs:16:25
    |
 LL | fn bar<T: Trait<method() -> (): Send>>() {}
    |                         ^^^^^^ help: remove the return type

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.next.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.next.stderr
@@ -1,0 +1,48 @@
+error: return type notation uses `()` instead of `(..)` for elided arguments
+  --> $DIR/bad-inputs-and-output.rs:20:24
+   |
+LL | fn baz<T: Trait<method(..): Send>>() {}
+   |                        ^^ help: remove the `..`
+
+error[E0658]: associated type bounds are unstable
+  --> $DIR/bad-inputs-and-output.rs:12:17
+   |
+LL | fn foo<T: Trait<method(i32): Send>>() {}
+   |                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+
+error[E0658]: associated type bounds are unstable
+  --> $DIR/bad-inputs-and-output.rs:16:17
+   |
+LL | fn bar<T: Trait<method() -> (): Send>>() {}
+   |                 ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/bad-inputs-and-output.rs:5:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: argument types not allowed with return type notation
+  --> $DIR/bad-inputs-and-output.rs:12:23
+   |
+LL | fn foo<T: Trait<method(i32): Send>>() {}
+   |                       ^^^^^ help: remove the input types: `()`
+
+error: return type not allowed with return type notation
+  --> $DIR/bad-inputs-and-output.rs:16:25
+   |
+LL | fn bar<T: Trait<method() -> (): Send>>() {}
+   |                         ^^^^^^ help: remove the return type
+
+error: aborting due to 5 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
@@ -1,4 +1,6 @@
 // edition: 2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_type_notation, async_fn_in_trait)]
 //~^ WARN the feature `return_type_notation` is incomplete

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.current_with.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.current_with.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/equality.rs:3:12
+  --> $DIR/basic.rs:8:12
    |
 LL | #![feature(return_type_notation, async_fn_in_trait)]
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -7,11 +7,5 @@ LL | #![feature(return_type_notation, async_fn_in_trait)]
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error: return type notation is not allowed to use type equality
-  --> $DIR/equality.rs:12:18
-   |
-LL | fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to previous error; 1 warning emitted
+warning: 1 warning emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.current_without.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.current_without.stderr
@@ -1,0 +1,29 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/basic.rs:8:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: future cannot be sent between threads safely
+  --> $DIR/basic.rs:26:13
+   |
+LL |     is_send(foo::<T>());
+   |             ^^^^^^^^^^ future returned by `foo` is not `Send`
+   |
+   = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>>`
+note: future is not `Send` as it awaits another future which is not `Send`
+  --> $DIR/basic.rs:16:5
+   |
+LL |     T::method().await?;
+   |     ^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), ()>>`, which is not `Send`
+note: required by a bound in `is_send`
+  --> $DIR/basic.rs:20:20
+   |
+LL | fn is_send(_: impl Send) {}
+   |                    ^^^^ required by this bound in `is_send`
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.next_with.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.next_with.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/basic.rs:8:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.next_without.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.next_without.stderr
@@ -1,0 +1,29 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/basic.rs:8:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: future cannot be sent between threads safely
+  --> $DIR/basic.rs:26:13
+   |
+LL |     is_send(foo::<T>());
+   |             ^^^^^^^^^^ future returned by `foo` is not `Send`
+   |
+   = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>>`
+note: future is not `Send` as it awaits another future which is not `Send`
+  --> $DIR/basic.rs:16:5
+   |
+LL |     T::method().await?;
+   |     ^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), ()>>`, which is not `Send`
+note: required by a bound in `is_send`
+  --> $DIR/basic.rs:20:20
+   |
+LL | fn is_send(_: impl Send) {}
+   |                    ^^^^ required by this bound in `is_send`
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.rs
@@ -1,6 +1,9 @@
-// revisions: with without
+// revisions: current_with current_without next_with next_without
+// [next_with] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// [next_without] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
 // edition: 2021
-//[with] check-pass
+// [current_with] check-pass
+// [next_with] check-pass
 
 #![feature(return_type_notation, async_fn_in_trait)]
 //~^ WARN the feature `return_type_notation` is incomplete
@@ -17,11 +20,12 @@ async fn foo<T: Foo>() -> Result<(), ()> {
 fn is_send(_: impl Send) {}
 
 fn test<
-    #[cfg(with)] T: Foo<method(): Send>,
-    #[cfg(without)] T: Foo,
+    #[cfg(any(current_with, next_with))] T: Foo<method(): Send>,
+    #[cfg(any(current_without, next_without))] T: Foo,
 >() {
     is_send(foo::<T>());
-    //[without]~^ ERROR future cannot be sent between threads safely
+    //[current_without]~^ ERROR future cannot be sent between threads safely
+    //[next_without]~^^ ERROR future cannot be sent between threads safely
 }
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.current.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.current.stderr
@@ -1,0 +1,17 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/equality.rs:5:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation is not allowed to use type equality
+  --> $DIR/equality.rs:14:18
+   |
+LL | fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.next.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.next.stderr
@@ -1,0 +1,17 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/equality.rs:5:12
+   |
+LL | #![feature(return_type_notation, async_fn_in_trait)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation is not allowed to use type equality
+  --> $DIR/equality.rs:14:18
+   |
+LL | fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.rs
@@ -1,4 +1,6 @@
 // edition: 2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_type_notation, async_fn_in_trait)]
 //~^ WARN the feature `return_type_notation` is incomplete

--- a/tests/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
@@ -1,18 +1,25 @@
-error[E0277]: `Sender<i32>` cannot be shared between threads safely
-  --> $DIR/issue-70935-complex-spans.rs:13:45
+error[E0277]: `*mut ()` cannot be shared between threads safely
+  --> $DIR/issue-70935-complex-spans.rs:18:23
    |
-LL | fn foo(tx: std::sync::mpsc::Sender<i32>) -> impl Future + Send {
-   |                                             ^^^^^^^^^^^^^^^^^^ `Sender<i32>` cannot be shared between threads safely
+LL | fn foo(x: NotSync) -> impl Future + Send {
+   |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `Sender<i32>`
-   = note: required for `&Sender<i32>` to implement `Send`
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
+note: required because it appears within the type `PhantomData<*mut ()>`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
+note: required because it appears within the type `NotSync`
+  --> $DIR/issue-70935-complex-spans.rs:12:8
+   |
+LL | struct NotSync(PhantomData<*mut ()>);
+   |        ^^^^^^^
+   = note: required for `&NotSync` to implement `Send`
 note: required because it's used within this closure
-  --> $DIR/issue-70935-complex-spans.rs:17:13
+  --> $DIR/issue-70935-complex-spans.rs:22:13
    |
-LL |         baz(|| async{
+LL |         baz(|| async {
    |             ^^
 note: required because it's used within this `async fn` body
-  --> $DIR/issue-70935-complex-spans.rs:10:67
+  --> $DIR/issue-70935-complex-spans.rs:15:67
    |
 LL |   async fn baz<T>(_c: impl FnMut() -> T) where T: Future<Output=()> {
    |  ___________________________________________________________________^
@@ -20,11 +27,11 @@ LL | | }
    | |_^
    = note: required because it captures the following types: `ResumeTy`, `impl Future<Output = ()>`, `()`
 note: required because it's used within this `async` block
-  --> $DIR/issue-70935-complex-spans.rs:16:5
+  --> $DIR/issue-70935-complex-spans.rs:21:5
    |
 LL | /     async move {
-LL | |         baz(|| async{
-LL | |             foo(tx.clone());
+LL | |         baz(|| async {
+LL | |             foo(x.clone());
 LL | |         }).await;
 LL | |     }
    | |_____^

--- a/tests/ui/async-await/issue-70935-complex-spans.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.drop_tracking_mir.stderr
@@ -1,18 +1,25 @@
-error[E0277]: `Sender<i32>` cannot be shared between threads safely
-  --> $DIR/issue-70935-complex-spans.rs:13:45
+error[E0277]: `*mut ()` cannot be shared between threads safely
+  --> $DIR/issue-70935-complex-spans.rs:18:23
    |
-LL | fn foo(tx: std::sync::mpsc::Sender<i32>) -> impl Future + Send {
-   |                                             ^^^^^^^^^^^^^^^^^^ `Sender<i32>` cannot be shared between threads safely
+LL | fn foo(x: NotSync) -> impl Future + Send {
+   |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `Sender<i32>`
-   = note: required for `&Sender<i32>` to implement `Send`
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
+note: required because it appears within the type `PhantomData<*mut ()>`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
+note: required because it appears within the type `NotSync`
+  --> $DIR/issue-70935-complex-spans.rs:12:8
+   |
+LL | struct NotSync(PhantomData<*mut ()>);
+   |        ^^^^^^^
+   = note: required for `&NotSync` to implement `Send`
 note: required because it's used within this closure
-  --> $DIR/issue-70935-complex-spans.rs:17:13
+  --> $DIR/issue-70935-complex-spans.rs:22:13
    |
-LL |         baz(|| async{
+LL |         baz(|| async {
    |             ^^
 note: required because it's used within this `async fn` body
-  --> $DIR/issue-70935-complex-spans.rs:10:67
+  --> $DIR/issue-70935-complex-spans.rs:15:67
    |
 LL |   async fn baz<T>(_c: impl FnMut() -> T) where T: Future<Output=()> {
    |  ___________________________________________________________________^
@@ -20,11 +27,11 @@ LL | | }
    | |_^
    = note: required because it captures the following types: `impl Future<Output = ()>`
 note: required because it's used within this `async` block
-  --> $DIR/issue-70935-complex-spans.rs:16:5
+  --> $DIR/issue-70935-complex-spans.rs:21:5
    |
 LL | /     async move {
-LL | |         baz(|| async{
-LL | |             foo(tx.clone());
+LL | |         baz(|| async {
+LL | |             foo(x.clone());
 LL | |         }).await;
 LL | |     }
    | |_____^

--- a/tests/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
@@ -1,21 +1,21 @@
 error: future cannot be sent between threads safely
-  --> $DIR/issue-70935-complex-spans.rs:13:45
+  --> $DIR/issue-70935-complex-spans.rs:18:23
    |
-LL | fn foo(tx: std::sync::mpsc::Sender<i32>) -> impl Future + Send {
-   |                                             ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
+LL | fn foo(x: NotSync) -> impl Future + Send {
+   |                       ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `Sender<i32>`
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
 note: future is not `Send` as this value is used across an await
-  --> $DIR/issue-70935-complex-spans.rs:19:12
+  --> $DIR/issue-70935-complex-spans.rs:24:12
    |
-LL |           baz(|| async{
+LL |           baz(|| async {
    |  _____________-
-LL | |             foo(tx.clone());
+LL | |             foo(x.clone());
 LL | |         }).await;
    | |         -  ^^^^^- the value is later dropped here
    | |         |  |
    | |_________|  await occurs here, with the value maybe used later
-   |           has type `[closure@$DIR/issue-70935-complex-spans.rs:17:13: 17:15]` which is not `Send`
+   |           has type `[closure@$DIR/issue-70935-complex-spans.rs:22:13: 22:15]` which is not `Send`
 
 error: aborting due to previous error
 

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.current.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/issue-110963-early.rs:4:12
+  --> $DIR/issue-110963-early.rs:6:12
    |
 LL | #![feature(return_type_notation)]
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![feature(return_type_notation)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: higher-ranked lifetime error
-  --> $DIR/issue-110963-early.rs:15:5
+  --> $DIR/issue-110963-early.rs:17:5
    |
 LL | /     spawn(async move {
 LL | |         let mut hc = hc;
@@ -18,10 +18,10 @@ LL | |         }
 LL | |     });
    | |______^
    |
-   = note: could not prove `[async block@$DIR/issue-110963-early.rs:15:11: 20:6]: Send`
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:17:11: 22:6]: Send`
 
 error: higher-ranked lifetime error
-  --> $DIR/issue-110963-early.rs:15:5
+  --> $DIR/issue-110963-early.rs:17:5
    |
 LL | /     spawn(async move {
 LL | |         let mut hc = hc;
@@ -31,7 +31,7 @@ LL | |         }
 LL | |     });
    | |______^
    |
-   = note: could not prove `[async block@$DIR/issue-110963-early.rs:15:11: 20:6]: Send`
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:17:11: 22:6]: Send`
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.next.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.next.stderr
@@ -1,0 +1,37 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-110963-early.rs:6:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: higher-ranked lifetime error
+  --> $DIR/issue-110963-early.rs:17:5
+   |
+LL | /     spawn(async move {
+LL | |         let mut hc = hc;
+LL | |         if !hc.check().await {
+LL | |             log_health_check_failure().await;
+LL | |         }
+LL | |     });
+   | |______^
+   |
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:17:11: 22:6]: Send`
+
+error: higher-ranked lifetime error
+  --> $DIR/issue-110963-early.rs:17:5
+   |
+LL | /     spawn(async move {
+LL | |         let mut hc = hc;
+LL | |         if !hc.check().await {
+LL | |             log_health_check_failure().await;
+LL | |         }
+LL | |     });
+   | |______^
+   |
+   = note: could not prove `[async block@$DIR/issue-110963-early.rs:17:11: 22:6]: Send`
+
+error: aborting due to 2 previous errors; 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.rs
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.rs
@@ -1,5 +1,7 @@
 // edition: 2021
 // known-bug: #110963
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_type_notation)]
 #![feature(async_fn_in_trait)]

--- a/tests/ui/async-await/return-type-notation/issue-110963-late.current.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-late.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/issue-110963-late.rs:4:12
+  --> $DIR/issue-110963-late.rs:6:12
    |
 LL | #![feature(return_type_notation)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/return-type-notation/issue-110963-late.next.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-late.next.stderr
@@ -1,8 +1,8 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/super-method-bound.rs:4:31
+  --> $DIR/issue-110963-late.rs:6:12
    |
-LL | #![feature(async_fn_in_trait, return_type_notation)]
-   |                               ^^^^^^^^^^^^^^^^^^^^
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = note: `#[warn(incomplete_features)]` on by default

--- a/tests/ui/async-await/return-type-notation/issue-110963-late.rs
+++ b/tests/ui/async-await/return-type-notation/issue-110963-late.rs
@@ -1,5 +1,7 @@
 // edition: 2021
 // check-pass
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_type_notation)]
 //~^ WARN the feature `return_type_notation` is incomplete

--- a/tests/ui/async-await/return-type-notation/super-method-bound.current.stderr
+++ b/tests/ui/async-await/return-type-notation/super-method-bound.current.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/super-method-bound.rs:6:31
+   |
+LL | #![feature(async_fn_in_trait, return_type_notation)]
+   |                               ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/super-method-bound.next.stderr
+++ b/tests/ui/async-await/return-type-notation/super-method-bound.next.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/super-method-bound.rs:6:31
+   |
+LL | #![feature(async_fn_in_trait, return_type_notation)]
+   |                               ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/super-method-bound.rs
+++ b/tests/ui/async-await/return-type-notation/super-method-bound.rs
@@ -1,5 +1,7 @@
 // edition:2021
 // check-pass
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(async_fn_in_trait, return_type_notation)]
 //~^ WARN the feature `return_type_notation` is incomplete

--- a/tests/ui/async-await/return-type-notation/supertrait-bound.current.stderr
+++ b/tests/ui/async-await/return-type-notation/supertrait-bound.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/supertrait-bound.rs:3:49
+  --> $DIR/supertrait-bound.rs:5:49
    |
 LL | #![feature(return_position_impl_trait_in_trait, return_type_notation)]
    |                                                 ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/return-type-notation/supertrait-bound.next.stderr
+++ b/tests/ui/async-await/return-type-notation/supertrait-bound.next.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/supertrait-bound.rs:5:49
+   |
+LL | #![feature(return_position_impl_trait_in_trait, return_type_notation)]
+   |                                                 ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/supertrait-bound.rs
+++ b/tests/ui/async-await/return-type-notation/supertrait-bound.rs
@@ -1,4 +1,6 @@
 // check-pass
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(return_position_impl_trait_in_trait, return_type_notation)]
 //~^ WARN the feature `return_type_notation` is incomplete and may not be safe to use

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.current.stderr
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/ty-or-ct-params.rs:3:31
+  --> $DIR/ty-or-ct-params.rs:5:31
    |
 LL | #![feature(async_fn_in_trait, return_type_notation)]
    |                               ^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![feature(async_fn_in_trait, return_type_notation)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: return type notation is not allowed for functions that have type parameters
-  --> $DIR/ty-or-ct-params.rs:14:12
+  --> $DIR/ty-or-ct-params.rs:16:12
    |
 LL |     async fn bar<T>() {}
    |                  - type parameter declared here
@@ -17,7 +17,7 @@ LL |     T: Foo<bar(): Send, baz(): Send>,
    |            ^^^^^^^^^^^
 
 error: return type notation is not allowed for functions that have const parameters
-  --> $DIR/ty-or-ct-params.rs:14:25
+  --> $DIR/ty-or-ct-params.rs:16:25
    |
 LL |     async fn baz<const N: usize>() {}
    |                  -------------- const parameter declared here

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.next.stderr
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.next.stderr
@@ -1,0 +1,29 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/ty-or-ct-params.rs:5:31
+   |
+LL | #![feature(async_fn_in_trait, return_type_notation)]
+   |                               ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation is not allowed for functions that have type parameters
+  --> $DIR/ty-or-ct-params.rs:16:12
+   |
+LL |     async fn bar<T>() {}
+   |                  - type parameter declared here
+...
+LL |     T: Foo<bar(): Send, baz(): Send>,
+   |            ^^^^^^^^^^^
+
+error: return type notation is not allowed for functions that have const parameters
+  --> $DIR/ty-or-ct-params.rs:16:25
+   |
+LL |     async fn baz<const N: usize>() {}
+   |                  -------------- const parameter declared here
+...
+LL |     T: Foo<bar(): Send, baz(): Send>,
+   |                         ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.rs
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.rs
@@ -1,4 +1,6 @@
 // edition: 2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
 
 #![feature(async_fn_in_trait, return_type_notation)]
 //~^ WARN the feature `return_type_notation` is incomplete

--- a/tests/ui/closures/closure-move-sync.rs
+++ b/tests/ui/closures/closure-move-sync.rs
@@ -13,10 +13,4 @@ fn bar() {
     t.join().unwrap();
 }
 
-fn foo() {
-    let (tx, _rx) = channel();
-    thread::spawn(|| tx.send(()).unwrap());
-    //~^ ERROR `Sender<()>` cannot be shared between threads safely
-}
-
 fn main() {}

--- a/tests/ui/closures/closure-move-sync.stderr
+++ b/tests/ui/closures/closure-move-sync.stderr
@@ -20,24 +20,6 @@ LL |     let t = thread::spawn(|| {
 note: required by a bound in `spawn`
   --> $SRC_DIR/std/src/thread/mod.rs:LL:COL
 
-error[E0277]: `Sender<()>` cannot be shared between threads safely
-  --> $DIR/closure-move-sync.rs:18:19
-   |
-LL |     thread::spawn(|| tx.send(()).unwrap());
-   |     ------------- ^^^^^^^^^^^^^^^^^^^^^^^ `Sender<()>` cannot be shared between threads safely
-   |     |
-   |     required by a bound introduced by this call
-   |
-   = help: the trait `Sync` is not implemented for `Sender<()>`
-   = note: required for `&Sender<()>` to implement `Send`
-note: required because it's used within this closure
-  --> $DIR/closure-move-sync.rs:18:19
-   |
-LL |     thread::spawn(|| tx.send(()).unwrap());
-   |                   ^^
-note: required by a bound in `spawn`
-  --> $SRC_DIR/std/src/thread/mod.rs:LL:COL
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.cfg_current.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.cfg_current.stderr
@@ -1,0 +1,27 @@
+error[E0658]: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+
+error: parenthesized generic arguments cannot be used in associated type constraints
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^--
+   |                  |
+   |                  help: remove these parentheses
+
+error[E0220]: associated type `m` not found for `Trait`
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^ associated type `m` not found
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0220, E0658.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.cfg_next.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.cfg_next.stderr
@@ -1,0 +1,27 @@
+error[E0658]: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+
+error: parenthesized generic arguments cannot be used in associated type constraints
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^--
+   |                  |
+   |                  help: remove these parentheses
+
+error[E0220]: associated type `m` not found for `Trait`
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^ associated type `m` not found
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0220, E0658.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.no_current.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.no_current.stderr
@@ -1,0 +1,13 @@
+warning: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+   = warning: unstable syntax can change at any point in the future, causing a hard error!
+   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+
+warning: 1 warning emitted
+

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.no_next.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.no_next.stderr
@@ -1,0 +1,13 @@
+warning: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:17:17
+   |
+LL | fn foo<T: Trait<m(): Send>>() {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+   = warning: unstable syntax can change at any point in the future, causing a hard error!
+   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+
+warning: 1 warning emitted
+

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.rs
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.rs
@@ -1,7 +1,10 @@
 // edition: 2021
-// revisions: cfg no
+// revisions: cfg_current cfg_next no_current no_next
+// [cfg_next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// [no_next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
 
-//[no] check-pass
+// [no_current] check-pass
+// [no_next] check-pass
 // Since we're not adding new syntax, `cfg`'d out RTN must pass.
 
 #![feature(async_fn_in_trait)]
@@ -10,12 +13,17 @@ trait Trait {
     async fn m();
 }
 
-#[cfg(cfg)]
+#[cfg(any(cfg_current, cfg_next))]
 fn foo<T: Trait<m(): Send>>() {}
-//[cfg]~^ ERROR return type notation is experimental
-//[cfg]~| ERROR parenthesized generic arguments cannot be used in associated type constraints
-//[cfg]~| ERROR associated type `m` not found for `Trait`
-//[no]~^^^^ WARN return type notation is experimental
-//[no]~| WARN unstable syntax can change at any point in the future, causing a hard error!
+//[cfg_current]~^ ERROR return type notation is experimental
+//[cfg_current]~| ERROR parenthesized generic arguments cannot be used in associated type constraints
+//[cfg_current]~| ERROR associated type `m` not found for `Trait`
+//[cfg_next]~^^^^ ERROR return type notation is experimental
+//[cfg_next]~| ERROR parenthesized generic arguments cannot be used in associated type constraints
+//[cfg_next]~| ERROR associated type `m` not found for `Trait`
+//[no_current]~^^^^^^^ WARN return type notation is experimental
+//[no_current]~| WARN unstable syntax can change at any point in the future, causing a hard error!
+//[no_next]~^^^^^^^^^ WARN return type notation is experimental
+//[no_next]~| WARN unstable syntax can change at any point in the future, causing a hard error!
 
 fn main() {}

--- a/tests/ui/for/issue-20605.next.stderr
+++ b/tests/ui/for/issue-20605.next.stderr
@@ -14,7 +14,7 @@ LL |     for item in *things { *item = 0 }
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
 
-error: the type `<_ as IntoIterator>::IntoIter` is not well-formed
+error: the type `<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
   --> $DIR/issue-20605.rs:5:17
    |
 LL |     for item in *things { *item = 0 }

--- a/tests/ui/for/issue-20605.rs
+++ b/tests/ui/for/issue-20605.rs
@@ -4,7 +4,7 @@
 fn changer<'a>(mut things: Box<dyn Iterator<Item=&'a mut u8>>) {
     for item in *things { *item = 0 }
     //~^ ERROR the size for values of type
-    //[next]~^^ ERROR the type `<_ as IntoIterator>::IntoIter` is not well-formed
+    //[next]~^^ ERROR the type `<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
     //[next]~| ERROR the trait bound `dyn Iterator<Item = &'a mut u8>: IntoIterator` is not satisfied
 }
 

--- a/tests/ui/stdlib-unit-tests/not-sync.rs
+++ b/tests/ui/stdlib-unit-tests/not-sync.rs
@@ -17,6 +17,4 @@ fn main() {
 
     test::<Receiver<i32>>();
     //~^ ERROR `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely [E0277]
-    test::<Sender<i32>>();
-    //~^ ERROR `Sender<i32>` cannot be shared between threads safely [E0277]
 }

--- a/tests/ui/stdlib-unit-tests/not-sync.stderr
+++ b/tests/ui/stdlib-unit-tests/not-sync.stderr
@@ -65,19 +65,6 @@ note: required by a bound in `test`
 LL | fn test<T: Sync>() {}
    |            ^^^^ required by this bound in `test`
 
-error[E0277]: `Sender<i32>` cannot be shared between threads safely
-  --> $DIR/not-sync.rs:20:12
-   |
-LL |     test::<Sender<i32>>();
-   |            ^^^^^^^^^^^ `Sender<i32>` cannot be shared between threads safely
-   |
-   = help: the trait `Sync` is not implemented for `Sender<i32>`
-note: required by a bound in `test`
-  --> $DIR/not-sync.rs:5:12
-   |
-LL | fn test<T: Sync>() {}
-   |            ^^^^ required by this bound in `test`
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/new-solver/alias-bound-unsound.rs
+++ b/tests/ui/traits/new-solver/alias-bound-unsound.rs
@@ -23,5 +23,7 @@ fn main() {
     drop(<() as Foo>::copy_me(&x));
     //~^ ERROR `<() as Foo>::Item: Copy` is not satisfied
     //~| ERROR `<() as Foo>::Item` is not well-formed
+    //~| ERROR `_` is not well-formed
+    //~| ERROR `_` is not well-formed
     println!("{x}");
 }

--- a/tests/ui/traits/new-solver/alias-bound-unsound.rs
+++ b/tests/ui/traits/new-solver/alias-bound-unsound.rs
@@ -23,7 +23,7 @@ fn main() {
     drop(<() as Foo>::copy_me(&x));
     //~^ ERROR `<() as Foo>::Item: Copy` is not satisfied
     //~| ERROR `<() as Foo>::Item` is not well-formed
-    //~| ERROR `_` is not well-formed
-    //~| ERROR `_` is not well-formed
+    //~| ERROR `<() as Foo>::Item` is not well-formed
+    //~| ERROR `<() as Foo>::Item` is not well-formed
     println!("{x}");
 }

--- a/tests/ui/traits/new-solver/alias-bound-unsound.stderr
+++ b/tests/ui/traits/new-solver/alias-bound-unsound.stderr
@@ -19,6 +19,18 @@ error: the type `<() as Foo>::Item` is not well-formed
 LL |     drop(<() as Foo>::copy_me(&x));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: the type `_` is not well-formed
+  --> $DIR/alias-bound-unsound.rs:23:5
+   |
+LL |     drop(<() as Foo>::copy_me(&x));
+   |     ^^^^
+
+error: the type `_` is not well-formed
+  --> $DIR/alias-bound-unsound.rs:23:10
+   |
+LL |     drop(<() as Foo>::copy_me(&x));
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/new-solver/alias-bound-unsound.stderr
+++ b/tests/ui/traits/new-solver/alias-bound-unsound.stderr
@@ -19,13 +19,13 @@ error: the type `<() as Foo>::Item` is not well-formed
 LL |     drop(<() as Foo>::copy_me(&x));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the type `_` is not well-formed
+error: the type `<() as Foo>::Item` is not well-formed
   --> $DIR/alias-bound-unsound.rs:23:5
    |
 LL |     drop(<() as Foo>::copy_me(&x));
    |     ^^^^
 
-error: the type `_` is not well-formed
+error: the type `<() as Foo>::Item` is not well-formed
   --> $DIR/alias-bound-unsound.rs:23:10
    |
 LL |     drop(<() as Foo>::copy_me(&x));


### PR DESCRIPTION
Successful merges:

 - #111087 (Implement `Sync` for `mpsc::Sender`)
 - #112763 (Bump compiler_builtins)
 - #112963 (Stop bubbling out hidden types from the eval obligation queries)
 - #112965 (Don't emit same goal as input during `wf::unnormalized_obligations`)
 - #112973 (Make sure to include default en-US ftl resources for `rustc_error` crate)
 - #112981 (Fix return type notation errors with -Zlower-impl-trait-in-trait-to-assoc-ty)
 - #112983 (Fix return type notation associated type suggestion when -Zlower-impl-trait-in-trait-to-assoc-ty)
 - #112986 (Update cargo)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=111087,112763,112963,112965,112973,112981,112983,112986)
<!-- homu-ignore:end -->