### PR TITLE
Check for `<&NotClone as Clone>::clone()` calls and suggest to add Clone trait appropriately

### DIFF
--- a/tests/ui/typeck/explain_clone_autoref.rs
+++ b/tests/ui/typeck/explain_clone_autoref.rs
@@ -11,3 +11,119 @@ fn clone_thing(nc: &NotClone) -> NotClone {
     //~| NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
     //~| NOTE expected `NotClone`, found `&NotClone`
 }
+
+fn clone_thing2(nc: &NotClone) -> NotClone {
+    let nc: NotClone = nc.clone();
+    //~^ ERROR mismatched type
+    //~| NOTE expected due to this
+    //~| NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+    //~| NOTE expected `NotClone`, found `&NotClone`
+    nc
+}
+
+fn clone_thing3(nc: &NotClone) -> NotClone {
+    //~^ NOTE expected `NotClone` because of return type
+    let nc = nc.clone();
+    //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+    nc
+    //~^ ERROR mismatched type
+    //~| NOTE expected `NotClone`, found `&NotClone`
+}
+
+fn clone_thing4(nc: &NotClone) -> NotClone {
+    //~^ NOTE expected `NotClone` because of return type
+    let nc = nc.clone();
+    //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+    let nc2 = nc;
+    nc2
+    //~^ ERROR mismatched type
+    //~| NOTE expected `NotClone`, found `&NotClone`
+}
+
+impl NotClone {
+    fn other_fn(&self) {}
+    fn get_ref_notclone(&self) -> &Self {
+        self
+    }
+}
+
+fn clone_thing5(nc: &NotClone) -> NotClone {
+    //~^ NOTE expected `NotClone` because of return type
+    let nc = nc.clone();
+    //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+    let nc2 = nc;
+    nc2.other_fn();
+    let nc3 = nc2;
+    nc3
+    //~^ ERROR mismatched type
+    //~| NOTE expected `NotClone`, found `&NotClone`
+}
+
+fn clone_thing6(nc: &NotClone) -> NotClone {
+    //~^ NOTE expected `NotClone` because of return type
+    let (ret, _) = (nc.clone(), 1);
+    //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+    let _ = nc.clone();
+    ret
+    //~^ ERROR mismatched type
+    //~| NOTE expected `NotClone`, found `&NotClone`
+}
+
+fn clone_thing7(nc: Vec<&NotClone>) -> NotClone {
+    //~^ NOTE expected `NotClone` because of return type
+    let ret = nc[0].clone();
+    //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+    ret
+    //~^ ERROR mismatched type
+    //~| NOTE expected `NotClone`, found `&NotClone`
+}
+
+fn clone_thing8(nc: &NotClone) -> NotClone {
+    //~^ NOTE expected `NotClone` because of return type
+    let ret = {
+        let a = nc.clone();
+        //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+        a
+    };
+    ret
+    //~^ ERROR mismatched type
+    //~| NOTE expected `NotClone`, found `&NotClone`
+}
+
+fn clone_thing9(nc: &NotClone) -> NotClone {
+    //~^ NOTE expected `NotClone` because of return type
+    let cl = || nc.clone();
+    //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+    let ret = cl();
+    ret
+    //~^ ERROR mismatched type
+    //~| NOTE expected `NotClone`, found `&NotClone`
+}
+
+fn clone_thing10(nc: &NotClone) -> (NotClone, NotClone) {
+    let (a, b) = {
+        let a = nc.clone();
+        //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+        (a, nc.clone())
+        //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+    };
+    (a, b)
+    //~^ ERROR mismatched type
+    //~| ERROR mismatched type
+    //~| NOTE expected `NotClone`, found `&NotClone`
+    //~| NOTE expected `NotClone`, found `&NotClone`
+}
+
+fn clone_thing11(nc: &NotClone) -> NotClone {
+    //~^ NOTE expected `NotClone` because of return type
+    let a = {
+        let nothing = nc.clone();
+        let a = nc.clone();
+        //~^ NOTE `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+        let nothing = nc.clone();
+        a
+    };
+    a
+    //~^ ERROR mismatched type
+    //~| NOTE expected `NotClone`, found `&NotClone`
+}

--- a/tests/ui/typeck/explain_clone_autoref.stderr
+++ b/tests/ui/typeck/explain_clone_autoref.stderr
@@ -18,6 +18,219 @@ LL + #[derive(Clone)]
 LL | struct NotClone;
    |
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:16:24
+   |
+LL |     let nc: NotClone = nc.clone();
+   |             --------   ^^^^^^^^^^ expected `NotClone`, found `&NotClone`
+   |             |
+   |             expected due to this
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:16:24
+   |
+LL |     let nc: NotClone = nc.clone();
+   |                        ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:28:5
+   |
+LL | fn clone_thing3(nc: &NotClone) -> NotClone {
+   |                                   -------- expected `NotClone` because of return type
+...
+LL |     nc
+   |     ^^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:26:14
+   |
+LL |     let nc = nc.clone();
+   |              ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:38:5
+   |
+LL | fn clone_thing4(nc: &NotClone) -> NotClone {
+   |                                   -------- expected `NotClone` because of return type
+...
+LL |     nc2
+   |     ^^^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:35:14
+   |
+LL |     let nc = nc.clone();
+   |              ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:57:5
+   |
+LL | fn clone_thing5(nc: &NotClone) -> NotClone {
+   |                                   -------- expected `NotClone` because of return type
+...
+LL |     nc3
+   |     ^^^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:52:14
+   |
+LL |     let nc = nc.clone();
+   |              ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:67:5
+   |
+LL | fn clone_thing6(nc: &NotClone) -> NotClone {
+   |                                   -------- expected `NotClone` because of return type
+...
+LL |     ret
+   |     ^^^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:64:21
+   |
+LL |     let (ret, _) = (nc.clone(), 1);
+   |                     ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:76:5
+   |
+LL | fn clone_thing7(nc: Vec<&NotClone>) -> NotClone {
+   |                                        -------- expected `NotClone` because of return type
+...
+LL |     ret
+   |     ^^^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:74:15
+   |
+LL |     let ret = nc[0].clone();
+   |               ^^^^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:88:5
+   |
+LL | fn clone_thing8(nc: &NotClone) -> NotClone {
+   |                                   -------- expected `NotClone` because of return type
+...
+LL |     ret
+   |     ^^^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:84:17
+   |
+LL |         let a = nc.clone();
+   |                 ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:98:5
+   |
+LL | fn clone_thing9(nc: &NotClone) -> NotClone {
+   |                                   -------- expected `NotClone` because of return type
+...
+LL |     ret
+   |     ^^^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:95:17
+   |
+LL |     let cl = || nc.clone();
+   |                 ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:110:6
+   |
+LL |     (a, b)
+   |      ^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:105:17
+   |
+LL |         let a = nc.clone();
+   |                 ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:110:9
+   |
+LL |     (a, b)
+   |         ^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:107:13
+   |
+LL |         (a, nc.clone())
+   |             ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/explain_clone_autoref.rs:126:5
+   |
+LL | fn clone_thing11(nc: &NotClone) -> NotClone {
+   |                                    -------- expected `NotClone` because of return type
+...
+LL |     a
+   |     ^ expected `NotClone`, found `&NotClone`
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> $DIR/explain_clone_autoref.rs:121:17
+   |
+LL |         let a = nc.clone();
+   |                 ^^
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Added recursive checking back up the HIR to see if a `Clone` suggestion would be helpful.

Addresses https://github.com/rust-lang/rust/issues/112857

Largely based on: https://github.com/rust-lang/rust/pull/112977