### PR TITLE
Migrate GUI colors test to original CSS color format

### DIFF
--- a/tests/rustdoc-gui/settings.goml
+++ b/tests/rustdoc-gui/settings.goml
@@ -56,19 +56,19 @@ move-cursor-to: "#settings-menu > a"
 assert-css: (
     "#theme-dark",
     {
-        "border-color": "rgb(153, 153, 153)",
-        "box-shadow": "rgb(53, 53, 53) 0px 0px 0px 3px inset",
+        "border-color": "#999",
+        "box-shadow": "#353535 0px 0px 0px 3px inset",
         "border-width": "2px",
     },
 )
-assert-css: ("#theme-light", {"border-color": "rgb(153, 153, 153)", "box-shadow": "none"})
+assert-css: ("#theme-light", {"border-color": "#999", "box-shadow": "none"})
 // Let's start with the hover for radio buttons.
 move-cursor-to: "#theme-dark"
 assert-css: (
     "#theme-dark",
     {
-        "border-color": "rgb(33, 150, 243)",
-        "box-shadow": "rgb(53, 53, 53) 0px 0px 0px 3px inset",
+        "border-color": "#2196f3",
+        "box-shadow": "#353535 0px 0px 0px 3px inset",
         "border-width": "2px",
     },
 )
@@ -76,7 +76,7 @@ move-cursor-to: "#theme-light"
 assert-css: (
     "#theme-light",
     {
-        "border-color": "rgb(33, 150, 243)",
+        "border-color": "#2196f3",
         "box-shadow": "none",
         "border-width": "2px",
     }
@@ -87,8 +87,8 @@ focus: "#theme-dark"
 assert-css: (
     "#theme-dark",
     {
-        "border-color": "rgb(153, 153, 153)",
-        "box-shadow": "rgb(53, 53, 53) 0px 0px 0px 3px inset, rgb(33, 150, 243) 0px 0px 2px 2px",
+        "border-color": "#999",
+        "box-shadow": "#353535 0px 0px 0px 3px inset, #2196f3 0px 0px 2px 2px",
         "border-width": "2px",
     },
 )
@@ -96,8 +96,8 @@ focus: "#theme-light"
 assert-css: (
     "#theme-light",
     {
-        "border-color": "rgb(153, 153, 153)",
-        "box-shadow": "rgb(33, 150, 243) 0px 0px 1px 1px",
+        "border-color": "#999",
+        "box-shadow": "#2196f3 0px 0px 1px 1px",
         "border-width": "2px",
     },
 )
@@ -107,8 +107,8 @@ focus: "#theme-dark"
 assert-css: (
     "#theme-dark",
     {
-        "border-color": "rgb(33, 150, 243)",
-        "box-shadow": "rgb(53, 53, 53) 0px 0px 0px 3px inset, rgb(33, 150, 243) 0px 0px 2px 2px",
+        "border-color": "#2196f3",
+        "box-shadow": "#353535 0px 0px 0px 3px inset, #2196f3 0px 0px 2px 2px",
         "border-width": "2px",
     },
 )
@@ -117,8 +117,8 @@ focus: "#theme-light"
 assert-css: (
     "#theme-light",
     {
-        "border-color": "rgb(33, 150, 243)",
-        "box-shadow": "rgb(33, 150, 243) 0px 0px 1px 1px",
+        "border-color": "#2196f3",
+        "box-shadow": "#2196f3 0px 0px 1px 1px",
         "border-width": "2px",
     },
 )
@@ -154,8 +154,8 @@ compare-elements-position-near: (
 assert-css: (
     "#auto-hide-large-items",
     {
-        "background-color": "rgb(33, 150, 243)",
-        "border-color": "rgb(153, 153, 153)",
+        "background-color": "#2196f3",
+        "border-color": "#999",
         // 1px border when checked
         "border-width": "1px",
     },
@@ -164,7 +164,7 @@ assert-css: (
     "#auto-hide-method-docs",
     {
         "background-color": "rgba(0, 0, 0, 0)",
-        "border-color": "rgb(153, 153, 153)",
+        "border-color": "#999",
         // 2px border when unchecked
         "border-width": "2px",
     },
@@ -174,8 +174,8 @@ move-cursor-to: "#auto-hide-large-items"
 assert-css: (
     "#auto-hide-large-items",
     {
-        "background-color": "rgb(33, 150, 243)",
-        "border-color": "rgb(33, 150, 243)",
+        "background-color": "#2196f3",
+        "border-color": "#2196f3",
         // 1px border when checked
         "border-width": "1px",
     },
@@ -185,7 +185,7 @@ assert-css: (
     "#auto-hide-method-docs",
     {
         "background-color": "rgba(0, 0, 0, 0)",
-        "border-color": "rgb(33, 150, 243)",
+        "border-color": "#2196f3",
         // 2px border when unchecked
         "border-width": "2px",
     },
@@ -196,9 +196,9 @@ focus: "#auto-hide-large-items"
 assert-css: (
     "#auto-hide-large-items",
     {
-        "background-color": "rgb(33, 150, 243)",
-        "border-color": "rgb(153, 153, 153)",
-        "box-shadow": "rgb(33, 150, 243) 0px 0px 1px 1px",
+        "background-color": "#2196f3",
+        "border-color": "#999",
+        "box-shadow": "#2196f3 0px 0px 1px 1px",
         // 1px border when checked
         "border-width": "1px",
     },
@@ -208,8 +208,8 @@ assert-css: (
     "#auto-hide-method-docs",
     {
         "background-color": "rgba(0, 0, 0, 0)",
-        "border-color": "rgb(153, 153, 153)",
-        "box-shadow": "rgb(33, 150, 243) 0px 0px 1px 1px",
+        "border-color": "#999",
+        "box-shadow": "#2196f3 0px 0px 1px 1px",
         // 2px border when unchecked
         "border-width": "2px",
     },
@@ -220,9 +220,9 @@ focus: "#auto-hide-large-items"
 assert-css: (
     "#auto-hide-large-items",
     {
-        "background-color": "rgb(33, 150, 243)",
-        "border-color": "rgb(33, 150, 243)",
-        "box-shadow": "rgb(33, 150, 243) 0px 0px 1px 1px",
+        "background-color": "#2196f3",
+        "border-color": "#2196f3",
+        "box-shadow": "#2196f3 0px 0px 1px 1px",
         // 1px border when checked
         "border-width": "1px",
     },
@@ -233,8 +233,8 @@ assert-css: (
     "#auto-hide-method-docs",
     {
         "background-color": "rgba(0, 0, 0, 0)",
-        "border-color": "rgb(33, 150, 243)",
-        "box-shadow": "rgb(33, 150, 243) 0px 0px 1px 1px",
+        "border-color": "#2196f3",
+        "box-shadow": "#2196f3 0px 0px 1px 1px",
         // 2px border when unchecked
         "border-width": "2px",
     },


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/111459.

r? @notriddle