### PR TITLE
don't overflow the stack when printing huge types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
           - name: x86_64-gnu-tools
             os: ubuntu-20.04-16core-64gb
             env: {}
+          - name: x86_64-msvc
+            env:
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-profiler"
+              SCRIPT: make ci-msvc
+            os: windows-2019-8core-32gb
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -1,5 +1,6 @@
 use super::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use super::{FixupError, FixupResult, InferCtxt, Span};
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_middle::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind};
 use rustc_middle::ty::fold::{FallibleTypeFolder, TypeFolder, TypeSuperFoldable};
 use rustc_middle::ty::visit::{TypeSuperVisitable, TypeVisitableExt, TypeVisitor};
@@ -39,7 +40,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for OpportunisticVarResolver<'a, 'tcx> {
             t // micro-optimize -- if there is nothing in this type that this fold affects...
         } else {
             let t = self.shallow_resolver.fold_ty(t);
-            t.super_fold_with(self)
+            ensure_sufficient_stack(|| t.super_fold_with(self))
         }
     }
 

--- a/compiler/rustc_middle/src/ty/visit.rs
+++ b/compiler/rustc_middle/src/ty/visit.rs
@@ -1,4 +1,5 @@
 use crate::ty::{self, flags::FlagComputation, Binder, Ty, TyCtxt, TypeFlags};
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::ErrorGuaranteed;
 
 use rustc_data_structures::fx::FxHashSet;
@@ -344,7 +345,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ValidateBoundVars<'tcx> {
             _ => (),
         };
 
-        t.super_visit_with(self)
+        ensure_sufficient_stack(|| t.super_visit_with(self))
     }
 
     fn visit_region(&mut self, r: ty::Region<'tcx>) -> ControlFlow<Self::BreakTy> {

--- a/library/std/src/sys/windows/stack_overflow.rs
+++ b/library/std/src/sys/windows/stack_overflow.rs
@@ -28,6 +28,12 @@ unsafe extern "system" fn vectored_handler(ExceptionInfo: *mut c::EXCEPTION_POIN
                 "\nthread '{}' has overflowed its stack\n",
                 thread::current().name().unwrap_or("<unknown>")
             );
+            crate::backtrace_rs::trace_unsynchronized(|frame| {
+                crate::backtrace_rs::resolve_frame_unsynchronized(frame, |symbol| {
+                    rtprintpanic!("{symbol:?}\n");
+                });
+                true // keep going to the next frame
+            });
         }
         c::EXCEPTION_CONTINUE_SEARCH
     }

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -328,6 +328,12 @@ jobs:
           - name: x86_64-gnu-tools
             <<: *job-linux-16c
 
+          - name: x86_64-msvc
+            env:
+              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
+              SCRIPT: make ci-msvc
+            <<: *job-windows-8c
+
   auto:
     <<: *base-ci-job
     name: auto - ${{ matrix.name }}

--- a/tests/ui/infinite/infer-stack-overflow.rs
+++ b/tests/ui/infinite/infer-stack-overflow.rs
@@ -1,0 +1,20 @@
+// rustc-env:RUST_MIN_STACK=1048576
+// normalize-stderr-test: "long-type-\d+" -> "long-type-hash"
+
+#![recursion_limit = "2048"]
+
+trait MyTrait {}
+
+impl<'a> MyTrait for &'a () {}
+impl<T> MyTrait for &'_ (T,) where for<'a> &'a T: MyTrait {}
+
+fn of<'a, T: 'a>() -> T
+where
+    &'a T: MyTrait,
+{
+    todo!()
+}
+
+fn main() {
+    let _x: () = of(); //~ ERROR overflow evaluating the requirement `for<'a> &'a (_,): MyTrait`
+}

--- a/tests/ui/infinite/infer-stack-overflow.stderr
+++ b/tests/ui/infinite/infer-stack-overflow.stderr
@@ -1,0 +1,27 @@
+error[E0275]: overflow evaluating the requirement `for<'a> &'a (_,): MyTrait`
+  --> $DIR/infer-stack-overflow.rs:19:18
+   |
+LL |     let _x: () = of();
+   |                  ^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "4096"]` attribute to your crate (`infer_stack_overflow`)
+note: required for `&'a ((_,),)` to implement `for<'a> MyTrait`
+  --> $DIR/infer-stack-overflow.rs:9:9
+   |
+LL | impl<T> MyTrait for &'_ (T,) where for<'a> &'a T: MyTrait {}
+   |         ^^^^^^^     ^^^^^^^^                      ------- unsatisfied trait bound introduced here
+   = note: 2046 redundant requirements hidden
+   = note: required for `&(((((((((((((((((((((((((((((((((((...,),),),),),),),),),),),),),),),),),),),),),),),),),),),),),),),),),),)` to implement `MyTrait`
+   = note: the full type name has been written to '$TEST_BUILD_DIR/infinite/infer-stack-overflow/infer-stack-overflow.long-type-hash.txt'
+note: required by a bound in `of`
+  --> $DIR/infer-stack-overflow.rs:13:12
+   |
+LL | fn of<'a, T: 'a>() -> T
+   |    -- required by a bound in this function
+LL | where
+LL |     &'a T: MyTrait,
+   |            ^^^^^^^ required by this bound in `of`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/infinite/write-long-type.rs
+++ b/tests/ui/infinite/write-long-type.rs
@@ -1,0 +1,67 @@
+//~ ERROR overflow evaluating the requirement `Cons<_, _>: Flat`
+
+// rustc-env:RUST_MIN_STACK=1048576
+// normalize-stderr-test: "long-type-\d+" -> "long-type-hash"
+
+// Test that printing long types doesn't overflow the stack.
+
+#![recursion_limit = "2048"]
+#![allow(unused)]
+use std::marker::PhantomData;
+
+struct Apple;
+
+struct Nil;
+struct Cons<Car, Cdr>(PhantomData<(Car, Cdr)>);
+
+// ========= Concat =========
+
+trait Concat {
+    type Output;
+}
+
+impl<L2> Concat for (Nil, L2) {
+    type Output = L2;
+}
+
+impl<Car, Cdr, L2> Concat for (Cons<Car, Cdr>, L2)
+where
+    (Cdr, L2): Concat, // Recursive step
+{
+    type Output = Cons<Car, <(Cdr, L2) as Concat>::Output>;
+}
+
+// ========= Flat =========
+
+trait Flat {
+    type Output;
+}
+
+impl Flat for Nil {
+    type Output = Nil;
+}
+
+// Head is not Cons
+impl<Head, Tail> Flat for Cons<Head, Tail>
+where
+    Tail: Flat,
+{
+    type Output = Cons<Head, <Tail as Flat>::Output>;
+}
+
+// Head is Cons
+impl<HeadCar, HeadCdr, Tail> Flat for Cons<Cons<HeadCar, HeadCdr>, Tail>
+where
+    Cons<HeadCar, HeadCdr>: Flat,
+    Tail: Flat,
+    (<Cons<HeadCar, HeadCdr> as Flat>::Output, <Tail as Flat>::Output): Concat,
+{
+    type Output =
+        <(<Cons<HeadCar, HeadCdr> as Flat>::Output, <Tail as Flat>::Output) as Concat>::Output;
+}
+
+type Computation = <Cons<Apple, Nil> as Flat>::Output;
+
+fn main() {
+    println!("{}", std::any::type_name::<Computation>());
+}

--- a/tests/ui/infinite/write-long-type.stderr
+++ b/tests/ui/infinite/write-long-type.stderr
@@ -1,0 +1,18 @@
+error[E0275]: overflow evaluating the requirement `Cons<_, _>: Flat`
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "4096"]` attribute to your crate (`write_long_type`)
+note: required for `Cons<Cons<_, _>, _>` to implement `Flat`
+  --> $DIR/write-long-type.rs:53:30
+   |
+LL | impl<HeadCar, HeadCdr, Tail> Flat for Cons<Cons<HeadCar, HeadCdr>, Tail>
+   |                              ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     (<Cons<HeadCar, HeadCdr> as Flat>::Output, <Tail as Flat>::Output): Concat,
+   |                                                                         ------ unsatisfied trait bound introduced here
+   = note: 2047 redundant requirements hidden
+   = note: required for `Cons<Cons<Cons<Cons<Cons<Cons<Cons<Cons<Cons<..., ...>, ...>, ...>, ...>, ...>, ...>, ...>, ...>, ...>` to implement `Flat`
+   = note: the full type name has been written to '$TEST_BUILD_DIR/infinite/write-long-type/write-long-type.long-type-hash.txt'
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/super-fast-paren-parsing.rs
+++ b/tests/ui/super-fast-paren-parsing.rs
@@ -1,14 +1,8 @@
-// run-pass
+// check-pass
 
 #![allow(unused_parens)]
-#![allow(non_upper_case_globals)]
-#![allow(dead_code)]
-// exec-env:RUST_MIN_STACK=16000000
-// rustc-env:RUST_MIN_STACK=16000000
-//
-// Big stack is needed for pretty printing, a little sad...
 
-static a: isize =
+static A: isize =
 (((((((((((((((((((((((((((((((((((((((((((((((((((
 (((((((((((((((((((((((((((((((((((((((((((((((((((
 (((((((((((((((((((((((((((((((((((((((((((((((((((


### PR DESCRIPTION
This PR fixes a few stack overflows by growing the stack in the appropriate places:
* in `tcx.short_ty_string` when generating the `the full type name has been written to '...'` diagnostic
* in `tcx.resolve_vars_if_possible`

fixes https://github.com/rust-lang/rust/issues/112800
fixes https://github.com/rust-lang/rust/issues/112992