### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Feature Request
     url: https://internals.rust-lang.org/
     about: Please discuss language feature requests on the internals forum.
+  - name: Clippy Bug
+    url: https://github.com/rust-lang/rust-clippy/issues/new/choose
+    about: Please report Clippy bugs such as false positives in the Clippy repo.

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -50,7 +50,6 @@ use rustc_mir_dataflow::impls::MaybeInitializedPlaces;
 use rustc_mir_dataflow::move_paths::MoveData;
 use rustc_mir_dataflow::ResultsCursor;
 
-use crate::renumber::RegionCtxt;
 use crate::session_diagnostics::MoveUnsized;
 use crate::{
     borrow_set::BorrowSet,
@@ -1041,9 +1040,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             .collect();
 
         let renumbered_opaques = self.infcx.tcx.fold_regions(opaques, |_, _| {
-            self.infcx.next_nll_region_var(
+            self.infcx.next_nll_region_var_in_universe(
                 NllRegionVariableOrigin::Existential { from_forall: false },
-                || RegionCtxt::Unknown,
+                ty::UniverseIndex::ROOT,
             )
         });
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1474,6 +1474,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// universes. Updates `self.universe` to that new universe.
     pub fn create_next_universe(&self) -> ty::UniverseIndex {
         let u = self.universe.get().next_universe();
+        debug!("create_next_universe {u:?}");
         self.universe.set(u);
         u
     }

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -609,7 +609,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         }
     }
 
-    fn throw_unresolved_import_error(&self, errors: Vec<(&Import<'_>, UnresolvedImportError)>) {
+    fn throw_unresolved_import_error(&mut self, errors: Vec<(&Import<'_>, UnresolvedImportError)>) {
         if errors.is_empty() {
             return;
         }
@@ -678,6 +678,17 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     }
                     _ => {}
                 }
+            }
+
+            match &import.kind {
+                ImportKind::Single { source, .. } => {
+                    if let Some(ModuleOrUniformRoot::Module(module)) = import.imported_module.get()
+                     && let Some(module) = module.opt_def_id()
+                    {
+                        self.find_cfg_stripped(&mut diag, &source.name, module)
+                    }
+                },
+                _ => {}
             }
         }
 

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -582,7 +582,7 @@ fn create_vscode_settings_maybe(config: &Config) -> io::Result<()> {
             Some(false) => {
                 // exists and is not current version or outdated, so back it up
                 let mut backup = vscode_settings.clone();
-                backup.set_extension("bak");
+                backup.set_extension("json.bak");
                 eprintln!("warning: copying `settings.json` to `settings.json.bak`");
                 fs::copy(&vscode_settings, &backup)?;
                 "Updated"

--- a/src/doc/style-guide/src/statements.md
+++ b/src/doc/style-guide/src/statements.md
@@ -101,22 +101,69 @@ let Foo {
 
 #### else blocks (let-else statements)
 
-If a let statement contains an `else` component, also known as a let-else statement,
-then the `else` component should be formatted according to the same rules as the `else` block
-in [control flow expressions (i.e. if-else, and if-let-else expressions)](./expressions.md#control-flow-expressions).
-Apply the same formatting rules to the components preceding
-the `else` block (i.e. the `let pattern: Type = initializer_expr ...` portion)
-as described [above](#let-statements)
+A let statement can contain an `else` component, making it a let-else statement.
+In this case, always apply the same formatting rules to the components preceding
+the `else` block (i.e. the `let pattern: Type = initializer_expr` portion)
+as described [for other let statements](#let-statements).
 
-Similarly to if-else expressions, if the initializer
-expression is multi-lined, then the `else` keyword and opening brace of the block (i.e. `else {`)
-should be put on the same line as the end of the initializer
-expression with a preceding space if all the following are true:
+The entire let-else statement may be formatted on a single line if all the
+following are true:
+
+* the entire statement is *short*
+* the `else` block contains only a single-line expression and no statements
+* the `else` block contains no comments
+* the let statement components preceding the `else` block can be formatted on a single line
+
+```rust
+let Some(1) = opt else { return };
+```
+
+Formatters may allow users to configure the value of the threshold
+used to determine whether a let-else statement is *short*.
+
+Otherwise, the let-else statement requires some line breaks.
+
+If breaking a let-else statement across multiple lines, never break between the
+`else` and the `{`, and always break before the `}`.
+
+If the let statement components preceding the `else` can be formatted on a
+single line, but the let-else does not qualify to be placed entirely on a
+single line, put the `else {` on the same line as the initializer expression,
+with a space between them, then break the line after the `{`. Indent the
+closing `}` to match the `let`, and indent the contained block one step
+further.
+
+```rust
+let Some(1) = opt else {
+    return;
+};
+
+let Some(1) = opt else {
+    // nope
+    return
+};
+```
+
+If the let statement components preceding the `else` can be formatted on a
+single line, but the `else {` does not fit on the same line, break the line
+before the `else`.
+
+```rust
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name
+    else {
+        return;
+    };
+```
+
+If the initializer expression is multi-line, the `else` keyword and opening
+brace of the block (i.e. `else {`) should be put on the same line as the end of
+the initializer expression, with a space between them, if all the following are
+true:
 
 * The initializer expression ends with one or more closing
   parentheses, square brackets, and/or braces
 * There is nothing else on that line
-* That line is not indented beyond the indent of the first line containing the `let` keyword
+* That line has the same indentation level as the initial `let` keyword.
 
 For example:
 
@@ -133,7 +180,9 @@ let Some(x) = y.foo(
 }
 ```
 
-Otherwise, the `else` keyword and opening brace should be placed on the next line after the end of the initializer expression, and should not be indented (the `else` keyword should be aligned with the `let` keyword).
+Otherwise, the `else` keyword and opening brace should be placed on the next
+line after the end of the initializer expression, and the `else` keyword should
+have the same indentation level as the `let` keyword.
 
 For example:
 
@@ -153,11 +202,6 @@ fn main() {
         return
     };
 
-    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name
-    else {
-        return;
-    };
-
     let Some(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) =
         bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     else {
@@ -165,31 +209,6 @@ fn main() {
     };
 }
 ```
-
-##### Single line let-else statements
-
-The entire let-else statement may be formatted on a single line if all the following are true:
-
-* the entire statement is *short*
-* the `else` block contains a single-line expression and no statements
-* the `else` block contains no comments
-* the let statement components preceding the `else` block can be formatted on a single line
-
-```rust
-let Some(1) = opt else { return };
-
-let Some(1) = opt else {
-    return;
-};
-
-let Some(1) = opt else {
-    // nope
-    return
-};
-```
-
-Formatters may allow users to configure the value of the threshold
-used to determine whether a let-else statement is *short*.
 
 ### Macros in statement position
 

--- a/src/etc/test-float-parse/runtests.py
+++ b/src/etc/test-float-parse/runtests.py
@@ -127,7 +127,7 @@ def write_errors():
         if not have_seen_error:
             have_seen_error = True
             msg("Something is broken:", *args)
-            msg("Future errors logged to errors.txt")
+            msg("Future errors will be logged to errors.txt")
             exit_status = 101
 
 

--- a/tests/ui/cfg/diagnostics-reexport.rs
+++ b/tests/ui/cfg/diagnostics-reexport.rs
@@ -9,6 +9,30 @@ pub mod inner {
     //~^ NOTE found an item that was configured out
 }
 
+pub use a::x;
+//~^ ERROR unresolved import `a::x`
+//~| NOTE no `x` in `a`
+
+mod a {
+    #[cfg(no)]
+    pub fn x() {}
+    //~^ NOTE found an item that was configured out
+}
+
+pub use b::{x, y};
+//~^ ERROR unresolved imports `b::x`, `b::y`
+//~| NOTE no `x` in `b`
+//~| NOTE no `y` in `b`
+
+mod b {
+    #[cfg(no)]
+    pub fn x() {}
+    //~^ NOTE found an item that was configured out
+    #[cfg(no)]
+    pub fn y() {}
+    //~^ NOTE found an item that was configured out
+}
+
 fn main() {
     // There is no uwu at this path - no diagnostic.
     inner::uwu(); //~ ERROR cannot find function

--- a/tests/ui/cfg/diagnostics-reexport.stderr
+++ b/tests/ui/cfg/diagnostics-reexport.stderr
@@ -1,5 +1,36 @@
+error[E0432]: unresolved import `a::x`
+  --> $DIR/diagnostics-reexport.rs:12:9
+   |
+LL | pub use a::x;
+   |         ^^^^ no `x` in `a`
+   |
+note: found an item that was configured out
+  --> $DIR/diagnostics-reexport.rs:18:12
+   |
+LL |     pub fn x() {}
+   |            ^
+
+error[E0432]: unresolved imports `b::x`, `b::y`
+  --> $DIR/diagnostics-reexport.rs:22:13
+   |
+LL | pub use b::{x, y};
+   |             ^  ^ no `y` in `b`
+   |             |
+   |             no `x` in `b`
+   |
+note: found an item that was configured out
+  --> $DIR/diagnostics-reexport.rs:29:12
+   |
+LL |     pub fn x() {}
+   |            ^
+note: found an item that was configured out
+  --> $DIR/diagnostics-reexport.rs:32:12
+   |
+LL |     pub fn y() {}
+   |            ^
+
 error[E0425]: cannot find function `uwu` in module `inner`
-  --> $DIR/diagnostics-reexport.rs:14:12
+  --> $DIR/diagnostics-reexport.rs:38:12
    |
 LL |     inner::uwu();
    |            ^^^ not found in `inner`
@@ -10,6 +41,7 @@ note: found an item that was configured out
 LL |     pub use super::uwu;
    |                    ^^^
 
-error: aborting due to previous error
+error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0425`.
+Some errors have detailed explanations: E0425, E0432.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.rs
@@ -1,0 +1,13 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+impl EntriesBuffer {
+    fn a(&self) -> impl Iterator {
+        self.0.iter_mut() //~ ERROR: cannot borrow `*self.0` as mutable, as it is behind a `&` reference
+    }
+}
+
+struct EntriesBuffer(Box<[[u8; HashesEntryLEN]; 5]>);
+//~^ ERROR: cannot find value `HashesEntryLEN` in this scope
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
@@ -1,0 +1,26 @@
+error[E0425]: cannot find value `HashesEntryLEN` in this scope
+  --> $DIR/issue-109141.rs:10:32
+   |
+LL | struct EntriesBuffer(Box<[[u8; HashesEntryLEN]; 5]>);
+   |                                ^^^^^^^^^^^^^^ not found in this scope
+   |
+help: you might be missing a const parameter
+   |
+LL | struct EntriesBuffer<const HashesEntryLEN: /* Type */>(Box<[[u8; HashesEntryLEN]; 5]>);
+   |                     ++++++++++++++++++++++++++++++++++
+
+error[E0596]: cannot borrow `*self.0` as mutable, as it is behind a `&` reference
+  --> $DIR/issue-109141.rs:6:9
+   |
+LL |         self.0.iter_mut()
+   |         ^^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |
+help: consider changing this to be a mutable reference
+   |
+LL |     fn a(&mut self) -> impl Iterator {
+   |          ~~~~~~~~~
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0425, E0596.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/traits/new-solver/member-constraints-in-root-universe.rs
+++ b/tests/ui/traits/new-solver/member-constraints-in-root-universe.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+trait Trait {
+    type Ty;
+}
+
+impl Trait for for<'a> fn(&'a u8, &'a u8) {
+    type Ty = ();
+}
+
+// argument is necessary to create universes before registering the hidden type.
+fn test<'a>(_: <fn(&u8, &u8) as Trait>::Ty) -> impl Sized {
+    "hidden type is `&'?0 str` with '?0 member of ['static,]"
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/normalize-hidden-types.current.stderr
+++ b/tests/ui/type-alias-impl-trait/normalize-hidden-types.current.stderr
@@ -1,0 +1,55 @@
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/normalize-hidden-types.rs:25:20
+   |
+LL |     fn define() -> Opaque {
+   |                    ^^^^^^ expected `*const (dyn FnOnce(()) + 'static)`, got `*const dyn for<'a> FnOnce(<u8 as Trait>::Gat<'a>)`
+   |
+note: previous use here
+  --> $DIR/normalize-hidden-types.rs:27:9
+   |
+LL |         dyn_hoops::<_>(0)
+   |         ^^^^^^^^^^^^^^^^^
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/normalize-hidden-types.rs:34:22
+   |
+LL |     fn define_1() -> Opaque { dyn_hoops::<_>(0) }
+   |                      ^^^^^^ expected `*const (dyn FnOnce(()) + 'static)`, got `*const dyn for<'a> FnOnce(<u8 as Trait>::Gat<'a>)`
+   |
+note: previous use here
+  --> $DIR/normalize-hidden-types.rs:34:31
+   |
+LL |     fn define_1() -> Opaque { dyn_hoops::<_>(0) }
+   |                               ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/normalize-hidden-types.rs:44:25
+   |
+LL |     type Opaque = impl Sized;
+   |                   ---------- the expected opaque type
+...
+LL |         let _: Opaque = dyn_hoops::<u8>(0);
+   |                ------   ^^^^^^^^^^^^^^^^^^ expected opaque type, found `*const dyn FnOnce(())`
+   |                |
+   |                expected due to this
+   |
+   = note: expected opaque type `typeck::Opaque`
+              found raw pointer `*const (dyn FnOnce(()) + 'static)`
+   = help: consider constraining the associated type `<u8 as Trait>::Gat<'_>` to `()` or calling a method that returns `<u8 as Trait>::Gat<'_>`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/normalize-hidden-types.rs:54:25
+   |
+LL |         let _: Opaque = dyn_hoops::<_>(0);
+   |                         ^^^^^^^^^^^^^^^^^ expected `*const (dyn FnOnce(()) + 'static)`, got `*const dyn for<'a> FnOnce(<u8 as Trait>::Gat<'a>)`
+   |
+note: previous use here
+  --> $DIR/normalize-hidden-types.rs:56:9
+   |
+LL |         None
+   |         ^^^^
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/normalize-hidden-types.rs
+++ b/tests/ui/type-alias-impl-trait/normalize-hidden-types.rs
@@ -1,0 +1,60 @@
+// Regression test for #112691
+//
+// revisions: current next
+// [next] compile-flags: -Ztrait-solver=next
+// [next] check-pass
+// [current]: known-bug: #112691
+
+#![feature(type_alias_impl_trait)]
+
+trait Trait {
+    type Gat<'lt>;
+}
+
+impl Trait for u8 {
+    type Gat<'lt> = ();
+}
+
+fn dyn_hoops<T: Trait>(_: T) -> *const dyn FnOnce(T::Gat<'_>) {
+    loop {}
+}
+
+mod typeof_1 {
+    use super::*;
+    type Opaque = impl Sized;
+    fn define() -> Opaque {
+        //[current]~^ ERROR concrete type differs
+        dyn_hoops::<_>(0)
+    }
+}
+
+mod typeof_2 {
+    use super::*;
+    type Opaque = impl Sized;
+    fn define_1() -> Opaque { dyn_hoops::<_>(0) }
+    //[current]~^ ERROR concrete type differs
+    fn define_2() -> Opaque { dyn_hoops::<u8>(0) }
+}
+
+mod typeck {
+    use super::*;
+    type Opaque = impl Sized;
+    fn define() -> Option<Opaque> {
+        let _: Opaque = dyn_hoops::<_>(0);
+        let _: Opaque = dyn_hoops::<u8>(0);
+        //[current]~^ ERROR mismatched types
+        None
+    }
+}
+
+mod borrowck {
+    use super::*;
+    type Opaque = impl Sized;
+    fn define() -> Option<Opaque> {
+        let _: Opaque = dyn_hoops::<_>(0);
+        //[current]~^ ERROR concrete type differs
+        None
+    }
+}
+
+fn main() {}

--- a/x.py
+++ b/x.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
     # soft deprecation of old python versions
     skip_check = os.environ.get("RUST_IGNORE_OLD_PYTHON") == "1"
-    if major < 3 or (major == 3 and minor < 6):
+    if not skip_check and (major < 3 or (major == 3 and minor < 6)):
         msg = cleandoc("""
             Using python {}.{} but >= 3.6 is recommended. Your python version
             should continue to work for the near future, but this will


### PR DESCRIPTION
Successful merges:

 - #112703 ([-Ztrait-solver=next, mir-typeck] instantiate hidden types in the root universe)
 - #112854 (fix: add cfg diagnostic for unresolved import error)
 - #112912 (style-guide: Rewrite let-else section for clarity, without changing formatting)
 - #112915 (Update runtests.py : grammar correction)
 - #112971 (issue template: add clippy entry which points to the clippy repo)
 - #112989 (Add a regression test for #109141)
 - #113002 (bootstrap: Backup `settings.json` to the correct filename)
 - #113003 (Fix old python deprecation check in x.py)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112703,112854,112912,112915,112971,112989,113002,113003)
<!-- homu-ignore:end -->