### PR TITLE
Revert "Structurally resolve correctly in check_pat_lit"

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -393,8 +393,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // They can denote both statically and dynamically-sized byte arrays.
         let mut pat_ty = ty;
         if let hir::ExprKind::Lit(Spanned { node: ast::LitKind::ByteStr(..), .. }) = lt.kind {
-            if let ty::Ref(_, inner_ty, _) = *self.structurally_resolved_type(span, expected).kind()
-                && self.structurally_resolved_type(span, inner_ty).is_slice()
+            let expected = self.structurally_resolved_type(span, expected);
+            if let ty::Ref(_, inner_ty, _) = expected.kind()
+                && matches!(inner_ty.kind(), ty::Slice(_))
             {
                 let tcx = self.tcx;
                 trace!(?lt.hir_id.local_id, "polymorphic byte string lit");

--- a/tests/ui/pattern/byte-string-inference.rs
+++ b/tests/ui/pattern/byte-string-inference.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+fn load<L>() -> Option<L> {
+    todo!()
+}
+
+fn main() {
+    while let Some(tag) = load() {
+        match &tag {
+            b"NAME" => {}
+            b"DATA" => {}
+            _ => {}
+        }
+    }
+}

--- a/tests/ui/traits/new-solver/slice-match-byte-lit.rs
+++ b/tests/ui/traits/new-solver/slice-match-byte-lit.rs
@@ -1,5 +1,5 @@
 // compile-flags: -Ztrait-solver=next
-// check-pass
+// known-bug: rust-lang/trait-system-refactor-initiative#38
 
 fn test(s: &[u8]) {
     match &s[0..3] {

--- a/tests/ui/traits/new-solver/slice-match-byte-lit.stderr
+++ b/tests/ui/traits/new-solver/slice-match-byte-lit.stderr
@@ -1,0 +1,11 @@
+error[E0271]: type mismatch resolving `[u8; 3] <: <Range<usize> as SliceIndex<[u8]>>::Output`
+  --> $DIR/slice-match-byte-lit.rs:6:9
+   |
+LL |     match &s[0..3] {
+   |           -------- this expression has type `&<std::ops::Range<usize> as SliceIndex<[u8]>>::Output`
+LL |         b"uwu" => {}
+   |         ^^^^^^ types differ
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
This reverts commit 54fb5a48b968b3a329ceeb57226d9ac60f983f04. Also adds a couple of tests, and downgrades the existing `-Ztrait-solver=next` test to a known-bug.

Fixes #112993