### PR TITLE
Move some docs from the README to the dev-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,24 +33,13 @@ format:
 ```
 
 This is how the documentation and examples assume you are running `x.py`.
-Some alternative ways are:
-
-```sh
-# On a Unix shell if you don't have the necessary `python3` command
-./x <subcommand> [flags]
-
-# On the Windows Command Prompt (if .py files are configured to run Python)
-x.py <subcommand> [flags]
-
-# You can also run Python yourself, e.g.:
-python x.py <subcommand> [flags]
-```
+See the [rustc dev guide][rustcguidebuild] if this does not work on your platform.
 
 More information about `x.py` can be found by running it with the `--help` flag
 or reading the [rustc dev guide][rustcguidebuild].
 
 [gettingstarted]: https://rustc-dev-guide.rust-lang.org/getting-started.html
-[rustcguidebuild]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html
+[rustcguidebuild]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html#what-is-xpy
 
 ### Dependencies
 

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -160,10 +160,10 @@ pub fn check(
     for &(name, _) in gate_untested.iter() {
         println!("Expected a gate test for the feature '{name}'.");
         println!(
-            "Hint: create a failing test file named 'feature-gate-{}.rs'\
-                \n      in the 'ui' test suite, with its failures due to\
-                \n      missing usage of `#![feature({})]`.",
-            name, name
+            "Hint: create a failing test file named 'tests/ui/feature-gates/feature-gate-{}.rs',\
+                \n      with its failures due to missing usage of `#![feature({})]`.",
+            name.replace("_", "-"),
+            name
         );
         println!(
             "Hint: If you already have such a test and don't want to rename it,\

--- a/x.ps1
+++ b/x.ps1
@@ -16,7 +16,13 @@ foreach ($arg in $args) {
 }
 
 function Get-Application($app) {
-    return Get-Command $app -ErrorAction SilentlyContinue -CommandType Application
+    $cmd = Get-Command $app -ErrorAction SilentlyContinue -CommandType Application | Select-Object -First 1
+    if ($cmd.source -match '.*AppData\\Local\\Microsoft\\WindowsApps\\.*exe') {
+        # Windows for some reason puts a `python3.exe` executable in PATH that just opens the windows store.
+        # Ignore it.
+        return $false
+    }
+    return $cmd
 }
 
 function Invoke-Application($application, $arguments) {
@@ -51,5 +57,7 @@ if (($null -ne $found) -and ($found.Length -ge 1)) {
     Invoke-Application $python $xpy_args
 }
 
-Write-Error "${PSCommandPath}: error: did not find python installed"
+$msg = "${PSCommandPath}: error: did not find python installed`n"
+$msg += "help: consider installing it from https://www.python.org/downloads/"
+Write-Error $msg -Category NotInstalled
 Exit 1

--- a/x.ps1
+++ b/x.ps1
@@ -5,7 +5,7 @@
 $ErrorActionPreference = "Stop"
 
 # syntax check
-Get-Command -syntax ${PSCommandPath}
+Get-Command -syntax ${PSCommandPath} >$null
 
 $xpy = Join-Path $PSScriptRoot x.py
 # Start-Process for some reason splits arguments on spaces. (Isn't powershell supposed to be simpler than bash?)


### PR DESCRIPTION
and as a drive-by cleanup, improve the error message for `x test tidy` when a feature gate is missing.

This also improves the error message you get on Windows if python isn't installed.

cc https://github.com/rust-lang/libs-team/issues/242#issuecomment-1597558557, https://github.com/rust-lang/rustc-dev-guide/pull/1701