### PR TITLE
Remove unnecessary `path` attribute

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -12,7 +12,6 @@ use crate::os::windows::io::{AsRawHandle, BorrowedHandle};
 use crate::ptr;
 use core::ffi::NonZero_c_ulong;
 
-#[path = "c/windows_sys.rs"] // c.rs is included from two places so we need to specify this
 mod windows_sys;
 pub use windows_sys::*;
 


### PR DESCRIPTION
Follow up to #111401. I missed this at the time but it should now be totally unnecessary since the other include was removed.

r? @workingjubilee 