### PR TITLE
rust-installer & rls: remove exclusion from rustfmt & tidy 

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -16,6 +16,8 @@ ignore = [
     "tests",
 
     # do not format submodules
+    # FIXME: sync submodule list with tidy/bootstrap/etc
+    # tidy/src/walk.rs:filter_dirs
     "library/backtrace",
     "library/portable-simd",
     "library/stdarch",
@@ -31,10 +33,8 @@ ignore = [
     "src/tools/cargo",
     "src/tools/clippy",
     "src/tools/miri",
-    "src/tools/rls",
     "src/tools/rust-analyzer",
     "src/tools/rustfmt",
-    "src/tools/rust-installer",
 
     # these are ignored by a standard cargo fmt run
     "compiler/rustc_codegen_cranelift/y.rs", # running rustfmt breaks this file

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -289,7 +289,7 @@ bootstrap_tool!(
     Compiletest, "src/tools/compiletest", "compiletest", is_unstable_tool = true, allow_features = "test";
     BuildManifest, "src/tools/build-manifest", "build-manifest";
     RemoteTestClient, "src/tools/remote-test-client", "remote-test-client";
-    RustInstaller, "src/tools/rust-installer", "rust-installer", is_external_tool = true;
+    RustInstaller, "src/tools/rust-installer", "rust-installer";
     RustdocTheme, "src/tools/rustdoc-themes", "rustdoc-themes";
     ExpandYamlAnchors, "src/tools/expand-yaml-anchors", "expand-yaml-anchors";
     LintDocs, "src/tools/lint-docs", "lint-docs";

--- a/src/tools/rust-installer/install-template.sh
+++ b/src/tools/rust-installer/install-template.sh
@@ -17,8 +17,8 @@ log_line() {
     local _line="$1"
 
     if [ -n "${LOGFILE-}" -a -e "${LOGFILE-}" ]; then
-	echo "$_line" >> "$LOGFILE"
-	# Ignore errors, which may happen e.g. after the manifest dir is deleted
+    echo "$_line" >> "$LOGFILE"
+    # Ignore errors, which may happen e.g. after the manifest dir is deleted
     fi
 }
 
@@ -30,9 +30,9 @@ msg() {
 
 verbose_msg() {
     if [ -n "${CFG_VERBOSE-}" ]; then
-	msg "${1-}"
+    msg "${1-}"
     else
-	log_line "install: ${1-}"
+    log_line "install: ${1-}"
     fi
 }
 
@@ -44,13 +44,13 @@ step_msg() {
 
 verbose_step_msg() {
     if [ -n "${CFG_VERBOSE-}" ]; then
-	msg
-	msg "$1"
-	msg
+    msg
+    msg "$1"
+    msg
     else
-	log_line ""
-	log_line "install: $1"
-	log_line ""
+    log_line ""
+    log_line "install: $1"
+    log_line ""
     fi
 }
 
@@ -91,7 +91,7 @@ critical_need_ok() {
 
 want_ok() {
     if [ $? -ne 0 ]; then
-	warn "$1"
+    warn "$1"
     fi
 }
 
@@ -321,40 +321,40 @@ uninstall_legacy() {
     # Uninstall from legacy manifests
     local _md
     for _md in $_legacy_manifest_dirs; do
-	# First, uninstall from the installation prefix.
-	# Errors are warnings - try to rm everything in the manifest even if some fail.
-	if [ -f "$_abs_libdir/$_md/manifest" ]
-	then
+    # First, uninstall from the installation prefix.
+    # Errors are warnings - try to rm everything in the manifest even if some fail.
+    if [ -f "$_abs_libdir/$_md/manifest" ]
+    then
 
-	    # iterate through installed manifest and remove files
-	    local _p;
-	    while read _p; do
-		# the installed manifest contains absolute paths
-		msg "removing legacy file $_p"
-		if [ -f "$_p" ]
-		then
-		    run rm -f "$_p"
-		    want_ok "failed to remove $_p"
-		else
-		    warn "supposedly installed file $_p does not exist!"
-		fi
-	    done < "$_abs_libdir/$_md/manifest"
+        # iterate through installed manifest and remove files
+        local _p;
+        while read _p; do
+        # the installed manifest contains absolute paths
+        msg "removing legacy file $_p"
+        if [ -f "$_p" ]
+        then
+            run rm -f "$_p"
+            want_ok "failed to remove $_p"
+        else
+            warn "supposedly installed file $_p does not exist!"
+        fi
+        done < "$_abs_libdir/$_md/manifest"
 
-	    # If we fail to remove $md below, then the
-	    # installed manifest will still be full; the installed manifest
-	    # needs to be empty before install.
-	    msg "removing legacy manifest $_abs_libdir/$_md/manifest"
-	    run rm -f "$_abs_libdir/$_md/manifest"
-	    # For the above reason, this is a hard error
-	    need_ok "failed to remove installed manifest"
+        # If we fail to remove $md below, then the
+        # installed manifest will still be full; the installed manifest
+        # needs to be empty before install.
+        msg "removing legacy manifest $_abs_libdir/$_md/manifest"
+        run rm -f "$_abs_libdir/$_md/manifest"
+        # For the above reason, this is a hard error
+        need_ok "failed to remove installed manifest"
 
-	    # Remove $template_rel_manifest_dir directory
-	    msg "removing legacy manifest dir $_abs_libdir/$_md"
-	    run rm -R "$_abs_libdir/$_md"
-	    want_ok "failed to remove $_md"
+        # Remove $template_rel_manifest_dir directory
+        msg "removing legacy manifest dir $_abs_libdir/$_md"
+        run rm -R "$_abs_libdir/$_md"
+        want_ok "failed to remove $_md"
 
-	    _uninstalled_something=true
-	fi
+        _uninstalled_something=true
+    fi
     done
 
     RETVAL="$_uninstalled_something"
@@ -373,133 +373,133 @@ uninstall_components() {
     uninstall_legacy "$_abs_libdir"
     assert_nz "$RETVAL", "RETVAL"
     if [ "$RETVAL" = true ]; then
-	_uninstalled_something=true;
+    _uninstalled_something=true;
     fi
 
     # Load the version of the installed installer
     local _installed_version=
     if [ -f "$abs_libdir/$TEMPLATE_REL_MANIFEST_DIR/rust-installer-version" ]; then
-	_installed_version=`cat "$_abs_libdir/$TEMPLATE_REL_MANIFEST_DIR/rust-installer-version"`
+    _installed_version=`cat "$_abs_libdir/$TEMPLATE_REL_MANIFEST_DIR/rust-installer-version"`
 
-	# Sanity check
-	if [ ! -n "$_installed_version" ]; then critical_err "rust installer version is empty"; fi
+    # Sanity check
+    if [ ! -n "$_installed_version" ]; then critical_err "rust installer version is empty"; fi
     fi
 
     # If there's something installed, then uninstall
     if [ -n "$_installed_version" ]; then
-	# Check the version of the installed installer
-	case "$_installed_version" in
+    # Check the version of the installed installer
+    case "$_installed_version" in
 
-	    # If this is a previous version, then upgrade in place to the
-	    # current version before uninstalling.
-	    2 )
-		# The only change between version 2 -> 3 is that components are placed
-		# in subdirectories of the installer tarball. There are no changes
-		# to the installed data format, so nothing to do.
-		;;
+        # If this is a previous version, then upgrade in place to the
+        # current version before uninstalling.
+        2 )
+        # The only change between version 2 -> 3 is that components are placed
+        # in subdirectories of the installer tarball. There are no changes
+        # to the installed data format, so nothing to do.
+        ;;
 
-	    # This is the current version. Nothing need to be done except uninstall.
-	    "$TEMPLATE_RUST_INSTALLER_VERSION")
-		;;
+        # This is the current version. Nothing need to be done except uninstall.
+        "$TEMPLATE_RUST_INSTALLER_VERSION")
+        ;;
 
-	    # If this is an unknown (future) version then bail.
-	    * )
-		echo "The copy of $TEMPLATE_PRODUCT_NAME at $_dest_prefix was installed using an"
-		echo "unknown version ($_installed_version) of rust-installer."
-		echo "Uninstall it first with the installer used for the original installation"
-		echo "before continuing."
-		exit 1
-		;;
-	esac
+        # If this is an unknown (future) version then bail.
+        * )
+        echo "The copy of $TEMPLATE_PRODUCT_NAME at $_dest_prefix was installed using an"
+        echo "unknown version ($_installed_version) of rust-installer."
+        echo "Uninstall it first with the installer used for the original installation"
+        echo "before continuing."
+        exit 1
+        ;;
+    esac
 
-	local _md="$_abs_libdir/$TEMPLATE_REL_MANIFEST_DIR"
-	local _installed_components="$(cat "$_md/components")"
+    local _md="$_abs_libdir/$TEMPLATE_REL_MANIFEST_DIR"
+    local _installed_components="$(cat "$_md/components")"
 
-	# Uninstall (our components only) before reinstalling
-	local _available_component
-	for _available_component in $_components; do
-	    local _installed_component
-	    for _installed_component in $_installed_components; do
-		if [ "$_available_component" = "$_installed_component" ]; then
-		    msg "uninstalling component '$_available_component'"
-		    local _component_manifest="$_md/manifest-$_installed_component"
+    # Uninstall (our components only) before reinstalling
+    local _available_component
+    for _available_component in $_components; do
+        local _installed_component
+        for _installed_component in $_installed_components; do
+        if [ "$_available_component" = "$_installed_component" ]; then
+            msg "uninstalling component '$_available_component'"
+            local _component_manifest="$_md/manifest-$_installed_component"
 
-		    # Sanity check: there should be a component manifest
-		    if [ ! -f "$_component_manifest" ]; then
-			critical_err "installed component '$_installed_component' has no manifest"
-		    fi
+            # Sanity check: there should be a component manifest
+            if [ ! -f "$_component_manifest" ]; then
+            critical_err "installed component '$_installed_component' has no manifest"
+            fi
 
-		    # Iterate through installed component manifest and remove files
-		    local _directive
-		    while read _directive; do
+            # Iterate through installed component manifest and remove files
+            local _directive
+            while read _directive; do
 
-			local _command=`echo $_directive | cut -f1 -d:`
-			local _file=`echo $_directive | cut -f2 -d:`
+            local _command=`echo $_directive | cut -f1 -d:`
+            local _file=`echo $_directive | cut -f2 -d:`
 
-			# Sanity checks
-			if [ ! -n "$_command" ]; then critical_err "malformed installation directive"; fi
-			if [ ! -n "$_file" ]; then critical_err "malformed installation directive"; fi
+            # Sanity checks
+            if [ ! -n "$_command" ]; then critical_err "malformed installation directive"; fi
+            if [ ! -n "$_file" ]; then critical_err "malformed installation directive"; fi
 
-			case "$_command" in
-			    file)
-				verbose_msg "removing file $_file"
-				if [ -f "$_file" ]; then
-				    run rm -f "$_file"
-				    want_ok "failed to remove $_file"
-				else
-				    warn "supposedly installed file $_file does not exist!"
-				fi
-				;;
+            case "$_command" in
+                file)
+                verbose_msg "removing file $_file"
+                if [ -f "$_file" ]; then
+                    run rm -f "$_file"
+                    want_ok "failed to remove $_file"
+                else
+                    warn "supposedly installed file $_file does not exist!"
+                fi
+                ;;
 
-			    dir)
-				verbose_msg "removing directory $_file"
-				run rm -r "$_file"
-				want_ok "unable to remove directory $_file"
-				;;
+                dir)
+                verbose_msg "removing directory $_file"
+                run rm -r "$_file"
+                want_ok "unable to remove directory $_file"
+                ;;
 
-			    *)
-				critical_err "unknown installation directive"
-				;;
-			esac
+                *)
+                critical_err "unknown installation directive"
+                ;;
+            esac
 
-		    done < "$_component_manifest"
+            done < "$_component_manifest"
 
-		    # Remove the installed component manifest
-		    verbose_msg "removing component manifest $_component_manifest"
-		    run rm "$_component_manifest"
-		    # This is a hard error because the installation is unrecoverable
-		    critical_need_ok "failed to remove installed manifest for component '$_installed_component'"
+            # Remove the installed component manifest
+            verbose_msg "removing component manifest $_component_manifest"
+            run rm "$_component_manifest"
+            # This is a hard error because the installation is unrecoverable
+            critical_need_ok "failed to remove installed manifest for component '$_installed_component'"
 
-		    # Update the installed component list
-		    local _modified_components="$(sed "/^$_installed_component\$/d" "$_md/components")"
-		    write_to_file "$_modified_components" "$_md/components"
-		    critical_need_ok "failed to update installed component list"
-		fi
-	    done
-	done
+            # Update the installed component list
+            local _modified_components="$(sed "/^$_installed_component\$/d" "$_md/components")"
+            write_to_file "$_modified_components" "$_md/components"
+            critical_need_ok "failed to update installed component list"
+        fi
+        done
+    done
 
-	# If there are no remaining components delete the manifest directory,
-	# but only if we're doing an uninstall - if we're doing an install,
-	# then leave the manifest directory around to hang onto the logs,
-	# and any files not managed by the installer.
-	if [ -n "${CFG_UNINSTALL-}" ]; then
-	    local _remaining_components="$(cat "$_md/components")"
-	    if [ ! -n "$_remaining_components" ]; then
-		verbose_msg "removing manifest directory $_md"
-		run rm -r "$_md"
-		want_ok "failed to remove $_md"
+    # If there are no remaining components delete the manifest directory,
+    # but only if we're doing an uninstall - if we're doing an install,
+    # then leave the manifest directory around to hang onto the logs,
+    # and any files not managed by the installer.
+    if [ -n "${CFG_UNINSTALL-}" ]; then
+        local _remaining_components="$(cat "$_md/components")"
+        if [ ! -n "$_remaining_components" ]; then
+        verbose_msg "removing manifest directory $_md"
+        run rm -r "$_md"
+        want_ok "failed to remove $_md"
 
-		maybe_unconfigure_ld
-	    fi
-	fi
+        maybe_unconfigure_ld
+        fi
+    fi
 
-	_uninstalled_something=true
+    _uninstalled_something=true
     fi
 
     # There's no installed version. If we were asked to uninstall, then that's a problem.
     if [ -n "${CFG_UNINSTALL-}" -a "$_uninstalled_something" = false ]
     then
-	err "unable to find installation manifest at $CFG_LIBDIR/$TEMPLATE_REL_MANIFEST_DIR"
+    err "unable to find installation manifest at $CFG_LIBDIR/$TEMPLATE_REL_MANIFEST_DIR"
     fi
 }
 
@@ -512,73 +512,73 @@ install_components() {
     local _component
     for _component in $_components; do
 
-	msg "installing component '$_component'"
+    msg "installing component '$_component'"
 
-	# The file name of the manifest we're installing from
-	local _input_manifest="$_src_dir/$_component/manifest.in"
+    # The file name of the manifest we're installing from
+    local _input_manifest="$_src_dir/$_component/manifest.in"
 
-	# Sanity check: do we have our input manifests?
-	if [ ! -f "$_input_manifest" ]; then
-	    critical_err "manifest for $_component does not exist at $_input_manifest"
-	fi
+    # Sanity check: do we have our input manifests?
+    if [ ! -f "$_input_manifest" ]; then
+        critical_err "manifest for $_component does not exist at $_input_manifest"
+    fi
 
-	# The installed manifest directory
-	local _md="$_abs_libdir/$TEMPLATE_REL_MANIFEST_DIR"
+    # The installed manifest directory
+    local _md="$_abs_libdir/$TEMPLATE_REL_MANIFEST_DIR"
 
-	# The file name of the manifest we're going to create during install
-	local _installed_manifest="$_md/manifest-$_component"
+    # The file name of the manifest we're going to create during install
+    local _installed_manifest="$_md/manifest-$_component"
 
-	# Create the installed manifest, which we will fill in with absolute file paths
-	touch "$_installed_manifest"
-	critical_need_ok "failed to create installed manifest"
+    # Create the installed manifest, which we will fill in with absolute file paths
+    touch "$_installed_manifest"
+    critical_need_ok "failed to create installed manifest"
 
-	# Add this component to the installed component list
-	append_to_file "$_component" "$_md/components"
-	critical_need_ok "failed to update components list for $_component"
+    # Add this component to the installed component list
+    append_to_file "$_component" "$_md/components"
+    critical_need_ok "failed to update components list for $_component"
 
-	# Now install, iterate through the new manifest and copy files
-	local _directive
-	while read _directive; do
+    # Now install, iterate through the new manifest and copy files
+    local _directive
+    while read _directive; do
 
-	    local _command=`echo $_directive | cut -f1 -d:`
-	    local _file=`echo $_directive | cut -f2 -d:`
+        local _command=`echo $_directive | cut -f1 -d:`
+        local _file=`echo $_directive | cut -f2 -d:`
 
-	    # Sanity checks
-	    if [ ! -n "$_command" ]; then critical_err "malformed installation directive"; fi
-	    if [ ! -n "$_file" ]; then critical_err "malformed installation directive"; fi
+        # Sanity checks
+        if [ ! -n "$_command" ]; then critical_err "malformed installation directive"; fi
+        if [ ! -n "$_file" ]; then critical_err "malformed installation directive"; fi
 
-	    # Decide the destination of the file
-	    local _file_install_path="$_dest_prefix/$_file"
+        # Decide the destination of the file
+        local _file_install_path="$_dest_prefix/$_file"
 
-	    if echo "$_file" | grep "^etc/" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^etc\///')"
-		_file_install_path="$CFG_SYSCONFDIR/$_f"
-	    fi
+        if echo "$_file" | grep "^etc/" > /dev/null
+        then
+        local _f="$(echo "$_file" | sed 's/^etc\///')"
+        _file_install_path="$CFG_SYSCONFDIR/$_f"
+        fi
 
-	    if echo "$_file" | grep "^bin/" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^bin\///')"
-		_file_install_path="$CFG_BINDIR/$_f"
-	    fi
+        if echo "$_file" | grep "^bin/" > /dev/null
+        then
+        local _f="$(echo "$_file" | sed 's/^bin\///')"
+        _file_install_path="$CFG_BINDIR/$_f"
+        fi
 
-	    if echo "$_file" | grep "^lib/" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^lib\///')"
-		_file_install_path="$CFG_LIBDIR/$_f"
-	    fi
+        if echo "$_file" | grep "^lib/" > /dev/null
+        then
+        local _f="$(echo "$_file" | sed 's/^lib\///')"
+        _file_install_path="$CFG_LIBDIR/$_f"
+        fi
 
-	    if echo "$_file" | grep "^share" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^share\///')"
-		_file_install_path="$CFG_DATADIR/$_f"
-	    fi
+        if echo "$_file" | grep "^share" > /dev/null
+        then
+        local _f="$(echo "$_file" | sed 's/^share\///')"
+        _file_install_path="$CFG_DATADIR/$_f"
+        fi
 
-	    if echo "$_file" | grep "^share/man/" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^share\/man\///')"
-		_file_install_path="$CFG_MANDIR/$_f"
-	    fi
+        if echo "$_file" | grep "^share/man/" > /dev/null
+        then
+        local _f="$(echo "$_file" | sed 's/^share\/man\///')"
+        _file_install_path="$CFG_MANDIR/$_f"
+        fi
 
             # HACK: Try to support overriding --docdir.  Paths with the form
             # "share/doc/$product/" can be redirected to a single --docdir
@@ -592,69 +592,69 @@ install_components() {
             # this problem to be a big deal in practice.
             if [ "$CFG_DOCDIR" != "<default>" ]
             then
-	        if echo "$_file" | grep "^share/doc/" > /dev/null
-	        then
-		    local _f="$(echo "$_file" | sed 's/^share\/doc\/[^/]*\///')"
-		    _file_install_path="$CFG_DOCDIR/$_f"
-	        fi
+            if echo "$_file" | grep "^share/doc/" > /dev/null
+            then
+            local _f="$(echo "$_file" | sed 's/^share\/doc\/[^/]*\///')"
+            _file_install_path="$CFG_DOCDIR/$_f"
+            fi
             fi
 
-	    # Make sure there's a directory for it
-	    make_dir_recursive "$(dirname "$_file_install_path")"
-	    critical_need_ok "directory creation failed"
+        # Make sure there's a directory for it
+        make_dir_recursive "$(dirname "$_file_install_path")"
+        critical_need_ok "directory creation failed"
 
-	    # Make the path absolute so we can uninstall it later without
-	    # starting from the installation cwd
-	    absolutify "$_file_install_path"
-	    _file_install_path="$RETVAL"
-	    assert_nz "$_file_install_path" "file_install_path"
+        # Make the path absolute so we can uninstall it later without
+        # starting from the installation cwd
+        absolutify "$_file_install_path"
+        _file_install_path="$RETVAL"
+        assert_nz "$_file_install_path" "file_install_path"
 
-	    case "$_command" in
-		file )
+        case "$_command" in
+        file )
 
-		    verbose_msg "copying file $_file_install_path"
+            verbose_msg "copying file $_file_install_path"
 
-		    maybe_backup_path "$_file_install_path"
+            maybe_backup_path "$_file_install_path"
 
-		    if echo "$_file" | grep "^bin/" > /dev/null || test -x "$_src_dir/$_component/$_file"
-		    then
-			run cp "$_src_dir/$_component/$_file" "$_file_install_path"
-			run chmod 755 "$_file_install_path"
-		    else
-			run cp "$_src_dir/$_component/$_file" "$_file_install_path"
-			run chmod 644 "$_file_install_path"
-		    fi
-		    critical_need_ok "file creation failed"
+            if echo "$_file" | grep "^bin/" > /dev/null || test -x "$_src_dir/$_component/$_file"
+            then
+            run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+            run chmod 755 "$_file_install_path"
+            else
+            run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+            run chmod 644 "$_file_install_path"
+            fi
+            critical_need_ok "file creation failed"
 
-		    # Update the manifest
-		    append_to_file "file:$_file_install_path" "$_installed_manifest"
-		    critical_need_ok "failed to update manifest"
+            # Update the manifest
+            append_to_file "file:$_file_install_path" "$_installed_manifest"
+            critical_need_ok "failed to update manifest"
 
-		    ;;
+            ;;
 
-		dir )
+        dir )
 
-		    verbose_msg "copying directory $_file_install_path"
+            verbose_msg "copying directory $_file_install_path"
 
-		    maybe_backup_path "$_file_install_path"
+            maybe_backup_path "$_file_install_path"
 
-		    run cp -R "$_src_dir/$_component/$_file" "$_file_install_path"
-		    critical_need_ok "failed to copy directory"
+            run cp -R "$_src_dir/$_component/$_file" "$_file_install_path"
+            critical_need_ok "failed to copy directory"
 
                     # Set permissions. 0755 for dirs, 644 for files
                     run chmod -R u+rwX,go+rX,go-w "$_file_install_path"
                     critical_need_ok "failed to set permissions on directory"
 
-		    # Update the manifest
-		    append_to_file "dir:$_file_install_path" "$_installed_manifest"
-		    critical_need_ok "failed to update manifest"
-		    ;;
+            # Update the manifest
+            append_to_file "dir:$_file_install_path" "$_installed_manifest"
+            critical_need_ok "failed to update manifest"
+            ;;
 
-		*)
-		    critical_err "unknown installation directive"
-		    ;;
-	    esac
-	done < "$_input_manifest"
+        *)
+            critical_err "unknown installation directive"
+            ;;
+        esac
+    done < "$_input_manifest"
 
     done
 }
@@ -667,33 +667,33 @@ maybe_configure_ld() {
 
     if [ "$_ostype" = "Linux" -a ! -n "${CFG_DISABLE_LDCONFIG-}" ]; then
 
-	# Fedora-based systems do not configure the dynamic linker to look
-	# /usr/local/lib, which is our default installation directory. To
-	# make things just work, try to put that directory in
-	# /etc/ld.so.conf.d/rust-installer-v1 so ldconfig picks it up.
-	# Issue #30.
-	#
-	# This will get rm'd when the last component is uninstalled in
-	# maybe_unconfigure_ld.
-	if [ "$_abs_libdir" = "/usr/local/lib" -a -d "/etc/ld.so.conf.d" ]; then
-	    echo "$_abs_libdir" > "/etc/ld.so.conf.d/rust-installer-v1-$TEMPLATE_REL_MANIFEST_DIR.conf"
-	    if [ $? -ne 0 ]; then
-		# This shouldn't happen if we've gotten this far
-		# installing to /usr/local
-		warn "failed to update /etc/ld.so.conf.d. this is unexpected"
-	    fi
-	fi
+    # Fedora-based systems do not configure the dynamic linker to look
+    # /usr/local/lib, which is our default installation directory. To
+    # make things just work, try to put that directory in
+    # /etc/ld.so.conf.d/rust-installer-v1 so ldconfig picks it up.
+    # Issue #30.
+    #
+    # This will get rm'd when the last component is uninstalled in
+    # maybe_unconfigure_ld.
+    if [ "$_abs_libdir" = "/usr/local/lib" -a -d "/etc/ld.so.conf.d" ]; then
+        echo "$_abs_libdir" > "/etc/ld.so.conf.d/rust-installer-v1-$TEMPLATE_REL_MANIFEST_DIR.conf"
+        if [ $? -ne 0 ]; then
+        # This shouldn't happen if we've gotten this far
+        # installing to /usr/local
+        warn "failed to update /etc/ld.so.conf.d. this is unexpected"
+        fi
+    fi
 
-	verbose_msg "running ldconfig"
-	if [ -n "${CFG_VERBOSE-}" ]; then
-	    ldconfig
-	else
-	    ldconfig 2> /dev/null
-	fi
-	if [ $? -ne 0 ]
-	then
+    verbose_msg "running ldconfig"
+    if [ -n "${CFG_VERBOSE-}" ]; then
+        ldconfig
+    else
+        ldconfig 2> /dev/null
+    fi
+    if [ $? -ne 0 ]
+    then
             warn "failed to run ldconfig. this may happen when not installing as root. run with --verbose to see the error"
-	fi
+    fi
     fi
 }
 
@@ -702,7 +702,7 @@ maybe_unconfigure_ld() {
     assert_nz "$_ostype"  "ostype"
 
     if [ "$_ostype" != "Linux" ]; then
-	return 0
+    return 0
     fi
 
     rm "/etc/ld.so.conf.d/rust-installer-v1-$TEMPLATE_REL_MANIFEST_DIR.conf" 2> /dev/null
@@ -714,9 +714,9 @@ maybe_backup_path() {
     local _file_install_path="$1"
 
     if [ -e "$_file_install_path" ]; then
-	msg "backing up existing file at $_file_install_path"
-	run mv -f "$_file_install_path" "$_file_install_path.old"
-	critical_need_ok "failed to back up $_file_install_path"
+    msg "backing up existing file at $_file_install_path"
+    run mv -f "$_file_install_path" "$_file_install_path.old"
+    critical_need_ok "failed to back up $_file_install_path"
     fi
 }
 
@@ -742,7 +742,7 @@ do_preflight_sanity_checks() {
     touch "$CFG_LIBDIR/rust-install-probe" > /dev/null
     if [ $? -ne 0 ]
     then
-	err "can't write to destination. consider \`sudo\`."
+    err "can't write to destination. consider \`sudo\`."
     fi
     rm "$CFG_LIBDIR/rust-install-probe"
     need_ok "failed to remove install probe"
@@ -752,7 +752,7 @@ do_preflight_sanity_checks() {
     verbose_msg "verifying destination is not the same as source"
     local _prefix_dir="$(abs_path "$dest_prefix")"
     if [ "$_src_dir" = "$_dest_prefix" -a "${CFG_UNINSTALL-}" != 1 ]; then
-	err "cannot install to same directory as installer"
+    err "cannot install to same directory as installer"
     fi
 }
 
@@ -857,8 +857,8 @@ src_basename="$(basename "$0")"
 # which just means 'uninstall my components'.
 if [ "$src_basename" = "uninstall.sh" ]; then
     if [ "${*:-}" != "" ]; then
-	# Currently don't know what to do with arguments in this mode
-	err "uninstall.sh does not take any arguments"
+    # Currently don't know what to do with arguments in this mode
+    err "uninstall.sh does not take any arguments"
     fi
     CFG_UNINSTALL=1
     CFG_DESTDIR_PREFIX="$(abs_path "$src_dir/../../")"
@@ -885,7 +885,7 @@ if [ -n "${CFG_LIST_COMPONENTS-}" ]; then
     echo "# Available components"
     echo
     for component in $components; do
-	echo "* $component"
+    echo "* $component"
     done
     echo
     exit 0
@@ -897,15 +897,15 @@ if [ -n "$CFG_COMPONENTS" ]; then
     # Remove commas
     user_components="$(echo "$CFG_COMPONENTS" | sed "s/,/ /g")"
     for user_component in $user_components; do
-	found=false
-	for my_component in $components; do
-	    if [ "$user_component" = "$my_component" ]; then
-		found=true
-	    fi
-	done
-	if [ "$found" = false ]; then
-	    err "unknown component: $user_component"
-	fi
+    found=false
+    for my_component in $components; do
+        if [ "$user_component" = "$my_component" ]; then
+        found=true
+        fi
+    done
+    if [ "$found" = false ]; then
+        err "unknown component: $user_component"
+    fi
     done
     components="$user_components"
 fi
@@ -937,9 +937,9 @@ fi
 
 if [ -z "$components" ]; then
     if [ -z "${CFG_UNINSTALL-}" ]; then
-	err "no components selected for installation"
+    err "no components selected for installation"
     else
-	err "no components selected for uninstallation"
+    err "no components selected for uninstallation"
     fi
 fi
 

--- a/src/tools/rust-installer/install-template.sh
+++ b/src/tools/rust-installer/install-template.sh
@@ -468,7 +468,8 @@ uninstall_components() {
             verbose_msg "removing component manifest $_component_manifest"
             run rm "$_component_manifest"
             # This is a hard error because the installation is unrecoverable
-            critical_need_ok "failed to remove installed manifest for component '$_installed_component'"
+            local _err_cant_r_manifest="failed to remove installed manifest for component"
+            critical_need_ok "$_err_cant_r_manifest '$_installed_component'"
 
             # Update the installed component list
             local _modified_components="$(sed "/^$_installed_component\$/d" "$_md/components")"
@@ -692,7 +693,9 @@ maybe_configure_ld() {
     fi
     if [ $? -ne 0 ]
     then
-            warn "failed to run ldconfig. this may happen when not installing as root. run with --verbose to see the error"
+            local _warn_s="failed to run ldconfig. this may happen when \
+not installing as root. run with --verbose to see the error"
+            warn "$_warn_s"
     fi
     fi
 }
@@ -977,7 +980,9 @@ make_dir_recursive "$abs_libdir/$TEMPLATE_REL_MANIFEST_DIR"
 need_ok "failed to create $TEMPLATE_REL_MANIFEST_DIR"
 
 # Drop the version number into the manifest dir
-write_to_file "$TEMPLATE_RUST_INSTALLER_VERSION" "$abs_libdir/$TEMPLATE_REL_MANIFEST_DIR/rust-installer-version"
+write_to_file "$TEMPLATE_RUST_INSTALLER_VERSION" \
+"$abs_libdir/$TEMPLATE_REL_MANIFEST_DIR/rust-installer-version"
+
 critical_need_ok "failed to write installer version"
 
 # Install the uninstaller
@@ -992,5 +997,3 @@ maybe_configure_ld "$abs_libdir"
 echo
 echo "    $TEMPLATE_SUCCESS_MESSAGE"
 echo
-
-

--- a/src/tools/rust-installer/src/generator.rs
+++ b/src/tools/rust-installer/src/generator.rs
@@ -86,12 +86,8 @@ impl Generator {
 
         // Write the installer version (only used by combine-installers.sh)
         let version = package_dir.join("rust-installer-version");
-        writeln!(
-            create_new_file(version)?,
-            "{}",
-            crate::RUST_INSTALLER_VERSION
-        )
-        .context("failed to write new installer version")?;
+        writeln!(create_new_file(version)?, "{}", crate::RUST_INSTALLER_VERSION)
+            .context("failed to write new installer version")?;
 
         // Copy the overlay
         if !self.non_installed_overlay.is_empty() {
@@ -128,33 +124,19 @@ impl Generator {
 /// Copies the `src` directory recursively to `dst`, writing `manifest.in` too.
 fn copy_and_manifest(src: &Path, dst: &Path, bulk_dirs: &str) -> Result<()> {
     let mut manifest = create_new_file(dst.join("manifest.in"))?;
-    let bulk_dirs: Vec<_> = bulk_dirs
-        .split(',')
-        .filter(|s| !s.is_empty())
-        .map(Path::new)
-        .collect();
+    let bulk_dirs: Vec<_> = bulk_dirs.split(',').filter(|s| !s.is_empty()).map(Path::new).collect();
 
     let mut paths = BTreeSet::new();
     copy_with_callback(src, dst, |path, file_type| {
         // We need paths to be compatible with both Unix and Windows.
-        if path
-            .components()
-            .filter_map(|c| c.as_os_str().to_str())
-            .any(|s| s.contains('\\'))
-        {
-            bail!(
-                "rust-installer doesn't support '\\' in path components: {:?}",
-                path
-            );
+        if path.components().filter_map(|c| c.as_os_str().to_str()).any(|s| s.contains('\\')) {
+            bail!("rust-installer doesn't support '\\' in path components: {:?}", path);
         }
 
         // Normalize to Unix-style path separators.
         let normalized_string;
         let mut string = path.to_str().ok_or_else(|| {
-            format_err!(
-                "rust-installer doesn't support non-Unicode paths: {:?}",
-                path
-            )
+            format_err!("rust-installer doesn't support non-Unicode paths: {:?}", path)
         })?;
         if string.contains('\\') {
             normalized_string = string.replace('\\', "/");

--- a/src/tools/rust-installer/src/main.rs
+++ b/src/tools/rust-installer/src/main.rs
@@ -19,8 +19,12 @@ fn main() -> Result<()> {
     let command_line = CommandLine::parse();
     match command_line.command {
         Subcommand::Combine(combiner) => combiner.run().context("failed to combine installers")?,
-        Subcommand::Generate(generator) => generator.run().context("failed to generate installer")?,
-        Subcommand::Script(scripter) => scripter.run().context("failed to generate installation script")?,
+        Subcommand::Generate(generator) => {
+            generator.run().context("failed to generate installer")?
+        }
+        Subcommand::Script(scripter) => {
+            scripter.run().context("failed to generate installation script")?
+        }
         Subcommand::Tarball(tarballer) => tarballer.run().context("failed to generate tarballs")?,
     }
     Ok(())

--- a/src/tools/rust-installer/src/scripter.rs
+++ b/src/tools/rust-installer/src/scripter.rs
@@ -33,11 +33,11 @@ impl Scripter {
     /// Generates the actual installer script
     pub fn run(self) -> Result<()> {
         // Replace dashes in the success message with spaces (our arg handling botches spaces)
-        // TODO: still needed? Kept for compatibility for now.
+        // FIXME: still needed? Kept for compatibility for now.
         let product_name = self.product_name.replace('-', " ");
 
         // Replace dashes in the success message with spaces (our arg handling botches spaces)
-        // TODO: still needed? Kept for compatibility for now.
+        // FIXME: still needed? Kept for compatibility for now.
         let success_message = self.success_message.replace('-', " ");
 
         let script = TEMPLATE

--- a/src/tools/rust-installer/src/scripter.rs
+++ b/src/tools/rust-installer/src/scripter.rs
@@ -44,10 +44,7 @@ impl Scripter {
             .replace("%%TEMPLATE_PRODUCT_NAME%%", &sh_quote(&product_name))
             .replace("%%TEMPLATE_REL_MANIFEST_DIR%%", &self.rel_manifest_dir)
             .replace("%%TEMPLATE_SUCCESS_MESSAGE%%", &sh_quote(&success_message))
-            .replace(
-                "%%TEMPLATE_LEGACY_MANIFEST_DIRS%%",
-                &sh_quote(&self.legacy_manifest_dirs),
-            )
+            .replace("%%TEMPLATE_LEGACY_MANIFEST_DIRS%%", &sh_quote(&self.legacy_manifest_dirs))
             .replace(
                 "%%TEMPLATE_RUST_INSTALLER_VERSION%%",
                 &sh_quote(&crate::RUST_INSTALLER_VERSION),

--- a/src/tools/rust-installer/src/scripter.rs
+++ b/src/tools/rust-installer/src/scripter.rs
@@ -32,7 +32,7 @@ actor! {
 impl Scripter {
     /// Generates the actual installer script
     pub fn run(self) -> Result<()> {
-        // Replace dashes in the success message with spaces (our arg handling botches spaces)
+        // Replace dashes in the product name with spaces (our arg handling botches spaces)
         // FIXME: still needed? Kept for compatibility for now.
         let product_name = self.product_name.replace('-', " ");
 

--- a/src/tools/rust-installer/src/tarballer.rs
+++ b/src/tools/rust-installer/src/tarballer.rs
@@ -58,10 +58,7 @@ impl Tarballer {
         let buf = BufWriter::with_capacity(1024 * 1024, encoder);
         let mut builder = Builder::new(buf);
 
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(2)
-            .build()
-            .unwrap();
+        let pool = rayon::ThreadPoolBuilder::new().num_threads(2).build().unwrap();
         pool.install(move || {
             for path in dirs {
                 let src = Path::new(&self.work_dir).join(&path);
@@ -122,11 +119,7 @@ where
     let name = name.as_ref();
 
     if !name.is_relative() && !name.starts_with(root) {
-        bail!(
-            "input '{}' is not in work dir '{}'",
-            name.display(),
-            root.display()
-        );
+        bail!("input '{}' is not in work dir '{}'", name.display(), root.display());
     }
 
     let mut dirs = vec![];

--- a/src/tools/rust-installer/src/util.rs
+++ b/src/tools/rust-installer/src/util.rs
@@ -15,8 +15,7 @@ use std::os::windows::fs::symlink_file;
 
 /// Converts a `&Path` to a UTF-8 `&str`.
 pub fn path_to_str(path: &Path) -> Result<&str> {
-    path.to_str()
-        .ok_or_else(|| format_err!("path is not valid UTF-8 '{}'", path.display()))
+    path.to_str().ok_or_else(|| format_err!("path is not valid UTF-8 '{}'", path.display()))
 }
 
 /// Wraps `fs::copy` with a nicer error message.
@@ -27,11 +26,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<u64> {
         Ok(0)
     } else {
         let amt = fs::copy(&from, &to).with_context(|| {
-            format!(
-                "failed to copy '{}' to '{}'",
-                from.as_ref().display(),
-                to.as_ref().display()
-            )
+            format!("failed to copy '{}' to '{}'", from.as_ref().display(), to.as_ref().display())
         })?;
         Ok(amt)
     }
@@ -123,8 +118,12 @@ where
 }
 
 macro_rules! actor_field_default {
-    () => { Default::default() };
-    (= $expr:expr) => { $expr.into() }
+    () => {
+        Default::default()
+    };
+    (= $expr:expr) => {
+        $expr.into()
+    };
 }
 
 /// Creates an "actor" with default values, setters for all fields, and Clap parser support.

--- a/src/tools/rust-installer/test.sh
+++ b/src/tools/rust-installer/test.sh
@@ -458,7 +458,8 @@ uninstall_from_installed_script_with_args_fails() {
     --output-dir="$OUT_DIR/c1" \
     --component-name=rustc
     try "$WORK_DIR/c1/package/install.sh" --prefix="$PREFIX_DIR"
-    expect_output_fail "uninstall.sh does not take any arguments" sh "$PREFIX_DIR/lib/packagelib/uninstall.sh" --prefix=foo
+    expect_output_fail "uninstall.sh does not take any arguments" \
+    sh "$PREFIX_DIR/lib/packagelib/uninstall.sh" --prefix=foo
 }
 runtest uninstall_from_installed_script_with_args_fails
 
@@ -680,7 +681,8 @@ select_components_to_install() {
     try test -e "$PREFIX_DIR/bin/program"
     try test -e "$PREFIX_DIR/bin/cargo"
     try test ! -e "$PREFIX_DIR/baz"
-    try "$WORK_DIR/rust/install.sh --uninstall" --prefix="$PREFIX_DIR" --components=rustc,cargo,rust-docs
+    try "$WORK_DIR/rust/install.sh --uninstall" --prefix="$PREFIX_DIR" \
+    --components=rustc,cargo,rust-docs
     try test ! -e "$PREFIX_DIR/bin/program"
     try test ! -e "$PREFIX_DIR/bin/cargo"
     try test ! -e "$PREFIX_DIR/baz"
@@ -733,7 +735,8 @@ select_components_to_uninstall() {
     try test ! -e "$PREFIX_DIR/bin/cargo"
     try test -e "$PREFIX_DIR/baz"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR"
-    try "$WORK_DIR/rust/install.sh --uninstall" --prefix="$PREFIX_DIR" --components=rustc,cargo,rust-docs
+    try "$WORK_DIR/rust/install.sh --uninstall" --prefix="$PREFIX_DIR" \
+    --components=rustc,cargo,rust-docs
     try test ! -e "$PREFIX_DIR/bin/program"
     try test ! -e "$PREFIX_DIR/bin/cargo"
     try test ! -e "$PREFIX_DIR/baz"
@@ -765,7 +768,8 @@ invalid_component() {
     --output-dir="$OUT_DIR" \
     --package-name=rust \
     --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
-    expect_output_fail "unknown component" "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" --components=foo
+    expect_output_fail "unknown component" "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" \
+    --components=foo
 }
 runtest invalid_component
 

--- a/src/tools/rust-installer/test.sh
+++ b/src/tools/rust-installer/test.sh
@@ -27,7 +27,7 @@ PREFIX_DIR="$TMP_DIR/prefix"
 case $(uname -s) in
 
     MINGW* | MSYS*)
-	WINDOWS=1
+    WINDOWS=1
         ;;
 esac
 
@@ -48,10 +48,10 @@ pre() {
 need_ok() {
     if [ $? -ne 0 ]
     then
-	echo
-	echo "TEST FAILED!"
-	echo
-	exit 1
+    echo
+    echo "TEST FAILED!"
+    echo
+    exit 1
     fi
 }
 
@@ -69,20 +69,20 @@ try() {
     _cmd="$@"
     _output=`$@ 2>&1`
     if [ $? -ne 0 ]; then
-	echo \$ "$_cmd"
-	# Using /bin/echo to avoid escaping
-	$ECHO "$_output"
-	echo
-	echo "TEST FAILED!"
-	echo
-	exit 1
+    echo \$ "$_cmd"
+    # Using /bin/echo to avoid escaping
+    $ECHO "$_output"
+    echo
+    echo "TEST FAILED!"
+    echo
+    exit 1
     else
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
-	    echo \$ "$_cmd"
-	fi
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
-	    $ECHO "$_output"
-	fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
+        echo \$ "$_cmd"
+    fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
+        $ECHO "$_output"
+    fi
     fi
     set -e
 }
@@ -92,20 +92,20 @@ expect_fail() {
     _cmd="$@"
     _output=`$@ 2>&1`
     if [ $? -eq 0 ]; then
-	echo \$ "$_cmd"
-	# Using /bin/echo to avoid escaping
-	$ECHO "$_output"
-	echo
-	echo "TEST FAILED!"
-	echo
-	exit 1
+    echo \$ "$_cmd"
+    # Using /bin/echo to avoid escaping
+    $ECHO "$_output"
+    echo
+    echo "TEST FAILED!"
+    echo
+    exit 1
     else
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
-	    echo \$ "$_cmd"
-	fi
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
-	    $ECHO "$_output"
-	fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
+        echo \$ "$_cmd"
+    fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
+        $ECHO "$_output"
+    fi
     fi
     set -e
 }
@@ -117,30 +117,30 @@ expect_output_ok() {
     _cmd="$@"
     _output=`$@ 2>&1`
     if [ $? -ne 0 ]; then
-	echo \$ "$_cmd"
-	# Using /bin/echo to avoid escaping
-	$ECHO "$_output"
-	echo
-	echo "TEST FAILED!"
-	echo
-	exit 1
+    echo \$ "$_cmd"
+    # Using /bin/echo to avoid escaping
+    $ECHO "$_output"
+    echo
+    echo "TEST FAILED!"
+    echo
+    exit 1
     elif ! echo "$_output" | grep -q "$_expected"; then
-	echo \$ "$_cmd"
-	$ECHO "$_output"
-	echo
-	echo "missing expected output '$_expected'"
-	echo
-	echo
-	echo "TEST FAILED!"
-	echo
-	exit 1
+    echo \$ "$_cmd"
+    $ECHO "$_output"
+    echo
+    echo "missing expected output '$_expected'"
+    echo
+    echo
+    echo "TEST FAILED!"
+    echo
+    exit 1
     else
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
-	    echo \$ "$_cmd"
-	fi
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
-	    $ECHO "$_output"
-	fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
+        echo \$ "$_cmd"
+    fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
+        $ECHO "$_output"
+    fi
     fi
     set -e
 }
@@ -152,30 +152,30 @@ expect_output_fail() {
     _cmd="$@"
     _output=`$@ 2>&1`
     if [ $? -eq 0 ]; then
-	echo \$ "$_cmd"
-	# Using /bin/echo to avoid escaping
-	$ECHO "$_output"
-	echo
-	echo "TEST FAILED!"
-	echo
-	exit 1
+    echo \$ "$_cmd"
+    # Using /bin/echo to avoid escaping
+    $ECHO "$_output"
+    echo
+    echo "TEST FAILED!"
+    echo
+    exit 1
     elif ! echo "$_output" | grep -q "$_expected"; then
-	echo \$ "$_cmd"
-	$ECHO "$_output"
-	echo
-	echo "missing expected output '$_expected'"
-	echo
-	echo
-	echo "TEST FAILED!"
-	echo
-	exit 1
+    echo \$ "$_cmd"
+    $ECHO "$_output"
+    echo
+    echo "missing expected output '$_expected'"
+    echo
+    echo
+    echo "TEST FAILED!"
+    echo
+    exit 1
     else
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
-	    echo \$ "$_cmd"
-	fi
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
-	    $ECHO "$_output"
-	fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
+        echo \$ "$_cmd"
+    fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
+        $ECHO "$_output"
+    fi
     fi
     set -e
 }
@@ -187,30 +187,30 @@ expect_not_output_ok() {
     _cmd="$@"
     _output=`$@ 2>&1`
     if [ $? -ne 0 ]; then
-	echo \$ "$_cmd"
-	# Using /bin/echo to avoid escaping
-	$ECHO "$_output"
-	echo
-	echo "TEST FAILED!"
-	echo
-	exit 1
+    echo \$ "$_cmd"
+    # Using /bin/echo to avoid escaping
+    $ECHO "$_output"
+    echo
+    echo "TEST FAILED!"
+    echo
+    exit 1
     elif echo "$_output" | grep -q "$_expected"; then
-	echo \$ "$_cmd"
-	$ECHO "$_output"
-	echo
-	echo "unexpected output '$_expected'"
-	echo
-	echo
-	echo "TEST FAILED!"
-	echo
-	exit 1
+    echo \$ "$_cmd"
+    $ECHO "$_output"
+    echo
+    echo "unexpected output '$_expected'"
+    echo
+    echo
+    echo "TEST FAILED!"
+    echo
+    exit 1
     else
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
-	    echo \$ "$_cmd"
-	fi
-	if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
-	    $ECHO "$_output"
-	fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_CMD-}" ]; then
+        echo \$ "$_cmd"
+    fi
+    if [ -n "${VERBOSE-}" -o -n "${VERBOSE_OUTPUT-}" ]; then
+        $ECHO "$_output"
+    fi
     fi
     set -e
 }
@@ -218,9 +218,9 @@ expect_not_output_ok() {
 runtest() {
     local _testname="$1"
     if [ -n "${TESTNAME-}" ]; then
-	if ! echo "$_testname" | grep -q "$TESTNAME"; then
-	    return 0
-	fi
+    if ! echo "$_testname" | grep -q "$TESTNAME"; then
+        return 0
+    fi
     fi
 
     pre "$_testname"
@@ -231,9 +231,9 @@ runtest() {
 
 basic_install() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR"
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/something-to-install"
     try test -e "$PREFIX_DIR/dir-to-install/foo"
@@ -245,9 +245,9 @@ runtest basic_install
 
 basic_uninstall() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR"
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
     try "$WORK_DIR/package/install.sh --uninstall" --prefix="$PREFIX_DIR"
     try test ! -e "$PREFIX_DIR/something-to-install"
@@ -263,10 +263,10 @@ not_installed_files() {
     mkdir -p "$WORK_DIR/overlay"
     touch "$WORK_DIR/overlay/not-installed"
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--non-installed-overlay="$WORK_DIR/overlay"
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --non-installed-overlay="$WORK_DIR/overlay"
     try test -e "$WORK_DIR/package/not-installed"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
     try test ! -e "$PREFIX_DIR/not-installed"
@@ -275,10 +275,10 @@ runtest not_installed_files
 
 tarball_with_package_name() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc-nightly
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc-nightly
     try "$WORK_DIR/rustc-nightly/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$OUT_DIR/rustc-nightly.tar.gz"
     try test -e "$OUT_DIR/rustc-nightly.tar.xz"
@@ -287,9 +287,9 @@ runtest tarball_with_package_name
 
 install_overwrite_backup() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR"
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR"
     try mkdir -p "$PREFIX_DIR/bin"
     touch "$PREFIX_DIR/bin/program"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
@@ -300,10 +300,10 @@ runtest install_overwrite_backup
 
 bulk_directory() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--bulk-dirs=dir-to-install
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --bulk-dirs=dir-to-install
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/something-to-install"
     try test -e "$PREFIX_DIR/dir-to-install/foo"
@@ -317,10 +317,10 @@ runtest bulk_directory
 
 bulk_directory_overwrite() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--bulk-dirs=dir-to-install
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --bulk-dirs=dir-to-install
     try mkdir -p "$PREFIX_DIR/dir-to-install"
     try touch "$PREFIX_DIR/dir-to-install/overwrite"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
@@ -333,10 +333,10 @@ runtest bulk_directory_overwrite
 
 bulk_directory_overwrite_existing_backup() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--bulk-dirs=dir-to-install
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --bulk-dirs=dir-to-install
     try mkdir -p "$PREFIX_DIR/dir-to-install"
     try touch "$PREFIX_DIR/dir-to-install/overwrite"
     # This time we've already got an existing backup of the overwritten directory.
@@ -351,10 +351,10 @@ runtest bulk_directory_overwrite_existing_backup
 
 nested_bulk_directory() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--bulk-dirs=dir-to-install/qux
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --bulk-dirs=dir-to-install/qux
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/dir-to-install/qux/bar"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR" --uninstall
@@ -364,10 +364,10 @@ runtest nested_bulk_directory
 
 only_bulk_directory_no_files() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image5" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--bulk-dirs=dir-to-install
+    --image-dir="$TEST_DIR/image5" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --bulk-dirs=dir-to-install
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/dir-to-install/foo"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR" --uninstall
@@ -379,10 +379,10 @@ nested_not_installed_files() {
     mkdir -p "$WORK_DIR/overlay"
     touch "$WORK_DIR/overlay/not-installed"
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--non-installed-overlay="$WORK_DIR/overlay"
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --non-installed-overlay="$WORK_DIR/overlay"
     try test -e "$WORK_DIR/package/not-installed"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
     try test ! -e "$PREFIX_DIR/not-installed"
@@ -391,15 +391,15 @@ runtest nested_not_installed_files
 
 multiple_components() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR/c1" \
-	--output-dir="$OUT_DIR/c1" \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR/c1" \
+    --output-dir="$OUT_DIR/c1" \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR/c2" \
-	--output-dir="$OUT_DIR/c2" \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR/c2" \
+    --output-dir="$OUT_DIR/c2" \
+    --component-name=cargo
     try "$WORK_DIR/c1/package/install.sh" --prefix="$PREFIX_DIR"
     try "$WORK_DIR/c2/package/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/something-to-install"
@@ -422,15 +422,15 @@ runtest multiple_components
 
 uninstall_from_installed_script() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR/c1" \
-	--output-dir="$OUT_DIR/c1" \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR/c1" \
+    --output-dir="$OUT_DIR/c1" \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR/c2" \
-	--output-dir="$OUT_DIR/c2" \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR/c2" \
+    --output-dir="$OUT_DIR/c2" \
+    --component-name=cargo
     try "$WORK_DIR/c1/package/install.sh" --prefix="$PREFIX_DIR"
     try "$WORK_DIR/c2/package/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/something-to-install"
@@ -453,10 +453,10 @@ runtest uninstall_from_installed_script
 
 uninstall_from_installed_script_with_args_fails() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR/c1" \
-	--output-dir="$OUT_DIR/c1" \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR/c1" \
+    --output-dir="$OUT_DIR/c1" \
+    --component-name=rustc
     try "$WORK_DIR/c1/package/install.sh" --prefix="$PREFIX_DIR"
     expect_output_fail "uninstall.sh does not take any arguments" sh "$PREFIX_DIR/lib/packagelib/uninstall.sh" --prefix=foo
 }
@@ -466,22 +466,22 @@ runtest uninstall_from_installed_script_with_args_fails
 
 combine_installers() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/something-to-install"
     try test -e "$PREFIX_DIR/dir-to-install/foo"
@@ -502,28 +502,28 @@ runtest combine_installers
 
 combine_three_installers() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/something-to-install"
     try test -e "$PREFIX_DIR/dir-to-install/foo"
@@ -546,25 +546,25 @@ runtest combine_three_installers
 
 combine_installers_with_overlay() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     mkdir -p "$WORK_DIR/overlay"
     touch "$WORK_DIR/overlay/README"
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz" \
-	--non-installed-overlay="$WORK_DIR/overlay"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz" \
+    --non-installed-overlay="$WORK_DIR/overlay"
     try test -e "$WORK_DIR/rust/README"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR"
     try test ! -e "$PREFIX_DIR/README"
@@ -573,23 +573,23 @@ runtest combine_installers_with_overlay
 
 combined_with_bulk_dirs() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc \
-	--bulk-dirs=dir-to-install
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc \
+    --bulk-dirs=dir-to-install
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/dir-to-install/foo"
     try "$WORK_DIR/rust/install.sh --uninstall" --prefix="$PREFIX_DIR"
@@ -599,25 +599,25 @@ runtest combined_with_bulk_dirs
 
 combine_install_with_separate_uninstall() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc \
-	--rel-manifest-dir=rustlib
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc \
+    --rel-manifest-dir=rustlib
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo \
-	--rel-manifest-dir=rustlib
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo \
+    --rel-manifest-dir=rustlib
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz" \
-	--rel-manifest-dir=rustlib
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz" \
+    --rel-manifest-dir=rustlib
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/something-to-install"
     try test -e "$PREFIX_DIR/dir-to-install/foo"
@@ -639,28 +639,28 @@ runtest combine_install_with_separate_uninstall
 
 select_components_to_install() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" --components=rustc
     try test -e "$PREFIX_DIR/bin/program"
     try test ! -e "$PREFIX_DIR/bin/cargo"
@@ -690,28 +690,28 @@ runtest select_components_to_install
 
 select_components_to_uninstall() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR"
     try "$WORK_DIR/rust/install.sh --uninstall" --prefix="$PREFIX_DIR" --components=rustc
     try test ! -e "$PREFIX_DIR/bin/program"
@@ -743,56 +743,56 @@ runtest select_components_to_uninstall
 
 invalid_component() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     expect_output_fail "unknown component" "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" --components=foo
 }
 runtest invalid_component
 
 without_components() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" --without=rust-docs
     try test -e "$PREFIX_DIR/bin/program"
     try test -e "$PREFIX_DIR/bin/cargo"
@@ -815,28 +815,28 @@ runtest without_components
 # --without causes components to remain installed
 uninstall_without_components() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR"
     try "$WORK_DIR/rust/install.sh --uninstall" --prefix="$PREFIX_DIR" --without=rust-docs
     try test ! -e "$PREFIX_DIR/bin/program"
@@ -857,88 +857,88 @@ runtest uninstall_without_components
 
 without_any_components() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     expect_output_fail "no components selected for installation" \
-	"$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" --without=rust-docs,rustc,cargo
+    "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" --without=rust-docs,rustc,cargo
 }
 runtest without_any_components
 
 uninstall_without_any_components() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR"
     expect_output_fail "no components selected for uninstallation" \
-	"$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" \
-	--uninstall --without=rust-docs,rustc,cargo
+    "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" \
+    --uninstall --without=rust-docs,rustc,cargo
 }
 runtest uninstall_without_any_components
 
 list_components() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     expect_output_ok "rustc" "$WORK_DIR/rust/install.sh" --list-components
     expect_output_ok "cargo" "$WORK_DIR/rust/install.sh" --list-components
     expect_output_ok "rust-docs" "$WORK_DIR/rust/install.sh" --list-components
@@ -947,32 +947,32 @@ runtest list_components
 
 combined_remains() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rustc \
-	--component-name=rustc
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rustc \
+    --component-name=rustc
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image3" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=cargo \
-	--component-name=cargo
+    --image-dir="$TEST_DIR/image3" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=cargo \
+    --component-name=cargo
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image4" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust-docs \
-	--component-name=rust-docs
+    --image-dir="$TEST_DIR/image4" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust-docs \
+    --component-name=rust-docs
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
     for component in rustc cargo rust-docs; do
-	# rustbuild wants the original extracted package intact too
-	try test -d "$WORK_DIR/$component/$component"
-	try test -d "$WORK_DIR/rust/$component"
+    # rustbuild wants the original extracted package intact too
+    try test -d "$WORK_DIR/$component/$component"
+    try test -d "$WORK_DIR/rust/$component"
     done
 }
 runtest combined_remains
@@ -982,34 +982,34 @@ runtest combined_remains
 cannot_write_error() {
     # chmod doesn't work on windows
     if [ ! -n "${WINDOWS-}" ]; then
-	try sh "$S/gen-installer.sh" \
-	    --image-dir="$TEST_DIR/image1" \
-	    --work-dir="$WORK_DIR" \
-	    --output-dir="$OUT_DIR"
-	chmod u-w "$PREFIX_DIR"
-	expect_fail "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
-	chmod u+w "$PREFIX_DIR"
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image1" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR"
+    chmod u-w "$PREFIX_DIR"
+    expect_fail "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
+    chmod u+w "$PREFIX_DIR"
     fi
 }
 runtest cannot_write_error
 
 cannot_install_to_installer() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=my-package
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=my-package
     expect_output_fail "cannot install to same directory as installer" \
-	"$WORK_DIR/my-package/install.sh" --prefix="$WORK_DIR/my-package"
+    "$WORK_DIR/my-package/install.sh" --prefix="$WORK_DIR/my-package"
 }
 runtest cannot_install_to_installer
 
 upgrade_from_future_installer_error() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--rel-manifest-dir=rustlib
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --rel-manifest-dir=rustlib
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
     echo 100 > "$PREFIX_DIR/lib/rustlib/rust-installer-version"
     expect_fail "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
@@ -1018,9 +1018,9 @@ runtest upgrade_from_future_installer_error
 
 destdir() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR"
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR"
     try "$WORK_DIR/package/install.sh" --destdir="$PREFIX_DIR/" --prefix=prefix
     try test -e "$PREFIX_DIR/prefix/bin/program"
 }
@@ -1028,9 +1028,9 @@ runtest destdir
 
 destdir_no_trailing_slash() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR"
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR"
     try "$WORK_DIR/package/install.sh" --destdir="$PREFIX_DIR" --prefix=prefix
     try test -e "$PREFIX_DIR/prefix/bin/program"
 }
@@ -1055,7 +1055,7 @@ create_log() {
     try test -e "$PREFIX_DIR/lib/packagelib/install.log"
     local _log="$(cat "$PREFIX_DIR/lib/packagelib/install.log")"
     if [ -z "$_log" ]; then
-	fail "log is empty"
+    fail "log is empty"
     fi
 }
 runtest create_log
@@ -1063,24 +1063,24 @@ runtest create_log
 leave_log_after_failure() {
     # chmod doesn't work on windows
     if [ ! -n "${WINDOWS-}" ]; then
-	try sh "$S/gen-installer.sh" \
-	    --image-dir="$TEST_DIR/image1" \
-	    --work-dir="$WORK_DIR" \
-	    --output-dir="$OUT_DIR"
-	mkdir -p "$PREFIX_DIR/lib/packagelib"
-	touch "$PREFIX_DIR/lib/packagelib/components"
-	chmod u-w "$PREFIX_DIR/lib/packagelib/components"
-	expect_fail "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
-	chmod u+w "$PREFIX_DIR/lib/packagelib/components"
-	try test -e "$PREFIX_DIR/lib/packagelib/install.log"
-	local _log="$(cat "$PREFIX_DIR/lib/packagelib/install.log")"
-	if [ -z "$_log" ]; then
-	    fail "log is empty"
-	fi
-	# script should tell user where the logs are
-	if ! grep -q "see logs at" "$PREFIX_DIR/lib/packagelib/install.log"; then
-	    fail "missing log message"
-	fi
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image1" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR"
+    mkdir -p "$PREFIX_DIR/lib/packagelib"
+    touch "$PREFIX_DIR/lib/packagelib/components"
+    chmod u-w "$PREFIX_DIR/lib/packagelib/components"
+    expect_fail "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
+    chmod u+w "$PREFIX_DIR/lib/packagelib/components"
+    try test -e "$PREFIX_DIR/lib/packagelib/install.log"
+    local _log="$(cat "$PREFIX_DIR/lib/packagelib/install.log")"
+    if [ -z "$_log" ]; then
+        fail "log is empty"
+    fi
+    # script should tell user where the logs are
+    if ! grep -q "see logs at" "$PREFIX_DIR/lib/packagelib/install.log"; then
+        fail "missing log message"
+    fi
     fi
 }
 runtest leave_log_after_failure
@@ -1088,9 +1088,9 @@ runtest leave_log_after_failure
 # https://github.com/rust-lang/rust-installer/issues/22
 help() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR"
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR"
     try "$WORK_DIR/package/install.sh" --help
 }
 runtest help
@@ -1098,9 +1098,9 @@ runtest help
 # https://github.com/rust-lang/rust-installer/issues/31
 CDPATH_does_not_destroy_things() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR"
+    --image-dir="$TEST_DIR/image1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR"
     cd "$WORK_DIR" || exit 1
     export CDPATH="../$(basename $WORK_DIR)/foo"
     try sh "package/install.sh" --prefix="$PREFIX_DIR"
@@ -1115,9 +1115,9 @@ runtest CDPATH_does_not_destroy_things
 
 docdir_default() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image-docdir1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR"
+    --image-dir="$TEST_DIR/image-docdir1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$PREFIX_DIR/share/doc/rust/README"
     try test -e "$PREFIX_DIR/share/doc/rust/rustdocs.txt"
@@ -1126,9 +1126,9 @@ runtest docdir_default
 
 docdir() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image-docdir1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR"
+    --image-dir="$TEST_DIR/image-docdir1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR"
     try mkdir "$WORK_DIR/docdir"
     try "$WORK_DIR/package/install.sh" --prefix="$PREFIX_DIR" --docdir="$WORK_DIR/docdir"
     try test -e "$WORK_DIR/docdir/README"
@@ -1138,22 +1138,22 @@ runtest docdir
 
 docdir_combined() {
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image-docdir1" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
+    --image-dir="$TEST_DIR/image-docdir1" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
         --package-name="rustc" \
         --component-name="rustc"
     try sh "$S/gen-installer.sh" \
-	--image-dir="$TEST_DIR/image-docdir2" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
+    --image-dir="$TEST_DIR/image-docdir2" \
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
         --package-name="cargo" \
         --component-name="cargo"
     try sh "$S/combine-installers.sh" \
-	--work-dir="$WORK_DIR" \
-	--output-dir="$OUT_DIR" \
-	--package-name=rust \
-	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz"
+    --work-dir="$WORK_DIR" \
+    --output-dir="$OUT_DIR" \
+    --package-name=rust \
+    --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz"
     try mkdir "$WORK_DIR/docdir"
     try "$WORK_DIR/rust/install.sh" --prefix="$PREFIX_DIR" --docdir="$WORK_DIR/docdir"
     try test -e "$WORK_DIR/docdir/README"

--- a/src/tools/tidy/src/walk.rs
+++ b/src/tools/tidy/src/walk.rs
@@ -4,6 +4,8 @@ use std::{ffi::OsStr, fs::File, io::Read, path::Path};
 
 /// The default directory filter.
 pub fn filter_dirs(path: &Path) -> bool {
+    // FIXME: sync submodule exclusion list with rustfmt.toml
+    // bootstrap/etc
     let skip = [
         "tidy-test-file",
         "compiler/rustc_codegen_cranelift",
@@ -15,9 +17,7 @@ pub fn filter_dirs(path: &Path) -> bool {
         "src/tools/cargo",
         "src/tools/clippy",
         "src/tools/miri",
-        "src/tools/rls",
         "src/tools/rust-analyzer",
-        "src/tools/rust-installer",
         "src/tools/rustfmt",
         "src/doc/book",
         "src/doc/edition-guide",


### PR DESCRIPTION
<strike>based on #112884</strike>

`rust-installer` and `rls` no longer submodules, but not removed from exclude list for rustfmt and tidy, preventing running fmt and lints on them.