### PR TITLE
Fix test for #96258

### DIFF
--- a/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.rs
+++ b/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.rs
@@ -1,4 +1,4 @@
-// compile-flags -Wrust-2021-incompatible-closure-captures
+#![warn(rust_2021_incompatible_closure_captures)]
 
 fn main() {}
 
@@ -9,7 +9,7 @@ impl Numberer {
     //~^ ERROR `async fn` is not permitted in Rust 2015
         interval: Duration,
         //~^ ERROR cannot find type `Duration` in this scope
-    ) -> Numberer {
+    ) -> Numberer { //~WARN: changes to closure capture in Rust 2021
         Numberer {}
     }
 }

--- a/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.stderr
+++ b/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.stderr
@@ -18,7 +18,32 @@ help: consider importing this struct
 LL + use std::time::Duration;
    |
 
-error: aborting due to 2 previous errors
+warning: changes to closure capture in Rust 2021 will affect drop order
+  --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.rs:12:19
+   |
+LL |           interval: Duration,
+   |           -------- in Rust 2018, this causes the closure to capture `interval`, but in Rust 2021, it has no effect
+LL |
+LL |       ) -> Numberer {
+   |  _________________-_^
+   | |                 |
+   | |                 in Rust 2018, `interval` is dropped here along with the closure, but in Rust 2021 `interval` is not part of the closure
+LL | |         Numberer {}
+LL | |     }
+   | |_____^
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+note: the lint level is defined here
+  --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.rs:1:9
+   |
+LL | #![warn(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: add a dummy let to cause `interval` to be fully captured
+   |
+LL |     ) -> Numberer { let _ = &interval;
+   |                     ++++++++++++++++++
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0412, E0670.
 For more information about an error, try `rustc --explain E0412`.


### PR DESCRIPTION
#98644 did not properly test enabling the problematic lint as a warning due to improper use of `compile-flags:` (missing `:`). This makes it use `#![warn]` instead, like in the reproducer.

cc #96258