### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -1,6 +1,7 @@
 use super::eval_queries::{mk_eval_cx, op_to_const};
 use super::machine::CompileTimeEvalContext;
 use super::{ValTreeCreationError, ValTreeCreationResult, VALTREE_MAX_NODES};
+use crate::const_eval::CanAccessStatics;
 use crate::interpret::{
     intern_const_alloc_recursive, ConstValue, ImmTy, Immediate, InternKind, MemPlaceMeta,
     MemoryKind, PlaceTy, Scalar,
@@ -263,7 +264,11 @@ pub fn valtree_to_const_value<'tcx>(
     // FIXME Does this need an example?
 
     let (param_env, ty) = param_env_ty.into_parts();
-    let mut ecx = mk_eval_cx(tcx, DUMMY_SP, param_env, false);
+    let mut ecx: crate::interpret::InterpCx<
+        '_,
+        '_,
+        crate::const_eval::CompileTimeInterpreter<'_, '_>,
+    > = mk_eval_cx(tcx, DUMMY_SP, param_env, CanAccessStatics::No);
 
     match ty.kind() {
         ty::FnDef(..) => {

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -2,7 +2,7 @@ use rustc_middle::ty::layout::{LayoutCx, LayoutError, LayoutOf, TyAndLayout, Val
 use rustc_middle::ty::{ParamEnv, ParamEnvAnd, Ty, TyCtxt};
 use rustc_target::abi::{Abi, FieldsShape, Scalar, Variants};
 
-use crate::const_eval::{CheckAlignment, CompileTimeInterpreter};
+use crate::const_eval::{CanAccessStatics, CheckAlignment, CompileTimeInterpreter};
 use crate::interpret::{InterpCx, MemoryKind, OpTy};
 
 /// Determines if this type permits "raw" initialization by just transmuting some memory into an
@@ -44,8 +44,7 @@ fn might_permit_raw_init_strict<'tcx>(
     tcx: TyCtxt<'tcx>,
     kind: ValidityRequirement,
 ) -> Result<bool, LayoutError<'tcx>> {
-    let machine =
-        CompileTimeInterpreter::new(/*can_access_statics:*/ false, CheckAlignment::Error);
+    let machine = CompileTimeInterpreter::new(CanAccessStatics::No, CheckAlignment::Error);
 
     let mut cx = InterpCx::new(tcx, rustc_span::DUMMY_SP, ParamEnv::reveal_all(), machine);
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-96699.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-96699.rs
@@ -1,0 +1,87 @@
+// check-pass
+
+#![allow(dead_code, incomplete_features)]
+#![feature(generic_const_exprs)]
+
+const fn min(a: usize, b: usize) -> usize {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+
+trait Trait1<Inner1>
+where
+    Self: Sized,
+{
+    fn crash_here()
+    where
+        Inner1: Default,
+    {
+        Inner1::default();
+    }
+}
+
+struct Struct1<T>(T);
+impl<T> Trait1<T> for Struct1<T> {}
+
+trait Trait2<Inner2>
+where
+    Self: Sized,
+{
+    type Assoc: Trait1<Inner2>;
+
+    fn call_crash()
+    where
+        Inner2: Default,
+    {
+        // if Inner2 implements Default, we can call crash_here.
+        Self::Assoc::crash_here();
+    }
+}
+
+struct Struct2<const SIZE1: usize, const SIZE2: usize> {}
+/*
+where
+    [(); min(SIZE1, SIZE2)]:,
+{
+    elem: [i32; min(SIZE1, SIZE2)],
+}
+*/
+
+impl<const SIZE1: usize, const SIZE2: usize> Trait2<[i32; min(SIZE1, SIZE2)]>
+    for Struct2<SIZE1, SIZE2>
+{
+    type Assoc = Struct1<[i32; min(SIZE1, SIZE2)]>;
+    // dose Struct1<[i32; min(SIZE1, SIZE2)]> implement Default?
+}
+
+fn main() {
+    pattern2();
+
+    print_fully_name(<Struct2<1, 2> as Trait2<[i32; min(1, 2)]>>::Assoc::crash_here);
+    // <compiler_bug2::Struct1<[i32; 1]> as compiler_bug2::Trait1<[i32; 1]>>::crash_here
+}
+
+fn pattern1() {
+    // no crash
+    <Struct2<1, 2> as Trait2<[i32; min(1, 2)]>>::Assoc::crash_here();
+    <Struct2<1, 2> as Trait2<[i32; min(1, 2)]>>::call_crash();
+}
+
+fn pattern2() {
+    // crash
+    <Struct2<1, 2> as Trait2<[i32; min(1, 2)]>>::call_crash();
+
+    // undefined reference to `compiler_bug2::Trait1::crash_here'
+}
+
+fn pattern3() {
+    // no crash
+    <Struct2<1, 2> as Trait2<[i32; min(1, 2)]>>::Assoc::crash_here();
+}
+
+fn print_fully_name<T>(_: T) {
+    let _ = std::any::type_name::<T>();
+}

--- a/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.rs
+++ b/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.rs
@@ -1,4 +1,4 @@
-// compile-flags -Wrust-2021-incompatible-closure-captures
+#![warn(rust_2021_incompatible_closure_captures)]
 
 fn main() {}
 
@@ -9,7 +9,7 @@ impl Numberer {
     //~^ ERROR `async fn` is not permitted in Rust 2015
         interval: Duration,
         //~^ ERROR cannot find type `Duration` in this scope
-    ) -> Numberer {
+    ) -> Numberer { //~WARN: changes to closure capture in Rust 2021
         Numberer {}
     }
 }

--- a/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.stderr
+++ b/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.stderr
@@ -18,7 +18,32 @@ help: consider importing this struct
 LL + use std::time::Duration;
    |
 
-error: aborting due to 2 previous errors
+warning: changes to closure capture in Rust 2021 will affect drop order
+  --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.rs:12:19
+   |
+LL |           interval: Duration,
+   |           -------- in Rust 2018, this causes the closure to capture `interval`, but in Rust 2021, it has no effect
+LL |
+LL |       ) -> Numberer {
+   |  _________________-_^
+   | |                 |
+   | |                 in Rust 2018, `interval` is dropped here along with the closure, but in Rust 2021 `interval` is not part of the closure
+LL | |         Numberer {}
+LL | |     }
+   | |_____^
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+note: the lint level is defined here
+  --> $DIR/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.rs:1:9
+   |
+LL | #![warn(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: add a dummy let to cause `interval` to be fully captured
+   |
+LL |     ) -> Numberer { let _ = &interval;
+   |                     ++++++++++++++++++
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0412, E0670.
 For more information about an error, try `rustc --explain E0412`.


### PR DESCRIPTION
Successful merges:

 - #112918 (display PID of process holding lock)
 - #112990 (Add a regression test for #96699)
 - #113011 (Add enum for `can_access_statics` boolean)
 - #113018 (Fix test for #96258)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112918,112990,113011,113018)
<!-- homu-ignore:end -->