### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -393,8 +393,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // They can denote both statically and dynamically-sized byte arrays.
         let mut pat_ty = ty;
         if let hir::ExprKind::Lit(Spanned { node: ast::LitKind::ByteStr(..), .. }) = lt.kind {
-            if let ty::Ref(_, inner_ty, _) = *self.structurally_resolved_type(span, expected).kind()
-                && self.structurally_resolved_type(span, inner_ty).is_slice()
+            let expected = self.structurally_resolved_type(span, expected);
+            if let ty::Ref(_, inner_ty, _) = expected.kind()
+                && matches!(inner_ty.kind(), ty::Slice(_))
             {
                 let tcx = self.tcx;
                 trace!(?lt.hir_id.local_id, "polymorphic byte string lit");

--- a/tests/rustdoc-gui/docblock-code-block-line-number.goml
+++ b/tests/rustdoc-gui/docblock-code-block-line-number.goml
@@ -37,15 +37,15 @@ define-function: (
 )
 call-function: ("check-colors", {
     "theme": "ayu",
-    "color": "rgb(92, 103, 115)",
+    "color": "#5c6773",
 })
 call-function: ("check-colors", {
     "theme": "dark",
-    "color": "rgb(59, 145, 226)",
+    "color": "#3b91e2",
 })
 call-function: ("check-colors", {
     "theme": "light",
-    "color": "rgb(198, 126, 45)",
+    "color": "#c67e2d",
 })
 
 // The first code block has two lines so let's check its `<pre>` elements lists both of them.

--- a/tests/ui/pattern/byte-string-inference.rs
+++ b/tests/ui/pattern/byte-string-inference.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+fn load<L>() -> Option<L> {
+    todo!()
+}
+
+fn main() {
+    while let Some(tag) = load() {
+        match &tag {
+            b"NAME" => {}
+            b"DATA" => {}
+            _ => {}
+        }
+    }
+}

--- a/tests/ui/traits/new-solver/slice-match-byte-lit.rs
+++ b/tests/ui/traits/new-solver/slice-match-byte-lit.rs
@@ -1,5 +1,5 @@
 // compile-flags: -Ztrait-solver=next
-// check-pass
+// known-bug: rust-lang/trait-system-refactor-initiative#38
 
 fn test(s: &[u8]) {
     match &s[0..3] {

--- a/tests/ui/traits/new-solver/slice-match-byte-lit.stderr
+++ b/tests/ui/traits/new-solver/slice-match-byte-lit.stderr
@@ -1,0 +1,11 @@
+error[E0271]: type mismatch resolving `[u8; 3] <: <Range<usize> as SliceIndex<[u8]>>::Output`
+  --> $DIR/slice-match-byte-lit.rs:6:9
+   |
+LL |     match &s[0..3] {
+   |           -------- this expression has type `&<std::ops::Range<usize> as SliceIndex<[u8]>>::Output`
+LL |         b"uwu" => {}
+   |         ^^^^^^ types differ
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
Successful merges:

 - #113007 (Revert "Structurally resolve correctly in check_pat_lit")
 - #113023 (Migrate GUI colors test to original CSS color format)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113007,113023)
<!-- homu-ignore:end -->