### PR TITLE
rustdoc: handle assoc const equalities in cross-crate APIT

### DIFF
--- a/tests/rustdoc/inline_cross/assoc-const-equality.rs
+++ b/tests/rustdoc/inline_cross/assoc-const-equality.rs
@@ -1,0 +1,8 @@
+// aux-crate:assoc_const_equality=assoc-const-equality.rs
+// edition:2021
+
+#![crate_name = "user"]
+
+// @has user/fn.accept.html
+// @has - '//pre[@class="rust item-decl"]' 'fn accept(_: impl Trait<K = 0>)'
+pub use assoc_const_equality::accept;

--- a/tests/rustdoc/inline_cross/auxiliary/assoc-const-equality.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/assoc-const-equality.rs
@@ -1,0 +1,7 @@
+#![feature(associated_const_equality)]
+
+pub fn accept(_: impl Trait<K = 0>) {}
+
+pub trait Trait {
+    const K: i32;
+}


### PR DESCRIPTION
Fixes FIXME (the added test previously lead to an ICE).

@rustbot label A-cross-crate-reexports