### PR TITLE
CI: do not run Bump dependencies workflow on forks

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   not-waiting-on-bors:
+    if: github.repository_owner == 'rust-lang'
     name: skip if S-waiting-on-bors
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +44,7 @@ jobs:
           fi
 
   update:
+    if: github.repository_owner == 'rust-lang'
     name: update dependencies
     needs: not-waiting-on-bors
     runs-on: ubuntu-latest
@@ -76,6 +78,7 @@ jobs:
           retention-days: 1
 
   pr:
+    if: github.repository_owner == 'rust-lang'
     name: amend PR
     needs: update
     runs-on: ubuntu-latest


### PR DESCRIPTION
I haven't found a prettier way of doing this. We can possibly only use the condition on the `pr` job (to just disallow the creation of the PR), or only on the `not-waiting-on-bors` step, as if it doesn't run, the following job (probably) also shouldn't run.

Fixes: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/.22Weekly.20cargo.20update.22.20on.20forks

r? @Mark-Simulacrum