### PR TITLE
[wip] ship rustc debuginfo on linux

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -526,6 +526,13 @@ changelog-seen = 2
 # producing a `.pdb` file.
 #split-debuginfo = if linux { off } else if windows { packed } else if apple { unpacked }
 
+# Should debuginfo be separated into additional .debug files in x dist.
+# This does not use split dwarf but objcopy. If this is enabled, all debuginfo
+# is stripped from the normal files. Also enables the .note.gnu.build-id section
+# to be generated for integration with debuginfo tooling.
+# Linux only.
+#separate-debuginfo = false
+
 # Whether or not `panic!`s generate backtraces (RUST_BACKTRACE)
 #backtrace = true
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1372,6 +1372,11 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Zunstable-options");
         }
 
+        if self.config.rust_separate_debuginfo && mode == Mode::Rustc {
+            // Embed a build-id in the binary to enable integration with debuginfo tooling.
+            rustflags.arg("-Clink-arg=-Wl,--build-id");
+        }
+
         // Enable cfg checking of cargo features for everything but std and also enable cfg
         // checking of names and values.
         //

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -215,6 +215,7 @@ pub struct Config {
     pub rust_debuginfo_level_tools: DebuginfoLevel,
     pub rust_debuginfo_level_tests: DebuginfoLevel,
     pub rust_split_debuginfo: SplitDebuginfo,
+    pub rust_separate_debuginfo: bool,
     pub rust_rpath: bool,
     pub rustc_parallel: bool,
     pub rustc_default_linker: Option<String>,
@@ -900,6 +901,7 @@ define_config! {
         debuginfo_level_tools: Option<DebuginfoLevel> = "debuginfo-level-tools",
         debuginfo_level_tests: Option<DebuginfoLevel> = "debuginfo-level-tests",
         split_debuginfo: Option<String> = "split-debuginfo",
+        separate_debuginfo: Option<bool> = "separate-debuginfo",
         run_dsymutil: Option<bool> = "run-dsymutil",
         backtrace: Option<bool> = "backtrace",
         incremental: Option<bool> = "incremental",
@@ -1299,6 +1301,7 @@ impl Config {
                 .map(SplitDebuginfo::from_str)
                 .map(|v| v.expect("invalid value for rust.split_debuginfo"))
                 .unwrap_or(SplitDebuginfo::default_for_platform(&config.build.triple));
+            config.rust_separate_debuginfo = rust.separate_debuginfo.unwrap_or(false);
             optimize = rust.optimize;
             omit_git_hash = rust.omit_git_hash;
             config.rust_new_symbol_mangling = rust.new_symbol_mangling;

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -431,7 +431,7 @@ impl Step for Rustc {
                 for entry in builder.read_dir(&libdir) {
                     let name = entry.file_name();
                     if let Some(s) = name.to_str() {
-                        if is_dylib(s) {
+                        if is_dylib(s) || s.ends_with(".debug") {
                             // Don't use custom libdir here because ^lib/ will be resolved again
                             // with installer
                             builder.install(&entry.path(), &image.join("lib"), 0o644);

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -62,7 +62,7 @@ pub fn is_dylib(name: &str) -> bool {
 /// Returns `true` if the file name given looks like a debug info file
 pub fn is_debug_info(name: &str) -> bool {
     // FIXME: consider split debug info on other platforms (e.g., Linux, macOS)
-    name.ends_with(".pdb")
+    name.ends_with(".pdb") || name.ends_with(".debug")
 }
 
 /// Returns the corresponding relative library directory that the compiler's

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -80,7 +80,9 @@ ENV RUST_CONFIGURE_ARGS \
       --set llvm.ninja=false \
       --set rust.jemalloc \
       --set rust.use-lld=true \
-      --set rust.lto=thin
+      --set rust.lto=thin \
+      --set rust.separate-debuginfo=true \
+      --set rust.debuginfo-level=1
 ENV SCRIPT python3 ../src/ci/stage-build.py python3 ../x.py dist \
     --host $HOSTS --target $HOSTS \
     --include-default-paths \


### PR DESCRIPTION
we now have a `librustc_driver.debug` ELF in the sysroot (not a separate component yet)

i haven't quite figured out how to best consume this downstream, mostly putting this up so i can play more with it

r? @ghost