### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   not-waiting-on-bors:
+    if: github.repository_owner == 'rust-lang'
     name: skip if S-waiting-on-bors
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +44,7 @@ jobs:
           fi
 
   update:
+    if: github.repository_owner == 'rust-lang'
     name: update dependencies
     needs: not-waiting-on-bors
     runs-on: ubuntu-latest
@@ -76,6 +78,7 @@ jobs:
           retention-days: 1
 
   pr:
+    if: github.repository_owner == 'rust-lang'
     name: amend PR
     needs: update
     runs-on: ubuntu-latest

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1046,6 +1046,8 @@ def bootstrap(args):
     if not using_default_path or os.path.exists(toml_path):
         with open(toml_path) as config:
             config_toml = config.read()
+    else:
+        config_toml = ''
 
     profile = RustBuild.get_toml_static(config_toml, 'profile')
     if profile is not None:

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -132,6 +132,7 @@ class BuildBootstrap(unittest.TestCase):
         parsed = bootstrap.parse_args(args)
         build = serialize_and_parse(configure_args, parsed)
         build.build_dir = os.environ["BUILD_DIR"]
+        build.build = os.environ["BUILD_PLATFORM"]
         return build.build_bootstrap_cmd(env), env
 
     def test_cargoflags(self):

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -15,6 +15,23 @@ from shutil import rmtree
 import bootstrap
 import configure
 
+def serialize_and_parse(args):
+    from io import StringIO
+
+    section_order, sections, targets = configure.parse_args(args)
+    buffer = StringIO()
+    configure.write_config_toml(buffer, section_order, targets, sections)
+    build = bootstrap.RustBuild()
+    build.config_toml = buffer.getvalue()
+
+    try:
+        import tomllib
+        # Verify this is actually valid TOML.
+        tomllib.loads(build.config_toml)
+    except ImportError:
+        print("warning: skipping TOML validation, need at least python 3.11", file=sys.stderr)
+    return build
+
 
 class VerifyTestCase(unittest.TestCase):
     """Test Case for verify"""
@@ -79,46 +96,57 @@ class ProgramOutOfDate(unittest.TestCase):
 
 class GenerateAndParseConfig(unittest.TestCase):
     """Test that we can serialize and deserialize a config.toml file"""
-    def serialize_and_parse(self, args):
-        from io import StringIO
-
-        section_order, sections, targets = configure.parse_args(args)
-        buffer = StringIO()
-        configure.write_config_toml(buffer, section_order, targets, sections)
-        build = bootstrap.RustBuild()
-        build.config_toml = buffer.getvalue()
-
-        try:
-            import tomllib
-            # Verify this is actually valid TOML.
-            tomllib.loads(build.config_toml)
-        except ImportError:
-            print("warning: skipping TOML validation, need at least python 3.11", file=sys.stderr)
-        return build
-
     def test_no_args(self):
-        build = self.serialize_and_parse([])
+        build = serialize_and_parse([])
         self.assertEqual(build.get_toml("changelog-seen"), '2')
         self.assertEqual(build.get_toml("profile"), 'user')
         self.assertIsNone(build.get_toml("llvm.download-ci-llvm"))
 
     def test_set_section(self):
-        build = self.serialize_and_parse(["--set", "llvm.download-ci-llvm"])
+        build = serialize_and_parse(["--set", "llvm.download-ci-llvm"])
         self.assertEqual(build.get_toml("download-ci-llvm", section="llvm"), 'true')
 
     def test_set_target(self):
-        build = self.serialize_and_parse(["--set", "target.x86_64-unknown-linux-gnu.cc=gcc"])
+        build = serialize_and_parse(["--set", "target.x86_64-unknown-linux-gnu.cc=gcc"])
         self.assertEqual(build.get_toml("cc", section="target.x86_64-unknown-linux-gnu"), 'gcc')
 
     def test_set_top_level(self):
-        build = self.serialize_and_parse(["--set", "profile=compiler"])
+        build = serialize_and_parse(["--set", "profile=compiler"])
         self.assertEqual(build.get_toml("profile"), 'compiler')
 
     def test_set_codegen_backends(self):
-        build = self.serialize_and_parse(["--set", "rust.codegen-backends=cranelift"])
+        build = serialize_and_parse(["--set", "rust.codegen-backends=cranelift"])
         self.assertNotEqual(build.config_toml.find("codegen-backends = ['cranelift']"), -1)
-        build = self.serialize_and_parse(["--set", "rust.codegen-backends=cranelift,llvm"])
+        build = serialize_and_parse(["--set", "rust.codegen-backends=cranelift,llvm"])
         self.assertNotEqual(build.config_toml.find("codegen-backends = ['cranelift', 'llvm']"), -1)
-        build = self.serialize_and_parse(["--enable-full-tools"])
+        build = serialize_and_parse(["--enable-full-tools"])
         self.assertNotEqual(build.config_toml.find("codegen-backends = ['llvm']"), -1)
 
+
+class BuildBootstrap(unittest.TestCase):
+    """Test that we generate the appropriate arguments when building bootstrap"""
+
+    def build_args(self, configure_args=[], args=[], env={}):
+        env = env.copy()
+        env["PATH"] = os.environ["PATH"]
+
+        build = serialize_and_parse(configure_args)
+        build.build_dir = os.environ["BUILD_DIR"]
+        parsed = bootstrap.parse_args(args)
+        return build.build_bootstrap_cmd(env, parsed.color, parsed.warnings, parsed.verbose), env
+
+    def test_cargoflags(self):
+        args, _ = self.build_args(env={"CARGOFLAGS": "--timings"})
+        self.assertTrue("--timings" in args)
+
+    def test_warnings(self):
+        for toml_warnings in ['false', 'true', None]:
+            configure_args = []
+            if toml_warnings is not None:
+                configure_args = ["--set", "rust.deny-warnings=" + toml_warnings]
+
+            _, env = self.build_args(configure_args, args=["--warnings=warn"])
+            self.assertFalse("-Dwarnings" in env["RUSTFLAGS"])
+
+            _, env = self.build_args(configure_args, args=["--warnings=deny"])
+            self.assertTrue("-Dwarnings" in env["RUSTFLAGS"])

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -1,4 +1,6 @@
-"""Bootstrap tests"""
+"""Bootstrap tests
+
+Run these with `x test bootstrap`, or `python -m unittest bootstrap_test.py`."""
 
 from __future__ import absolute_import, division, print_function
 import os
@@ -120,15 +122,3 @@ class GenerateAndParseConfig(unittest.TestCase):
         build = self.serialize_and_parse(["--enable-full-tools"])
         self.assertNotEqual(build.config_toml.find("codegen-backends = ['llvm']"), -1)
 
-if __name__ == '__main__':
-    SUITE = unittest.TestSuite()
-    TEST_LOADER = unittest.TestLoader()
-    SUITE.addTest(doctest.DocTestSuite(bootstrap))
-    SUITE.addTests([
-        TEST_LOADER.loadTestsFromTestCase(VerifyTestCase),
-        TEST_LOADER.loadTestsFromTestCase(GenerateAndParseConfig),
-        TEST_LOADER.loadTestsFromTestCase(ProgramOutOfDate)])
-
-    RUNNER = unittest.TextTestRunner(stream=sys.stdout, verbosity=2)
-    result = RUNNER.run(SUITE)
-    sys.exit(0 if result.wasSuccessful() else 1)

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -280,7 +280,7 @@ def parse_args(args):
 
     config = {}
 
-    set('build.configure-args', sys.argv[1:], config)
+    set('build.configure-args', args, config)
     apply_args(known_args, option_checking, config)
     return parse_example_config(known_args, config)
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -400,7 +400,9 @@ def parse_example_config(known_args, config):
     targets = {}
     top_level_keys = []
 
-    for line in open(rust_dir + '/config.example.toml').read().split("\n"):
+    with open(rust_dir + '/config.example.toml') as example_config:
+        example_lines = example_config.read().split("\n")
+    for line in example_lines:
         if cur_section is None:
             if line.count('=') == 1:
                 top_level_key = line.split('=')[0]

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -2664,7 +2664,12 @@ impl Step for Bootstrap {
     /// Tests the build system itself.
     fn run(self, builder: &Builder<'_>) {
         let mut check_bootstrap = Command::new(&builder.python());
-        check_bootstrap.arg("bootstrap_test.py").current_dir(builder.src.join("src/bootstrap/"));
+        check_bootstrap
+            .arg("-m")
+            .arg("unittest")
+            .arg("bootstrap_test.py")
+            .current_dir(builder.src.join("src/bootstrap/"))
+            .args(builder.config.test_args());
         try_run(builder, &mut check_bootstrap).unwrap();
 
         let host = builder.config.build;

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -2665,9 +2665,8 @@ impl Step for Bootstrap {
     fn run(self, builder: &Builder<'_>) {
         let mut check_bootstrap = Command::new(&builder.python());
         check_bootstrap
-            .arg("-m")
-            .arg("unittest")
-            .arg("bootstrap_test.py")
+            .args(["-m", "unittest", "bootstrap_test.py"])
+            .env("BUILD_DIR", &builder.out)
             .current_dir(builder.src.join("src/bootstrap/"))
             .args(builder.config.test_args());
         try_run(builder, &mut check_bootstrap).unwrap();

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -2667,6 +2667,7 @@ impl Step for Bootstrap {
         check_bootstrap
             .args(["-m", "unittest", "bootstrap_test.py"])
             .env("BUILD_DIR", &builder.out)
+            .env("BUILD_PLATFORM", &builder.build.build.triple)
             .current_dir(builder.src.join("src/bootstrap/"))
             .args(builder.config.test_args());
         try_run(builder, &mut check_bootstrap).unwrap();

--- a/tests/rustdoc/inline_cross/assoc-const-equality.rs
+++ b/tests/rustdoc/inline_cross/assoc-const-equality.rs
@@ -1,0 +1,8 @@
+// aux-crate:assoc_const_equality=assoc-const-equality.rs
+// edition:2021
+
+#![crate_name = "user"]
+
+// @has user/fn.accept.html
+// @has - '//pre[@class="rust item-decl"]' 'fn accept(_: impl Trait<K = 0>)'
+pub use assoc_const_equality::accept;

--- a/tests/rustdoc/inline_cross/auxiliary/assoc-const-equality.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/assoc-const-equality.rs
@@ -1,0 +1,7 @@
+#![feature(associated_const_equality)]
+
+pub fn accept(_: impl Trait<K = 0>) {}
+
+pub trait Trait {
+    const K: i32;
+}


### PR DESCRIPTION
Successful merges:

 - #112281 (Test the cargo args generated by bootstrap.py)
 - #113028 (rustdoc: handle assoc const equalities in cross-crate impl-Trait-in-arg-pos)
 - #113029 (CI: do not run Bump dependencies workflow on forks)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112281,113028,113029)
<!-- homu-ignore:end -->