### PR TITLE
Compute more pointer comparisons in CTFE

### DIFF
--- a/tests/ui/consts/ptr_comparisons.stderr
+++ b/tests/ui/consts/ptr_comparisons.stderr
@@ -6,19 +6,19 @@ error[E0080]: evaluation of constant value failed
 note: inside `ptr::const_ptr::<impl *const usize>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `_`
-  --> $DIR/ptr_comparisons.rs:50:34
+  --> $DIR/ptr_comparisons.rs:65:34
    |
 LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ptr_comparisons.rs:53:33
+  --> $DIR/ptr_comparisons.rs:68:33
    |
 LL |     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereferencing pointer failed: alloc3 has size $WORD, so pointer to 1000 bytes starting at offset 0 is out-of-bounds
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ptr_comparisons.rs:57:27
+  --> $DIR/ptr_comparisons.rs:72:27
    |
 LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into raw bytes
@@ -27,7 +27,7 @@ LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) +
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ptr_comparisons.rs:61:27
+  --> $DIR/ptr_comparisons.rs:76:27
    |
 LL | const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into raw bytes


### PR DESCRIPTION
IIUC, pointers from the same allocation can be reliably compared by just looking at their offsets. This PR implements this in CTFE and therefore makes it possible to write e.g. pointer-based slice iterators by substituting the pointer comparisons with calls to `guaranteed_eq`. 

As the FIXMEs in the current code pointed out, function pointers and vtables do not have stable addresses, so the comparison still fails in those cases.

@rustbot label +A-const-eval