### PR TITLE
fix(parse): avoid panic when cfg wrapper by bracket under `capture-cfg` mode

### DIFF
--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -362,7 +362,10 @@ impl<'a> Parser<'a> {
             let start_pos = if has_outer_attrs { attrs.start_pos } else { start_pos };
             let new_tokens = vec![(FlatToken::AttrTarget(attr_data), Spacing::Alone)];
 
-            assert!(!self.break_last_token, "Should not have unglued last token with cfg attr");
+            if !(self.token.kind == TokenKind::Gt && self.unmatched_angle_bracket_count > 0) {
+                assert!(!self.break_last_token, "Should not have unglued last token with cfg attr");
+            }
+
             let range: Range<u32> = (start_pos.try_into().unwrap())..(end_pos.try_into().unwrap());
             self.capture_state.replace_ranges.push((range, new_tokens));
             self.capture_state.replace_ranges.extend(inner_attr_replace_ranges);

--- a/tests/ui/unpretty/unglued-token.rs
+++ b/tests/ui/unpretty/unglued-token.rs
@@ -1,0 +1,11 @@
+// check-pass
+// compile-flags: -Zunpretty=hir
+
+// https://github.com/rust-lang/rust/issues/87577
+
+#[derive(Debug)]
+struct S<#[cfg(feature = "alloc")] N: A<T>>;
+
+fn main() {
+    let s = S;
+}

--- a/tests/ui/unpretty/unglued-token.stdout
+++ b/tests/ui/unpretty/unglued-token.stdout
@@ -1,0 +1,17 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// check-pass
+// compile-flags: -Zunpretty=hir
+
+// https://github.com/rust-lang/rust/issues/87577
+
+struct S;
+#[automatically_derived]
+impl ::core::fmt::Debug for S {
+    fn fmt<'_, '_, '_>(self: &'_ Self, f: &'_ mut ::core::fmt::Formatter<>)
+        -> ::core::fmt::Result { ::core::fmt::Formatter::write_str(f, "S") }
+}
+
+fn main() { let s = S; }


### PR DESCRIPTION
Fixes #87577

The parser expected to encounter the `Token::Gt` but instead encountered `BinOp(shr)` when parsing `A<T>` during macro expand. As a result, the `self.token_cursor.break_last_token = true` in `break_and_eat` had been executed. This caused the parser to encounter `assert!(!self.token_cursor.break_last_token, xxx)` in `﻿collect_tokens_trailing_token` under `cpature-cfg` mode.

To prevent this issue, an extra restriction was added to the `assert` statement. By the way, I think the better solution may be to simply remove the `assert` altogether.