### PR TITLE
CI: do not cancel concurrent builds on the same branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ defaults:
   run:
     shell: bash
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}"
+  group: "${{ ((github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf') && github.sha) || github.ref }}"
   cancel-in-progress: true
 jobs:
   pr:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ defaults:
   run:
     shell: bash
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}"
   cancel-in-progress: true
 jobs:
   pr:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -299,9 +299,10 @@ defaults:
     shell: bash
 
 concurrency:
-  # For a given workflow, if we push to the same PR, cancel all previous builds on that PR.
-  # If the push is not attached to a PR, we will cancel all builds related to the same commit SHA.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  # For a given workflow, if we push to the same branch, cancel all previous builds on that branch.
+  # We add an exception for try builds (try branch) and unrolled rollup builds (try-perf), which
+  # are all triggered on the same branch, but which should be able to run concurrently.
+  group: ${{ ((github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf') && github.sha) || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -301,7 +301,7 @@ defaults:
 concurrency:
   # For a given workflow, if we push to the same PR, cancel all previous builds on that PR.
   # If the push is not attached to a PR, we will cancel all builds related to the same commit SHA.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Do not cancel concurrent builds on the same branch (outside of PRs).

Instead, only cancel them if the builds have the same commit SHA.

From the [documentation](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context):
> The commit SHA that triggered the workflow. The value of this commit SHA depends on the event that triggered the workflow. For more information, see "[Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)." For example, ffac537e6cbbf934b08745a378932722df287a53.

Fixes: https://github.com/rust-lang/rust/pull/112955#discussion_r1242273658

r? @pietroalbini