### PR TITLE
Add `ptr::read_move`

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -384,6 +384,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
             sym::unlikely => (0, vec![tcx.types.bool], tcx.types.bool),
 
             sym::read_via_copy => (1, vec![tcx.mk_imm_ptr(param(0))], param(0)),
+            sym::read_via_move => (1, vec![tcx.mk_imm_ptr(param(0))], param(0)),
             sym::write_via_move => (1, vec![tcx.mk_mut_ptr(param(0)), param(0)], tcx.mk_unit()),
 
             sym::discriminant_value => {

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -194,6 +194,35 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                             }
                         }
                     }
+                    sym::read_via_move => {
+                        let [arg] = args.as_slice() else {
+                            span_bug!(terminator.source_info.span, "Wrong number of arguments");
+                        };
+                        let derefed_place =
+                            if let Some(place) = arg.place() && let Some(local) = place.as_local() {
+                                tcx.mk_place_deref(local.into())
+                            } else {
+                                span_bug!(terminator.source_info.span, "Only passing a local is supported");
+                            };
+                        terminator.kind = match *target {
+                            None => {
+                                // No target means this read something uninhabited,
+                                // so it must be unreachable, and we don't need to
+                                // preserve the assignment either.
+                                TerminatorKind::Unreachable
+                            }
+                            Some(target) => {
+                                block.statements.push(Statement {
+                                    source_info: terminator.source_info,
+                                    kind: StatementKind::Assign(Box::new((
+                                        *destination,
+                                        Rvalue::Use(Operand::Move(derefed_place)),
+                                    ))),
+                                });
+                                TerminatorKind::Goto { target }
+                            }
+                        }
+                    }
                     sym::write_via_move => {
                         let target = target.unwrap();
                         let Ok([ptr, val]) = <[_; 2]>::try_from(std::mem::take(args)) else {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1182,6 +1182,7 @@ symbols! {
         read_struct,
         read_struct_field,
         read_via_copy,
+        read_via_move,
         readonly,
         realloc,
         reason,

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2272,6 +2272,15 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn read_via_copy<T>(ptr: *const T) -> T;
 
+    /// This is an implementation detail of [`crate::ptr::read_move`] and should
+    /// not be used anywhere else.
+    ///
+    /// This intrinsic can *only* be called where the pointer is a local without
+    /// projections (`read_via_move(ptr)`, not `read_via_move(*ptr)`) so that it
+    /// trivially obeys runtime-MIR rules about derefs in operands.
+    #[rustc_nounwind]
+    pub fn read_via_move<T>(ptr: *mut T) -> T;
+
     /// This is an implementation detail of [`crate::ptr::write`] and should
     /// not be used anywhere else.  See its comments for why this exists.
     ///

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2279,6 +2279,7 @@ extern "rust-intrinsic" {
     /// projections (`read_via_move(ptr)`, not `read_via_move(*ptr)`) so that it
     /// trivially obeys runtime-MIR rules about derefs in operands.
     #[rustc_nounwind]
+    #[cfg(not(bootstrap))]
     pub fn read_via_move<T>(ptr: *mut T) -> T;
 
     /// This is an implementation detail of [`crate::ptr::write`] and should

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1180,6 +1180,37 @@ pub const unsafe fn read<T>(src: *const T) -> T {
     }
 }
 
+/// Reads the value from `src` by moving it.
+///
+/// # Safety
+///
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `src` must be [valid] for reads.
+///
+/// * `src` must be properly aligned.
+///
+/// * `src` must point to a properly initialized value of type `T`.
+///
+/// * `src` must not be read or written while the return value exists.
+///
+/// Note that even if `T` has size `0`, the pointer must be non-null and properly aligned.
+///
+/// [valid]: self#safety
+#[inline]
+#[rustc_const_unstable(feature = "read_move", issue = "0")]
+#[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+pub const unsafe fn read_move<T>(src: *mut T) -> T {
+    // SAFETY: the caller must guarantee that `src` is valid for reads.
+    unsafe {
+        assert_unsafe_precondition!(
+            "ptr::read_move requires that the pointer argument is aligned and non-null",
+            [T](src: *mut T) => is_aligned_and_not_null(src)
+        );
+        crate::intrinsics::read_via_move(src)
+    }
+}
+
 /// Reads the value from `src` without moving it. This leaves the
 /// memory in `src` unchanged.
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1198,7 +1198,7 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 ///
 /// [valid]: self#safety
 #[inline]
-#[rustc_const_unstable(feature = "read_move", issue = "0")]
+#[rustc_const_unstable(feature = "read_move", issue = "none")]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 pub const unsafe fn read_move<T>(src: *mut T) -> T {
     // SAFETY: the caller must guarantee that `src` is valid for reads.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1200,6 +1200,7 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 #[inline]
 #[rustc_const_unstable(feature = "read_move", issue = "none")]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+#[cfg(not(bootstrap))]
 pub const unsafe fn read_move<T>(src: *mut T) -> T {
     // SAFETY: the caller must guarantee that `src` is valid for reads.
     unsafe {


### PR DESCRIPTION
Experimental support for reading from pointer by moving from it. It's necessary to allow compiler to reuse memory behind the "read" pointer. See this discussion for more context: https://internals.rust-lang.org/t/19038

This implementation mirrors `ptr::read`, but with the small change in the intrinsic implementation.