### PR TITLE
Create `implicit_transmute_types` lint

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -248,6 +248,9 @@ lint_identifier_uncommon_codepoints = identifier contains uncommon Unicode codep
 
 lint_ignored_unless_crate_specified = {$level}({$name}) is ignored unless specified at crate level
 
+lint_implicit_transmute_types = `transmute` called without explicit type parameters
+    .suggestion = consider specifying the types intended to be transmuted
+
 lint_improper_ctypes = `extern` {$desc} uses type `{$ty}`, which is not FFI-safe
     .label = not FFI-safe
     .note = the type is defined here

--- a/compiler/rustc_lint/src/implicit_transmute_types.rs
+++ b/compiler/rustc_lint/src/implicit_transmute_types.rs
@@ -1,0 +1,89 @@
+use crate::{context::LintContext, lints::ImplicitTransmuteTypesDiag, LateContext, LateLintPass};
+use rustc_hir::{self as hir, ExprKind};
+use rustc_span::symbol::sym;
+
+declare_lint! {
+    /// The `implicit_transmute_types` lint checks for calls to [`transmute`]
+    /// without explicit type parameters (i.e. without turbofish syntax).
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(implicit_transmute_types)]
+    ///
+    /// #[repr(transparent)]
+    /// struct CharWrapper {
+    ///     _inner: char,
+    /// }
+    ///
+    /// let wrapped = CharWrapper { _inner: 'a' };
+    /// let transmuted = unsafe { core::mem::transmute(wrapped) };
+    ///
+    /// // This is sound now, but if it gets changed in the future to
+    /// // something that expects a type other than `char`, the transmute
+    /// // would infer it returns that type, which is likely unsound.
+    /// // But because we have `deny(implicit_transmute_types)`, the
+    /// // compiler will force us to come back and reassess whenever
+    /// // the types change.
+    /// let _ = char::is_lowercase(transmuted);
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// In most cases Rust's type inference is helpful, however it can cause
+    /// problems with [`transmute`]. `transmute` is wildly unsafe
+    /// unless the types being transmuted are known to be compatible. As such,
+    /// a seemingly innocent change in something's type can end up making a
+    /// previously-valid `transmute` suddenly become unsound. Thus it is
+    /// good practice to always be explicit about the types you expect to be
+    /// transmuting between, so that the compiler will force you to
+    /// reexamine the `transmute` if either type changes.
+    ///
+    /// If you have decided that you *do* want the types to be inferred,
+    /// you can convey that explicitly:
+    ///
+    /// ```rust
+    /// # use std::mem::transmute;
+    /// # fn main() {
+    /// #     unsafe {
+    /// #         let foo: i32 = 123;
+    /// #         let _: u32 =
+    /// transmute::<_, _>(foo);
+    /// #     }
+    /// # }
+    /// ```
+    ///
+    /// This lint is `allow` by default because it triggers on a lot of
+    /// already-written existing code, including many instances in core
+    /// libraries.
+    ///
+    /// [`transmute`]: https://doc.rust-lang.org/core/mem/fn.transmute.html
+    IMPLICIT_TRANSMUTE_TYPES,
+    Allow,
+    "calling mem::transmute without explicit type parameters"
+}
+
+declare_lint_pass!(ImplicitTransmuteTypes => [IMPLICIT_TRANSMUTE_TYPES]);
+
+impl<'tcx> LateLintPass<'tcx> for ImplicitTransmuteTypes {
+    fn check_expr(&mut self, cx: &LateContext<'_>, e: &hir::Expr<'_>) {
+        if let ExprKind::Call(func, _) = &e.kind
+            && let ExprKind::Path(qpath) = &func.kind
+            && let Some(def_id) = cx.qpath_res(qpath, func.hir_id).opt_def_id()
+            && let Some(sym::transmute) = cx.tcx.get_diagnostic_name(def_id)
+            && let hir::QPath::Resolved(_, path) = qpath
+            && let Some(last_segment) = path.segments.last()
+            && let None = last_segment.args
+        {
+            let suggestion_span = qpath.span().with_lo(qpath.span().hi());
+
+            cx.emit_spanned_lint(
+                IMPLICIT_TRANSMUTE_TYPES,
+                e.span,
+                ImplicitTransmuteTypesDiag { suggestion: suggestion_span }
+            );
+        }
+    }
+}

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -60,6 +60,7 @@ mod errors;
 mod expect;
 mod for_loops_over_fallibles;
 pub mod hidden_unicode_codepoints;
+mod implicit_transmute_types;
 mod internal;
 mod invalid_from_utf8;
 mod late;
@@ -104,6 +105,7 @@ use drop_forget_useless::*;
 use enum_intrinsics_non_enums::EnumIntrinsicsNonEnums;
 use for_loops_over_fallibles::*;
 use hidden_unicode_codepoints::*;
+use implicit_transmute_types::ImplicitTransmuteTypes;
 use internal::*;
 use invalid_from_utf8::*;
 use let_underscore::*;
@@ -251,6 +253,7 @@ late_lint_methods!(
             OpaqueHiddenInferredBound: OpaqueHiddenInferredBound,
             MultipleSupertraitUpcastable: MultipleSupertraitUpcastable,
             MapUnitFn: MapUnitFn,
+            ImplicitTransmuteTypes: ImplicitTransmuteTypes,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -828,6 +828,14 @@ impl AddToDiagnostic for HiddenUnicodeCodepointsDiagSub {
     }
 }
 
+// implicit_transmute_types.rs
+#[derive(LintDiagnostic)]
+#[diag(lint_implicit_transmute_types)]
+pub struct ImplicitTransmuteTypesDiag {
+    #[suggestion(style = "verbose", code = "::<Src, Dst>", applicability = "has-placeholders")]
+    pub suggestion: Span,
+}
+
 // map_unit_fn.rs
 #[derive(LintDiagnostic)]
 #[diag(lint_map_unit_fn)]

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1147,6 +1147,13 @@ extern "rust-intrinsic" {
     /// may lead to unexpected and unstable compilation results. This makes `transmute` **incredibly
     /// unsafe**. `transmute` should be the absolute last resort.
     ///
+    /// It is suggested that you specify the `Src` and `Dst` types explicitly
+    /// (using turbofish syntax) so that if a change in surrounding code causes the types being
+    /// transmuted to change, then typechecking will fail and you will be directed to update
+    /// the specified types and reassess the soundness of the transmute between the new types.
+    /// You may wish to use `#![deny(implicit_transmute_types)]` and have the compiler enforce
+    /// this for you.
+    ///
     /// Transmuting pointers to integers in a `const` context is [undefined behavior][ub].
     /// Any attempt to use the resulting value for integer operations will abort const-evaluation.
     /// (And even outside `const`, such transmutation is touching on many unspecified aspects of the

--- a/tests/ui/lint/lint-implicit-transmute-types.rs
+++ b/tests/ui/lint/lint-implicit-transmute-types.rs
@@ -1,0 +1,15 @@
+// Test the implicit_transmute_types lint.
+
+#![deny(implicit_transmute_types)]
+
+use std::mem::transmute;
+
+fn main() {
+    unsafe {
+        let _: i32 = transmute(123u32);
+        //~^ ERROR: `transmute` called without explicit type parameters
+
+        let _: i32 = transmute::<u32, i32>(123u32);
+        let _: i32 = transmute::<_, _>(123u32);
+    }
+}

--- a/tests/ui/lint/lint-implicit-transmute-types.stderr
+++ b/tests/ui/lint/lint-implicit-transmute-types.stderr
@@ -1,0 +1,18 @@
+error: `transmute` called without explicit type parameters
+  --> $DIR/lint-implicit-transmute-types.rs:9:22
+   |
+LL |         let _: i32 = transmute(123u32);
+   |                      ^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-implicit-transmute-types.rs:3:9
+   |
+LL | #![deny(implicit_transmute_types)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider specifying the types intended to be transmuted
+   |
+LL |         let _: i32 = transmute::<Src, Dst>(123u32);
+   |                               ++++++++++++
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Type inference is useful in most cases, but it can cause issues around usage of transmute.
Even though a specific usage of transmute may have been confirmed to be sound, someone might
unintentionally change a piece of surrounding code that causes the transmuted types to
change and possibly become unsound. Despite that, `transmute()` will happily continue to infer these
changed types.

This commit adds a lint `implicit_transmute_types` that catches calls to transmute without
an explicit turbofish. The idea is that the initial author of code that uses a transmute will
verify the soundness of converting between the two types, and specify those types on the transmute
call. If the types end up changing later, typecheck will fail and force the transmute call to be
updated and remind the user to reassess the soundness of transmuting between the new types.

The lint is "allow" by default because it would trigger in lots of existing rust code, including
many cases in the core libraries. It may be beneficial to make it warn-by-default in the future
though.