### PR TITLE
rustdoc: Strikethrough deprecated items in sidebar

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -22,6 +22,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_hir::{BodyId, Mutability};
 use rustc_hir_analysis::check::intrinsic::intrinsic_operation_unsafety;
 use rustc_index::IndexVec;
+use rustc_middle::middle::stability;
 use rustc_middle::ty::fast_reject::SimplifiedType;
 use rustc_middle::ty::{self, TyCtxt, Visibility};
 use rustc_resolve::rustdoc::{add_doc_fragment, attrs_to_doc_fragments, inner_docs, DocFragment};
@@ -367,6 +368,13 @@ impl Item {
 
     pub(crate) fn deprecation(&self, tcx: TyCtxt<'_>) -> Option<Deprecation> {
         self.def_id().and_then(|did| tcx.lookup_deprecation(did))
+    }
+
+    pub(crate) fn is_deprecated(&self, tcx: TyCtxt<'_>) -> bool {
+        match self.deprecation(tcx) {
+            Some(depr) => stability::deprecation_in_effect(&depr),
+            None => false,
+        }
     }
 
     pub(crate) fn inner_docs(&self, tcx: TyCtxt<'_>) -> bool {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -466,7 +466,8 @@ function preLoadCss(cssUrl) {
             const ul = document.createElement("ul");
             ul.className = "block " + shortty;
 
-            for (const name of filtered) {
+            for (const entry of filtered) {
+                const name = entry.name;
                 let path;
                 if (shortty === "mod") {
                     path = name + "/index.html";
@@ -479,7 +480,13 @@ function preLoadCss(cssUrl) {
                 if (path === current_page) {
                     link.className = "current";
                 }
-                link.textContent = name;
+                if (entry.is_deprecated) {
+                    const s = document.createElement("s");
+                    s.textContent = name;
+                    link.appendChild(s);
+                } else {
+                    link.textContent = name;
+                }
                 const li = document.createElement("li");
                 li.appendChild(link);
                 ul.appendChild(li);

--- a/src/librustdoc/html/templates/sidebar.html
+++ b/src/librustdoc/html/templates/sidebar.html
@@ -23,7 +23,13 @@
                     {% if !block.links.is_empty() %}
                         <ul class="block">
                             {% for link in block.links %}
-                                <li><a href="#{{link.href|safe}}">{{link.name}}</a></li>
+                                <li><a href="#{{link.href|safe}}">
+                                {% if link.is_deprecated %}
+                                    <s>{{link.name}}</s>
+                                {% else %}
+                                    {{link.name}}
+                                {% endif %}
+                                </a></li>
                             {% endfor %}
                         </ul>
                     {% endif %}


### PR DESCRIPTION
Fixes #107568 by indicating deprecated items in the sidebar with strikethrough.

This is my first Rustdoc contribution, and I would appreciate guidance on how to write/where to add tests.

@rustbot label A-rustdoc-ui T-rustdoc