### PR TITLE
rustdoc: Reduce internal function visibility.

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1459,7 +1459,7 @@ impl clean::FnDecl {
         Ok(())
     }
 
-    pub(crate) fn print_output<'a, 'tcx: 'a>(
+    fn print_output<'a, 'tcx: 'a>(
         &'a self,
         cx: &'a Context<'tcx>,
     ) -> impl fmt::Display + 'a + Captures<'tcx> {


### PR DESCRIPTION
As suggested [here](https://github.com/rust-lang/rust/pull/112113/files/1862fcb1df05b116443ad3b27028616a180ffadb#r1211200570).