### PR TITLE
don't suggest `move` for borrows that aren't closures

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1730,18 +1730,19 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             (
                 Some(name),
                 BorrowExplanation::UsedLater(LaterUseKind::ClosureCapture, var_or_use_span, _),
-            ) => self.report_escaping_closure_capture(
-                borrow_spans,
-                borrow_span,
-                &RegionName {
-                    name: self.synthesize_region_name(),
-                    source: RegionNameSource::Static,
-                },
-                ConstraintCategory::CallArgument(None),
-                var_or_use_span,
-                &format!("`{}`", name),
-                "block",
-            ),
+            ) if borrow_spans.for_generator() || borrow_spans.for_closure() => self
+                .report_escaping_closure_capture(
+                    borrow_spans,
+                    borrow_span,
+                    &RegionName {
+                        name: self.synthesize_region_name(),
+                        source: RegionNameSource::Static,
+                    },
+                    ConstraintCategory::CallArgument(None),
+                    var_or_use_span,
+                    &format!("`{}`", name),
+                    "block",
+                ),
             (
                 Some(name),
                 BorrowExplanation::MustBeValidFor {
@@ -1754,7 +1755,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     span,
                     ..
                 },
-            ) if borrow_spans.for_generator() | borrow_spans.for_closure() => self
+            ) if borrow_spans.for_generator() || borrow_spans.for_closure() => self
                 .report_escaping_closure_capture(
                     borrow_spans,
                     borrow_span,

--- a/tests/ui/closures/issue-113087.rs
+++ b/tests/ui/closures/issue-113087.rs
@@ -1,0 +1,11 @@
+fn some_fn<'a>(_: &'a i32, _: impl FnOnce(&'a i32)) {}
+
+fn main() {
+    let some_closure = |_| {};
+
+    for a in [1] {
+        some_fn(&a, |c| { //~ ERROR does not live long enough
+            some_closure(c);
+        });
+    }
+}

--- a/tests/ui/closures/issue-113087.stderr
+++ b/tests/ui/closures/issue-113087.stderr
@@ -1,0 +1,16 @@
+error[E0597]: `a` does not live long enough
+  --> $DIR/issue-113087.rs:7:17
+   |
+LL |     for a in [1] {
+   |         - binding `a` declared here
+LL |         some_fn(&a, |c| {
+   |                 ^^ borrowed value does not live long enough
+LL |             some_closure(c);
+   |             ------------ borrow later captured here by closure
+LL |         });
+LL |     }
+   |     - `a` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/113087