### PR TITLE
style-guide: Add an example of formatting a multi-line attribute

### DIFF
--- a/src/doc/style-guide/src/README.md
+++ b/src/doc/style-guide/src/README.md
@@ -186,6 +186,11 @@ For attributes with argument lists, format like functions.
 ```rust
 #[repr(C)]
 #[foo(foo, bar)]
+#[long_multi_line_attribute(
+    split,
+    across,
+    lines,
+)]
 struct CRepr {
     #![repr(C)]
     x: f32,


### PR DESCRIPTION
We already say to format attributes like functions, but we didn't have
an example of formatting a multi-line attribute.
