### PR TITLE
tests: unset `RUSTC_LOG_COLOR` in a test

### DIFF
--- a/tests/ui/consts/const_in_pattern/issue-73431.rs
+++ b/tests/ui/consts/const_in_pattern/issue-73431.rs
@@ -1,4 +1,5 @@
 // run-pass
+// unset-rustc-env:RUSTC_LOG_COLOR
 
 // Regression test for https://github.com/rust-lang/rust/issues/73431.
 


### PR DESCRIPTION
Setting `RUSTC_LOG_COLOR=always` is sometimes useful if tools that one pipes `RUSTC_LOG` into support coloured output, but it makes this test fail because it has a `.stderr` file with `WARN` log output.