### PR TITLE
Encode item bounds for `DefKind::ImplTraitPlaceholder`

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1447,6 +1447,9 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     .is_type_alias_impl_trait
                     .set(def_id.index, self.tcx.is_type_alias_impl_trait(def_id));
             }
+            if let DefKind::ImplTraitPlaceholder = def_kind {
+                self.encode_explicit_item_bounds(def_id);
+            }
             if tcx.impl_method_has_trait_impl_trait_tys(def_id)
                 && let Ok(table) = self.tcx.collect_return_position_impl_trait_in_trait_tys(def_id)
             {

--- a/tests/ui/impl-trait/in-trait/foreign.rs
+++ b/tests/ui/impl-trait/in-trait/foreign.rs
@@ -14,6 +14,10 @@ impl Foo for Local {
     fn bar(self) -> Arc<String> { Arc::new(String::new()) }
 }
 
+fn generic(f: impl Foo) {
+    let x = &*f.bar();
+}
+
 fn main() {
     // Witness an RPITIT from another crate.
     let &() = Foreign.bar();


### PR DESCRIPTION
This was lost in a refactoring -- `hir::ItemKind::OpaqueTy` doesn't always map to `DefKind::Opaque`, specifically for RPITITs, so the check was migrated subtly wrong, and unfortunately I never had a test for this 🙃 

Fixes #113155

r? @cjgillot 