### PR TITLE
fix(resolve): skip assertion judgment when NonModule is dummy

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -370,7 +370,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
     /// expansion and import resolution (perhaps they can be merged in the future).
     /// The function is used for resolving initial segments of macro paths (e.g., `foo` in
     /// `foo::bar!();` or `foo!();`) and also for import paths on 2018 edition.
-    #[instrument(level = "debug", skip(self, scope_set))]
+    #[instrument(level = "debug", skip(self))]
     pub(crate) fn early_resolve_ident_in_lexical_scope(
         &mut self,
         orig_ident: Ident,

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -894,8 +894,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 }
                 return None;
             }
-            PathResult::NonModule(_) => {
-                if no_ambiguity {
+            PathResult::NonModule(partial_res) => {
+                if no_ambiguity && partial_res.full_res() != Some(Res::Err) {
+                    // Check if there are no ambiguities and the result is not dummy.
                     assert!(import.imported_module.get().is_none());
                 }
                 // The error was already reported earlier.

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -128,7 +128,7 @@ enum Scope<'a> {
 /// with different restrictions when looking up the resolution.
 /// This enum is currently used only for early resolution (imports and macros),
 /// but not for late resolution yet.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum ScopeSet<'a> {
     /// All scopes with the given namespace.
     All(Namespace),

--- a/tests/ui/imports/auxiliary/issue-85992-extern-1.rs
+++ b/tests/ui/imports/auxiliary/issue-85992-extern-1.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! m {
+   () => {
+        use issue_85992_extern_2::Outcome;
+   }
+}

--- a/tests/ui/imports/auxiliary/issue-85992-extern-2.rs
+++ b/tests/ui/imports/auxiliary/issue-85992-extern-2.rs
@@ -1,0 +1,1 @@
+// nothing

--- a/tests/ui/imports/issue-85992.rs
+++ b/tests/ui/imports/issue-85992.rs
@@ -1,0 +1,11 @@
+// edition: 2021
+// compile-flags: --extern issue_85992_extern_1 --extern issue_85992_extern_2
+// aux-build: issue-85992-extern-1.rs
+// aux-build: issue-85992-extern-2.rs
+
+issue_85992_extern_1::m!();
+
+use crate::issue_85992_extern_2;
+//~^ ERROR unresolved import `crate::issue_85992_extern_2`
+
+fn main() {}

--- a/tests/ui/imports/issue-85992.stderr
+++ b/tests/ui/imports/issue-85992.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `crate::issue_85992_extern_2`
+  --> $DIR/issue-85992.rs:8:5
+   |
+LL | use crate::issue_85992_extern_2;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `issue_85992_extern_2` in the root
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
Fixes #85992 

## Why #85992 panic

During `resolve_imports`, the `path_res` of the import `issue_85992_extern_2::Outcome` is pointing to `external::issue_85992_extern_2` instead of `crate::issue_85992_extern_2`. As a result `import.imported_module.set` had been executed.

Attached 1: the state of `early_resolve_ident_in_lexical_scope` during the `resolve_imports` for `use issue_85992_extern_2::Outcome` is as follows:

|iter in `visit_scopes`  | `scope` | `result.binding` |
| -    | -               | -                                                            |
| init | -               | -                                                            |
| 0    | `CrateRoot`     | Err(Determined)     | 
| 1    | `ExternPrelude` | pointing to the `issue_85992_extern_2`(external) | 

However, during finalization for `issue_85992_extern_2::Outcome`, the `innermost_result` was pointed to `crate::issue_85992_extern_2` and no ambiguity was generated, leading to a panic.

Attached 2: the state of `early_resolve_ident_in_lexical_scope` during the `finalize_import` for `use issue_85992_extern_2::Outcome` is as follows:

|iter in `visit_scopes`  | `scope` | `result.binding` | `innermost_result` |
| -    | -               | -                                                            | -                     |
| init | -               | -                                                            | `None`                | 
| 0    | `CrateRoot`     | pointing to `use crate::issue_85992_extern_2` **(introdcued by dummy)**    | same as `result` but with a `Some` wapper|
| 1    | `ExternPrelude` | pointing to the `issue_85992_extern_2`(external) | smae as above |


## Try to solve

Skip assertion judgment when `NonModule` is dummy

r? @petrochenkov 
