### PR TITLE
Properly implement variances_of for RPITIT GAT

### DIFF
--- a/tests/ui/impl-trait/in-trait/variances-of-gat.rs
+++ b/tests/ui/impl-trait/in-trait/variances-of-gat.rs
@@ -1,0 +1,19 @@
+// check-pass
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
+
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Foo {}
+
+impl Foo for () {}
+
+trait ThreeCellFragment {
+    fn ext_cells<'a>(&'a self) -> impl Foo + 'a {
+        self.ext_adjacent_cells()
+    }
+
+    fn ext_adjacent_cells<'a>(&'a self) -> impl Foo + 'a;
+}
+
+fn main() {}


### PR DESCRIPTION
This fixes some of the issues found by crater run in https://github.com/rust-lang/rust/pull/112988#issuecomment-1610019572

r? @compiler-errors