### PR TITLE
Only emit one error per unsized binding, instead of one per usage

### DIFF
--- a/tests/ui/sized/unsized-binding.rs
+++ b/tests/ui/sized/unsized-binding.rs
@@ -1,5 +1,5 @@
 fn main() {
     let x = *""; //~ ERROR E0277
-    println!("{}", x); //~ ERROR E0277
-    println!("{}", x); //~ ERROR E0277
+    println!("{}", x);
+    println!("{}", x);
 }

--- a/tests/ui/sized/unsized-binding.rs
+++ b/tests/ui/sized/unsized-binding.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let x = *""; //~ ERROR E0277
+    println!("{}", x); //~ ERROR E0277
+    println!("{}", x); //~ ERROR E0277
+}

--- a/tests/ui/sized/unsized-binding.stderr
+++ b/tests/ui/sized/unsized-binding.stderr
@@ -8,32 +8,6 @@ LL |     let x = *"";
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
 
-error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-binding.rs:3:20
-   |
-LL |     println!("{}", x);
-   |               --   ^ doesn't have a size known at compile-time
-   |               |
-   |               required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `str`
-note: required by a bound in `core::fmt::rt::Argument::<'a>::new_display`
-  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-binding.rs:4:20
-   |
-LL |     println!("{}", x);
-   |               --   ^ doesn't have a size known at compile-time
-   |               |
-   |               required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `str`
-note: required by a bound in `core::fmt::rt::Argument::<'a>::new_display`
-  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/sized/unsized-binding.stderr
+++ b/tests/ui/sized/unsized-binding.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/unsized-binding.rs:2:9
+   |
+LL |     let x = *"";
+   |         ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/unsized-binding.rs:3:20
+   |
+LL |     println!("{}", x);
+   |               --   ^ doesn't have a size known at compile-time
+   |               |
+   |               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `core::fmt::rt::Argument::<'a>::new_display`
+  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/unsized-binding.rs:4:20
+   |
+LL |     println!("{}", x);
+   |               --   ^ doesn't have a size known at compile-time
+   |               |
+   |               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `core::fmt::rt::Argument::<'a>::new_display`
+  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fix #56607.