### PR TITLE
Set `channel = nightly` in dist profile

### DIFF
--- a/src/bootstrap/defaults/config.dist.toml
+++ b/src/bootstrap/defaults/config.dist.toml
@@ -12,6 +12,9 @@ extended = true
 [llvm]
 download-ci-llvm = false
 [rust]
+# We have several defaults in bootstrap that depend on whether the channel is `dev` (e.g. `omit-git-hash` and `download-ci-llvm`).
+# Make sure they don't get set when installing from source.
+channel = "nightly"
 download-rustc = false
 
 [dist]


### PR DESCRIPTION
This avoids some channel-specific defaults leaking into local installs. It also makes it easier to set options for compiler/library/codegen profiles in the future, since they can be gated off `channel` instead of being duplicated between all three files.

Here are the exact things `channel` controls today:
https://github.com/rust-lang/rust/blob/68d458bb402b873b9ae80423710c2672967479df/src/bootstrap/llvm.rs#L466-L470
https://github.com/rust-lang/rust/blob/85c4ea0138fcca2e8cf4515a063cd3b762d64aec/src/bootstrap/config.rs#L1374-L1375
https://github.com/rust-lang/rust/blob/85c4ea0138fcca2e8cf4515a063cd3b762d64aec/src/bootstrap/config.rs#L1464-L1465
@cuviper i expect you don't want any of those to be set in distro builds, right?