### PR TITLE
compiletest: Only trim the end of process output

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -4374,7 +4374,7 @@ impl ProcRes {
     pub fn print_info(&self) {
         fn render(name: &str, contents: &str) -> String {
             let contents = json::extract_rendered(contents);
-            let contents = contents.trim();
+            let contents = contents.trim_end();
             if contents.is_empty() {
                 format!("{name}: none")
             } else {


### PR DESCRIPTION
As of #94196, compiletest automatically trims process stderr/stdout output before printing it, to make failure info more compact.

This causes the first line of `run-coverage` output to be displayed incorrectly, because it uses leading whitespace to align line numbers.

Trimming only the end of the output string should still have the intended effect (e.g. removing trailing newlines), without causing problems for output that deliberately uses leading whitespace on the first line.

## Before
```
--- stdout -------------------------------
1|      1|fn main() { //
    2|      1|    let num = 9;
    3|      1|    while num >= 10 {
    4|      0|    }
    5|      1|}
------------------------------------------
stderr: none
```

## After
```
--- stdout -------------------------------
    1|      1|fn main() { //
    2|      1|    let num = 9;
    3|      1|    while num >= 10 {
    4|      0|    }
    5|      1|}
------------------------------------------
stderr: none
```