### PR TITLE
Remove lifetime bound for A for `impl Extend<&'a T> for Vec<T, A>`.

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2971,7 +2971,7 @@ impl<T, A: Allocator> Vec<T, A> {
 /// [`copy_from_slice`]: slice::copy_from_slice
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "extend_ref", since = "1.2.0")]
-impl<'a, T: Copy + 'a, A: Allocator + 'a> Extend<&'a T> for Vec<T, A> {
+impl<'a, T: Copy + 'a, A: Allocator> Extend<&'a T> for Vec<T, A> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         self.spec_extend(iter.into_iter())
     }

--- a/library/alloc/src/vec/spec_extend.rs
+++ b/library/alloc/src/vec/spec_extend.rs
@@ -36,7 +36,7 @@ impl<T, A: Allocator> SpecExtend<T, IntoIter<T>> for Vec<T, A> {
     }
 }
 
-impl<'a, T: 'a, I, A: Allocator + 'a> SpecExtend<&'a T, I> for Vec<T, A>
+impl<'a, T: 'a, I, A: Allocator> SpecExtend<&'a T, I> for Vec<T, A>
 where
     I: Iterator<Item = &'a T>,
     T: Clone,
@@ -46,7 +46,7 @@ where
     }
 }
 
-impl<'a, T: 'a, A: Allocator + 'a> SpecExtend<&'a T, slice::Iter<'a, T>> for Vec<T, A>
+impl<'a, T: 'a, A: Allocator> SpecExtend<&'a T, slice::Iter<'a, T>> for Vec<T, A>
 where
     T: Copy,
 {


### PR DESCRIPTION
The lifetime of the references being copied from is unrelated to the allocator.

Compare with [`impl<'a, T: 'a + Copy, A: Allocator> Extend<&'a T> for VecDeque<T, A>`](https://doc.rust-lang.org/alloc/collections/vec_deque/struct.VecDeque.html#impl-Extend%3C%26'a+T%3E-for-VecDeque%3CT,+A%3E) which does not have the `A: 'a` bound already.

Since `Allocator` is unstable, the only possible `A` on stable is `Global`, and `Global: 'static`, so this change is not (should not be) observable on stable (or without `#![feature(allocator_api)]`). [This is observable on nightly](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=8c4aa166c6116a90593d2934d30cfeb3).