### PR TITLE
Update Rustfmt (add let-else support) (1.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+
+## [1.6.0] 2023-07-02
+
+### Added
+
+- Support for formatting let-else statements [#5690]
+- New config option, `single_line_let_else_max_width`, that allows users to configure the maximum length of single line `let-else` statements. `let-else` statements that otherwise meet the requirements to be formatted on a single line will have their divergent`else` block formatted over multiple lines if they exceed this length [#5684]
+
+[#5690]: (https://github.com/rust-lang/rustfmt/pulls/5690)
+[#5684]: https://github.com/rust-lang/rustfmt/issues/5684
+
 ## [1.5.3] 2023-06-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.5.3"
+version = "1.6.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.5.3"
+version = "1.6.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustfmt-nightly"
-version = "1.5.3"
+version = "1.6.0"
 description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang/rustfmt"
 readme = "README.md"

--- a/Configurations.md
+++ b/Configurations.md
@@ -2392,6 +2392,78 @@ By default this option is set as a percentage of [`max_width`](#max_width) provi
 
 See also [`max_width`](#max_width) and [`use_small_heuristics`](#use_small_heuristics)
 
+## `single_line_let_else_max_width`
+
+Maximum line length for single line let-else statements.
+See the [let-else statement section of the Rust Style Guide](https://github.com/rust-lang/rust/blob/master/src/doc/style-guide/src/statements.md#else-blocks-let-else-statements) for more details on when a let-else statement may be written on a single line.
+A value of `0` (zero) means the divergent `else` block will always be formatted over multiple lines.
+Note this occurs when `use_small_heuristics` is set to `Off`.
+
+By default this option is set as a percentage of [`max_width`](#max_width) provided by [`use_small_heuristics`](#use_small_heuristics), but a value set directly for `single_line_let_else_max_width` will take precedence.
+
+- **Default value**: `50`
+- **Possible values**: any positive integer that is less than or equal to the value specified for [`max_width`](#max_width)
+- **Stable**: Yes
+
+#### `50` (default):
+
+```rust
+fn main() {
+    let Some(w) = opt else { return Ok(()) };
+
+    let Some(x) = opt else { return };
+
+    let Some(y) = opt else {
+        return;
+    };
+
+    let Some(z) = some_very_very_very_very_long_name else {
+        return;
+    };
+}
+```
+
+#### `0`:
+
+```rust
+fn main() {
+    let Some(w) = opt else {
+        return Ok(());
+    };
+
+    let Some(x) = opt else {
+        return;
+    };
+
+    let Some(y) = opt else {
+        return;
+    };
+
+    let Some(z) = some_very_very_very_very_long_name else {
+        return;
+    };
+}
+```
+
+#### `100`:
+
+```rust
+fn main() {
+    let Some(w) = opt else { return Ok(()) };
+
+    let Some(x) = opt else { return };
+
+    let Some(y) = opt else {
+        return;
+    };
+
+    let Some(z) = some_very_very_very_very_long_name else { return };
+}
+```
+
+See also [`max_width`](#max_width) and [`use_small_heuristics`](#use_small_heuristics)
+
+
 ## `space_after_colon`
 
 Leave a space after the colon.
@@ -2804,6 +2876,7 @@ The ratios are:
 * [`array_width`](#array_width) - `60%`
 * [`chain_width`](#chain_width) - `60%`
 * [`single_line_if_else_max_width`](#single_line_if_else_max_width) - `50%`
+* [`single_line_let_else_max_width`](#single_line_let_else_max_width) - `50%`
 
 For example when `max_width` is set to `100`, the width settings are:
 * `fn_call_width=60`
@@ -2813,6 +2886,7 @@ For example when `max_width` is set to `100`, the width settings are:
 * `array_width=60`
 * `chain_width=60`
 * `single_line_if_else_max_width=50`
+* `single_line_let_else_max_width=50`
 
 and when `max_width` is set to `200`:
 * `fn_call_width=120`
@@ -2822,6 +2896,7 @@ and when `max_width` is set to `200`:
 * `array_width=120`
 * `chain_width=120`
 * `single_line_if_else_max_width=100`
+* `single_line_let_else_max_width=100`
 
 ```rust
 enum Lorem {
@@ -2891,6 +2966,7 @@ So if `max_width` is set to `200`, then all the width settings are also set to `
 * `array_width=200`
 * `chain_width=200`
 * `single_line_if_else_max_width=200`
+* `single_line_let_else_max_width=200`
 
 ```rust
 enum Lorem {
@@ -2918,6 +2994,7 @@ See also:
 * [`array_width`](#array_width)
 * [`chain_width`](#chain_width)
 * [`single_line_if_else_max_width`](#single_line_if_else_max_width)
+* [`single_line_let_else_max_width`](#single_line_let_else_max_width)
 
 ## `use_try_shorthand`
 

--- a/config_proc_macro/Cargo.lock
+++ b/config_proc_macro/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-06-19"
+channel = "nightly-2023-07-01"
 components = ["llvm-tools", "rustc-dev"]

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -121,6 +121,7 @@ macro_rules! create_config {
                     | "use_small_heuristics"
                     | "fn_call_width"
                     | "single_line_if_else_max_width"
+                    | "single_line_let_else_max_width"
                     | "attr_fn_like_width"
                     | "struct_lit_width"
                     | "struct_variant_width"
@@ -269,6 +270,7 @@ macro_rules! create_config {
                     | "use_small_heuristics"
                     | "fn_call_width"
                     | "single_line_if_else_max_width"
+                    | "single_line_let_else_max_width"
                     | "attr_fn_like_width"
                     | "struct_lit_width"
                     | "struct_variant_width"
@@ -407,6 +409,14 @@ macro_rules! create_config {
                     "single_line_if_else_max_width",
                 );
                 self.single_line_if_else_max_width.2 = single_line_if_else_max_width;
+
+                let single_line_let_else_max_width = get_width_value(
+                    self.was_set().single_line_let_else_max_width(),
+                    self.single_line_let_else_max_width.2,
+                    heuristics.single_line_let_else_max_width,
+                    "single_line_let_else_max_width",
+                );
+                self.single_line_let_else_max_width.2 = single_line_let_else_max_width;
             }
 
             fn set_heuristics(&mut self) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -58,6 +58,9 @@ create_config! {
     chain_width: usize, 60, true, "Maximum length of a chain to fit on a single line.";
     single_line_if_else_max_width: usize, 50, true, "Maximum line length for single line if-else \
         expressions. A value of zero means always break if-else expressions.";
+    single_line_let_else_max_width: usize, 50, true, "Maximum line length for single line \
+        let-else statements. A value of zero means always format the divergent `else` block \
+        over multiple lines.";
 
     // Comments. macros, and strings
     wrap_comments: bool, false, false, "Break comments to fit on the line";
@@ -473,6 +476,9 @@ mod test {
             chain_width: usize, 60, true, "Maximum length of a chain to fit on a single line.";
             single_line_if_else_max_width: usize, 50, true, "Maximum line length for single \
                 line if-else expressions. A value of zero means always break if-else expressions.";
+            single_line_let_else_max_width: usize, 50, false, "Maximum line length for single \
+                line let-else statements. A value of zero means always format the divergent \
+                `else` block over multiple lines.";
 
             // Options that are used by the tests
             stable_option: bool, false, true, "A stable option";
@@ -619,6 +625,7 @@ struct_variant_width = 35
 array_width = 60
 chain_width = 60
 single_line_if_else_max_width = 50
+single_line_let_else_max_width = 50
 wrap_comments = false
 format_code_in_doc_comments = false
 doc_comment_code_block_width = 100

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -236,6 +236,9 @@ pub struct WidthHeuristics {
     // Maximum line length for single line if-else expressions. A value
     // of zero means always break if-else expressions.
     pub(crate) single_line_if_else_max_width: usize,
+    // Maximum line length for single line let-else statements. A value of zero means
+    // always format the divergent `else` block over multiple lines.
+    pub(crate) single_line_let_else_max_width: usize,
 }
 
 impl fmt::Display for WidthHeuristics {
@@ -255,6 +258,7 @@ impl WidthHeuristics {
             array_width: usize::max_value(),
             chain_width: usize::max_value(),
             single_line_if_else_max_width: 0,
+            single_line_let_else_max_width: 0,
         }
     }
 
@@ -267,6 +271,7 @@ impl WidthHeuristics {
             array_width: max_width,
             chain_width: max_width,
             single_line_if_else_max_width: max_width,
+            single_line_let_else_max_width: max_width,
         }
     }
 
@@ -288,6 +293,7 @@ impl WidthHeuristics {
             array_width: (60.0 * max_width_ratio).round() as usize,
             chain_width: (60.0 * max_width_ratio).round() as usize,
             single_line_if_else_max_width: (50.0 * max_width_ratio).round() as usize,
+            single_line_let_else_max_width: (50.0 * max_width_ratio).round() as usize,
         }
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -232,6 +232,7 @@ pub(crate) fn format_expr(
         ast::ExprKind::Ret(Some(ref expr)) => {
             rewrite_unary_prefix(context, "return ", &**expr, shape)
         }
+        ast::ExprKind::Become(ref expr) => rewrite_unary_prefix(context, "become ", &**expr, shape),
         ast::ExprKind::Yeet(None) => Some("do yeet".to_owned()),
         ast::ExprKind::Yeet(Some(ref expr)) => {
             rewrite_unary_prefix(context, "do yeet ", &**expr, shape)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -609,6 +609,16 @@ fn rewrite_block_inner(
     result
 }
 
+/// Rewrite the divergent block of a `let-else` statement.
+pub(crate) fn rewrite_let_else_block(
+    block: &ast::Block,
+    allow_single_line: bool,
+    context: &RewriteContext<'_>,
+    shape: Shape,
+) -> Option<String> {
+    rewrite_block_inner(block, None, None, allow_single_line, context, shape)
+}
+
 // Rewrite condition if the given expression has one.
 pub(crate) fn rewrite_cond(
     context: &RewriteContext<'_>,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1027,12 +1027,14 @@ impl<'a> ControlFlow<'a> {
 
 /// Rewrite the `else` keyword with surrounding comments.
 ///
+/// force_newline_else: whether or not to rewrite the `else` keyword on a newline.
 /// is_last: true if this is an `else` and `false` if this is an `else if` block.
 /// context: rewrite context
 /// span: Span between the end of the last expression and the start of the else block,
 ///       which contains the `else` keyword
 /// shape: Shape
 pub(crate) fn rewrite_else_kw_with_comments(
+    force_newline_else: bool,
     is_last: bool,
     context: &RewriteContext<'_>,
     span: Span,
@@ -1048,6 +1050,7 @@ pub(crate) fn rewrite_else_kw_with_comments(
 
     let newline_sep = &shape.indent.to_string_with_newline(context.config);
     let before_sep = match context.config.control_brace_style() {
+        _ if force_newline_else => newline_sep.as_ref(),
         ControlBraceStyle::AlwaysNextLine | ControlBraceStyle::ClosingNextLine => {
             newline_sep.as_ref()
         }
@@ -1132,6 +1135,7 @@ impl<'a> Rewrite for ControlFlow<'a> {
             };
 
             let else_kw = rewrite_else_kw_with_comments(
+                false,
                 last_in_chain,
                 context,
                 self.block.span.between(else_block.span),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -576,6 +576,17 @@ fn rewrite_block(
     context: &RewriteContext<'_>,
     shape: Shape,
 ) -> Option<String> {
+    rewrite_block_inner(block, attrs, label, true, context, shape)
+}
+
+fn rewrite_block_inner(
+    block: &ast::Block,
+    attrs: Option<&[ast::Attribute]>,
+    label: Option<ast::Label>,
+    allow_single_line: bool,
+    context: &RewriteContext<'_>,
+    shape: Shape,
+) -> Option<String> {
     let prefix = block_prefix(context, block, shape)?;
 
     // shape.width is used only for the single line case: either the empty block `{}`,
@@ -586,7 +597,7 @@ fn rewrite_block(
 
     let result = rewrite_block_with_visitor(context, &prefix, block, attrs, label, shape, true);
     if let Some(ref result_str) = result {
-        if result_str.lines().count() <= 3 {
+        if allow_single_line && result_str.lines().count() <= 3 {
             if let rw @ Some(_) =
                 rewrite_single_line_block(context, &prefix, block, attrs, label, shape)
             {

--- a/src/items.rs
+++ b/src/items.rs
@@ -18,7 +18,8 @@ use crate::config::lists::*;
 use crate::config::{BraceStyle, Config, IndentStyle, Version};
 use crate::expr::{
     is_empty_block, is_simple_block_stmt, rewrite_assign_rhs, rewrite_assign_rhs_with,
-    rewrite_assign_rhs_with_comments, rewrite_else_kw_with_comments, RhsAssignKind, RhsTactics,
+    rewrite_assign_rhs_with_comments, rewrite_else_kw_with_comments, rewrite_let_else_block,
+    RhsAssignKind, RhsTactics,
 };
 use crate::lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
 use crate::macros::{rewrite_macro, MacroPosition};
@@ -132,7 +133,13 @@ impl Rewrite for ast::Local {
                     shape,
                 );
                 result.push_str(&else_kw);
-                result.push_str(&block.rewrite(context, shape)?);
+                let allow_single_line = !result.contains('\n');
+                result.push_str(&rewrite_let_else_block(
+                    block,
+                    allow_single_line,
+                    context,
+                    shape,
+                )?);
             };
         }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -175,8 +175,10 @@ fn same_line_else_kw_and_brace(
     init_shape: Shape,
 ) -> bool {
     if !init_str.contains('\n') {
-        // initializer expression is single lined so the "else {" should be placed on the same line
-        return true;
+        // initializer expression is single lined. The "else {" can only be placed on the same line
+        // as the initializer expression if there is enough room for it.
+        // 7 = ` else {`
+        return init_shape.width.saturating_sub(init_str.len()) >= 7;
     }
 
     // 1. The initializer expression ends with one or more `)`, `]`, `}`.

--- a/src/items.rs
+++ b/src/items.rs
@@ -156,7 +156,8 @@ impl Rewrite for ast::Local {
                     rewrite_let_else_block(block, allow_single_line, context, shape)?;
 
                 let single_line_else = !rw_else_block.contains('\n');
-                let else_block_exceeds_width = available_space <= rw_else_block.len();
+                // +1 for the trailing `;`
+                let else_block_exceeds_width = rw_else_block.len() + 1 > available_space;
 
                 if allow_single_line && single_line_else && else_block_exceeds_width {
                     // writing this on one line would exceed the available width

--- a/src/items.rs
+++ b/src/items.rs
@@ -127,8 +127,8 @@ impl Rewrite for ast::Local {
 
             if let Some(block) = else_block {
                 let else_kw_span = init.span.between(block.span);
-                let force_newline_else =
-                    !same_line_else_kw_and_brace(&result, context, else_kw_span, nested_shape);
+                let force_newline_else = pat_str.contains('\n')
+                    || !same_line_else_kw_and_brace(&result, context, else_kw_span, nested_shape);
                 let else_kw = rewrite_else_kw_with_comments(
                     force_newline_else,
                     true,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -505,6 +505,7 @@ pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr
         | ast::ExprKind::Range(..)
         | ast::ExprKind::Repeat(..)
         | ast::ExprKind::Ret(..)
+        | ast::ExprKind::Become(..)
         | ast::ExprKind::Yeet(..)
         | ast::ExprKind::Tup(..)
         | ast::ExprKind::Type(..)

--- a/tests/source/configs/single_line_let_else_max_width/100.rs
+++ b/tests/source/configs/single_line_let_else_max_width/100.rs
@@ -1,0 +1,40 @@
+// rustfmt-single_line_let_else_max_width: 100
+
+fn main() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else {
+        return
+    };
+
+    let Some(c) = opt else {
+        // a comment should always force the block to be multi-lined
+        return
+    };
+
+    let Some(c) = opt else { /* a comment should always force the block to be multi-lined */ return };
+
+    let Some(d) = some_very_very_very_very_long_name else { return };
+
+    let Expr::Slice(ast::ExprSlice { lower, upper, step, range: _ }) = slice.as_ref() else {
+        return
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true)? else {
+        return Ok(None)
+    };
+
+    let Some(doc_attr) = variant.attrs.iter().find(|attr| attr.path().is_ident("doc")) else {
+        return Err(Error::new(variant.span(), r#"expected a doc comment"#))
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true) else {
+        return Ok(None)
+    };
+
+    let Stmt::Expr(Expr::Call(ExprCall { args: some_args, .. }), _) = last_stmt else {
+        return Err(Error::new(last_stmt.span(), "expected last expression to be `Some(match (..) { .. })`"))
+    };
+}

--- a/tests/source/configs/single_line_let_else_max_width/50.rs
+++ b/tests/source/configs/single_line_let_else_max_width/50.rs
@@ -1,0 +1,40 @@
+// rustfmt-single_line_let_else_max_width: 50
+
+fn main() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else {
+        return
+    };
+
+    let Some(c) = opt else {
+        // a comment should always force the block to be multi-lined
+        return
+    };
+
+    let Some(c) = opt else { /* a comment should always force the block to be multi-lined */ return };
+
+    let Some(d) = some_very_very_very_very_long_name else { return };
+
+    let Expr::Slice(ast::ExprSlice { lower, upper, step, range: _ }) = slice.as_ref() else {
+        return
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true)? else {
+        return Ok(None)
+    };
+
+    let Some(doc_attr) = variant.attrs.iter().find(|attr| attr.path().is_ident("doc")) else {
+        return Err(Error::new(variant.span(), r#"expected a doc comment"#))
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true) else {
+        return Ok(None)
+    };
+
+    let Stmt::Expr(Expr::Call(ExprCall { args: some_args, .. }), _) = last_stmt else {
+        return Err(Error::new(last_stmt.span(), "expected last expression to be `Some(match (..) { .. })`"))
+    };
+}

--- a/tests/source/configs/single_line_let_else_max_width/zero.rs
+++ b/tests/source/configs/single_line_let_else_max_width/zero.rs
@@ -1,0 +1,40 @@
+// rustfmt-single_line_let_else_max_width: 0
+
+fn main() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else {
+        return
+    };
+
+    let Some(c) = opt else {
+        // a comment should always force the block to be multi-lined
+        return
+    };
+
+    let Some(c) = opt else { /* a comment should always force the block to be multi-lined */ return };
+
+    let Some(d) = some_very_very_very_very_long_name else { return };
+
+    let Expr::Slice(ast::ExprSlice { lower, upper, step, range: _ }) = slice.as_ref() else {
+        return
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true)? else {
+        return Ok(None)
+    };
+
+    let Some(doc_attr) = variant.attrs.iter().find(|attr| attr.path().is_ident("doc")) else {
+        return Err(Error::new(variant.span(), r#"expected a doc comment"#))
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true) else {
+        return Ok(None)
+    };
+
+    let Stmt::Expr(Expr::Call(ExprCall { args: some_args, .. }), _) = last_stmt else {
+        return Err(Error::new(last_stmt.span(), "expected last expression to be `Some(match (..) { .. })`"))
+    };
+}

--- a/tests/source/configs/use_small_heuristics/default.rs
+++ b/tests/source/configs/use_small_heuristics/default.rs
@@ -23,3 +23,13 @@ fn main() {
         sit
     };
 }
+
+fn format_let_else() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else { return };
+
+    let Some(d) = some_very_very_very_very_long_name else { return };
+}

--- a/tests/source/configs/use_small_heuristics/max.rs
+++ b/tests/source/configs/use_small_heuristics/max.rs
@@ -23,3 +23,13 @@ fn main() {
         sit
     };
 }
+
+fn format_let_else() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else { return };
+
+    let Some(d) = some_very_very_very_very_long_name else { return };
+}

--- a/tests/source/configs/use_small_heuristics/off.rs
+++ b/tests/source/configs/use_small_heuristics/off.rs
@@ -23,3 +23,13 @@ fn main() {
         sit
     };
 }
+
+fn format_let_else() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else { return };
+
+    let Some(d) = some_very_very_very_very_long_name else { return };
+}

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -1,3 +1,0 @@
-fn main() {
-    let Some(1) = Some(1) else { return };
-}

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -79,18 +79,18 @@ fn unbreakable_initializer_expr_pre_formatting_let_else_length_near_max_width() 
 
 fn unbreakable_initializer_expr_pre_formatting_length_up_to_opening_brace_near_max_width() {
     // Pre Formatting:
-    // The length of `(indent)let pat = init else {` is 100 (max_width)
+    // The length of `(indent)let pat = init else {` is 99 (< max_width)
     // Post Formatting:
     // The else keyword and opening brace remain on the same line as the initializer expr,
     // and the else block is formatted over multiple lines because we can't fit the
     // else block on the same line as the initializer expr.
-    let Some(x) = some_really_really_really_really_really_really_really_really_long_name____E else {return};
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name___E else {return};
 
     // Pre Formatting:
     // The length of `(indent)let pat = init else {` is 101 (> max_width)
     // Post Formatting:
-    // The else keyword and opening brace remain on the same line as the initializer expr,
-    // which leads to the `{` exceeding the max width
+    // The else keyword and opening brace cannot fit on the same line as the initializer expr.
+    // They are formatted on the next line.
     let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F else {return};
 }
 
@@ -98,8 +98,8 @@ fn unbreakable_initializer_expr_pre_formatting_length_through_initializer_expr_n
     // Pre Formatting:
     // The length of `(indent)let pat = init` is 99 (< max_width)
     // Post Formatting:
-    // The else keyword and opening brace remain on the same line as the initializer expr,
-    // which leads to the `else {` exceeding the max width
+    // The else keyword and opening brace cannot fit on the same line as the initializer expr.
+    // They are formatted on the next line.
     let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G else {return};
 
     // Pre Formatting:

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -7,4 +7,8 @@ fn main() {
         // nope
         return;
     };
+
+    let Some(x) = y.foo("abc", fairly_long_identifier, "def", "123456", "string", "cheese") else { bar() };
+
+    let Some(x) = abcdef().foo("abc", some_really_really_really_long_ident, "ident", "123456").bar().baz().qux("fffffffffffffffff") else { foo_bar() };
 }

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let Some(x) = opt else { return };
+
+    let Some(x) = opt else { return; };
+
+    let Some(x) = opt else {
+        // nope
+        return;
+    };
+}

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -1,5 +1,14 @@
 fn main() {
+    // Although this won't compile it still parses so make sure we can format empty else blocks
+    let Some(x) = opt else {};
+
+    // let-else may be formatted on a single line if they are "short"
+    // and only contain a single expression
     let Some(x) = opt else { return };
+
+    let Some(x) = opt else {
+        return
+    };
 
     let Some(x) = opt else { return; };
 
@@ -8,7 +17,135 @@ fn main() {
         return;
     };
 
+    let Some(x) = opt else { let y = 1; return y };
+
     let Some(x) = y.foo("abc", fairly_long_identifier, "def", "123456", "string", "cheese") else { bar() };
 
     let Some(x) = abcdef().foo("abc", some_really_really_really_long_ident, "ident", "123456").bar().baz().qux("fffffffffffffffff") else { foo_bar() };
+}
+
+fn with_comments_around_else_keyword() {
+    let Some(x) = opt /* pre else keyword block-comment */ else { return };
+
+    let Some(x) = opt else /* post else keyword block-comment */ { return };
+
+    let Some(x) = opt /* pre else keyword block-comment */ else /* post else keyword block-comment */ { return };
+
+    let Some(x) = opt // pre else keyword line-comment
+    else { return };
+
+    let Some(x) = opt else
+     // post else keyword line-comment
+    { return };
+
+    let Some(x) = opt // pre else keyword line-comment
+    else
+    // post else keyword line-comment
+    { return };
+
+}
+
+fn unbreakable_initializer_expr_pre_formatting_let_else_length_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The formatting is left unchanged!
+    let Some(x) = some_really_really_really_really_really_really_really_long_name_A else { return };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_long_name___B else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_long_name_____C else {some_divergent_function()};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 101 (> max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_long_name__D else { return };
+}
+
+fn unbreakable_initializer_expr_pre_formatting_length_up_to_opening_brace_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else {` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name____E else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else {` is 101 (> max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // which leads to the `{` exceeding the max width
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F else {return};
+}
+
+fn unbreakable_initializer_expr_pre_formatting_length_through_initializer_expr_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 99 (< max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // which leads to the `else {` exceeding the max width
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 100 (max_width)
+    // Post Formatting:
+    // Break after the `=` and put the initializer expr on it's own line.
+    // Because the initializer expr is multi-lined the else is placed on it's own line.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name____H else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 109 (> max_width)
+    // Post Formatting:
+    // Break after the `=` and put the initializer expr on it's own line.
+    // Because the initializer expr is multi-lined the else is placed on it's own line.
+    // The initializer expr has a length of 91, which when indented on the next line
+    // The `(indent)init` line has a lengh of 99. This is the max length that the `init` can be
+    // before we start running into max_width issues. I suspect this is becuase the shape is
+    // accounting for the `;` at the end of the `let-else` statement.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_really_long_name______I else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 110 (> max_width)
+    // Post Formatting:
+    // Max length issues prevent us from formatting.
+    // The initializer expr has a length of 92, which if it would be indented on the next line
+    // the `(indent)init` line has a lengh of 100 which == max_width of 100.
+    // One might expect formatting to succeed, but I suspect the reason we hit max_width issues is
+    // because the Shape is accounting for the `;` at the end of the `let-else` statement.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_really_really_long_nameJ else {return};
+}
+
+fn long_patterns() {
+    let Foo {x: Bar(..), y: FooBar(..), z: Baz(..)} = opt else {
+        return;
+    };
+
+    // with version=One we don't wrap long array patterns
+    let [aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbb, cccccccccccccccccc, dddddddddddddddddd] = opt else {
+        return;
+    };
+
+    let ("aaaaaaaaaaaaaaaaaaa" | "bbbbbbbbbbbbbbbbb" | "cccccccccccccccccccccccc" | "dddddddddddddddd" | "eeeeeeeeeeeeeeee") = opt else {
+        return;
+    };
+
+    let Some(Ok((Message::ChangeColor(super::color::Color::Rgb(r, g, b)), Point { x, y, z }))) = opt else {
+        return;
+    };
 }

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -1,3 +1,5 @@
+// rustfmt-single_line_let_else_max_width: 100
+
 fn main() {
     // Although this won't compile it still parses so make sure we can format empty else blocks
     let Some(x) = opt else {};
@@ -148,4 +150,13 @@ fn long_patterns() {
     let Some(Ok((Message::ChangeColor(super::color::Color::Rgb(r, g, b)), Point { x, y, z }))) = opt else {
         return;
     };
+}
+
+fn with_trailing_try_operator() {
+    // Currently the trailing ? forces the else on the next line
+    // This may be revisited in style edition 2024
+    let Some(next_bucket) = ranking_rules[cur_ranking_rule_index].next_bucket(ctx, logger, &ranking_rule_universes[cur_ranking_rule_index])? else { return };
+
+    // Maybe this is a workaround?
+    let Ok(Some(next_bucket)) = ranking_rules[cur_ranking_rule_index].next_bucket(ctx, logger, &ranking_rule_universes[cur_ranking_rule_index]) else { return };
 }

--- a/tests/target/configs/single_line_let_else_max_width/100.rs
+++ b/tests/target/configs/single_line_let_else_max_width/100.rs
@@ -24,7 +24,8 @@ fn main() {
         upper,
         step,
         range: _,
-    }) = slice.as_ref() else {
+    }) = slice.as_ref()
+    else {
         return;
     };
 

--- a/tests/target/configs/single_line_let_else_max_width/100.rs
+++ b/tests/target/configs/single_line_let_else_max_width/100.rs
@@ -1,0 +1,59 @@
+// rustfmt-single_line_let_else_max_width: 100
+
+fn main() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else { return };
+
+    let Some(c) = opt else {
+        // a comment should always force the block to be multi-lined
+        return;
+    };
+
+    let Some(c) = opt else {
+        /* a comment should always force the block to be multi-lined */
+        return;
+    };
+
+    let Some(d) = some_very_very_very_very_long_name else { return };
+
+    let Expr::Slice(ast::ExprSlice {
+        lower,
+        upper,
+        step,
+        range: _,
+    }) = slice.as_ref() else {
+        return;
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true)? else {
+        return Ok(None);
+    };
+
+    let Some(doc_attr) = variant
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("doc"))
+    else {
+        return Err(Error::new(variant.span(), r#"expected a doc comment"#));
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true) else {
+        return Ok(None);
+    };
+
+    let Stmt::Expr(
+        Expr::Call(ExprCall {
+            args: some_args, ..
+        }),
+        _,
+    ) = last_stmt
+    else {
+        return Err(Error::new(
+            last_stmt.span(),
+            "expected last expression to be `Some(match (..) { .. })`",
+        ));
+    };
+}

--- a/tests/target/configs/single_line_let_else_max_width/50.rs
+++ b/tests/target/configs/single_line_let_else_max_width/50.rs
@@ -26,7 +26,8 @@ fn main() {
         upper,
         step,
         range: _,
-    }) = slice.as_ref() else {
+    }) = slice.as_ref()
+    else {
         return;
     };
 

--- a/tests/target/configs/single_line_let_else_max_width/50.rs
+++ b/tests/target/configs/single_line_let_else_max_width/50.rs
@@ -1,0 +1,61 @@
+// rustfmt-single_line_let_else_max_width: 50
+
+fn main() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else { return };
+
+    let Some(c) = opt else {
+        // a comment should always force the block to be multi-lined
+        return;
+    };
+
+    let Some(c) = opt else {
+        /* a comment should always force the block to be multi-lined */
+        return;
+    };
+
+    let Some(d) = some_very_very_very_very_long_name else {
+        return;
+    };
+
+    let Expr::Slice(ast::ExprSlice {
+        lower,
+        upper,
+        step,
+        range: _,
+    }) = slice.as_ref() else {
+        return;
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true)? else {
+        return Ok(None);
+    };
+
+    let Some(doc_attr) = variant
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("doc"))
+    else {
+        return Err(Error::new(variant.span(), r#"expected a doc comment"#));
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true) else {
+        return Ok(None);
+    };
+
+    let Stmt::Expr(
+        Expr::Call(ExprCall {
+            args: some_args, ..
+        }),
+        _,
+    ) = last_stmt
+    else {
+        return Err(Error::new(
+            last_stmt.span(),
+            "expected last expression to be `Some(match (..) { .. })`",
+        ));
+    };
+}

--- a/tests/target/configs/single_line_let_else_max_width/zero.rs
+++ b/tests/target/configs/single_line_let_else_max_width/zero.rs
@@ -1,0 +1,65 @@
+// rustfmt-single_line_let_else_max_width: 0
+
+fn main() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else {
+        return;
+    };
+
+    let Some(c) = opt else {
+        return;
+    };
+
+    let Some(c) = opt else {
+        // a comment should always force the block to be multi-lined
+        return;
+    };
+
+    let Some(c) = opt else {
+        /* a comment should always force the block to be multi-lined */
+        return;
+    };
+
+    let Some(d) = some_very_very_very_very_long_name else {
+        return;
+    };
+
+    let Expr::Slice(ast::ExprSlice {
+        lower,
+        upper,
+        step,
+        range: _,
+    }) = slice.as_ref() else {
+        return;
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true)? else {
+        return Ok(None);
+    };
+
+    let Some(doc_attr) = variant
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("doc"))
+    else {
+        return Err(Error::new(variant.span(), r#"expected a doc comment"#));
+    };
+
+    let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true) else {
+        return Ok(None);
+    };
+
+    let Stmt::Expr(
+        Expr::Call(ExprCall {
+            args: some_args, ..
+        }),
+        _,
+    ) = last_stmt
+    else {
+        return Err(Error::new(
+            last_stmt.span(),
+            "expected last expression to be `Some(match (..) { .. })`",
+        ));
+    };
+}

--- a/tests/target/configs/single_line_let_else_max_width/zero.rs
+++ b/tests/target/configs/single_line_let_else_max_width/zero.rs
@@ -30,7 +30,8 @@ fn main() {
         upper,
         step,
         range: _,
-    }) = slice.as_ref() else {
+    }) = slice.as_ref()
+    else {
         return;
     };
 

--- a/tests/target/configs/use_small_heuristics/default.rs
+++ b/tests/target/configs/use_small_heuristics/default.rs
@@ -24,3 +24,15 @@ fn main() {
 
     let lorem = if ipsum { dolor } else { sit };
 }
+
+fn format_let_else() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else { return };
+
+    let Some(d) = some_very_very_very_very_long_name else {
+        return;
+    };
+}

--- a/tests/target/configs/use_small_heuristics/max.rs
+++ b/tests/target/configs/use_small_heuristics/max.rs
@@ -13,3 +13,13 @@ fn main() {
 
     let lorem = if ipsum { dolor } else { sit };
 }
+
+fn format_let_else() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else { return };
+
+    let Some(c) = opt else { return };
+
+    let Some(d) = some_very_very_very_very_long_name else { return };
+}

--- a/tests/target/configs/use_small_heuristics/off.rs
+++ b/tests/target/configs/use_small_heuristics/off.rs
@@ -23,3 +23,19 @@ fn main() {
         sit
     };
 }
+
+fn format_let_else() {
+    let Some(a) = opt else {};
+
+    let Some(b) = opt else {
+        return;
+    };
+
+    let Some(c) = opt else {
+        return;
+    };
+
+    let Some(d) = some_very_very_very_very_long_name else {
+        return;
+    };
+}

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -1,3 +1,0 @@
-fn main() {
-    let Some(1) = Some(1) else { return };
-}

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -130,21 +130,22 @@ fn unbreakable_initializer_expr_pre_formatting_let_else_length_near_max_width() 
 
 fn unbreakable_initializer_expr_pre_formatting_length_up_to_opening_brace_near_max_width() {
     // Pre Formatting:
-    // The length of `(indent)let pat = init else {` is 100 (max_width)
+    // The length of `(indent)let pat = init else {` is 99 (< max_width)
     // Post Formatting:
     // The else keyword and opening brace remain on the same line as the initializer expr,
     // and the else block is formatted over multiple lines because we can't fit the
     // else block on the same line as the initializer expr.
-    let Some(x) = some_really_really_really_really_really_really_really_really_long_name____E else {
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name___E else {
         return;
     };
 
     // Pre Formatting:
     // The length of `(indent)let pat = init else {` is 101 (> max_width)
     // Post Formatting:
-    // The else keyword and opening brace remain on the same line as the initializer expr,
-    // which leads to the `{` exceeding the max width
-    let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F else {
+    // The else keyword and opening brace cannot fit on the same line as the initializer expr.
+    // They are formatted on the next line.
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F
+    else {
         return;
     };
 }
@@ -153,9 +154,10 @@ fn unbreakable_initializer_expr_pre_formatting_length_through_initializer_expr_n
     // Pre Formatting:
     // The length of `(indent)let pat = init` is 99 (< max_width)
     // Post Formatting:
-    // The else keyword and opening brace remain on the same line as the initializer expr,
-    // which leads to the `else {` exceeding the max width
-    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G else {
+    // The else keyword and opening brace cannot fit on the same line as the initializer expr.
+    // They are formatted on the next line.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G
+    else {
         return;
     };
 

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -1,4 +1,11 @@
 fn main() {
+    // Although this won't compile it still parses so make sure we can format empty else blocks
+    let Some(x) = opt else {};
+
+    // let-else may be formatted on a single line if they are "short"
+    // and only contain a single expression
+    let Some(x) = opt else { return };
+
     let Some(x) = opt else { return };
 
     let Some(x) = opt else {
@@ -8,6 +15,11 @@ fn main() {
     let Some(x) = opt else {
         // nope
         return;
+    };
+
+    let Some(x) = opt else {
+        let y = 1;
+        return y;
     };
 
     let Some(x) = y.foo(
@@ -33,5 +45,184 @@ fn main() {
         .qux("fffffffffffffffff")
     else {
         foo_bar()
+    };
+}
+
+fn with_comments_around_else_keyword() {
+    let Some(x) = opt
+    /* pre else keyword block-comment */
+    else {
+        return;
+    };
+
+    let Some(x) = opt else
+    /* post else keyword block-comment */
+    {
+        return;
+    };
+
+    let Some(x) = opt
+    /* pre else keyword block-comment */
+    else
+    /* post else keyword block-comment */
+    {
+        return;
+    };
+
+    let Some(x) = opt
+    // pre else keyword line-comment
+    else {
+        return;
+    };
+
+    let Some(x) = opt else
+    // post else keyword line-comment
+    {
+        return;
+    };
+
+    let Some(x) = opt
+    // pre else keyword line-comment
+    else
+    // post else keyword line-comment
+    {
+        return;
+    };
+}
+
+fn unbreakable_initializer_expr_pre_formatting_let_else_length_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The formatting is left unchanged!
+    let Some(x) = some_really_really_really_really_really_really_really_long_name_A else { return };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_long_name___B else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_long_name_____C else {
+        some_divergent_function()
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 101 (> max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_long_name__D else {
+        return;
+    };
+}
+
+fn unbreakable_initializer_expr_pre_formatting_length_up_to_opening_brace_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else {` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name____E else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else {` is 101 (> max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // which leads to the `{` exceeding the max width
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F else {
+        return;
+    };
+}
+
+fn unbreakable_initializer_expr_pre_formatting_length_through_initializer_expr_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 99 (< max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // which leads to the `else {` exceeding the max width
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 100 (max_width)
+    // Post Formatting:
+    // Break after the `=` and put the initializer expr on it's own line.
+    // Because the initializer expr is multi-lined the else is placed on it's own line.
+    let Some(x) =
+        some_really_really_really_really_really_really_really_really_really_long_name____H
+    else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 109 (> max_width)
+    // Post Formatting:
+    // Break after the `=` and put the initializer expr on it's own line.
+    // Because the initializer expr is multi-lined the else is placed on it's own line.
+    // The initializer expr has a length of 91, which when indented on the next line
+    // The `(indent)init` line has a lengh of 99. This is the max length that the `init` can be
+    // before we start running into max_width issues. I suspect this is becuase the shape is
+    // accounting for the `;` at the end of the `let-else` statement.
+    let Some(x) =
+        some_really_really_really_really_really_really_really_really_really_really_long_name______I
+    else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 110 (> max_width)
+    // Post Formatting:
+    // Max length issues prevent us from formatting.
+    // The initializer expr has a length of 92, which if it would be indented on the next line
+    // the `(indent)init` line has a lengh of 100 which == max_width of 100.
+    // One might expect formatting to succeed, but I suspect the reason we hit max_width issues is
+    // because the Shape is accounting for the `;` at the end of the `let-else` statement.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_really_really_long_nameJ else {return};
+}
+
+fn long_patterns() {
+    let Foo {
+        x: Bar(..),
+        y: FooBar(..),
+        z: Baz(..),
+    } = opt
+    else {
+        return;
+    };
+
+    // with version=One we don't wrap long array patterns
+    let [aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbb, cccccccccccccccccc, dddddddddddddddddd] = opt else {
+        return;
+    };
+
+    let ("aaaaaaaaaaaaaaaaaaa"
+    | "bbbbbbbbbbbbbbbbb"
+    | "cccccccccccccccccccccccc"
+    | "dddddddddddddddd"
+    | "eeeeeeeeeeeeeeee") = opt
+    else {
+        return;
+    };
+
+    let Some(Ok((Message::ChangeColor(super::color::Color::Rgb(r, g, b)), Point { x, y, z }))) =
+        opt
+    else {
+        return;
     };
 }

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -9,4 +9,29 @@ fn main() {
         // nope
         return;
     };
+
+    let Some(x) = y.foo(
+        "abc",
+        fairly_long_identifier,
+        "def",
+        "123456",
+        "string",
+        "cheese",
+    ) else {
+        bar()
+    };
+
+    let Some(x) = abcdef()
+        .foo(
+            "abc",
+            some_really_really_really_long_ident,
+            "ident",
+            "123456",
+        )
+        .bar()
+        .baz()
+        .qux("fffffffffffffffff")
+    else {
+        foo_bar()
+    };
 }

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let Some(x) = opt else { return };
+
+    let Some(x) = opt else {
+        return;
+    };
+
+    let Some(x) = opt else {
+        // nope
+        return;
+    };
+}

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -1,3 +1,5 @@
+// rustfmt-single_line_let_else_max_width: 100
+
 fn main() {
     // Although this won't compile it still parses so make sure we can format empty else blocks
     let Some(x) = opt else {};
@@ -225,6 +227,28 @@ fn long_patterns() {
     let Some(Ok((Message::ChangeColor(super::color::Color::Rgb(r, g, b)), Point { x, y, z }))) =
         opt
     else {
+        return;
+    };
+}
+
+fn with_trailing_try_operator() {
+    // Currently the trailing ? forces the else on the next line
+    // This may be revisited in style edition 2024
+    let Some(next_bucket) = ranking_rules[cur_ranking_rule_index].next_bucket(
+        ctx,
+        logger,
+        &ranking_rule_universes[cur_ranking_rule_index],
+    )?
+    else {
+        return;
+    };
+
+    // Maybe this is a workaround?
+    let Ok(Some(next_bucket)) = ranking_rules[cur_ranking_rule_index].next_bucket(
+        ctx,
+        logger,
+        &ranking_rule_universes[cur_ranking_rule_index],
+    ) else {
         return;
     };
 }


### PR DESCRIPTION
Adds let-else formatting support 

Bit more detail in: https://github.com/rust-lang/rustfmt/blob/master/CHANGELOG.md#160-2023-07-02
Accompanying blog post: https://github.com/rust-lang/blog.rust-lang.org/pull/1117

I know we're getting close to tool week, however, there's been extensive discussion and testing of the changes in this between both t-style and t-rustfmt. Our confidence level is extremely high, and even if it's only on nightly for a few days, I'd still much prefer that and being able to get this out with 1.72 vs having to push to 1.73

Closes https://github.com/rust-lang/rustfmt/issues/4914
cc @rust-lang/style for awareness