### PR TITLE
Fix `dropping_copy_types` lint from linting in match-arm with side-effects

### DIFF
--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -194,7 +194,7 @@ fn is_single_call_in_arm<'tcx>(
     arg: &'tcx Expr<'_>,
     drop_expr: &'tcx Expr<'_>,
 ) -> bool {
-    if matches!(arg.kind, ExprKind::Call(..) | ExprKind::MethodCall(..)) {
+    if arg.can_have_side_effects() {
         let parent_node = cx.tcx.hir().find_parent(drop_expr.hir_id);
         if let Some(Node::Arm(Arm { body, .. })) = &parent_node {
             return body.hir_id == drop_expr.hir_id;

--- a/tests/ui/lint/dropping_copy_types.rs
+++ b/tests/ui/lint/dropping_copy_types.rs
@@ -77,3 +77,22 @@ fn issue9482(x: u8) {
         _ => (),
     }
 }
+
+fn issue112653() {
+    fn foo() -> Result<u8, ()> {
+        println!("doing foo");
+        Ok(0) // result is not always useful, the side-effect matters
+    }
+    fn bar() {
+        println!("doing bar");
+    }
+
+    fn stuff() -> Result<(), ()> {
+        match 42 {
+            0 => drop(foo()?),  // drop is needed because we only care about side-effects
+            1 => bar(),
+            _ => (),  // doing nothing (no side-effects needed here)
+        }
+        Ok(())
+    }
+}

--- a/tests/ui/lint/dropping_references.rs
+++ b/tests/ui/lint/dropping_references.rs
@@ -97,3 +97,22 @@ fn issue10122(x: u8) {
         _ => (),
     }
 }
+
+fn issue112653() {
+    fn foo() -> Result<&'static u8, ()> {
+        println!("doing foo");
+        Ok(&0) // result is not always useful, the side-effect matters
+    }
+    fn bar() {
+        println!("doing bar");
+    }
+
+    fn stuff() -> Result<(), ()> {
+        match 42 {
+            0 => drop(foo()?),  // drop is needed because we only care about side-effects
+            1 => bar(),
+            _ => (),  // doing nothing (no side-effects needed here)
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR fixes an issue with the `dropping_copy_types` and `dropping_references` lints when not all patterns that can have side-effects were detected and ignored.

Nearly _fixes_ https://github.com/rust-lang/rust/issues/112653 (will need beta-backport to completely fix the issue)
r? @Nilstrieb 