### PR TITLE
resolve: Update glob bindings in case of ambiguities (non-recursively)

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -324,6 +324,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         } else if !old_binding.vis.is_at_least(binding.vis, this.tcx) {
                             // We are glob-importing the same item but with greater visibility.
                             resolution.binding = Some(binding);
+                        } else if binding.is_ambiguity() {
+                            resolution.binding = Some(binding);
                         }
                     }
                     (old_glob @ true, false) | (old_glob @ false, true) => {

--- a/tests/ui/imports/duplicate.rs
+++ b/tests/ui/imports/duplicate.rs
@@ -33,7 +33,7 @@ mod g {
 fn main() {
     e::foo();
     f::foo(); //~ ERROR `foo` is ambiguous
-    g::foo();
+    g::foo(); //~ ERROR `foo` is ambiguous
 }
 
 mod ambiguous_module_errors {

--- a/tests/ui/imports/duplicate.stderr
+++ b/tests/ui/imports/duplicate.stderr
@@ -49,6 +49,26 @@ LL |     pub use b::*;
    = help: consider adding an explicit import of `foo` to disambiguate
 
 error[E0659]: `foo` is ambiguous
+  --> $DIR/duplicate.rs:36:8
+   |
+LL |     g::foo();
+   |        ^^^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `foo` could refer to the function imported here
+  --> $DIR/duplicate.rs:24:13
+   |
+LL |     pub use a::*;
+   |             ^^^^
+   = help: consider adding an explicit import of `foo` to disambiguate
+note: `foo` could also refer to the function imported here
+  --> $DIR/duplicate.rs:25:13
+   |
+LL |     pub use b::*;
+   |             ^^^^
+   = help: consider adding an explicit import of `foo` to disambiguate
+
+error[E0659]: `foo` is ambiguous
   --> $DIR/duplicate.rs:49:9
    |
 LL |         foo::bar();
@@ -68,7 +88,7 @@ LL |     use self::m2::*;
    |         ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0252, E0659.
 For more information about an error, try `rustc --explain E0252`.


### PR DESCRIPTION
One independent subset of https://github.com/rust-lang/rust/pull/112743 for a mini crater run.
cc @bvanjoi 

TODO: `@craterbot check p=1 crates=https://crater-reports.s3.amazonaws.com/pr-112743/retry-regressed-list.txt`