### PR TITLE
resolve: Always update globs importing from a module when bindings in that module change

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -391,17 +391,17 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         // during which the resolution might end up getting re-defined via a glob cycle.
         let (binding, t) = {
             let resolution = &mut *self.resolution(module, key).borrow_mut();
-            let old_binding = resolution.binding();
+            let old_binding = resolution.binding;
 
             let t = f(self, resolution);
 
-            match resolution.binding() {
-                _ if old_binding.is_some() => return t,
-                None => return t,
-                Some(binding) => match old_binding {
-                    Some(old_binding) if ptr::eq(old_binding, binding) => return t,
-                    _ => (binding, t),
-                },
+            match resolution.binding {
+                Some(binding)
+                    if !old_binding.is_some_and(|old_binding| ptr::eq(binding, old_binding)) =>
+                {
+                    (binding, t)
+                }
+                _ => return t,
             }
         };
 

--- a/tests/ui/resolve/issue-112831.rs
+++ b/tests/ui/resolve/issue-112831.rs
@@ -1,4 +1,3 @@
-// check-pass
 // aux-build:issue-112831-aux.rs
 
 mod zeroable {
@@ -9,7 +8,7 @@ use zeroable::*;
 
 mod pod {
     use super::*;
-    pub trait Pod: Zeroable {}
+    pub trait Pod: Zeroable {} //~ ERROR expected trait, found derive macro `Zeroable`
 }
 
 use pod::*;

--- a/tests/ui/resolve/issue-112831.stderr
+++ b/tests/ui/resolve/issue-112831.stderr
@@ -1,0 +1,14 @@
+error[E0404]: expected trait, found derive macro `Zeroable`
+  --> $DIR/issue-112831.rs:11:20
+   |
+LL |     pub trait Pod: Zeroable {}
+   |                    ^^^^^^^^ not a trait
+   |
+help: consider importing this trait through its public re-export instead
+   |
+LL +     use Zeroable;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0404`.


### PR DESCRIPTION
Second independent subset of https://github.com/rust-lang/rust/pull/112743 for a mini crater run.
cc @bvanjoi 

TODO: `@craterbot check p=1 crates=https://crater-reports.s3.amazonaws.com/pr-112743/retry-regressed-list.txt`