### PR TITLE
fix compiletest crash

### DIFF
--- a/src/tools/compiletest/src/read2.rs
+++ b/src/tools/compiletest/src/read2.rs
@@ -83,7 +83,7 @@ impl ProcOutput {
                 }
 
                 let new_len = bytes.len();
-                if *filtered_len <= HEAD_LEN + TAIL_LEN {
+                if (*filtered_len).min(new_len) <= HEAD_LEN + TAIL_LEN {
                     return;
                 }
 


### PR DESCRIPTION
### Motivation
When running compiler-tests locally for the `wasm32` platform, one test repeatedly crashed. It does not crash on the CI, only locally. Investigation shows that the `compiletest` itself crashes

> panicked-at-attempt-to-subtract-with-overflow

```rust
let mut head = replace(bytes, Vec::new());
let mut middle = head.split_off(HEAD_LEN);

// The following line will panic
let tail = middle.split_off(middle.len() - TAIL_LEN).into_boxed_slice();
let skipped = new_len - HEAD_LEN - TAIL_LEN;
```

### Background
The code in question collects the output of a process. Small output is kept completely, but larger output is kept only partially: the first 160 kB and the last 256 kB.

The code that performs this split crashes if the data size is less than 416 kB. There is an early out based on the "filtered" length, but it is possible that the filtered length is greater than the real length. It seems that this code was written with the assumption that the filtered length is larger than the real length, which is not true in general.

When running CI tests locally using `src/ci/docker/run.sh`, the filtered folder is `/checkout`, which is shorter than the placeholder length of 32 bytes.

### Note
This PR should not change any behaviour. It only adds an early our for a case which will definitely crash (at least if compiletest is build with integer checks).

Note that an early out makes sense here: If the real data is too small, it does not sense to split it.