### PR TITLE
Document tracking issue for rustdoc `show-type-layout`

### DIFF
--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -310,6 +310,8 @@ the source.
 
 ### `--show-type-layout`: add a section to each type's docs describing its memory layout
 
+* Tracking issue: [#113248](https://github.com/rust-lang/rust/issues/113248)
+
 Using this flag looks like this:
 
 ```bash


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/113248

@rustbot label +T-rustdoc +A-docs