### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,21 +414,21 @@ dependencies = [
 
 [[package]]
 name = "chalk-derive"
-version = "0.87.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d552b2fa341f5fc35c6b917b1d289d3c3a34d0b74e579390ea6192d6152a8cdb"
+checksum = "ff5053a8a42dbff5279a82423946fc56dc1253b76cf211b2b3c14b3aad4e1281"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.102",
- "synstructure 0.12.6",
+ "syn 2.0.8",
+ "synstructure 0.13.0",
 ]
 
 [[package]]
 name = "chalk-engine"
-version = "0.87.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54ac43048cb31c470d7b3e3acd409090ef4a5abddfe02455187aebc3d6879f"
+checksum = "b9d0e18f29b8b0f4dcf7d31fe00c884af67719699e381e8dcc9d9624b1621c60"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-ir"
-version = "0.87.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43aa55deff4e7fbdb09fa014543372f2c95a06835ac487b9ce57b5099b950838"
+checksum = "8a56de2146a8ed0fcd54f4bd50db852f1de4eac9e1efe568494f106c21b77d2a"
 dependencies = [
  "bitflags",
  "chalk-derive",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.87.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61213deefc36ba265ad01c4d997e18bcddf7922862a4594a47ca4575afb3dab4"
+checksum = "b392e02b4c81ec76d3748da839fc70a5539b83d27c9030668463d34d5110b860"
 dependencies = [
  "chalk-derive",
  "chalk-ir",

--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -194,7 +194,7 @@ fn is_single_call_in_arm<'tcx>(
     arg: &'tcx Expr<'_>,
     drop_expr: &'tcx Expr<'_>,
 ) -> bool {
-    if matches!(arg.kind, ExprKind::Call(..) | ExprKind::MethodCall(..)) {
+    if arg.can_have_side_effects() {
         let parent_node = cx.tcx.hir().find_parent(drop_expr.hir_id);
         if let Some(Node::Arm(Arm { body, .. })) = &parent_node {
             return body.hir_id == drop_expr.hir_id;

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bitflags = "1.2.1"
-chalk-ir = "0.87.0"
+chalk-ir = "0.92.0"
 derive_more = "0.99.17"
 either = "1.5.0"
 gsgdt = "0.1.2"

--- a/compiler/rustc_traits/Cargo.toml
+++ b/compiler/rustc_traits/Cargo.toml
@@ -11,9 +11,9 @@ rustc_hir = { path = "../rustc_hir" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
-chalk-ir = "0.87.0"
-chalk-engine = "0.87.0"
-chalk-solve = "0.87.0"
+chalk-ir = "0.92.0"
+chalk-engine = "0.92.0"
+chalk-solve = "0.92.0"
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 rustc_infer = { path = "../rustc_infer" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }

--- a/compiler/rustc_traits/src/chalk/db.rs
+++ b/compiler/rustc_traits/src/chalk/db.rs
@@ -572,6 +572,8 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
             DiscriminantKind => lang_items.discriminant_kind_trait(),
             DispatchFromDyn => lang_items.dispatch_from_dyn_trait(),
             Tuple => lang_items.tuple_trait(),
+            Pointee => lang_items.pointee_trait(),
+            FnPtr => lang_items.fn_ptr_trait(),
         };
         def_id.map(chalk_ir::TraitId)
     }

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -560,22 +560,20 @@ impl<T> Vec<T> {
     /// Using memory that was allocated elsewhere:
     ///
     /// ```rust
-    /// #![feature(allocator_api)]
-    ///
-    /// use std::alloc::{AllocError, Allocator, Global, Layout};
+    /// use std::alloc::{alloc, Layout};
     ///
     /// fn main() {
     ///     let layout = Layout::array::<u32>(16).expect("overflow cannot happen");
     ///
     ///     let vec = unsafe {
-    ///         let mem = match Global.allocate(layout) {
-    ///             Ok(mem) => mem.cast::<u32>().as_ptr(),
-    ///             Err(AllocError) => return,
-    ///         };
+    ///         let mem = alloc(layout).cast::<u32>();
+    ///         if mem.is_null() {
+    ///             return;
+    ///         }
     ///
     ///         mem.write(1_000_000);
     ///
-    ///         Vec::from_raw_parts_in(mem, 1, 16, Global)
+    ///         Vec::from_raw_parts(mem, 1, 16)
     ///     };
     ///
     ///     assert_eq!(vec, &[1_000_000]);
@@ -758,19 +756,22 @@ impl<T, A: Allocator> Vec<T, A> {
     /// Using memory that was allocated elsewhere:
     ///
     /// ```rust
-    /// use std::alloc::{alloc, Layout};
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::{AllocError, Allocator, Global, Layout};
     ///
     /// fn main() {
     ///     let layout = Layout::array::<u32>(16).expect("overflow cannot happen");
+    ///
     ///     let vec = unsafe {
-    ///         let mem = alloc(layout).cast::<u32>();
-    ///         if mem.is_null() {
-    ///             return;
-    ///         }
+    ///         let mem = match Global.allocate(layout) {
+    ///             Ok(mem) => mem.cast::<u32>().as_ptr(),
+    ///             Err(AllocError) => return,
+    ///         };
     ///
     ///         mem.write(1_000_000);
     ///
-    ///         Vec::from_raw_parts(mem, 1, 16)
+    ///         Vec::from_raw_parts_in(mem, 1, 16, Global)
     ///     };
     ///
     ///     assert_eq!(vec, &[1_000_000]);

--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -13,9 +13,10 @@ use crate::sync::{Condvar, Mutex};
 /// use std::sync::{Arc, Barrier};
 /// use std::thread;
 ///
-/// let mut handles = Vec::with_capacity(10);
-/// let barrier = Arc::new(Barrier::new(10));
-/// for _ in 0..10 {
+/// let n = 10;
+/// let mut handles = Vec::with_capacity(n);
+/// let barrier = Arc::new(Barrier::new(n));
+/// for _ in 0..n {
 ///     let c = Arc::clone(&barrier);
 ///     // The same messages will be printed together.
 ///     // You will NOT see any interleaving.
@@ -105,9 +106,10 @@ impl Barrier {
     /// use std::sync::{Arc, Barrier};
     /// use std::thread;
     ///
-    /// let mut handles = Vec::with_capacity(10);
-    /// let barrier = Arc::new(Barrier::new(10));
-    /// for _ in 0..10 {
+    /// let n = 10;
+    /// let mut handles = Vec::with_capacity(n);
+    /// let barrier = Arc::new(Barrier::new(n));
+    /// for _ in 0..n {
     ///     let c = Arc::clone(&barrier);
     ///     // The same messages will be printed together.
     ///     // You will NOT see any interleaving.

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -1,6 +1,6 @@
 """Bootstrap tests
 
-Run these with `x test bootstrap`, or `python -m unittest bootstrap_test.py`."""
+Run these with `x test bootstrap`, or `python -m unittest src/bootstrap/bootstrap_test.py`."""
 
 from __future__ import absolute_import, division, print_function
 import os
@@ -12,6 +12,10 @@ import sys
 
 from shutil import rmtree
 
+# Allow running this from the top-level directory.
+bootstrap_dir = os.path.dirname(os.path.abspath(__file__))
+# For the import below, have Python search in src/bootstrap first.
+sys.path.insert(0, bootstrap_dir)
 import bootstrap
 import configure
 
@@ -131,8 +135,13 @@ class BuildBootstrap(unittest.TestCase):
 
         parsed = bootstrap.parse_args(args)
         build = serialize_and_parse(configure_args, parsed)
-        build.build_dir = os.environ["BUILD_DIR"]
-        build.build = os.environ["BUILD_PLATFORM"]
+        # Make these optional so that `python -m unittest` works when run manually.
+        build_dir = os.environ.get("BUILD_DIR")
+        if build_dir is not None:
+            build.build_dir = build_dir
+        build_platform = os.environ.get("BUILD_PLATFORM")
+        if build_platform is not None:
+            build.build = build_platform
         return build.build_bootstrap_cmd(env), env
 
     def test_cargoflags(self):

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -2682,8 +2682,9 @@ impl Step for Bootstrap {
             .args(["-m", "unittest", "bootstrap_test.py"])
             .env("BUILD_DIR", &builder.out)
             .env("BUILD_PLATFORM", &builder.build.build.triple)
-            .current_dir(builder.src.join("src/bootstrap/"))
-            .args(builder.config.test_args());
+            .current_dir(builder.src.join("src/bootstrap/"));
+        // NOTE: we intentionally don't pass test_args here because the args for unittest and cargo test are mutually incompatible.
+        // Use `python -m unittest` manually if you want to pass arguments.
         try_run(builder, &mut check_bootstrap).unwrap();
 
         let host = builder.config.build;

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -379,7 +379,9 @@ impl Step for RustAnalyzer {
         let host = self.host;
         let compiler = builder.compiler(stage, host);
 
-        builder.ensure(tool::RustAnalyzer { compiler, target: self.host }).expect("in-tree tool");
+        // We don't need to build the whole Rust Analyzer for the proc-macro-srv test suite,
+        // but we do need the standard library to be present.
+        builder.ensure(compile::Std::new(compiler, host));
 
         let workspace_path = "src/tools/rust-analyzer";
         // until the whole RA test suite runs on `i686`, we only run

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -310,6 +310,8 @@ the source.
 
 ### `--show-type-layout`: add a section to each type's docs describing its memory layout
 
+* Tracking issue: [#113248](https://github.com/rust-lang/rust/issues/113248)
+
 Using this flag looks like this:
 
 ```bash

--- a/tests/rustdoc-gui/search-filter.goml
+++ b/tests/rustdoc-gui/search-filter.goml
@@ -65,9 +65,9 @@ reload:
 set-timeout: 2000
 wait-for: "#crate-search"
 assert-css: ("#crate-search", {
-    "border": "1px solid rgb(224, 224, 224)",
-    "color": "rgb(0, 0, 0)",
-    "background-color": "rgb(255, 255, 255)",
+    "border": "1px solid #e0e0e0",
+    "color": "black",
+    "background-color": "white",
 })
 
 // We now check the dark theme.
@@ -75,15 +75,15 @@ click: "#settings-menu"
 wait-for: "#settings"
 click: "#theme-dark"
 wait-for-css: ("#crate-search", {
-    "border": "1px solid rgb(224, 224, 224)",
-    "color": "rgb(221, 221, 221)",
-    "background-color": "rgb(53, 53, 53)",
+    "border": "1px solid #e0e0e0",
+    "color": "#ddd",
+    "background-color": "#353535",
 })
 
 // And finally we check the ayu theme.
 click: "#theme-ayu"
 wait-for-css: ("#crate-search", {
-    "border": "1px solid rgb(92, 103, 115)",
-    "color": "rgb(255, 255, 255)",
-    "background-color": "rgb(15, 20, 25)",
+    "border": "1px solid #5c6773",
+    "color": "#fff",
+    "background-color": "#0f1419",
 })

--- a/tests/ui/lint/dropping_copy_types.rs
+++ b/tests/ui/lint/dropping_copy_types.rs
@@ -77,3 +77,22 @@ fn issue9482(x: u8) {
         _ => (),
     }
 }
+
+fn issue112653() {
+    fn foo() -> Result<u8, ()> {
+        println!("doing foo");
+        Ok(0) // result is not always useful, the side-effect matters
+    }
+    fn bar() {
+        println!("doing bar");
+    }
+
+    fn stuff() -> Result<(), ()> {
+        match 42 {
+            0 => drop(foo()?),  // drop is needed because we only care about side-effects
+            1 => bar(),
+            _ => (),  // doing nothing (no side-effects needed here)
+        }
+        Ok(())
+    }
+}

--- a/tests/ui/lint/dropping_references.rs
+++ b/tests/ui/lint/dropping_references.rs
@@ -97,3 +97,22 @@ fn issue10122(x: u8) {
         _ => (),
     }
 }
+
+fn issue112653() {
+    fn foo() -> Result<&'static u8, ()> {
+        println!("doing foo");
+        Ok(&0) // result is not always useful, the side-effect matters
+    }
+    fn bar() {
+        println!("doing bar");
+    }
+
+    fn stuff() -> Result<(), ()> {
+        match 42 {
+            0 => drop(foo()?),  // drop is needed because we only care about side-effects
+            1 => bar(),
+            _ => (),  // doing nothing (no side-effects needed here)
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Successful merges:

 - #113147 (Fix document examples of Vec::from_raw_parts and Vec::from_raw_parts_in)
 - #113202 (std docs: factorize literal in Barrier example)
 - #113228 (Migrate GUI colors test to original CSS color format)
 - #113231 (Fix `dropping_copy_types` lint from linting in match-arm with side-effects)
 - #113233 (Update chalk)
 - #113234 (Don't pass --test-args to `python -m unitest`)
 - #113244 (Make Rust Analyzer tests faster by compiling less code)
 - #113249 (Document tracking issue for rustdoc `show-type-layout`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113147,113202,113228,113231,113233,113234,113244,113249)
<!-- homu-ignore:end -->