### PR TITLE
Update compiler builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.93"
+version = "0.1.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76630810d973ecea3dbf611e1b7aecfb1012751ef1ff8de3998f89014a166781"
+checksum = "6866e0f3638013234db3c89ead7a14d278354338e7237257407500009012b23f"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,8 +18,7 @@ panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
 libc = { version = "0.2.146", default-features = false, features = ['rustc-dep-of-std'], public = true }
-# FIXME(Nilstrieb): https://github.com/rust-lang/compiler-builtins/pull/532/files#r1249354225
-compiler_builtins = { version = "=0.1.93" }
+compiler_builtins = { version = "0.1.95" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = ['rustc-dep-of-std'] }


### PR DESCRIPTION
cc https://github.com/rust-lang/compiler-builtins/pull/532#discussion_r1249354225

in particular this pulls in https://github.com/rust-lang/compiler-builtins/pull/532 and https://github.com/rust-lang/compiler-builtins/pull/535.

Fixes https://github.com/rust-lang/rust/issues/93166. Fixes https://github.com/rust-lang/git2-rs/issues/706. Fixes https://github.com/rust-lang/rust/issues/109064. Fixes https://github.com/rust-lang/wg-cargo-std-aware/issues/74.