### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -25,6 +25,9 @@ metadata_conflicting_alloc_error_handler =
 metadata_conflicting_global_alloc =
     the `#[global_allocator]` in {$other_crate_name} conflicts with global allocator in: {$crate_name}
 
+metadata_consider_adding_std =
+    consider adding the standard library to the sysroot with `x build library --target {$locator_triple}`
+
 metadata_consider_building_std =
     consider building the standard library from source with `cargo build -Zbuild-std`
 

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -646,12 +646,18 @@ impl IntoDiagnostic<'_> for CannotFindCrate {
             } else {
                 diag.note(fluent::metadata_target_no_std_support);
             }
-            // NOTE: this suggests using rustup, even though the user may not have it installed.
-            // That's because they could choose to install it; or this may give them a hint which
-            // target they need to install from their distro.
+
             if self.missing_core {
-                diag.help(fluent::metadata_consider_downloading_target);
+                if env!("CFG_RELEASE_CHANNEL") == "dev" {
+                    diag.help(fluent::metadata_consider_adding_std);
+                } else {
+                    // NOTE: this suggests using rustup, even though the user may not have it installed.
+                    // That's because they could choose to install it; or this may give them a hint which
+                    // target they need to install from their distro.
+                    diag.help(fluent::metadata_consider_downloading_target);
+                }
             }
+
             // Suggest using #![no_std]. #[no_core] is unstable and not really supported anyway.
             // NOTE: this is a dummy span if `extern crate std` was injected by the compiler.
             // If it's not a dummy, that means someone added `extern crate std` explicitly and

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -888,7 +888,7 @@ impl From<&CStr> for Arc<CStr> {
 #[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<CString> for Rc<CStr> {
     /// Converts a [`CString`] into an <code>[Rc]<[CStr]></code> by moving the [`CString`]
-    /// data into a new [`Arc`] buffer.
+    /// data into a new [`Rc`] buffer.
     #[inline]
     fn from(s: CString) -> Rc<CStr> {
         let rc: Rc<[u8]> = Rc::from(s.into_inner());

--- a/tests/rustdoc-gui/notable-trait.goml
+++ b/tests/rustdoc-gui/notable-trait.goml
@@ -175,11 +175,11 @@ call-function: (
     "check-colors",
     {
         "theme": "ayu",
-        "link_color": "rgb(57, 175, 215)",
-        "content_color": "rgb(230, 225, 207)",
-        "header_color": "rgb(255, 255, 255)",
-        "type_color": "rgb(255, 160, 165)",
-        "trait_color": "rgb(57, 175, 215)",
+        "link_color": "#39afd7",
+        "content_color": "#e6e1cf",
+        "header_color": "#fff",
+        "type_color": "#ffa0a5",
+        "trait_color": "#39afd7",
     },
 )
 
@@ -187,11 +187,11 @@ call-function: (
     "check-colors",
     {
         "theme": "dark",
-        "link_color": "rgb(210, 153, 29)",
-        "content_color": "rgb(221, 221, 221)",
-        "header_color": "rgb(221, 221, 221)",
-        "type_color": "rgb(45, 191, 184)",
-        "trait_color": "rgb(183, 140, 242)",
+        "link_color": "#d2991d",
+        "content_color": "#ddd",
+        "header_color": "#ddd",
+        "type_color": "#2dbfb8",
+        "trait_color": "#b78cf2",
     },
 )
 
@@ -199,11 +199,11 @@ call-function: (
     "check-colors",
     {
         "theme": "light",
-        "link_color": "rgb(56, 115, 173)",
-        "content_color": "rgb(0, 0, 0)",
-        "header_color": "rgb(0, 0, 0)",
-        "type_color": "rgb(173, 55, 138)",
-        "trait_color": "rgb(110, 79, 201)",
+        "link_color": "#3873ad",
+        "content_color": "black",
+        "header_color": "black",
+        "type_color": "#ad378a",
+        "trait_color": "#6e4fc9",
     },
 )
 


### PR DESCRIPTION
Successful merges:

 - #113253 (Fixed documentation of from<CString> for Rc<CStr>: Arc -> Rc)
 - #113258 (Migrate GUI colors test to original CSS color format)
 - #113259 (Suggest `x build library` for a custom toolchain that fails to load `core`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113253,113258,113259)
<!-- homu-ignore:end -->