### PR TITLE
Remove `mips*-unknown-linux-gnu*` builders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,18 +211,6 @@ jobs:
           - name: dist-loongarch64-linux
             os: ubuntu-20.04-8core-32gb
             env: {}
-          - name: dist-mips-linux
-            os: ubuntu-20.04-8core-32gb
-            env: {}
-          - name: dist-mips64-linux
-            os: ubuntu-20.04-8core-32gb
-            env: {}
-          - name: dist-mips64el-linux
-            os: ubuntu-20.04-8core-32gb
-            env: {}
-          - name: dist-mipsel-linux
-            os: ubuntu-20.04-8core-32gb
-            env: {}
           - name: dist-powerpc-linux
             os: ubuntu-20.04-8core-32gb
             env: {}

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -374,18 +374,6 @@ jobs:
           - name: dist-loongarch64-linux
             <<: *job-linux-8c
 
-          - name: dist-mips-linux
-            <<: *job-linux-8c
-
-          - name: dist-mips64-linux
-            <<: *job-linux-8c
-
-          - name: dist-mips64el-linux
-            <<: *job-linux-8c
-
-          - name: dist-mipsel-linux
-            <<: *job-linux-8c
-
           - name: dist-powerpc-linux
             <<: *job-linux-8c
 


### PR DESCRIPTION
Pursuant to the current consensus in https://github.com/rust-lang/compiler-team/issues/648