### PR TITLE
[rustdoc] Fix display of long inline cfg labels

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -971,6 +971,8 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	display: flex;
 	padding: 3px;
 	margin-bottom: 5px;
+	align-items: center;
+	vertical-align: text-bottom;
 }
 .item-name .stab {
 	margin-left: 0.3125em;
@@ -982,11 +984,9 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	color: var(--main-color);
 	background-color: var(--stab-background-color);
 	width: fit-content;
-	align-items: center;
 	white-space: pre-wrap;
 	border-radius: 3px;
-	display: inline-flex;
-	vertical-align: text-bottom;
+	display: inline;
 }
 
 .stab.portability > code {

--- a/tests/rustdoc-gui/label-next-to-symbol.goml
+++ b/tests/rustdoc-gui/label-next-to-symbol.goml
@@ -37,7 +37,6 @@ compare-elements-position: (
     ("y"),
 )
 
-
 // Mobile view
 set-window-size: (600, 600)
 // staggered layout with 2em spacing
@@ -62,5 +61,16 @@ compare-elements-position-false: (
 compare-elements-position-false: (
     ".item-name .stab.deprecated",
     "//*[@class='desc docblock-short'][text()='a thing with a label']",
+    ("y"),
+)
+
+// Ensure it doesn't expand.
+set-window-size: (800, 800)
+go-to: "file://" + |DOC_PATH| + "/test_docs/cfgs/index.html"
+// This part of the tags should not be on the same line as the beginning since the width
+// is too small for that.
+compare-elements-position-false: (
+    "//*[@class='stab portability']/code[text()='appservice-api-c']",
+    "//*[@class='stab portability']/code[text()='server']",
     ("y"),
 )

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -507,3 +507,12 @@ pub mod fields {
         },
     }
 }
+
+pub mod cfgs {
+    #[doc(cfg(all(
+        any(not(feature = "appservice-api-c"), not(feature = "appservice-api-s")),
+        any(not(feature = "client"), not(feature = "server")),
+    )))]
+    /// Some docs.
+    pub mod cfgs {}
+}


### PR DESCRIPTION
Fixes #87957.
Fixes #112880.

Before:

![Screenshot from 2023-07-03 13-25-47](https://github.com/rust-lang/rust/assets/3050060/401e2c6b-2cfd-4ae3-9d15-b5e1dfec4201)

After:

![Screenshot from 2023-07-03 13-24-49](https://github.com/rust-lang/rust/assets/3050060/e42a34a8-bf60-409d-8a0c-1669d09e7e1e)

r? @notriddle 