### PR TITLE
enable test_join test in Miri

### DIFF
--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1906,6 +1906,7 @@ fn test_stable_pointers() {
     assert_eq!(*v0, 13);
 
     // Smoke test that would fire even outside Miri if an actual relocation happened.
+    // Also ensures the pointer is still writeable after all this.
     *v0 -= 13;
     assert_eq!(v[0], 0);
 }

--- a/library/core/tests/future.rs
+++ b/library/core/tests/future.rs
@@ -30,7 +30,6 @@ fn poll_n(val: usize, num: usize) -> PollN {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // self-referential generators do not work with Miri's aliasing checks
 fn test_join() {
     block_on(async move {
         let x = join!(async { 0 }).await;


### PR DESCRIPTION
Miri for quite a while now has a hack to support self-referential generators: non-`Unique` mutable references are exempt from aliasing conditions. So we can run this test now. (It passes.)

Also extend a comment in a Vec test, while I am at it.