### PR TITLE
Revert "Suggest `x build library` for a custom toolchain that fails to load `core`"

### DIFF
--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -25,9 +25,6 @@ metadata_conflicting_alloc_error_handler =
 metadata_conflicting_global_alloc =
     the `#[global_allocator]` in {$other_crate_name} conflicts with global allocator in: {$crate_name}
 
-metadata_consider_adding_std =
-    consider adding the standard library to the sysroot with `x build library --target {$locator_triple}`
-
 metadata_consider_building_std =
     consider building the standard library from source with `cargo build -Zbuild-std`
 

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -646,18 +646,12 @@ impl IntoDiagnostic<'_> for CannotFindCrate {
             } else {
                 diag.note(fluent::metadata_target_no_std_support);
             }
-
+            // NOTE: this suggests using rustup, even though the user may not have it installed.
+            // That's because they could choose to install it; or this may give them a hint which
+            // target they need to install from their distro.
             if self.missing_core {
-                if env!("CFG_RELEASE_CHANNEL") == "dev" {
-                    diag.help(fluent::metadata_consider_adding_std);
-                } else {
-                    // NOTE: this suggests using rustup, even though the user may not have it installed.
-                    // That's because they could choose to install it; or this may give them a hint which
-                    // target they need to install from their distro.
-                    diag.help(fluent::metadata_consider_downloading_target);
-                }
+                diag.help(fluent::metadata_consider_downloading_target);
             }
-
             // Suggest using #![no_std]. #[no_core] is unstable and not really supported anyway.
             // NOTE: this is a dummy span if `extern crate std` was injected by the compiler.
             // If it's not a dummy, that means someone added `extern crate std` explicitly and


### PR DESCRIPTION
This reverts commit b913f5593d2e2698d18034b56dd538ee745f1adc.

CI builds with profile=nightly, causing different test output.

Making the output depend on the release channel was not a great idea and we have to be more careful with this.

I did not realize that the change could have such effects on test output but it's kinda obvious with hindsight >.<.