### PR TITLE
Suggest `x build library` for a custom toolchain that fails to load `core`

### DIFF
--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -25,6 +25,9 @@ metadata_conflicting_alloc_error_handler =
 metadata_conflicting_global_alloc =
     the `#[global_allocator]` in {$other_crate_name} conflicts with global allocator in: {$crate_name}
 
+metadata_consider_adding_std =
+    consider adding the standard library to the sysroot with `x build library --target {$locator_triple}`
+
 metadata_consider_building_std =
     consider building the standard library from source with `cargo build -Zbuild-std`
 

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -1125,6 +1125,7 @@ impl CrateError {
                         is_nightly_build: sess.is_nightly_build(),
                         profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                         locator_triple: locator.triple,
+                        is_ui_testing: sess.opts.unstable_opts.ui_testing,
                     });
                 }
             }
@@ -1141,6 +1142,7 @@ impl CrateError {
                     is_nightly_build: sess.is_nightly_build(),
                     profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                     locator_triple: sess.opts.target_triple.clone(),
+                    is_ui_testing: sess.opts.unstable_opts.ui_testing,
                 });
             }
         }


### PR DESCRIPTION
Fixes #113222

The nicer suggestion for dev-channel won't be emitted if `-Z ui-testing` enabled. IMO, this is acceptable for now.