### PR TITLE
Remove another DefiningAnchor::Bubble usage

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -293,7 +293,8 @@ fn check_opaque_type_well_formed<'tcx>(
         return Ok(definition_ty);
     };
     let param_env = tcx.param_env(def_id);
-    // HACK This bubble is required for this tests to pass:
+    // HACK We use the function's anchor, instead of the TAIT's `DefId`, because the
+    // `TAIT` may not be in the defining scope of the other (nested) TAITs.
     // nested-return-type2-tait2.rs
     // nested-return-type2-tait3.rs
     // FIXME(-Ztrait-solver=next): We probably should use `DefiningAnchor::Error`
@@ -302,11 +303,7 @@ fn check_opaque_type_well_formed<'tcx>(
     let infcx = tcx
         .infer_ctxt()
         .with_next_trait_solver(next_trait_solver)
-        .with_opaque_type_inference(if next_trait_solver {
-            DefiningAnchor::Bind(def_id)
-        } else {
-            DefiningAnchor::Bubble
-        })
+        .with_opaque_type_inference(DefiningAnchor::Bind(def_id))
         .build();
     let ocx = ObligationCtxt::new(&infcx);
     let identity_substs = InternalSubsts::identity_for_item(tcx, def_id);

--- a/tests/ui/impl-trait/nested-return-type2-tait2.rs
+++ b/tests/ui/impl-trait/nested-return-type2-tait2.rs
@@ -17,6 +17,7 @@ impl<R: Duh, F: FnMut() -> R> Trait for F {
 
 type Sendable = impl Send;
 type Traitable = impl Trait<Assoc = Sendable>;
+//~^ ERROR opaque type `Traitable` does not satisfy its associated type bounds
 
 // The `impl Send` here is then later compared against the inference var
 // created, causing the inference var to be set to `impl Send` instead of
@@ -25,8 +26,6 @@ type Traitable = impl Trait<Assoc = Sendable>;
 // type does not implement `Duh`, even if its hidden type does. So we error out.
 fn foo() -> Traitable {
     || 42
-    //~^ ERROR `Sendable: Duh` is not satisfied
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/impl-trait/nested-return-type2-tait2.stderr
+++ b/tests/ui/impl-trait/nested-return-type2-tait2.stderr
@@ -1,18 +1,11 @@
-error[E0277]: the trait bound `Sendable: Duh` is not satisfied
-  --> $DIR/nested-return-type2-tait2.rs:27:5
+error: opaque type `Traitable` does not satisfy its associated type bounds
+  --> $DIR/nested-return-type2-tait2.rs:19:29
    |
-LL |     || 42
-   |     ^^^^^ the trait `Duh` is not implemented for `Sendable`
-   |
-   = help: the trait `Duh` is implemented for `i32`
-note: required for `[closure@$DIR/nested-return-type2-tait2.rs:27:5: 27:7]` to implement `Trait`
-  --> $DIR/nested-return-type2-tait2.rs:14:31
-   |
-LL | impl<R: Duh, F: FnMut() -> R> Trait for F {
-   |         ---                   ^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
+LL |     type Assoc: Duh;
+   |                 --- this associated type bound is unsatisfied for `Sendable`
+...
+LL | type Traitable = impl Trait<Assoc = Sendable>;
+   |                             ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/nested-return-type2-tait3.rs
+++ b/tests/ui/impl-trait/nested-return-type2-tait3.rs
@@ -15,17 +15,16 @@ impl<R: Duh, F: FnMut() -> R> Trait for F {
     type Assoc = R;
 }
 
-type Traitable = impl Trait<Assoc = impl Send>;
-
 // The `impl Send` here is then later compared against the inference var
 // created, causing the inference var to be set to `impl Send` instead of
 // the hidden type. We already have obligations registered on the inference
 // var to make it uphold the `: Duh` bound on `Trait::Assoc`. The opaque
 // type does not implement `Duh`, even if its hidden type does. So we error out.
+type Traitable = impl Trait<Assoc = impl Send>;
+//~^ ERROR opaque type `Traitable` does not satisfy its associated type bounds
+
 fn foo() -> Traitable {
     || 42
-    //~^ ERROR `impl Send: Duh` is not satisfied
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/impl-trait/nested-return-type2-tait3.stderr
+++ b/tests/ui/impl-trait/nested-return-type2-tait3.stderr
@@ -1,18 +1,16 @@
-error[E0277]: the trait bound `impl Send: Duh` is not satisfied
-  --> $DIR/nested-return-type2-tait3.rs:26:5
+error: opaque type `Traitable` does not satisfy its associated type bounds
+  --> $DIR/nested-return-type2-tait3.rs:23:29
    |
-LL |     || 42
-   |     ^^^^^ the trait `Duh` is not implemented for `impl Send`
+LL |     type Assoc: Duh;
+   |                 --- this associated type bound is unsatisfied for `impl Send`
+...
+LL | type Traitable = impl Trait<Assoc = impl Send>;
+   |                             ^^^^^^^^^^^^^^^^^
    |
-   = help: the trait `Duh` is implemented for `i32`
-note: required for `[closure@$DIR/nested-return-type2-tait3.rs:26:5: 26:7]` to implement `Trait`
-  --> $DIR/nested-return-type2-tait3.rs:14:31
+help: add this bound
    |
-LL | impl<R: Duh, F: FnMut() -> R> Trait for F {
-   |         ---                   ^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
+LL | type Traitable = impl Trait<Assoc = impl Send + Duh>;
+   |                                               +++++
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/nested-return-type3-tait2.rs
+++ b/tests/ui/impl-trait/nested-return-type3-tait2.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 #![feature(type_alias_impl_trait)]
 
 trait Duh {}
@@ -16,11 +14,10 @@ impl<F: Duh> Trait for F {
 
 type Sendable = impl Send;
 type Traitable = impl Trait<Assoc = Sendable>;
-//~^ WARN opaque type `Traitable` does not satisfy its associated type bounds
+//~^ ERROR opaque type `Traitable` does not satisfy its associated type bounds
 
 fn foo() -> Traitable {
     42
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/impl-trait/nested-return-type3-tait2.stderr
+++ b/tests/ui/impl-trait/nested-return-type3-tait2.stderr
@@ -1,13 +1,11 @@
-warning: opaque type `Traitable` does not satisfy its associated type bounds
-  --> $DIR/nested-return-type3-tait2.rs:18:29
+error: opaque type `Traitable` does not satisfy its associated type bounds
+  --> $DIR/nested-return-type3-tait2.rs:16:29
    |
 LL |     type Assoc: Duh;
    |                 --- this associated type bound is unsatisfied for `Sendable`
 ...
 LL | type Traitable = impl Trait<Assoc = Sendable>;
    |                             ^^^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(opaque_hidden_inferred_bound)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/ui/impl-trait/nested-return-type3-tait3.rs
+++ b/tests/ui/impl-trait/nested-return-type3-tait3.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 #![feature(type_alias_impl_trait)]
 
 trait Duh {}
@@ -15,7 +13,7 @@ impl<F: Duh> Trait for F {
 }
 
 type Traitable = impl Trait<Assoc = impl Send>;
-//~^ WARN opaque type `Traitable` does not satisfy its associated type bounds
+//~^ ERROR opaque type `Traitable` does not satisfy its associated type bounds
 
 fn foo() -> Traitable {
     42

--- a/tests/ui/impl-trait/nested-return-type3-tait3.stderr
+++ b/tests/ui/impl-trait/nested-return-type3-tait3.stderr
@@ -1,5 +1,5 @@
-warning: opaque type `Traitable` does not satisfy its associated type bounds
-  --> $DIR/nested-return-type3-tait3.rs:17:29
+error: opaque type `Traitable` does not satisfy its associated type bounds
+  --> $DIR/nested-return-type3-tait3.rs:15:29
    |
 LL |     type Assoc: Duh;
    |                 --- this associated type bound is unsatisfied for `impl Send`
@@ -7,11 +7,10 @@ LL |     type Assoc: Duh;
 LL | type Traitable = impl Trait<Assoc = impl Send>;
    |                             ^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(opaque_hidden_inferred_bound)]` on by default
 help: add this bound
    |
 LL | type Traitable = impl Trait<Assoc = impl Send + Duh>;
    |                                               +++++
 
-warning: 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/ui/type-alias-impl-trait/stronger_where_bounds.rs
+++ b/tests/ui/type-alias-impl-trait/stronger_where_bounds.rs
@@ -1,0 +1,53 @@
+// known-bug: #113278
+// run-fail
+
+#![feature(trivial_bounds, type_alias_impl_trait)]
+#![allow(trivial_bounds)]
+
+mod sus {
+    use super::*;
+    pub type Sep = impl Sized + std::fmt::Display;
+    pub fn mk_sep() -> Sep {
+        String::from("hello")
+    }
+
+    pub trait Proj {
+        type Assoc;
+    }
+    impl Proj for () {
+        type Assoc = sus::Sep;
+    }
+
+    pub struct Bar<T: Proj> {
+        pub inner: <T as Proj>::Assoc,
+        pub _marker: T,
+    }
+    impl<T: Proj> Clone for Bar<T> {
+        fn clone(&self) -> Self {
+            todo!()
+        }
+    }
+    impl<T: Proj<Assoc = i32> + Copy> Copy for Bar<T> {}
+    pub type Tait = impl Copy + From<Bar<()>> + Into<Bar<()>>;
+    pub fn define_tait() -> Tait
+    where
+        // This bound does not exist on `type Tait`, but will
+        // constrain `Sep` to `i32`, and then forget about it.
+        // On the other hand `mk_sep` constrains it to `String`.
+        // Since `Tait: Copy`, we can now copy `String`s.
+        (): Proj<Assoc = i32>,
+    {
+        Bar { inner: 1i32, _marker: () }
+    }
+}
+
+fn copy_tait(x: sus::Tait) -> (sus::Tait, sus::Tait) {
+    (x, x)
+}
+
+fn main() {
+    let bar = sus::Bar { inner: sus::mk_sep(), _marker: () };
+    let (y, z) = copy_tait(bar.into()); // copy a string
+    drop(y.into()); // drop one instance
+    println!("{}", z.into().inner); // print the other
+}


### PR DESCRIPTION
This doesn't affect anything, but removes one difference between the new and the old solver.

r? @lcnr 

cc https://github.com/rust-lang/rust/issues/113278