### PR TITLE
Implement Step for ascii::Char

### DIFF
--- a/library/core/tests/iter/range.rs
+++ b/library/core/tests/iter/range.rs
@@ -1,5 +1,6 @@
-use core::num::NonZeroUsize;
 use super::*;
+use core::ascii::Char as AsciiChar;
+use core::num::NonZeroUsize;
 
 #[test]
 fn test_range() {
@@ -37,6 +38,21 @@ fn test_char_range() {
     assert_eq!(('\u{D7FF}'..='\u{E000}').size_hint(), (2, Some(2)));
     assert_eq!(('\u{D7FF}'..'\u{E000}').count(), 1);
     assert_eq!(('\u{D7FF}'..'\u{E000}').size_hint(), (1, Some(1)));
+}
+
+#[test]
+fn test_ascii_char_range() {
+    let from = AsciiChar::Null;
+    let to = AsciiChar::Delete;
+    assert!((from..=to).eq((from as u8..=to as u8).filter_map(AsciiChar::from_u8)));
+    assert!((from..=to).rev().eq((from as u8..=to as u8).filter_map(AsciiChar::from_u8).rev()));
+
+    assert_eq!((AsciiChar::CapitalA..=AsciiChar::CapitalZ).count(), 26);
+    assert_eq!((AsciiChar::CapitalA..=AsciiChar::CapitalZ).size_hint(), (26, Some(26)));
+    assert_eq!((AsciiChar::SmallA..=AsciiChar::SmallZ).count(), 26);
+    assert_eq!((AsciiChar::SmallA..=AsciiChar::SmallZ).size_hint(), (26, Some(26)));
+    assert_eq!((AsciiChar::Digit0..=AsciiChar::Digit9).count(), 10);
+    assert_eq!((AsciiChar::Digit0..=AsciiChar::Digit9).size_hint(), (10, Some(10)));
 }
 
 #[test]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -2,6 +2,8 @@
 #![feature(array_chunks)]
 #![feature(array_methods)]
 #![feature(array_windows)]
+#![feature(ascii_char)]
+#![feature(ascii_char_variants)]
 #![feature(bigint_helper_methods)]
 #![feature(cell_update)]
 #![feature(const_align_offset)]

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -19,7 +19,7 @@ LL |     for i in false..true {}
              i64
              i128
              usize
-           and 5 others
+           and 6 others
    = note: required for `std::ops::Range<bool>` to implement `Iterator`
    = note: required for `std::ops::Range<bool>` to implement `IntoIterator`
 


### PR DESCRIPTION
This allows iterating over ranges of `ascii::Char`, similarly to ranges of `char`.

Note that `ascii::Char` is still unstable, tracked in #110998.