### PR TITLE
add flag for enabling global cache usage for proof trees and printing proof trees on error

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -748,7 +748,7 @@ pub enum TraitSolver {
 #[derive(Default, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum SolverProofTreeCondition {
     #[default]
-    Never,
+    OnRequest,
     Always,
     OnError,
 }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -746,11 +746,11 @@ pub enum TraitSolver {
 }
 
 #[derive(Default, Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum SolverProofTreeCondition {
-    #[default]
-    OnRequest,
+pub enum DumpSolverProofTree {
     Always,
     OnError,
+    #[default]
+    Never,
 }
 
 pub enum Input {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -745,6 +745,14 @@ pub enum TraitSolver {
     NextCoherence,
 }
 
+#[derive(Default, Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum SolverProofTreeCondition {
+    #[default]
+    Never,
+    Always,
+    OnError,
+}
+
 pub enum Input {
     /// Load source code from a file.
     File(PathBuf),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -418,8 +418,7 @@ mod desc {
         "a `,` separated combination of `bti`, `b-key`, `pac-ret`, or `leaf`";
     pub const parse_proc_macro_execution_strategy: &str =
         "one of supported execution strategies (`same-thread`, or `cross-thread`)";
-    pub const parse_solver_proof_tree_condition: &str =
-        "one of: `always`, `on-request`, `on-error`";
+    pub const parse_dump_solver_proof_tree: &str = "one of: `always`, `on-request`, `on-error`";
 }
 
 mod parse {
@@ -1241,14 +1240,14 @@ mod parse {
         true
     }
 
-    pub(crate) fn parse_solver_proof_tree_condition(
-        slot: &mut SolverProofTreeCondition,
+    pub(crate) fn parse_dump_solver_proof_tree(
+        slot: &mut DumpSolverProofTree,
         v: Option<&str>,
     ) -> bool {
         match v {
-            None | Some("always") => *slot = SolverProofTreeCondition::Always,
-            Some("on-request") => *slot = SolverProofTreeCondition::OnRequest,
-            Some("on-error") => *slot = SolverProofTreeCondition::OnError,
+            None | Some("always") => *slot = DumpSolverProofTree::Always,
+            Some("never") => *slot = DumpSolverProofTree::Never,
+            Some("on-error") => *slot = DumpSolverProofTree::OnError,
             _ => return false,
         };
         true
@@ -1478,11 +1477,11 @@ options! {
         "output statistics about monomorphization collection"),
     dump_mono_stats_format: DumpMonoStatsFormat = (DumpMonoStatsFormat::Markdown, parse_dump_mono_stats, [UNTRACKED],
         "the format to use for -Z dump-mono-stats (`markdown` (default) or `json`)"),
-    dump_solver_proof_tree: SolverProofTreeCondition = (SolverProofTreeCondition::OnRequest, parse_solver_proof_tree_condition, [UNTRACKED],
+    dump_solver_proof_tree: DumpSolverProofTree = (DumpSolverProofTree::Never, parse_dump_solver_proof_tree, [UNTRACKED],
         "dump a proof tree for every goal evaluated by the new trait solver. If the flag is specified without any options after it
         then it defaults to `always`. If the flag is not specified at all it defaults to `on-request`."),
     dump_solver_proof_tree_use_cache: Option<bool> = (None, parse_opt_bool, [UNTRACKED],
-        "determines whether proof tree generation uses the global cache"),
+        "determines whether dumped proof trees use the global cache"),
     dwarf_version: Option<u32> = (None, parse_opt_number, [TRACKED],
         "version of DWARF debug information to emit (default: 2 or 4, depending on platform)"),
     dylib_lto: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1481,7 +1481,7 @@ options! {
     dump_solver_proof_tree: SolverProofTreeCondition = (SolverProofTreeCondition::OnRequest, parse_solver_proof_tree_condition, [UNTRACKED],
         "dump a proof tree for every goal evaluated by the new trait solver. If the flag is specified without any options after it
         then it defaults to `always`. If the flag is not specified at all it defaults to `on-request`."),
-    dump_solver_proof_tree_uses_cache: Option<bool> = (None, parse_opt_bool, [UNTRACKED],
+    dump_solver_proof_tree_use_cache: Option<bool> = (None, parse_opt_bool, [UNTRACKED],
         "determines whether proof tree generation uses the global cache"),
     dwarf_version: Option<u32> = (None, parse_opt_number, [TRACKED],
         "version of DWARF debug information to emit (default: 2 or 4, depending on platform)"),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -418,7 +418,8 @@ mod desc {
         "a `,` separated combination of `bti`, `b-key`, `pac-ret`, or `leaf`";
     pub const parse_proc_macro_execution_strategy: &str =
         "one of supported execution strategies (`same-thread`, or `cross-thread`)";
-    pub const parse_solver_proof_tree_condition: &str = "one of: `always`, `never`, `on_error`";
+    pub const parse_solver_proof_tree_condition: &str =
+        "one of: `always`, `on-request`, `on-error`";
 }
 
 mod parse {
@@ -1246,7 +1247,7 @@ mod parse {
     ) -> bool {
         match v {
             None | Some("always") => *slot = SolverProofTreeCondition::Always,
-            Some("never") => *slot = SolverProofTreeCondition::Never,
+            Some("on-request") => *slot = SolverProofTreeCondition::OnRequest,
             Some("on-error") => *slot = SolverProofTreeCondition::OnError,
             _ => return false,
         };
@@ -1477,8 +1478,9 @@ options! {
         "output statistics about monomorphization collection"),
     dump_mono_stats_format: DumpMonoStatsFormat = (DumpMonoStatsFormat::Markdown, parse_dump_mono_stats, [UNTRACKED],
         "the format to use for -Z dump-mono-stats (`markdown` (default) or `json`)"),
-    dump_solver_proof_tree: SolverProofTreeCondition = (SolverProofTreeCondition::Never, parse_solver_proof_tree_condition, [UNTRACKED],
-        "dump a proof tree for every goal evaluated by the new trait solver. The default is `always`"),
+    dump_solver_proof_tree: SolverProofTreeCondition = (SolverProofTreeCondition::OnRequest, parse_solver_proof_tree_condition, [UNTRACKED],
+        "dump a proof tree for every goal evaluated by the new trait solver. If the flag is specified without any options after it
+        then it defaults to `always`. If the flag is not specified at all it defaults to `on-request`."),
     dump_solver_proof_tree_uses_cache: Option<bool> = (None, parse_opt_bool, [UNTRACKED],
         "determines whether proof tree generation uses the global cache"),
     dwarf_version: Option<u32> = (None, parse_opt_number, [TRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -418,6 +418,7 @@ mod desc {
         "a `,` separated combination of `bti`, `b-key`, `pac-ret`, or `leaf`";
     pub const parse_proc_macro_execution_strategy: &str =
         "one of supported execution strategies (`same-thread`, or `cross-thread`)";
+    pub const parse_solver_proof_tree_condition: &str = "one of: `always`, `never`, `on_error`";
 }
 
 mod parse {
@@ -1238,6 +1239,19 @@ mod parse {
         };
         true
     }
+
+    pub(crate) fn parse_solver_proof_tree_condition(
+        slot: &mut SolverProofTreeCondition,
+        v: Option<&str>,
+    ) -> bool {
+        match v {
+            None | Some("always") => *slot = SolverProofTreeCondition::Always,
+            Some("never") => *slot = SolverProofTreeCondition::Never,
+            Some("on-error") => *slot = SolverProofTreeCondition::OnError,
+            _ => return false,
+        };
+        true
+    }
 }
 
 options! {
@@ -1463,8 +1477,10 @@ options! {
         "output statistics about monomorphization collection"),
     dump_mono_stats_format: DumpMonoStatsFormat = (DumpMonoStatsFormat::Markdown, parse_dump_mono_stats, [UNTRACKED],
         "the format to use for -Z dump-mono-stats (`markdown` (default) or `json`)"),
-    dump_solver_proof_tree: bool = (false, parse_bool, [UNTRACKED],
-        "dump a proof tree for every goal evaluated by the new trait solver"),
+    dump_solver_proof_tree: SolverProofTreeCondition = (SolverProofTreeCondition::Never, parse_solver_proof_tree_condition, [UNTRACKED],
+        "dump a proof tree for every goal evaluated by the new trait solver. The default is `always`"),
+    dump_solver_proof_tree_uses_cache: Option<bool> = (None, parse_opt_bool, [UNTRACKED],
+        "determines whether proof tree generation uses the global cache"),
     dwarf_version: Option<u32> = (None, parse_opt_number, [TRACKED],
         "version of DWARF debug information to emit (default: 2 or 4, depending on platform)"),
     dylib_lto: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -19,7 +19,7 @@ use rustc_middle::ty::{
     self, OpaqueTypeKey, Ty, TyCtxt, TypeFoldable, TypeSuperVisitable, TypeVisitable,
     TypeVisitableExt, TypeVisitor,
 };
-use rustc_session::config::SolverProofTreeCondition;
+use rustc_session::config::DumpSolverProofTree;
 use rustc_span::DUMMY_SP;
 use std::io::Write;
 use std::ops::ControlFlow;
@@ -115,20 +115,20 @@ impl NestedGoals<'_> {
 
 #[derive(PartialEq, Eq, Debug, Hash, HashStable, Clone, Copy)]
 pub enum GenerateProofTree {
-    Yes(DisableGlobalCache),
+    Yes(UseGlobalCache),
     No,
 }
 
 #[derive(PartialEq, Eq, Debug, Hash, HashStable, Clone, Copy)]
-pub enum DisableGlobalCache {
+pub enum UseGlobalCache {
     Yes,
     No,
 }
-impl DisableGlobalCache {
-    pub fn from_bool(disable_cache: bool) -> Self {
-        match disable_cache {
-            true => DisableGlobalCache::Yes,
-            false => DisableGlobalCache::No,
+impl UseGlobalCache {
+    pub fn from_bool(use_cache: bool) -> Self {
+        match use_cache {
+            true => UseGlobalCache::Yes,
+            false => UseGlobalCache::No,
         }
     }
 }
@@ -198,7 +198,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
         let result = f(&mut ecx);
 
         let tree = ecx.inspect.finalize();
-        if let (Some(tree), SolverProofTreeCondition::Always) =
+        if let (Some(tree), DumpSolverProofTree::Always) =
             (&tree, infcx.tcx.sess.opts.unstable_opts.dump_solver_proof_tree)
         {
             let mut lock = std::io::stdout().lock();

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -183,7 +183,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
         let inspect = {
             let generate_proof_tree = match (
                 infcx.tcx.sess.opts.unstable_opts.dump_solver_proof_tree,
-                infcx.tcx.sess.opts.unstable_opts.dump_solver_proof_tree_uses_cache,
+                infcx.tcx.sess.opts.unstable_opts.dump_solver_proof_tree_use_cache,
                 generate_proof_tree,
             ) {
                 (_, Some(use_cache), GenerateProofTree::Yes(_)) => {

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -196,9 +196,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
                 }
 
                 (_, None, GenerateProofTree::Yes(_)) => generate_proof_tree,
-                // `Never` is kind of weird- it doesn't actually force us to not generate proof trees
-                // its just the default setting for rustflags forced proof tree generation.
-                (SolverProofTreeCondition::Never, _, _) => generate_proof_tree,
+                (SolverProofTreeCondition::OnRequest, _, _) => generate_proof_tree,
                 (SolverProofTreeCondition::OnError, _, _) => generate_proof_tree,
             };
 

--- a/compiler/rustc_trait_selection/src/solve/inspect/dump.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/dump.rs
@@ -1,5 +1,0 @@
-use rustc_middle::traits::solve::inspect::GoalEvaluation;
-
-pub fn print_tree(tree: &GoalEvaluation<'_>) {
-    debug!(?tree);
-}

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -33,7 +33,9 @@ mod search_graph;
 mod trait_goals;
 mod weak_types;
 
-pub use eval_ctxt::{EvalCtxt, InferCtxtEvalExt, InferCtxtSelectExt};
+pub use eval_ctxt::{
+    DisableGlobalCache, EvalCtxt, GenerateProofTree, InferCtxtEvalExt, InferCtxtSelectExt,
+};
 pub use fulfill::FulfillmentCtxt;
 pub(crate) use normalize::deeply_normalize;
 

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -34,7 +34,7 @@ mod trait_goals;
 mod weak_types;
 
 pub use eval_ctxt::{
-    DisableGlobalCache, EvalCtxt, GenerateProofTree, InferCtxtEvalExt, InferCtxtSelectExt,
+    EvalCtxt, GenerateProofTree, InferCtxtEvalExt, InferCtxtSelectExt, UseGlobalCache,
 };
 pub use fulfill::FulfillmentCtxt;
 pub(crate) use normalize::deeply_normalize;

--- a/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
@@ -13,7 +13,6 @@ use rustc_middle::traits::solve::{CanonicalInput, Certainty, MaybeCause, QueryRe
 use rustc_middle::ty::TyCtxt;
 use std::{collections::hash_map::Entry, mem};
 
-use super::eval_ctxt::DisableGlobalCache;
 use super::inspect::ProofTreeBuilder;
 use super::SolverMode;
 
@@ -214,9 +213,7 @@ impl<'tcx> SearchGraph<'tcx> {
         inspect: &mut ProofTreeBuilder<'tcx>,
         mut loop_body: impl FnMut(&mut Self, &mut ProofTreeBuilder<'tcx>) -> QueryResult<'tcx>,
     ) -> QueryResult<'tcx> {
-        if self.should_use_global_cache()
-            && inspect.disable_global_cache() == DisableGlobalCache::No
-        {
+        if self.should_use_global_cache() && inspect.use_global_cache() {
             if let Some(result) = tcx.new_solver_evaluation_cache.get(&canonical_input, tcx) {
                 debug!(?canonical_input, ?result, "cache hit");
                 inspect.cache_hit(CacheHit::Global);

--- a/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
@@ -13,6 +13,7 @@ use rustc_middle::traits::solve::{CanonicalInput, Certainty, MaybeCause, QueryRe
 use rustc_middle::ty::TyCtxt;
 use std::{collections::hash_map::Entry, mem};
 
+use super::eval_ctxt::DisableGlobalCache;
 use super::inspect::ProofTreeBuilder;
 use super::SolverMode;
 
@@ -213,7 +214,9 @@ impl<'tcx> SearchGraph<'tcx> {
         inspect: &mut ProofTreeBuilder<'tcx>,
         mut loop_body: impl FnMut(&mut Self, &mut ProofTreeBuilder<'tcx>) -> QueryResult<'tcx>,
     ) -> QueryResult<'tcx> {
-        if self.should_use_global_cache() {
+        if self.should_use_global_cache()
+            && inspect.disable_global_cache() == DisableGlobalCache::No
+        {
             if let Some(result) = tcx.new_solver_evaluation_cache.get(&canonical_input, tcx) {
                 debug!(?canonical_input, ?result, "cache hit");
                 inspect.cache_hit(CacheHit::Global);


### PR DESCRIPTION
This adds a few new things:
- `-Zdump-solver-proof-tree=always/never/on-error`
    - `always`/`never` were previosuly specifiable by whether the flag exists or not, th new flag is `on_error` which reruns obligations of fulfillment and selection errors with proof tree generation enabled and prints them out
- `-Zdump-solver-proof-tree-uses-cache`
    - allows forcing global cache to be used or unused for all generated proof trees, global cache is enabled by default for `always` so that it accurately represents what happend. This flag currently would affect misc uses of `GenerateProofTree::Yes` which will be added in the future for things like diagnostics logic and rustdoc's auto_trait file. We can fix this when we start using proof tree generation for those use cases if it's desirable.

I also changed the output to go straight to stdout instead of going through `debug!` so that `-Zdump-solver-proof-tree` can be adequately used on `nightly` not just a locally built toolchain.

The idea for `on-error` is that it should hopefully make it easier to quickly figure out "why doesnt this code compile"- you just pass in `-Zdump-solver-proof-tree=on-error` and you'll only get proof trees you care about.

---

r? @lcnr @compiler-errors 