### PR TITLE
Unite bless environment variables under `RUSTC_BLESS`

### DIFF
--- a/compiler/rustc_errors/src/markdown/tests/term.rs
+++ b/compiler/rustc_errors/src/markdown/tests/term.rs
@@ -63,7 +63,7 @@ fn test_wrapping_write() {
 #[test]
 fn test_output() {
     // Capture `--bless` when run via ./x
-    let bless = std::env::var("RUSTC_BLESS").unwrap_or_default() == "1";
+    let bless = std::env::var_os("RUSTC_BLESS").is_some_and(|v| v != "0");
     let ast = MdStream::parse_str(INPUT);
     let bufwtr = BufferWriter::stderr(ColorChoice::Always);
     let mut buffer = bufwtr.buffer();

--- a/src/tools/clippy/tests/compile-test.rs
+++ b/src/tools/clippy/tests/compile-test.rs
@@ -115,7 +115,9 @@ fn base_config(test_dir: &str) -> compiletest::Config {
         mode: TestMode::Yolo,
         stderr_filters: vec![],
         stdout_filters: vec![],
-        output_conflict_handling: if var_os("BLESS").is_some() || env::args().any(|arg| arg == "--bless") {
+        // FIXME(tgross35): deduplicate bless env once clippy can update
+        output_conflict_handling: if var_os("RUSTC_BLESS").is_some_and(|v| v != "0")
+        || env::args().any(|arg| arg == "--bless") {
             compiletest::OutputConflictHandling::Bless
         } else {
             compiletest::OutputConflictHandling::Error("cargo test -- -- --bless".into())

--- a/src/tools/miri/README.md
+++ b/src/tools/miri/README.md
@@ -482,7 +482,7 @@ Moreover, Miri recognizes some environment variables:
   purpose.
 * `MIRI_NO_STD` (recognized by `cargo miri` and the test suite) makes sure that the target's
   sysroot is built without libstd. This allows testing and running no_std programs.
-* `MIRI_BLESS` (recognized by the test suite and `cargo-miri-test/run-test.py`): overwrite all
+* `RUSTC_BLESS` (recognized by the test suite and `cargo-miri-test/run-test.py`): overwrite all
   `stderr` and `stdout` files instead of checking whether the output matches.
 * `MIRI_SKIP_UI_CHECKS` (recognized by the test suite): don't check whether the
   `stderr` or `stdout` files match the actual output.

--- a/src/tools/miri/miri
+++ b/src/tools/miri/miri
@@ -303,7 +303,7 @@ test|bless)
     $CARGO build $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml
     find_sysroot
     if [ "$COMMAND" = "bless" ]; then
-        export MIRI_BLESS="Gesundheit"
+        export RUSTC_BLESS="Gesundheit"
     fi
     # Then test, and let caller control flags.
     # Only in root project as `cargo-miri` has no tests.

--- a/src/tools/miri/test-cargo-miri/run-test.py
+++ b/src/tools/miri/test-cargo-miri/run-test.py
@@ -8,8 +8,8 @@ and the working directory to contain the cargo-miri-test project.
 import difflib
 import os
 import re
-import sys
 import subprocess
+import sys
 
 CGREEN  = '\33[32m'
 CBOLD   = '\33[1m'
@@ -37,7 +37,8 @@ def normalize_stderr(str):
     return str
 
 def check_output(actual, path, name):
-    if 'MIRI_BLESS' in os.environ:
+    if os.environ.get("RUSTC_BLESS", "0") != "0":
+        # Write the output only if bless is set
         open(path, mode='w').write(actual)
         return True
     expected = open(path).read()

--- a/src/tools/miri/tests/compiletest.rs
+++ b/src/tools/miri/tests/compiletest.rs
@@ -72,13 +72,14 @@ fn test_config(target: &str, path: &str, mode: Mode, with_dependencies: bool) ->
         program.args.push(flag);
     }
 
+    let bless = env::var_os("RUSTC_BLESS").is_some_and(|v| v !="0");
     let skip_ui_checks = env::var_os("MIRI_SKIP_UI_CHECKS").is_some();
 
-    let output_conflict_handling = match (env::var_os("MIRI_BLESS").is_some(), skip_ui_checks) {
+    let output_conflict_handling = match (bless, skip_ui_checks) {
         (false, false) => OutputConflictHandling::Error("./miri bless".into()),
         (true, false) => OutputConflictHandling::Bless,
         (false, true) => OutputConflictHandling::Ignore,
-        (true, true) => panic!("cannot use MIRI_BLESS and MIRI_SKIP_UI_CHECKS at the same time"),
+        (true, true) => panic!("cannot use RUSTC_BLESS and MIRI_SKIP_UI_CHECKS at the same time"),
     };
 
     let mut config = Config {

--- a/src/tools/rustfmt/src/test/mod.rs
+++ b/src/tools/rustfmt/src/test/mod.rs
@@ -838,11 +838,9 @@ fn handle_result(
 
         // Ignore LF and CRLF difference for Windows.
         if !string_eq_ignore_newline_repr(&fmt_text, &text) {
-            if let Some(bless) = std::env::var_os("BLESS") {
-                if bless != "0" {
-                    std::fs::write(file_name, fmt_text).unwrap();
-                    continue;
-                }
+            if std::env::var_os("RUSTC_BLESS").is_some_and(|v| v != "0") {
+                std::fs::write(file_name, fmt_text).unwrap();
+                continue;
             }
             let diff = make_diff(&text, &fmt_text, DIFF_CONTEXT_SIZE);
             assert!(


### PR DESCRIPTION
Currently, Clippy and Miri both use an environment variable to indicate that output should be blessed, but they use different variable names. In order to improve consistency, this patch applies the following changes:

- Rename the variable `MIRI_BLESS` (as used in the Miri subtree) to `RUST_BLESS`
- Rename the variable `BLESS` (as used in the Clippy subtree) to `RUST_BLESS`
- Move emitting `RUST_BLESS` into `prepare_cargo_test` so it is always available (I need this for a WIP PR)

---

I prefer something like `RUST_BLESS` to `BLESS` just for a lower chance of conflict (not super common but other tools [do use `BLESS`](https://grep.app/search?q=%22BLESS%22&case=true&words=true&filter[lang][0]=Text&filter[lang][1]=Rust&filter[lang][2]=Python&filter[lang][3]=C%2B%2B&filter[lang][4]=Markdown&filter[lang][5]=C&filter[lang][6]=JSON)), but I can change it to whatever is preferred.

Original discussion: https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/BLESS.20env.20var.3A.20rename.20to.20CLIPPY_BLESS

r? @oli-obk
cc @flip1995 