### PR TITLE
Upgrade to indexmap 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "curl",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "serde",
  "serde_json",
  "toml 0.5.11",
@@ -1694,8 +1694,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "rustc-rayon",
- "serde",
 ]
 
 [[package]]
@@ -1706,6 +1704,8 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "rustc-rayon",
+ "serde",
 ]
 
 [[package]]
@@ -3190,7 +3190,7 @@ dependencies = [
  "cfg-if",
  "elsa",
  "ena",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "itertools",
  "jobserver",
  "libc",
@@ -3968,7 +3968,7 @@ dependencies = [
 name = "rustc_serialize"
 version = "0.0.0"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "rustc_macros",
  "smallvec",
  "tempfile",
@@ -4016,7 +4016,7 @@ name = "rustc_span"
 version = "0.0.0"
 dependencies = [
  "cfg-if",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "md-5",
  "rustc_arena",
  "rustc_data_structures",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -10,7 +10,7 @@ arrayvec = { version = "0.7", default-features = false }
 bitflags = "1.2.1"
 cfg-if = "1.0"
 ena = "0.14.2"
-indexmap = { version = "1.9.3" }
+indexmap = { version = "2.0.0" }
 jobserver_crate = { version = "0.1.13", package = "jobserver" }
 libc = "0.2"
 measureme = "10.0.0"

--- a/compiler/rustc_serialize/Cargo.toml
+++ b/compiler/rustc_serialize/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-indexmap = "1.9.3"
+indexmap = "2.0.0"
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 thin-vec = "0.2.12"
 

--- a/compiler/rustc_span/Cargo.toml
+++ b/compiler/rustc_span/Cargo.toml
@@ -18,4 +18,4 @@ tracing = "0.1"
 sha1 = "0.10.0"
 sha2 = "0.10.1"
 md5 = { package = "md-5", version = "0.10.0" }
-indexmap = { version = "1.9.3" }
+indexmap = { version = "2.0.0" }

--- a/src/tools/bump-stage0/Cargo.toml
+++ b/src/tools/bump-stage0/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.34"
 curl = "0.4.38"
-indexmap = { version = "1.9.1", features = ["serde"] }
+indexmap = { version = "2.0.0", features = ["serde"] }
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = { version = "1.0.59", features = ["preserve_order"] }
 toml = "0.5.7"

--- a/tests/ui-fulldeps/missing-rustc-driver-error.stderr
+++ b/tests/ui-fulldeps/missing-rustc-driver-error.stderr
@@ -10,15 +10,7 @@ error: crate `indexmap` required to be available in rlib format, but was not fou
 
 error: crate `hashbrown` required to be available in rlib format, but was not found in this form
 
-error: crate `ahash` required to be available in rlib format, but was not found in this form
+error: crate `equivalent` required to be available in rlib format, but was not found in this form
 
-error: crate `once_cell` required to be available in rlib format, but was not found in this form
-
-error: crate `getrandom` required to be available in rlib format, but was not found in this form
-
-error: crate `cfg_if` required to be available in rlib format, but was not found in this form
-
-error: crate `libc` required to be available in rlib format, but was not found in this form
-
-error: aborting due to 10 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
The new version was already added to the tree as an indirect dependency
in #113046, but now our direct dependents are using it too.
