### PR TITLE
Support overriding `warnings` level for a specific lint via command line

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -490,7 +490,7 @@ pub static TRACK_DIAGNOSTICS: AtomicRef<fn(&mut Diagnostic, &mut dyn FnMut(&mut 
 #[derive(Copy, Clone, Default)]
 pub struct HandlerFlags {
     /// If false, warning-level lints are suppressed.
-    /// (rustc: see `--allow warnings` and `--cap-lints`)
+    /// (rustc: see `--cap-lints`)
     pub can_emit_warnings: bool,
     /// If true, error-level diagnostics are upgraded to bug-level.
     /// (rustc: see `-Z treat-err-as-bug`)

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -157,7 +157,7 @@ fn test_switch_implies_cfg_test_unless_cfg_test() {
 #[test]
 fn test_can_print_warnings() {
     rustc_span::create_default_session_globals_then(|| {
-        let matches = optgroups().parse(&["-Awarnings".to_string()]).unwrap();
+        let matches = optgroups().parse(&["--cap-lints=allow".to_string()]).unwrap();
         let mut handler = EarlyErrorHandler::new(ErrorOutputType::default());
         let (sess, _) = mk_session(&mut handler, matches);
         assert!(!sess.diagnostic().can_emit_warnings());

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1393,16 +1393,8 @@ pub fn build_session(
     target_override: Option<Target>,
     cfg_version: &'static str,
 ) -> Session {
-    // FIXME: This is not general enough to make the warning lint completely override
-    // normal diagnostic warnings, since the warning lint can also be denied and changed
-    // later via the source code.
-    let warnings_allow = sopts
-        .lint_opts
-        .iter()
-        .rfind(|&(key, _)| *key == "warnings")
-        .is_some_and(|&(_, level)| level == lint::Allow);
     let cap_lints_allow = sopts.lint_cap.is_some_and(|cap| cap == lint::Allow);
-    let can_emit_warnings = !(warnings_allow || cap_lints_allow);
+    let can_emit_warnings = !cap_lints_allow;
 
     let sysroot = match &sopts.maybe_sysroot {
         Some(sysroot) => sysroot.clone(),

--- a/tests/ui/lint/command-line-allow-warnings.rs
+++ b/tests/ui/lint/command-line-allow-warnings.rs
@@ -1,0 +1,27 @@
+// compile-flags: -A warnings
+
+fn main() {
+    // This will be overriden by the `-A warnings` command line option.
+    #[warn(non_snake_case)]
+    let _OwO = 0u8;
+
+    // But this should not.
+    #[deny(non_snake_case)]
+    let _UwU = 0u8;
+    //~^ ERROR variable `_UwU` should have a snake case name
+
+    bar();
+    baz();
+}
+
+#[warn(warnings)]
+fn bar() {
+    let _OwO = 0u8;
+    //~^ WARN variable `_OwO` should have a snake case name
+}
+
+#[deny(warnings)]
+fn baz() {
+    let _OwO = 0u8;
+    //~^ ERROR variable `_OwO` should have a snake case name
+}

--- a/tests/ui/lint/command-line-allow-warnings.stderr
+++ b/tests/ui/lint/command-line-allow-warnings.stderr
@@ -1,0 +1,35 @@
+error: variable `_UwU` should have a snake case name
+  --> $DIR/command-line-allow-warnings.rs:10:9
+   |
+LL |     let _UwU = 0u8;
+   |         ^^^^ help: convert the identifier to snake case: `_uw_u`
+   |
+note: the lint level is defined here
+  --> $DIR/command-line-allow-warnings.rs:9:12
+   |
+LL |     #[deny(non_snake_case)]
+   |            ^^^^^^^^^^^^^^
+
+warning: variable `_OwO` should have a snake case name
+  --> $DIR/command-line-allow-warnings.rs:19:9
+   |
+LL |     let _OwO = 0u8;
+   |         ^^^^ help: convert the identifier to snake case: `_ow_o`
+   |
+   = note: `#[warn(non_snake_case)]` on by default
+
+error: variable `_OwO` should have a snake case name
+  --> $DIR/command-line-allow-warnings.rs:25:9
+   |
+LL |     let _OwO = 0u8;
+   |         ^^^^ help: convert the identifier to snake case: `_ow_o`
+   |
+note: the lint level is defined here
+  --> $DIR/command-line-allow-warnings.rs:23:8
+   |
+LL | #[deny(warnings)]
+   |        ^^^^^^^^
+   = note: `#[deny(non_snake_case)]` implied by `#[deny(warnings)]`
+
+error: aborting due to 2 previous errors; 1 warning emitted
+

--- a/tests/ui/lint/command-line-lint-level-specific-lint.rs
+++ b/tests/ui/lint/command-line-lint-level-specific-lint.rs
@@ -1,0 +1,11 @@
+// compile-flags: -A warnings -W unused-variables
+
+fn main() {
+    let x = 0u8;
+    //~^ WARNING unused variable
+
+    // Source code lint level should override command-line lint level in any case.
+    #[deny(unused_variables)]
+    let y = 0u8;
+    //~^ ERROR unused variable
+}

--- a/tests/ui/lint/command-line-lint-level-specific-lint.stderr
+++ b/tests/ui/lint/command-line-lint-level-specific-lint.stderr
@@ -1,0 +1,22 @@
+warning: unused variable: `x`
+  --> $DIR/command-line-lint-level-specific-lint.rs:4:9
+   |
+LL |     let x = 0u8;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: requested on the command line with `-W unused-variables`
+
+error: unused variable: `y`
+  --> $DIR/command-line-lint-level-specific-lint.rs:9:9
+   |
+LL |     let y = 0u8;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_y`
+   |
+note: the lint level is defined here
+  --> $DIR/command-line-lint-level-specific-lint.rs:8:12
+   |
+LL |     #[deny(unused_variables)]
+   |            ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+


### PR DESCRIPTION
Supports the use case to

> silence all but one particular rustc lint.
> `rustc -Awarnings` "allows" all the warnings, easy so we only need to re-warn a single lint:
> `rustc -Awarnings -Wdead-code`.

This PR allows the user to refine the more general `warnings` level specified on the command line with a more specific level for a particular lint.

Closes #105104.