### PR TITLE
fix: extract rustc_test_marker attr in test_case

### DIFF
--- a/tests/ui/custom_test_frameworks/auxiliary/issue-100263-macro.rs
+++ b/tests/ui/custom_test_frameworks/auxiliary/issue-100263-macro.rs
@@ -1,0 +1,12 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn test(_args: TokenStream, _item: TokenStream) -> TokenStream {
+    TokenStream::default()
+}

--- a/tests/ui/custom_test_frameworks/issue-100263.rs
+++ b/tests/ui/custom_test_frameworks/issue-100263.rs
@@ -1,0 +1,12 @@
+// compile-flags: --test
+// aux-build: issue-100263-macro.rs
+#![feature(custom_test_frameworks)]
+
+extern crate issue_100263_macro;
+
+#[test_case]
+#[issue_100263_macro::test]
+fn foo() {}
+//~^ ERROR mismatched types
+
+fn main() {}

--- a/tests/ui/custom_test_frameworks/issue-100263.stderr
+++ b/tests/ui/custom_test_frameworks/issue-100263.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-100263.rs:9:1
+   |
+LL | #[test_case]
+   | ------------ in this procedural macro expansion
+LL | #[issue_100263_macro::test]
+LL | fn foo() {}
+   | ^^^^^^^^^^^ expected `&TestDescAndFn`, found `&fn() {foo}`
+   |
+   = note: expected reference `&TestDescAndFn`
+              found reference `&fn() {foo}`
+   = note: this error originates in the attribute macro `test_case` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #100263

To prevent ice caused [by normal.tokens.as_ref.unwrap()](https://github.com/rust-lang/rust/blob/master/compiler/rustc_ast/src/attr/mod.rs#L181), which attempts to unwrap the ﻿`None` generated by [attr_name_value_str](https://github.com/rust-lang/rust/blob/master/compiler/rustc_builtin_macros/src/test.rs#L60)