### PR TITLE
Revert "alloc: Allow comparing Boxs over different allocators", add regression test

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1319,56 +1319,39 @@ impl Clone for Box<str> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T, A1, A2> PartialEq<Box<T, A2>> for Box<T, A1>
-where
-    T: ?Sized + PartialEq,
-    A1: Allocator,
-    A2: Allocator,
-{
+impl<T: ?Sized + PartialEq, A: Allocator> PartialEq for Box<T, A> {
     #[inline]
-    fn eq(&self, other: &Box<T, A2>) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         PartialEq::eq(&**self, &**other)
     }
-
     #[inline]
-    fn ne(&self, other: &Box<T, A2>) -> bool {
+    fn ne(&self, other: &Self) -> bool {
         PartialEq::ne(&**self, &**other)
     }
 }
-
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T, A1, A2> PartialOrd<Box<T, A2>> for Box<T, A1>
-where
-    T: ?Sized + PartialOrd,
-    A1: Allocator,
-    A2: Allocator,
-{
+impl<T: ?Sized + PartialOrd, A: Allocator> PartialOrd for Box<T, A> {
     #[inline]
-    fn partial_cmp(&self, other: &Box<T, A2>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         PartialOrd::partial_cmp(&**self, &**other)
     }
-
     #[inline]
-    fn lt(&self, other: &Box<T, A2>) -> bool {
+    fn lt(&self, other: &Self) -> bool {
         PartialOrd::lt(&**self, &**other)
     }
-
     #[inline]
-    fn le(&self, other: &Box<T, A2>) -> bool {
+    fn le(&self, other: &Self) -> bool {
         PartialOrd::le(&**self, &**other)
     }
-
     #[inline]
-    fn ge(&self, other: &Box<T, A2>) -> bool {
+    fn ge(&self, other: &Self) -> bool {
         PartialOrd::ge(&**self, &**other)
     }
-
     #[inline]
-    fn gt(&self, other: &Box<T, A2>) -> bool {
+    fn gt(&self, other: &Self) -> bool {
         PartialOrd::gt(&**self, &**other)
     }
 }
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + Ord, A: Allocator> Ord for Box<T, A> {
     #[inline]

--- a/tests/ui/type-inference/issue-113283-alllocator-trait-eq.rs
+++ b/tests/ui/type-inference/issue-113283-alllocator-trait-eq.rs
@@ -1,0 +1,18 @@
+// run-pass
+// Verify that PartialEq implementations do not break type inference when
+// accepting types with different allocators
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+
+fn main() {
+    let boxed: Vec<Box<i32>> = vec![];
+    assert_eq!(boxed, vec![]);
+
+    let rc: Vec<Rc<i32>> = vec![];
+    assert_eq!(rc, vec![]);
+
+    let arc: Vec<Arc<i32>> = vec![];
+    assert_eq!(arc, vec![]);
+}


### PR DESCRIPTION
Temporary fix for #113283
    
Adds a test to fix the regression introduced in 001b081cc1b and revert that commit. The test fails without the revert.
