### PR TITLE
Use `llvm-config` instead of `download-ci-llvm` in PGO script

### DIFF
--- a/src/ci/stage-build.py
+++ b/src/ci/stage-build.py
@@ -842,7 +842,7 @@ def run_tests(pipeline: Pipeline):
 
     # Specify path to a LLVM config so that LLVM is not rebuilt.
     # It doesn't really matter which LLVM config we choose, because no sysroot will be compiled.
-    llvm_config = pipeline.build_artifacts() / "llvm" / "bin" / "llvm-config"
+    llvm_config = pipeline.build_artifacts() / "llvm" / "bin" / f"llvm-config{pipeline.executable_extension()}"
     assert llvm_config.is_file()
 
     config_content = f"""profile = "user"

--- a/src/ci/stage-build.py
+++ b/src/ci/stage-build.py
@@ -840,6 +840,11 @@ def run_tests(pipeline: Pipeline):
     cargo_path = cargo_dir / "bin" / f"cargo{pipeline.executable_extension()}"
     assert cargo_path.is_file()
 
+    # Specify path to a LLVM config so that LLVM is not rebuilt.
+    # It doesn't really matter which LLVM config we choose, because no sysroot will be compiled.
+    llvm_config = pipeline.build_artifacts() / "llvm" / "bin" / "llvm-config"
+    assert llvm_config.is_file()
+
     config_content = f"""profile = "user"
 changelog-seen = 2
 
@@ -847,8 +852,8 @@ changelog-seen = 2
 rustc = "{rustc_path.as_posix()}"
 cargo = "{cargo_path.as_posix()}"
 
-[llvm]
-download-ci-llvm = true
+[target.{PGO_HOST}]
+llvm-config = "{llvm_config.as_posix()}"
 """
     logging.info(f"Using following `config.toml` for running tests:\n{config_content}")
 


### PR DESCRIPTION
This should avoid CI breakage when the LLVM stamp is updated, and also it will avoid an unnecessary LLVM download from CI.

r? @jyn514