### PR TITLE
Winnow specialized impls during selection in new solver

### DIFF
--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -410,8 +410,8 @@ impl<'tcx> Instance<'tcx> {
     ) -> Instance<'tcx> {
         match ty::Instance::resolve(tcx, param_env, def_id, substs) {
             Ok(Some(instance)) => instance,
-            _ => bug!(
-                "failed to resolve instance for {}",
+            instance => bug!(
+                "failed to resolve instance for {}: {instance:#?}",
                 tcx.def_path_str_with_substs(def_id, substs)
             ),
         }

--- a/tests/ui/traits/new-solver/winnow-specializing-impls.rs
+++ b/tests/ui/traits/new-solver/winnow-specializing-impls.rs
@@ -1,0 +1,22 @@
+// build-pass
+// compile-flags: -Ztrait-solver=next
+
+// Tests that the specializing impl `<() as Foo>` holds during codegen.
+
+#![feature(min_specialization)]
+
+trait Foo {
+    fn bar();
+}
+
+impl<T> Foo for T {
+    default fn bar() {}
+}
+
+impl Foo for () {
+    fn bar() {}
+}
+
+fn main() {
+    <() as Foo>::bar();
+}


### PR DESCRIPTION
We need to be able to winnow impls that are specialized by more specific impls in order for codegen to be able to proceed.

r? @lcnr