### PR TITLE
Update the alignment checks to match rust-lang/reference#1387

### DIFF
--- a/tests/debuginfo/simple-struct.rs
+++ b/tests/debuginfo/simple-struct.rs
@@ -1,7 +1,7 @@
 // min-lldb-version: 310
 // ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
-// compile-flags:-g
+// compile-flags: -g -Zmir-enable-passes=-CheckAlignment
 
 // === GDB TESTS ===================================================================================
 

--- a/tests/ui/mir/alignment/addrof_alignment.rs
+++ b/tests/ui/mir/alignment/addrof_alignment.rs
@@ -1,5 +1,4 @@
 // run-pass
-// ignore-wasm32-bare: No panic messages
 // compile-flags: -C debug-assertions
 
 struct Misalignment {
@@ -9,7 +8,7 @@ struct Misalignment {
 fn main() {
     let items: [Misalignment; 2] = [Misalignment { a: 0 }, Misalignment { a: 1 }];
     unsafe {
-        let ptr: *const Misalignment = items.as_ptr().cast::<u8>().add(1).cast::<Misalignment>();
+        let ptr: *const Misalignment = items.as_ptr().byte_add(1);
         let _ptr = core::ptr::addr_of!((*ptr).a);
     }
 }

--- a/tests/ui/mir/alignment/i686-pc-windows-msvc.rs
+++ b/tests/ui/mir/alignment/i686-pc-windows-msvc.rs
@@ -11,9 +11,9 @@
 
 fn main() {
     let mut x = [0u64; 2];
-    let ptr: *mut u8 = x.as_mut_ptr().cast::<u8>();
+    let ptr = x.as_mut_ptr();
     unsafe {
-        let misaligned = ptr.add(4).cast::<u64>();
+        let misaligned = ptr.byte_add(4);
         assert!(misaligned.addr() % 8 != 0);
         assert!(misaligned.addr() % 4 == 0);
         *misaligned = 42;

--- a/tests/ui/mir/alignment/misaligned_lhs.rs
+++ b/tests/ui/mir/alignment/misaligned_lhs.rs
@@ -1,0 +1,13 @@
+// run-fail
+// ignore-wasm32-bare: No panic messages
+// ignore-i686-pc-windows-msvc: #112480
+// compile-flags: -C debug-assertions
+// error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
+
+fn main() {
+    let mut x = [0u32; 2];
+    let ptr = x.as_mut_ptr();
+    unsafe {
+        *(ptr.byte_add(1)) = 42;
+    }
+}

--- a/tests/ui/mir/alignment/misaligned_rhs.rs
+++ b/tests/ui/mir/alignment/misaligned_rhs.rs
@@ -1,0 +1,13 @@
+// run-fail
+// ignore-wasm32-bare: No panic messages
+// ignore-i686-pc-windows-msvc: #112480
+// compile-flags: -C debug-assertions
+// error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
+
+fn main() {
+    let mut x = [0u32; 2];
+    let ptr = x.as_mut_ptr();
+    unsafe {
+        let _v = *(ptr.byte_add(1));
+    }
+}

--- a/tests/ui/mir/alignment/packed.rs
+++ b/tests/ui/mir/alignment/packed.rs
@@ -1,0 +1,29 @@
+// run-pass
+// compile-flags: -C debug-assertions
+
+#![feature(strict_provenance, pointer_is_aligned)]
+
+#[repr(packed)]
+struct Misaligner {
+    _head: u8,
+    tail: u64,
+}
+
+fn main() {
+    let memory = [Misaligner { _head: 0, tail: 0}, Misaligner { _head: 0, tail: 0}];
+    // Test that we can use addr_of! to get the address of a packed member which according to its
+    // type is not aligned, but because it is a projection from a packed type is a valid place.
+    let ptr0 = std::ptr::addr_of!(memory[0].tail);
+    let ptr1 = std::ptr::addr_of!(memory[0].tail);
+    // Even if ptr0 happens to be aligned by chance, ptr1 is not.
+    assert!(!ptr0.is_aligned() || !ptr1.is_aligned());
+
+    // And also test that we can get the addr of a packed struct then do a member read from it.
+    unsafe {
+        let ptr = std::ptr::addr_of!(memory[0]);
+        let _tail = (*ptr).tail;
+
+        let ptr = std::ptr::addr_of!(memory[1]);
+        let _tail = (*ptr).tail;
+    }
+}

--- a/tests/ui/mir/alignment/place_computation.rs
+++ b/tests/ui/mir/alignment/place_computation.rs
@@ -1,0 +1,16 @@
+// run-pass
+// compile-flags: -C debug-assertions
+
+#[repr(align(8))]
+struct Misalignment {
+    a: u8,
+}
+
+fn main() {
+    let mem = 0u64;
+    let ptr = &mem as *const u64 as *const Misalignment;
+    unsafe {
+        let ptr = ptr.byte_add(1);
+        let _ref: &u8 = &(*ptr).a;
+    }
+}

--- a/tests/ui/mir/alignment/place_without_read.rs
+++ b/tests/ui/mir/alignment/place_without_read.rs
@@ -1,0 +1,9 @@
+// run-pass
+// compile-flags: -C debug-assertions
+
+fn main() {
+    let ptr = 1 as *const u16;
+    unsafe {
+        let _ = *ptr;
+    }
+}

--- a/tests/ui/mir/alignment/two_pointers.rs
+++ b/tests/ui/mir/alignment/two_pointers.rs
@@ -5,9 +5,11 @@
 // error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
 
 fn main() {
-    let mut x = [0u32; 2];
-    let ptr: *mut u8 = x.as_mut_ptr().cast::<u8>();
+    let x = [0u32; 2];
+    let ptr = x.as_ptr();
+    let mut dest = 0u32;
+    let dest_ptr = &mut dest as *mut u32;
     unsafe {
-        *(ptr.add(1).cast::<u32>()) = 42;
+        *dest_ptr = *(ptr.byte_add(1));
     }
 }


### PR DESCRIPTION
Previously, we had a special case to not check `Rvalue::AddressOf` in this pass because we weren't quite sure if pointers needed to be aligned in the Place passed to it: https://github.com/rust-lang/rust/pull/112026

Since https://github.com/rust-lang/reference/pull/1387 merged, this PR updates this pass to match. The behavior of the check is nearly unchanged, except we also avoid inserting a check for creating references. Most of the changes in this PR are cleanup and new tests.