### PR TITLE
`ptr::copy_nonoverlapping` is not memcpy

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2681,17 +2681,14 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 /// Copies `count * size_of::<T>()` bytes from `src` to `dst`. The source
 /// and destination may overlap.
 ///
-/// If the source and destination will *never* overlap,
-/// [`copy_nonoverlapping`] can be used instead.
-///
-/// `copy` is semantically equivalent to C's [`memmove`], but with the argument
-/// order swapped. Copying takes place as if the bytes were copied from `src`
-/// to a temporary array and then copied from the array to `dst`.
+/// `copy` may temporarily use additional space to copy bytes from `src` into an array, before
+/// copying them to `dst`. This lets `copy` correctly handle overlapping locations.
+/// If `src` and `dst` *never* overlap, [`copy_nonoverlapping`] may be used to avoid overhead.
+/// Note that in many cases, this additional overhead can be removed or reduced by the compiler,
+/// as this is an "intrinsic function" implemented directly through the compiler.
 ///
 /// The copy is "untyped" in the sense that data may be uninitialized or otherwise violate the
 /// requirements of `T`. The initialization state is preserved exactly.
-///
-/// [`memmove`]: https://en.cppreference.com/w/c/string/byte/memmove
 ///
 /// # Safety
 ///
@@ -2768,10 +2765,8 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
 /// Sets `count * size_of::<T>()` bytes of memory starting at `dst` to
 /// `val`.
 ///
-/// `write_bytes` is similar to C's [`memset`], but sets `count *
-/// size_of::<T>()` bytes to `val`.
-///
-/// [`memset`]: https://en.cppreference.com/w/c/string/byte/memset
+/// Note that this means that if `T` is multiple bytes, each byte is set to the same value,
+/// which may be interpreted to mean a very different value when interpreted as `T`.
 ///
 /// # Safety
 ///

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2574,13 +2574,8 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 ///
 /// For regions of memory which might overlap, use [`copy`] instead.
 ///
-/// `copy_nonoverlapping` is semantically equivalent to C's [`memcpy`], but
-/// with the argument order swapped.
-///
 /// The copy is "untyped" in the sense that data may be uninitialized or otherwise violate the
 /// requirements of `T`. The initialization state is preserved exactly.
-///
-/// [`memcpy`]: https://en.cppreference.com/w/c/string/byte/memcpy
 ///
 /// # Safety
 ///
@@ -2603,6 +2598,10 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 ///
 /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
 /// `0`, the pointers must be non-null and properly aligned.
+///
+/// In the case of a 0-byte read, the pointers may be the same pointer,
+/// as a region of 0 bytes overlaps with a region of 0 bytes for 0 bytes.
+/// A copy of 1 or more bytes to the same address incurs undefined behavior.
 ///
 /// [`read`]: crate::ptr::read
 /// [read-ownership]: crate::ptr::read#ownership-of-the-returned-value

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2598,9 +2598,8 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 ///
 /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
 /// `0`, the pointers must be non-null and properly aligned.
-///
-/// In the case of a 0-byte read, the pointers may be the same pointer,
-/// as a region of 0 bytes overlaps with a region of 0 bytes for 0 bytes.
+/// In this case, the pointers may share the same address, as
+/// a region of 0 bytes overlaps with a region of 0 bytes for 0 bytes.
 /// A copy of 1 or more bytes to the same address incurs undefined behavior.
 ///
 /// [`read`]: crate::ptr::read

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2599,7 +2599,7 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
 /// `0`, the pointers must be non-null and properly aligned.
 /// In this case, the pointers may share the same address, as
-/// a region of 0 bytes overlaps with a region of 0 bytes for 0 bytes.
+/// a region of 0 bytes does not overlap with a region of 0 bytes.
 ///
 /// [`read`]: crate::ptr::read
 /// [read-ownership]: crate::ptr::read#ownership-of-the-returned-value

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2600,7 +2600,6 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 /// `0`, the pointers must be non-null and properly aligned.
 /// In this case, the pointers may share the same address, as
 /// a region of 0 bytes overlaps with a region of 0 bytes for 0 bytes.
-/// A copy of 1 or more bytes to the same address incurs undefined behavior.
 ///
 /// [`read`]: crate::ptr::read
 /// [read-ownership]: crate::ptr::read#ownership-of-the-returned-value

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -825,7 +825,7 @@ impl<T> MaybeUninit<T> {
     /// // Initialize `buf`:
     /// unsafe { initialize_buffer(buf.as_mut_ptr()); }
     /// // Now we know that `buf` has been initialized, so we could `.assume_init()` it.
-    /// // However, using `.assume_init()` may trigger a `memcpy` of the 1024 bytes.
+    /// // However, using `.assume_init()` may trigger a copy of the 1024 bytes.
     /// // To assert our buffer has been initialized without copying it, we upgrade
     /// // the `&mut MaybeUninit<[u8; 1024]>` to a `&mut [u8; 1024]`:
     /// let buf: &mut [u8; 1024] = unsafe {

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1449,8 +1449,7 @@ impl<T: ?Sized> *mut T {
         unsafe { write(self, val) }
     }
 
-    /// Invokes memset on the specified pointer, setting `count * size_of::<T>()`
-    /// bytes of memory starting at `self` to `val`.
+    /// Sets `count * size_of::<T>()` bytes starting at `self` to `val`.
     ///
     /// See [`ptr::write_bytes`] for safety concerns and examples.
     ///

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3531,7 +3531,7 @@ impl<T> [T] {
         self.spec_clone_from(src);
     }
 
-    /// Copies all elements from `src` into `self`, using a memcpy.
+    /// Copies all elements from `src` into `self`, using [`ptr::copy_nonoverlapping`].
     ///
     /// The length of `src` must be the same as `self`.
     ///
@@ -3617,7 +3617,7 @@ impl<T> [T] {
     }
 
     /// Copies elements from one part of the slice to another part of itself,
-    /// using a memmove.
+    /// using [`ptr::copy`].
     ///
     /// `src` is the range within `self` to copy from. `dest` is the starting
     /// index of the range within `self` to copy to, which will have the same

--- a/library/core/src/slice/rotate.rs
+++ b/library/core/src/slice/rotate.rs
@@ -41,7 +41,7 @@ use crate::ptr;
 /// only once.
 ///
 /// Algorithm 2 is used if `left + right` is large but `min(left, right)` is small enough to
-/// fit onto a stack buffer. The `min(left, right)` elements are copied onto the buffer, `memmove`
+/// fit onto a stack buffer. The `min(left, right)` elements are copied onto the buffer, [`ptr::copy`]
 /// is applied to the others, and the ones on the buffer are moved back into the hole on the
 /// opposite side of where they originated.
 ///


### PR DESCRIPTION
A C implementation may treat memcpy calls Rust expects `ptr::copy_nonoverlapping` to handle correctly as UB. Stop confusing the matter.

r? @RalfJung