### PR TITLE
Implement selection for `Unsize` for better coercion behavior

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -636,6 +636,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                 Some(ty::PredicateKind::Clause(ty::ClauseKind::Trait(trait_pred)))
                     if traits.contains(&trait_pred.def_id()) =>
                 {
+                    let trait_pred = self.resolve_vars_if_possible(trait_pred);
                     if unsize_did == trait_pred.def_id() {
                         let self_ty = trait_pred.self_ty();
                         let unsize_ty = trait_pred.trait_ref.substs[1].expect_ty();
@@ -662,7 +663,6 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                 // Uncertain or unimplemented.
                 Ok(None) => {
                     if trait_pred.def_id() == unsize_did {
-                        let trait_pred = self.resolve_vars_if_possible(trait_pred);
                         let self_ty = trait_pred.self_ty();
                         let unsize_ty = trait_pred.trait_ref.substs[1].expect_ty();
                         debug!("coerce_unsized: ambiguous unsize case for {:?}", trait_pred);

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
-const ISSUES_ENTRY_LIMIT: usize = 1896;
+const ISSUES_ENTRY_LIMIT: usize = 1894;
 const ROOT_ENTRY_LIMIT: usize = 870;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[

--- a/tests/ui/traits/issue-24010.rs
+++ b/tests/ui/traits/issue-24010.rs
@@ -1,4 +1,6 @@
 // run-pass
+// revisions: classic next
+//[next] compile-flags: -Ztrait-solver=next
 
 trait Foo: Fn(i32) -> i32 + Send {}
 

--- a/tests/ui/traits/new-solver/unsize-although-ambiguous.rs
+++ b/tests/ui/traits/new-solver/unsize-although-ambiguous.rs
@@ -1,0 +1,13 @@
+// check-pass
+// compile-flags: -Ztrait-solver=next
+
+use std::fmt::Display;
+
+fn box_dyn_display(_: Box<dyn Display>) {}
+
+fn main() {
+    // During coercion, we don't necessarily know whether `{integer}` implements
+    // `Display`. Before, that would cause us to bail out in the coercion loop when
+    // checking `{integer}: Unsize<dyn Display>`.
+    box_dyn_display(Box::new(1));
+}

--- a/tests/ui/traits/trait-upcasting/issue-11515.current.stderr
+++ b/tests/ui/traits/trait-upcasting/issue-11515.current.stderr
@@ -1,5 +1,5 @@
 error[E0658]: cannot cast `dyn Fn()` to `dyn FnMut()`, trait upcasting coercion is experimental
-  --> $DIR/issue-11515.rs:9:38
+  --> $DIR/issue-11515.rs:10:38
    |
 LL |     let test = Box::new(Test { func: closure });
    |                                      ^^^^^^^

--- a/tests/ui/traits/trait-upcasting/issue-11515.next.stderr
+++ b/tests/ui/traits/trait-upcasting/issue-11515.next.stderr
@@ -1,0 +1,13 @@
+error[E0658]: cannot cast `dyn Fn()` to `dyn FnMut()`, trait upcasting coercion is experimental
+  --> $DIR/issue-11515.rs:10:38
+   |
+LL |     let test = Box::new(Test { func: closure });
+   |                                      ^^^^^^^
+   |
+   = note: see issue #65991 <https://github.com/rust-lang/rust/issues/65991> for more information
+   = help: add `#![feature(trait_upcasting)]` to the crate attributes to enable
+   = note: required when coercing `Box<(dyn Fn() + 'static)>` into `Box<(dyn FnMut() + 'static)>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/traits/trait-upcasting/issue-11515.rs
+++ b/tests/ui/traits/trait-upcasting/issue-11515.rs
@@ -1,8 +1,9 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+
 struct Test {
     func: Box<dyn FnMut() + 'static>,
 }
-
-
 
 fn main() {
     let closure: Box<dyn Fn() + 'static> = Box::new(|| ());


### PR DESCRIPTION
In order for much of coercion to succeed, we need to be able to deal with partial ambiguity of `Unsize` traits during selection. However, I pessimistically implemented selection in the new trait solver to just bail out with ambiguity if it was a built-in impl:
https://github.com/rust-lang/rust/blob/9227ff28aff55b252314076fcf21c9a66f10ac1e/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs#L126

This implements a proper "rematch" procedure for dealing with built-in `Unsize` goals, so that even if the goal is ambiguous, we are able to get nested obligations which are used in the coercion selection-like loop:
https://github.com/rust-lang/rust/blob/9227ff28aff55b252314076fcf21c9a66f10ac1e/compiler/rustc_hir_typeck/src/coercion.rs#L702

Second commit just moves a `resolve_vars_if_possible` call to fix a bug where we weren't detecting a trait upcasting to occur.

r? @lcnr