### PR TITLE
`unix::init`: Also fall back from `poll` on `ENOSYS`

### DIFF
--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -109,7 +109,7 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
             while libc::poll(pfds.as_mut_ptr(), 3, 0) == -1 {
                 match errno() {
                     libc::EINTR => continue,
-                    libc::EINVAL | libc::EAGAIN | libc::ENOMEM => {
+                    libc::ENOSYS | libc::EINVAL | libc::EAGAIN | libc::ENOMEM => {
                         // RLIMIT_NOFILE or temporary allocation failures
                         // may be preventing use of poll(), fall back to fcntl
                         break 'poll;


### PR DESCRIPTION
Operating systems like [Unikraft] may return [`ENOSYS`] (Function not implemented (POSIX.1-2001)) on certain syscalls.

Falling back from using `poll` at runtime initialization allows starting Rust applications on such systems.

[Unikraft]: https://unikraft.org/
[`ENOSYS`]: https://www.man7.org/linux/man-pages/man3/errno.3.html

Closes https://github.com/unikraft/lib-musl/issues/58.