### PR TITLE
Fix submodule handling when the current branch is named after a tag

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -599,6 +599,9 @@ impl Build {
 
             let mut git = self.config.git();
             if let Some(branch) = current_branch {
+                // If there is a tag named after the current branch, git will try to disambiguate by prepending `heads/` to the branch name.
+                // This syntax isn't accepted by `branch.{branch}`. Strip it.
+                let branch = branch.strip_prefix("heads/").unwrap_or(&branch);
                 git.arg("-c").arg(format!("branch.{branch}.remote=origin"));
             }
             git.args(&["submodule", "update", "--init", "--recursive", "--depth=1"]);


### PR DESCRIPTION
If:
1. The current branch has the same name as git tag, and
2. The current branch is set to track a remote other than `origin`, and
3. We try to update a submodule

then we'll get the following error:
```
; x c
Updating submodule src/doc/reference
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
fatal: 'personal' does not appear to be a git repository
fatal: Could not read from remote repository.
```

The problem is that 1. causes `git symbolic-ref --short HEAD` to try and disambiguate the branch from the tag using `heads/branch-name`, which breaks a previous workaround for a bug in `git submodule update` that uses the wrong remote.

Adapt the workaround to strip `heads/` from the output.