### PR TITLE
style-guide: Clarify grammar for small patterns (not a semantic change)

### DIFF
--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -768,13 +768,13 @@ matches "small" in the following grammar:
 
 ```
 small:
-    - smallntp
-    - unary tuple constructor: `(` smallntp `,` `)`
+    - small_no_tuple
+    - unary tuple constructor: `(` small_no_tuple `,` `)`
     - `&` small
 
-smallntp:
+small_no_tuple:
     - single token
-    - `&` smallntp
+    - `&` small_no_tuple
 ```
 
 E.g., `&&Some(foo)` matches, `Foo(4, Bar)` does not.

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -752,9 +752,9 @@ not put the `if` clause on a newline. E.g.,
     }
 ```
 
-If every clause in a pattern is *small*, but does not fit on one line, then the
-pattern may be formatted across multiple lines with as many clauses per line as
-possible. Again break before a `|`:
+If every clause in a pattern is *small*, but the whole pattern does not fit on
+one line, then the pattern may be formatted across multiple lines with as many
+clauses per line as possible. Again break before a `|`:
 
 ```rust
     foo | bar | baz
@@ -763,17 +763,18 @@ possible. Again break before a `|`:
     }
 ```
 
-We define a pattern clause to be *small* if it matches the following grammar:
+We define a pattern clause to be *small* if it fits on a single line and
+matches "small" in the following grammar:
 
 ```
-[small, ntp]:
-    - single token
-    - `&[single-line, ntp]`
+small:
+    - smallntp
+    - unary tuple constructor: `(` smallntp `,` `)`
+    - `&` small
 
-[small]:
-    - `[small, ntp]`
-    - unary tuple constructor `([small, ntp])`
-    - `&[small]`
+smallntp:
+    - single token
+    - `&` smallntp
 ```
 
 E.g., `&&Some(foo)` matches, `Foo(4, Bar)` does not.


### PR DESCRIPTION
The grammar as written feels ambiguous and confusing, in large part
because it uses square brackets and commas in the names of
non-terminals. Rewrite it to avoid symbols in the names of
non-terminals, and to instead wrap terminals in backquotes.

Also rename "smallntp" to "small_no_tuple" to make it self-describing.
