### PR TITLE
style-guide: Expand example of combinable expressions to include arrays

### DIFF
--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -801,6 +801,16 @@ foo(|param| {
     action();
     foo(param)
 })
+
+let x = combinable([
+    an_expr,
+    another_expr,
+]);
+
+let arr = [combinable(
+    an_expr,
+    another_expr,
+)];
 ```
 
 Such behaviour should extend recursively, however, tools may choose to limit the


### PR DESCRIPTION
Arrays are allowed as combinable expressions, but none of the examples
show that.
