### PR TITLE
Re-enable some coverage tests on Linux

### DIFF
--- a/tests/run-coverage/uses_crate.coverage
+++ b/tests/run-coverage/uses_crate.coverage
@@ -148,8 +148,8 @@ $DIR/auxiliary/used_crate.rs:
   100|       |// `unused_generic_function<T>()`, below.
 
 $DIR/uses_crate.rs:
-    1|       |// FIXME #110395
-    2|       |// ignore-linux
+    1|       |// This test was failing on Linux for a while due to #110393 somehow making
+    2|       |// the unused functions not instrumented, but it seems to be fine now.
     3|       |
     4|       |// Validates coverage now works with optimizations
     5|       |// compile-flags: -C opt-level=3

--- a/tests/run-coverage/uses_crate.rs
+++ b/tests/run-coverage/uses_crate.rs
@@ -1,5 +1,5 @@
-// FIXME #110395
-// ignore-linux
+// This test was failing on Linux for a while due to #110393 somehow making
+// the unused functions not instrumented, but it seems to be fine now.
 
 // Validates coverage now works with optimizations
 // compile-flags: -C opt-level=3

--- a/tests/run-coverage/uses_inline_crate.coverage
+++ b/tests/run-coverage/uses_inline_crate.coverage
@@ -139,8 +139,8 @@ $DIR/auxiliary/used_inline_crate.rs:
    90|      2|}
 
 $DIR/uses_inline_crate.rs:
-    1|       |// FIXME #110395
-    2|       |// ignore-linux
+    1|       |// This test was failing on Linux for a while due to #110393 somehow making
+    2|       |// the unused functions not instrumented, but it seems to be fine now.
     3|       |
     4|       |// Validates coverage now works with optimizations
     5|       |// compile-flags: -C opt-level=3

--- a/tests/run-coverage/uses_inline_crate.rs
+++ b/tests/run-coverage/uses_inline_crate.rs
@@ -1,5 +1,5 @@
-// FIXME #110395
-// ignore-linux
+// This test was failing on Linux for a while due to #110393 somehow making
+// the unused functions not instrumented, but it seems to be fine now.
 
 // Validates coverage now works with optimizations
 // compile-flags: -C opt-level=3


### PR DESCRIPTION
These tests were originally disabled (on all platforms) in #110393, because those changes had made them start failing on Linux for unclear reasons.

I tried to re-enable them unconditionally in #111179, since they worked locally on my Mac, but I found that they were still failing on Linux, so I gave up at that time.

Later while working on #112300 I was able to re-enable them on Windows and Mac, since those changes made it possible to add specific `ignore-` directives to individual tests. I noticed at the time that the tests actually seemed to be working again on Linux, but by that point I didn't want to risk more CI failures, so I left them disabled on Linux with an intention to re-enable them later.

Now I'm going back to re-enable them on Linux too, since they seem to work fine.

---

Because `run-coverage` tests are sensitive to line numbers, and `x test tidy` doesn't like leading blank lines, I've replaced the old comment/ignore with an informative comment that occupies the same number of lines.