### PR TITLE
style-guide: Some cleanups from the fmt-rfcs repo history

### DIFF
--- a/src/doc/style-guide/src/README.md
+++ b/src/doc/style-guide/src/README.md
@@ -37,8 +37,8 @@ options.
 ### Indentation and line width
 
 * Use spaces, not tabs.
-* Each level of indentation must be four spaces (that is, all indentation
-  outside of string literals and comments must be a multiple of four).
+* Each level of indentation must be 4 spaces (that is, all indentation
+  outside of string literals and comments must be a multiple of 4).
 * The maximum width for a line is 100 characters.
 
 #### Block indent

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -178,10 +178,12 @@ let f = Foo {
 Functional record update syntax is treated like a field, but it must never have
 a trailing comma. Do not put a space after `..`.
 
+```rust
 let f = Foo {
     field1,
     ..an_expr
 };
+```
 
 
 ### Tuple literals

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -126,8 +126,8 @@ but elide types where possible.
 
 Use closures without the enclosing `{}`, if possible. Add the `{}` when you have
 a return type, when there are statements, when there are comments inside the
-closure, or when the body expression spans multiple lines and is a control-flow
-expression. If using braces, follow the rules above for blocks. Examples:
+closure, or when the body expression is a control-flow expression that spans
+multiple lines. If using braces, follow the rules above for blocks. Examples:
 
 ```rust
 |arg1, arg2| expr

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -64,8 +64,8 @@ Write an empty block as `{}`.
 Write a block on a single line if:
 
 * it is either used in expression position (not statement position) or is an
-  unsafe block in statement position
-* it contains a single-line expression and no statements
+  unsafe block in statement position,
+* it contains a single-line expression and no statements, and
 * it contains no comments
 
 For a single-line block, put spaces after the opening brace and before the

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -125,9 +125,9 @@ expression of the closure. Between the `|`s, use function definition syntax,
 but elide types where possible.
 
 Use closures without the enclosing `{}`, if possible. Add the `{}` when you have
-a return type, when there are statements, there are comments in the body, or the
-body expression spans multiple lines and is a control-flow expression. If using
-braces, follow the rules above for blocks. Examples:
+a return type, when there are statements, when there are comments in the body,
+or when the body expression spans multiple lines and is a control-flow
+expression. If using braces, follow the rules above for blocks. Examples:
 
 ```rust
 |arg1, arg2| expr

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -125,8 +125,8 @@ expression of the closure. Between the `|`s, use function definition syntax,
 but elide types where possible.
 
 Use closures without the enclosing `{}`, if possible. Add the `{}` when you have
-a return type, when there are statements, when there are comments in the body,
-or when the body expression spans multiple lines and is a control-flow
+a return type, when there are statements, when there are comments inside the
+closure, or when the body expression spans multiple lines and is a control-flow
 expression. If using braces, follow the rules above for blocks. Examples:
 
 ```rust


### PR DESCRIPTION
There were a few commits that seem to have gone missing between the fmt-rfcs repo and the style guide. Re-apply those commits to the version of the style-guide in `rust-lang/rust`.

All of these are cleanups that don't change meaning.