### PR TITLE
style-guide: Document style editions, start 2024 style edition

### DIFF
--- a/src/doc/style-guide/src/SUMMARY.md
+++ b/src/doc/style-guide/src/SUMMARY.md
@@ -9,4 +9,5 @@
 - [Other style advice](advice.md)
 - [`Cargo.toml` conventions](cargo.md)
 - [Guiding principles and rationale](principles.md)
+- [Rust style editions](editions.md)
 - [Nightly-only syntax](nightly.md)

--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -4,10 +4,12 @@ The default Rust style evolves over time, as Rust does. However, to avoid
 breaking established code style, and CI jobs checking code style, changes to
 the default Rust style only appear in *style editions*.
 
-Code written in a given Rust edition uses the corresponding Rust style edition
-by default. To make it easier to migrate code style separately from the
-semantic changes between Rust editions, formatting tools such as `rustfmt`
-allow updating the style edition separately from the Rust edition.
+Code written in a given
+[Rust edition](https://doc.rust-lang.org/edition-guide/)
+uses the corresponding Rust style edition by default. To make it easier to
+migrate code style separately from the semantic changes between Rust editions,
+formatting tools such as `rustfmt` allow updating the style edition separately
+from the Rust edition.
 
 The current version of the style guide describes the latest Rust style edition.
 Each distinct past style will have a corresponding archived version of the

--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -1,0 +1,44 @@
+# Rust style editions
+
+The default Rust style evolves over time, as Rust does. However, to avoid
+breaking established code style, and CI jobs checking code style, changes to
+the default Rust style only appear in *style editions*.
+
+Code written in a given Rust edition uses the corresponding Rust style edition
+by default. To make it easier to migrate code style separately from the
+semantic changes between Rust editions, formatting tools such as `rustfmt`
+allow updating the style edition separately from the Rust edition.
+
+The current version of the style guide describes the latest Rust style edition.
+Each distinct past style will have a corresponding archived version of the
+style guide.
+
+Note that archived versions of the style guide do not document formatting for
+newer Rust constructs that did not exist at the time that version of the style
+guide was archived. However, each style edition will still format all
+constructs valid in that Rust edition, with the style of newer constructs
+coming from the first subsequent style edition providing formatting rules for
+that construct (without any of the systematic/global changes from that style
+edition).
+
+Not all Rust editions have corresponding changes to the Rust style. For
+instance, Rust 2015, Rust 2018, and Rust 2021 all use the same style edition.
+
+## Rust 2024 style edition
+
+This style guide describes the Rust 2024 style edition. The Rust 2024 style
+edition is currently nightly-only and may change before the release of Rust
+2024.
+
+For a full history of changes in the Rust 2024 style edition, see the git
+history of the style guide. Notable changes in the Rust 2024 style edition
+include:
+
+- Miscellaneous `rustfmt` bugfixes.
+
+## Rust 2015/2018/2021 style edition
+
+The archived version of the style guide at
+<https://github.com/rust-lang/rust/tree/37343f4a4d4ed7ad0891cb79e8eb25acf43fb821/src/doc/style-guide/src>
+describes the style edition corresponding to Rust 2015, Rust 2018, and Rust
+2021.


### PR DESCRIPTION
Link to a snapshot for the 2015/2018/2021 style edition.

This is a draft, because I'd like to wait for a few style guide fixes to merge
before snapshotting the 2015/2018/2021 style edition:

- https://github.com/rust-lang/rust/pull/113145
- https://github.com/rust-lang/rust/pull/113380
- https://github.com/rust-lang/rust/pull/113384
- https://github.com/rust-lang/rust/pull/113385
- https://github.com/rust-lang/rust/pull/113386
- https://github.com/rust-lang/rust/pull/113392

I'd like to wait for these for two reasons: to make it easier to see the
differences between the 2015/2018/2021 style edition and the 2024 style
edition (without the noise of guide-wide changes), and to minimize confusion so
that bugfixes to the style guide that we include in the previous edition don't
look like they're only part of the 2024 style edition.

I've used "Miscellaneous `rustfmt` bugfixes" as a starting point for the list
of 2024 changes, for now. We can update that when we add more 2024 changes.

The section added in this PR can then serve as a baseline for our drafts of
2024 style edition changes.

In the meantime, I'd like to get someone from @rust-lang/style to review and
approve the text here; I'll update it with a commit hash when the above PRs
have merged.