### PR TITLE
Dont ICE for `dyn* Trait: Trait` (built-in object) goals during selection in new trait solver

### DIFF
--- a/tests/ui/dyn-star/box.rs
+++ b/tests/ui/dyn-star/box.rs
@@ -1,5 +1,7 @@
 // run-pass
-// compile-flags: -C opt-level=0
+// revisions: current next
+//[current] compile-flags: -C opt-level=0
+//[next] compile-flags: -Ztrait-solver=next -C opt-level=0
 
 #![feature(dyn_star)]
 #![allow(incomplete_features)]


### PR DESCRIPTION
We were ICEing too eagerly during selection for `dyn*` goals -- both for dyn unsizing candidates and for built-in object candidates. The former should only be performed on `dyn` objects, but the latter are totally fine.