### PR TITLE
Prefer object candidates in new selection

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
@@ -173,10 +173,18 @@ fn candidate_should_be_dropped_in_favor_of<'tcx>(
             victim_idx >= other_idx
         }
         (_, CandidateSource::ParamEnv(_)) => true,
+
+        (
+            CandidateSource::BuiltinImpl(BuiltinImplSource::Object),
+            CandidateSource::BuiltinImpl(BuiltinImplSource::Object),
+        ) => false,
+        (_, CandidateSource::BuiltinImpl(BuiltinImplSource::Object)) => true,
+
         (CandidateSource::Impl(victim_def_id), CandidateSource::Impl(other_def_id)) => {
             tcx.specializes((other_def_id, victim_def_id))
                 && other.result.value.certainty == Certainty::Yes
         }
+
         _ => false,
     }
 }

--- a/tests/ui/traits/new-solver/dyn-any-dont-prefer-impl.rs
+++ b/tests/ui/traits/new-solver/dyn-any-dont-prefer-impl.rs
@@ -1,0 +1,13 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+use std::any::Any;
+
+fn needs_usize(_: &usize) {}
+
+fn main() {
+    let x: &dyn Any = &1usize;
+    if let Some(x) = x.downcast_ref::<usize>() {
+        needs_usize(x);
+    }
+}


### PR DESCRIPTION
`dyn Any` shouldn't be using [this implementation](https://doc.rust-lang.org/std/any/trait.Any.html#impl-Any-for-T) during codegen.

Prefer object candidates over other candidates, except for other object candidates.