### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -187,7 +187,13 @@ where
     }
 
     // Ensure CGUs are sorted by name, so that we get deterministic results.
-    assert!(codegen_units.is_sorted_by(|a, b| Some(a.name().as_str().cmp(b.name().as_str()))));
+    if !codegen_units.is_sorted_by(|a, b| Some(a.name().as_str().cmp(b.name().as_str()))) {
+        let mut names = String::new();
+        for cgu in codegen_units.iter() {
+            names += &format!("- {}\n", cgu.name());
+        }
+        bug!("unsorted CGUs:\n{names}");
+    }
 
     codegen_units
 }

--- a/src/tools/compiletest/src/read2.rs
+++ b/src/tools/compiletest/src/read2.rs
@@ -83,7 +83,7 @@ impl ProcOutput {
                 }
 
                 let new_len = bytes.len();
-                if *filtered_len <= HEAD_LEN + TAIL_LEN {
+                if (*filtered_len).min(new_len) <= HEAD_LEN + TAIL_LEN {
                     return;
                 }
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3712,8 +3712,11 @@ impl<'test> TestCx<'test> {
     }
 
     fn normalize_output(&self, output: &str, custom_rules: &[(String, String)]) -> String {
+        let rflags = self.props.run_flags.as_ref();
         let cflags = self.props.compile_flags.join(" ");
-        let json = cflags.contains("--error-format json")
+        let json = rflags
+            .map_or(false, |s| s.contains("--format json") || s.contains("--format=json"))
+            || cflags.contains("--error-format json")
             || cflags.contains("--error-format pretty-json")
             || cflags.contains("--error-format=json")
             || cflags.contains("--error-format=pretty-json")

--- a/tests/ui/dyn-star/box.rs
+++ b/tests/ui/dyn-star/box.rs
@@ -1,5 +1,7 @@
 // run-pass
-// compile-flags: -C opt-level=0
+// revisions: current next
+//[current] compile-flags: -C opt-level=0
+//[next] compile-flags: -Ztrait-solver=next -C opt-level=0
 
 #![feature(dyn_star)]
 #![allow(incomplete_features)]


### PR DESCRIPTION
Successful merges:

 - #112295 (Fix the tests-listing-format-json test on Windows)
 - #113246 (fix compiletest crash)
 - #113395 (Dont ICE for `dyn* Trait: Trait` (built-in object) goals during selection in new trait solver)
 - #113402 (Diagnose unsorted CGUs.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112295,113246,113395,113402)
<!-- homu-ignore:end -->