### PR TITLE
Add a type field to `mir::ConstantKind::Ty`.

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -351,7 +351,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'tcx> {
         } else {
             let tcx = self.tcx();
             let maybe_uneval = match constant.literal {
-                ConstantKind::Ty(ct) => match ct.kind() {
+                ConstantKind::Ty(ct, _) => match ct.kind() {
                     ty::ConstKind::Unevaluated(_) => {
                         bug!("should not encounter unevaluated ConstantKind::Ty here, got {:?}", ct)
                     }
@@ -1811,7 +1811,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
         if let Operand::Constant(constant) = op {
             let maybe_uneval = match constant.literal {
-                ConstantKind::Val(..) | ConstantKind::Ty(_) => None,
+                ConstantKind::Val(..) | ConstantKind::Ty(..) => None,
                 ConstantKind::Unevaluated(uv, _) => Some(uv),
             };
 

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -79,10 +79,10 @@ pub(crate) fn eval_mir_constant<'tcx>(
 ) -> Option<(ConstValue<'tcx>, Ty<'tcx>)> {
     let constant_kind = fx.monomorphize(constant.literal);
     let uv = match constant_kind {
-        ConstantKind::Ty(const_) => match const_.kind() {
+        ConstantKind::Ty(const_, ty) => match const_.kind() {
             ty::ConstKind::Unevaluated(uv) => uv.expand(),
             ty::ConstKind::Value(val) => {
-                return Some((fx.tcx.valtree_to_const_val((const_.ty(), val)), const_.ty()));
+                return Some((fx.tcx.valtree_to_const_val((ty, val)), const_.assert_ty_is(ty)));
             }
             err => span_bug!(
                 constant.span,

--- a/compiler/rustc_codegen_ssa/src/mir/constant.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/constant.rs
@@ -26,10 +26,10 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) -> Result<ConstValue<'tcx>, ErrorHandled> {
         let ct = self.monomorphize(constant.literal);
         let uv = match ct {
-            mir::ConstantKind::Ty(ct) => match ct.kind() {
+            mir::ConstantKind::Ty(ct, ty) => match ct.kind() {
                 ty::ConstKind::Unevaluated(uv) => uv.expand(),
                 ty::ConstKind::Value(val) => {
-                    return Ok(self.cx.tcx().valtree_to_const_val((ct.ty(), val)));
+                    return Ok(self.cx.tcx().valtree_to_const_val((ct.assert_ty_is(ty), val)));
                 }
                 err => span_bug!(
                     constant.span,

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -619,8 +619,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
         match *val {
-            mir::ConstantKind::Ty(ct) => {
-                let ty = ct.ty();
+            mir::ConstantKind::Ty(ct, ty) => {
+                ct.assert_ty_is(ty);
                 let valtree = self.eval_ty_constant(ct, span)?;
                 let const_val = self.tcx.valtree_to_const_val((ty, valtree));
                 self.const_val_to_op(const_val, ty, layout)

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -345,7 +345,7 @@ where
 
     // Check the qualifs of the value of `const` items.
     let uneval = match constant.literal {
-        ConstantKind::Ty(ct)
+        ConstantKind::Ty(ct, _)
             if matches!(
                 ct.kind(),
                 ty::ConstKind::Param(_) | ty::ConstKind::Error(_) | ty::ConstKind::Value(_)
@@ -353,7 +353,7 @@ where
         {
             None
         }
-        ConstantKind::Ty(c) => {
+        ConstantKind::Ty(c, _) => {
             bug!("expected ConstKind::Param or ConstKind::Value here, found {:?}", c)
         }
         ConstantKind::Unevaluated(uv, _) => Some(uv),

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -70,8 +70,8 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
         }
     }
 
-    fn print_const(self, ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
-        self.pretty_print_const(ct, false)
+    fn print_const(self, ct: ty::Const<'tcx>, ty: Ty<'tcx>) -> Result<Self::Const, Self::Error> {
+        self.pretty_print_const(ct, ty, false)
     }
 
     fn print_dyn_existential(

--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -97,7 +97,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if let Some(size) = size.try_eval_target_usize(tcx, self.param_env) {
                     format!("{size} bytes")
                 } else {
-                    format!("generic size {size}")
+                    format!("generic size {}", size.display(tcx.types.usize))
                 }
             }
             Err(LayoutError::Unknown(bad)) => {

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -609,7 +609,11 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 Err(NonTrivialPath)
             }
 
-            fn print_const(self, _ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
+            fn print_const(
+                self,
+                _ct: ty::Const<'tcx>,
+                _ty: Ty<'tcx>,
+            ) -> Result<Self::Const, Self::Error> {
                 Err(NonTrivialPath)
             }
 

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1183,10 +1183,10 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             (&ty::Adt(def1, sub1), &ty::Adt(def2, sub2)) => {
                 let did1 = def1.did();
                 let did2 = def2.did();
-                let sub_no_defaults_1 =
-                    self.tcx.generics_of(did1).own_substs_no_defaults(self.tcx, sub1);
-                let sub_no_defaults_2 =
-                    self.tcx.generics_of(did2).own_substs_no_defaults(self.tcx, sub2);
+                let generics1 = self.tcx.generics_of(did1);
+                let generics2 = self.tcx.generics_of(did2);
+                let sub_no_defaults_1 = generics1.own_substs_no_defaults(self.tcx, sub1);
+                let sub_no_defaults_2 = generics2.own_substs_no_defaults(self.tcx, sub2);
                 let mut values = (DiagnosticStyledString::new(), DiagnosticStyledString::new());
                 let path1 = self.tcx.def_path_str(did1);
                 let path2 = self.tcx.def_path_str(did2);
@@ -1290,8 +1290,13 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             values.0.push_normal("_");
                             values.1.push_normal("_");
                         } else {
-                            values.0.push_highlighted(ca1.to_string());
-                            values.1.push_highlighted(ca2.to_string());
+                            let tcx = self.tcx;
+                            let ty1 =
+                                tcx.type_of(generics1.param_at(i, tcx).def_id).subst(tcx, sub1);
+                            let ty2 =
+                                tcx.type_of(generics2.param_at(i, tcx).def_id).subst(tcx, sub2);
+                            values.0.push_highlighted(ca1.display(ty1).to_string());
+                            values.1.push_highlighted(ca2.display(ty2).to_string());
                         }
                         self.push_comma(&mut values.0, &mut values.1, len, i);
                     }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1965,7 +1965,7 @@ fn replace_param_and_infer_substs_with_placeholder<'tcx>(
                 let ty = c.ty();
                 // If the type references param or infer then ICE ICE ICE
                 if ty.has_non_region_param() || ty.has_non_region_infer() {
-                    bug!("const `{c}`'s type should not reference params or types");
+                    bug!("const `{c:?}`'s type should not reference params or types");
                 }
                 ty::Const::new_placeholder(
                     self.tcx,

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -1251,7 +1251,11 @@ impl<'tcx> LateContext<'tcx> {
                 Ok(())
             }
 
-            fn print_const(self, _ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
+            fn print_const(
+                self,
+                _ct: ty::Const<'tcx>,
+                _ty: Ty<'tcx>,
+            ) -> Result<Self::Const, Self::Error> {
                 Ok(())
             }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2278,8 +2278,9 @@ impl<'tcx> ConstantKind<'tcx> {
     #[inline(always)]
     pub fn ty(&self) -> Ty<'tcx> {
         match self {
-            ConstantKind::Ty(c, ty) => c.assert_ty_is(*ty),
-            ConstantKind::Val(_, ty) | ConstantKind::Unevaluated(_, ty) => *ty,
+            ConstantKind::Ty(_, ty)
+            | ConstantKind::Val(_, ty)
+            | ConstantKind::Unevaluated(_, ty) => *ty,
         }
     }
 

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -474,7 +474,7 @@ impl<'tcx> Visitor<'tcx> for ExtraComments<'tcx> {
             };
 
             let val = match literal {
-                ConstantKind::Ty(ct) => match ct.kind() {
+                ConstantKind::Ty(ct, _ty) => match ct.kind() {
                     ty::ConstKind::Param(p) => format!("Param({})", p),
                     ty::ConstKind::Unevaluated(uv) => {
                         format!("Unevaluated({}, {:?})", self.tcx.def_path_str(uv.def), uv.substs,)
@@ -728,7 +728,7 @@ pub fn write_allocations<'tcx>(
     impl<'tcx> Visitor<'tcx> for CollectAllocIds {
         fn visit_constant(&mut self, c: &Constant<'tcx>, _: Location) {
             match c.literal {
-                ConstantKind::Ty(_) | ConstantKind::Unevaluated(..) => {}
+                ConstantKind::Ty(..) | ConstantKind::Unevaluated(..) => {}
                 ConstantKind::Val(val, _) => {
                     self.0.extend(alloc_ids_from_const_val(val));
                 }

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -885,7 +885,10 @@ macro_rules! make_mir_visitor {
 
                 self.visit_span($(& $mutability)? *span);
                 match literal {
-                    ConstantKind::Ty(ct) => self.visit_ty_const($(&$mutability)? *ct, location),
+                    ConstantKind::Ty(ct, ty) => {
+                        self.visit_ty_const($(&$mutability)? *ct, location);
+                        self.visit_ty($(& $mutability)? *ty, TyContext::Location(location))
+                    },
                     ConstantKind::Val(_, ty) => self.visit_ty($(& $mutability)? *ty, TyContext::Location(location)),
                     ConstantKind::Unevaluated(_, ty) => self.visit_ty($(& $mutability)? *ty, TyContext::Location(location)),
                 }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -52,6 +52,15 @@ impl<'tcx> Const<'tcx> {
         self.0.ty
     }
 
+    /// A helper function while we transition into removing [Const::ty].
+    /// Use this instead of `ty` if you can, as this function ensures
+    /// your type matches with the internal state of the [Const].
+    #[inline]
+    pub fn assert_ty_is(self, ty: Ty<'tcx>) -> Ty<'tcx> {
+        assert_eq!(self.0.ty, ty);
+        ty
+    }
+
     #[inline]
     pub fn kind(self) -> ConstKind<'tcx> {
         self.0.kind.clone()

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -189,9 +189,12 @@ impl<'tcx> TypeError<'tcx> {
                 &format!("trait `{}`", values.found),
             )
             .into(),
-            ConstMismatch(ref values) => {
-                format!("expected `{}`, found `{}`", values.expected, values.found).into()
-            }
+            ConstMismatch(ref values) => format!(
+                "expected `{}`, found `{}`",
+                values.expected.display(values.expected.ty()),
+                values.found.display(values.found.ty())
+            )
+            .into(),
             IntrinsicCast => "cannot coerce intrinsics to function pointers".into(),
             TargetFeatureCast(_) => {
                 "cannot coerce functions with `#[target_feature]` to safe function pointers".into()

--- a/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
+++ b/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
@@ -21,7 +21,7 @@ impl<'tcx> NormalizationError<'tcx> {
     pub fn get_type_for_failure(&self) -> String {
         match self {
             NormalizationError::Type(t) => format!("{}", t),
-            NormalizationError::Const(c) => format!("{}", c),
+            NormalizationError::Const(c) => format!("{}", c.display(c.ty())),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -211,7 +211,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
                             .tcx
                             .sess
                             .create_err(ConstNotUsedTraitAlias {
-                                ct: ct.to_string(),
+                                ct: ct.display(Ty::new_misc_error(self.tcx)).to_string(),
                                 span: self.span,
                             })
                             .emit_unless(self.ignore_errors);

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -321,8 +321,15 @@ impl<'tcx, P: Printer<'tcx>> Print<'tcx, P> for ty::Const<'tcx> {
     type Output = P::Const;
     type Error = P::Error;
     fn print(&self, cx: P) -> Result<Self::Output, Self::Error> {
-        // TODO: implement Print for `(ty::Const, Ty)`
         cx.print_const(*self, self.ty())
+    }
+}
+
+impl<'tcx, P: Printer<'tcx>> Print<'tcx, P> for (ty::Const<'tcx>, Ty<'tcx>) {
+    type Output = P::Const;
+    type Error = P::Error;
+    fn print(&self, cx: P) -> Result<Self::Output, Self::Error> {
+        cx.print_const(self.0, self.1)
     }
 }
 

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -66,7 +66,7 @@ pub trait Printer<'tcx>: Sized {
         predicates: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
     ) -> Result<Self::DynExistential, Self::Error>;
 
-    fn print_const(self, ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error>;
+    fn print_const(self, ct: ty::Const<'tcx>, ty: Ty<'tcx>) -> Result<Self::Const, Self::Error>;
 
     fn path_crate(self, cnum: CrateNum) -> Result<Self::Path, Self::Error>;
 
@@ -321,7 +321,8 @@ impl<'tcx, P: Printer<'tcx>> Print<'tcx, P> for ty::Const<'tcx> {
     type Output = P::Const;
     type Error = P::Error;
     fn print(&self, cx: P) -> Result<Self::Output, Self::Error> {
-        cx.print_const(*self)
+        // TODO: implement Print for `(ty::Const, Ty)`
+        cx.print_const(*self, self.ty())
     }
 }
 

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2703,7 +2703,6 @@ forward_display_to_print! {
     ty::Region<'tcx>,
     Ty<'tcx>,
     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
-    ty::Const<'tcx>,
 
     // HACK(eddyb) these are exhaustive instead of generic,
     // because `for<'tcx>` isn't possible yet.

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1314,12 +1314,13 @@ pub trait PrettyPrinter<'tcx>:
     fn pretty_print_const(
         mut self,
         ct: ty::Const<'tcx>,
+        ty: Ty<'tcx>,
         print_ty: bool,
     ) -> Result<Self::Const, Self::Error> {
         define_scoped_cx!(self);
 
         if self.should_print_verbose() {
-            p!(write("{:?}", ct));
+            p!(write("Const {{ ty: {ty}, kind: {:?} }}", ct.kind()));
             return Ok(self);
         }
 
@@ -1331,7 +1332,7 @@ pub trait PrettyPrinter<'tcx>:
                             write!(this, "_")?;
                             Ok(this)
                         },
-                        |this| this.print_type(ct.ty()),
+                        |this| this.print_type(ct.assert_ty_is(ty)),
                         ": ",
                     )?;
                 } else {
@@ -1925,8 +1926,8 @@ impl<'tcx> Printer<'tcx> for FmtPrinter<'_, 'tcx> {
         self.pretty_print_dyn_existential(predicates)
     }
 
-    fn print_const(self, ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
-        self.pretty_print_const(ct, false)
+    fn print_const(self, ct: ty::Const<'tcx>, ty: Ty<'tcx>) -> Result<Self::Const, Self::Error> {
+        self.pretty_print_const(ct, ty, false)
     }
 
     fn path_crate(mut self, cnum: CrateNum) -> Result<Self::Path, Self::Error> {

--- a/compiler/rustc_mir_build/src/build/expr/as_constant.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_constant.rs
@@ -52,7 +52,7 @@ pub fn as_constant_inner<'tcx>(
                 match lit_to_mir_constant(tcx, LitToConstInput { lit: &lit.node, ty, neg }) {
                     Ok(c) => c,
                     Err(LitToConstError::Reported(guar)) => {
-                        ConstantKind::Ty(ty::Const::new_error(tcx, guar, ty))
+                        ConstantKind::Ty(ty::Const::new_error(tcx, guar, ty), ty)
                     }
                     Err(LitToConstError::TypeError) => {
                         bug!("encountered type error in `lit_to_mir_constant`")
@@ -85,7 +85,7 @@ pub fn as_constant_inner<'tcx>(
         }
         ExprKind::ConstParam { param, def_id: _ } => {
             let const_param = ty::Const::new_param(tcx, param, expr.ty);
-            let literal = ConstantKind::Ty(const_param);
+            let literal = ConstantKind::Ty(const_param, ty);
 
             Constant { user_ty: None, span, literal }
         }

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -142,7 +142,7 @@ impl IntRange {
         let ty = value.ty();
         let (target_size, bias) = Self::integral_size_and_signed_bias(tcx, ty)?;
         let val = match value {
-            mir::ConstantKind::Ty(c) if let ty::ConstKind::Value(valtree) = c.kind() => {
+            mir::ConstantKind::Ty(c, _) if let ty::ConstKind::Value(valtree) = c.kind() => {
                 valtree.unwrap_leaf().to_bits(target_size).ok()
             },
             // This is a more general form of the previous case.

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -143,7 +143,7 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
     fn visit_operand(&mut self, op: &Operand<'tcx>, location: Location) {
         if let Operand::Constant(constant) = op {
             let maybe_uneval = match constant.literal {
-                ConstantKind::Val(..) | ConstantKind::Ty(_) => None,
+                ConstantKind::Val(..) | ConstantKind::Ty(..) => None,
                 ConstantKind::Unevaluated(uv, _) => Some(uv),
             };
 

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -591,7 +591,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
 
         if let Rvalue::Use(Operand::Constant(c)) = rval {
             match c.literal {
-                ConstantKind::Ty(c) if matches!(c.kind(), ConstKind::Unevaluated(..)) => {}
+                ConstantKind::Ty(c, _) if matches!(c.kind(), ConstKind::Unevaluated(..)) => {}
                 _ => {
                     trace!("skipping replace of Rvalue::Use({:?} because it is already a const", c);
                     return;

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -631,7 +631,7 @@ impl<'tcx> Inliner<'tcx> {
                 // because we are calling `subst_and_normalize_erasing_regions`.
                 caller_body.required_consts.extend(
                     callee_body.required_consts.iter().copied().filter(|&ct| match ct.literal {
-                        ConstantKind::Ty(_) => {
+                        ConstantKind::Ty(..) => {
                             bug!("should never encounter ty::UnevaluatedConst in `required_consts`")
                         }
                         ConstantKind::Val(..) | ConstantKind::Unevaluated(..) => true,

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -136,7 +136,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
                     return;
                 }
 
-                let literal = ConstantKind::from_const(len, self.tcx);
+                let literal = ConstantKind::from_const(len, self.tcx.types.usize, self.tcx);
                 let constant = Constant { span: source_info.span, literal, user_ty: None };
                 *rvalue = Rvalue::Use(Operand::Constant(Box::new(constant)));
             }

--- a/compiler/rustc_mir_transform/src/normalize_array_len.rs
+++ b/compiler/rustc_mir_transform/src/normalize_array_len.rs
@@ -93,7 +93,7 @@ impl<'tcx> MutVisitor<'tcx> for Replacer<'tcx> {
             *rvalue = Rvalue::Use(Operand::Constant(Box::new(Constant {
                 span: rustc_span::DUMMY_SP,
                 user_ty: None,
-                literal: ConstantKind::from_const(len, self.tcx),
+                literal: ConstantKind::from_const(len, self.tcx.types.usize, self.tcx),
             })));
         }
         self.super_rvalue(rvalue, loc);

--- a/compiler/rustc_mir_transform/src/required_consts.rs
+++ b/compiler/rustc_mir_transform/src/required_consts.rs
@@ -16,7 +16,7 @@ impl<'tcx> Visitor<'tcx> for RequiredConstsVisitor<'_, 'tcx> {
     fn visit_constant(&mut self, constant: &Constant<'tcx>, _: Location) {
         let literal = constant.literal;
         match literal {
-            ConstantKind::Ty(c) => match c.kind() {
+            ConstantKind::Ty(c, _) => match c.kind() {
                 ConstKind::Param(_) | ConstKind::Error(_) | ConstKind::Value(_) => {}
                 _ => bug!("only ConstKind::Param/Value should be encountered here, got {:#?}", c),
             },

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -696,8 +696,10 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
         let literal = self.monomorphize(constant.literal);
         let val = match literal {
             mir::ConstantKind::Val(val, _) => val,
-            mir::ConstantKind::Ty(ct) => match ct.kind() {
-                ty::ConstKind::Value(val) => self.tcx.valtree_to_const_val((ct.ty(), val)),
+            mir::ConstantKind::Ty(ct, ty) => match ct.kind() {
+                ty::ConstKind::Value(val) => {
+                    self.tcx.valtree_to_const_val((ct.assert_ty_is(ty), val))
+                }
                 ty::ConstKind::Unevaluated(ct) => {
                     debug!(?ct);
                     let param_env = ty::ParamEnv::reveal_all();

--- a/compiler/rustc_monomorphize/src/polymorphize.rs
+++ b/compiler/rustc_monomorphize/src/polymorphize.rs
@@ -265,8 +265,9 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkUsedGenericParams<'a, 'tcx> {
 
     fn visit_constant(&mut self, ct: &Constant<'tcx>, location: Location) {
         match ct.literal {
-            ConstantKind::Ty(c) => {
+            ConstantKind::Ty(c, ty) => {
                 c.visit_with(self);
+                Visitor::visit_ty(self, ty, TyContext::Location(location));
             }
             ConstantKind::Unevaluated(mir::UnevaluatedConst { def, substs: _, promoted }, ty) => {
                 // Avoid considering `T` unused when constants are of the form:

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -262,9 +262,9 @@ impl<'tcx> Printer<'tcx> for &mut SymbolPrinter<'tcx> {
         Ok(self)
     }
 
-    fn print_const(self, ct: ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
+    fn print_const(self, ct: ty::Const<'tcx>, ty: Ty<'tcx>) -> Result<Self::Const, Self::Error> {
         // only print integers
-        match (ct.kind(), ct.ty().kind()) {
+        match (ct.kind(), ct.assert_ty_is(ty).kind()) {
             (ty::ConstKind::Value(ty::ValTree::Leaf(scalar)), ty::Int(_) | ty::Uint(_)) => {
                 // The `pretty_print_const` formatting depends on -Zverbose
                 // flag, so we cannot reuse it here.

--- a/compiler/rustc_trait_selection/src/solve/normalize.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalize.rs
@@ -96,7 +96,7 @@ impl<'tcx> NormalizationFolder<'_, 'tcx> {
         let recursion_limit = tcx.recursion_limit();
         if !recursion_limit.value_within_limit(self.depth) {
             self.at.infcx.err_ctxt().report_overflow_error(
-                &ty::Const::new_unevaluated(tcx, uv, ty),
+                &ty::Const::new_unevaluated(tcx, uv, ty).display(ty),
                 self.at.cause.span,
                 true,
                 |_| {},

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1110,7 +1110,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType(ct, ty)) => {
                         let mut diag = self.tcx.sess.struct_span_err(
                             span,
-                            format!("the constant `{}` is not of type `{}`", ct, ty),
+                            format!("the constant `{}` is not of type `{}`", ct.display(ct.ty()), ty),
                         );
                         self.note_type_err(
                             &mut diag,

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -268,7 +268,7 @@ pub(crate) fn print_const(cx: &DocContext<'_>, n: ty::Const<'_>) -> String {
         {
             scalar.to_string()
         }
-        _ => n.to_string(),
+        _ => n.display(n.ty()).to_string(),
     }
 }
 


### PR DESCRIPTION
This is preparatory work in removing the dependencies on `ty::Const::ty` by tracking the types separately.

Next steps

* [x] Remove Display impls from ty::Const
* [ ] move Ty from mir ConstKind to mir Constant
* [x] thread type through pretty printing
* [ ] replace more `Const::ty` calls with `Const::assert_ty_is` calls.
* [ ] remove `Const::ty` function
* [ ] remove `Const::ty` field and make constructors stop taking a type

r? @BoxyUwU 