### PR TITLE
Only allow impl lifetimes in RPITIT hidden type that come from self type

### DIFF
--- a/tests/ui/impl-trait/in-trait/only-mentions-self-lt.bad.stderr
+++ b/tests/ui/impl-trait/in-trait/only-mentions-self-lt.bad.stderr
@@ -1,0 +1,17 @@
+error: return type captures more lifetimes than trait definition
+  --> $DIR/only-mentions-self-lt.rs:12:26
+   |
+LL | impl<'a> Foo<'a> for () {
+   |      -- this lifetime was captured
+LL |     fn test(&'a self) -> &'a Self { self }
+   |                          ^^^^^^^^
+   |
+note: hidden type must only reference lifetimes captured by this impl trait
+  --> $DIR/only-mentions-self-lt.rs:7:26
+   |
+LL |     fn test(&'a self) -> impl Sized;
+   |                          ^^^^^^^^^^
+   = note: hidden type inferred to be `&'a ()`
+
+error: aborting due to previous error
+

--- a/tests/ui/impl-trait/in-trait/only-mentions-self-lt.rs
+++ b/tests/ui/impl-trait/in-trait/only-mentions-self-lt.rs
@@ -1,0 +1,21 @@
+// revisions: good bad
+//[good] check-pass
+
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Foo<'a> {
+    fn test(&'a self) -> impl Sized;
+}
+
+#[cfg(bad)]
+impl<'a> Foo<'a> for () {
+    fn test(&'a self) -> &'a Self { self }
+    //[bad]~^ return type captures more lifetimes than trait definition
+}
+
+#[cfg(good)]
+impl<'a> Foo<'a> for &'a () {
+    fn test(&'a self) -> &'a Self { self }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/unconstrained-lt.current.stderr
+++ b/tests/ui/impl-trait/in-trait/unconstrained-lt.current.stderr
@@ -1,9 +1,17 @@
-error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/unconstrained-lt.rs:10:6
+error: return type captures more lifetimes than trait definition
+  --> $DIR/unconstrained-lt.rs:11:18
    |
 LL | impl<'a, T> Foo for T {
-   |      ^^ unconstrained lifetime parameter
+   |      -- this lifetime was captured
+LL |     fn test() -> &'a () { &() }
+   |                  ^^^^^^
+   |
+note: hidden type must only reference lifetimes captured by this impl trait
+  --> $DIR/unconstrained-lt.rs:7:18
+   |
+LL |     fn test() -> impl Sized;
+   |                  ^^^^^^^^^^
+   = note: hidden type inferred to be `&'a ()`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/impl-trait/in-trait/unconstrained-lt.next.stderr
+++ b/tests/ui/impl-trait/in-trait/unconstrained-lt.next.stderr
@@ -1,9 +1,17 @@
-error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/unconstrained-lt.rs:10:6
+error: return type captures more lifetimes than trait definition
+  --> $DIR/unconstrained-lt.rs:11:18
    |
 LL | impl<'a, T> Foo for T {
-   |      ^^ unconstrained lifetime parameter
+   |      -- this lifetime was captured
+LL |     fn test() -> &'a () { &() }
+   |                  ^^^^^^
+   |
+note: hidden type must only reference lifetimes captured by this impl trait
+  --> $DIR/unconstrained-lt.rs:7:18
+   |
+LL |     fn test() -> impl Sized;
+   |                  ^^^^^^^^^^
+   = note: hidden type inferred to be `&'a ()`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/impl-trait/in-trait/unconstrained-lt.rs
+++ b/tests/ui/impl-trait/in-trait/unconstrained-lt.rs
@@ -8,9 +8,8 @@ trait Foo {
 }
 
 impl<'a, T> Foo for T {
-    //~^ ERROR the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
-
     fn test() -> &'a () { &() }
+    //~^ ERROR return type captures more lifetimes than trait definition
 }
 
 fn main() {}


### PR DESCRIPTION
Follow-up to #113182, but now we limit the lifetimes that RPITITs are allowed to reference (without mentioning them in the `impl Trait` bounds) *just* to the Self type of the impl, rather than all of the lifetimes in the impl header.

Putting this up for discussion for #112194.

r? @oli-obk