### PR TITLE
Do not assert >1 RPITITs on collect_return_position_impl_trait_in_trait_tys

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -669,11 +669,13 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
         )
         .fold_with(&mut collector);
 
-    debug_assert_ne!(
-        collector.types.len(),
-        0,
-        "expect >1 RPITITs in call to `collect_return_position_impl_trait_in_trait_tys`"
-    );
+    if !unnormalized_trait_sig.output().references_error() {
+        debug_assert_ne!(
+            collector.types.len(),
+            0,
+            "expect >1 RPITITs in call to `collect_return_position_impl_trait_in_trait_tys`"
+        );
+    }
 
     let trait_sig = ocx.normalize(&norm_cause, param_env, unnormalized_trait_sig);
     trait_sig.error_reported()?;

--- a/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.current.stderr
+++ b/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.current.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/return-not-existing-type-wrapping-rpitit.rs:10:25
+   |
+LL |     fn bar() -> Wrapper<Missing<impl Sized>>;
+   |                         ^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.next.stderr
+++ b/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.next.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/return-not-existing-type-wrapping-rpitit.rs:10:25
+   |
+LL |     fn bar() -> Wrapper<Missing<impl Sized>>;
+   |                         ^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.rs
+++ b/tests/ui/async-await/in-trait/return-not-existing-type-wrapping-rpitit.rs
@@ -1,0 +1,20 @@
+// edition:2021
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
+
+#![feature(return_position_impl_trait_in_trait)]
+
+struct Wrapper<T>(T);
+
+trait Foo {
+    fn bar() -> Wrapper<Missing<impl Sized>>;
+    //~^ ERROR: cannot find type `Missing` in this scope [E0412]
+}
+
+impl Foo for () {
+    fn bar() -> Wrapper<i32> {
+        Wrapper(0)
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #113403

Assert on collect_return_position_impl_trait_in_trait_tys is not correct when we call it from type_of(GAT). The included test is an example of a situation that collector collects 0 types.

r? @compiler-errors 