### PR TITLE
Remove `variances_of` on RPITIT GATs, remove its one use-case

### DIFF
--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -473,17 +473,6 @@ where
                 }
             }
 
-            ty::Alias(ty::Projection, proj) if self.tcx.is_impl_trait_in_trait(proj.def_id) => {
-                // Skip lifetime parameters that are not captures.
-                let variances = self.tcx.variances_of(proj.def_id);
-
-                for (v, s) in std::iter::zip(variances, proj.substs.iter()) {
-                    if *v != ty::Variance::Bivariant {
-                        s.visit_with(self);
-                    }
-                }
-            }
-
             _ => {
                 ty.super_visit_with(self);
             }


### PR DESCRIPTION
It doesn't make sense to implement variances on a GAT anyways, since we don't relate GATs with variance:

https://github.com/rust-lang/rust/blob/85bf07972a1041b9e25393b803d0e006bec3eaaf/compiler/rustc_middle/src/ty/relate.rs#L569-L579

r? @spastorino 