### PR TITLE
Disable building `rustc` with (Thin)LTO on Windows

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -817,6 +817,13 @@ impl Step for Rustc {
         if compiler.stage != 0 {
             match builder.config.rust_lto {
                 RustcLto::Thin | RustcLto::Fat => {
+                    if target == "x86_64-pc-windows-msvc" {
+                        panic!(
+                            "(Thin)LTO is currently known to produce miscompilations on `x86_64-pc-windows-msvc`. \
+See https://github.com/rust-lang/rust/issues/109067."
+                        );
+                    }
+
                     // Since using LTO for optimizing dylibs is currently experimental,
                     // we need to pass -Zdylib-lto.
                     cargo.rustflag("-Zdylib-lto");


### PR DESCRIPTION
We know that `rustc` currently produces miscompilations when it is compiled with (Thin)LTO on Windows (https://github.com/rust-lang/rust/issues/109067). We have therefore disabled LTO for `dist` windows builds. However, other people who build their own `rustc` might now know this, and this leads to them having miscompilations in the wild (https://github.com/rust-lang/rust/pull/112946#issuecomment-1622565305).

I think that we should give a loud warning that this build configuration produces known miscompilations.