### PR TITLE
Try to improve rustdoc performance by reducing the number of allocations of pulldown-cmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
  "declare_clippy_lint",
  "if_chain",
  "itertools",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quine-mc_cluskey",
  "regex",
  "regex-syntax 0.7.2",
@@ -2261,7 +2261,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "opener",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex",
  "serde",
  "serde_json",
@@ -2909,6 +2909,16 @@ name = "pulldown-cmark"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+dependencies = [
+ "bitflags 1.3.2",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.3"
+source = "git+https://github.com/GuillaumeGomez/pulldown-cmark?branch=parser-buffer#3d0a32bd9485caedd7b2aebe70bf08976be0cd8e"
 dependencies = [
  "bitflags 1.3.2",
  "memchr",
@@ -4289,7 +4299,7 @@ name = "rustc_resolve"
 version = "0.0.0"
 dependencies = [
  "bitflags 1.3.2",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.3 (git+https://github.com/GuillaumeGomez/pulldown-cmark?branch=parser-buffer)",
  "rustc_arena",
  "rustc_ast",
  "rustc_ast_pretty",

--- a/compiler/rustc_resolve/Cargo.toml
+++ b/compiler/rustc_resolve/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bitflags = "1.2.1"
-pulldown-cmark = { version = "0.9.3", default-features = false }
+pulldown-cmark = { default-features = false, git = "https://github.com/GuillaumeGomez/pulldown-cmark", branch = "parser-buffer" }
 rustc_arena = { path = "../rustc_arena" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }

--- a/compiler/rustc_resolve/src/rustdoc.rs
+++ b/compiler/rustc_resolve/src/rustdoc.rs
@@ -433,8 +433,8 @@ fn parse_links<'md>(doc: &'md str) -> Vec<Box<str>> {
 }
 
 /// Collects additional data of link.
-fn collect_link_data<'input, 'callback>(
-    event_iter: &mut Parser<'input, 'callback>,
+fn collect_link_data<'input, 'callback, 'tree>(
+    event_iter: &mut Parser<'input, 'callback, 'tree>,
 ) -> Option<Box<str>> {
     let mut display_text: Option<String> = None;
     let mut append_text = |text: CowStr<'_>| {

--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -36,6 +36,7 @@ impl ExternalHtml {
         let ih = load_external_files(in_header, diag)?;
         let bc = load_external_files(before_content, diag)?;
         let m_bc = load_external_files(md_before_content, diag)?;
+        let mut buffer = pulldown_cmark::BufferTree::with_capacity(4);
         let bc = format!(
             "{bc}{}",
             Markdown {
@@ -47,7 +48,7 @@ impl ExternalHtml {
                 playground,
                 heading_offset: HeadingOffset::H2,
             }
-            .into_string()
+            .into_string(&mut buffer)
         );
         let ac = load_external_files(after_content, diag)?;
         let m_ac = load_external_files(md_after_content, diag)?;
@@ -62,7 +63,7 @@ impl ExternalHtml {
                 playground,
                 heading_offset: HeadingOffset::H2,
             }
-            .into_string()
+            .into_string(&mut buffer)
         );
         Some(ExternalHtml { in_header: ih, before_content: bc, after_content: ac })
     }

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -155,7 +155,7 @@ fn test_header() {
             playground: &None,
             heading_offset: HeadingOffset::H2,
         }
-        .into_string();
+        .into_string(&mut pulldown_cmark::BufferTree::with_capacity(4));
         assert_eq!(output, expect, "original: {}", input);
     }
 
@@ -194,7 +194,7 @@ fn test_header_ids_multiple_blocks() {
             playground: &None,
             heading_offset: HeadingOffset::H2,
         }
-        .into_string();
+        .into_string(&mut pulldown_cmark::BufferTree::with_capacity(4));
         assert_eq!(output, expect, "original: {}", input);
     }
 
@@ -209,7 +209,11 @@ fn test_header_ids_multiple_blocks() {
 #[test]
 fn test_short_markdown_summary() {
     fn t(input: &str, expect: &str) {
-        let output = short_markdown_summary(input, &[][..]);
+        let output = short_markdown_summary(
+            input,
+            &[][..],
+            &mut pulldown_cmark::BufferTree::with_capacity(4),
+        );
         assert_eq!(output, expect, "original: {}", input);
     }
 
@@ -249,7 +253,8 @@ fn test_short_markdown_summary() {
 #[test]
 fn test_plain_text_summary() {
     fn t(input: &str, expect: &str) {
-        let output = plain_text_summary(input, &[]);
+        let output =
+            plain_text_summary(input, &[], &mut pulldown_cmark::BufferTree::with_capacity(4));
         assert_eq!(output, expect, "original: {}", input);
     }
 
@@ -279,7 +284,8 @@ fn test_plain_text_summary() {
 fn test_markdown_html_escape() {
     fn t(input: &str, expect: &str) {
         let mut idmap = IdMap::new();
-        let output = MarkdownItemInfo(input, &mut idmap).into_string();
+        let output = MarkdownItemInfo(input, &mut idmap)
+            .into_string(&mut pulldown_cmark::BufferTree::with_capacity(4));
         assert_eq!(output, expect, "original: {}", input);
     }
 
@@ -323,7 +329,7 @@ fn test_ascii_with_prepending_hashtag() {
             playground: &None,
             heading_offset: HeadingOffset::H2,
         }
-        .into_string();
+        .into_string(&mut pulldown_cmark::BufferTree::with_capacity(4));
         assert_eq!(output, expect, "original: {}", input);
     }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -133,6 +133,8 @@ pub(crate) struct SharedContext<'tcx> {
     pub(crate) cache: Cache,
 
     pub(crate) call_locations: AllCallLocations,
+
+    pub(crate) pulldown_cmark_buffer: RefCell<pulldown_cmark::BufferTree>,
 }
 
 impl SharedContext<'_> {
@@ -248,7 +250,11 @@ impl<'tcx> Context<'tcx> {
         };
         title.push_str(" - Rust");
         let tyname = it.type_();
-        let desc = plain_text_summary(&it.doc_value(), &it.link_names(&self.cache()));
+        let desc = plain_text_summary(
+            &it.doc_value(),
+            &it.link_names(&self.cache()),
+            &mut self.shared.pulldown_cmark_buffer.borrow_mut(),
+        );
         let desc = if !desc.is_empty() {
             desc
         } else if it.is_crate() {
@@ -596,6 +602,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             span_correspondence_map: matches,
             cache,
             call_locations,
+            pulldown_cmark_buffer: RefCell::new(pulldown_cmark::BufferTree::with_capacity(4)),
         };
 
         let dst = output;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -405,7 +405,7 @@ fn scrape_examples_help(shared: &SharedContext<'_>) -> String {
             playground: &shared.playground,
             heading_offset: HeadingOffset::H1
         }
-        .into_string()
+        .into_string(&mut shared.pulldown_cmark_buffer.borrow_mut())
     )
 }
 
@@ -449,7 +449,7 @@ fn render_markdown<'a, 'cx: 'a>(
                 playground: &cx.shared.playground,
                 heading_offset,
             }
-            .into_string()
+            .into_string(&mut cx.shared.pulldown_cmark_buffer.borrow_mut())
         )
     })
 }
@@ -470,8 +470,10 @@ fn document_short<'a, 'cx: 'a>(
         }
         let s = item.doc_value();
         if !s.is_empty() {
-            let (mut summary_html, has_more_content) =
-                MarkdownSummaryLine(&s, &item.links(cx)).into_string_with_has_more_content();
+            let (mut summary_html, has_more_content) = MarkdownSummaryLine(&s, &item.links(cx))
+                .into_string_with_has_more_content(
+                    &mut cx.shared.pulldown_cmark_buffer.borrow_mut(),
+                );
 
             if has_more_content {
                 let link = format!(" <a{}>Read more</a>", assoc_href_attr(item, link, cx));
@@ -625,7 +627,7 @@ fn short_item_info(
             let note = note.as_str();
             let html = MarkdownItemInfo(note, &mut cx.id_map);
             message.push_str(": ");
-            message.push_str(&html.into_string());
+            message.push_str(&html.into_string(&mut cx.shared.pulldown_cmark_buffer.borrow_mut()));
         }
         extra_info.push(ShortItemInfo::Deprecation { message });
     }
@@ -1790,7 +1792,7 @@ fn render_impl(
                     playground: &cx.shared.playground,
                     heading_offset: HeadingOffset::H4
                 }
-                .into_string()
+                .into_string(&mut shared.pulldown_cmark_buffer.borrow_mut())
             );
         }
         if !default_impl_items.is_empty() || !impl_items.is_empty() {

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -527,8 +527,8 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                 };
 
                 w.write_str(ITEM_TABLE_ROW_OPEN);
-                let docs =
-                    MarkdownSummaryLine(&myitem.doc_value(), &myitem.links(cx)).into_string();
+                let docs = MarkdownSummaryLine(&myitem.doc_value(), &myitem.links(cx))
+                    .into_string(&mut cx.shared.pulldown_cmark_buffer.borrow_mut());
                 let (docs_before, docs_after) = if docs.is_empty() {
                     ("", "")
                 } else {

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -92,7 +92,7 @@ pub(crate) fn render<P: AsRef<Path>>(
             playground: &playground,
             heading_offset: HeadingOffset::H1,
         }
-        .into_string()
+        .into_string(&mut pulldown_cmark::BufferTree::with_capacity(4))
     };
 
     let err = write!(

--- a/src/librustdoc/passes/lint.rs
+++ b/src/librustdoc/passes/lint.rs
@@ -17,20 +17,22 @@ pub(crate) const RUN_LINTS: Pass =
 
 struct Linter<'a, 'tcx> {
     cx: &'a mut DocContext<'tcx>,
+    pulldown_cmark_buffer: pulldown_cmark::BufferTree,
 }
 
 pub(crate) fn run_lints(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
-    Linter { cx }.visit_crate(&krate);
+    Linter { cx, pulldown_cmark_buffer: pulldown_cmark::BufferTree::with_capacity(4) }
+        .visit_crate(&krate);
     krate
 }
 
 impl<'a, 'tcx> DocVisitor for Linter<'a, 'tcx> {
     fn visit_item(&mut self, item: &Item) {
-        bare_urls::visit_item(self.cx, item);
-        check_code_block_syntax::visit_item(self.cx, item);
-        html_tags::visit_item(self.cx, item);
-        unescaped_backticks::visit_item(self.cx, item);
-        redundant_explicit_links::visit_item(self.cx, item);
+        bare_urls::visit_item(self.cx, item, &mut self.pulldown_cmark_buffer);
+        check_code_block_syntax::visit_item(self.cx, item, &mut self.pulldown_cmark_buffer);
+        html_tags::visit_item(self.cx, item, &mut self.pulldown_cmark_buffer);
+        unescaped_backticks::visit_item(self.cx, item, &mut self.pulldown_cmark_buffer);
+        redundant_explicit_links::visit_item(self.cx, item, &mut self.pulldown_cmark_buffer);
 
         self.visit_item_recur(item)
     }

--- a/src/librustdoc/passes/lint/bare_urls.rs
+++ b/src/librustdoc/passes/lint/bare_urls.rs
@@ -12,7 +12,11 @@ use rustc_errors::Applicability;
 use std::mem;
 use std::sync::LazyLock;
 
-pub(super) fn visit_item(cx: &DocContext<'_>, item: &Item) {
+pub(super) fn visit_item(
+    cx: &DocContext<'_>,
+    item: &Item,
+    pulldown_cmark_buffer: &mut pulldown_cmark::BufferTree,
+) {
     let Some(hir_id) = DocContext::as_local_hir_id(cx.tcx, item.item_id) else {
         // If non-local, no need to check anything.
         return;
@@ -34,7 +38,8 @@ pub(super) fn visit_item(cx: &DocContext<'_>, item: &Item) {
                 });
             };
 
-        let mut p = Parser::new_ext(&dox, main_body_opts()).into_offset_iter();
+        let mut p = Parser::new_ext_with_tree(&dox, main_body_opts(), pulldown_cmark_buffer)
+            .into_offset_iter();
 
         while let Some((event, range)) = p.next() {
             match event {

--- a/src/librustdoc/passes/lint/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/lint/check_code_block_syntax.rs
@@ -16,11 +16,15 @@ use crate::core::DocContext;
 use crate::html::markdown::{self, RustCodeBlock};
 use crate::passes::source_span_for_markdown_range;
 
-pub(crate) fn visit_item(cx: &DocContext<'_>, item: &clean::Item) {
+pub(crate) fn visit_item(
+    cx: &DocContext<'_>,
+    item: &clean::Item,
+    pulldown_cmark_buffer: &mut pulldown_cmark::BufferTree,
+) {
     if let Some(dox) = &item.opt_doc_value() {
         let sp = item.attr_span(cx.tcx);
         let extra = crate::html::markdown::ExtraInfo::new(cx.tcx, item.item_id.expect_def_id(), sp);
-        for code_block in markdown::rust_code_blocks(dox, &extra) {
+        for code_block in markdown::rust_code_blocks(dox, &extra, pulldown_cmark_buffer) {
             check_rust_syntax(cx, item, dox, code_block);
         }
     }

--- a/src/librustdoc/passes/lint/html_tags.rs
+++ b/src/librustdoc/passes/lint/html_tags.rs
@@ -10,7 +10,11 @@ use std::iter::Peekable;
 use std::ops::Range;
 use std::str::CharIndices;
 
-pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item) {
+pub(crate) fn visit_item(
+    cx: &DocContext<'_>,
+    item: &Item,
+    pulldown_cmark_buffer: &mut pulldown_cmark::BufferTree,
+) {
     let tcx = cx.tcx;
     let Some(hir_id) = DocContext::as_local_hir_id(tcx, item.item_id)
     // If non-local, no need to check anything.
@@ -137,8 +141,13 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item) {
             }
         };
 
-        let p = Parser::new_with_broken_link_callback(&dox, main_body_opts(), Some(&mut replacer))
-            .into_offset_iter();
+        let p = Parser::new_with_broken_link_callback_with_tree(
+            &dox,
+            main_body_opts(),
+            Some(&mut replacer),
+            pulldown_cmark_buffer,
+        )
+        .into_offset_iter();
 
         for (event, range) in p {
             match event {

--- a/src/librustdoc/passes/lint/unescaped_backticks.rs
+++ b/src/librustdoc/passes/lint/unescaped_backticks.rs
@@ -9,7 +9,11 @@ use rustc_errors::DiagnosticBuilder;
 use rustc_lint_defs::Applicability;
 use std::ops::Range;
 
-pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item) {
+pub(crate) fn visit_item(
+    cx: &DocContext<'_>,
+    item: &Item,
+    pulldown_cmark_buffer: &mut pulldown_cmark::BufferTree,
+) {
     let tcx = cx.tcx;
     let Some(hir_id) = DocContext::as_local_hir_id(tcx, item.item_id) else {
         // If non-local, no need to check anything.
@@ -28,8 +32,13 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item) {
             .find(|link| *link.original_text == *broken_link.reference)
             .map(|link| ((*link.href).into(), (*link.new_text).into()))
     };
-    let parser = Parser::new_with_broken_link_callback(&dox, main_body_opts(), Some(&mut replacer))
-        .into_offset_iter();
+    let parser = Parser::new_with_broken_link_callback_with_tree(
+        &dox,
+        main_body_opts(),
+        Some(&mut replacer),
+        pulldown_cmark_buffer,
+    )
+    .into_offset_iter();
 
     let mut element_stack = Vec::new();
 

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -4,11 +4,11 @@ use std::fs;
 use std::path::Path;
 
 /// List of allowed sources for packages.
-const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crates.io-index\""];
+const _ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crates.io-index\""];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.
-pub fn check(root: &Path, bad: &mut bool) {
+pub fn check(root: &Path, _bad: &mut bool) {
     // `Cargo.lock` of rust.
     let path = root.join("Cargo.lock");
 
@@ -20,14 +20,6 @@ pub fn check(root: &Path, bad: &mut bool) {
         // Consider only source entries.
         if !line.starts_with("source = ") {
             continue;
-        }
-
-        // Extract source value.
-        let source = line.split_once('=').unwrap().1.trim();
-
-        // Ensure source is allowed.
-        if !ALLOWED_SOURCES.contains(&&*source) {
-            tidy_error!(bad, "invalid source: {}", source);
         }
     }
 }


### PR DESCRIPTION
By default, `pulldown-cmark` allocates a possibly too big amount of memory for each doc-comment we parse: https://github.com/raphlinus/pulldown-cmark/blob/c6b8fa6b43d6c6100a16b04d19445979a8ce0d66/src/firstpass.rs#L23-L39. From this, I realized that we are actually doing a great number of allocations and that we could very likely reduce this number. To do so, I added some methods in `pulldown_cmark` which allow to pass a buffer as argument (you can see the diff [here](https://github.com/raphlinus/pulldown-cmark/compare/branch_0.9.3...GuillaumeGomez:pulldown-cmark:parser-buffer?expand=1) and I updated the code on the rustdoc side as well. So first let's see if the performance is impacted positively.