### PR TITLE
fix: skip cast if `Ctor` has an invalid type

### DIFF
--- a/tests/ui/cast/issue-112630.rs
+++ b/tests/ui/cast/issue-112630.rs
@@ -1,0 +1,7 @@
+enum Foo {
+    Bar(B) //~ ERROR cannot find type `B` in this scope [E0412]
+}
+
+fn main() {
+    let _ = [0; Foo::Bar as usize];
+}

--- a/tests/ui/cast/issue-112630.stderr
+++ b/tests/ui/cast/issue-112630.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `B` in this scope
+  --> $DIR/issue-112630.rs:2:9
+   |
+LL |     Bar(B)
+   |         ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | enum Foo<B> {
+   |         +++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #112630

#112630 encounters an ice because it does not report the `fn({type error}) -> xxx` earlier and eventually causes a panic in `mir_cast_kind`.

In this PR, I made that `type_of` returns `TyKind::Error` to ensure it enters the `if let Err(guar) = (t_expr, t_cast).error_reported() { xxxx }` branch in [check_expr_cast](https://github.com/rust-lang/rust/blob/master/compiler/rustc_hir_typeck/src/expr.rs#L1324-L1326) in order to bypass the cast for invalid type. 