### PR TITLE
tidy: remove filtering for wasm32 deps, as this don't work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5453,7 +5453,6 @@ dependencies = [
 name = "tidy"
 version = "0.1.0"
 dependencies = [
- "cargo-platform",
  "cargo_metadata 0.15.4",
  "ignore",
  "lazy_static",

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -6,7 +6,6 @@ autobins = false
 
 [dependencies]
 cargo_metadata = "0.15"
-cargo-platform = "0.1.2"
 regex = "1"
 miropt-test-tools = { path = "../miropt-test-tools" }
 lazy_static = "1"

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -189,6 +189,7 @@ const PERMITTED_DEPS_LOCATION: &str = concat!(file!(), ":", line!());
 /// rustc. Please check with the compiler team before adding an entry.
 const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     // tidy-alphabetical-start
+    "addr2line",
     "adler",
     "ahash",
     "aho-corasick",
@@ -429,6 +430,7 @@ const PERMITTED_CRANELIFT_DEPENDENCIES: &[&str] = &[
     "mach",
     "memchr",
     "object",
+    "once_cell",
     "regalloc2",
     "region",
     "rustc-hash",
@@ -614,27 +616,7 @@ fn check_permitted_dependencies(
     let mut deps = HashSet::new();
     for to_check in restricted_dependency_crates {
         let to_check = pkg_from_name(metadata, to_check);
-        use cargo_platform::Cfg;
-        use std::str::FromStr;
-        // We don't expect the compiler to ever run on wasm32, so strip
-        // out those dependencies to avoid polluting the permitted list.
-        deps_of_filtered(metadata, &to_check.id, &mut deps, &|dep_kinds| {
-            dep_kinds.iter().any(|dep_kind| {
-                dep_kind
-                    .target
-                    .as_ref()
-                    .map(|target| {
-                        !target.matches(
-                            "wasm32-unknown-unknown",
-                            &[
-                                Cfg::from_str("target_arch=\"wasm32\"").unwrap(),
-                                Cfg::from_str("target_os=\"unknown\"").unwrap(),
-                            ],
-                        )
-                    })
-                    .unwrap_or(true)
-            })
-        });
+        deps_of_filtered(metadata, &to_check.id, &mut deps, &|_| true);
     }
 
     // Check that the PERMITTED_DEPENDENCIES does not have unused entries.


### PR DESCRIPTION
This was added in #106470, from that time something changed and now it don't work as expected.