### PR TITLE
Fix failing clippy tests

### DIFF
--- a/src/tools/clippy/clippy_lints/src/incorrect_impls.rs
+++ b/src/tools/clippy/clippy_lints/src/incorrect_impls.rs
@@ -82,7 +82,7 @@ impl LateLintPass<'_> for IncorrectImpls {
                     cx,
                     hir_ty_to_ty(cx.tcx, imp.self_ty),
                     copy_def_id,
-                    trait_impl.substs,
+                    &[],
                 )
         {
             if impl_item.ident.name == sym::clone {

--- a/src/tools/clippy/tests/ui/needless_raw_string.fixed
+++ b/src/tools/clippy/tests/ui/needless_raw_string.fixed
@@ -10,7 +10,8 @@ fn main() {
     b"aaa";
     br#""aaa""#;
     br#"\s"#;
-    c"aaa";
-    cr#""aaa""#;
-    cr#"\s"#;
+    // currently disabled: https://github.com/rust-lang/rust/issues/113333
+    // cr#"aaa"#;
+    // cr#""aaa""#;
+    // cr#"\s"#;
 }

--- a/src/tools/clippy/tests/ui/needless_raw_string.rs
+++ b/src/tools/clippy/tests/ui/needless_raw_string.rs
@@ -10,7 +10,8 @@ fn main() {
     br#"aaa"#;
     br#""aaa""#;
     br#"\s"#;
-    cr#"aaa"#;
-    cr#""aaa""#;
-    cr#"\s"#;
+    // currently disabled: https://github.com/rust-lang/rust/issues/113333
+    // cr#"aaa"#;
+    // cr#""aaa""#;
+    // cr#"\s"#;
 }

--- a/src/tools/clippy/tests/ui/needless_raw_string.stderr
+++ b/src/tools/clippy/tests/ui/needless_raw_string.stderr
@@ -12,11 +12,5 @@ error: unnecessary raw string literal
 LL |     br#"aaa"#;
    |     ^^^^^^^^^ help: try: `b"aaa"`
 
-error: unnecessary raw string literal
-  --> $DIR/needless_raw_string.rs:13:5
-   |
-LL |     cr#"aaa"#;
-   |     ^^^^^^^^^ help: try: `c"aaa"`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui/needless_raw_string_hashes.fixed
+++ b/src/tools/clippy/tests/ui/needless_raw_string_hashes.fixed
@@ -12,8 +12,9 @@ fn main() {
     br#"Hello "world"!"#;
     br####" "### "## "# "####;
     br###" "aa" "# "## "###;
-    cr#"aaa"#;
-    cr#"Hello "world"!"#;
-    cr####" "### "## "# "####;
-    cr###" "aa" "# "## "###;
+    // currently disabled: https://github.com/rust-lang/rust/issues/113333
+    // cr#"aaa"#;
+    // cr##"Hello "world"!"##;
+    // cr######" "### "## "# "######;
+    // cr######" "aa" "# "## "######;
 }

--- a/src/tools/clippy/tests/ui/needless_raw_string_hashes.rs
+++ b/src/tools/clippy/tests/ui/needless_raw_string_hashes.rs
@@ -12,8 +12,9 @@ fn main() {
     br##"Hello "world"!"##;
     br######" "### "## "# "######;
     br######" "aa" "# "## "######;
-    cr#"aaa"#;
-    cr##"Hello "world"!"##;
-    cr######" "### "## "# "######;
-    cr######" "aa" "# "## "######;
+    // currently disabled: https://github.com/rust-lang/rust/issues/113333
+    // cr#"aaa"#;
+    // cr##"Hello "world"!"##;
+    // cr######" "### "## "# "######;
+    // cr######" "aa" "# "## "######;
 }

--- a/src/tools/clippy/tests/ui/needless_raw_string_hashes.stderr
+++ b/src/tools/clippy/tests/ui/needless_raw_string_hashes.stderr
@@ -36,23 +36,5 @@ error: unnecessary hashes around raw string literal
 LL |     br######" "aa" "# "## "######;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `br###" "aa" "# "## "###`
 
-error: unnecessary hashes around raw string literal
-  --> $DIR/needless_raw_string_hashes.rs:16:5
-   |
-LL |     cr##"Hello "world"!"##;
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `cr#"Hello "world"!"#`
-
-error: unnecessary hashes around raw string literal
-  --> $DIR/needless_raw_string_hashes.rs:17:5
-   |
-LL |     cr######" "### "## "# "######;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cr####" "### "## "# "####`
-
-error: unnecessary hashes around raw string literal
-  --> $DIR/needless_raw_string_hashes.rs:18:5
-   |
-LL |     cr######" "aa" "# "## "######;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cr###" "aa" "# "## "###`
-
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Comments out the C string literals due to https://github.com/rust-lang/rust/pull/113334

Fixes https://github.com/rust-lang/rust-clippy/issues/11121

Opened against `rust-lang/rust` in order to unblock https://github.com/rust-lang/rust/pull/113450

r? @Nilstrieb 