### PR TITLE
Make type_of for RPITITs GAT on traits return a ty::Error if no default provided

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -446,10 +446,11 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<Ty
                     ..
                 }) => {
                     if in_trait && !tcx.defaultness(owner).has_value() {
-                        span_bug!(
+                        return ty::EarlyBinder::bind(Ty::new_error_with_message(
+                            tcx,
                             tcx.def_span(def_id),
-                            "tried to get type of this RPITIT with no definition"
-                        );
+                            "tried to get type of this RPITIT with no definition",
+                        ));
                     }
                     opaque::find_opaque_ty_constraints_for_rpit(tcx, def_id, owner)
                 }

--- a/tests/ui/impl-trait/in-trait/missing-type-parameter.current.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-type-parameter.current.stderr
@@ -1,0 +1,19 @@
+error: cannot check whether the hidden type of opaque type satisfies auto traits
+  --> $DIR/missing-type-parameter.rs:9:17
+   |
+LL |     fn bar() -> Wrapper<impl Sized>;
+   |                 ^^^^^^^^^^^^^^^^^^^
+   |
+note: opaque type is declared here
+  --> $DIR/missing-type-parameter.rs:9:25
+   |
+LL |     fn bar() -> Wrapper<impl Sized>;
+   |                         ^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/missing-type-parameter.rs:6:19
+   |
+LL | struct Wrapper<G: Send>(G);
+   |                   ^^^^ required by this bound in `Wrapper`
+
+error: aborting due to previous error
+

--- a/tests/ui/impl-trait/in-trait/missing-type-parameter.next.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-type-parameter.next.stderr
@@ -1,0 +1,19 @@
+error: cannot check whether the hidden type of opaque type satisfies auto traits
+  --> $DIR/missing-type-parameter.rs:9:17
+   |
+LL |     fn bar() -> Wrapper<impl Sized>;
+   |                 ^^^^^^^^^^^^^^^^^^^
+   |
+note: opaque type is declared here
+  --> $DIR/missing-type-parameter.rs:9:25
+   |
+LL |     fn bar() -> Wrapper<impl Sized>;
+   |                         ^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/missing-type-parameter.rs:6:19
+   |
+LL | struct Wrapper<G: Send>(G);
+   |                   ^^^^ required by this bound in `Wrapper`
+
+error: aborting due to previous error
+

--- a/tests/ui/impl-trait/in-trait/missing-type-parameter.rs
+++ b/tests/ui/impl-trait/in-trait/missing-type-parameter.rs
@@ -1,0 +1,13 @@
+// [next] compile-flags: -Zlower-impl-trait-in-trait-to-assoc-ty
+// revisions: current next
+
+#![feature(return_position_impl_trait_in_trait)]
+
+struct Wrapper<G: Send>(G);
+
+trait Foo {
+    fn bar() -> Wrapper<impl Sized>;
+    //~^ ERROR: cannot check whether the hidden type of opaque type satisfies auto traits
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #113434

This one is interesting because it ICEs on both master and in the new RPITIT impl.

I think the code is self-explanatory but we want to avoid delaying a bug and calling `opaque::find_opaque_ty_constraints_for_rpit(tcx, def_id, owner)` when we already know we can't build a type. 

r? @compiler-errors