### PR TITLE
#[inline] on Option::copied

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1822,6 +1822,7 @@ impl<T> Option<&T> {
     /// let copied = opt_x.copied();
     /// assert_eq!(copied, Some(12));
     /// ```
+    #[inline]
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "copied", since = "1.35.0")]
     #[rustc_const_unstable(feature = "const_option", issue = "67441")]
@@ -1875,6 +1876,7 @@ impl<T> Option<&mut T> {
     /// let copied = opt_x.copied();
     /// assert_eq!(copied, Some(12));
     /// ```
+    #[inline]
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "copied", since = "1.35.0")]
     #[rustc_const_unstable(feature = "const_option_ext", issue = "91930")]


### PR DESCRIPTION
Found out that this didn't seem to be inlining as much as it should be locally. Its a very small function, so it should pretty much always be inlined.