### PR TITLE
Don't normalize projections referencing type error

### DIFF
--- a/tests/ui/traits/new-solver/dont-try-normalizing-proj-with-errors.rs
+++ b/tests/ui/traits/new-solver/dont-try-normalizing-proj-with-errors.rs
@@ -1,0 +1,19 @@
+// compile-flags: -Ztrait-solver=next
+
+trait Mirror {
+    type Assoc: ?Sized;
+}
+
+struct Wrapper<T: ?Sized>(T);
+impl<T: ?Sized> Mirror for Wrapper<T> {
+    type Assoc = T;
+}
+
+fn mirror<W: Mirror>(_: W) -> Box<W::Assoc> { todo!() }
+
+fn type_error() -> TypeError { todo!() }
+//~^ ERROR cannot find type `TypeError` in this scope
+
+fn main() {
+    let x = mirror(type_error());
+}

--- a/tests/ui/traits/new-solver/dont-try-normalizing-proj-with-errors.stderr
+++ b/tests/ui/traits/new-solver/dont-try-normalizing-proj-with-errors.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `TypeError` in this scope
+  --> $DIR/dont-try-normalizing-proj-with-errors.rs:14:20
+   |
+LL | fn type_error() -> TypeError { todo!() }
+   |                    ^^^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Please see UI test for example referenced here: If we try to equate the projection goal `<[type error] as Mirror>::Assoc` against an impl header that looks like `<Wrapper<?0> as Mirror>::Assoc`, this will succeed without constraining `?0` since `[type error]` unifies with everything.

This means that sometimes we can get a *non-ambiguous* response that does not constrain a projection, which causes these assertions to trigger in some UI tests:

https://github.com/rust-lang/rust/blob/eee6b31c0c3b7c3ad8733957eaa122ae1a07e299/compiler/rustc_hir_typeck/src/writeback.rs#L139-L142

https://github.com/rust-lang/rust/blob/eee6b31c0c3b7c3ad8733957eaa122ae1a07e299/compiler/rustc_traits/src/normalize_erasing_regions.rs#L50

r? @lcnr
