### PR TITLE
impl `From<&[T; N]>` for `Cow<[T]>`

### DIFF
--- a/library/alloc/src/vec/cow.rs
+++ b/library/alloc/src/vec/cow.rs
@@ -15,7 +15,7 @@ impl<'a, T: Clone> From<&'a [T]> for Cow<'a, [T]> {
     }
 }
 
-#[unstable(feature = "cow_from_array_ref", issue = "none")]
+#[stable(feature = "cow_from_array_ref", since = "CURRENT_RUSTC_VERSION")]
 impl<'a, T: Clone, const N: usize> From<&'a [T; N]> for Cow<'a, [T]> {
     /// Creates a [`Borrowed`] variant of [`Cow`]
     /// from a reference to an array.

--- a/library/alloc/src/vec/cow.rs
+++ b/library/alloc/src/vec/cow.rs
@@ -15,6 +15,19 @@ impl<'a, T: Clone> From<&'a [T]> for Cow<'a, [T]> {
     }
 }
 
+#[unstable(feature = "cow_from_array_ref", issue = "none")]
+impl<'a, T: Clone, const N: usize> From<&'a [T; N]> for Cow<'a, [T]> {
+    /// Creates a [`Borrowed`] variant of [`Cow`]
+    /// from a reference to an array.
+    ///
+    /// This conversion does not allocate or clone the data.
+    ///
+    /// [`Borrowed`]: crate::borrow::Cow::Borrowed
+    fn from(s: &'a [T; N]) -> Cow<'a, [T]> {
+        Cow::Borrowed(s as &[_])
+    }
+}
+
 #[stable(feature = "cow_from_vec", since = "1.8.0")]
 impl<'a, T: Clone> From<Vec<T>> for Cow<'a, [T]> {
     /// Creates an [`Owned`] variant of [`Cow`]


### PR DESCRIPTION
Implement `From<&[T; N]>` for `Cow<[T]>` to simplify its usage in the following example.

```rust
fn foo(data: impl Into<Cow<'static, [&'static str]>>) { /* ... */ }

fn main() {
    foo(vec!["hello", "world"]);
    foo(&["hello", "world"]); // Error: the trait `From<&[&str; 2]>` is not implemented for `Cow<'static, [&'static str]>`
    foo(&["hello", "world"] as &[_]); // Explicit convertion into a slice is required
}
```