### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Read ["Installation"] from [The Book].
 
 The Rust build system uses a Python script called `x.py` to build the compiler,
 which manages the bootstrapping process. It lives at the root of the project.
-It also uses a file named `config.toml` to determine various configuration settings for the build.
-You can see a full list of options in `config.example.toml`.
+It also uses a file named `config.toml` to determine various configuration
+settings for the build. You can see a full list of options in
+`config.example.toml`.
 
 The `x.py` command can be run directly on most Unix systems in the following
 format:
@@ -33,7 +34,8 @@ format:
 ```
 
 This is how the documentation and examples assume you are running `x.py`.
-See the [rustc dev guide][rustcguidebuild] if this does not work on your platform.
+See the [rustc dev guide][rustcguidebuild] if this does not work on your
+platform.
 
 More information about `x.py` can be found by running it with the `--help` flag
 or reading the [rustc dev guide][rustcguidebuild].
@@ -105,24 +107,26 @@ See [the rustc-dev-guide for more info][sysllvm].
 
    When complete, `./x.py install` will place several programs into
    `$PREFIX/bin`: `rustc`, the Rust compiler, and `rustdoc`, the
-   API-documentation tool. By default, it will also include [Cargo], Rust's package manager.
-   You can disable this behavior by passing `--set build.extended=false` to `./configure`.
+   API-documentation tool. By default, it will also include [Cargo], Rust's
+   package manager. You can disable this behavior by passing
+   `--set build.extended=false` to `./configure`.
 
 [Cargo]: https://github.com/rust-lang/cargo
 
 #### Configure and Make
 
-This project provides a configure script and makefile (the latter of which just invokes `x.py`).
-`./configure` is the recommended way to programatically generate a `config.toml`. `make` is not
-recommended (we suggest using `x.py` directly), but it is supported and we try not to break it
-unnecessarily.
+This project provides a configure script and makefile (the latter of which just
+invokes `x.py`). `./configure` is the recommended way to programatically
+generate a `config.toml`. `make` is not recommended (we suggest using `x.py`
+directly), but it is supported and we try not to break it unnecessarily.
 
 ```sh
 ./configure
 make && sudo make install
 ```
 
-`configure` generates a `config.toml` which can also be used with normal `x.py` invocations.
+`configure` generates a `config.toml` which can also be used with normal `x.py`
+invocations.
 
 ### Building on Windows
 
@@ -193,7 +197,7 @@ toolchain.
 #### MSVC
 
 MSVC builds of Rust additionally require an installation of Visual Studio 2017
-(or later) so `rustc` can use its linker.  The simplest way is to get
+(or later) so `rustc` can use its linker. The simplest way is to get
 [Visual Studio], check the "C++ build tools" and "Windows 10 SDK" workload.
 
 [Visual Studio]: https://visualstudio.microsoft.com/downloads/
@@ -234,7 +238,8 @@ Windows build triples are:
 
 The build triple can be specified by either specifying `--build=<triple>` when
 invoking `x.py` commands, or by creating a `config.toml` file (as described in
-[Building on a Unix-like system](#building-on-a-unix-like-system)), and passing `--set build.build=<triple>` to `./configure`.
+[Building on a Unix-like system](#building-on-a-unix-like-system)), and passing
+`--set build.build=<triple>` to `./configure`.
 
 ## Building Documentation
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -39,6 +39,9 @@ for more information on Rust's tiered platform support.
 
 Libraries
 ---------
+- [Rework handling of recursive panics.](https://github.com/rust-lang/rust/pull/110975/)
+  Additional panics are allowed while unwinding, as long as they are caught before escaping
+  a `Drop` implementation, but panicking within a panic hook is now an immediate abort.
 - [Loosen `From<&[T]> for Box<[T]>` bound to `T: Clone`.](https://github.com/rust-lang/rust/pull/103406/)
 - [Remove unnecessary `T: Send` bound](https://github.com/rust-lang/rust/pull/111134/)
   in `Error for mpsc::SendError<T>` and `TrySendError<T>`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -39,7 +39,6 @@ for more information on Rust's tiered platform support.
 
 Libraries
 ---------
-- [Remove structural match from `TypeId`.](https://github.com/rust-lang/rust/pull/103291/)
 - [Loosen `From<&[T]> for Box<[T]>` bound to `T: Clone`.](https://github.com/rust-lang/rust/pull/103406/)
 - [Remove unnecessary `T: Send` bound](https://github.com/rust-lang/rust/pull/111134/)
   in `Error for mpsc::SendError<T>` and `TrySendError<T>`.
@@ -111,6 +110,10 @@ Misc
 Compatibility Notes
 -------------------
 
+- [Remove structural match from `TypeId`.](https://github.com/rust-lang/rust/pull/103291/)
+  Code that uses a constant `TypeId` in a pattern will potentially be broken.
+  Known cases have already been fixed -- in particular, users of the `log`
+  crate's `kv_unstable` feature should update to `log v0.4.18` or later.
 - [Add a `sysroot` crate to represent the standard library crates.](https://github.com/rust-lang/rust/pull/108865/)
   This does not affect stable users, but may require adjustment in tools that build their own standard library.
 - [Cargo optimizes its usage under `rustup`.](https://github.com/rust-lang/cargo/pull/11917/) When

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,6 @@ Version 1.71.0 (2023-07-13)
 Language
 --------
 
-- [Remove misleading target feature aliases, inappropriately connected to AVX-512.](https://github.com/rust-lang/rust/pull/107707/)
 - [Stabilize `raw-dylib`, `link_ordinal`, `import_name_type` and `-Cdlltool`.](https://github.com/rust-lang/rust/pull/109677/)
 - [Uplift `clippy::{drop,forget}_{ref,copy}` lints.](https://github.com/rust-lang/rust/pull/109732/)
 - [Type inference is more conservative around constrained vars.](https://github.com/rust-lang/rust/pull/110100/)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,141 @@
+Version 1.71.0 (2023-07-13)
+==========================
+
+<a id="1.71.0-Language"></a>
+
+Language
+--------
+
+- [Remove misleading target feature aliases, inappropriately connected to AVX-512.](https://github.com/rust-lang/rust/pull/107707/)
+- [Stabilize `raw-dylib`, `link_ordinal`, `import_name_type` and `-Cdlltool`.](https://github.com/rust-lang/rust/pull/109677/)
+- [Uplift `clippy::{drop,forget}_{ref,copy}` lints.](https://github.com/rust-lang/rust/pull/109732/)
+- [Type inference is more conservative around constrained vars.](https://github.com/rust-lang/rust/pull/110100/)
+- [Use fulfillment to check `Drop` impl compatibility](https://github.com/rust-lang/rust/pull/110577/)
+
+<a id="1.71.0-Compiler"></a>
+
+Compiler
+--------
+
+- [Evaluate place expression in `PlaceMention`](https://github.com/rust-lang/rust/pull/104844/),
+  making `let _ =` patterns more consistent with respect to the borrow checker.
+- [Add `--print deployment-target` flag for Apple targets.](https://github.com/rust-lang/rust/pull/105354/)
+- [Stabilize `extern "C-unwind"` and friends.](https://github.com/rust-lang/rust/pull/106075/)
+  The existing `extern "C"` etc. may change behavior for cross-language unwinding in a future release.
+- [Update the version of musl used on `*-linux-musl` targets to 1.2.3](https://github.com/rust-lang/rust/pull/107129/),
+  enabling [time64](https://musl.libc.org/time64.html) on 32-bit systems.
+- [Stabilize `debugger_visualizer`](https://github.com/rust-lang/rust/pull/108668/)
+  for embedding metadata like Microsoft's Natvis.
+- [Enable flatten-format-args by default.](https://github.com/rust-lang/rust/pull/109999/)
+- [Make `Self` respect tuple constructor privacy.](https://github.com/rust-lang/rust/pull/111245/)
+- [Improve niche placement by trying two strategies and picking the better result.](https://github.com/rust-lang/rust/pull/108106/)
+- [Use `apple-m1` as the target CPU for `aarch64-apple-darwin`.](https://github.com/rust-lang/rust/pull/109899/)
+- [Add Tier 3 support for the `x86_64h-apple-darwin` target.](https://github.com/rust-lang/rust/pull/108795/)
+- [Promote `loongarch64-unknown-linux-gnu` to Tier 2 with host tools.](https://github.com/rust-lang/rust/pull/110936/)
+
+Refer to Rust's [platform support page][platform-support-doc]
+for more information on Rust's tiered platform support.
+
+<a id="1.71.0-Libraries"></a>
+
+Libraries
+---------
+- [Remove structural match from `TypeId`.](https://github.com/rust-lang/rust/pull/103291/)
+- [Loosen `From<&[T]> for Box<[T]>` bound to `T: Clone`.](https://github.com/rust-lang/rust/pull/103406/)
+- [Remove unnecessary `T: Send` bound](https://github.com/rust-lang/rust/pull/111134/)
+  in `Error for mpsc::SendError<T>` and `TrySendError<T>`.
+- [Fix docs for `alloc::realloc`](https://github.com/rust-lang/rust/pull/108630/)
+  to match `Layout` requirements that the size must not exceed `isize::MAX`.
+- [Document `const {}` syntax for `std::thread_local`.](https://github.com/rust-lang/rust/pull/110620/)
+  This syntax was stabilized in Rust 1.59, but not previously mentioned in release notes.
+
+<a id="1.71.0-Stabilized-APIs"></a>
+
+Stabilized APIs
+---------------
+
+- [`CStr::is_empty`](https://doc.rust-lang.org/stable/std/ffi/struct.CStr.html#method.is_empty)
+- [`BuildHasher::hash_one`](https://doc.rust-lang.org/stable/std/hash/trait.BuildHasher.html#method.hash_one)
+- [`NonZeroI*::is_positive`](https://doc.rust-lang.org/stable/std/num/struct.NonZeroI32.html#method.is_positive)
+- [`NonZeroI*::is_negative`](https://doc.rust-lang.org/stable/std/num/struct.NonZeroI32.html#method.is_negative)
+- [`NonZeroI*::checked_neg`](https://doc.rust-lang.org/stable/std/num/struct.NonZeroI32.html#method.checked_neg)
+- [`NonZeroI*::overflowing_neg`](https://doc.rust-lang.org/stable/std/num/struct.NonZeroI32.html#method.overflowing_neg)
+- [`NonZeroI*::saturating_neg`](https://doc.rust-lang.org/stable/std/num/struct.NonZeroI32.html#method.saturating_neg)
+- [`NonZeroI*::wrapping_neg`](https://doc.rust-lang.org/stable/std/num/struct.NonZeroI32.html#method.wrapping_neg)
+- [`Neg for NonZeroI*`](https://doc.rust-lang.org/stable/std/num/struct.NonZeroI32.html#impl-Neg-for-NonZeroI32)
+- [`Neg for &NonZeroI*`](https://doc.rust-lang.org/stable/std/num/struct.NonZeroI32.html#impl-Neg-for-%26NonZeroI32)
+- [`From<[T; N]> for (T...)`](https://doc.rust-lang.org/stable/std/primitive.array.html#impl-From%3C%5BT;+1%5D%3E-for-(T,))
+  (array to N-tuple for N in 1..=12)
+- [`From<(T...)> for [T; N]`](https://doc.rust-lang.org/stable/std/primitive.array.html#impl-From%3C(T,)%3E-for-%5BT;+1%5D)
+  (N-tuple to array for N in 1..=12)
+- [`windows::io::AsHandle for Box<T>`](https://doc.rust-lang.org/stable/std/os/windows/io/trait.AsHandle.html#impl-AsHandle-for-Box%3CT%3E)
+- [`windows::io::AsHandle for Rc<T>`](https://doc.rust-lang.org/stable/std/os/windows/io/trait.AsHandle.html#impl-AsHandle-for-Rc%3CT%3E)
+- [`windows::io::AsHandle for Arc<T>`](https://doc.rust-lang.org/stable/std/os/windows/io/trait.AsHandle.html#impl-AsHandle-for-Arc%3CT%3E)
+- [`windows::io::AsSocket for Box<T>`](https://doc.rust-lang.org/stable/std/os/windows/io/trait.AsSocket.html#impl-AsSocket-for-Box%3CT%3E)
+- [`windows::io::AsSocket for Rc<T>`](https://doc.rust-lang.org/stable/std/os/windows/io/trait.AsSocket.html#impl-AsSocket-for-Rc%3CT%3E)
+- [`windows::io::AsSocket for Arc<T>`](https://doc.rust-lang.org/stable/std/os/windows/io/trait.AsSocket.html#impl-AsSocket-for-Arc%3CT%3E)
+
+These APIs are now stable in const contexts:
+
+- [`<*const T>::read`](https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.read)
+- [`<*const T>::read_unaligned`](https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.read_unaligned)
+- [`<*mut T>::read`](https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.read-1)
+- [`<*mut T>::read_unaligned`](https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.read_unaligned-1)
+- [`ptr::read`](https://doc.rust-lang.org/stable/std/ptr/fn.read.html)
+- [`ptr::read_unaligned`](https://doc.rust-lang.org/stable/std/ptr/fn.read_unaligned.html)
+- [`<[T]>::split_at`](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.split_at)
+
+<a id="1.71.0-Cargo"></a>
+
+Cargo
+-----
+- [Allow named debuginfo options in `Cargo.toml`.](https://github.com/rust-lang/cargo/pull/11958/)
+- [Add `workspace_default_members` to the output of `cargo metadata`.](https://github.com/rust-lang/cargo/pull/11978/)
+- [`cargo add` now considers `rust-version` when selecting packages.](https://github.com/rust-lang/cargo/pull/12078/)
+- [Automatically inherit workspace fields when running `cargo new`/`cargo init`.](https://github.com/rust-lang/cargo/pull/12069/)
+
+<a id="1.71.0-Rustdoc"></a>
+
+Rustdoc
+-------
+
+- [Add a new `rustdoc::unescaped_backticks` lint for broken inline code.](https://github.com/rust-lang/rust/pull/105848/)
+- [Support strikethrough with single tildes.](https://github.com/rust-lang/rust/pull/111152/) (`~~old~~` vs. `~new~`)
+
+<a id="1.71.0-Misc"></a>
+
+Misc
+----
+
+<a id="1.71.0-Compatibility-Notes"></a>
+
+Compatibility Notes
+-------------------
+
+- [Add a `sysroot` crate to represent the standard library crates.](https://github.com/rust-lang/rust/pull/108865/)
+  This does not affect stable users, but may require adjustment in tools that build their own standard library.
+- [Cargo optimizes its usage under `rustup`.](https://github.com/rust-lang/cargo/pull/11917/) When
+  Cargo detects it will run `rustc` pointing to a rustup proxy, it'll try bypassing the proxy and
+  use the underlying binary directly. There are assumptions around the interaction with rustup and
+  `RUSTUP_TOOLCHAIN`. However, it's not expected to affect normal users.
+- [When querying a package, Cargo tries only the original name, all hyphens, and all underscores to
+  handle misspellings.](https://github.com/rust-lang/cargo/pull/12083/) Previously, Cargo tried each
+  combination of hyphens and underscores, causing excessive requests to crates.io.
+- Cargo now [disallows `RUSTUP_HOME`](https://github.com/rust-lang/cargo/pull/12101/) and
+  [`RUSTUP_TOOLCHAIN`](https://github.com/rust-lang/cargo/pull/12107/) in the `[env]` configuration
+  table. This is considered to be not a use case Cargo would like to support, since it will likely
+  cause problems or lead to confusion.
+
+<a id="1.71.0-Internal-Changes"></a>
+
+Internal Changes
+----------------
+
+These changes do not affect any public interfaces of Rust, but they represent
+significant improvements to the performance or internals of rustc and related
+tools.
+
+
 Version 1.70.0 (2023-06-01)
 ==========================
 

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -208,17 +208,18 @@ impl<'tcx> Cx<'tcx> {
             // so we wouldn't have to compute and store the actual value
 
             let hir::ExprKind::Path(ref qpath) = source.kind else {
-                return ExprKind::Cast { source: self.mirror_expr(source)};
+                return ExprKind::Cast { source: self.mirror_expr(source) };
             };
 
             let res = self.typeck_results().qpath_res(qpath, source.hir_id);
             let ty = self.typeck_results().node_type(source.hir_id);
             let ty::Adt(adt_def, substs) = ty.kind() else {
-                return ExprKind::Cast { source: self.mirror_expr(source)};
+                return ExprKind::Cast { source: self.mirror_expr(source) };
             };
 
-            let Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Const), variant_ctor_id) = res else {
-                return ExprKind::Cast { source: self.mirror_expr(source)};
+            let Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Const), variant_ctor_id) = res
+            else {
+                return ExprKind::Cast { source: self.mirror_expr(source) };
             };
 
             let idx = adt_def.variant_index_with_ctor_id(variant_ctor_id);
@@ -351,28 +352,29 @@ impl<'tcx> Cx<'tcx> {
                             });
                         }
                     }
-                    let adt_data = if let hir::ExprKind::Path(qpath) = fun.kind {
+
+                    // Tuple-like ADTs are represented as ExprKind::Call. We convert them here.
+                    let adt_data = if let hir::ExprKind::Path(ref qpath) = fun.kind
+                    && let Some(adt_def) = expr_ty.ty_adt_def() {
                         match qpath {
-                            // Tuple-like ADTs are represented as ExprKind::Call. We convert them here.
                             hir::QPath::Resolved(_, ref path) => {
-                                expr_ty.ty_adt_def().and_then(|adt_def| match path.res {
+                                match path.res {
                                     Res::Def(DefKind::Ctor(_, CtorKind::Fn), ctor_id) => {
                                         Some((adt_def, adt_def.variant_index_with_ctor_id(ctor_id)))
                                     }
                                     Res::SelfCtor(..) => Some((adt_def, FIRST_VARIANT)),
                                     _ => None,
-                                })
+                                }
                             }
                             hir::QPath::TypeRelative(_ty, _) => {
-                                expr_ty.ty_adt_def().and_then(|adt_def| {
-                                    if let Some((DefKind::Ctor(_, CtorKind::Fn), ctor_id)) =
-                                        self.typeck_results().type_dependent_def(fun.hir_id)
-                                    {
-                                        Some((adt_def, adt_def.variant_index_with_ctor_id(ctor_id)))
-                                    } else {
-                                        None
-                                    }
-                                })
+                                if let Some((DefKind::Ctor(_, CtorKind::Fn), ctor_id)) =
+                                    self.typeck_results().type_dependent_def(fun.hir_id)
+                                {
+                                    Some((adt_def, adt_def.variant_index_with_ctor_id(ctor_id)))
+                                } else {
+                                    None
+                                }
+
                             }
                             _ => None,
                         }

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -351,19 +351,34 @@ impl<'tcx> Cx<'tcx> {
                             });
                         }
                     }
-                    let adt_data =
-                        if let hir::ExprKind::Path(hir::QPath::Resolved(_, ref path)) = fun.kind {
+                    let adt_data = if let hir::ExprKind::Path(qpath) = fun.kind {
+                        match qpath {
                             // Tuple-like ADTs are represented as ExprKind::Call. We convert them here.
-                            expr_ty.ty_adt_def().and_then(|adt_def| match path.res {
-                                Res::Def(DefKind::Ctor(_, CtorKind::Fn), ctor_id) => {
-                                    Some((adt_def, adt_def.variant_index_with_ctor_id(ctor_id)))
-                                }
-                                Res::SelfCtor(..) => Some((adt_def, FIRST_VARIANT)),
-                                _ => None,
-                            })
-                        } else {
-                            None
-                        };
+                            hir::QPath::Resolved(_, ref path) => {
+                                expr_ty.ty_adt_def().and_then(|adt_def| match path.res {
+                                    Res::Def(DefKind::Ctor(_, CtorKind::Fn), ctor_id) => {
+                                        Some((adt_def, adt_def.variant_index_with_ctor_id(ctor_id)))
+                                    }
+                                    Res::SelfCtor(..) => Some((adt_def, FIRST_VARIANT)),
+                                    _ => None,
+                                })
+                            }
+                            hir::QPath::TypeRelative(_ty, _) => {
+                                expr_ty.ty_adt_def().and_then(|adt_def| {
+                                    if let Some((DefKind::Ctor(_, CtorKind::Fn), ctor_id)) =
+                                        self.typeck_results().type_dependent_def(fun.hir_id)
+                                    {
+                                        Some((adt_def, adt_def.variant_index_with_ctor_id(ctor_id)))
+                                    } else {
+                                        None
+                                    }
+                                })
+                            }
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    };
                     if let Some((adt_def, index)) = adt_data {
                         let substs = self.typeck_results().node_substs(fun.hir_id);
                         let user_provided_types = self.typeck_results().user_provided_types();

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -851,6 +851,8 @@ impl<T> [T] {
 
     /// Swaps two elements in the slice.
     ///
+    /// If `a` equals to `b`, it's guaranteed that elements won't change value.
+    ///
     /// # Arguments
     ///
     /// * a - The index of the first element

--- a/tests/mir-opt/building/issue_110508.rs
+++ b/tests/mir-opt/building/issue_110508.rs
@@ -1,0 +1,13 @@
+// EMIT_MIR issue_110508.{impl#0}-BAR1.built.after.mir
+// EMIT_MIR issue_110508.{impl#0}-BAR2.built.after.mir
+
+enum Foo {
+    Bar(()),
+}
+
+impl Foo {
+    const BAR1: Foo = Foo::Bar(());
+    const BAR2: Foo = Self::Bar(());
+}
+
+fn main() {}

--- a/tests/mir-opt/building/issue_110508.rs
+++ b/tests/mir-opt/building/issue_110508.rs
@@ -1,13 +1,13 @@
-// EMIT_MIR issue_110508.{impl#0}-BAR1.built.after.mir
-// EMIT_MIR issue_110508.{impl#0}-BAR2.built.after.mir
+// EMIT_MIR issue_110508.{impl#0}-BAR.built.after.mir
+// EMIT_MIR issue_110508.{impl#0}-SELF_BAR.built.after.mir
 
 enum Foo {
     Bar(()),
 }
 
 impl Foo {
-    const BAR1: Foo = Foo::Bar(());
-    const BAR2: Foo = Self::Bar(());
+    const BAR: Foo = Foo::Bar(());
+    const SELF_BAR: Foo = Self::Bar(());
 }
 
 fn main() {}

--- a/tests/mir-opt/building/issue_110508.{impl#0}-BAR.built.after.mir
+++ b/tests/mir-opt/building/issue_110508.{impl#0}-BAR.built.after.mir
@@ -1,6 +1,6 @@
-// MIR for `<impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR2` after built
+// MIR for `<impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR` after built
 
-const <impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR2: Foo = {
+const <impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR: Foo = {
     let mut _0: Foo;
     let mut _1: ();
 

--- a/tests/mir-opt/building/issue_110508.{impl#0}-BAR1.built.after.mir
+++ b/tests/mir-opt/building/issue_110508.{impl#0}-BAR1.built.after.mir
@@ -1,0 +1,14 @@
+// MIR for `<impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR1` after built
+
+const <impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR1: Foo = {
+    let mut _0: Foo;
+    let mut _1: ();
+
+    bb0: {
+        StorageLive(_1);
+        _1 = ();
+        _0 = Foo::Bar(move _1);
+        StorageDead(_1);
+        return;
+    }
+}

--- a/tests/mir-opt/building/issue_110508.{impl#0}-BAR2.built.after.mir
+++ b/tests/mir-opt/building/issue_110508.{impl#0}-BAR2.built.after.mir
@@ -1,0 +1,14 @@
+// MIR for `<impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR2` after built
+
+const <impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR2: Foo = {
+    let mut _0: Foo;
+    let mut _1: ();
+
+    bb0: {
+        StorageLive(_1);
+        _1 = ();
+        _0 = Foo::Bar(move _1);
+        StorageDead(_1);
+        return;
+    }
+}

--- a/tests/mir-opt/building/issue_110508.{impl#0}-SELF_BAR.built.after.mir
+++ b/tests/mir-opt/building/issue_110508.{impl#0}-SELF_BAR.built.after.mir
@@ -1,6 +1,6 @@
-// MIR for `<impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR1` after built
+// MIR for `<impl at $DIR/issue_110508.rs:8:1: 8:9>::SELF_BAR` after built
 
-const <impl at $DIR/issue_110508.rs:8:1: 8:9>::BAR1: Foo = {
+const <impl at $DIR/issue_110508.rs:8:1: 8:9>::SELF_BAR: Foo = {
     let mut _0: Foo;
     let mut _1: ();
 

--- a/tests/rustdoc-gui/sidebar-source-code.goml
+++ b/tests/rustdoc-gui/sidebar-source-code.goml
@@ -25,24 +25,24 @@ call-function: (
     "check-colors",
     {
         "theme": "ayu",
-        "color": "rgb(197, 197, 197)",
-        "background_color": "rgb(20, 25, 31)",
+        "color": "#c5c5c5",
+        "background_color": "#14191f",
     }
 )
 call-function: (
     "check-colors",
     {
         "theme": "dark",
-        "color": "rgb(221, 221, 221)",
-        "background_color": "rgb(80, 80, 80)",
+        "color": "#ddd",
+        "background_color": "#505050",
     }
 )
 call-function: (
     "check-colors",
     {
         "theme": "light",
-        "color": "rgb(0, 0, 0)",
-        "background_color": "rgb(245, 245, 245)",
+        "color": "black",
+        "background_color": "#F5F5F5",
     }
 )
 

--- a/tests/ui/binop/binop-mul-i32-f32.stderr
+++ b/tests/ui/binop/binop-mul-i32-f32.stderr
@@ -6,10 +6,10 @@ LL |     x * y
    |
    = help: the trait `Mul<f32>` is not implemented for `i32`
    = help: the following other types implement trait `Mul<Rhs>`:
+             <i32 as Mul>
+             <i32 as Mul<&i32>>
              <&'a i32 as Mul<i32>>
              <&i32 as Mul<&i32>>
-             <i32 as Mul<&i32>>
-             <i32 as Mul>
 
 error: aborting due to previous error
 

--- a/tests/ui/binop/shift-various-bad-types.stderr
+++ b/tests/ui/binop/shift-various-bad-types.stderr
@@ -6,14 +6,14 @@ LL |     22 >> p.char;
    |
    = help: the trait `Shr<char>` is not implemented for `{integer}`
    = help: the following other types implement trait `Shr<Rhs>`:
-             <&'a i128 as Shr<i128>>
-             <&'a i128 as Shr<i16>>
-             <&'a i128 as Shr<i32>>
-             <&'a i128 as Shr<i64>>
-             <&'a i128 as Shr<i8>>
-             <&'a i128 as Shr<isize>>
-             <&'a i128 as Shr<u128>>
-             <&'a i128 as Shr<u16>>
+             <isize as Shr>
+             <isize as Shr<i8>>
+             <isize as Shr<i16>>
+             <isize as Shr<i32>>
+             <isize as Shr<i64>>
+             <isize as Shr<i128>>
+             <isize as Shr<usize>>
+             <isize as Shr<u8>>
            and 568 others
 
 error[E0277]: no implementation for `{integer} >> &str`
@@ -24,14 +24,14 @@ LL |     22 >> p.str;
    |
    = help: the trait `Shr<&str>` is not implemented for `{integer}`
    = help: the following other types implement trait `Shr<Rhs>`:
-             <&'a i128 as Shr<i128>>
-             <&'a i128 as Shr<i16>>
-             <&'a i128 as Shr<i32>>
-             <&'a i128 as Shr<i64>>
-             <&'a i128 as Shr<i8>>
-             <&'a i128 as Shr<isize>>
-             <&'a i128 as Shr<u128>>
-             <&'a i128 as Shr<u16>>
+             <isize as Shr>
+             <isize as Shr<i8>>
+             <isize as Shr<i16>>
+             <isize as Shr<i32>>
+             <isize as Shr<i64>>
+             <isize as Shr<i128>>
+             <isize as Shr<usize>>
+             <isize as Shr<u8>>
            and 568 others
 
 error[E0277]: no implementation for `{integer} >> &Panolpy`
@@ -42,14 +42,14 @@ LL |     22 >> p;
    |
    = help: the trait `Shr<&Panolpy>` is not implemented for `{integer}`
    = help: the following other types implement trait `Shr<Rhs>`:
-             <&'a i128 as Shr<i128>>
-             <&'a i128 as Shr<i16>>
-             <&'a i128 as Shr<i32>>
-             <&'a i128 as Shr<i64>>
-             <&'a i128 as Shr<i8>>
-             <&'a i128 as Shr<isize>>
-             <&'a i128 as Shr<u128>>
-             <&'a i128 as Shr<u16>>
+             <isize as Shr>
+             <isize as Shr<i8>>
+             <isize as Shr<i16>>
+             <isize as Shr<i32>>
+             <isize as Shr<i64>>
+             <isize as Shr<i128>>
+             <isize as Shr<usize>>
+             <isize as Shr<u8>>
            and 568 others
 
 error[E0308]: mismatched types

--- a/tests/ui/const-generics/exhaustive-value.stderr
+++ b/tests/ui/const-generics/exhaustive-value.stderr
@@ -6,13 +6,13 @@ LL |     <() as Foo<N>>::test()
    |
    = help: the following other types implement trait `Foo<N>`:
              <() as Foo<0>>
-             <() as Foo<100>>
-             <() as Foo<101>>
-             <() as Foo<102>>
-             <() as Foo<103>>
-             <() as Foo<104>>
-             <() as Foo<105>>
-             <() as Foo<106>>
+             <() as Foo<1>>
+             <() as Foo<2>>
+             <() as Foo<3>>
+             <() as Foo<4>>
+             <() as Foo<5>>
+             <() as Foo<6>>
+             <() as Foo<7>>
            and 248 others
 
 error: aborting due to previous error

--- a/tests/ui/const-generics/generic_arg_infer/issue-91614.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/issue-91614.stderr
@@ -6,11 +6,11 @@ LL |     let y = Mask::<_, _>::splat(false);
    |
    = note: cannot satisfy `_: MaskElement`
    = help: the following types implement trait `MaskElement`:
+             isize
+             i8
              i16
              i32
              i64
-             i8
-             isize
 note: required by a bound in `Mask::<T, LANES>::splat`
   --> $SRC_DIR/core/src/../../portable-simd/crates/core_simd/src/masks.rs:LL:COL
 help: consider giving `y` an explicit type, where the type for type parameter `T` is specified

--- a/tests/ui/const-generics/issues/issue-67185-2.stderr
+++ b/tests/ui/const-generics/issues/issue-67185-2.stderr
@@ -5,8 +5,8 @@ LL |     <u8 as Baz>::Quaks: Bar,
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
    = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
              [u16; 4]
+             [[u16; 3]; 3]
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
@@ -17,8 +17,8 @@ LL |     [<u8 as Baz>::Quaks; 2]: Bar,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
    = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
              [u16; 4]
+             [[u16; 3]; 3]
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
@@ -29,8 +29,8 @@ LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
    = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
              [u16; 4]
+             [[u16; 3]; 3]
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:15:25
    |
@@ -47,8 +47,8 @@ LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
    = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
              [u16; 4]
+             [[u16; 3]; 3]
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:14:30
    |
@@ -65,8 +65,8 @@ LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
    = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
              [u16; 4]
+             [[u16; 3]; 3]
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:14:30
    |
@@ -83,8 +83,8 @@ LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
    = help: the following other types implement trait `Bar`:
-             [[u16; 3]; 3]
              [u16; 4]
+             [[u16; 3]; 3]
 note: required by a bound in `Foo`
   --> $DIR/issue-67185-2.rs:15:25
    |

--- a/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
@@ -12,10 +12,10 @@ LL |     = [0; (i8::MAX + 1u8) as usize];
    |
    = help: the trait `Add<u8>` is not implemented for `i8`
    = help: the following other types implement trait `Add<Rhs>`:
+             <i8 as Add>
+             <i8 as Add<&i8>>
              <&'a i8 as Add<i8>>
              <&i8 as Add<&i8>>
-             <i8 as Add<&i8>>
-             <i8 as Add>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
@@ -12,10 +12,10 @@ LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    |
    = help: the trait `Add<u8>` is not implemented for `i8`
    = help: the following other types implement trait `Add<Rhs>`:
+             <i8 as Add>
+             <i8 as Add<&i8>>
              <&'a i8 as Add<i8>>
              <&i8 as Add<&i8>>
-             <i8 as Add<&i8>>
-             <i8 as Add>
 
 error[E0604]: only `u8` can be cast as `char`, not `i8`
   --> $DIR/const-eval-overflow-4b.rs:22:13

--- a/tests/ui/consts/missing-larger-array-impl.rs
+++ b/tests/ui/consts/missing-larger-array-impl.rs
@@ -1,0 +1,9 @@
+struct X;
+
+// Make sure that we show the impl trait refs in the help message with
+// their evaluated constants, rather than `core::::array::{impl#30}::{constant#0}`
+
+fn main() {
+    <[X; 35] as Default>::default();
+    //~^ ERROR the trait bound `[X; 35]: Default` is not satisfied
+}

--- a/tests/ui/consts/missing-larger-array-impl.stderr
+++ b/tests/ui/consts/missing-larger-array-impl.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the trait bound `[X; 35]: Default` is not satisfied
+  --> $DIR/missing-larger-array-impl.rs:7:5
+   |
+LL |     <[X; 35] as Default>::default();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `[X; 35]`
+   |
+   = help: the following other types implement trait `Default`:
+             &[T]
+             &mut [T]
+             [T; 0]
+             [T; 10]
+             [T; 11]
+             [T; 12]
+             [T; 13]
+             [T; 14]
+           and 27 others
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/consts/missing-larger-array-impl.stderr
+++ b/tests/ui/consts/missing-larger-array-impl.stderr
@@ -5,14 +5,14 @@ LL |     <[X; 35] as Default>::default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `[X; 35]`
    |
    = help: the following other types implement trait `Default`:
-             &[T]
-             &mut [T]
              [T; 0]
-             [T; 10]
-             [T; 11]
-             [T; 12]
-             [T; 13]
-             [T; 14]
+             [T; 1]
+             [T; 2]
+             [T; 3]
+             [T; 4]
+             [T; 5]
+             [T; 6]
+             [T; 7]
            and 27 others
 
 error: aborting due to previous error

--- a/tests/ui/consts/too_generic_eval_ice.stderr
+++ b/tests/ui/consts/too_generic_eval_ice.stderr
@@ -22,14 +22,14 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
    |
    = help: the trait `PartialEq<[{integer}; 0]>` is not implemented for `[{integer}; Self::HOST_SIZE]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
-             <&[B] as PartialEq<[A; N]>>
-             <&[T] as PartialEq<Vec<U, A>>>
-             <&mut [B] as PartialEq<[A; N]>>
-             <&mut [T] as PartialEq<Vec<U, A>>>
-             <[A; N] as PartialEq<&[B]>>
-             <[A; N] as PartialEq<&mut [B]>>
              <[A; N] as PartialEq<[B; N]>>
              <[A; N] as PartialEq<[B]>>
+             <[A; N] as PartialEq<&[B]>>
+             <[A; N] as PartialEq<&mut [B]>>
+             <[T] as PartialEq<Vec<U, A>>>
+             <[A] as PartialEq<[B]>>
+             <[B] as PartialEq<[A; N]>>
+             <&[T] as PartialEq<Vec<U, A>>>
            and 3 others
 
 error: aborting due to 3 previous errors

--- a/tests/ui/deriving/issue-103157.stderr
+++ b/tests/ui/deriving/issue-103157.stderr
@@ -8,14 +8,14 @@ LL |     Float(Option<f64>),
    |           ^^^^^^^^^^^ the trait `Eq` is not implemented for `f64`
    |
    = help: the following other types implement trait `Eq`:
-             i128
+             isize
+             i8
              i16
              i32
              i64
-             i8
-             isize
-             u128
-             u16
+             i128
+             usize
+             u8
            and 4 others
    = note: required for `Option<f64>` to implement `Eq`
 note: required by a bound in `AssertParamIsEq`

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
@@ -7,12 +7,12 @@ LL |     f1.foo(1usize);
    |        required by a bound introduced by this call
    |
    = help: the following other types implement trait `Foo<A>`:
+             <Bar as Foo<i8>>
              <Bar as Foo<i16>>
              <Bar as Foo<i32>>
-             <Bar as Foo<i8>>
+             <Bar as Foo<u8>>
              <Bar as Foo<u16>>
              <Bar as Foo<u32>>
-             <Bar as Foo<u8>>
 
 error: aborting due to previous error
 

--- a/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -8,10 +8,10 @@ LL |     Foo::<i32>::bar(&1i8);
    |
    = help: the following other types implement trait `Foo<B>`:
              <i8 as Foo<bool>>
+             <i8 as Foo<u8>>
              <i8 as Foo<u16>>
              <i8 as Foo<u32>>
              <i8 as Foo<u64>>
-             <i8 as Foo<u8>>
 
 error[E0277]: the trait bound `u8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:25:21
@@ -38,10 +38,10 @@ LL |     Foo::<i32>::bar(&true);
    = help: the following other types implement trait `Foo<B>`:
              <bool as Foo<bool>>
              <bool as Foo<i8>>
+             <bool as Foo<u8>>
              <bool as Foo<u16>>
              <bool as Foo<u32>>
              <bool as Foo<u64>>
-             <bool as Foo<u8>>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
+++ b/tests/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
@@ -23,14 +23,14 @@ LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹
    |
    = help: the trait `Sub<{integer}>` is not implemented for `{float}`
    = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&'a f64 as Sub<f64>>
-             <&'a i128 as Sub<i128>>
-             <&'a i16 as Sub<i16>>
-             <&'a i32 as Sub<i32>>
-             <&'a i64 as Sub<i64>>
-             <&'a i8 as Sub<i8>>
-             <&'a isize as Sub<isize>>
+             <isize as Sub>
+             <isize as Sub<&isize>>
+             <i8 as Sub>
+             <i8 as Sub<&i8>>
+             <i16 as Sub>
+             <i16 as Sub<&i16>>
+             <i32 as Sub>
+             <i32 as Sub<&i32>>
            and 48 others
 
 error: aborting due to 3 previous errors

--- a/tests/ui/fmt/ifmt-unimpl.stderr
+++ b/tests/ui/fmt/ifmt-unimpl.stderr
@@ -7,14 +7,14 @@ LL |     format!("{:X}", "3");
    |              required by a bound introduced by this call
    |
    = help: the following other types implement trait `UpperHex`:
-             &T
-             &mut T
-             NonZeroI128
-             NonZeroI16
-             NonZeroI32
-             NonZeroI64
-             NonZeroI8
-             NonZeroIsize
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
            and 20 others
    = note: required for `&str` to implement `UpperHex`
 note: required by a bound in `core::fmt::rt::Argument::<'a>::new_upper_hex`

--- a/tests/ui/impl-trait/equality.stderr
+++ b/tests/ui/impl-trait/equality.stderr
@@ -30,10 +30,10 @@ LL |         n + sum_to(n - 1)
    |
    = help: the trait `Add<impl Foo>` is not implemented for `u32`
    = help: the following other types implement trait `Add<Rhs>`:
+             <u32 as Add>
+             <u32 as Add<&u32>>
              <&'a u32 as Add<u32>>
              <&u32 as Add<&u32>>
-             <u32 as Add<&u32>>
-             <u32 as Add>
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/issues/issue-11771.stderr
+++ b/tests/ui/issues/issue-11771.stderr
@@ -6,14 +6,14 @@ LL |     1 +
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
+             <isize as Add>
+             <isize as Add<&isize>>
+             <i8 as Add>
+             <i8 as Add<&i8>>
+             <i16 as Add>
+             <i16 as Add<&i16>>
+             <i32 as Add>
+             <i32 as Add<&i32>>
            and 48 others
 
 error[E0277]: cannot add `()` to `{integer}`
@@ -24,14 +24,14 @@ LL |     1 +
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
+             <isize as Add>
+             <isize as Add<&isize>>
+             <i8 as Add>
+             <i8 as Add<&i8>>
+             <i16 as Add>
+             <i16 as Add<&i16>>
+             <i32 as Add>
+             <i32 as Add<&i32>>
            and 48 others
 
 error: aborting due to 2 previous errors

--- a/tests/ui/issues/issue-24352.stderr
+++ b/tests/ui/issues/issue-24352.stderr
@@ -6,10 +6,10 @@ LL |     1.0f64 - 1
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
+             <f64 as Sub>
+             <f64 as Sub<&f64>>
              <&'a f64 as Sub<f64>>
              <&f64 as Sub<&f64>>
-             <f64 as Sub<&f64>>
-             <f64 as Sub>
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     1.0f64 - 1.0

--- a/tests/ui/issues/issue-32709.stderr
+++ b/tests/ui/issues/issue-32709.stderr
@@ -8,6 +8,7 @@ LL |     Err(5)?;
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
+             <(T,) as From<[T; 1]>>
              <(T, T) as From<[T; 2]>>
              <(T, T, T) as From<[T; 3]>>
              <(T, T, T, T) as From<[T; 4]>>
@@ -15,7 +16,6 @@ LL |     Err(5)?;
              <(T, T, T, T, T, T) as From<[T; 6]>>
              <(T, T, T, T, T, T, T) as From<[T; 7]>>
              <(T, T, T, T, T, T, T, T) as From<[T; 8]>>
-             <(T, T, T, T, T, T, T, T, T) as From<[T; 9]>>
            and 4 others
    = note: required for `Result<i32, ()>` to implement `FromResidual<Result<Infallible, {integer}>>`
 

--- a/tests/ui/issues/issue-50582.stderr
+++ b/tests/ui/issues/issue-50582.stderr
@@ -15,14 +15,14 @@ LL |     Vec::<[(); 1 + for x in 0..1 {}]>::new();
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
+             <isize as Add>
+             <isize as Add<&isize>>
+             <i8 as Add>
+             <i8 as Add<&i8>>
+             <i16 as Add>
+             <i16 as Add<&i16>>
+             <i32 as Add>
+             <i32 as Add<&i32>>
            and 48 others
 
 error: aborting due to 2 previous errors

--- a/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
@@ -6,8 +6,8 @@ LL |     let x = Some(()).iter().map(|()| 1).sum::<f32>();
    |
    = help: the trait `Sum<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Sum<A>`:
-             <f32 as Sum<&'a f32>>
              <f32 as Sum>
+             <f32 as Sum<&'a f32>>
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-with-int-infer.rs:2:29
    |

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -24,8 +24,8 @@ LL |     println!("{}", scores.sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
              <i32 as Sum>
+             <i32 as Sum<&'a i32>>
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:12:10
    |
@@ -49,8 +49,8 @@ LL |             .sum::<i32>(),
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
              <i32 as Sum>
+             <i32 as Sum<&'a i32>>
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:25:14
    |
@@ -81,8 +81,8 @@ LL |             .sum::<i32>(),
    |
    = help: the trait `Sum<f64>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
              <i32 as Sum>
+             <i32 as Sum<&'a i32>>
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:33:14
    |
@@ -109,8 +109,8 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
              <i32 as Sum>
+             <i32 as Sum<&'a i32>>
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:38:38
    |
@@ -130,8 +130,8 @@ LL |     println!("{}", vec![(), ()].iter().sum::<i32>());
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
              <i32 as Sum>
+             <i32 as Sum<&'a i32>>
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:39:33
    |

--- a/tests/ui/mismatched_types/binops.stderr
+++ b/tests/ui/mismatched_types/binops.stderr
@@ -6,14 +6,14 @@ LL |     1 + Some(1);
    |
    = help: the trait `Add<Option<{integer}>>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
-             <&'a i8 as Add<i8>>
-             <&'a isize as Add<isize>>
+             <isize as Add>
+             <isize as Add<&isize>>
+             <i8 as Add>
+             <i8 as Add<&i8>>
+             <i16 as Add>
+             <i16 as Add<&i16>>
+             <i32 as Add>
+             <i32 as Add<&i32>>
            and 48 others
 
 error[E0277]: cannot subtract `Option<{integer}>` from `usize`
@@ -24,10 +24,10 @@ LL |     2 as usize - Some(1);
    |
    = help: the trait `Sub<Option<{integer}>>` is not implemented for `usize`
    = help: the following other types implement trait `Sub<Rhs>`:
+             <usize as Sub>
+             <usize as Sub<&usize>>
              <&'a usize as Sub<usize>>
              <&usize as Sub<&usize>>
-             <usize as Sub<&usize>>
-             <usize as Sub>
 
 error[E0277]: cannot multiply `{integer}` by `()`
   --> $DIR/binops.rs:4:7
@@ -37,14 +37,14 @@ LL |     3 * ();
    |
    = help: the trait `Mul<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f32 as Mul<f32>>
-             <&'a f64 as Mul<f64>>
-             <&'a i128 as Mul<i128>>
-             <&'a i16 as Mul<i16>>
-             <&'a i32 as Mul<i32>>
-             <&'a i64 as Mul<i64>>
-             <&'a i8 as Mul<i8>>
-             <&'a isize as Mul<isize>>
+             <isize as Mul>
+             <isize as Mul<&isize>>
+             <i8 as Mul>
+             <i8 as Mul<&i8>>
+             <i16 as Mul>
+             <i16 as Mul<&i16>>
+             <i32 as Mul>
+             <i32 as Mul<&i32>>
            and 49 others
 
 error[E0277]: cannot divide `{integer}` by `&str`
@@ -55,14 +55,14 @@ LL |     4 / "";
    |
    = help: the trait `Div<&str>` is not implemented for `{integer}`
    = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f32 as Div<f32>>
-             <&'a f64 as Div<f64>>
-             <&'a i128 as Div<i128>>
-             <&'a i16 as Div<i16>>
-             <&'a i32 as Div<i32>>
-             <&'a i64 as Div<i64>>
-             <&'a i8 as Div<i8>>
-             <&'a isize as Div<isize>>
+             <isize as Div>
+             <isize as Div<&isize>>
+             <i8 as Div>
+             <i8 as Div<&i8>>
+             <i16 as Div>
+             <i16 as Div<&i16>>
+             <i32 as Div>
+             <i32 as Div<&i32>>
            and 54 others
 
 error[E0277]: can't compare `{integer}` with `String`
@@ -73,14 +73,14 @@ LL |     5 < String::new();
    |
    = help: the trait `PartialOrd<String>` is not implemented for `{integer}`
    = help: the following other types implement trait `PartialOrd<Rhs>`:
-             f32
-             f64
-             i128
+             isize
+             i8
              i16
              i32
              i64
-             i8
-             isize
+             i128
+             usize
+             u8
            and 6 others
 
 error[E0277]: can't compare `{integer}` with `Result<{integer}, _>`
@@ -91,14 +91,14 @@ LL |     6 == Ok(1);
    |
    = help: the trait `PartialEq<Result<{integer}, _>>` is not implemented for `{integer}`
    = help: the following other types implement trait `PartialEq<Rhs>`:
-             f32
-             f64
-             i128
+             isize
+             i8
              i16
              i32
              i64
-             i8
-             isize
+             i128
+             usize
+             u8
            and 6 others
 
 error: aborting due to 6 previous errors

--- a/tests/ui/never_type/diverging-fallback-no-leak.fallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.fallback.stderr
@@ -7,8 +7,8 @@ LL |     unconstrained_arg(return);
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `Test`:
-             ()
              i32
+             ()
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: did you intend to use the type `()` here instead?
 note: required by a bound in `unconstrained_arg`

--- a/tests/ui/never_type/issue-13352.stderr
+++ b/tests/ui/never_type/issue-13352.stderr
@@ -6,10 +6,10 @@ LL |     2_usize + (loop {});
    |
    = help: the trait `Add<()>` is not implemented for `usize`
    = help: the following other types implement trait `Add<Rhs>`:
+             <usize as Add>
+             <usize as Add<&usize>>
              <&'a usize as Add<usize>>
              <&usize as Add<&usize>>
-             <usize as Add<&usize>>
-             <usize as Add>
 
 error: aborting due to previous error
 

--- a/tests/ui/nll/user-annotations/normalization-2.stderr
+++ b/tests/ui/nll/user-annotations/normalization-2.stderr
@@ -147,7 +147,7 @@ LL | fn test_variants<'a, 'b, 'c>() {
    |                      -- lifetime `'b` defined here
 ...
 LL |     <Ty<'b>>::Tuple();
-   |     ^^^^^^^^^^^^^^^ requires that `'b` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/normalization-2.rs:93:5

--- a/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
@@ -6,10 +6,10 @@ LL |     x + 100.0
    |
    = help: the trait `Add<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Add<Rhs>`:
+             <u8 as Add>
+             <u8 as Add<&u8>>
              <&'a u8 as Add<u8>>
              <&u8 as Add<&u8>>
-             <u8 as Add<&u8>>
-             <u8 as Add>
 
 error[E0277]: cannot add `&str` to `f64`
   --> $DIR/not-suggest-float-literal.rs:6:7
@@ -19,10 +19,10 @@ LL |     x + "foo"
    |
    = help: the trait `Add<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Add<Rhs>`:
+             <f64 as Add>
+             <f64 as Add<&f64>>
              <&'a f64 as Add<f64>>
              <&f64 as Add<&f64>>
-             <f64 as Add<&f64>>
-             <f64 as Add>
 
 error[E0277]: cannot add `{integer}` to `f64`
   --> $DIR/not-suggest-float-literal.rs:11:7
@@ -32,10 +32,10 @@ LL |     x + y
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Add<Rhs>`:
+             <f64 as Add>
+             <f64 as Add<&f64>>
              <&'a f64 as Add<f64>>
              <&f64 as Add<&f64>>
-             <f64 as Add<&f64>>
-             <f64 as Add>
 
 error[E0277]: cannot subtract `{float}` from `u8`
   --> $DIR/not-suggest-float-literal.rs:15:7
@@ -45,10 +45,10 @@ LL |     x - 100.0
    |
    = help: the trait `Sub<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Sub<Rhs>`:
+             <u8 as Sub>
+             <u8 as Sub<&u8>>
              <&'a u8 as Sub<u8>>
              <&u8 as Sub<&u8>>
-             <u8 as Sub<&u8>>
-             <u8 as Sub>
 
 error[E0277]: cannot subtract `&str` from `f64`
   --> $DIR/not-suggest-float-literal.rs:19:7
@@ -58,10 +58,10 @@ LL |     x - "foo"
    |
    = help: the trait `Sub<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
+             <f64 as Sub>
+             <f64 as Sub<&f64>>
              <&'a f64 as Sub<f64>>
              <&f64 as Sub<&f64>>
-             <f64 as Sub<&f64>>
-             <f64 as Sub>
 
 error[E0277]: cannot subtract `{integer}` from `f64`
   --> $DIR/not-suggest-float-literal.rs:24:7
@@ -71,10 +71,10 @@ LL |     x - y
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
+             <f64 as Sub>
+             <f64 as Sub<&f64>>
              <&'a f64 as Sub<f64>>
              <&f64 as Sub<&f64>>
-             <f64 as Sub<&f64>>
-             <f64 as Sub>
 
 error[E0277]: cannot multiply `u8` by `{float}`
   --> $DIR/not-suggest-float-literal.rs:28:7
@@ -84,10 +84,10 @@ LL |     x * 100.0
    |
    = help: the trait `Mul<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Mul<Rhs>`:
+             <u8 as Mul>
+             <u8 as Mul<&u8>>
              <&'a u8 as Mul<u8>>
              <&u8 as Mul<&u8>>
-             <u8 as Mul<&u8>>
-             <u8 as Mul>
 
 error[E0277]: cannot multiply `f64` by `&str`
   --> $DIR/not-suggest-float-literal.rs:32:7
@@ -97,10 +97,10 @@ LL |     x * "foo"
    |
    = help: the trait `Mul<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Mul<Rhs>`:
+             <f64 as Mul>
+             <f64 as Mul<&f64>>
              <&'a f64 as Mul<f64>>
              <&f64 as Mul<&f64>>
-             <f64 as Mul<&f64>>
-             <f64 as Mul>
 
 error[E0277]: cannot multiply `f64` by `{integer}`
   --> $DIR/not-suggest-float-literal.rs:37:7
@@ -110,10 +110,10 @@ LL |     x * y
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Mul<Rhs>`:
+             <f64 as Mul>
+             <f64 as Mul<&f64>>
              <&'a f64 as Mul<f64>>
              <&f64 as Mul<&f64>>
-             <f64 as Mul<&f64>>
-             <f64 as Mul>
 
 error[E0277]: cannot divide `u8` by `{float}`
   --> $DIR/not-suggest-float-literal.rs:41:7
@@ -123,11 +123,11 @@ LL |     x / 100.0
    |
    = help: the trait `Div<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Div<Rhs>`:
+             <u8 as Div>
+             <u8 as Div<NonZeroU8>>
+             <u8 as Div<&u8>>
              <&'a u8 as Div<u8>>
              <&u8 as Div<&u8>>
-             <u8 as Div<&u8>>
-             <u8 as Div<NonZeroU8>>
-             <u8 as Div>
 
 error[E0277]: cannot divide `f64` by `&str`
   --> $DIR/not-suggest-float-literal.rs:45:7
@@ -137,10 +137,10 @@ LL |     x / "foo"
    |
    = help: the trait `Div<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Div<Rhs>`:
+             <f64 as Div>
+             <f64 as Div<&f64>>
              <&'a f64 as Div<f64>>
              <&f64 as Div<&f64>>
-             <f64 as Div<&f64>>
-             <f64 as Div>
 
 error[E0277]: cannot divide `f64` by `{integer}`
   --> $DIR/not-suggest-float-literal.rs:50:7
@@ -150,10 +150,10 @@ LL |     x / y
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Div<Rhs>`:
+             <f64 as Div>
+             <f64 as Div<&f64>>
              <&'a f64 as Div<f64>>
              <&f64 as Div<&f64>>
-             <f64 as Div<&f64>>
-             <f64 as Div>
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
@@ -6,10 +6,10 @@ LL |     x + 100
    |
    = help: the trait `Add<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Add<Rhs>`:
+             <f32 as Add>
+             <f32 as Add<&f32>>
              <&'a f32 as Add<f32>>
              <&f32 as Add<&f32>>
-             <f32 as Add<&f32>>
-             <f32 as Add>
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x + 100.0
@@ -23,10 +23,10 @@ LL |     x + 100
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Add<Rhs>`:
+             <f64 as Add>
+             <f64 as Add<&f64>>
              <&'a f64 as Add<f64>>
              <&f64 as Add<&f64>>
-             <f64 as Add<&f64>>
-             <f64 as Add>
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x + 100.0
@@ -40,10 +40,10 @@ LL |     x - 100
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Sub<Rhs>`:
+             <f32 as Sub>
+             <f32 as Sub<&f32>>
              <&'a f32 as Sub<f32>>
              <&f32 as Sub<&f32>>
-             <f32 as Sub<&f32>>
-             <f32 as Sub>
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x - 100.0
@@ -57,10 +57,10 @@ LL |     x - 100
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
+             <f64 as Sub>
+             <f64 as Sub<&f64>>
              <&'a f64 as Sub<f64>>
              <&f64 as Sub<&f64>>
-             <f64 as Sub<&f64>>
-             <f64 as Sub>
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x - 100.0
@@ -74,10 +74,10 @@ LL |     x * 100
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Mul<Rhs>`:
+             <f32 as Mul>
+             <f32 as Mul<&f32>>
              <&'a f32 as Mul<f32>>
              <&f32 as Mul<&f32>>
-             <f32 as Mul<&f32>>
-             <f32 as Mul>
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x * 100.0
@@ -91,10 +91,10 @@ LL |     x * 100
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Mul<Rhs>`:
+             <f64 as Mul>
+             <f64 as Mul<&f64>>
              <&'a f64 as Mul<f64>>
              <&f64 as Mul<&f64>>
-             <f64 as Mul<&f64>>
-             <f64 as Mul>
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x * 100.0
@@ -108,10 +108,10 @@ LL |     x / 100
    |
    = help: the trait `Div<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Div<Rhs>`:
+             <f32 as Div>
+             <f32 as Div<&f32>>
              <&'a f32 as Div<f32>>
              <&f32 as Div<&f32>>
-             <f32 as Div<&f32>>
-             <f32 as Div>
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x / 100.0
@@ -125,10 +125,10 @@ LL |     x / 100
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Div<Rhs>`:
+             <f64 as Div>
+             <f64 as Div<&f64>>
              <&'a f64 as Div<f64>>
              <&f64 as Div<&f64>>
-             <f64 as Div<&f64>>
-             <f64 as Div>
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x / 100.0

--- a/tests/ui/on-unimplemented/multiple-impls.stderr
+++ b/tests/ui/on-unimplemented/multiple-impls.stderr
@@ -8,8 +8,8 @@ LL |     Index::index(&[] as &[i32], 2u32);
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5
@@ -19,8 +19,8 @@ LL |     Index::index(&[] as &[i32], 2u32);
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:37:33
@@ -32,8 +32,8 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:37:5
@@ -43,8 +43,8 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:41:33
@@ -56,8 +56,8 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:41:5
@@ -67,8 +67,8 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5
@@ -78,8 +78,8 @@ LL |     Index::index(&[] as &[i32], 2u32);
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:37:5
@@ -89,8 +89,8 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:41:5
@@ -100,8 +100,8 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
              <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -16,8 +16,8 @@ LL |     x[..1i32];
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `RangeTo<i32>`
    = help: the following other types implement trait `SliceIndex<T>`:
-             <RangeTo<usize> as SliceIndex<[T]>>
              <RangeTo<usize> as SliceIndex<str>>
+             <RangeTo<usize> as SliceIndex<[T]>>
    = note: required for `[i32]` to implement `Index<RangeTo<i32>>`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/on-unimplemented/sum.stderr
+++ b/tests/ui/on-unimplemented/sum.stderr
@@ -6,8 +6,8 @@ LL |     vec![(), ()].iter().sum::<i32>();
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
              <i32 as Sum>
+             <i32 as Sum<&'a i32>>
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:4:18
    |
@@ -26,8 +26,8 @@ LL |     vec![(), ()].iter().product::<i32>();
    |
    = help: the trait `Product<&()>` is not implemented for `i32`
    = help: the following other types implement trait `Product<A>`:
-             <i32 as Product<&'a i32>>
              <i32 as Product>
+             <i32 as Product<&'a i32>>
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:7:18
    |

--- a/tests/ui/pattern/issue-110508.rs
+++ b/tests/ui/pattern/issue-110508.rs
@@ -1,0 +1,38 @@
+// run-pass
+
+#[derive(PartialEq, Eq)]
+pub enum Foo {
+    FooA(()),
+    FooB(Vec<()>),
+}
+
+impl Foo {
+    const A1: Foo = Foo::FooA(());
+    const A2: Foo = Self::FooA(());
+    const A3: Self = Foo::FooA(());
+    const A4: Self = Self::FooA(());
+}
+
+fn main() {
+    let foo = Foo::FooA(());
+
+    match foo {
+        Foo::A1 => {},
+        _ => {},
+    }
+
+    match foo {
+        Foo::A2 => {},
+        _ => {},
+    }
+
+    match foo {
+        Foo::A3 => {},
+        _ => {},
+    }
+
+    match foo {
+        Foo::A4 => {},
+        _ => {},
+    }
+}

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -12,13 +12,13 @@ LL |     for i in false..true {}
    |
    = help: the following other types implement trait `Step`:
              char
-             i128
+             isize
+             i8
              i16
              i32
              i64
-             i8
-             isize
-             u128
+             i128
+             usize
            and 5 others
    = note: required for `std::ops::Range<bool>` to implement `Iterator`
    = note: required for `std::ops::Range<bool>` to implement `IntoIterator`

--- a/tests/ui/span/multiline-span-simple.stderr
+++ b/tests/ui/span/multiline-span-simple.stderr
@@ -6,10 +6,10 @@ LL |     foo(1 as u32 +
    |
    = help: the trait `Add<()>` is not implemented for `u32`
    = help: the following other types implement trait `Add<Rhs>`:
+             <u32 as Add>
+             <u32 as Add<&u32>>
              <&'a u32 as Add<u32>>
              <&u32 as Add<&u32>>
-             <u32 as Add<&u32>>
-             <u32 as Add>
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/impl-trait-return-trailing-semicolon.stderr
+++ b/tests/ui/suggestions/impl-trait-return-trailing-semicolon.stderr
@@ -16,8 +16,8 @@ LL | fn bar() -> impl Bar {
    |             ^^^^^^^^ the trait `Bar` is not implemented for `()`
    |
    = help: the following other types implement trait `Bar`:
-             Qux
              i32
+             Qux
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/into-str.stderr
+++ b/tests/ui/suggestions/into-str.stderr
@@ -8,12 +8,12 @@ LL |     foo(String::new());
    |
    = note: to coerce a `String` into a `&str`, use `&*` as a prefix
    = help: the following other types implement trait `From<T>`:
-             <String as From<&String>>
-             <String as From<&mut str>>
-             <String as From<&str>>
+             <String as From<char>>
              <String as From<Box<str>>>
              <String as From<Cow<'a, str>>>
-             <String as From<char>>
+             <String as From<&str>>
+             <String as From<&mut str>>
+             <String as From<&String>>
    = note: required for `String` to implement `Into<&str>`
 note: required by a bound in `foo`
   --> $DIR/into-str.rs:1:31

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -5,14 +5,14 @@ LL |     let _: &[i8] = data.into();
    |                         ^^^^ the trait `From<&[u8]>` is not implemented for `&[i8]`
    |
    = help: the following other types implement trait `From<T>`:
-             <&'input [u8] as From<gimli::read::endian_slice::EndianSlice<'input, Endian>>>
-             <[T; 10] as From<(T, T, T, T, T, T, T, T, T, T)>>
-             <[T; 11] as From<(T, T, T, T, T, T, T, T, T, T, T)>>
-             <[T; 12] as From<(T, T, T, T, T, T, T, T, T, T, T, T)>>
+             <[bool; LANES] as From<Mask<T, LANES>>>
+             <[T; N] as From<Simd<T, N>>>
              <[T; 1] as From<(T,)>>
              <[T; 2] as From<(T, T)>>
              <[T; 3] as From<(T, T, T)>>
              <[T; 4] as From<(T, T, T, T)>>
+             <[T; 5] as From<(T, T, T, T, T)>>
+             <[T; 6] as From<(T, T, T, T, T, T)>>
            and 7 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 

--- a/tests/ui/thir-print/thir-flat-const-variant.rs
+++ b/tests/ui/thir-print/thir-flat-const-variant.rs
@@ -1,0 +1,18 @@
+// compile-flags: -Z unpretty=thir-flat
+// check-pass
+
+// Previously, the constants with `Self::Bar(())` would be `Call`s instead of
+// `Adt`s in THIR.
+
+pub enum Foo {
+    Bar(()),
+}
+
+impl Foo {
+    const BAR1: Foo = Foo::Bar(());
+    const BAR2: Foo = Self::Bar(());
+    const BAR3: Self = Foo::Bar(());
+    const BAR4: Self = Self::Bar(());
+}
+
+fn main() {}

--- a/tests/ui/thir-print/thir-flat-const-variant.stdout
+++ b/tests/ui/thir-print/thir-flat-const-variant.stdout
@@ -1,0 +1,399 @@
+DefId(0:8 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR1):
+Thir {
+    body_type: Const(
+        Foo,
+    ),
+    arms: [],
+    blocks: [],
+    exprs: [
+        Expr {
+            kind: Tuple {
+                fields: [],
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:12:32: 12:34 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(7),
+                lint_level: Explicit(
+                    HirId(DefId(0:8 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR1).7),
+                ),
+                value: e0,
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:12:32: 12:34 (#0),
+        },
+        Expr {
+            kind: Adt(
+                AdtExpr {
+                    adt_def: Foo,
+                    variant_index: 0,
+                    substs: [],
+                    user_ty: None,
+                    fields: [
+                        FieldExpr {
+                            name: 0,
+                            expr: e1,
+                        },
+                    ],
+                    base: None,
+                },
+            ),
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:12:23: 12:35 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(3),
+                lint_level: Explicit(
+                    HirId(DefId(0:8 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR1).3),
+                ),
+                value: e2,
+            },
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:12:23: 12:35 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Destruction(3),
+                lint_level: Inherited,
+                value: e3,
+            },
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:12:23: 12:35 (#0),
+        },
+    ],
+    stmts: [],
+    params: [],
+}
+
+DefId(0:9 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR2):
+Thir {
+    body_type: Const(
+        Foo,
+    ),
+    arms: [],
+    blocks: [],
+    exprs: [
+        Expr {
+            kind: Tuple {
+                fields: [],
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:13:33: 13:35 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(8),
+                lint_level: Explicit(
+                    HirId(DefId(0:9 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR2).8),
+                ),
+                value: e0,
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:13:33: 13:35 (#0),
+        },
+        Expr {
+            kind: Adt(
+                AdtExpr {
+                    adt_def: Foo,
+                    variant_index: 0,
+                    substs: [],
+                    user_ty: None,
+                    fields: [
+                        FieldExpr {
+                            name: 0,
+                            expr: e1,
+                        },
+                    ],
+                    base: None,
+                },
+            ),
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:13:23: 13:36 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(3),
+                lint_level: Explicit(
+                    HirId(DefId(0:9 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR2).3),
+                ),
+                value: e2,
+            },
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:13:23: 13:36 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Destruction(3),
+                lint_level: Inherited,
+                value: e3,
+            },
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:13:23: 13:36 (#0),
+        },
+    ],
+    stmts: [],
+    params: [],
+}
+
+DefId(0:10 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR3):
+Thir {
+    body_type: Const(
+        Foo,
+    ),
+    arms: [],
+    blocks: [],
+    exprs: [
+        Expr {
+            kind: Tuple {
+                fields: [],
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:14:33: 14:35 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(7),
+                lint_level: Explicit(
+                    HirId(DefId(0:10 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR3).7),
+                ),
+                value: e0,
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:14:33: 14:35 (#0),
+        },
+        Expr {
+            kind: Adt(
+                AdtExpr {
+                    adt_def: Foo,
+                    variant_index: 0,
+                    substs: [],
+                    user_ty: None,
+                    fields: [
+                        FieldExpr {
+                            name: 0,
+                            expr: e1,
+                        },
+                    ],
+                    base: None,
+                },
+            ),
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:14:24: 14:36 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(3),
+                lint_level: Explicit(
+                    HirId(DefId(0:10 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR3).3),
+                ),
+                value: e2,
+            },
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:14:24: 14:36 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Destruction(3),
+                lint_level: Inherited,
+                value: e3,
+            },
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:14:24: 14:36 (#0),
+        },
+    ],
+    stmts: [],
+    params: [],
+}
+
+DefId(0:11 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR4):
+Thir {
+    body_type: Const(
+        Foo,
+    ),
+    arms: [],
+    blocks: [],
+    exprs: [
+        Expr {
+            kind: Tuple {
+                fields: [],
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:15:34: 15:36 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(8),
+                lint_level: Explicit(
+                    HirId(DefId(0:11 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR4).8),
+                ),
+                value: e0,
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:15:34: 15:36 (#0),
+        },
+        Expr {
+            kind: Adt(
+                AdtExpr {
+                    adt_def: Foo,
+                    variant_index: 0,
+                    substs: [],
+                    user_ty: None,
+                    fields: [
+                        FieldExpr {
+                            name: 0,
+                            expr: e1,
+                        },
+                    ],
+                    base: None,
+                },
+            ),
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:15:24: 15:37 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(3),
+                lint_level: Explicit(
+                    HirId(DefId(0:11 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR4).3),
+                ),
+                value: e2,
+            },
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:15:24: 15:37 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Destruction(3),
+                lint_level: Inherited,
+                value: e3,
+            },
+            ty: Foo,
+            temp_lifetime: Some(
+                Node(3),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:15:24: 15:37 (#0),
+        },
+    ],
+    stmts: [],
+    params: [],
+}
+
+DefId(0:12 ~ thir_flat_const_variant[1f54]::main):
+Thir {
+    body_type: Fn(
+        fn(),
+    ),
+    arms: [],
+    blocks: [
+        Block {
+            targeted_by_break: false,
+            region_scope: Node(1),
+            opt_destruction_scope: None,
+            span: $DIR/thir-flat-const-variant.rs:18:11: 18:13 (#0),
+            stmts: [],
+            expr: None,
+            safety_mode: Safe,
+        },
+    ],
+    exprs: [
+        Expr {
+            kind: Block {
+                block: b0,
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(2),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:18:11: 18:13 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(2),
+                lint_level: Explicit(
+                    HirId(DefId(0:12 ~ thir_flat_const_variant[1f54]::main).2),
+                ),
+                value: e0,
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(2),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:18:11: 18:13 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Destruction(2),
+                lint_level: Inherited,
+                value: e1,
+            },
+            ty: (),
+            temp_lifetime: Some(
+                Node(2),
+            ),
+            span: $DIR/thir-flat-const-variant.rs:18:11: 18:13 (#0),
+        },
+    ],
+    stmts: [],
+    params: [],
+}
+

--- a/tests/ui/traits/bound/assoc-fn-bound-root-obligation.stderr
+++ b/tests/ui/traits/bound/assoc-fn-bound-root-obligation.stderr
@@ -6,13 +6,13 @@ LL |     s.strip_suffix(b'\n').unwrap_or(s)
    |
    = help: the trait `FnMut<(char,)>` is not implemented for `u8`
    = help: the following other types implement trait `Pattern<'a>`:
+             char
+             [char; N]
              &'b String
              &'b [char; N]
              &'b [char]
-             &'b str
              &'c &'b str
-             [char; N]
-             char
+             &'b str
    = note: required for `u8` to implement `Pattern<'_>`
 
 error: aborting due to previous error

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -8,8 +8,8 @@ LL |     Ok(Err(123_i32)?)
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
-             <u8 as From<NonZeroU8>>
              <u8 as From<bool>>
+             <u8 as From<NonZeroU8>>
    = note: required for `Result<u64, u8>` to implement `FromResidual<Result<Infallible, i32>>`
 
 error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in a function that returns `Result`
@@ -22,8 +22,8 @@ LL |     Some(3)?;
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u64, String>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
              <Result<T, F> as FromResidual<Yeet<E>>>
+             <Result<T, F> as FromResidual<Result<Infallible, E>>>
 
 error[E0277]: the `?` operator can only be used on `Result`s in a function that returns `Result`
   --> $DIR/bad-interconversion.rs:17:31
@@ -35,8 +35,8 @@ LL |     Ok(ControlFlow::Break(123)?)
    |
    = help: the trait `FromResidual<ControlFlow<{integer}, Infallible>>` is not implemented for `Result<u64, String>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
              <Result<T, F> as FromResidual<Yeet<E>>>
+             <Result<T, F> as FromResidual<Result<Infallible, E>>>
 
 error[E0277]: the `?` operator can only be used on `Option`s, not `Result`s, in a function that returns `Option`
   --> $DIR/bad-interconversion.rs:22:22

--- a/tests/ui/try-trait/option-to-result.stderr
+++ b/tests/ui/try-trait/option-to-result.stderr
@@ -9,8 +9,8 @@ LL |     a?;
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<(), ()>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
              <Result<T, F> as FromResidual<Yeet<E>>>
+             <Result<T, F> as FromResidual<Result<Infallible, E>>>
 
 error[E0277]: the `?` operator can only be used on `Option`s, not `Result`s, in a function that returns `Option`
   --> $DIR/option-to-result.rs:11:6

--- a/tests/ui/try-trait/try-on-option.stderr
+++ b/tests/ui/try-trait/try-on-option.stderr
@@ -9,8 +9,8 @@ LL |     x?;
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u32, ()>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
              <Result<T, F> as FromResidual<Yeet<E>>>
+             <Result<T, F> as FromResidual<Result<Infallible, E>>>
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option.rs:11:6

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference2.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference2.stderr
@@ -8,8 +8,8 @@ LL |     ()
    |     -- return type was inferred to be `()` here
    |
    = help: the following other types implement trait `Foo<A>`:
-             <() as Foo<()>>
              <() as Foo<u32>>
+             <() as Foo<()>>
 
 error: aborting due to previous error
 

--- a/tests/ui/type/type-check-defaults.stderr
+++ b/tests/ui/type/type-check-defaults.stderr
@@ -66,10 +66,10 @@ LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    |
    = help: the trait `Add<u8>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:
+             <i32 as Add>
+             <i32 as Add<&i32>>
              <&'a i32 as Add<i32>>
              <&i32 as Add<&i32>>
-             <i32 as Add<&i32>>
-             <i32 as Add>
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/typeck/issue-81293.stderr
+++ b/tests/ui/typeck/issue-81293.stderr
@@ -21,10 +21,10 @@ LL |     a = c + b * 5;
    |
    = help: the trait `Add<u16>` is not implemented for `usize`
    = help: the following other types implement trait `Add<Rhs>`:
+             <usize as Add>
+             <usize as Add<&usize>>
              <&'a usize as Add<usize>>
              <&usize as Add<&usize>>
-             <usize as Add<&usize>>
-             <usize as Add>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/issue-90101.stderr
+++ b/tests/ui/typeck/issue-90101.stderr
@@ -7,11 +7,11 @@ LL |     func(Path::new("hello").to_path_buf().to_string_lossy(), "world")
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `From<T>`:
-             <PathBuf as From<&T>>
              <PathBuf as From<Box<Path>>>
              <PathBuf as From<Cow<'a, Path>>>
              <PathBuf as From<OsString>>
              <PathBuf as From<String>>
+             <PathBuf as From<&T>>
    = note: required for `Cow<'_, str>` to implement `Into<PathBuf>`
 note: required by a bound in `func`
   --> $DIR/issue-90101.rs:3:20

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -8,10 +8,10 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:
+             <i32 as Add>
+             <i32 as Add<&i32>>
              <&'a i32 as Add<i32>>
              <&i32 as Add<&i32>>
-             <i32 as Add<&i32>>
-             <i32 as Add>
 
 error[E0308]: mismatched types
   --> $DIR/ufcs-qpath-self-mismatch.rs:7:28
@@ -65,10 +65,10 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:
+             <i32 as Add>
+             <i32 as Add<&i32>>
              <&'a i32 as Add<i32>>
              <&i32 as Add<&i32>>
-             <i32 as Add<&i32>>
-             <i32 as Add>
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #113005 (Don't call `query_normalize` when reporting similar impls)
 - #113064 (std: edit [T]::swap docs)
 - #113138 (Add release notes for 1.71.0)
 - #113217 (resolve typerelative ctors to adt)
 - #113254 (Use consistent formatting in Readme)
 - #113482 (Migrate GUI colors test to original CSS color format)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113005,113064,113138,113217,113254,113482)
<!-- homu-ignore:end -->