### PR TITLE
Don't label tracking issues with `needs-triage`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -257,6 +257,9 @@ new_pr = true
 
 [autolabel."needs-triage"]
 new_issue = true
+exclude_labels = [
+    "C-tracking-issue"
+]
 
 [autolabel."WG-trait-system-refactor"]
 trigger_files = [


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/issues/113261#issuecomment-1627789571.

CC @Nilstrieb