### PR TITLE
typeck in parallel

### DIFF
--- a/compiler/rustc_hir_analysis/src/check_unused.rs
+++ b/compiler/rustc_hir_analysis/src/check_unused.rs
@@ -7,6 +7,10 @@ use rustc_session::lint;
 pub fn check_crate(tcx: TyCtxt<'_>) {
     let mut used_trait_imports: UnordSet<LocalDefId> = Default::default();
 
+    // FIXME: Use `tcx.hir().par_body_owners()` when we implement creating `DefId`s
+    // for anon constants during their parents' typeck.
+    // Doing so at current will produce queries cycle errors because it may typeck
+    // on anon constants directly.
     for item_def_id in tcx.hir().body_owners() {
         let imports = tcx.used_trait_imports(item_def_id);
         debug!("GatherVisitor: item_def_id={:?} with imports {:#?}", item_def_id, imports);

--- a/tests/run-make/short-ice/check.sh
+++ b/tests/run-make/short-ice/check.sh
@@ -28,8 +28,8 @@ echo "rustc_query_count_full: $rustc_query_count_full"
 ## and marks are in pairs.
 if [ $short -lt $full ] &&
     [ $begin_count -eq $end_count ] &&
-    [ $(($rustc_query_count + 10)) -lt $rustc_query_count_full ] &&
-    [ $rustc_query_count_full -gt 10 ]; then
+    [ $(($rustc_query_count + 5)) -lt $rustc_query_count_full ] &&
+    [ $rustc_query_count_full -gt 5 ]; then
     exit 0
 else
     exit 1

--- a/tests/ui/const-generics/late-bound-vars/in_closure.stderr
+++ b/tests/ui/const-generics/late-bound-vars/in_closure.stderr
@@ -6,8 +6,7 @@ error: query stack during panic:
 #4 [eval_to_allocation_raw] const-evaluating + checking `test::{closure#0}::{constant#1}`
 #5 [eval_to_valtree] evaluating type-level constant
 #6 [typeck] type-checking `test`
-#7 [used_trait_imports] finding used_trait_imports `test`
-#8 [analysis] running analysis passes on this crate
+#7 [analysis] running analysis passes on this crate
 end of query stack
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/late-bound-vars/simple.stderr
+++ b/tests/ui/const-generics/late-bound-vars/simple.stderr
@@ -6,8 +6,7 @@ error: query stack during panic:
 #4 [eval_to_allocation_raw] const-evaluating + checking `test::{constant#1}`
 #5 [eval_to_valtree] evaluating type-level constant
 #6 [typeck] type-checking `test`
-#7 [used_trait_imports] finding used_trait_imports `test`
-#8 [analysis] running analysis passes on this crate
+#7 [analysis] running analysis passes on this crate
 end of query stack
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/transmute-fail.stderr
+++ b/tests/ui/const-generics/transmute-fail.stderr
@@ -16,18 +16,6 @@ LL |     std::mem::transmute(v)
    = note: source type: `[[u32; H]; W]` (this type does not have a fixed size)
    = note: target type: `[[u32; W]; H]` (size can vary because of [u32; W])
 
-error[E0308]: mismatched types
-  --> $DIR/transmute-fail.rs:12:53
-   |
-LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
-   |                                                     ^ expected `usize`, found `bool`
-
-error[E0308]: mismatched types
-  --> $DIR/transmute-fail.rs:12:67
-   |
-LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
-   |                                                                   ^ expected `usize`, found `bool`
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-fail.rs:23:5
    |
@@ -45,6 +33,18 @@ LL |     std::mem::transmute(v)
    |
    = note: source type: `[[[u32; 8888888]; 9999999]; 777777777]` (values of the type `[[u32; 8888888]; 9999999]` are too big for the current architecture)
    = note: target type: `[[[u32; 9999999]; 777777777]; 8888888]` (values of the type `[[u32; 9999999]; 777777777]` are too big for the current architecture)
+
+error[E0308]: mismatched types
+  --> $DIR/transmute-fail.rs:12:53
+   |
+LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
+   |                                                     ^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/transmute-fail.rs:12:67
+   |
+LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
+   |                                                                   ^ expected `usize`, found `bool`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/const-generics/type_mismatch.stderr
+++ b/tests/ui/const-generics/type_mismatch.stderr
@@ -11,18 +11,18 @@ LL | fn bar<const N: u8>() -> [u8; N] {}
    |        ^^^^^^^^^^^ required by this bound in `bar`
 
 error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:2:11
-   |
-LL |     bar::<N>()
-   |           ^ expected `u8`, found `usize`
-
-error[E0308]: mismatched types
   --> $DIR/type_mismatch.rs:6:26
    |
 LL | fn bar<const N: u8>() -> [u8; N] {}
    |    ---                   ^^^^^^^ expected `[u8; N]`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:2:11
+   |
+LL |     bar::<N>()
+   |           ^ expected `u8`, found `usize`
 
 error[E0308]: mismatched types
   --> $DIR/type_mismatch.rs:6:31

--- a/tests/ui/privacy/privacy2.rs
+++ b/tests/ui/privacy/privacy2.rs
@@ -1,3 +1,5 @@
+// compile-flags: -Zdeduplicate-diagnostics=yes
+
 #![feature(start, no_core)]
 #![no_core] // makes debugging this test *a lot* easier (during resolve)
 

--- a/tests/ui/privacy/privacy2.stderr
+++ b/tests/ui/privacy/privacy2.stderr
@@ -1,22 +1,22 @@
 error[E0432]: unresolved import `bar::foo`
-  --> $DIR/privacy2.rs:17:9
+  --> $DIR/privacy2.rs:19:9
    |
 LL |     use bar::foo;
    |         ^^^^^^^^ no `foo` in `bar`
 
 error[E0603]: function import `foo` is private
-  --> $DIR/privacy2.rs:23:20
+  --> $DIR/privacy2.rs:25:20
    |
 LL |     use bar::glob::foo;
    |                    ^^^ private function import
    |
 note: the function import `foo` is defined here...
-  --> $DIR/privacy2.rs:10:13
+  --> $DIR/privacy2.rs:12:13
    |
 LL |         use foo;
    |             ^^^
 note: ...and refers to the function `foo` which is defined here
-  --> $DIR/privacy2.rs:14:1
+  --> $DIR/privacy2.rs:16:1
    |
 LL | pub fn foo() {}
    | ^^^^^^^^^^^^ consider importing it directly

--- a/tests/ui/privacy/privacy3.rs
+++ b/tests/ui/privacy/privacy3.rs
@@ -1,3 +1,5 @@
+// compile-flags: -Zdeduplicate-diagnostics=yes
+
 #![feature(start, no_core)]
 #![no_core] // makes debugging this test *a lot* easier (during resolve)
 

--- a/tests/ui/privacy/privacy3.stderr
+++ b/tests/ui/privacy/privacy3.stderr
@@ -1,5 +1,5 @@
 error[E0432]: unresolved import `bar::gpriv`
-  --> $DIR/privacy3.rs:18:9
+  --> $DIR/privacy3.rs:20:9
    |
 LL |     use bar::gpriv;
    |         ^^^^^^^^^^ no `gpriv` in `bar`


### PR DESCRIPTION
#108118 caused `typeck` to be transferred to the serial part (`check_unused`), which made the performance of parallel rustc significantly reduced. 

This pr re-parallelize this part, which increases the average performance improvement of parallel rustc in `full` and `incr-full` scenarios from [14.4%](https://github.com/rust-lang/rust/pull/110284#issuecomment-1545354608) to [23.2%](https://github.com/rust-lang/rust/pull/110284#issuecomment-1624770626).

r? @cjgillot 
cc @oli-obk @Zoxc 