### PR TITLE
Rollup of 1 pull requests

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -257,6 +257,9 @@ new_pr = true
 
 [autolabel."needs-triage"]
 new_issue = true
+exclude_labels = [
+    "C-tracking-issue"
+]
 
 [autolabel."WG-trait-system-refactor"]
 trigger_files = [


### PR DESCRIPTION
Successful merges:

 - #113515 (Don't label tracking issues with `needs-triage`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113515)
<!-- homu-ignore:end -->