### PR TITLE
Forbid old-style `simd_shuffleN` intrinsics

### DIFF
--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1020,28 +1020,20 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
         ));
     }
 
-    if let Some(stripped) = name.as_str().strip_prefix("simd_shuffle") {
-        // If this intrinsic is the older "simd_shuffleN" form, simply parse the integer.
-        // If there is no suffix, use the index array length.
-        let n: u64 = if stripped.is_empty() {
-            // Make sure this is actually an array, since typeck only checks the length-suffixed
-            // version of this intrinsic.
-            match args[2].layout.ty.kind() {
-                ty::Array(ty, len) if matches!(ty.kind(), ty::Uint(ty::UintTy::U32)) => {
-                    len.try_eval_target_usize(bx.cx.tcx, ty::ParamEnv::reveal_all()).unwrap_or_else(
-                        || span_bug!(span, "could not evaluate shuffle index array length"),
-                    )
-                }
-                _ => return_error!(InvalidMonomorphization::SimdShuffle {
-                    span,
-                    name,
-                    ty: args[2].layout.ty
-                }),
+    if name == sym::simd_shuffle {
+        // Make sure this is actually an array, since typeck only checks the length-suffixed
+        // version of this intrinsic.
+        let n: u64 = match args[2].layout.ty.kind() {
+            ty::Array(ty, len) if matches!(ty.kind(), ty::Uint(ty::UintTy::U32)) => {
+                len.try_eval_target_usize(bx.cx.tcx, ty::ParamEnv::reveal_all()).unwrap_or_else(
+                    || span_bug!(span, "could not evaluate shuffle index array length"),
+                )
             }
-        } else {
-            stripped.parse().unwrap_or_else(|_| {
-                span_bug!(span, "bad `simd_shuffle` instruction only caught in codegen?")
-            })
+            _ => return_error!(InvalidMonomorphization::SimdShuffle {
+                span,
+                name,
+                ty: args[2].layout.ty
+            }),
         };
 
         require_simd!(ret_ty, InvalidMonomorphization::SimdReturn { span, name, ty: ret_ty });

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -862,11 +862,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     .iter()
                     .enumerate()
                     .map(|(i, arg)| {
-                        // The indices passed to simd_shuffle* in the
+                        // The indices passed to simd_shuffle in the
                         // third argument must be constant. This is
                         // checked by const-qualification, which also
                         // promotes any complex rvalues to constants.
-                        if i == 2 && intrinsic.as_str().starts_with("simd_shuffle") {
+                        if i == 2 && intrinsic == sym::simd_shuffle {
                             if let mir::Operand::Constant(constant) = arg {
                                 let (llval, ty) = self.simd_shuffle_indices(&bx, constant);
                                 return OperandRef {

--- a/compiler/rustc_error_codes/src/error_codes/E0439.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0439.md
@@ -16,7 +16,7 @@ extern "platform-intrinsic" {
 The `simd_shuffle` function needs the length of the array passed as
 last parameter in its name. Example:
 
-```
+```ignore (no longer compiles)
 #![feature(platform_intrinsics)]
 
 extern "platform-intrinsic" {

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -567,20 +567,6 @@ pub fn check_platform_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>)
         | sym::simd_reduce_min_nanless
         | sym::simd_reduce_max_nanless => (2, vec![param(0)], param(1)),
         sym::simd_shuffle => (3, vec![param(0), param(0), param(1)], param(2)),
-        name if name.as_str().starts_with("simd_shuffle") => {
-            match name.as_str()["simd_shuffle".len()..].parse() {
-                Ok(n) => {
-                    let params = vec![param(0), param(0), Ty::new_array(tcx, tcx.types.u32, n)];
-                    (2, params, param(1))
-                }
-                Err(_) => {
-                    let msg =
-                        format!("unrecognized platform-specific intrinsic function: `{name}`");
-                    tcx.sess.struct_span_err(it.span, msg).emit();
-                    return;
-                }
-            }
-        }
         _ => {
             let msg = format!("unrecognized platform-specific intrinsic function: `{name}`");
             tcx.sess.struct_span_err(it.span, msg).emit();

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -305,7 +305,7 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                             terminator.kind = TerminatorKind::Unreachable;
                         }
                     }
-                    _ if intrinsic_name.as_str().starts_with("simd_shuffle") => {
+                    sym::simd_shuffle => {
                         validate_simd_shuffle(tcx, args, terminator.source_info.span);
                     }
                     _ => {}

--- a/tests/incremental/issue-61530.rs
+++ b/tests/incremental/issue-61530.rs
@@ -6,13 +6,13 @@
 struct I32x2(i32, i32);
 
 extern "platform-intrinsic" {
-    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
 fn main() {
     unsafe {
         const IDX: [u32; 2] = [0, 0];
-        let _: I32x2 = simd_shuffle2(I32x2(1, 2), I32x2(3, 4), IDX);
-        let _: I32x2 = simd_shuffle2(I32x2(1, 2), I32x2(3, 4), IDX);
+        let _: I32x2 = simd_shuffle(I32x2(1, 2), I32x2(3, 4), IDX);
+        let _: I32x2 = simd_shuffle(I32x2(1, 2), I32x2(3, 4), IDX);
     }
 }

--- a/tests/ui/simd/intrinsic/generic-elements-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-elements-pass.rs
@@ -22,9 +22,7 @@ extern "platform-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 
-    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
-    fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
-    fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
+    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
 macro_rules! all_eq {
@@ -83,19 +81,19 @@ fn main() {
     let y4 = i32x4(140, 141, 142, 143);
     let y8 = i32x8(180, 181, 182, 183, 184, 185, 186, 187);
     unsafe {
-        all_eq!(simd_shuffle2(x2, y2, const { [3u32, 0] }), i32x2(121, 20));
-        all_eq!(simd_shuffle4(x2, y2, const { [3u32, 0, 1, 2] }), i32x4(121, 20, 21, 120));
-        all_eq!(simd_shuffle8(x2, y2, const { [3u32, 0, 1, 2, 1, 2, 3, 0] }),
+        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0] }), i32x2(121, 20));
+        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0, 1, 2] }), i32x4(121, 20, 21, 120));
+        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0, 1, 2, 1, 2, 3, 0] }),
                 i32x8(121, 20, 21, 120, 21, 120, 121, 20));
 
-        all_eq!(simd_shuffle2(x4, y4, const { [7u32, 2] }), i32x2(143, 42));
-        all_eq!(simd_shuffle4(x4, y4, const { [7u32, 2, 5, 0] }), i32x4(143, 42, 141, 40));
-        all_eq!(simd_shuffle8(x4, y4, const { [7u32, 2, 5, 0, 3, 6, 4, 1] }),
+        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2] }), i32x2(143, 42));
+        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2, 5, 0] }), i32x4(143, 42, 141, 40));
+        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2, 5, 0, 3, 6, 4, 1] }),
                 i32x8(143, 42, 141, 40, 43, 142, 140, 41));
 
-        all_eq!(simd_shuffle2(x8, y8, const { [11u32, 5] }), i32x2(183, 85));
-        all_eq!(simd_shuffle4(x8, y8, const { [11u32, 5, 15, 0] }), i32x4(183, 85, 187, 80));
-        all_eq!(simd_shuffle8(x8, y8, const { [11u32, 5, 15, 0, 3, 8, 12, 1] }),
+        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5] }), i32x2(183, 85));
+        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5, 15, 0] }), i32x4(183, 85, 187, 80));
+        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5, 15, 0, 3, 8, 12, 1] }),
                 i32x8(183, 85, 187, 80, 83, 180, 184, 81));
     }
 

--- a/tests/ui/simd/intrinsic/generic-elements.rs
+++ b/tests/ui/simd/intrinsic/generic-elements.rs
@@ -34,9 +34,7 @@ extern "platform-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 
-    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
-    fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
-    fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
+    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
 fn main() {
@@ -51,27 +49,27 @@ fn main() {
         //~^ ERROR expected return type `i32` (element of input `i32x4`), found `f32`
 
         const IDX2: [u32; 2] = [0; 2];
-        simd_shuffle2::<i32, i32>(0, 0, IDX2);
+        simd_shuffle::<i32, _, i32>(0, 0, IDX2);
         //~^ ERROR expected SIMD input type, found non-SIMD `i32`
         const IDX4: [u32; 4] = [0; 4];
-        simd_shuffle4::<i32, i32>(0, 0, IDX4);
+        simd_shuffle::<i32, _, i32>(0, 0, IDX4);
         //~^ ERROR expected SIMD input type, found non-SIMD `i32`
         const IDX8: [u32; 8] = [0; 8];
-        simd_shuffle8::<i32, i32>(0, 0, IDX8);
+        simd_shuffle::<i32, _, i32>(0, 0, IDX8);
         //~^ ERROR expected SIMD input type, found non-SIMD `i32`
 
-        simd_shuffle2::<_, f32x2>(x, x, IDX2);
+        simd_shuffle::<_, _, f32x2>(x, x, IDX2);
 //~^ ERROR element type `i32` (element of input `i32x4`), found `f32x2` with element type `f32`
-        simd_shuffle4::<_, f32x4>(x, x, IDX4);
+        simd_shuffle::<_, _, f32x4>(x, x, IDX4);
 //~^ ERROR element type `i32` (element of input `i32x4`), found `f32x4` with element type `f32`
-        simd_shuffle8::<_, f32x8>(x, x, IDX8);
+        simd_shuffle::<_, _, f32x8>(x, x, IDX8);
 //~^ ERROR element type `i32` (element of input `i32x4`), found `f32x8` with element type `f32`
 
-        simd_shuffle2::<_, i32x8>(x, x, IDX2);
+        simd_shuffle::<_, _, i32x8>(x, x, IDX2);
         //~^ ERROR expected return type of length 2, found `i32x8` with length 8
-        simd_shuffle4::<_, i32x8>(x, x, IDX4);
+        simd_shuffle::<_, _, i32x8>(x, x, IDX4);
         //~^ ERROR expected return type of length 4, found `i32x8` with length 8
-        simd_shuffle8::<_, i32x2>(x, x, IDX8);
+        simd_shuffle::<_, _, i32x2>(x, x, IDX8);
         //~^ ERROR expected return type of length 8, found `i32x2` with length 2
     }
 }

--- a/tests/ui/simd/intrinsic/generic-elements.stderr
+++ b/tests/ui/simd/intrinsic/generic-elements.stderr
@@ -1,74 +1,74 @@
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:46:9
+  --> $DIR/generic-elements.rs:44:9
    |
 LL |         simd_insert(0, 0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected inserted type `i32` (element of input `i32x4`), found `f64`
-  --> $DIR/generic-elements.rs:48:9
+  --> $DIR/generic-elements.rs:46:9
    |
 LL |         simd_insert(x, 0, 1.0);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_extract` intrinsic: expected return type `i32` (element of input `i32x4`), found `f32`
-  --> $DIR/generic-elements.rs:50:9
+  --> $DIR/generic-elements.rs:48:9
    |
 LL |         simd_extract::<_, f32>(x, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:54:9
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected SIMD input type, found non-SIMD `i32`
+  --> $DIR/generic-elements.rs:52:9
    |
-LL |         simd_shuffle2::<i32, i32>(0, 0, IDX2);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         simd_shuffle::<i32, _, i32>(0, 0, IDX2);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:57:9
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected SIMD input type, found non-SIMD `i32`
+  --> $DIR/generic-elements.rs:55:9
    |
-LL |         simd_shuffle4::<i32, i32>(0, 0, IDX4);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         simd_shuffle::<i32, _, i32>(0, 0, IDX4);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:60:9
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected SIMD input type, found non-SIMD `i32`
+  --> $DIR/generic-elements.rs:58:9
    |
-LL |         simd_shuffle8::<i32, i32>(0, 0, IDX8);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         simd_shuffle::<i32, _, i32>(0, 0, IDX8);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x2` with element type `f32`
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x2` with element type `f32`
+  --> $DIR/generic-elements.rs:61:9
+   |
+LL |         simd_shuffle::<_, _, f32x2>(x, x, IDX2);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x4` with element type `f32`
   --> $DIR/generic-elements.rs:63:9
    |
-LL |         simd_shuffle2::<_, f32x2>(x, x, IDX2);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         simd_shuffle::<_, _, f32x4>(x, x, IDX4);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x4` with element type `f32`
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x8` with element type `f32`
   --> $DIR/generic-elements.rs:65:9
    |
-LL |         simd_shuffle4::<_, f32x4>(x, x, IDX4);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         simd_shuffle::<_, _, f32x8>(x, x, IDX8);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x8` with element type `f32`
-  --> $DIR/generic-elements.rs:67:9
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 2, found `i32x8` with length 8
+  --> $DIR/generic-elements.rs:68:9
    |
-LL |         simd_shuffle8::<_, f32x8>(x, x, IDX8);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         simd_shuffle::<_, _, i32x8>(x, x, IDX2);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: expected return type of length 2, found `i32x8` with length 8
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 4, found `i32x8` with length 8
   --> $DIR/generic-elements.rs:70:9
    |
-LL |         simd_shuffle2::<_, i32x8>(x, x, IDX2);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         simd_shuffle::<_, _, i32x8>(x, x, IDX4);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: expected return type of length 4, found `i32x8` with length 8
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 8, found `i32x2` with length 2
   --> $DIR/generic-elements.rs:72:9
    |
-LL |         simd_shuffle4::<_, i32x8>(x, x, IDX4);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: expected return type of length 8, found `i32x2` with length 2
-  --> $DIR/generic-elements.rs:74:9
-   |
-LL |         simd_shuffle8::<_, i32x2>(x, x, IDX8);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         simd_shuffle::<_, _, i32x2>(x, x, IDX8);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
@@ -6,7 +6,7 @@
 #![feature(platform_intrinsics, repr_simd)]
 
 extern "platform-intrinsic" {
-    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
 #[repr(simd)]
@@ -22,5 +22,5 @@ fn main() {
 #[inline(always)]
 unsafe fn inline_me() -> Simd2 {
     const IDX: [u32; 2] = [0, 3];
-    simd_shuffle2(Simd2(10, 11), Simd2(12, 13), IDX)
+    simd_shuffle(Simd2(10, 11), Simd2(12, 13), IDX)
 }

--- a/tests/ui/simd/intrinsic/inlining-issue67557.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557.rs
@@ -6,7 +6,7 @@
 #![feature(platform_intrinsics, repr_simd)]
 
 extern "platform-intrinsic" {
-    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
 #[repr(simd)]
@@ -16,7 +16,7 @@ struct Simd2(u8, u8);
 fn main() {
     unsafe {
         const IDX: [u32; 2] = [0, 1];
-        let p_res: Simd2 = simd_shuffle2(Simd2(10, 11), Simd2(12, 13), IDX);
+        let p_res: Simd2 = simd_shuffle(Simd2(10, 11), Simd2(12, 13), IDX);
         let a_res: Simd2 = inline_me();
 
         assert_10_11(p_res);
@@ -38,5 +38,5 @@ fn assert_10_13(x: Simd2) {
 #[inline(always)]
 unsafe fn inline_me() -> Simd2 {
     const IDX: [u32; 2] = [0, 3];
-    simd_shuffle2(Simd2(10, 11), Simd2(12, 13), IDX)
+    simd_shuffle(Simd2(10, 11), Simd2(12, 13), IDX)
 }

--- a/tests/ui/simd/shuffle-not-out-of-bounds.rs
+++ b/tests/ui/simd/shuffle-not-out-of-bounds.rs
@@ -29,12 +29,7 @@ struct u8x32([u8; 32]);
 struct u8x64([u8; 64]);
 
 extern "platform-intrinsic" {
-    pub fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
-    pub fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
-    pub fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
-    pub fn simd_shuffle16<T, U>(x: T, y: T, idx: [u32; 16]) -> U;
-    pub fn simd_shuffle32<T, U>(x: T, y: T, idx: [u32; 32]) -> U;
-    pub fn simd_shuffle64<T, U>(x: T, y: T, idx: [u32; 64]) -> U;
+    pub fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
 // Test vectors by lane size. Since LLVM does not distinguish between a shuffle
@@ -58,22 +53,22 @@ macro_rules! test_shuffle_lanes {
         }
     }
 }
-//~^^^^^ ERROR: invalid monomorphization of `simd_shuffle2` intrinsic
-//~| ERROR: invalid monomorphization of `simd_shuffle4` intrinsic
-//~| ERROR: invalid monomorphization of `simd_shuffle8` intrinsic
-//~| ERROR: invalid monomorphization of `simd_shuffle16` intrinsic
-//~| ERROR: invalid monomorphization of `simd_shuffle32` intrinsic
-//~| ERROR: invalid monomorphization of `simd_shuffle64` intrinsic
+//~^^^^^ ERROR: invalid monomorphization of `simd_shuffle` intrinsic
+//~| ERROR: invalid monomorphization of `simd_shuffle` intrinsic
+//~| ERROR: invalid monomorphization of `simd_shuffle` intrinsic
+//~| ERROR: invalid monomorphization of `simd_shuffle` intrinsic
+//~| ERROR: invalid monomorphization of `simd_shuffle` intrinsic
+//~| ERROR: invalid monomorphization of `simd_shuffle` intrinsic
 // Because the test is mostly embedded in a macro, all the errors have the same origin point.
 // And unfortunately, standard comments, as in the UI test harness, disappear in macros!
 
 fn main() {
-    test_shuffle_lanes!(2, u8x2, simd_shuffle2);
-    test_shuffle_lanes!(4, u8x4, simd_shuffle4);
-    test_shuffle_lanes!(8, u8x8, simd_shuffle8);
-    test_shuffle_lanes!(16, u8x16, simd_shuffle16);
-    test_shuffle_lanes!(32, u8x32, simd_shuffle32);
-    test_shuffle_lanes!(64, u8x64, simd_shuffle64);
+    test_shuffle_lanes!(2, u8x2, simd_shuffle);
+    test_shuffle_lanes!(4, u8x4, simd_shuffle);
+    test_shuffle_lanes!(8, u8x8, simd_shuffle);
+    test_shuffle_lanes!(16, u8x16, simd_shuffle);
+    test_shuffle_lanes!(32, u8x32, simd_shuffle);
+    test_shuffle_lanes!(64, u8x64, simd_shuffle);
 
     extern "platform-intrinsic" {
         fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;

--- a/tests/ui/simd/shuffle-not-out-of-bounds.stderr
+++ b/tests/ui/simd/shuffle-not-out-of-bounds.stderr
@@ -1,71 +1,71 @@
-error[E0511]: invalid monomorphization of `simd_shuffle2` intrinsic: shuffle index #0 is out of bounds (limit 4)
-  --> $DIR/shuffle-not-out-of-bounds.rs:56:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 4)
+  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
-LL |     test_shuffle_lanes!(2, u8x2, simd_shuffle2);
-   |     ------------------------------------------- in this macro invocation
+LL |     test_shuffle_lanes!(2, u8x2, simd_shuffle);
+   |     ------------------------------------------ in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: shuffle index #0 is out of bounds (limit 8)
-  --> $DIR/shuffle-not-out-of-bounds.rs:56:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 8)
+  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
-LL |     test_shuffle_lanes!(4, u8x4, simd_shuffle4);
-   |     ------------------------------------------- in this macro invocation
+LL |     test_shuffle_lanes!(4, u8x4, simd_shuffle);
+   |     ------------------------------------------ in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: shuffle index #0 is out of bounds (limit 16)
-  --> $DIR/shuffle-not-out-of-bounds.rs:56:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 16)
+  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
-LL |     test_shuffle_lanes!(8, u8x8, simd_shuffle8);
-   |     ------------------------------------------- in this macro invocation
+LL |     test_shuffle_lanes!(8, u8x8, simd_shuffle);
+   |     ------------------------------------------ in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle16` intrinsic: shuffle index #0 is out of bounds (limit 32)
-  --> $DIR/shuffle-not-out-of-bounds.rs:56:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 32)
+  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
-LL |     test_shuffle_lanes!(16, u8x16, simd_shuffle16);
-   |     ---------------------------------------------- in this macro invocation
+LL |     test_shuffle_lanes!(16, u8x16, simd_shuffle);
+   |     -------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle32` intrinsic: shuffle index #0 is out of bounds (limit 64)
-  --> $DIR/shuffle-not-out-of-bounds.rs:56:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 64)
+  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
-LL |     test_shuffle_lanes!(32, u8x32, simd_shuffle32);
-   |     ---------------------------------------------- in this macro invocation
+LL |     test_shuffle_lanes!(32, u8x32, simd_shuffle);
+   |     -------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle64` intrinsic: shuffle index #0 is out of bounds (limit 128)
-  --> $DIR/shuffle-not-out-of-bounds.rs:56:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 128)
+  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
-LL |     test_shuffle_lanes!(64, u8x64, simd_shuffle64);
-   |     ---------------------------------------------- in this macro invocation
+LL |     test_shuffle_lanes!(64, u8x64, simd_shuffle);
+   |     -------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 4)
-  --> $DIR/shuffle-not-out-of-bounds.rs:84:23
+  --> $DIR/shuffle-not-out-of-bounds.rs:79:23
    |
 LL |         let _: u8x2 = simd_shuffle(v, v, I);
    |                       ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/shuffle.rs
+++ b/tests/ui/simd/shuffle.rs
@@ -8,7 +8,6 @@
 
 extern "platform-intrinsic" {
     fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;
-    fn simd_shuffle16<T, U>(x: T, y: T, idx: [u32; 16]) -> U;
 }
 
 #[derive(Copy, Clone)]
@@ -16,7 +15,7 @@ extern "platform-intrinsic" {
 struct Simd<T, const N: usize>([T; N]);
 
 pub unsafe fn __shuffle_vector16<const IDX: [u32; 16], T, U>(x: T, y: T) -> U {
-    simd_shuffle16(x, y, IDX)
+    simd_shuffle(x, y, IDX)
 }
 
 fn main() {


### PR DESCRIPTION
Don't merge before https://github.com/rust-lang/packed_simd/pull/350 has made its way to crates.io

We used to support specifying the lane length of simd_shuffle ops by attaching the lane length to the name of the intrinsic (like `simd_shuffle16`). After this PR, you cannot do that anymore, and need to instead either rely on inference of the `idx` argument type or specify it as `simd_shuffle::<_, [u32; 16], _>`.

r? @workingjubilee 