### PR TITLE
Add a sparc-unknown-none-elf target.

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1433,6 +1433,8 @@ supported_targets! {
     ("riscv64gc-unknown-linux-gnu", riscv64gc_unknown_linux_gnu),
     ("riscv64gc-unknown-linux-musl", riscv64gc_unknown_linux_musl),
 
+    ("sparc-unknown-none-elf", sparc_unknown_none_elf),
+
     ("loongarch64-unknown-none", loongarch64_unknown_none),
     ("loongarch64-unknown-none-softfloat", loongarch64_unknown_none_softfloat),
 

--- a/compiler/rustc_target/src/spec/sparc_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/sparc_unknown_none_elf.rs
@@ -1,0 +1,27 @@
+use crate::abi::Endian;
+use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetOptions};
+
+pub fn target() -> Target {
+    let options = TargetOptions {
+        linker_flavor: LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+        linker: Some("sparc-elf-gcc".into()),
+        endian: Endian::Big,
+        cpu: "v7".into(),
+        abi: "elf".into(),
+        max_atomic_width: Some(32),
+        atomic_cas: true,
+        panic_strategy: PanicStrategy::Abort,
+        relocation_model: RelocModel::Static,
+        no_default_libraries: false,
+        emit_debug_gdb_scripts: false,
+        eh_frame_header: false,
+        ..Default::default()
+    };
+    Target {
+        data_layout: "E-m:e-p:32:32-i64:64-f128:64-n32-S64".into(),
+        llvm_target: "sparc-unknown-none-elf".into(),
+        pointer_width: 32,
+        arch: "sparc".into(),
+        options,
+    }
+}

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -38,6 +38,7 @@
     - [mipsel-sony-psx](platform-support/mipsel-sony-psx.md)
     - [nvptx64-nvidia-cuda](platform-support/nvptx64-nvidia-cuda.md)
     - [riscv32imac-unknown-xous-elf](platform-support/riscv32imac-unknown-xous-elf.md)
+    - [sparc-unknown-none-elf](./platform-support/sparc-unknown-none-elf.md)
     - [*-pc-windows-gnullvm](platform-support/pc-windows-gnullvm.md)
     - [\*-nto-qnx-\*](platform-support/nto-qnx.md)
     - [\*-unknown-netbsd\*](platform-support/netbsd.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -176,6 +176,7 @@ target | std | notes
 `thumbv8m.base-none-eabi` | * | Bare ARMv8-M Baseline
 `thumbv8m.main-none-eabi` | * | Bare ARMv8-M Mainline
 `thumbv8m.main-none-eabihf` | * | Bare ARMv8-M Mainline, hardfloat
+`sparc-unknown-none-elf` | * | Bare 32-bit SPARC V7+
 `wasm32-unknown-emscripten` | ✓ | WebAssembly via Emscripten
 `wasm32-unknown-unknown` | ✓ | WebAssembly
 `wasm32-wasi` | ✓ | WebAssembly with WASI

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -176,7 +176,7 @@ target | std | notes
 `thumbv8m.base-none-eabi` | * | Bare ARMv8-M Baseline
 `thumbv8m.main-none-eabi` | * | Bare ARMv8-M Mainline
 `thumbv8m.main-none-eabihf` | * | Bare ARMv8-M Mainline, hardfloat
-`sparc-unknown-none-elf` | * | Bare 32-bit SPARC V7+
+[`sparc-unknown-none-elf`](./platform-support/sparc-unknown-none-elf.md) | * | Bare 32-bit SPARC V7+
 `wasm32-unknown-emscripten` | ✓ | WebAssembly via Emscripten
 `wasm32-unknown-unknown` | ✓ | WebAssembly
 `wasm32-wasi` | ✓ | WebAssembly with WASI

--- a/src/doc/rustc/src/platform-support/sparc-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/sparc-unknown-none-elf.md
@@ -1,0 +1,164 @@
+# `sparc-unknown-none-elf`
+
+**Tier: 3**
+
+Rust for bare-metal 32-bit SPARC V7 and V8 systems, e.g. the Gaisler LEON3.
+
+| Target                 | Descriptions                              |
+| ---------------------- | ----------------------------------------- |
+| sparc-unknown-none-elf | SPARC V7 32-bit (freestanding, hardfloat) |
+
+## Target maintainers
+
+- Jonathan Pallant, <jonathan.pallant@ferrous-systems.com>, https://ferrous-systems.com
+
+## Requirements
+
+This target is cross-compiled. There is no support for `std`. There is no
+default allocator, but it's possible to use `alloc` by supplying an allocator.
+
+This allows the generated code to run in environments, such as kernels, which
+may need to avoid the use of such registers or which may have special
+considerations about the use of such registers (e.g. saving and restoring them
+to avoid breaking userspace code using the same registers). You can change code
+generation to use additional CPU features via the `-C target-feature=` codegen
+options to rustc, or via the `#[target_feature]` mechanism within Rust code.
+
+By default, code generated with this target should run on any `SPARC` hardware;
+enabling additional target features may raise this baseline.
+
+- `-Ctarget-cpu=v8` adds the extra SPARC V8 instructions.
+
+- `-Ctarget-cpu=leon3` adds the SPARC V8 instructions and sets up scheduling to
+  suit the Gaisler Leon3.
+
+Functions marked `extern "C"` use the [standard SPARC architecture calling
+convention](https://sparc.org/technical-documents/).
+
+This target generates ELF binaries. Any alternate formats or special
+considerations for binary layout will require linker options or linker scripts.
+
+## Building the target
+
+You can build Rust with support for the target by adding it to the `target`
+list in `config.toml`:
+
+```toml
+[build]
+build-stage = 1
+target = ["sparc-unknown-none-elf"]
+```
+
+## Building Rust programs
+
+```text
+cargo build --target sparc-unknown-none-elf
+```
+
+This target uses GCC as a linker, and so you will need an appropriate GCC
+compatible `sparc-unknown-none` toolchain.
+
+The default linker name is `sparc-elf-gcc`, but you can override this in your
+project configuration.
+
+## Testing
+
+As `sparc-unknown-none-elf` supports a variety of different environments and does
+not support `std`, this target does not support running the Rust test suite.
+
+## Cross-compilation toolchains and C code
+
+This target was initially tested using [BCC2] from Gaisler, along with the TSIM
+Leon3 processor simulator. Both [BCC2] GCC and [BCC2] Clang have been shown to
+work. To work with these tools, your project configuration should contain
+something like:
+
+[BCC2]: https://www.gaisler.com/index.php/downloads/compilers
+
+`.cargo/config.toml`:
+```toml
+[target.sparc-unknown-none-elf]
+linker = "sparc-gaisler-elf-gcc"
+runner = "tsim-leon3"
+
+[build]
+target = ["sparc-unknown-none-elf"]
+rustflags = "-Ctarget-cpu=leon3"
+
+[unstable]
+build-std = ["core"]
+```
+
+With this configuration, running `cargo run` will compile your code for the
+SPARC V8 compatible Gaisler Leon3 processor and then start the `tsim-leon3`
+simulator. Once the simulator is running, simply enter the command
+`run` to start the code executing in the simulator.
+
+The default C toolchain libraries are linked in, so with the Gaisler [BCC2]
+toolchain, and using its default Leon3 BSP, you can use call the C `putchar`
+function and friends to output to the simulator console.
+
+Here's a complete example:
+
+```rust,ignore (cannot-test-this-because-it-assumes-special-libc-functions)
+#![no_std]
+#![no_main]
+
+extern "C" {
+    fn putchar(ch: i32);
+    fn _exit(code: i32) -> !;
+}
+
+#[no_mangle]
+extern "C" fn main() -> i32 {
+    let message = "Hello, this is Rust!";
+    for b in message.bytes() {
+        unsafe {
+            putchar(b as i32);
+        }
+    }
+    0
+}
+
+#[panic_handler]
+fn panic(_panic: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        _exit(1);
+    }
+}
+```
+
+```console
+$ cargo run --target=sparc-unknown-none-elf
+   Compiling sparc-demo-rust v0.1.0 (/work/sparc-demo-rust)
+    Finished dev [unoptimized + debuginfo] target(s) in 3.44s
+     Running `tsim-leon3 target/sparc-unknown-none-elf/debug/sparc-demo-rust`
+
+ TSIM3 LEON3 SPARC simulator, version 3.1.9 (evaluation version)
+
+ Copyright (C) 2023, Frontgrade Gaisler - all rights reserved.
+ This software may only be used with a valid license.
+ For latest updates, go to https://www.gaisler.com/
+ Comments or bug-reports to support@gaisler.com
+
+ This TSIM evaluation version will expire 2023-11-28
+
+Number of CPUs: 2
+system frequency: 50.000 MHz
+icache: 1 * 4 KiB, 16 bytes/line (4 KiB total)
+dcache: 1 * 4 KiB, 16 bytes/line (4 KiB total)
+Allocated 8192 KiB SRAM memory, in 1 bank at 0x40000000
+Allocated 32 MiB SDRAM memory, in 1 bank at 0x60000000
+Allocated 8192 KiB ROM memory at 0x00000000
+section: .text, addr: 0x40000000, size: 20528 bytes
+section: .rodata, addr: 0x40005030, size: 128 bytes
+section: .data, addr: 0x400050b0, size: 1176 bytes
+read 347 symbols
+
+tsim> run
+  Initializing and starting from 0x40000000
+Hello, this is Rust!
+
+  Program exited normally on CPU 0.
+tsim>
+```

--- a/src/doc/rustc/src/platform-support/sparc-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/sparc-unknown-none-elf.md
@@ -17,13 +17,6 @@ Rust for bare-metal 32-bit SPARC V7 and V8 systems, e.g. the Gaisler LEON3.
 This target is cross-compiled. There is no support for `std`. There is no
 default allocator, but it's possible to use `alloc` by supplying an allocator.
 
-This allows the generated code to run in environments, such as kernels, which
-may need to avoid the use of such registers or which may have special
-considerations about the use of such registers (e.g. saving and restoring them
-to avoid breaking userspace code using the same registers). You can change code
-generation to use additional CPU features via the `-C target-feature=` codegen
-options to rustc, or via the `#[target_feature]` mechanism within Rust code.
-
 By default, code generated with this target should run on any `SPARC` hardware;
 enabling additional target features may raise this baseline.
 

--- a/src/doc/rustc/src/platform-support/sparc-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/sparc-unknown-none-elf.md
@@ -39,20 +39,31 @@ list in `config.toml`:
 ```toml
 [build]
 build-stage = 1
-target = ["sparc-unknown-none-elf"]
+host = ["<target for your host>"]
+target = ["<target for your host>", "sparc-unknown-none-elf"]
 ```
+
+Replace `<target for your host>` with `x86_64-unknown-linux-gnu` or whatever
+else is appropriate for your host machine.
 
 ## Building Rust programs
 
-```text
+To build with this target, pass it to the `--target` argument, like:
+
+```console
 cargo build --target sparc-unknown-none-elf
 ```
 
 This target uses GCC as a linker, and so you will need an appropriate GCC
-compatible `sparc-unknown-none` toolchain.
+compatible `sparc-unknown-none` toolchain. The default linker binary is
+`sparc-elf-gcc`, but you can override this in your project configuration, as
+follows:
 
-The default linker name is `sparc-elf-gcc`, but you can override this in your
-project configuration.
+`.cargo/config.toml`:
+```toml
+[target.sparc-unknown-none-elf]
+linker = "sparc-custom-elf-gcc"
+```
 
 ## Testing
 
@@ -77,21 +88,41 @@ runner = "tsim-leon3"
 [build]
 target = ["sparc-unknown-none-elf"]
 rustflags = "-Ctarget-cpu=leon3"
+```
+
+With this configuration, running `cargo run` will compile your code for the
+SPARC V8 compatible Gaisler Leon3 processor and then start the `tsim-leon3`
+simulator. The `libcore` was pre-compiled as part of the `rustc` compilation
+process using the SPARC V7 baseline, but if you are using a nightly toolchain
+you can use the
+[`-Z build-std=core`](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std)
+option to rebuild `libcore` from source. This may be useful if you want to
+compile it for SPARC V8 and take advantage of the extra instructions.
+
+`.cargo/config.toml`:
+```toml
+[target.sparc-unknown-none-elf]
+linker = "sparc-gaisler-elf-gcc"
+runner = "tsim-leon3"
+
+[build]
+target = ["sparc-unknown-none-elf"]
+rustflags = "-Ctarget-cpu=leon3"
 
 [unstable]
 build-std = ["core"]
 ```
 
-With this configuration, running `cargo run` will compile your code for the
-SPARC V8 compatible Gaisler Leon3 processor and then start the `tsim-leon3`
-simulator. Once the simulator is running, simply enter the command
-`run` to start the code executing in the simulator.
+Either way, once the simulator is running, simply enter the command `run` to
+start the code executing in the simulator.
 
 The default C toolchain libraries are linked in, so with the Gaisler [BCC2]
 toolchain, and using its default Leon3 BSP, you can use call the C `putchar`
-function and friends to output to the simulator console.
+function and friends to output to the simulator console. The default linker
+script is also appropriate for the Leon3 simulator, so no linker script is
+required.
 
-Here's a complete example:
+Here's a complete example using the above config file:
 
 ```rust,ignore (cannot-test-this-because-it-assumes-special-libc-functions)
 #![no_std]

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -127,6 +127,7 @@ static TARGETS: &[&str] = &[
     "s390x-unknown-linux-gnu",
     "sparc64-unknown-linux-gnu",
     "sparcv9-sun-solaris",
+    "sparc-unknown-none-elf",
     "thumbv6m-none-eabi",
     "thumbv7em-none-eabi",
     "thumbv7em-none-eabihf",


### PR DESCRIPTION
# `sparc-unknown-none-elf`

**Tier: 3**

Rust for bare-metal 32-bit SPARC V7 and V8 systems, e.g. the Gaisler LEON3.

## Target maintainers

- Jonathan Pallant, `jonathan.pallant@ferrous-systems.com`, https://ferrous-systems.com

## Requirements

> Does the target support host tools, or only cross-compilation?

Only cross-compilation.

> Does the target support std, or alloc (either with a default allocator, or if the user supplies an allocator)?

Only tested with `libcore` but I see no reason why you couldn't also support `liballoc`.

> Document the expectations of binaries built for the target. Do they assume
specific minimum features beyond the baseline of the CPU/environment/etc? What
version of the OS or environment do they expect?

Tested by linking with a standard SPARC bare-metal toolchain - specifically I used the [BCC2] toolchain from Gaisler (both GCC and clang variants, both pre-compiled for x64 Linux and compiling my own SPARC GCC from source to run on `aarch64-apple-darwin`).

The target is set to use the lowest-common-denominator `SPARC V7` architecture (yes, they started at V7 - see [Wikipedia](https://en.wikipedia.org/wiki/SPARC#History)).

[BCC2]: https://www.gaisler.com/index.php/downloads/compilers

> Are there notable `#[target_feature(...)]` or `-C target-feature=` values that
programs may wish to use?

`-Ctarget-cpu=v8` adds the instructions added in V8.

`-Ctarget-cpu=leon3` adds the V8 instructions and sets up scheduling to suit the Gaisler LEON3.

> What calling convention does `extern "C"` use on the target?

I believe this is defined by the SPARC architecture reference manuals and V7, V8 and V9 are all compatible.

> What format do binaries use by default? ELF, PE, something else?

ELF

## Building the target

> If Rust doesn't build the target by default, how can users build it? Can users
just add it to the `target` list in `config.toml`?

Yes. I did:

```toml
target = ["aarch64-apple-darwin", "sparc-unknown-none-elf"]
```

## Building Rust programs

> Rust does not yet ship pre-compiled artifacts for this target. To compile for
this target, you will either need to build Rust with the target enabled (see
"Building the target" above), or build your own copy of `core` by using
`build-std` or similar.

Correct.

## Testing

> Does the target support running binaries, or do binaries have varying
expectations that prevent having a standard way to run them?

No - it's a bare metal platform.

> If users can run binaries, can they do so in some common emulator, or do they need native
hardware?

But if you use [BCC2] as the linker, you get default memory map suitable for the LEON3, and a default BSP for the LEON3, and so you can run the binaries in the `tsim-leon3` simulator from Gaisler.

```console
$ cat .cargo/config.toml | grep runner
runner = "tsim-leon3 -c sim-commands.txt"
$ cat sim-commands.txt
run
quit
$ cargo +sparcrust run --targe=sparc-unknown-none-elf
   Compiling sparc-demo-rust v0.1.0 (/work/sparc-demo-rust)
    Finished dev [unoptimized + debuginfo] target(s) in 3.44s
     Running `tsim-leon3 -c sim-commands.txt target/sparc-unknown-none-elf/debug/sparc-demo-rust`

 TSIM3 LEON3 SPARC simulator, version 3.1.9 (evaluation version)

 Copyright (C) 2023, Frontgrade Gaisler - all rights reserved.
 This software may only be used with a valid license.
 For latest updates, go to https://www.gaisler.com/
 Comments or bug-reports to support@gaisler.com

 This TSIM evaluation version will expire 2023-11-28

Number of CPUs: 2
system frequency: 50.000 MHz
icache: 1 * 4 KiB, 16 bytes/line (4 KiB total)
dcache: 1 * 4 KiB, 16 bytes/line (4 KiB total)
Allocated 8192 KiB SRAM memory, in 1 bank at 0x40000000
Allocated 32 MiB SDRAM memory, in 1 bank at 0x60000000
Allocated 8192 KiB ROM memory at 0x00000000
section: .text, addr: 0x40000000, size: 104400 bytes
section: .rodata, addr: 0x400197d0, size: 15616 bytes
section: .data, addr: 0x4001d4d0, size: 1176 bytes
read 1006 symbols


  Initializing and starting from 0x40000000
Hello, this is Rust!
PANIC: PanicInfo { payload: Any { .. }, message: Some(I am a panic), location: Location { file: "src/main.rs", line: 33, col: 5 }, can_unwind: true }

  Program exited normally on CPU 0.
```

> Does the target support running the Rust testsuite?

I don't think so, the testsuite requires `libstd` IIRC.

## Cross-compilation toolchains and C code

> Does the target support C code?

Yes.

> If so, what toolchain target should users use to build compatible C code? (This may match the target triple, or it may be a toolchain for a different target triple, potentially with specific options or caveats.)

I suggest [BCC2] from Gaisler. It comes in both GCC and Clang variants.
