### PR TITLE
Don't use serde-derive in the rls shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,7 +3021,6 @@ dependencies = [
 name = "rls"
 version = "2.0.0"
 dependencies = [
- "serde",
  "serde_json",
 ]
 

--- a/src/tools/rls/Cargo.toml
+++ b/src/tools/rls/Cargo.toml
@@ -5,5 +5,4 @@ edition = "2021"
 license = "Apache-2.0/MIT"
 
 [dependencies]
-serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"

--- a/src/tools/rls/src/main.rs
+++ b/src/tools/rls/src/main.rs
@@ -3,7 +3,7 @@
 //! This is a small stub that replaces RLS to alert the user that RLS is no
 //! longer available.
 
-use serde::Deserialize;
+use serde_json::Value;
 use std::error::Error;
 use std::io::BufRead;
 use std::io::Write;
@@ -21,7 +21,6 @@ fn main() {
     }
 }
 
-#[derive(Deserialize)]
 struct Message {
     method: Option<String>,
 }
@@ -88,8 +87,10 @@ fn read_message_raw<R: BufRead>(reader: &mut R) -> Result<String, Box<dyn Error>
 
 fn read_message<R: BufRead>(reader: &mut R) -> Result<Message, Box<dyn Error>> {
     let m = read_message_raw(reader)?;
-    match serde_json::from_str(&m) {
-        Ok(m) => Ok(m),
+    match serde_json::from_str::<Value>(&m) {
+        Ok(message) => Ok(Message {
+            method: message.get("method").and_then(|value| value.as_str().map(String::from)),
+        }),
         Err(e) => Err(format!("failed to parse message {m}\n{e}").into()),
     }
 }


### PR DESCRIPTION
The already-small RLS shim can get a little smaller, and faster to
build, if we drop the serde-derive dependency and decode the one
"method" field it needs manually from `serde_json::Value`.
