### PR TITLE
Only use max_line_length = 100 for *.rs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,8 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+
+[*.rs]
 max_line_length = 100
 
 [*.md]


### PR DESCRIPTION
This setting was added to match rustfmt, but it's been taking effect on
all file editing, which I notice most on git `COMMIT_EDITMSG`. I want to
keep my default 72-width commit messages, please. :)
