### PR TITLE
don't ICE on higher ranked hidden types

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -351,6 +351,15 @@ pub fn unexpected_hidden_region_diagnostic<'tcx>(
                 )
             }
         }
+        ty::RePlaceholder(_) => {
+            explain_free_region(
+                tcx,
+                &mut err,
+                &format!("hidden type `{}` captures ", hidden_ty),
+                hidden_region,
+                "",
+            );
+        }
         ty::ReError(_) => {
             err.delay_as_bug();
         }

--- a/tests/ui/impl-trait/nested-rpit-hrtb-2.rs
+++ b/tests/ui/impl-trait/nested-rpit-hrtb-2.rs
@@ -1,0 +1,9 @@
+// The nested impl Trait references a higher-ranked region
+
+trait Trait<'a> { type Assoc; }
+impl<'a> Trait<'a> for () { type Assoc = &'a str; }
+
+fn test() -> impl for<'a> Trait<'a, Assoc = impl Sized> {}
+//~^ ERROR captures lifetime that does not appear in bounds
+
+fn main() {}

--- a/tests/ui/impl-trait/nested-rpit-hrtb-2.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb-2.stderr
@@ -1,0 +1,12 @@
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/nested-rpit-hrtb-2.rs:6:57
+   |
+LL | fn test() -> impl for<'a> Trait<'a, Assoc = impl Sized> {}
+   |                       --                    ----------  ^^
+   |                       |                     |
+   |                       |                     opaque type defined here
+   |                       hidden type `&'a str` captures the lifetime `'a` as defined here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0700`.

--- a/tests/ui/type-alias-impl-trait/nested-tait-hrtb.rs
+++ b/tests/ui/type-alias-impl-trait/nested-tait-hrtb.rs
@@ -1,0 +1,15 @@
+#![feature(type_alias_impl_trait)]
+
+trait Trait<'a> { type Assoc; }
+impl<'a> Trait<'a> for () { type Assoc = &'a str; }
+
+type WithoutLt = impl Sized;
+fn without_lt() -> impl for<'a> Trait<'a, Assoc = WithoutLt> {}
+//~^ ERROR captures lifetime that does not appear in bounds
+
+type WithLt<'a> = impl Sized + 'a;
+//~^ ERROR concrete type differs from previous defining opaque type use
+fn with_lt() -> impl for<'a> Trait<'a, Assoc = WithLt<'a>> {}
+//~^ ERROR expected generic lifetime parameter, found `'a`
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/nested-tait-hrtb.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-hrtb.stderr
@@ -1,0 +1,35 @@
+error[E0700]: hidden type for `WithoutLt` captures lifetime that does not appear in bounds
+  --> $DIR/nested-tait-hrtb.rs:7:62
+   |
+LL | type WithoutLt = impl Sized;
+   |                  ---------- opaque type defined here
+LL | fn without_lt() -> impl for<'a> Trait<'a, Assoc = WithoutLt> {}
+   |                             --                               ^^
+   |                             |
+   |                             hidden type `&'a str` captures the lifetime `'a` as defined here
+
+error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/nested-tait-hrtb.rs:12:60
+   |
+LL | type WithLt<'a> = impl Sized + 'a;
+   |             -- this generic parameter must be used with a generic lifetime parameter
+LL |
+LL | fn with_lt() -> impl for<'a> Trait<'a, Assoc = WithLt<'a>> {}
+   |                                                            ^^
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/nested-tait-hrtb.rs:10:19
+   |
+LL | type WithLt<'a> = impl Sized + 'a;
+   |                   ^^^^^^^^^^^^^^^ expected `&'a str`, got `{type error}`
+   |
+note: previous use here
+  --> $DIR/nested-tait-hrtb.rs:12:17
+   |
+LL | fn with_lt() -> impl for<'a> Trait<'a, Assoc = WithLt<'a>> {}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0700, E0792.
+For more information about an error, try `rustc --explain E0700`.


### PR DESCRIPTION
This shouldn't allow more code to compile, only replaces the ICE with a nicer error message.

Fixes https://github.com/rust-lang/rust/issues/97098.
Fixes https://github.com/rust-lang/rust/issues/97099.
Fixes #108399
Fixes #104196
Fixes #113481
Fixes #103186
Fixes #100818

r? @lcnr (because you showed interest in #100503 :)