### PR TITLE
Add a short-circuiting path to slice comparison

### DIFF
--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -87,7 +87,8 @@ where
         // SAFETY: `self` and `other` are references and are thus guaranteed to be valid.
         // The two slices have been checked to have the same size above.
         unsafe {
-            let size = mem::size_of_val(self);
+            let size =
+                if self.as_ptr() == other.as_ptr().cast() { 0 } else { mem::size_of_val(self) };
             memcmp(self.as_ptr() as *const u8, other.as_ptr() as *const u8, size) == 0
         }
     }


### PR DESCRIPTION
This adds a short-circuiting path to slice comparison using the fact that two slices of the same length and pointing at the same address are equal.

Ideally this would be implemented for both:
- comparisons where A and B can be compared byte-wise (done)
- ~comparisons where A is B (cannot be done currently due to limitation in trait specialization)~ **edit:** this is false, see float for example