### PR TITLE
Don't say that a type is uncallable if its fn signature has errors in it

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -581,6 +581,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         callee_ty: Ty<'tcx>,
         arg_exprs: &'tcx [hir::Expr<'tcx>],
     ) -> ErrorGuaranteed {
+        // Callee probe fails when APIT references errors, so suppress those
+        // errors here.
+        if let Some((_, _, args)) = self.extract_callable_info(callee_ty)
+            && let Err(err) = args.error_reported()
+        {
+            return err;
+        }
+
         let mut unit_variant = None;
         if let hir::ExprKind::Path(qpath) = &callee_expr.kind
             && let Res::Def(def::DefKind::Ctor(kind, CtorKind::Const), _)

--- a/tests/ui/typeck/apit-with-error-type-in-sig.rs
+++ b/tests/ui/typeck/apit-with-error-type-in-sig.rs
@@ -1,0 +1,8 @@
+type Foo = Bar;
+//~^ ERROR cannot find type `Bar` in this scope
+
+fn check(f: impl FnOnce(Foo), val: Foo) {
+    f(val);
+}
+
+fn main() {}

--- a/tests/ui/typeck/apit-with-error-type-in-sig.stderr
+++ b/tests/ui/typeck/apit-with-error-type-in-sig.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Bar` in this scope
+  --> $DIR/apit-with-error-type-in-sig.rs:1:12
+   |
+LL | type Foo = Bar;
+   |            ^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
This is fallout from #106309, where we don't consider param-env candidates that reference errors because they unify with everything. This means, however, that we don't consider an APIT like `impl Fn(MissingType)` isn't considered to implement `Fn`, for example. 

We can double-check that with a weaker heuristic [`extract_callable_info`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_typeck/fn_ctxt/struct.FnCtxt.html#method.extract_callable_info), and suppress the knock-down error using that.

Fixes #113566