### PR TITLE
Enforce full from_bytes_with_nul debug assertion

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -419,8 +419,7 @@ impl CStr {
     pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
         #[inline]
         fn rt_impl(bytes: &[u8]) -> &CStr {
-            // Chance at catching some UB at runtime with debug builds.
-            debug_assert!(!bytes.is_empty() && bytes[bytes.len() - 1] == 0);
+            debug_assert!(!bytes.is_empty() && memchr::memchr(0, bytes) == Some(bytes.len() - 1));
 
             // SAFETY: Casting to CStr is safe because its internal representation
             // is a [u8] too (safe only inside std).


### PR DESCRIPTION
I wrote the assertion in a weird way originally because it has to work in a const context, but that's no longer the case after someone refactored things to use const_eval.