### PR TITLE
Add debug assertions to get_unchecked{_mut} methods

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -659,10 +659,17 @@ impl<T> [T] {
     where
         I: SliceIndex<Self>,
     {
+        #[cfg(debug_assertions)]
+        {
+            self.get(index).unwrap()
+        }
+        #[cfg(not(debug_assertions))]
         // SAFETY: the caller must uphold most of the safety requirements for `get_unchecked`;
         // the slice is dereferenceable because `self` is a safe reference.
         // The returned pointer is safe because impls of `SliceIndex` have to guarantee that it is.
-        unsafe { &*index.get_unchecked(self) }
+        unsafe {
+            &*index.get_unchecked(self)
+        }
     }
 
     /// Returns a mutable reference to an element or subslice, without doing
@@ -696,10 +703,17 @@ impl<T> [T] {
     where
         I: SliceIndex<Self>,
     {
+        #[cfg(debug_assertions)]
+        {
+            self.get_mut(index).unwrap()
+        }
+        #[cfg(not(debug_assertions))]
         // SAFETY: the caller must uphold the safety requirements for `get_unchecked_mut`;
         // the slice is dereferenceable because `self` is a safe reference.
         // The returned pointer is safe because impls of `SliceIndex` have to guarantee that it is.
-        unsafe { &mut *index.get_unchecked_mut(self) }
+        unsafe {
+            &mut *index.get_unchecked_mut(self)
+        }
     }
 
     /// Returns a raw pointer to the slice's buffer.


### PR DESCRIPTION
I'm not sure if this makes any sense, but it'd be nice to still have bounds checking in debug mode. Maybe this should be part of the intrinsic? And probs needs greater discussion. In general, my opinion is that debug mode should always have safety checks while release mode allows you to turn them off with some unsafe. Not sure if that's a shared opinion though.