### PR TITLE
Don't require each rustc_interface tool to opt-in to parallel_compiler

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -279,9 +279,6 @@ fn run_compiler(
 
     let sopts = config::build_session_options(&mut early_error_handler, &matches);
 
-    // Set parallel mode before thread pool creation, which will create `Lock`s.
-    interface::set_thread_safe_mode(&sopts.unstable_opts);
-
     if let Some(ref code) = matches.opt_str("explain") {
         handle_explain(&early_error_handler, diagnostics_registry(), code, sopts.color);
         return Ok(());

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -59,11 +59,6 @@ impl Compiler {
     }
 }
 
-#[allow(rustc::bad_opt_access)]
-pub fn set_thread_safe_mode(sopts: &config::UnstableOptions) {
-    rustc_data_structures::sync::set_dyn_thread_safe_mode(sopts.threads > 1);
-}
-
 /// Converts strings provided as `--cfg [cfgspec]` into a `crate_cfg`.
 pub fn parse_cfgspecs(
     handler: &EarlyErrorHandler,
@@ -288,6 +283,10 @@ pub struct Config {
 #[allow(rustc::bad_opt_access)]
 pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Send) -> R {
     trace!("run_compiler");
+
+    // Set parallel mode before thread pool creation, which will create `Lock`s.
+    rustc_data_structures::sync::set_dyn_thread_safe_mode(config.opts.unstable_opts.threads > 1);
+
     util::run_in_thread_pool_with_globals(
         config.opts.edition,
         config.opts.unstable_opts.threads,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -744,9 +744,6 @@ fn main_args(handler: &mut EarlyErrorHandler, at_args: &[String]) -> MainResult 
         }
     };
 
-    // Set parallel mode before error handler creation, which will create `Lock`s.
-    interface::set_thread_safe_mode(&options.unstable_opts);
-
     let diag = core::new_handler(
         options.error_format,
         None,

--- a/tests/run-make-fulldeps/issue-19371/foo.rs
+++ b/tests/run-make-fulldeps/issue-19371/foo.rs
@@ -68,6 +68,6 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
             let ongoing_codegen = queries.ongoing_codegen()?;
             queries.linker(ongoing_codegen)
         });
-        linker.unwrap().link();
+        linker.unwrap().link().unwrap();
     });
 }


### PR DESCRIPTION
Previously, forgetting to call `interface::set_thread_safe_mode` would cause the following ICE:
```
thread 'rustc' panicked at 'uninitialized dyn_thread_safe mode!', /rustc/dfe0683138de0959b6ab6a039b54d9347f6a6355/compiler/rustc_data_structures/src/sync.rs:74:18
```

This calls `set_thread_safe_mode` in `interface::run_compiler` to avoid requiring it in the caller.

Fixes `tests/run-make-fulldeps/issue-19371` when parallel-compiler is enabled.

r? @SparrowLii cc https://github.com/rust-lang/rust/issues/75760