### PR TITLE
Remap paths for ~/.cargo in UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,17 @@ jobs:
           - name: x86_64-gnu-tools
             os: ubuntu-20.04-16core-64gb
             env: {}
+          - name: x86_64-apple-1
+            env:
+              SCRIPT: "./x.py --stage 2 test --skip tests/ui --skip tests/rustdoc --skip tests/run-make-fulldeps"
+              RUST_CONFIGURE_ARGS: "--build=x86_64-apple-darwin --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false"
+              RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+              MACOSX_DEPLOYMENT_TARGET: 10.12
+              MACOSX_STD_DEPLOYMENT_TARGET: 10.12
+              NO_LLVM_ASSERTIONS: 1
+              NO_DEBUG_ASSERTIONS: 1
+              NO_OVERFLOW_CHECKS: 1
+            os: macos-13
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1779,6 +1779,18 @@ impl<'a> Builder<'a> {
             hostflags.arg(format!("-Ctarget-feature={sign}crt-static"));
         }
 
+        // Users won't have the original cargo registry from the CI builder available, even if they have `rust-src` installed.
+        // Don't show their sources in UI tests even if they're available.
+        // As a happy side-effect, this fixes a few UI tests when download-rustc is enabled.
+        // NOTE: only set this when building std so the error messages are better for rustc itself.
+        if mode == Mode::Std {
+            let cargo_home = env::var("CARGO_HOME").unwrap_or_else(|_| {
+                let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+                env::var(home_var).unwrap()
+            });
+            rustflags.arg(&format!("--remap-path-prefix={cargo_home}=/cargo/FAKE_PREFIX"));
+        }
+
         if let Some(map_to) = self.build.debuginfo_map_to(GitRepo::Rustc) {
             let map = format!("{}={}", self.build.src.display(), map_to);
             cargo.env("RUSTC_DEBUGINFO_MAP", map);

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -341,6 +341,18 @@ jobs:
 
           - name: x86_64-gnu-tools
             <<: *job-linux-16c
+          
+          - name: x86_64-apple-1
+            env: &env-x86_64-apple-tests
+              SCRIPT: ./x.py --stage 2 test --skip tests/ui --skip tests/rustdoc --skip tests/run-make-fulldeps
+              RUST_CONFIGURE_ARGS: --build=x86_64-apple-darwin --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false
+              RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+              MACOSX_DEPLOYMENT_TARGET: 10.12
+              MACOSX_STD_DEPLOYMENT_TARGET: 10.12
+              NO_LLVM_ASSERTIONS: 1
+              NO_DEBUG_ASSERTIONS: 1
+              NO_OVERFLOW_CHECKS: 1
+            <<: *job-macos-xl
 
   auto:
     <<: *base-ci-job


### PR DESCRIPTION
Users won't have the original cargo registry from the CI builder available, even if they have `rust-src` installed. Don't show their sources in UI tests even if they're available. As a happy side-effect, this fixes a few UI tests when download-rustc is enabled.

Helps with https://github.com/rust-lang/rust/pull/112143.