### PR TITLE
Allow to have `-` in rustdoc-json test file name

### DIFF
--- a/src/tools/jsondocck/src/cache.rs
+++ b/src/tools/jsondocck/src/cache.rs
@@ -15,8 +15,10 @@ impl Cache {
     /// Create a new cache, used to read files only once and otherwise store their contents.
     pub fn new(config: &Config) -> Cache {
         let root = Path::new(&config.doc_dir);
-        let filename = Path::new(&config.template).file_stem().unwrap();
-        let file_path = root.join(&Path::with_extension(Path::new(filename), "json"));
+        // `filename` needs to replace `-` with `_` to be sure the JSON path will always be valid.
+        let filename =
+            Path::new(&config.template).file_stem().unwrap().to_str().unwrap().replace('-', "_");
+        let file_path = root.join(&Path::with_extension(Path::new(&filename), "json"));
         let content = fs::read_to_string(&file_path).expect("failed to read JSON file");
 
         Cache {


### PR DESCRIPTION
I extracted this commit from https://github.com/rust-lang/rust/pull/113574.

When I added the test, it kept saying that the JSON file couldn't be found. After investigating for a while, I discovered that we were expecting files to always use `_`, which is quite bad. So I added support for `-` in file names.

r? @notriddle 