### PR TITLE
Fix bootstrap.py uname error

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -256,7 +256,7 @@ def default_build_triple(verbose):
     if uname is None:
         return 'x86_64-pc-windows-msvc'
 
-    kernel, cputype, processor = uname.decode(default_encoding).split()
+    kernel, cputype, processor = uname.decode(default_encoding).split(maxsplit=2)
 
     # The goal here is to come up with the same triple as LLVM would,
     # at least for the subset of platforms we're willing to target.


### PR DESCRIPTION
The x.py script fails with `ValueError: too many values to unpack (expected 3)` when uname -smp gives more than 3 words

The error I got:
```
❯ ./x check
Traceback (most recent call last):
  File "/data1/edgar/rust/x.py", line 50, in <module>
    bootstrap.main()
  File "/data1/edgar/rust/src/bootstrap/bootstrap.py", line 1113, in main
    bootstrap(args)
  File "/data1/edgar/rust/src/bootstrap/bootstrap.py", line 1070, in bootstrap
    build = RustBuild(config_toml, args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data1/edgar/rust/src/bootstrap/bootstrap.py", line 505, in __init__
    self.build = args.build or self.build_triple()
                               ^^^^^^^^^^^^^^^^^^^
  File "/data1/edgar/rust/src/bootstrap/bootstrap.py", line 976, in build_triple
    return config or default_build_triple(self.verbose)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data1/edgar/rust/src/bootstrap/bootstrap.py", line 259, in default_build_triple
    kernel, cputype, processor = uname.decode(default_encoding).split()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 3)
```

This is because

```
❯ uname -smp
Linux x86_64 AMD Ryzen 7 5800X 8-Core Processor
```
Returns more than 3 space separated words.