### PR TITLE
std windows ERROR_BAD_COMMAND could match ErrorKind::InvalidInput.

### DIFF
--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -75,7 +75,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         | c::ERROR_BAD_NET_NAME => return NotFound,
         c::ERROR_NO_DATA => return BrokenPipe,
         c::ERROR_INVALID_NAME | c::ERROR_BAD_PATHNAME => return InvalidFilename,
-        c::ERROR_INVALID_PARAMETER => return InvalidInput,
+        c::ERROR_INVALID_PARAMETER | c::ERROR_BAD_COMMAND => return InvalidInput,
         c::ERROR_NOT_ENOUGH_MEMORY | c::ERROR_OUTOFMEMORY => return OutOfMemory,
         c::ERROR_SEM_TIMEOUT
         | c::WAIT_TIMEOUT


### PR DESCRIPTION
Hello, we had some trouble on [heed](https://github.com/meilisearch/heed/) with windows equivalent of `EINVAL` known as `ERRROR_BAD_COMMAND` returned by lmdb as a `EINVAL`, it fall in the `Uncategorized` section of the errors.

Related CI:
https://github.com/meilisearch/heed/actions/runs/5531804792/jobs/10092987681#step:4:133

Here the code returning the EINVAL in lmdb for us even on windows:
https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/mdb.c#L6822C17-L6822C17

```c
	if (!key || !data || !TXN_DBI_EXIST(txn, dbi, DB_USRVALID))
		return EINVAL;
```

So I opened a PR to suggest a categorization, fell free to close or suggest an other one! :)

According to windows docs:
https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
```
ERROR_BAD_COMMAND
    22 (0x16)
    The device does not recognize the command.
```
Note: `EINVAL` is also error 22 on unixes.

Support for `ERROR_BAD_COMMAND` was added in this PR/commit: https://github.com/rust-lang/rust/pull/79965/files#diff-79412455c23661431ab047a480dfe894701779b8e3010b7c8e65d5c7ff881180R54

Disclaimer: I don't have a windows personally, spotted it with heed CI.

