### PR TITLE
Add jump to doc

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -988,6 +988,11 @@ fn string_without_closing_tag<T: Display>(
                     )
                     .ok()
                     .map(|(url, _, _)| url),
+                    LinkFromSrc::Doc(def_id) => {
+                        format::href_with_root_path(*def_id, context, Some(&href_context.root_path))
+                            .ok()
+                            .map(|(doc_link, _, _)| doc_link)
+                    }
                 }
             })
         {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -349,7 +349,12 @@ impl<'tcx> Context<'tcx> {
                     let e = ExternalCrate { crate_num: cnum };
                     (e.name(self.tcx()), e.src_root(self.tcx()))
                 }
-                ExternalLocation::Unknown => return None,
+                ExternalLocation::Unknown => {
+                    let e = ExternalCrate { crate_num: cnum };
+                    let name = e.name(self.tcx());
+                    root = name.to_string();
+                    (name, e.src_root(self.tcx()))
+                }
             };
 
             let href = RefCell::new(PathBuf::new());

--- a/tests/rustdoc-gui/source-anchor-scroll.goml
+++ b/tests/rustdoc-gui/source-anchor-scroll.goml
@@ -7,11 +7,11 @@ set-window-size: (600, 800)
 // We check that the scroll is at the top first.
 assert-property: ("html", {"scrollTop": "0"})
 
-click: '//a[text() = "barbar"]'
+click: '//a[text() = "barbar" and @href="#5-7"]'
 assert-property: ("html", {"scrollTop": "149"})
-click: '//a[text() = "bar"]'
+click: '//a[text() = "bar" and @href="#28-36"]'
 assert-property: ("html", {"scrollTop": "180"})
-click: '//a[text() = "sub_fn"]'
+click: '//a[text() = "sub_fn" and @href="#2-4"]'
 assert-property: ("html", {"scrollTop": "77"})
 
 // We now check that clicking on lines doesn't change the scroll

--- a/tests/rustdoc/check-source-code-urls-to-def.rs
+++ b/tests/rustdoc/check-source-code-urls-to-def.rs
@@ -14,10 +14,10 @@ extern crate source_code;
 #[path = "auxiliary/source-code-bar.rs"]
 pub mod bar;
 
-// @count - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#5"]' 4
+// @count - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#5-7"]' 4
 use bar::Bar;
-// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#13"]' 'self'
-// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14"]' 'Trait'
+// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#13-17"]' 'self'
+// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14-16"]' 'Trait'
 use bar::sub::{self, Trait};
 
 pub struct Foo;
@@ -32,7 +32,8 @@ fn babar() {}
 // @has - '//pre[@class="rust"]//a/@href' '/primitive.u32.html'
 // @has - '//pre[@class="rust"]//a/@href' '/primitive.str.html'
 // @count - '//pre[@class="rust"]//a[@href="#23"]' 5
-// @has - '//pre[@class="rust"]//a[@href="../../source_code/struct.SourceCode.html"]' 'source_code::SourceCode'
+// @has - '//pre[@class="rust"]//a[@href="../../source_code/struct.SourceCode.html"]' \
+//        'source_code::SourceCode'
 pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar, f: source_code::SourceCode) {
     let x = 12;
     let y: Foo = Foo;
@@ -42,15 +43,15 @@ pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar, f: source_code::Sour
     y.hello();
 }
 
-// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14"]' 'bar::sub::Trait'
-// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14"]' 'Trait'
+// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14-16"]' 'bar::sub::Trait'
+// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14-16"]' 'Trait'
 pub fn foo2<T: bar::sub::Trait, V: Trait>(t: &T, v: &V, b: bool) {}
 
 pub trait AnotherTrait {}
 pub trait WhyNot {}
 
-// @has - '//pre[@class="rust"]//a[@href="#49"]' 'AnotherTrait'
-// @has - '//pre[@class="rust"]//a[@href="#50"]' 'WhyNot'
+// @has - '//pre[@class="rust"]//a[@href="#50"]' 'AnotherTrait'
+// @has - '//pre[@class="rust"]//a[@href="#51"]' 'WhyNot'
 pub fn foo3<T, V>(t: &T, v: &V)
 where
     T: AnotherTrait,
@@ -59,7 +60,7 @@ where
 
 pub trait AnotherTrait2 {}
 
-// @has - '//pre[@class="rust"]//a[@href="#60"]' 'AnotherTrait2'
+// @has - '//pre[@class="rust"]//a[@href="#61"]' 'AnotherTrait2'
 pub fn foo4() {
     let x: Vec<AnotherTrait2> = Vec::new();
 }

--- a/tests/rustdoc/jump-to-def-doc-links.rs
+++ b/tests/rustdoc/jump-to-def-doc-links.rs
@@ -1,0 +1,51 @@
+// compile-flags: -Zunstable-options --generate-link-to-definition
+
+#![crate_name = "foo"]
+
+// @has 'src/foo/jump-to-def-doc-links.rs.html'
+
+// @has - '//a[@href="../../foo/struct.Bar.html"]' 'Bar'
+// @has - '//a[@href="../../foo/struct.Foo.html"]' 'Foo'
+pub struct Bar; pub struct Foo;
+
+// @has - '//a[@href="../../foo/enum.Enum.html"]' 'Enum'
+pub enum Enum {
+    Variant1(String),
+    Variant2(u8),
+}
+
+// @has - '//a[@href="../../foo/struct.Struct.html"]' 'Struct'
+pub struct Struct {
+    pub a: u8,
+    b: Foo,
+}
+
+impl Struct {
+    pub fn foo() {}
+    pub fn foo2(&self) {}
+    fn bar() {}
+    fn bar(&self) {}
+}
+
+// @has - '//a[@href="../../foo/trait.Trait.html"]' 'Trait'
+pub trait Trait {
+    fn foo();
+}
+
+impl Trait for Struct {
+    fn foo() {}
+}
+
+// @has - '//a[@href="../../foo/union.Union.html"]' 'Union'
+pub union Union {
+    pub a: u16,
+    pub f: u32,
+}
+
+// @has - '//a[@href="../../foo/fn.bar.html"]' 'bar'
+pub fn bar(b: Bar) {
+     let x = Foo;
+}
+
+// @has - '//a[@href="../../foo/bar/index.html"]' 'bar'
+pub mod bar {}


### PR DESCRIPTION
I'm using the source code pages of the compiler quite a lot, but one thing missing is the possibility to jump back from the source code to the item documentation. Since I also got a few others complaining about it, I think it's fine to add it since this option is nightly only.

This PR adds a link to jump back to item's documentation on the item definition (so on `Bar` in `struct Bar {... }`, as described in the unofficial [RFC](https://github.com/GuillaumeGomez/rfcs/blob/rustdoc-jump-to-definition/text/000-rustdoc-jump-to-definition.md)).

Part of https://github.com/rust-lang/rust/issues/89095.

r? @notriddle 