### PR TITLE
De-duplicate consecutive libs when printing native-static-libs

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1392,6 +1392,11 @@ fn print_native_static_libs(
     let mut lib_args: Vec<_> = all_native_libs
         .iter()
         .filter(|l| relevant_lib(sess, l))
+        // Deduplication of successive repeated libraries, see rust-lang/rust#113209
+        //
+        // note: we don't use PartialEq/Eq because NativeLib transitively depends on local
+        // elements like spans, which we don't care about and would make the deduplication impossible
+        .dedup_by(|l1, l2| l1.name == l2.name && l1.kind == l2.kind && l1.verbatim == l2.verbatim)
         .filter_map(|lib| {
             let name = lib.name;
             match lib.kind {

--- a/tests/run-make/print-native-static-libs/Makefile
+++ b/tests/run-make/print-native-static-libs/Makefile
@@ -5,7 +5,7 @@ include ../tools.mk
 
 all:
 	$(RUSTC) --crate-type rlib -lbar_cli bar.rs
-	$(RUSTC) foo.rs -lfoo_cli --crate-type staticlib --print native-static-libs 2>&1 \
+	$(RUSTC) foo.rs -lfoo_cli -lfoo_cli --crate-type staticlib --print native-static-libs 2>&1 \
 		| grep 'note: native-static-libs: ' \
 		| sed 's/note: native-static-libs: \(.*\)/\1/' > $(TMPDIR)/libs.txt
 
@@ -13,3 +13,7 @@ all:
 	cat $(TMPDIR)/libs.txt | grep -F "systemd" # in foo.rs
 	cat $(TMPDIR)/libs.txt | grep -F "bar_cli"
 	cat $(TMPDIR)/libs.txt | grep -F "foo_cli"
+
+    # make sure that foo_cli and glib-2.0 are not consecutively present
+	cat $(TMPDIR)/libs.txt | grep -Fv "foo_cli -lfoo_cli"
+	cat $(TMPDIR)/libs.txt | grep -Fv "glib-2.0 -lglib-2.0"

--- a/tests/run-make/print-native-static-libs/bar.rs
+++ b/tests/run-make/print-native-static-libs/bar.rs
@@ -3,6 +3,7 @@ pub extern "C" fn my_bar_add(left: i32, right: i32) -> i32 {
     // Obviously makes no sense but...
     unsafe {
         g_free(std::ptr::null_mut());
+        g_free2(std::ptr::null_mut());
     }
     left + right
 }
@@ -10,4 +11,9 @@ pub extern "C" fn my_bar_add(left: i32, right: i32) -> i32 {
 #[link(name = "glib-2.0")]
 extern "C" {
     fn g_free(p: *mut ());
+}
+
+#[link(name = "glib-2.0")]
+extern "C" {
+    fn g_free2(p: *mut ());
 }


### PR DESCRIPTION
This PR adds a de-duplicate step just before printing the `native-static-libs`.

This step de-duplicates all the consecutive libs based only on the relevant comparison elements (this exclude spans, ast elements, ...).

Fixes https://github.com/rust-lang/rust/issues/113209