### PR TITLE
Allow formatted probe candidates

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/probe.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/probe.rs
@@ -55,10 +55,23 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
         impl FnOnce(&QueryResult<'tcx>) -> inspect::CandidateKind<'tcx>,
         QueryResult<'tcx>,
     > {
+        self.probe_candidate_formatted(move || name)
+    }
+
+    pub(in crate::solve) fn probe_candidate_formatted<S: ToString>(
+        &mut self,
+        name: impl FnOnce() -> S,
+    ) -> ProbeCtxt<
+        '_,
+        'a,
+        'tcx,
+        impl FnOnce(&QueryResult<'tcx>) -> inspect::CandidateKind<'tcx>,
+        QueryResult<'tcx>,
+    > {
         ProbeCtxt {
             ecx: self,
             probe_kind: move |result: &QueryResult<'tcx>| inspect::CandidateKind::Candidate {
-                name: name.to_string(),
+                name: name().to_string(),
                 result: *result,
             },
             _result: PhantomData,

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -9,7 +9,6 @@ use rustc_hir::LangItem;
 use rustc_infer::traits::query::NoSolution;
 use rustc_infer::traits::specialization_graph::LeafDef;
 use rustc_infer::traits::Reveal;
-use rustc_middle::traits::solve::inspect::CandidateKind;
 use rustc_middle::traits::solve::{CanonicalResponse, Certainty, Goal, QueryResult};
 use rustc_middle::ty::fast_reject::{DeepRejectCtxt, TreatParams};
 use rustc_middle::ty::ProjectionPredicate;
@@ -146,8 +145,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
             return Err(NoSolution);
         }
 
-        ecx.probe(
-            |r| CandidateKind::Candidate { name: "impl".into(), result: *r }).enter(
+        ecx.probe_candidate_formatted(|| format!("impl {impl_def_id:?}")).enter(
             |ecx| {
                 let impl_substs = ecx.fresh_substs_for_item(impl_def_id);
                 let impl_trait_ref = impl_trait_ref.subst(tcx, impl_substs);

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -62,7 +62,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
             },
         };
 
-        ecx.probe_candidate("impl").enter(|ecx| {
+        ecx.probe_candidate_formatted(|| format!("impl {impl_def_id:?}")).enter(|ecx| {
             let impl_substs = ecx.fresh_substs_for_item(impl_def_id);
             let impl_trait_ref = impl_trait_ref.subst(tcx, impl_substs);
 


### PR DESCRIPTION
It's not easy to understand which impl an impl candidate comes from in the new solver's proof tree output. I'd like if we exposed an API to format a string candidate name instead of having all of the candidate names required to be a `&'static str`.

Here's a real-life snippet of a new-solver bug I was solving where just having "CANDIDATE impl" without a def-id was literally impossible to understand (after the PR is applied, so we're printing the def ids now). 

```
    CANDIDATE impl DefId(1:5157 ~ std[f0f6]::path::{impl#44}): Ok(Canonical { value: Response { certainty: Yes, var_values: CanonicalVarValues { var_values: [std::path::Path] }, external_constraints: ExternalConstraints(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }) }, max_universe: U0, variables: [] })
        TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
        REVISION 0
    CANDIDATE impl DefId(1:6676 ~ std[f0f6]::sync::rwlock::{impl#17}): Ok(Canonical { value: Response { certainty: Yes, var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
       TRY_EVALUATE_ADDED_GOALS: Ok(Yes)
        REVISION 0
    CANDIDATE impl DefId(1:6080 ~ std[f0f6]::sync::mpmc::utils::{impl#1}): Ok(Canonical { value: Response { certainty: Maybe(Ambiguity), var_values: CanonicalVarValues { var_values: [^0] }, external_constraints: ExternalConstraints(ExternalConstraintsData { region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] })
        TRY_EVALUATE_ADDED_GOALS: Ok(Maybe(Ambiguity))
```

I think other candidates could benefit from this, but for now I'm just doing this for impls.

r? @BoxyUwU 