### PR TITLE
Inject compiler_builtins during crate resolution

### DIFF
--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -216,6 +216,9 @@ metadata_no_transitive_needs_dep =
 metadata_non_ascii_name =
     cannot load a crate with a non-ascii name `{$crate_name}`
 
+metadata_not_compiler_builtins =
+    the crate `{$crate_name}` is not the compiler builtins crate
+
 metadata_not_profiler_runtime =
     the crate `{$crate_name}` is not a profiler runtime
 

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -333,6 +333,12 @@ pub struct NoPanicStrategy {
 }
 
 #[derive(Diagnostic)]
+#[diag(metadata_not_compiler_builtins)]
+pub struct NotCompilerBuiltins {
+    pub crate_name: Symbol,
+}
+
+#[derive(Diagnostic)]
 #[diag(metadata_profiler_builtins_needs_core)]
 pub struct ProfilerBuiltinsNeedsCore;
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1700,6 +1700,10 @@ impl CrateMetadata {
         self.root.panic_runtime
     }
 
+    pub(crate) fn is_compiler_builtins(&self) -> bool {
+        self.root.compiler_builtins
+    }
+
     pub(crate) fn is_profiler_runtime(&self) -> bool {
         self.root.profiler_runtime
     }


### PR DESCRIPTION
This is an alternative to #113557 which removes `compiler_builtins` from the prelude and injects it during crate resolution instead.

Fixes #113533

r? @petrochenkov 