### PR TITLE
Restrict recursive opaque type check

### DIFF
--- a/tests/ui/type-alias-impl-trait/recursive-tait-conflicting-defn-2.rs
+++ b/tests/ui/type-alias-impl-trait/recursive-tait-conflicting-defn-2.rs
@@ -1,0 +1,21 @@
+// issue: 113314
+
+#![feature(type_alias_impl_trait)]
+
+type Op = impl std::fmt::Display;
+fn foo() -> Op { &"hello world" }
+
+fn transform<S>() -> impl std::fmt::Display {
+    &0usize
+}
+fn bad() -> Op {
+    transform::<Op>()
+    //~^ ERROR concrete type differs from previous defining opaque type use
+}
+
+fn main() {
+    let mut x = foo();
+    println!("{x}");
+    x = bad();
+    println!("{x}");
+}

--- a/tests/ui/type-alias-impl-trait/recursive-tait-conflicting-defn-2.stderr
+++ b/tests/ui/type-alias-impl-trait/recursive-tait-conflicting-defn-2.stderr
@@ -1,0 +1,14 @@
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/recursive-tait-conflicting-defn-2.rs:12:5
+   |
+LL |     transform::<Op>()
+   |     ^^^^^^^^^^^^^^^^^ expected `&'static &'static str`, got `impl std::fmt::Display`
+   |
+note: previous use here
+  --> $DIR/recursive-tait-conflicting-defn-2.rs:6:18
+   |
+LL | fn foo() -> Op { &"hello world" }
+   |                  ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/type-alias-impl-trait/recursive-tait-conflicting-defn.rs
+++ b/tests/ui/type-alias-impl-trait/recursive-tait-conflicting-defn.rs
@@ -1,0 +1,34 @@
+// issue: 113596
+
+#![feature(type_alias_impl_trait)]
+
+trait Test {}
+
+struct A;
+
+impl Test for A {}
+
+struct B<T> {
+  inner: T,
+}
+
+impl<T: Test> Test for B<T> {}
+
+type TestImpl = impl Test;
+
+fn test() -> TestImpl {
+  A
+}
+
+fn make_option() -> Option<TestImpl> {
+  Some(test())
+}
+
+fn make_option2() -> Option<TestImpl> {
+  let inner = make_option().unwrap();
+
+  Some(B { inner })
+  //~^ ERROR concrete type differs from previous defining opaque type use
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/recursive-tait-conflicting-defn.stderr
+++ b/tests/ui/type-alias-impl-trait/recursive-tait-conflicting-defn.stderr
@@ -1,0 +1,14 @@
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/recursive-tait-conflicting-defn.rs:30:3
+   |
+LL |   Some(B { inner })
+   |   ^^^^^^^^^^^^^^^^^ expected `A`, got `B<TestImpl>`
+   |
+note: previous use here
+  --> $DIR/recursive-tait-conflicting-defn.rs:20:3
+   |
+LL |   A
+   |   ^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
We have a recursive opaque check in writeback to avoid inferring the hidden of an opaque type to be itself:

https://github.com/rust-lang/rust/blob/33a2c2487ac5d9927830ea4c1844335c6b9f77db/compiler/rustc_hir_typeck/src/writeback.rs#L556-L575

Issue #113619 treats `make_option2` as not defining the TAIT `TestImpl` since it is inferred to have the definition `TestImpl := B<TestImpl>`, which fails this check. This regressed in #102700 (5d15beb5919e4ed481c44a1ac19c2ad04a36ee8a), I think due to the refactoring that made us record the hidden types of TAITs during writeback.

However, nothing actually seems to go bad if we relax this recursion checker to only check for directly recursive definitions. This PR fixes #113619 by changing this recursive check from being a visitor to just checking that the hidden type is exactly the same as the opaque being inferred.

Alternatively, we may be able to fix #113619 by restricting this recursion check only to RPITs/async fns. It seems to only be possible to use misuse the recursion check to cause ICEs for TAITs (though I didn't try too hard to create a bad RPIT example... may be possible, actually.)

r? @oli-obk

-- 

Fixes #113314