### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
@@ -1864,7 +1864,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1881,7 +1881,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "rustix 0.38.2",
  "windows-sys 0.48.0",
 ]
@@ -2396,7 +2396,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -4819,7 +4819,7 @@ dependencies = [
  "dlmalloc",
  "fortanix-sgx-abi",
  "hashbrown 0.14.0",
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "miniz_oxide",
  "object",

--- a/compiler/rustc_codegen_ssa/src/mir/constant.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/constant.rs
@@ -67,6 +67,20 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) -> Result<Option<ty::ValTree<'tcx>>, ErrorHandled> {
         let uv = match constant.literal {
             mir::ConstantKind::Unevaluated(uv, _) => uv.shrink(),
+            mir::ConstantKind::Ty(c) => match c.kind() {
+                // A constant that came from a const generic but was then used as an argument to old-style
+                // simd_shuffle (passing as argument instead of as a generic param).
+                rustc_type_ir::ConstKind::Value(valtree) => return Ok(Some(valtree)),
+                other => span_bug!(constant.span, "{other:#?}"),
+            },
+            // We should never encounter `ConstantKind::Val` unless MIR opts (like const prop) evaluate
+            // a constant and write that value back into `Operand`s. This could happen, but is unlikely.
+            // Also: all users of `simd_shuffle` are on unstable and already need to take a lot of care
+            // around intrinsics. For an issue to happen here, it would require a macro expanding to a
+            // `simd_shuffle` call without wrapping the constant argument in a `const {}` block, but
+            // the user pass through arbitrary expressions.
+            // FIXME(oli-obk): replace the magic const generic argument of `simd_shuffle` with a real
+            // const generic.
             other => span_bug!(constant.span, "{other:#?}"),
         };
         let uv = self.monomorphize(uv);

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -956,6 +956,14 @@ pub trait LintContext: Sized {
                     db.span_note(glob_reexport_span, format!("the name `{}` in the {} namespace is supposed to be publicly re-exported here", name, namespace));
                     db.span_note(private_item_span, "but the private item here shadows it".to_owned());
                 }
+                BuiltinLintDiagnostics::UnusedQualifications { path_span, unqualified_path } => {
+                    db.span_suggestion_verbose(
+                        path_span,
+                        "replace it with the unqualified path",
+                        unqualified_path,
+                        Applicability::MachineApplicable
+                    );
+                }
             }
             // Rewrap `db`, and pass control to the user.
             decorate(db)

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -550,6 +550,12 @@ pub enum BuiltinLintDiagnostics {
         /// The local binding that shadows the glob reexport.
         private_item_span: Span,
     },
+    UnusedQualifications {
+        /// The span of the unnecessarily-qualified path.
+        path_span: Span,
+        /// The replacement unqualified path.
+        unqualified_path: Ident,
+    },
 }
 
 /// Lints that are buffered up early on in the `Session` before the

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3917,11 +3917,15 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
             };
             if res == unqualified_result {
                 let lint = lint::builtin::UNUSED_QUALIFICATIONS;
-                self.r.lint_buffer.buffer_lint(
+                self.r.lint_buffer.buffer_lint_with_diagnostic(
                     lint,
                     finalize.node_id,
                     finalize.path_span,
                     "unnecessary qualification",
+                    lint::BuiltinLintDiagnostics::UnusedQualifications {
+                        path_span: finalize.path_span,
+                        unqualified_path: path.last().unwrap().ident
+                    }
                 )
             }
         }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -96,9 +96,11 @@ impl<'tcx> Tables<'tcx> {
             },
             ty::Adt(_, _) => todo!(),
             ty::Foreign(_) => todo!(),
-            ty::Str => todo!(),
-            ty::Array(_, _) => todo!(),
-            ty::Slice(_) => todo!(),
+            ty::Str => TyKind::RigidTy(RigidTy::Str),
+            ty::Array(ty, constant) => {
+                TyKind::RigidTy(RigidTy::Array(self.intern_ty(*ty), opaque(constant)))
+            }
+            ty::Slice(ty) => TyKind::RigidTy(RigidTy::Slice(self.intern_ty(*ty))),
             ty::RawPtr(_) => todo!(),
             ty::Ref(_, _, _) => todo!(),
             ty::FnDef(_, _) => todo!(),

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -1,4 +1,5 @@
 use super::with;
+use crate::rustc_internal::Opaque;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Ty(pub usize);
@@ -21,6 +22,9 @@ pub enum RigidTy {
     Int(IntTy),
     Uint(UintTy),
     Float(FloatTy),
+    Str,
+    Array(Ty, Const),
+    Slice(Ty),
     Tuple(Vec<Ty>),
 }
 
@@ -49,3 +53,5 @@ pub enum FloatTy {
     F32,
     F64,
 }
+
+type Const = Opaque;

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -1,6 +1,8 @@
 use super::with;
 use crate::rustc_internal::Opaque;
 
+type Const = Opaque;
+
 #[derive(Copy, Clone, Debug)]
 pub struct Ty(pub usize);
 
@@ -53,5 +55,3 @@ pub enum FloatTy {
     F32,
     F64,
 }
-
-type Const = Opaque;

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -45,7 +45,7 @@ dlmalloc = { version = "0.2.3", features = ['rustc-dep-of-std'] }
 fortanix-sgx-abi = { version = "0.5.0", features = ['rustc-dep-of-std'], public = true }
 
 [target.'cfg(target_os = "hermit")'.dependencies]
-hermit-abi = { version = "0.3.1", features = ['rustc-dep-of-std'], public = true }
+hermit-abi = { version = "0.3.2", features = ['rustc-dep-of-std'], public = true }
 
 [target.wasm32-wasi.dependencies]
 wasi = { version = "0.11.0", features = ['rustc-dep-of-std'], default-features = false }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -45,7 +45,7 @@ dlmalloc = { version = "0.2.3", features = ['rustc-dep-of-std'] }
 fortanix-sgx-abi = { version = "0.5.0", features = ['rustc-dep-of-std'], public = true }
 
 [target.'cfg(target_os = "hermit")'.dependencies]
-hermit-abi = { version = "0.3.0", features = ['rustc-dep-of-std'] }
+hermit-abi = { version = "0.3.1", features = ['rustc-dep-of-std'], public = true }
 
 [target.wasm32-wasi.dependencies]
 wasi = { version = "0.11.0", features = ['rustc-dep-of-std'], default-features = false }

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -65,8 +65,8 @@ use super::map::{map_try_reserve_error, RandomState};
 /// ```
 ///
 /// The easiest way to use `HashSet` with a custom type is to derive
-/// [`Eq`] and [`Hash`]. We must also derive [`PartialEq`], this will in the
-/// future be implied by [`Eq`].
+/// [`Eq`] and [`Hash`]. We must also derive [`PartialEq`],
+/// which is implied by [`Eq`].
 ///
 /// ```
 /// use std::collections::HashSet;

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -66,7 +66,7 @@ use super::map::{map_try_reserve_error, RandomState};
 ///
 /// The easiest way to use `HashSet` with a custom type is to derive
 /// [`Eq`] and [`Hash`]. We must also derive [`PartialEq`],
-/// which is implied by [`Eq`].
+/// which is required if [`Eq`] is derived.
 ///
 /// ```
 /// use std::collections::HashSet;

--- a/library/std/src/sys/hermit/thread.rs
+++ b/library/std/src/sys/hermit/thread.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use super::unsupported;
 use crate::ffi::CStr;
 use crate::io;
 use crate::mem;
@@ -99,7 +98,7 @@ impl Thread {
 }
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
-    unsupported()
+    unsafe { Ok(NonZeroUsize::new_unchecked(abi::get_processor_count())) }
 }
 
 pub mod guard {

--- a/library/std/src/sys/hermit/time.rs
+++ b/library/std/src/sys/hermit/time.rs
@@ -40,7 +40,7 @@ impl Timespec {
     }
 
     fn checked_add_duration(&self, other: &Duration) -> Option<Timespec> {
-        let mut secs = self.tv_sec.checked_add_unsigned(other.as_secs())?;
+        let mut secs = self.t.tv_sec.checked_add_unsigned(other.as_secs())?;
 
         // Nano calculations can't overflow because nanos are <1B which fit
         // in a u32.
@@ -53,7 +53,7 @@ impl Timespec {
     }
 
     fn checked_sub_duration(&self, other: &Duration) -> Option<Timespec> {
-        let mut secs = self.tv_sec.checked_sub_unsigned(other.as_secs())?;
+        let mut secs = self.t.tv_sec.checked_sub_unsigned(other.as_secs())?;
 
         // Similar to above, nanos can't overflow.
         let mut nsec = self.t.tv_nsec as i32 - other.subsec_nanos() as i32;

--- a/tests/ui/lint/lint-qualification.stderr
+++ b/tests/ui/lint/lint-qualification.stderr
@@ -9,6 +9,10 @@ note: the lint level is defined here
    |
 LL | #![deny(unused_qualifications)]
    |         ^^^^^^^^^^^^^^^^^^^^^
+help: replace it with the unqualified path
+   |
+LL |     bar();
+   |     ~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/resolve/unused-qualifications-suggestion.fixed
+++ b/tests/ui/resolve/unused-qualifications-suggestion.fixed
@@ -1,0 +1,23 @@
+// run-rustfix
+
+#![deny(unused_qualifications)]
+
+mod foo {
+    pub fn bar() {}
+}
+
+mod baz {
+    pub mod qux {
+        pub fn quux() {}
+    }
+}
+
+fn main() {
+    use foo::bar;
+    bar();
+    //~^ ERROR unnecessary qualification
+
+    use baz::qux::quux;
+    quux();
+    //~^ ERROR unnecessary qualification
+}

--- a/tests/ui/resolve/unused-qualifications-suggestion.rs
+++ b/tests/ui/resolve/unused-qualifications-suggestion.rs
@@ -1,0 +1,23 @@
+// run-rustfix
+
+#![deny(unused_qualifications)]
+
+mod foo {
+    pub fn bar() {}
+}
+
+mod baz {
+    pub mod qux {
+        pub fn quux() {}
+    }
+}
+
+fn main() {
+    use foo::bar;
+    foo::bar();
+    //~^ ERROR unnecessary qualification
+
+    use baz::qux::quux;
+    baz::qux::quux();
+    //~^ ERROR unnecessary qualification
+}

--- a/tests/ui/resolve/unused-qualifications-suggestion.stderr
+++ b/tests/ui/resolve/unused-qualifications-suggestion.stderr
@@ -1,0 +1,29 @@
+error: unnecessary qualification
+  --> $DIR/unused-qualifications-suggestion.rs:17:5
+   |
+LL |     foo::bar();
+   |     ^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-qualifications-suggestion.rs:3:9
+   |
+LL | #![deny(unused_qualifications)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+help: replace it with the unqualified path
+   |
+LL |     bar();
+   |     ~~~
+
+error: unnecessary qualification
+  --> $DIR/unused-qualifications-suggestion.rs:21:5
+   |
+LL |     baz::qux::quux();
+   |     ^^^^^^^^^^^^^^
+   |
+help: replace it with the unqualified path
+   |
+LL |     quux();
+   |     ~~~~
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/simd/shuffle.rs
+++ b/tests/ui/simd/shuffle.rs
@@ -1,13 +1,20 @@
 //run-pass
 #![feature(repr_simd, platform_intrinsics)]
+#![allow(incomplete_features)]
+#![feature(adt_const_params)]
 
 extern "platform-intrinsic" {
     fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;
+    fn simd_shuffle16<T, U>(x: T, y: T, idx: [u32; 16]) -> U;
 }
 
 #[derive(Copy, Clone)]
 #[repr(simd)]
 struct Simd<T, const N: usize>([T; N]);
+
+pub unsafe fn __shuffle_vector16<const IDX: [u32; 16], T, U>(x: T, y: T) -> U {
+    simd_shuffle16(x, y, IDX)
+}
 
 fn main() {
     const I1: [u32; 4] = [0, 2, 4, 6];
@@ -20,5 +27,17 @@ fn main() {
 
         let y: Simd<u8, 2> = simd_shuffle(a, b, I2);
         assert_eq!(y.0, [1, 5]);
+    }
+    // Test that an indirection (via an unnamed constant)
+    // through a const generic parameter also works.
+    // See https://github.com/rust-lang/rust/issues/113500 for details.
+    let a = Simd::<u8, 16>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    let b = Simd::<u8, 16>([16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
+    unsafe {
+        __shuffle_vector16::<
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] },
+            Simd<u8, 16>,
+            Simd<u8, 16>,
+        >(a, b);
     }
 }

--- a/tests/ui/traits/new-solver/trait-upcast-lhs-needs-normalization.rs
+++ b/tests/ui/traits/new-solver/trait-upcast-lhs-needs-normalization.rs
@@ -1,0 +1,18 @@
+// check-pass
+// compile-flags: -Ztrait-solver=next
+
+pub trait A {}
+pub trait B: A {}
+
+pub trait Mirror {
+    type Assoc: ?Sized;
+}
+impl<T: ?Sized> Mirror for T {
+    type Assoc = T;
+}
+
+pub fn foo<'a>(x: &'a <dyn B + 'static as Mirror>::Assoc) -> &'a (dyn A + 'static) {
+    x
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #112525 (Adjustments for RustyHermit)
 - #112729 (Add machine-applicable suggestion for `unused_qualifications` lint)
 - #113529 (Permit pre-evaluated constants in simd_shuffle)
 - #113618 (update ancient note)
 - #113625 (Structurally normalize in selection)
 - #113639 (Add more ty conversions to smir)
 - #113640 (Make `nodejs` control the default for RustdocJs tests instead of a hard-off switch)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112525,112729,113529,113618,113625,113639,113640)
<!-- homu-ignore:end -->