### PR TITLE
don't replace opaque types under binders with infer vars

### DIFF
--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -64,7 +64,7 @@ impl<'tcx> InferCtxt<'tcx> {
             ct_op: |ct| ct,
             ty_op: |ty| match *ty.kind() {
                 ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. })
-                    if replace_opaque_type(def_id) =>
+                    if replace_opaque_type(def_id) && !ty.has_escaping_bound_vars() =>
                 {
                     let def_span = self.tcx.def_span(def_id);
                     let span = if span.contains(def_span) { def_span } else { span };

--- a/tests/ui/generic-associated-types/issue-90014-tait2.rs
+++ b/tests/ui/generic-associated-types/issue-90014-tait2.rs
@@ -1,27 +1,9 @@
 //! This test checks that opaque type collection doesn't try to normalize the projection
 //! without respecting its binders (which would ICE).
 //! Unfortunately we don't even reach opaque type collection, as we ICE in typeck before that.
-// known-bug: #109281
-// failure-status: 101
-// error-pattern:internal compiler error
-// normalize-stderr-test "internal compiler error.*" -> ""
-// normalize-stderr-test "DefId\([^)]*\)" -> "..."
-// normalize-stderr-test "\nerror: internal compiler error.*\n\n" -> ""
-// normalize-stderr-test "note:.*unexpectedly panicked.*\n\n" -> ""
-// normalize-stderr-test "note: we would appreciate a bug report.*\n\n" -> ""
-// normalize-stderr-test "note: compiler flags.*\n\n" -> ""
-// normalize-stderr-test "note: rustc.*running on.*\n\n" -> ""
-// normalize-stderr-test "thread.*panicked.*:\n.*\n" -> ""
-// normalize-stderr-test "stack backtrace:\n" -> ""
-// normalize-stderr-test "\s\d{1,}: .*\n" -> ""
-// normalize-stderr-test "\s at .*\n" -> ""
-// normalize-stderr-test ".*note: Some details.*\n" -> ""
-// normalize-stderr-test "\n\n[ ]*\n" -> ""
-// normalize-stderr-test "compiler/.*: projection" -> "projection"
-// normalize-stderr-test ".*omitted \d{1,} frame.*\n" -> ""
-// normalize-stderr-test "error: [\s\n]*query stack" -> "error: query stack"
-// normalize-stderr-test "[\n\s]*\nquery stack during panic:" -> "query stack during panic:"
+//! See #109281 for the original report.
 // edition:2018
+// error-pattern: expected generic lifetime parameter, found `'a`
 
 #![feature(type_alias_impl_trait)]
 #![allow(incomplete_features)]

--- a/tests/ui/generic-associated-types/issue-90014-tait2.stderr
+++ b/tests/ui/generic-associated-types/issue-90014-tait2.stderr
@@ -1,12 +1,5 @@
-error: 
-  --> $DIR/issue-90014-tait2.rs:44:27
-   |
-LL |     fn make_fut(&self) -> Box<dyn for<'a> Trait<'a, Thing = Fut<'a>>> {
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^query stack during panic:
-#0 [typeck] type-checking `<impl at $DIR/issue-90014-tait2.rs:43:1: 43:13>::make_fut`
-#1 [type_of] computing type of `Fut::{opaque#0}`
-#2 [check_mod_item_types] checking item types in top-level module
-#3 [analysis] running analysis passes on this crate
-end of query stack
+error[E0792]: expected generic lifetime parameter, found `'a`
+
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/under-binder.rs
+++ b/tests/ui/type-alias-impl-trait/under-binder.rs
@@ -1,0 +1,9 @@
+#![feature(type_alias_impl_trait)]
+
+type Opaque<'a> = impl Sized + 'a;
+
+fn test(f: fn(u8)) -> fn(Opaque<'_>) {
+    f //~ ERROR E0792
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/under-binder.stderr
+++ b/tests/ui/type-alias-impl-trait/under-binder.stderr
@@ -1,0 +1,12 @@
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/under-binder.rs:6:5
+   |
+LL | type Opaque<'a> = impl Sized + 'a;
+   |             -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     f
+   |     ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0792`.


### PR DESCRIPTION
Fixes an ICE in the ui test code.

Fixes #109636
Fixes #109281
Fixes #86800

r? @oli-obk