### PR TITLE
self type param infer, avoid ICE

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -2,7 +2,7 @@ use crate::FnCtxt;
 use rustc_hir as hir;
 use rustc_hir::def::Res;
 use rustc_hir::def_id::DefId;
-use rustc_infer::traits::ObligationCauseCode;
+use rustc_infer::{infer::type_variable::TypeVariableOriginKind, traits::ObligationCauseCode};
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitor};
 use rustc_span::{self, symbol::kw, Span};
 use rustc_trait_selection::traits;
@@ -267,8 +267,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             type BreakTy = ty::GenericArg<'tcx>;
             fn visit_ty(&mut self, ty: Ty<'tcx>) -> std::ops::ControlFlow<Self::BreakTy> {
                 if let Some(origin) = self.0.type_var_origin(ty)
-                    && let rustc_infer::infer::type_variable::TypeVariableOriginKind::TypeParameterDefinition(_, def_id) =
-                        origin.kind
+                    && let TypeVariableOriginKind::TypeParameterDefinition(_, def_id) = origin.kind
                     && let generics = self.0.tcx.generics_of(self.1)
                     && let Some(index) = generics.param_def_id_to_index(self.0.tcx, def_id)
                     && let Some(subst) = ty::GenericArgs::identity_for_item(self.0.tcx, self.1)

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -163,7 +163,7 @@ fn fmt_printer<'a, 'tcx>(infcx: &'a InferCtxt<'tcx>, ns: Namespace) -> FmtPrinte
         let ty_vars = infcx_inner.type_variables();
         let var_origin = ty_vars.var_origin(ty_vid);
         if let TypeVariableOriginKind::TypeParameterDefinition(name, def_id) = var_origin.kind
-            && !var_origin.span.from_expansion()
+            && name != kw::SelfUpper && !var_origin.span.from_expansion()
         {
             let generics = infcx.tcx.generics_of(infcx.tcx.parent(def_id));
             let idx = generics.param_def_id_to_index(infcx.tcx, def_id).unwrap();

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2388,14 +2388,11 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             // If there is only one implementation of the trait, suggest using it.
                             // Otherwise, use a placeholder comment for the implementation.
                             let (message, impl_suggestion) = if non_blanket_impl_count == 1 {(
-                                "use the fully-qualified path to the only available implementation".to_string(),
+                                "use the fully-qualified path to the only available implementation",
                                 format!("<{} as ", self.tcx.type_of(impl_def_id).instantiate_identity())
-                            )} else {(
-                                format!(
-                                    "use a fully-qualified path to a specific available implementation ({} found)",
-                                    non_blanket_impl_count
-                                ),
-                                "</* self type */ as ".to_string()
+                            )} else {
+                                ("use a fully-qualified path to a specific available implementation",
+                                                                "</* self type */ as ".to_string()
                             )};
                             let mut suggestions = vec![(
                                 path.span.shrink_to_lo(),

--- a/tests/ui/error-codes/E0283.stderr
+++ b/tests/ui/error-codes/E0283.stderr
@@ -7,7 +7,7 @@ LL |     fn create() -> u32;
 LL |     let cont: u32 = Generator::create();
    |                     ^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
-help: use a fully-qualified path to a specific available implementation (2 found)
+help: use a fully-qualified path to a specific available implementation
    |
 LL |     let cont: u32 = </* self type */ as Generator>::create();
    |                     +++++++++++++++++++          +

--- a/tests/ui/error-codes/E0790.stderr
+++ b/tests/ui/error-codes/E0790.stderr
@@ -63,7 +63,7 @@ LL |     fn my_fn();
 LL |     MyTrait2::my_fn();
    |     ^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
-help: use a fully-qualified path to a specific available implementation (2 found)
+help: use a fully-qualified path to a specific available implementation
    |
 LL |     </* self type */ as MyTrait2>::my_fn();
    |     +++++++++++++++++++         +

--- a/tests/ui/inference/need_type_info/infer-var-for-self-param.rs
+++ b/tests/ui/inference/need_type_info/infer-var-for-self-param.rs
@@ -1,0 +1,7 @@
+// Regression test for #113610 where we ICEd when trying to print
+// inference variables created by instantiating the self type parameter.
+
+fn main() {
+    let _ = (Default::default(),);
+    //~^ ERROR cannot call associated function on trait
+}

--- a/tests/ui/inference/need_type_info/infer-var-for-self-param.stderr
+++ b/tests/ui/inference/need_type_info/infer-var-for-self-param.stderr
@@ -1,0 +1,14 @@
+error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
+  --> $DIR/infer-var-for-self-param.rs:5:14
+   |
+LL |     let _ = (Default::default(),);
+   |              ^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |
+help: use a fully-qualified path to a specific available implementation (271 found)
+   |
+LL |     let _ = (</* self type */ as Default>::default(),);
+   |              +++++++++++++++++++        +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0790`.

--- a/tests/ui/inference/need_type_info/infer-var-for-self-param.stderr
+++ b/tests/ui/inference/need_type_info/infer-var-for-self-param.stderr
@@ -4,7 +4,7 @@ error[E0790]: cannot call associated function on trait without specifying the co
 LL |     let _ = (Default::default(),);
    |              ^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
-help: use a fully-qualified path to a specific available implementation (271 found)
+help: use a fully-qualified path to a specific available implementation
    |
 LL |     let _ = (</* self type */ as Default>::default(),);
    |              +++++++++++++++++++        +


### PR DESCRIPTION
fixes #113610, which is caused by https://github.com/rust-lang/rust/blob/33a2c2487ac5d9927830ea4c1844335c6b9f77db/compiler/rustc_hir_analysis/src/collect/generics_of.rs#L190-L205