### PR TITLE
Non memcmp slice comparison optimization

### DIFF
--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -70,7 +70,24 @@ where
             return false;
         }
 
-        self.iter().zip(other.iter()).all(|(x, y)| x == y)
+        let mut i = self.len();
+        let mut ptr_self = self.as_ptr();
+        let mut ptr_other = other.as_ptr();
+        // SAFETY:
+        // This is sound because:
+        // - self.len == other.len
+        // - self.len <= isize::MAX
+        // so the two pointers will not overflow,
+        // will remain in bounds of the slice,
+        // and dereferencing them is sound.
+        unsafe {
+            while (i > 0) && (*ptr_self == *ptr_other) {
+                i -= 1;
+                ptr_self = ptr_self.add(1);
+                ptr_other = ptr_other.add(1);
+            }
+        }
+        i == 0
     }
 }
 

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -55,6 +55,7 @@ const EXCEPTION_PATHS: &[&str] = &[
     "library/std/src/path.rs",
     "library/std/src/sys_common", // Should only contain abstractions over platforms
     "library/std/src/net/test.rs", // Utility helpers for tests
+    "library/core/src/slice/cmp.rs", // To comment better
 ];
 
 pub fn check(path: &Path, bad: &mut bool) {


### PR DESCRIPTION
This PR:

1. Changes the implementation for `[T]` slice comparison when `T: !BytewiseEq`. The previous implementation used `zip` which is not as optimized as it could be. Performance improvements are for example 20% when testing that `[Some(0_u64); 4096].as_slice() == [Some(0_u64); 4096].as_slice()`.
2. On musl (and maybe others), `memcmp` is equivalent to the new code added in the previous point. On such platforms it is better to never call `memcmp` because the compiler can leverage `T`'s alignment to generate better code than for `memcmp`'s `*const u8`.

I only realized when running `./x.py test` that platform specific code is not allowed in `core`. However, I would argue that this may be acceptable because:
- It does not affect portability so much, both implementations work fine, and this is only a matter of performance
- Deferring to libc's `memcmp` on the ground that it is more optimized than our generic one is already a kind of platform specific assumption. Arguably, rather than a `cfg(not()` making it opt-out, using `memcmp` should be opt-in.

This is likely more a draft than something ready to merge given the discussions that it must go through, but here is to starting these discussions.