### PR TITLE
add a csky-unknown-linux-gnuabiv2 target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,17 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
- "compiler_builtins",
  "gimli 0.27.3",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "compiler_builtins",
+ "gimli 0.28.0",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
 ]
@@ -22,17 +31,6 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -178,11 +176,11 @@ dependencies = [
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cfb39880a59e122232cb5fb06b20b4382d58c12fa9747d16f846d38a7b094c"
+checksum = "9792d37ca5173d7e7f4fe453739a0671d0557915a030a383d6b866476bbc3e71"
 dependencies = [
- "object",
+ "object 0.32.0",
 ]
 
 [[package]]
@@ -252,12 +250,12 @@ version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
- "addr2line",
+ "addr2line 0.20.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.31.1",
  "rustc-demangle",
 ]
 
@@ -1159,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -1439,24 +1437,22 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-dependencies = [
- "fallible-iterator",
- "indexmap 1.9.3",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 dependencies = [
  "compiler_builtins",
+ "fallible-iterator",
+ "indexmap 2.0.0",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1525,18 +1521,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.3",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1544,6 +1528,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
+ "ahash",
  "allocator-api2",
  "compiler_builtins",
  "rustc-std-workspace-alloc",
@@ -2450,11 +2435,20 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+dependencies = [
  "compiler_builtins",
  "crc32fast",
  "flate2",
- "hashbrown 0.13.2",
- "indexmap 1.9.3",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
  "memchr",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -3362,7 +3356,7 @@ dependencies = [
  "cstr",
  "libc",
  "measureme",
- "object",
+ "object 0.32.0",
  "rustc-demangle",
  "rustc_ast",
  "rustc_attr",
@@ -3398,7 +3392,7 @@ dependencies = [
  "itertools",
  "jobserver",
  "libc",
- "object",
+ "object 0.32.0",
  "pathdiff",
  "regex",
  "rustc_arena",
@@ -4332,7 +4326,7 @@ name = "rustc_target"
 version = "0.0.0"
 dependencies = [
  "bitflags 1.3.2",
- "object",
+ "object 0.32.0",
  "rustc_abi",
  "rustc_data_structures",
  "rustc_feature",
@@ -4587,12 +4581,12 @@ checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ruzstd"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+checksum = "ac3ffab8f9715a0d455df4bbb9d21e91135aab3cd3ca187af0cd0c3c3f868fdc"
 dependencies = [
  "byteorder",
- "thiserror",
+ "thiserror-core",
  "twox-hash",
 ]
 
@@ -4861,7 +4855,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "std"
 version = "0.0.0"
 dependencies = [
- "addr2line",
+ "addr2line 0.21.0",
  "alloc",
  "cfg-if",
  "compiler_builtins",
@@ -4872,7 +4866,7 @@ dependencies = [
  "hermit-abi 0.3.2",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.32.0",
  "panic_abort",
  "panic_unwind",
  "profiler_builtins",
@@ -5140,6 +5134,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-core"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d97345f6437bb2004cd58819d8a9ef8e36cdd7661c2abc4bbde0a7c40d9f497"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ac1c5050e43014d16b2f94d0d2ce79e65ffdd8b38d8048f9c8f6a8a6da62ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "thiserror-impl"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5152,13 +5166,13 @@ dependencies = [
 
 [[package]]
 name = "thorin-dwp"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c040e1340b889d4180c64e1d787efa9c32cb1617757e101480b61238b0d927"
+checksum = "4db52ee8fec06e119b692ef3dd2c4cf621a99204c1b8c47407870ed050305b9b"
 dependencies = [
- "gimli 0.26.2",
- "hashbrown 0.12.3",
- "object",
+ "gimli 0.28.0",
+ "hashbrown 0.14.0",
+ "object 0.32.0",
  "tracing",
 ]
 

--- a/compiler/rustc_codegen_cranelift/Cargo.lock
+++ b/compiler/rustc_codegen_cranelift/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.27.2",
+ "gimli",
  "hashbrown 0.13.2",
  "log",
  "regalloc2",
@@ -180,7 +180,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-module",
  "log",
- "object 0.30.4",
+ "object",
  "target-lexicon",
 ]
 
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "fallible-iterator"
@@ -214,15 +214,6 @@ dependencies = [
  "fallible-iterator",
  "indexmap 1.9.3",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
-dependencies = [
- "indexmap 2.0.0",
 ]
 
 [[package]]
@@ -245,9 +236,6 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "indexmap"
@@ -322,18 +310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
-dependencies = [
- "crc32fast",
- "hashbrown 0.14.0",
- "indexmap 2.0.0",
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,10 +356,10 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
- "gimli 0.28.0",
+ "gimli",
  "indexmap 2.0.0",
  "libloading",
- "object 0.32.0",
+ "object",
  "smallvec",
  "target-lexicon",
 ]

--- a/compiler/rustc_codegen_cranelift/Cargo.lock
+++ b/compiler/rustc_codegen_cranelift/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-object",
  "gimli 0.28.0",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "libloading",
  "object 0.32.0",
  "smallvec",

--- a/compiler/rustc_codegen_cranelift/Cargo.lock
+++ b/compiler/rustc_codegen_cranelift/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.27.2",
  "hashbrown 0.13.2",
  "log",
  "regalloc2",
@@ -180,7 +180,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-module",
  "log",
- "object",
+ "object 0.30.4",
  "target-lexicon",
 ]
 
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fallible-iterator"
@@ -214,6 +214,15 @@ dependencies = [
  "fallible-iterator",
  "indexmap 1.9.3",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+dependencies = [
+ "indexmap 2.0.0",
 ]
 
 [[package]]
@@ -236,6 +245,9 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "indexmap"
@@ -310,6 +322,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,10 +380,10 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
- "gimli",
- "indexmap 2.0.0",
+ "gimli 0.28.0",
+ "indexmap 1.9.3",
  "libloading",
- "object",
+ "object 0.32.0",
  "smallvec",
  "target-lexicon",
 ]

--- a/compiler/rustc_codegen_cranelift/Cargo.toml
+++ b/compiler/rustc_codegen_cranelift/Cargo.toml
@@ -15,8 +15,8 @@ cranelift-native = { version = "0.98" }
 cranelift-jit = { version = "0.98", optional = true }
 cranelift-object = { version = "0.98" }
 target-lexicon = "0.12.0"
-gimli = { version = "0.28.0", default-features = false, features = ["write"]}
-object = { version = "0.32.0", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
+gimli = { version = "0.27.2", default-features = false, features = ["write"]}
+object = { version = "0.30.4", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
 
 indexmap = "2.0.0"
 libloading = { version = "0.7.3", optional = true }

--- a/compiler/rustc_codegen_cranelift/Cargo.toml
+++ b/compiler/rustc_codegen_cranelift/Cargo.toml
@@ -16,7 +16,7 @@ cranelift-jit = { version = "0.98", optional = true }
 cranelift-object = { version = "0.98" }
 target-lexicon = "0.12.0"
 gimli = { version = "0.27.2", default-features = false, features = ["write"]}
-object = { version = "0.30.4", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
+object = { version = "0.30.3", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
 
 indexmap = "2.0.0"
 libloading = { version = "0.7.3", optional = true }

--- a/compiler/rustc_codegen_cranelift/Cargo.toml
+++ b/compiler/rustc_codegen_cranelift/Cargo.toml
@@ -15,8 +15,8 @@ cranelift-native = { version = "0.98" }
 cranelift-jit = { version = "0.98", optional = true }
 cranelift-object = { version = "0.98" }
 target-lexicon = "0.12.0"
-gimli = { version = "0.27.2", default-features = false, features = ["write"]}
-object = { version = "0.30.3", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
+gimli = { version = "0.28.0", default-features = false, features = ["write"]}
+object = { version = "0.32.0", default-features = false, features = ["std", "read_core", "write", "archive", "coff", "elf", "macho", "pe"] }
 
 indexmap = "2.0.0"
 libloading = { version = "0.7.3", optional = true }

--- a/compiler/rustc_codegen_gcc/example/alloc_system.rs
+++ b/compiler/rustc_codegen_gcc/example/alloc_system.rs
@@ -12,6 +12,7 @@
               target_arch = "mips",
               target_arch = "mips32r6",
               target_arch = "powerpc",
+              target_arch = "csky"
               target_arch = "powerpc64"))]
 const MIN_ALIGN: usize = 8;
 #[cfg(any(target_arch = "x86_64",

--- a/compiler/rustc_codegen_gcc/src/asm.rs
+++ b/compiler/rustc_codegen_gcc/src/asm.rs
@@ -597,6 +597,8 @@ fn reg_to_gcc(reg: InlineAsmRegOrRegClass) -> ConstraintOrRegister {
             InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg) => "r",
             InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg_addr) => "a",
             InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg_data) => "d",
+            InlineAsmRegClass::CSKY(CSKYInlineAsmRegClass::reg) => "r",
+            InlineAsmRegClass::CSKY(CSKYInlineAsmRegClass::freg) => "f",
             InlineAsmRegClass::Mips(MipsInlineAsmRegClass::reg) => "d", // more specific than "r"
             InlineAsmRegClass::Mips(MipsInlineAsmRegClass::freg) => "f",
             InlineAsmRegClass::Msp430(Msp430InlineAsmRegClass::reg) => "r",
@@ -673,6 +675,8 @@ fn dummy_output_type<'gcc, 'tcx>(cx: &CodegenCx<'gcc, 'tcx>, reg: InlineAsmRegCl
         InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg) => cx.type_i32(),
         InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg_addr) => cx.type_i32(),
         InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg_data) => cx.type_i32(),
+        InlineAsmRegClass::CSKY(CSKYInlineAsmRegClass::reg) => cx.type_i32(),
+        InlineAsmRegClass::CSKY(CSKYInlineAsmRegClass::freg) => cx.type_f32(),
         InlineAsmRegClass::Mips(MipsInlineAsmRegClass::reg) => cx.type_i32(),
         InlineAsmRegClass::Mips(MipsInlineAsmRegClass::freg) => cx.type_f32(),
         InlineAsmRegClass::Msp430(_) => unimplemented!(),
@@ -860,6 +864,7 @@ fn modifier_to_gcc(arch: InlineAsmArch, reg: InlineAsmRegClass, modifier: Option
         InlineAsmRegClass::S390x(_) => None,
         InlineAsmRegClass::Msp430(_) => None,
         InlineAsmRegClass::M68k(_) => None,
+        InlineAsmRegClass::CSKY(_) => None,
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -11,7 +11,7 @@ bitflags = "1.0"
 cstr = "0.2"
 libc = "0.2"
 measureme = "10.0.0"
-object = { version = "0.31.1", default-features = false, features = [
+object = { version = "0.32.0", default-features = false, features = [
     "std",
     "read",
 ] }

--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -261,6 +261,7 @@ impl<'ll, 'tcx> AsmBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 InlineAsmArch::M68k => {
                     constraints.push("~{ccr}".to_string());
                 }
+                InlineAsmArch::CSKY => {} // https://github.com/llvm/llvm-project/blob/8b76aea8d8b1b71f6220bc2845abc749f18a19b7/clang/lib/Basic/Targets/CSKY.h getClobers()
             }
         }
         if !options.contains(InlineAsmOptions::NOMEM) {
@@ -693,6 +694,8 @@ fn reg_to_llvm(reg: InlineAsmRegOrRegClass, layout: Option<&TyAndLayout<'_>>) ->
             InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg) => "r",
             InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg_addr) => "a",
             InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg_data) => "d",
+            InlineAsmRegClass::CSKY(CSKYInlineAsmRegClass::reg) => "r",
+            InlineAsmRegClass::CSKY(CSKYInlineAsmRegClass::freg) => "f",
             InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
                 bug!("LLVM backend does not support SPIR-V")
             }
@@ -792,6 +795,7 @@ fn modifier_to_llvm(
             bug!("LLVM backend does not support SPIR-V")
         }
         InlineAsmRegClass::M68k(_) => None,
+        InlineAsmRegClass::CSKY(_) => None,
         InlineAsmRegClass::Err => unreachable!(),
     }
 }
@@ -868,6 +872,8 @@ fn dummy_output_type<'ll>(cx: &CodegenCx<'ll, '_>, reg: InlineAsmRegClass) -> &'
         InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg) => cx.type_i32(),
         InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg_addr) => cx.type_i32(),
         InlineAsmRegClass::M68k(M68kInlineAsmRegClass::reg_data) => cx.type_i32(),
+        InlineAsmRegClass::CSKY(CSKYInlineAsmRegClass::reg) => cx.type_i32(),
+        InlineAsmRegClass::CSKY(CSKYInlineAsmRegClass::freg) => cx.type_f32(),
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }

--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -261,7 +261,7 @@ impl<'ll, 'tcx> AsmBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 InlineAsmArch::M68k => {
                     constraints.push("~{ccr}".to_string());
                 }
-                InlineAsmArch::CSKY => {} // https://github.com/llvm/llvm-project/blob/8b76aea8d8b1b71f6220bc2845abc749f18a19b7/clang/lib/Basic/Targets/CSKY.h getClobers()
+                InlineAsmArch::CSKY => {}
             }
         }
         if !options.contains(InlineAsmOptions::NOMEM) {

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ar_archive_writer = "0.1.3"
+ar_archive_writer = "0.1.5"
 bitflags = "1.2.1"
 cc = "1.0.69"
 itertools = "0.10.1"
 tracing = "0.1"
 jobserver = "0.1.22"
 tempfile = "3.2"
-thorin-dwp = "0.6"
+thorin-dwp = "0.7"
 pathdiff = "0.2.0"
 serde_json = "1.0.59"
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
@@ -42,7 +42,7 @@ rustc_session = { path = "../rustc_session" }
 libc = "0.2.50"
 
 [dependencies.object]
-version = "0.31.1"
+version = "0.32.0"
 default-features = false
 features = ["read_core", "elf", "macho", "pe", "xcoff", "unaligned", "archive", "write"]
 

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -209,6 +209,7 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
         "hexagon" => Architecture::Hexagon,
         "bpf" => Architecture::Bpf,
         "loongarch64" => Architecture::LoongArch64,
+        "csky" => Architecture::Csky,
         // Unsupported architecture.
         _ => return None,
     };
@@ -306,6 +307,13 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
             // Resolve the ISA revision and set
             // the appropriate EF_AVR_ARCH flag.
             ef_avr_arch(&sess.target.options.cpu)
+        }
+        Architecture::Csky => {
+            let e_flags = match sess.target.options.abi.as_ref() {
+                "abiv2" => elf::EF_CSKY_ABIV2,
+                _ => elf::EF_CSKY_ABIV1,
+            };
+            e_flags
         }
         _ => 0,
     };

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -297,14 +297,50 @@ const WASM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
 const BPF_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[("alu32", Some(sym::bpf_target_feature))];
 
 const CSKY_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
+    // tidy-alphabetical-start
+    ("10e60", Some(sym::csky_target_feature)),
+    ("2e3", Some(sym::csky_target_feature)),
+    ("3e3r1", Some(sym::csky_target_feature)),
+    ("3e3r2", Some(sym::csky_target_feature)),
+    ("3e3r3", Some(sym::csky_target_feature)),
+    ("3e7", Some(sym::csky_target_feature)),
+    ("7e10", Some(sym::csky_target_feature)),
+    ("cache", Some(sym::csky_target_feature)),
+    ("doloop", Some(sym::csky_target_feature)),
+    ("dsp1e2", Some(sym::csky_target_feature)),
+    ("dspe60", Some(sym::csky_target_feature)),
+    ("e1", Some(sym::csky_target_feature)),
+    ("e2", Some(sym::csky_target_feature)),
+    ("edsp", Some(sym::csky_target_feature)),
+    ("elrw", Some(sym::csky_target_feature)),
+    ("float1e2", Some(sym::csky_target_feature)),
+    ("float1e3", Some(sym::csky_target_feature)),
+    ("float3e4", Some(sym::csky_target_feature)),
+    ("float7e60", Some(sym::csky_target_feature)),
+    ("floate1", Some(sym::csky_target_feature)),
+    ("hard-tp", Some(sym::csky_target_feature)),
+    ("high-registers", Some(sym::csky_target_feature)),
+    ("hwdiv", Some(sym::csky_target_feature)),
+    ("mp", Some(sym::csky_target_feature)),
+    ("mp1e2", Some(sym::csky_target_feature)),
+    ("nvic", Some(sym::csky_target_feature)),
+    ("trust", Some(sym::csky_target_feature)),
+    ("vdsp2e60f", Some(sym::csky_target_feature)),
+    ("vdspv1", Some(sym::csky_target_feature)),
+    ("vdspv2", Some(sym::csky_target_feature)),
+    // tidy-alphabetical-end
+    //fpu
+    // tidy-alphabetical-start
+    ("fdivdu", Some(sym::csky_target_feature)),
+    ("fpuv2_df", Some(sym::csky_target_feature)),
+    ("fpuv2_sf", Some(sym::csky_target_feature)),
+    ("fpuv3_df", Some(sym::csky_target_feature)),
+    ("fpuv3_hf", Some(sym::csky_target_feature)),
+    ("fpuv3_hi", Some(sym::csky_target_feature)),
+    ("fpuv3_sf", Some(sym::csky_target_feature)),
     ("hard-float", Some(sym::csky_target_feature)),
     ("hard-float-abi", Some(sym::csky_target_feature)),
-    ("fpuv2_sf", Some(sym::csky_target_feature)),
-    ("fpuv2_df", Some(sym::csky_target_feature)),
-    ("fpuv3_sf", Some(sym::csky_target_feature)),
-    ("fpuv3_df", Some(sym::csky_target_feature)),
-    ("vdspv2", Some(sym::csky_target_feature)),
-    ("dspv2", Some(sym::csky_target_feature)),
+    // tidy-alphabetical-end
 ];
 /// When rustdoc is running, provide a list of all known features so that all their respective
 /// primitives may be documented.

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -296,6 +296,16 @@ const WASM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
 
 const BPF_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[("alu32", Some(sym::bpf_target_feature))];
 
+const CSKY_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
+    ("hard-float", Some(sym::csky_target_feature)),
+    ("hard-float-abi", Some(sym::csky_target_feature)),
+    ("fpuv2_sf", Some(sym::csky_target_feature)),
+    ("fpuv2_df", Some(sym::csky_target_feature)),
+    ("fpuv3_sf", Some(sym::csky_target_feature)),
+    ("fpuv3_df", Some(sym::csky_target_feature)),
+    ("vdspv2", Some(sym::csky_target_feature)),
+    ("dspv2", Some(sym::csky_target_feature)),
+];
 /// When rustdoc is running, provide a list of all known features so that all their respective
 /// primitives may be documented.
 ///
@@ -311,6 +321,7 @@ pub fn all_known_features() -> impl Iterator<Item = (&'static str, Option<Symbol
         .chain(RISCV_ALLOWED_FEATURES.iter())
         .chain(WASM_ALLOWED_FEATURES.iter())
         .chain(BPF_ALLOWED_FEATURES.iter())
+        .chain(CSKY_ALLOWED_FEATURES)
         .cloned()
 }
 
@@ -325,6 +336,7 @@ pub fn supported_target_features(sess: &Session) -> &'static [(&'static str, Opt
         "riscv32" | "riscv64" => RISCV_ALLOWED_FEATURES,
         "wasm32" | "wasm64" => WASM_ALLOWED_FEATURES,
         "bpf" => BPF_ALLOWED_FEATURES,
+        "csky" => CSKY_ALLOWED_FEATURES,
         _ => &[],
     }
 }
@@ -396,6 +408,7 @@ pub fn from_target_feature(
                 Some(sym::ermsb_target_feature) => rust_features.ermsb_target_feature,
                 Some(sym::bpf_target_feature) => rust_features.bpf_target_feature,
                 Some(sym::aarch64_ver_target_feature) => rust_features.aarch64_ver_target_feature,
+                Some(sym::csky_target_feature) => rust_features.csky_target_feature,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -282,7 +282,7 @@ declare_features! (
     (active, arm_target_feature, "1.27.0", Some(44839), None),
     (active, avx512_target_feature, "1.27.0", Some(44839), None),
     (active, bpf_target_feature, "1.54.0", Some(44839), None),
-    (active, csky_target_feature, "1.72.0", Some(44839), None),
+    (active, csky_target_feature, "CURRENT_RUSTC_VERSION", Some(44839), None),
     (active, ermsb_target_feature, "1.49.0", Some(44839), None),
     (active, hexagon_target_feature, "1.27.0", Some(44839), None),
     (active, mips_target_feature, "1.27.0", Some(44839), None),

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -282,6 +282,7 @@ declare_features! (
     (active, arm_target_feature, "1.27.0", Some(44839), None),
     (active, avx512_target_feature, "1.27.0", Some(44839), None),
     (active, bpf_target_feature, "1.54.0", Some(44839), None),
+    (active, csky_target_feature, "1.72.0", Some(44839), None),
     (active, ermsb_target_feature, "1.49.0", Some(44839), None),
     (active, hexagon_target_feature, "1.27.0", Some(44839), None),
     (active, mips_target_feature, "1.27.0", Some(44839), None),

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -12,6 +12,7 @@ const OPTIONAL_COMPONENTS: &[&str] = &[
     "avr",
     "loongarch",
     "m68k",
+    "csky",
     "mips",
     "powerpc",
     "systemz",

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -105,6 +105,12 @@ extern "C" void LLVMTimeTraceProfilerFinish(const char* FileName) {
 #define SUBTARGET_M68K
 #endif
 
+#ifdef LLVM_COMPONENT_CSKY
+#define SUBTARGET_CSKY SUBTARGET(CSKY)
+#else
+#define SUBTARGET_CSKY
+#endif
+
 #ifdef LLVM_COMPONENT_MIPS
 #define SUBTARGET_MIPS SUBTARGET(Mips)
 #else
@@ -159,6 +165,7 @@ extern "C" void LLVMTimeTraceProfilerFinish(const char* FileName) {
   SUBTARGET_AARCH64                                                            \
   SUBTARGET_AVR                                                                \
   SUBTARGET_M68K                                                               \
+  SUBTARGET_CSKY                                                               \
   SUBTARGET_MIPS                                                               \
   SUBTARGET_PPC                                                                \
   SUBTARGET_SYSTEMZ                                                            \

--- a/compiler/rustc_llvm/src/lib.rs
+++ b/compiler/rustc_llvm/src/lib.rs
@@ -103,6 +103,14 @@ pub fn initialize_available_targets() {
         LLVMInitializeM68kAsmParser
     );
     init_target!(
+        llvm_component = "csky",
+        LLVMInitializeCSKYTargetInfo,
+        LLVMInitializeCSKYTarget,
+        LLVMInitializeCSKYTargetMC,
+        LLVMInitializeCSKYAsmPrinter,
+        LLVMInitializeCSKYAsmParser
+    );
+    init_target!(
         llvm_component = "loongarch",
         LLVMInitializeLoongArchTargetInfo,
         LLVMInitializeLoongArchTarget,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -574,6 +574,7 @@ symbols! {
         crate_type,
         crate_visibility_modifier,
         crt_dash_static: "crt-static",
+        csky_target_feature,
         cstring_type,
         ctlz,
         ctlz_nonzero,

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -16,6 +16,6 @@ rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
 
 [dependencies.object]
-version = "0.31.1"
+version = "0.32.0"
 default-features = false
 features = ["elf"]

--- a/compiler/rustc_target/src/abi/call/csky.rs
+++ b/compiler/rustc_target/src/abi/call/csky.rs
@@ -1,0 +1,31 @@
+//see https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/CSKY/CSKYCallingConv.td
+use crate::abi::call::{ArgAbi, FnAbi};
+
+fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
+    if ret.layout.is_aggregate() || ret.layout.size.bits() > 64 {
+        ret.make_indirect();
+    } else {
+        ret.extend_integer_width_to(32);
+    }
+}
+
+fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
+    if arg.layout.is_aggregate() || arg.layout.size.bits() > 64 {
+        arg.make_indirect();
+    } else {
+        arg.extend_integer_width_to(32);
+    }
+}
+
+pub fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
+    if !fn_abi.ret.is_ignore() {
+        classify_ret(&mut fn_abi.ret);
+    }
+
+    for arg in fn_abi.args.iter_mut() {
+        if arg.is_ignore() {
+            continue;
+        }
+        classify_arg(arg);
+    }
+}

--- a/compiler/rustc_target/src/abi/call/csky.rs
+++ b/compiler/rustc_target/src/abi/call/csky.rs
@@ -1,4 +1,4 @@
-//see https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/CSKY/CSKYCallingConv.td
+// See https://github.com/llvm/llvm-project/blob/d85b94bf0080dcd780656c0f5e6342800720eba9/llvm/lib/Target/CSKY/CSKYCallingConv.td
 use crate::abi::call::{ArgAbi, FnAbi};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -9,6 +9,7 @@ mod amdgpu;
 mod arm;
 mod avr;
 mod bpf;
+mod csky;
 mod hexagon;
 mod loongarch;
 mod m68k;
@@ -712,6 +713,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             "avr" => avr::compute_abi_info(self),
             "loongarch64" => loongarch::compute_abi_info(cx, self),
             "m68k" => m68k::compute_abi_info(self),
+            "csky" => csky::compute_abi_info(self),
             "mips" | "mips32r6" => mips::compute_abi_info(cx, self),
             "mips64" | "mips64r6" => mips64::compute_abi_info(cx, self),
             "powerpc" => powerpc::compute_abi_info(self),

--- a/compiler/rustc_target/src/asm/csky.rs
+++ b/compiler/rustc_target/src/asm/csky.rs
@@ -1,0 +1,142 @@
+use super::{InlineAsmArch, InlineAsmType};
+use rustc_macros::HashStable_Generic;
+use rustc_span::Symbol;
+use std::fmt;
+
+def_reg_class! {
+    CSKY CSKYInlineAsmRegClass {
+        reg,
+        freg,
+    }
+}
+
+impl CSKYInlineAsmRegClass {
+    pub fn valid_modifiers(self, _arch: super::InlineAsmArch) -> &'static [char] {
+        &[]
+    }
+
+    pub fn suggest_class(self, _arch: InlineAsmArch, _ty: InlineAsmType) -> Option<Self> {
+        None
+    }
+
+    pub fn suggest_modifier(
+        self,
+        _arch: InlineAsmArch,
+        _ty: InlineAsmType,
+    ) -> Option<(char, &'static str)> {
+        None
+    }
+
+    pub fn default_modifier(self, _arch: InlineAsmArch) -> Option<(char, &'static str)> {
+        None
+    }
+
+    pub fn supported_types(
+        self,
+        _arch: InlineAsmArch,
+    ) -> &'static [(InlineAsmType, Option<Symbol>)] {
+        match self {
+            Self::reg => types! { _: I8, I16, I32, I64, F32, F64; },
+            Self::freg => types! { _: F32, F64; },
+        }
+    }
+}
+
+// The reserved registers are taken from <https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/CSKY/CSKYRegisterInfo.cpp#79>
+def_regs! {
+    CSKY CSKYInlineAsmReg CSKYInlineAsmRegClass {
+        r0: reg = ["r0","a0"],
+        r1: reg = ["r1","a1"],
+        r2: reg = ["r2","a2"],
+        r3: reg = ["r3","a3"],
+        r4: reg = ["r4","l0"],
+        r5: reg = ["r5","l1"],
+        r6: reg = ["r6","l2"],
+        // r7: reg = ["r7","l3"],
+        // r8: reg = ["r8","l4"],
+        // r9: reg = ["r9","l5"],
+        // r10: reg = ["r10","l6"],
+        // r11: reg = ["r11","l7"],
+        // r12: reg = ["r12","t0"],
+        // r13: reg = ["r13","t1"],
+        // r14: reg = ["r14","sp"],
+        // r15: reg = ["r15","lr"],
+        // r16: reg = ["r16","l8"],
+        // r17: reg = ["r17","l9"],
+        // r18: reg = ["r18","t2"],
+        // r19: reg = ["r19","t3"],
+        // r20: reg = ["r20","t4"],
+        // r21: reg = ["r21","t5"],
+        // r22: reg = ["r22","t6"],
+        // r23: reg = ["r23","t7", "fp"],
+        // r24: reg = ["r24","t8", "sop"],
+        // r25: reg = ["r25","tp", "bsp"],
+        // r26: reg = ["r26"],
+        // r27: reg = ["r27"],
+        // r28: reg = ["r28","gb", "rgb", "rdb"],
+        // r29: reg = ["r29","tb", "rtb"],
+        // r30: reg = ["r30","svbr"],
+        // r31: reg = ["r31","tls"],
+        f0: freg = ["fr0","vr0"],
+        f1: freg = ["fr1","vr1"],
+        f2: freg = ["fr2","vr2"],
+        f3: freg = ["fr3","vr3"],
+        f4: freg = ["fr4","vr4"],
+        f5: freg = ["fr5","vr5"],
+        f6: freg = ["fr6","vr6"],
+        f7: freg = ["fr7","vr7"],
+        f8: freg = ["fr8","vr8"],
+        f9: freg = ["fr9","vr9"],
+        f10: freg = ["fr10","vr10"],
+        f11: freg = ["fr11","vr11"],
+        f12: freg = ["fr12","vr12"],
+        f13: freg = ["fr13","vr13"],
+        f14: freg = ["fr14","vr14"],
+        f15: freg = ["fr15","vr15"],
+        f16: freg = ["fr16","vr16"],
+        f17: freg = ["fr17","vr17"],
+        f18: freg = ["fr18","vr18"],
+        f19: freg = ["fr19","vr19"],
+        f20: freg = ["fr20","vr20"],
+        f21: freg = ["fr21","vr21"],
+        f22: freg = ["fr22","vr22"],
+        f23: freg = ["fr23","vr23"],
+        f24: freg = ["fr24","vr24"],
+        f25: freg = ["fr25","vr25"],
+        f26: freg = ["fr26","vr26"],
+        f27: freg = ["fr27","vr27"],
+        f28: freg = ["fr28","vr28"],
+        f29: freg = ["fr29","vr29"],
+        f30: freg = ["fr30","vr30"],
+        f31: freg = ["fr31","vr31"],
+        #error = ["r7", "l3"] =>
+            "the base pointer cannot be used as an operand for inline asm",
+        #error = ["r8","l4"] =>
+            "the frame pointer cannot be used as an operand for inline asm",
+        #error = ["r14","sp"] =>
+            "the stack pointer cannot be used as an operand for inline asm",
+        #error = ["r15","lr"] =>
+            "the link register cannot be used as an operand for inline asm",
+        #error = ["r31","tls"] =>
+            "reserver for tls",
+        #error = ["r28", "gb", "rgb", "rdb"] =>
+            "the global pointer cannot be used as an operand for inline asm",
+        #error = ["r9","l5", "r10","l6", "r11","l7", "r12","t0", "r13","t1"] =>
+            "reserved (no E2)",
+        #error = ["r16","l8", "r17","l9", "r18","t2", "r19","t3", "r20","t4", "r21","t5", "r22","t6", "r23","t7", "fp", "r24","t8", "sop", "r25","tp", "bsp"] =>
+            "reserved (no HighRegisters)",
+        #error = ["r26","r27","r29","tb", "rtb", "r30","svbr"] =>
+            "reserved by the ABI",
+    }
+}
+
+impl CSKYInlineAsmReg {
+    pub fn emit(
+        self,
+        out: &mut dyn fmt::Write,
+        _arch: InlineAsmArch,
+        _modifier: Option<char>,
+    ) -> fmt::Result {
+        out.write_str(self.name())
+    }
+}

--- a/compiler/rustc_target/src/asm/csky.rs
+++ b/compiler/rustc_target/src/asm/csky.rs
@@ -36,8 +36,8 @@ impl CSKYInlineAsmRegClass {
         _arch: InlineAsmArch,
     ) -> &'static [(InlineAsmType, Option<Symbol>)] {
         match self {
-            Self::reg => types! { _: I8, I16, I32, I64, F32, F64; },
-            Self::freg => types! { _: F32, F64; },
+            Self::reg => types! { _: I8, I16, I32; },
+            Self::freg => types! { _: F32; },
         }
     }
 }
@@ -52,31 +52,21 @@ def_regs! {
         r4: reg = ["r4","l0"],
         r5: reg = ["r5","l1"],
         r6: reg = ["r6","l2"],
-        // r7: reg = ["r7","l3"],
-        // r8: reg = ["r8","l4"],
-        // r9: reg = ["r9","l5"],
-        // r10: reg = ["r10","l6"],
-        // r11: reg = ["r11","l7"],
-        // r12: reg = ["r12","t0"],
-        // r13: reg = ["r13","t1"],
-        // r14: reg = ["r14","sp"],
-        // r15: reg = ["r15","lr"],
-        // r16: reg = ["r16","l8"],
-        // r17: reg = ["r17","l9"],
-        // r18: reg = ["r18","t2"],
-        // r19: reg = ["r19","t3"],
-        // r20: reg = ["r20","t4"],
-        // r21: reg = ["r21","t5"],
-        // r22: reg = ["r22","t6"],
-        // r23: reg = ["r23","t7", "fp"],
-        // r24: reg = ["r24","t8", "sop"],
-        // r25: reg = ["r25","tp", "bsp"],
-        // r26: reg = ["r26"],
-        // r27: reg = ["r27"],
-        // r28: reg = ["r28","gb", "rgb", "rdb"],
-        // r29: reg = ["r29","tb", "rtb"],
-        // r30: reg = ["r30","svbr"],
-        // r31: reg = ["r31","tls"],
+        r9: reg = ["r9","l5"],// feature e2
+        r10: reg = ["r10","l6"],// feature e2
+        r11: reg = ["r11","l7"],// feature e2
+        r12: reg = ["r12","t0"],// feature e2
+        r13: reg = ["r13","t1"],// feature e2
+        r16: reg = ["r16","l8"],// feature high-register
+        r17: reg = ["r17","l9"],// feature high-register
+        r18: reg = ["r18","t2"],// feature high-register
+        r19: reg = ["r19","t3"],// feature high-register
+        r20: reg = ["r20","t4"],// feature high-register
+        r21: reg = ["r21","t5"],// feature high-register
+        r22: reg = ["r22","t6"],// feature high-register
+        r23: reg = ["r23","t7", "fp"],// feature high-register
+        r24: reg = ["r24","t8", "sop"],// feature high-register
+        r25: reg = ["r25","t9","tp", "bsp"],// feature high-register
         f0: freg = ["fr0","vr0"],
         f1: freg = ["fr1","vr1"],
         f2: freg = ["fr2","vr2"],
@@ -121,10 +111,6 @@ def_regs! {
             "reserver for tls",
         #error = ["r28", "gb", "rgb", "rdb"] =>
             "the global pointer cannot be used as an operand for inline asm",
-        #error = ["r9","l5", "r10","l6", "r11","l7", "r12","t0", "r13","t1"] =>
-            "reserved (no E2)",
-        #error = ["r16","l8", "r17","l9", "r18","t2", "r19","t3", "r20","t4", "r21","t5", "r22","t6", "r23","t7", "fp", "r24","t8", "sop", "r25","tp", "bsp"] =>
-            "reserved (no HighRegisters)",
         #error = ["r26","r27","r29","tb", "rtb", "r30","svbr"] =>
             "reserved by the ABI",
     }

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -167,6 +167,7 @@ mod aarch64;
 mod arm;
 mod avr;
 mod bpf;
+mod csky;
 mod hexagon;
 mod loongarch;
 mod m68k;
@@ -184,6 +185,7 @@ pub use aarch64::{AArch64InlineAsmReg, AArch64InlineAsmRegClass};
 pub use arm::{ArmInlineAsmReg, ArmInlineAsmRegClass};
 pub use avr::{AvrInlineAsmReg, AvrInlineAsmRegClass};
 pub use bpf::{BpfInlineAsmReg, BpfInlineAsmRegClass};
+pub use csky::{CSKYInlineAsmReg, CSKYInlineAsmRegClass};
 pub use hexagon::{HexagonInlineAsmReg, HexagonInlineAsmRegClass};
 pub use loongarch::{LoongArchInlineAsmReg, LoongArchInlineAsmRegClass};
 pub use m68k::{M68kInlineAsmReg, M68kInlineAsmRegClass};
@@ -220,6 +222,7 @@ pub enum InlineAsmArch {
     Avr,
     Msp430,
     M68k,
+    CSKY,
 }
 
 impl FromStr for InlineAsmArch {
@@ -248,6 +251,7 @@ impl FromStr for InlineAsmArch {
             "avr" => Ok(Self::Avr),
             "msp430" => Ok(Self::Msp430),
             "m68k" => Ok(Self::M68k),
+            "csky" => Ok(Self::CSKY),
             _ => Err(()),
         }
     }
@@ -272,6 +276,7 @@ pub enum InlineAsmReg {
     Avr(AvrInlineAsmReg),
     Msp430(Msp430InlineAsmReg),
     M68k(M68kInlineAsmReg),
+    CSKY(CSKYInlineAsmReg),
     // Placeholder for invalid register constraints for the current target
     Err,
 }
@@ -292,6 +297,7 @@ impl InlineAsmReg {
             Self::Avr(r) => r.name(),
             Self::Msp430(r) => r.name(),
             Self::M68k(r) => r.name(),
+            Self::CSKY(r) => r.name(),
             Self::Err => "<reg>",
         }
     }
@@ -311,6 +317,7 @@ impl InlineAsmReg {
             Self::Avr(r) => InlineAsmRegClass::Avr(r.reg_class()),
             Self::Msp430(r) => InlineAsmRegClass::Msp430(r.reg_class()),
             Self::M68k(r) => InlineAsmRegClass::M68k(r.reg_class()),
+            Self::CSKY(r) => InlineAsmRegClass::CSKY(r.reg_class()),
             Self::Err => InlineAsmRegClass::Err,
         }
     }
@@ -344,6 +351,7 @@ impl InlineAsmReg {
             InlineAsmArch::Avr => Self::Avr(AvrInlineAsmReg::parse(name)?),
             InlineAsmArch::Msp430 => Self::Msp430(Msp430InlineAsmReg::parse(name)?),
             InlineAsmArch::M68k => Self::M68k(M68kInlineAsmReg::parse(name)?),
+            InlineAsmArch::CSKY => Self::CSKY(CSKYInlineAsmReg::parse(name)?),
         })
     }
 
@@ -371,6 +379,7 @@ impl InlineAsmReg {
             Self::Avr(r) => r.validate(arch, reloc_model, target_features, target, is_clobber),
             Self::Msp430(r) => r.validate(arch, reloc_model, target_features, target, is_clobber),
             Self::M68k(r) => r.validate(arch, reloc_model, target_features, target, is_clobber),
+            Self::CSKY(r) => r.validate(arch, reloc_model, target_features, target, is_clobber),
             Self::Err => unreachable!(),
         }
     }
@@ -397,6 +406,7 @@ impl InlineAsmReg {
             Self::Avr(r) => r.emit(out, arch, modifier),
             Self::Msp430(r) => r.emit(out, arch, modifier),
             Self::M68k(r) => r.emit(out, arch, modifier),
+            Self::CSKY(r) => r.emit(out, arch, modifier),
             Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
     }
@@ -416,6 +426,7 @@ impl InlineAsmReg {
             Self::Avr(r) => r.overlapping_regs(|r| cb(Self::Avr(r))),
             Self::Msp430(_) => cb(self),
             Self::M68k(_) => cb(self),
+            Self::CSKY(_) => cb(self),
             Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
     }
@@ -440,6 +451,7 @@ pub enum InlineAsmRegClass {
     Avr(AvrInlineAsmRegClass),
     Msp430(Msp430InlineAsmRegClass),
     M68k(M68kInlineAsmRegClass),
+    CSKY(CSKYInlineAsmRegClass),
     // Placeholder for invalid register constraints for the current target
     Err,
 }
@@ -463,6 +475,7 @@ impl InlineAsmRegClass {
             Self::Avr(r) => r.name(),
             Self::Msp430(r) => r.name(),
             Self::M68k(r) => r.name(),
+            Self::CSKY(r) => r.name(),
             Self::Err => rustc_span::symbol::sym::reg,
         }
     }
@@ -488,6 +501,7 @@ impl InlineAsmRegClass {
             Self::Avr(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Avr),
             Self::Msp430(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Msp430),
             Self::M68k(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::M68k),
+            Self::CSKY(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::CSKY),
             Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
@@ -520,6 +534,7 @@ impl InlineAsmRegClass {
             Self::Avr(r) => r.suggest_modifier(arch, ty),
             Self::Msp430(r) => r.suggest_modifier(arch, ty),
             Self::M68k(r) => r.suggest_modifier(arch, ty),
+            Self::CSKY(r) => r.suggest_modifier(arch, ty),
             Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
@@ -548,6 +563,7 @@ impl InlineAsmRegClass {
             Self::Avr(r) => r.default_modifier(arch),
             Self::Msp430(r) => r.default_modifier(arch),
             Self::M68k(r) => r.default_modifier(arch),
+            Self::CSKY(r) => r.default_modifier(arch),
             Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
@@ -575,6 +591,7 @@ impl InlineAsmRegClass {
             Self::Avr(r) => r.supported_types(arch),
             Self::Msp430(r) => r.supported_types(arch),
             Self::M68k(r) => r.supported_types(arch),
+            Self::CSKY(r) => r.supported_types(arch),
             Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
@@ -607,6 +624,7 @@ impl InlineAsmRegClass {
             InlineAsmArch::Avr => Self::Avr(AvrInlineAsmRegClass::parse(name)?),
             InlineAsmArch::Msp430 => Self::Msp430(Msp430InlineAsmRegClass::parse(name)?),
             InlineAsmArch::M68k => Self::M68k(M68kInlineAsmRegClass::parse(name)?),
+            InlineAsmArch::CSKY => Self::CSKY(CSKYInlineAsmRegClass::parse(name)?),
         })
     }
 
@@ -630,6 +648,7 @@ impl InlineAsmRegClass {
             Self::Avr(r) => r.valid_modifiers(arch),
             Self::Msp430(r) => r.valid_modifiers(arch),
             Self::M68k(r) => r.valid_modifiers(arch),
+            Self::CSKY(r) => r.valid_modifiers(arch),
             Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
@@ -824,6 +843,11 @@ pub fn allocatable_registers(
         InlineAsmArch::M68k => {
             let mut map = m68k::regclass_map();
             m68k::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
+            map
+        }
+        InlineAsmArch::CSKY => {
+            let mut map = csky::regclass_map();
+            csky::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
     }

--- a/compiler/rustc_target/src/spec/csky_unknown_linux_gnuabiv2.rs
+++ b/compiler/rustc_target/src/spec/csky_unknown_linux_gnuabiv2.rs
@@ -6,7 +6,7 @@ use crate::spec::{Target, TargetOptions};
 pub fn target() -> Target {
     Target {
         //https://github.com/llvm/llvm-project/blob/8b76aea8d8b1b71f6220bc2845abc749f18a19b7/clang/lib/Basic/Targets/CSKY.h
-        llvm_target: "csky-unknown-linux".into(),
+        llvm_target: "csky-unknown-linux-gnuabiv2".into(),
         pointer_width: 32,
         data_layout: "e-m:e-S32-p:32:32-i32:32:32-i64:32:32-f32:32:32-f64:32:32-v64:32:32-v128:32:32-a:0:32-Fi32-n32".into(),
         arch: "csky".into(),

--- a/compiler/rustc_target/src/spec/csky_unknown_linux_gnuabiv2.rs
+++ b/compiler/rustc_target/src/spec/csky_unknown_linux_gnuabiv2.rs
@@ -1,0 +1,22 @@
+use crate::spec::{Target, TargetOptions};
+
+// This target is for glibc Linux on Csky
+// hardfloat.
+
+pub fn target() -> Target {
+    Target {
+        //https://github.com/llvm/llvm-project/blob/8b76aea8d8b1b71f6220bc2845abc749f18a19b7/clang/lib/Basic/Targets/CSKY.h
+        llvm_target: "csky-unknown-linux".into(),
+        pointer_width: 32,
+        data_layout: "e-m:e-S32-p:32:32-i32:32:32-i64:32:32-f32:32:32-f64:32:32-v64:32:32-v128:32:32-a:0:32-Fi32-n32".into(),
+        arch: "csky".into(),
+        options: TargetOptions {
+            abi: "abiv2".into(),
+            //+hard-float, +hard-float-abi, +fpuv2_sf, +fpuv2_df, +fpuv3_sf, +fpuv3_df,  +vdspv2, +dspv2, +vdspv1, +3e3r1
+            features: "".into(),
+            max_atomic_width: Some(32),
+            // mcount: "\u{1}__gnu_mcount_nc".into(),
+            ..super::linux_gnu_base::opts()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/csky_unknown_linux_gnuabiv2.rs
+++ b/compiler/rustc_target/src/spec/csky_unknown_linux_gnuabiv2.rs
@@ -1,7 +1,6 @@
-use crate::spec::{Target, TargetOptions};
+use crate::spec::{Cc, LinkerFlavor, Lld, Target, TargetOptions};
 
 // This target is for glibc Linux on Csky
-// hardfloat.
 
 pub fn target() -> Target {
     Target {
@@ -12,10 +11,9 @@ pub fn target() -> Target {
         arch: "csky".into(),
         options: TargetOptions {
             abi: "abiv2".into(),
-            //+hard-float, +hard-float-abi, +fpuv2_sf, +fpuv2_df, +fpuv3_sf, +fpuv3_df,  +vdspv2, +dspv2, +vdspv1, +3e3r1
-            features: "".into(),
+            features: "+2e3,+3e7,+7e10,+cache,+dsp1e2,+dspe60,+e1,+e2,+edsp,+elrw,+hard-tp,+high-registers,+hwdiv,+mp,+mp1e2,+nvic,+trust".into(),
+            late_link_args_static: TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-l:libatomic.a"]),
             max_atomic_width: Some(32),
-            // mcount: "\u{1}__gnu_mcount_nc".into(),
             ..super::linux_gnu_base::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1246,6 +1246,7 @@ supported_targets! {
     ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
     ("loongarch64-unknown-linux-gnu", loongarch64_unknown_linux_gnu),
     ("m68k-unknown-linux-gnu", m68k_unknown_linux_gnu),
+    ("csky-unknown-linux-gnuabiv2", csky_unknown_linux_gnuabiv2),
     ("mips-unknown-linux-gnu", mips_unknown_linux_gnu),
     ("mips64-unknown-linux-gnuabi64", mips64_unknown_linux_gnuabi64),
     ("mips64el-unknown-linux-gnuabi64", mips64el_unknown_linux_gnuabi64),

--- a/config.example.toml
+++ b/config.example.toml
@@ -94,7 +94,7 @@ changelog-seen = 2
 # the same format as above, but since these targets are experimental, they are
 # not built by default and the experimental Rust compilation targets that depend
 # on them will not work unless the user opts in to building them.
-#experimental-targets = "AVR;M68k"
+#experimental-targets = "AVR;M68k;CSKY"
 
 # Cap the number of parallel linker invocations when compiling LLVM.
 # This can be useful when building LLVM with debug info, which significantly

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -110,7 +110,8 @@ mod c_char_definition {
                     target_arch = "powerpc64",
                     target_arch = "s390x",
                     target_arch = "riscv64",
-                    target_arch = "riscv32"
+                    target_arch = "riscv32",
+                    target_arch = "csky"
                 )
             ),
             all(target_os = "android", any(target_arch = "aarch64", target_arch = "arm")),

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -29,8 +29,8 @@ rustc-demangle = { version = "0.1.21", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.7.0", optional = true, default-features = false }
-addr2line = { version = "0.20.0", optional = true, default-features = false }
-object = { version = "0.31.1", default-features = false, optional = true, features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive'] }
+addr2line = { version = "0.21.0", optional = true, default-features = false }
+object = { version = "0.32.0", default-features = false, optional = true, features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -894,6 +894,7 @@ pub mod consts {
     /// - aarch64
     /// - loongarch64
     /// - m68k
+    /// - csky
     /// - mips
     /// - mips64
     /// - powerpc

--- a/library/std/src/os/l4re/raw.rs
+++ b/library/std/src/os/l4re/raw.rs
@@ -27,6 +27,7 @@ pub use self::arch::{blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "m68k",
+    target_arch = "csky",
     target_arch = "powerpc",
     target_arch = "sparc",
     target_arch = "arm",

--- a/library/std/src/os/linux/raw.rs
+++ b/library/std/src/os/linux/raw.rs
@@ -27,6 +27,7 @@ pub use self::arch::{blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "m68k",
+    target_arch = "csky",
     target_arch = "powerpc",
     target_arch = "sparc",
     target_arch = "arm",

--- a/library/std/src/sys/common/alloc.rs
+++ b/library/std/src/sys/common/alloc.rs
@@ -8,6 +8,7 @@ use crate::ptr;
     target_arch = "x86",
     target_arch = "arm",
     target_arch = "m68k",
+    target_arch = "csky",
     target_arch = "mips",
     target_arch = "mips32r6",
     target_arch = "powerpc",

--- a/library/std/src/sys/personality/gcc.rs
+++ b/library/std/src/sys/personality/gcc.rs
@@ -67,6 +67,9 @@ const UNWIND_DATA_REG: (i32, i32) = (0, 1); // D0, D1
 ))]
 const UNWIND_DATA_REG: (i32, i32) = (4, 5); // A0, A1
 
+#[cfg(target_arch = "csky")]
+const UNWIND_DATA_REG: (i32, i32) = (0, 1); // R0, R1
+
 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
 const UNWIND_DATA_REG: (i32, i32) = (3, 4); // R3, R4 / X3, X4
 

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -54,6 +54,9 @@ pub const unwinder_private_data_size: usize = 2;
 #[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
 pub const unwinder_private_data_size: usize = 2;
 
+#[cfg(target_arch = "csky")]
+pub const unwinder_private_data_size: usize = 2;
+
 #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
 pub const unwinder_private_data_size: usize = 2;
 

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
 dependencies = [
  "memchr",
 ]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -36,7 +36,7 @@ filetime = "0.2"
 cc = "1.0.69"
 libc = "0.2"
 hex = "0.4"
-object = { version = "0.31.1", default-features = false, features = ["archive", "coff", "read_core", "unaligned"] }
+object = { version = "0.32.0", default-features = false, features = ["archive", "coff", "read_core", "unaligned"] }
 serde = "1.0.137"
 # Directly use serde_derive rather than through the derive feature of serde to allow building both
 # in parallel and to allow serde_json and toml to start building as soon as serde has been built.

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -332,6 +332,7 @@ def default_build_triple(verbose):
         'i786': 'i686',
         'loongarch64': 'loongarch64',
         'm68k': 'm68k',
+        'csky': 'csky',
         'powerpc': 'powerpc',
         'powerpc64': 'powerpc64',
         'powerpc64le': 'powerpc64le',

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -138,7 +138,7 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &'static str, Option<&[&'static str]>)]
     (
         Some(Mode::Std),
         "target_arch",
-        Some(&["asmjs", "spirv", "nvptx", "xtensa", "mips32r6", "mips64r6"]),
+        Some(&["asmjs", "spirv", "nvptx", "xtensa", "mips32r6", "mips64r6", "csky"]),
     ),
     /* Extra names used by dependencies */
     // FIXME: Used by serde_json, but we should not be triggering on external dependencies.

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -299,7 +299,7 @@ impl Step for Llvm {
 
         let llvm_exp_targets = match builder.config.llvm_experimental_targets {
             Some(ref s) => s,
-            None => "AVR;M68k",
+            None => "AVR;M68k;CSKY",
         };
 
         let assertions = if builder.config.llvm_assertions { "ON" } else { "OFF" };

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -374,8 +374,7 @@ impl Step for Llvm {
             cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
         }
 
-        if (target.starts_with("riscv")
-            || target.starts_with("csky"))
+        if (target.starts_with("riscv") || target.starts_with("csky"))
             && !target.contains("freebsd")
             && !target.contains("openbsd")
             && !target.contains("netbsd")

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -390,6 +390,22 @@ impl Step for Llvm {
             ldflags.shared.push(" -latomic");
         }
 
+        if target.starts_with("csky")
+            && !target.contains("freebsd")
+            && !target.contains("openbsd")
+            && !target.contains("netbsd")
+        {
+            // CSKY GCC erroneously requires linking against
+            // `libatomic` when using 1-byte and 2-byte C++
+            // atomics but the LLVM build system check cannot
+            // detect this. Therefore it is set manually here.
+            // Some BSD uses Clang as its system compiler and
+            // provides no libatomic in its base system so does
+            // not want this.
+            ldflags.exe.push(" -latomic");
+            ldflags.shared.push(" -latomic");
+        }
+
         if target.contains("msvc") {
             cfg.define("LLVM_USE_CRT_DEBUG", "MT");
             cfg.define("LLVM_USE_CRT_RELEASE", "MT");

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -374,28 +374,13 @@ impl Step for Llvm {
             cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
         }
 
-        if target.starts_with("riscv")
+        if (target.starts_with("riscv")
+            || target.starts_with("csky"))
             && !target.contains("freebsd")
             && !target.contains("openbsd")
             && !target.contains("netbsd")
         {
-            // RISC-V GCC erroneously requires linking against
-            // `libatomic` when using 1-byte and 2-byte C++
-            // atomics but the LLVM build system check cannot
-            // detect this. Therefore it is set manually here.
-            // Some BSD uses Clang as its system compiler and
-            // provides no libatomic in its base system so does
-            // not want this.
-            ldflags.exe.push(" -latomic");
-            ldflags.shared.push(" -latomic");
-        }
-
-        if target.starts_with("csky")
-            && !target.contains("freebsd")
-            && !target.contains("openbsd")
-            && !target.contains("netbsd")
-        {
-            // CSKY GCC erroneously requires linking against
+            // RISC-V and CSKY GCC erroneously requires linking against
             // `libatomic` when using 1-byte and 2-byte C++
             // atomics but the LLVM build system check cannot
             // detect this. Therefore it is set manually here.

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -32,6 +32,7 @@
     - [\*-esp-espidf](platform-support/esp-idf.md)
     - [\*-unknown-fuchsia](platform-support/fuchsia.md)
     - [\*-kmc-solid_\*](platform-support/kmc-solid.md)
+    - [csky-unknown-linux-gnuabiv2](platform-support/csky-unknown-linux-gnuabiv2.md)
     - [loongarch\*-unknown-linux-\*](platform-support/loongarch-linux.md)
     - [loongarch\*-unknown-none\*](platform-support/loongarch-none.md)
     - [m68k-unknown-linux-gnu](platform-support/m68k-unknown-linux-gnu.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -259,7 +259,7 @@ target | std | host | notes
 `avr-unknown-gnu-atmega328` | * |  | AVR. Requires `-Z build-std=core`
 `bpfeb-unknown-none` | * |  | BPF (big endian)
 `bpfel-unknown-none` | * |  | BPF (little endian)
-`csky-unknown-linux-gnuabiv2` | ? |  | C-SKY iv2 Linux
+`csky-unknown-linux-gnuabiv2` | ✓ |  | C-SKY abiv2 Linux(little endian)
 `hexagon-unknown-linux-musl` | ? |  |
 `i386-apple-ios` | ✓ |  | 32-bit x86 iOS
 [`i586-pc-nto-qnx700`](platform-support/nto-qnx.md) | * |  | 32-bit x86 QNX Neutrino 7.0 RTOS |

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -259,6 +259,7 @@ target | std | host | notes
 `avr-unknown-gnu-atmega328` | * |  | AVR. Requires `-Z build-std=core`
 `bpfeb-unknown-none` | * |  | BPF (big endian)
 `bpfel-unknown-none` | * |  | BPF (little endian)
+`csky-unknown-linux-gnuabiv2` | ? |  | C-SKY iv2 Linux
 `hexagon-unknown-linux-musl` | ? |  |
 `i386-apple-ios` | ✓ |  | 32-bit x86 iOS
 [`i586-pc-nto-qnx700`](platform-support/nto-qnx.md) | * |  | 32-bit x86 QNX Neutrino 7.0 RTOS |

--- a/src/doc/rustc/src/platform-support/csky-unknown-linux-gnuabiv2.md
+++ b/src/doc/rustc/src/platform-support/csky-unknown-linux-gnuabiv2.md
@@ -2,7 +2,7 @@
 
 **Tier: 3**
 
-This target supports [C-SKY](https://github.com/c-sky) v2 CPUs with `glibc`.
+This target supports [C-SKY](https://github.com/c-sky) CPUs with `abi` v2 and `glibc`.
 
 https://c-sky.github.io/
 ## Target maintainers

--- a/src/doc/rustc/src/platform-support/csky-unknown-linux-gnuabiv2.md
+++ b/src/doc/rustc/src/platform-support/csky-unknown-linux-gnuabiv2.md
@@ -1,0 +1,33 @@
+# `csky-unknown-linux-gnuabiv2`
+
+**Tier: 3**
+
+This target supports [C-SKY](https://github.com/c-sky) v2 CPUs with `glibc`.
+
+https://c-sky.github.io/
+## Target maintainers
+
+* [@Dirreke](https://github.com/Dirreke)
+
+## Requirements
+
+
+## Building the target
+
+add `csky-unknown-linux-gnuabiv2` to the `target` list in `config.toml` and `./x build`.
+
+## Building Rust programs
+
+Rust programs can be built for that target:
+
+```text
+cargo +stage2 --target csky-unknown-linux-gnuabiv2 your-code.rs
+```
+
+## Testing
+
+Currently there is no support to run the rustc test suite for this target.
+
+## Cross-compilation toolchains and C code
+
+This target can be cross-compiled from `x86_64` on either Linux systems with [`csky-linux-gunabiv2-tools-x86_64-glibc-linux`](https://github.com/c-sky/toolchain-build).

--- a/src/doc/rustc/src/platform-support/csky-unknown-linux-gnuabiv2.md
+++ b/src/doc/rustc/src/platform-support/csky-unknown-linux-gnuabiv2.md
@@ -5,6 +5,8 @@
 This target supports [C-SKY](https://github.com/c-sky) CPUs with `abi` v2 and `glibc`.
 
 https://c-sky.github.io/
+https://gitlab.com/c-sky/
+
 ## Target maintainers
 
 * [@Dirreke](https://github.com/Dirreke)
@@ -14,20 +16,55 @@ https://c-sky.github.io/
 
 ## Building the target
 
-add `csky-unknown-linux-gnuabiv2` to the `target` list in `config.toml` and `./x build`.
+### Get a C toolchain
 
-## Building Rust programs
+Compiling rust for this target has been tested on `x86_64` linux hosts.  Other host types have not been tested, but may work, if you can find a suitable cross compilation toolchain for them.
 
-Rust programs can be built for that target:
+If you don't already have a suitable toolchain, you can download from [here](https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource/1356021/1619528643136/csky-linux-gnuabiv2-tools-x86_64-glibc-linux-4.9.56-20210423.tar.gz), and unpack it into a directory.
 
-```text
-cargo +stage2 --target csky-unknown-linux-gnuabiv2 your-code.rs
+### Configure rust
+
+The target can be built by enabling it for a `rustc` build, by placing the following in `config.toml`:
+
+```toml
+[build]
+target = ["x86_64-unknown-linux-gnu", "csky-unknown-linux-gnuabiv2"]
+stage = 2
+
+[target.csky-unknown-linux-gnuabiv2]
+# ADJUST THIS PATH TO POINT AT YOUR TOOLCHAIN
+cc = "${TOOLCHAIN_PATH}/bin/csky-linux-gnuabiv2-gcc"
+
+### Build
+
+```sh
+# in rust dir
+./x.py build --stage 2
 ```
 
-## Testing
+## Building and Running Rust programs
 
-Currently there is no support to run the rustc test suite for this target.
+To test cross-compiled binaries on a `x86_64` system, you can use the `qemu-cskyv2`. This avoids having a full emulated ARM system by doing dynamic binary translation and dynamic system call translation.  It lets you run CSKY programs directly on your `x86_64` kernel.  It's very convenient!
 
-## Cross-compilation toolchains and C code
+To use:
 
-This target can be cross-compiled from `x86_64` on either Linux systems with [`csky-linux-gunabiv2-tools-x86_64-glibc-linux`](https://github.com/c-sky/toolchain-build).
+* Install `qemu-cskyv2` (If you don't already have a qemu, you can download from [here](https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1689324918932/xuantie-qemu-x86_64-Ubuntu-18.04-20230714-0202.tar.gz"), and unpack it into a directory.)
+* Link your built toolchain via:
+  * `rustup toolchain link stage2 ${RUST}/build/x86_64-unknown-linux-gnu/stage2`
+* Create a test program
+
+```sh
+cargo new hello_world
+cd hello_world
+```
+
+* Build and run
+
+```sh
+CARGO_TARGET_CSKY_UNKNOWN_LINUX_GNUABIV2_RUNNER=${QEMU_PATH}/bin/qemu-cskyv2 -L ${TOOLCHAIN_PATH}/csky-linux-gnuabiv2/libc \
+CARGO_TARGET_CSKY_UNKNOWN_LINUX_GNUABIV2_LINKER=${TOOLCHAIN_PATH}/bin/csky-linux-gnuabiv2-gcc \
+RUSTFLAGS="-C target-features=+crt-static" \
+cargo +stage2 run --target csky-unknown-linux-gnuabiv2
+```
+
+Attention: The dynamic-linked program may nor be run by `qemu-cskyv2` but can be run on the target.

--- a/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
@@ -17,6 +17,7 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 - AVR
 - MSP430
 - M68k
+- CSKY
 - s390x
 
 ## Register classes
@@ -46,6 +47,8 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | M68k         | `reg`          | `d[0-7]`, `a[0-7]`                 | `r`                  |
 | M68k         | `reg_data`     | `d[0-7]`                           | `d`                  |
 | M68k         | `reg_addr`     | `a[0-3]`                           | `a`                  |
+| CSKY         | `reg`          | `r[0-31]`                          | `r`                  |
+| CSKY         | `freg`         | `f[0-31]`                          | `f`                  |
 | s390x        | `reg`          | `r[0-10]`, `r[12-14]`              | `r`                  |
 | s390x        | `freg`         | `f[0-15]`                          | `f`                  |
 
@@ -79,6 +82,8 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | MSP430       | `reg`                           | None           | `i8`, `i16`                             |
 | M68k         | `reg`, `reg_addr`               | None           | `i16`, `i32`                            |
 | M68k         | `reg_data`                      | None           | `i8`, `i16`, `i32`                      |
+| CSKY         | `reg`                           | None           | `i8`, `i16`, `i32`, `i64`               |
+| CSKY         | `freg`                          | None           | `f32`, `f64`                            |
 | s390x        | `reg`                           | None           | `i8`, `i16`, `i32`, `i64`               |
 | s390x        | `freg`                          | None           | `f32`, `f64`                            |
 
@@ -102,6 +107,10 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | M68k         | `a5`          | `bp`      |
 | M68k         | `a6`          | `fp`      |
 | M68k         | `a7`          | `sp`, `usp`, `ssp`, `isp` |
+| CSKY         | `r14`         | `sp`      |
+| CSKY         | `r15`         | `lr`      |
+| CSKY         | `r28`         | `gb`, `rgb`, `rdb` |
+| CSKY         | `r31`         | `tls`     |
 
 > **Notes**:
 > - TI does not mandate a frame pointer for MSP430, but toolchains are allowed

--- a/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
@@ -82,8 +82,8 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | MSP430       | `reg`                           | None           | `i8`, `i16`                             |
 | M68k         | `reg`, `reg_addr`               | None           | `i16`, `i32`                            |
 | M68k         | `reg_data`                      | None           | `i8`, `i16`, `i32`                      |
-| CSKY         | `reg`                           | None           | `i8`, `i16`, `i32`, `i64`               |
-| CSKY         | `freg`                          | None           | `f32`, `f64`                            |
+| CSKY         | `reg`                           | None           | `i8`, `i16`, `i32`                      |
+| CSKY         | `freg`                          | None           | `f32`,                                  |
 | s390x        | `reg`                           | None           | `i8`, `i16`, `i32`, `i64`               |
 | s390x        | `freg`                          | None           | `f32`, `f64`                            |
 
@@ -107,9 +107,16 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | M68k         | `a5`          | `bp`      |
 | M68k         | `a6`          | `fp`      |
 | M68k         | `a7`          | `sp`, `usp`, `ssp`, `isp` |
+| CSKY         | `r[0-3]`      | `a[0-3]`  |
+| CSKY         | `r[4-11]`     | `l[0-7]`  |
+| CSKY         | `r[12-13]`    | `t[0-1]`  |
 | CSKY         | `r14`         | `sp`      |
 | CSKY         | `r15`         | `lr`      |
-| CSKY         | `r28`         | `gb`, `rgb`, `rdb` |
+| CSKY         | `r[16-17]`    | `l[8-9]`  |
+| CSKY         | `r[18-25]`    | `t[2-9]`  |
+| CSKY         | `r28`         | `rgb`     |
+| CSKY         | `r29`         | `rtb`     |
+| CSKY         | `r30`         | `svbr`    |
 | CSKY         | `r31`         | `tls`     |
 
 > **Notes**:
@@ -132,6 +139,13 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | AVR          | `r0`, `r1`, `r1r0`                      | Due to an issue in LLVM, the `r0` and `r1` registers cannot be used as inputs or outputs.  If modified, they must be restored to their original values before the end of the block. |
 |MSP430        | `r0`, `r2`, `r3`                        | These are the program counter, status register, and constant generator respectively. Neither the status register nor constant generator can be written to.                          |
 | M68k         | `a4`, `a5`                              | Used internally by LLVM for the base pointer and global base pointer. |
+| CSKY         | `r7`, `r28`                             | Used internally by LLVM for the base pointer and global base pointer. |
+| CSKY         | `r8`                                    | Used internally by LLVM for the frame pointer. |
+| CSKY         | `r14`                                   | Used internally by LLVM for the stack pointer. |
+| CSKY         | `r15`                                   | This is the link register. |
+| CSKY         | `r[26-30]`                              | Reserved by its ABI.       |
+| CSKY         | `r31`                                   | This is the TLS register.  |
+
 
 ## Template modifiers
 
@@ -148,6 +162,8 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | PowerPC      | `freg`         | None     | `0`            | None          |
 | s390x        | `reg`          | None     | `%r0`          | None          |
 | s390x        | `freg`         | None     | `%f0`          | None          |
+| CSKY         | `reg`          | None     | `r0`           | None          |
+| CSKY         | `freg`         | None     | `f0`           | None          |
 
 # Flags covered by `preserves_flags`
 

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -519,6 +519,7 @@ impl<'a> fmt::Display for Display<'a> {
                         "asmjs" => "JavaScript",
                         "loongarch64" => "LoongArch LA64",
                         "m68k" => "M68k",
+                        "csky" => "CSKY",
                         "mips" => "MIPS",
                         "mips32r6" => "MIPS Release 6",
                         "mips64" => "MIPS-64",

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -100,6 +100,7 @@ static TARGETS: &[&str] = &[
     "i686-unknown-uefi",
     "loongarch64-unknown-linux-gnu",
     "m68k-unknown-linux-gnu",
+    "csky-unknown-linux-gnuabiv2",
     "mips-unknown-linux-gnu",
     "mips-unknown-linux-musl",
     "mips64-unknown-linux-gnuabi64",

--- a/src/tools/rust-analyzer/Cargo.lock
+++ b/src/tools/rust-analyzer/Cargo.lock
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
 dependencies = [
  "memchr",
 ]
@@ -1337,7 +1337,7 @@ name = "proc-macro-api"
 version = "0.0.0"
 dependencies = [
  "memmap2",
- "object 0.31.1",
+ "object 0.32.0",
  "paths",
  "profile",
  "serde",
@@ -1357,7 +1357,7 @@ dependencies = [
  "libloading",
  "mbe",
  "memmap2",
- "object 0.31.1",
+ "object 0.32.0",
  "paths",
  "proc-macro-api",
  "proc-macro-test",

--- a/src/tools/rust-analyzer/crates/ide-completion/src/completions/attribute/cfg.rs
+++ b/src/tools/rust-analyzer/crates/ide-completion/src/completions/attribute/cfg.rs
@@ -46,6 +46,7 @@ const KNOWN_ARCH: [&str; 19] = [
     "aarch64",
     "arm",
     "avr",
+    "csky",
     "hexagon",
     "mips",
     "mips64",

--- a/src/tools/rust-analyzer/crates/ide-completion/src/completions/attribute/cfg.rs
+++ b/src/tools/rust-analyzer/crates/ide-completion/src/completions/attribute/cfg.rs
@@ -42,7 +42,7 @@ pub(crate) fn complete_cfg(acc: &mut Completions, ctx: &CompletionContext<'_>) {
     };
 }
 
-const KNOWN_ARCH: [&str; 19] = [
+const KNOWN_ARCH: [&str; 20] = [
     "aarch64",
     "arm",
     "avr",

--- a/src/tools/rust-analyzer/crates/proc-macro-api/Cargo.toml
+++ b/src/tools/rust-analyzer/crates/proc-macro-api/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-object = { version = "0.31.0", default-features = false, features = [
+object = { version = "0.32.0", default-features = false, features = [
     "std",
     "read_core",
     "elf",

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/Cargo.toml
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-object = { version = "0.31.0", default-features = false, features = [
+object = { version = "0.32.0", default-features = false, features = [
     "std",
     "read_core",
     "elf",

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -258,6 +258,8 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "termize",
     "thin-vec",
     "thiserror",
+    "thiserror-core",
+    "thiserror-core-impl",
     "thiserror-impl",
     "thorin-dwp",
     "thread_local",

--- a/tests/ui/check-cfg/compact-values.stderr
+++ b/tests/ui/check-cfg/compact-values.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition value
 LL | #[cfg(target(os = "linux", arch = "X"))]
    |                            ^^^^^^^^^^
    |
-   = note: expected values for `target_arch` are: `aarch64`, `arm`, `avr`, `bpf`, `hexagon`, `loongarch64`, `m68k`, `mips`, `mips32r6`, `mips64`, `mips64r6`, `msp430`, `nvptx64`, `powerpc`, `powerpc64`, `riscv32`, `riscv64`, `s390x`, `sparc`, `sparc64`, `wasm32`, `wasm64`, `x86`, `x86_64`
+   = note: expected values for `target_arch` are: `aarch64`, `arm`, `avr`, `bpf`, `csky`, `hexagon`, `loongarch64`, `m68k`, `mips`, `mips32r6`, `mips64`, `mips64r6`, `msp430`, `nvptx64`, `powerpc`, `powerpc64`, `riscv32`, `riscv64`, `s390x`, `sparc`, `sparc64`, `wasm32`, `wasm64`, `x86`, `x86_64`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -13,7 +13,7 @@ LL |     let _: &[i8] = data.into();
              <[T; 4] as From<(T, T, T, T)>>
              <[T; 5] as From<(T, T, T, T, T)>>
              <[T; 6] as From<(T, T, T, T, T, T)>>
-           and 7 others
+           and 6 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 
 error: aborting due to previous error

--- a/tests/ui/target-feature/gate.rs
+++ b/tests/ui/target-feature/gate.rs
@@ -17,6 +17,7 @@
 // gate-test-ermsb_target_feature
 // gate-test-bpf_target_feature
 // gate-test-aarch64_ver_target_feature
+// gate-test-csky_target_feature
 
 #[target_feature(enable = "avx512bw")]
 //~^ ERROR: currently unstable

--- a/tests/ui/target-feature/gate.stderr
+++ b/tests/ui/target-feature/gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `avx512bw` is currently unstable
-  --> $DIR/gate.rs:21:18
+  --> $DIR/gate.rs:22:18
    |
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This is the rustc side changes to support csky based Linux target(`csky-unknown-linux-gnuabiv2`).

Tier 3 policy:

> A tier 3 target must have a designated developer or developers (the "target maintainers") on record to be CCed when issues arise regarding the target. (The mechanism to track and CC such developers may evolve over time.)

I pledge to do my best maintaining it.

> Targets must use naming consistent with any existing targets; for instance, a target for the same CPU or OS as an existing Rust target should use the same name for that CPU or OS. Targets should normally use the same names and naming conventions as used elsewhere in the broader ecosystem beyond Rust (such as in other toolchains), unless they have a very good reason to diverge. Changing the name of a target can be highly disruptive, especially once the target reaches a higher tier, so getting the name right is important even for a tier 3 target.

This `csky`  section is the arch name and the `unknown-linux` section is the same as other linux target, and `gnuabiv2` is from the  cross-compile toolchain of  `gcc`

> Target names should not introduce undue confusion or ambiguity unless absolutely necessary to maintain ecosystem compatibility. For example, if the name of the target makes people extremely likely to form incorrect beliefs about what it targets, the name should be changed or augmented to disambiguate it.

I think the explanation in platform support doc is enough to make this aspect clear.

> Tier 3 targets may have unusual requirements to build or use, but must not create legal issues or impose onerous legal terms for the Rust project or for Rust developers or users.

It's using open source tools only.

> The target must not introduce license incompatibilities.

No new license

> Anything added to the Rust repository must be under the standard Rust license (MIT OR Apache-2.0).

Understood.

> The target must not cause the Rust tools or libraries built for any other host (even when supporting cross-compilation to the target) to depend on any new dependency less permissive than the Rust licensing policy. This applies whether the dependency is a Rust crate that would require adding new license exceptions (as specified by the tidy tool in the rust-lang/rust repository), or whether the dependency is a native library or binary. In other words, the introduction of the target must not cause a user installing or running a version of Rust or the Rust tools to be subject to any new license requirements.

There are no new dependencies/features required.

> Compiling, linking, and emitting functional binaries, libraries, or other code for the target (whether hosted on the target itself or cross-compiling from another target) must not depend on proprietary (non-FOSS) libraries. Host tools built for the target itself may depend on the ordinary runtime libraries supplied by the platform and commonly used by other applications built for the target, but those libraries must not be required for code generation for the target; cross-compilation to the target must not require such libraries at all. For instance, rustc built for the target may depend on a common proprietary C runtime library or console output library, but must not depend on a proprietary code generation library or code optimization library. Rust's license permits such combinations, but the Rust project has no interest in maintaining such combinations within the scope of Rust itself, even at tier 3.

As previously said it's using open source tools only.

> "onerous" here is an intentionally subjective term. At a minimum, "onerous" legal/licensing terms include but are not limited to: non-disclosure requirements, non-compete requirements, contributor license agreements (CLAs) or equivalent, "non-commercial"/"research-only"/etc terms, requirements conditional on the employer or employment of any particular Rust developers, revocable terms, any requirements that create liability for the Rust project or its developers or users, or any requirements that adversely affect the livelihood or prospects of the Rust project or its developers or users.

There are no such terms present/

> Neither this policy nor any decisions made regarding targets shall create any binding agreement or estoppel by any party. If any member of an approving Rust team serves as one of the maintainers of a target, or has any legal or employment requirement (explicit or implicit) that might affect their decisions regarding a target, they must recuse themselves from any approval decisions regarding the target's tier status, though they may otherwise participate in discussions.

I'm not the reviewer here.

> This requirement does not prevent part or all of this policy from being cited in an explicit contract or work agreement (e.g. to implement or maintain support for a target). This requirement exists to ensure that a developer or team responsible for reviewing and approving a target does not face any legal threats or obligations that would prevent them from freely exercising their judgment in such approval, even if such judgment involves subjective matters or goes beyond the letter of these requirements.

I'm not the reviewer here.

> Tier 3 targets should attempt to implement as much of the standard libraries as possible and appropriate (core for most targets, alloc for targets that can support dynamic memory allocation, std for targets with an operating system or equivalent layer of system-provided functionality), but may leave some code unimplemented (either unavailable or stubbed out as appropriate), whether because the target makes it impossible to implement or challenging to implement. The authors of pull requests are not obligated to avoid calling any portions of the standard library on the basis of a tier 3 target not implementing those portions.

It supports for std

> The target must provide documentation for the Rust community explaining how to build for the target, using cross-compilation if possible. If the target supports running binaries, or running tests (even if they do not pass), the documentation must explain how to run such binaries or tests for the target, using emulation if possible or dedicated hardware if necessary.

I have added the documentation, and I think it's clear. 

> Tier 3 targets must not impose burden on the authors of pull requests, or other developers in the community, to maintain the target. In particular, do not post comments (automated or manual) on a PR that derail or suggest a block on the PR based on a tier 3 target. Do not send automated messages or notifications (via any medium, including via @) to a PR author or others involved with a PR regarding a tier 3 target, unless they have opted into such messages.

Understood.

> Backlinks such as those generated by the issue/PR tracker when linking to an issue or PR are not considered a violation of this policy, within reason. However, such messages (even on a separate repository) must not generate notifications to anyone involved with a PR who has not requested such notifications.

Understood.

> Patches adding or updating tier 3 targets must not break any existing tier 2 or tier 1 target, and must not knowingly break another tier 3 target without approval of either the compiler team or the maintainers of the other tier 3 target.

I believe I didn't break any other target.

> In particular, this may come up when working on closely related targets, such as variations of the same architecture with different features. Avoid introducing unconditional uses of features that another variation of the target may not have; use conditional compilation or runtime detection, as appropriate, to let each target run code supported by that target.

I think there are no such problems in this PR.