### PR TITLE
Rename VecDeque's `rotate_left` and `rotate_right` parameters

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2283,21 +2283,21 @@ impl<T, A: Allocator> VecDeque<T, A> {
         unsafe { slice::from_raw_parts_mut(ptr.add(self.head), self.len) }
     }
 
-    /// Rotates the double-ended queue `mid` places to the left.
+    /// Rotates the double-ended queue `n` places to the left.
     ///
     /// Equivalently,
-    /// - Rotates item `mid` into the first position.
-    /// - Pops the first `mid` items and pushes them to the end.
-    /// - Rotates `len() - mid` places to the right.
+    /// - Rotates item `n` into the first position.
+    /// - Pops the first `n` items and pushes them to the end.
+    /// - Rotates `len() - n` places to the right.
     ///
     /// # Panics
     ///
-    /// If `mid` is greater than `len()`. Note that `mid == len()`
+    /// If `n` is greater than `len()`. Note that `n == len()`
     /// does _not_ panic and is a no-op rotation.
     ///
     /// # Complexity
     ///
-    /// Takes `*O*(min(mid, len() - mid))` time and no extra space.
+    /// Takes `*O*(min(n, len() - n))` time and no extra space.
     ///
     /// # Examples
     ///
@@ -2316,31 +2316,31 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// assert_eq!(buf, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     /// ```
     #[stable(feature = "vecdeque_rotate", since = "1.36.0")]
-    pub fn rotate_left(&mut self, mid: usize) {
-        assert!(mid <= self.len());
-        let k = self.len - mid;
-        if mid <= k {
-            unsafe { self.rotate_left_inner(mid) }
+    pub fn rotate_left(&mut self, n: usize) {
+        assert!(n <= self.len());
+        let k = self.len - n;
+        if n <= k {
+            unsafe { self.rotate_left_inner(n) }
         } else {
             unsafe { self.rotate_right_inner(k) }
         }
     }
 
-    /// Rotates the double-ended queue `k` places to the right.
+    /// Rotates the double-ended queue `n` places to the right.
     ///
     /// Equivalently,
-    /// - Rotates the first item into position `k`.
-    /// - Pops the last `k` items and pushes them to the front.
-    /// - Rotates `len() - k` places to the left.
+    /// - Rotates the first item into position `n`.
+    /// - Pops the last `n` items and pushes them to the front.
+    /// - Rotates `len() - n` places to the left.
     ///
     /// # Panics
     ///
-    /// If `k` is greater than `len()`. Note that `k == len()`
+    /// If `n` is greater than `len()`. Note that `n == len()`
     /// does _not_ panic and is a no-op rotation.
     ///
     /// # Complexity
     ///
-    /// Takes `*O*(min(k, len() - k))` time and no extra space.
+    /// Takes `*O*(min(n, len() - n))` time and no extra space.
     ///
     /// # Examples
     ///
@@ -2359,13 +2359,13 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// assert_eq!(buf, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     /// ```
     #[stable(feature = "vecdeque_rotate", since = "1.36.0")]
-    pub fn rotate_right(&mut self, k: usize) {
-        assert!(k <= self.len());
-        let mid = self.len - k;
-        if k <= mid {
-            unsafe { self.rotate_right_inner(k) }
+    pub fn rotate_right(&mut self, n: usize) {
+        assert!(n <= self.len());
+        let k = self.len - n;
+        if n <= k {
+            unsafe { self.rotate_right_inner(n) }
         } else {
-            unsafe { self.rotate_left_inner(mid) }
+            unsafe { self.rotate_left_inner(k) }
         }
     }
 

--- a/library/alloc/src/collections/vec_deque/tests.rs
+++ b/library/alloc/src/collections/vec_deque/tests.rs
@@ -351,14 +351,14 @@ fn test_rotate_left_right() {
 }
 
 #[test]
-#[should_panic = "assertion failed: mid <= self.len()"]
+#[should_panic = "assertion failed: n <= self.len()"]
 fn test_rotate_left_panic() {
     let mut tester: VecDeque<_> = (1..=10).collect();
     tester.rotate_left(tester.len() + 1);
 }
 
 #[test]
-#[should_panic = "assertion failed: k <= self.len()"]
+#[should_panic = "assertion failed: n <= self.len()"]
 fn test_rotate_right_panic() {
     let mut tester: VecDeque<_> = (1..=10).collect();
     tester.rotate_right(tester.len() + 1);


### PR DESCRIPTION
This pull request introduces a modification to the `VecDeque` collection, specifically the `rotate_left` and `rotate_right` functions, by renaming the parameter associated with these functions.
 
The rationale behind this change is to provide clearer and more consistent naming for the parameter that specifies the number of places to rotate the double-ended queue. By using `n` as the parameter name in both functions, it becomes easier to understand and remember the purpose of the parameter.