### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,8 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+
+[*.rs]
 max_line_length = 100
 
 [*.md]

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -2,7 +2,7 @@ use crate::FnCtxt;
 use rustc_hir as hir;
 use rustc_hir::def::Res;
 use rustc_hir::def_id::DefId;
-use rustc_infer::traits::ObligationCauseCode;
+use rustc_infer::{infer::type_variable::TypeVariableOriginKind, traits::ObligationCauseCode};
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitor};
 use rustc_span::{self, symbol::kw, Span};
 use rustc_trait_selection::traits;
@@ -254,8 +254,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             type BreakTy = ty::GenericArg<'tcx>;
             fn visit_ty(&mut self, ty: Ty<'tcx>) -> std::ops::ControlFlow<Self::BreakTy> {
                 if let Some(origin) = self.0.type_var_origin(ty)
-                    && let rustc_infer::infer::type_variable::TypeVariableOriginKind::TypeParameterDefinition(_, def_id) =
-                        origin.kind
+                    && let TypeVariableOriginKind::TypeParameterDefinition(_, def_id) = origin.kind
                     && let generics = self.0.tcx.generics_of(self.1)
                     && let Some(index) = generics.param_def_id_to_index(self.0.tcx, def_id)
                     && let Some(subst) = ty::InternalSubsts::identity_for_item(self.0.tcx, self.1)

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -163,7 +163,7 @@ fn fmt_printer<'a, 'tcx>(infcx: &'a InferCtxt<'tcx>, ns: Namespace) -> FmtPrinte
         let ty_vars = infcx_inner.type_variables();
         let var_origin = ty_vars.var_origin(ty_vid);
         if let TypeVariableOriginKind::TypeParameterDefinition(name, def_id) = var_origin.kind
-            && !var_origin.span.from_expansion()
+            && name != kw::SelfUpper && !var_origin.span.from_expansion()
         {
             let generics = infcx.tcx.generics_of(infcx.tcx.parent(def_id));
             let idx = generics.param_def_id_to_index(infcx.tcx, def_id).unwrap();

--- a/compiler/rustc_middle/src/traits/solve/inspect.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect.rs
@@ -32,7 +32,7 @@ pub enum GoalEvaluationKind<'tcx> {
 }
 impl Debug for GoalEvaluation<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        ProofTreeFormatter { f, on_newline: true }.format_goal_evaluation(self)
+        ProofTreeFormatter::new(f).format_goal_evaluation(self)
     }
 }
 
@@ -43,7 +43,7 @@ pub struct AddedGoalsEvaluation<'tcx> {
 }
 impl Debug for AddedGoalsEvaluation<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        ProofTreeFormatter { f, on_newline: true }.format_nested_goal_evaluation(self)
+        ProofTreeFormatter::new(f).format_nested_goal_evaluation(self)
     }
 }
 
@@ -58,7 +58,7 @@ pub struct GoalEvaluationStep<'tcx> {
 }
 impl Debug for GoalEvaluationStep<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        ProofTreeFormatter { f, on_newline: true }.format_evaluation_step(self)
+        ProofTreeFormatter::new(f).format_evaluation_step(self)
     }
 }
 
@@ -78,6 +78,6 @@ pub enum CandidateKind<'tcx> {
 }
 impl Debug for GoalCandidate<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        ProofTreeFormatter { f, on_newline: true }.format_candidate(self)
+        ProofTreeFormatter::new(f).format_candidate(self)
     }
 }

--- a/compiler/rustc_middle/src/traits/solve/inspect/format.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect/format.rs
@@ -1,11 +1,19 @@
 use super::*;
 
 pub(super) struct ProofTreeFormatter<'a, 'b> {
-    pub(super) f: &'a mut (dyn Write + 'b),
-    pub(super) on_newline: bool,
+    f: &'a mut (dyn Write + 'b),
 }
 
-impl Write for ProofTreeFormatter<'_, '_> {
+/// A formatter which adds 4 spaces of identation to its input before
+/// passing it on to its nested formatter.
+///
+/// We can use this for arbitrary levels of indentation by nesting it.
+struct Indentor<'a, 'b> {
+    f: &'a mut (dyn Write + 'b),
+    on_newline: bool,
+}
+
+impl Write for Indentor<'_, '_> {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         for line in s.split_inclusive("\n") {
             if self.on_newline {
@@ -19,49 +27,52 @@ impl Write for ProofTreeFormatter<'_, '_> {
     }
 }
 
-impl ProofTreeFormatter<'_, '_> {
-    fn nested(&mut self) -> ProofTreeFormatter<'_, '_> {
-        ProofTreeFormatter { f: self, on_newline: true }
+impl<'a, 'b> ProofTreeFormatter<'a, 'b> {
+    pub(super) fn new(f: &'a mut (dyn Write + 'b)) -> Self {
+        ProofTreeFormatter { f }
+    }
+
+    fn nested<F, R>(&mut self, func: F) -> R
+    where
+        F: FnOnce(&mut ProofTreeFormatter<'_, '_>) -> R,
+    {
+        func(&mut ProofTreeFormatter { f: &mut Indentor { f: self.f, on_newline: true } })
     }
 
     pub(super) fn format_goal_evaluation(&mut self, goal: &GoalEvaluation<'_>) -> std::fmt::Result {
-        let f = &mut *self.f;
-
         let goal_text = match goal.is_normalizes_to_hack {
             IsNormalizesToHack::Yes => "NORMALIZES-TO HACK GOAL",
             IsNormalizesToHack::No => "GOAL",
         };
 
-        writeln!(f, "{}: {:?}", goal_text, goal.uncanonicalized_goal,)?;
-        writeln!(f, "CANONICALIZED: {:?}", goal.canonicalized_goal)?;
+        writeln!(self.f, "{}: {:?}", goal_text, goal.uncanonicalized_goal)?;
+        writeln!(self.f, "CANONICALIZED: {:?}", goal.canonicalized_goal)?;
 
         match &goal.kind {
             GoalEvaluationKind::CacheHit(CacheHit::Global) => {
-                writeln!(f, "GLOBAL CACHE HIT: {:?}", goal.result)
+                writeln!(self.f, "GLOBAL CACHE HIT: {:?}", goal.result)
             }
             GoalEvaluationKind::CacheHit(CacheHit::Provisional) => {
-                writeln!(f, "PROVISIONAL CACHE HIT: {:?}", goal.result)
+                writeln!(self.f, "PROVISIONAL CACHE HIT: {:?}", goal.result)
             }
             GoalEvaluationKind::Uncached { revisions } => {
                 for (n, step) in revisions.iter().enumerate() {
-                    let f = &mut *self.f;
-                    writeln!(f, "REVISION {n}: {:?}", step.result)?;
-                    let mut f = self.nested();
-                    f.format_evaluation_step(step)?;
+                    writeln!(self.f, "REVISION {n}: {:?}", step.result)?;
+                    self.nested(|this| this.format_evaluation_step(step))?;
                 }
-
-                let f = &mut *self.f;
-                writeln!(f, "RESULT: {:?}", goal.result)
+                writeln!(self.f, "RESULT: {:?}", goal.result)
             }
         }?;
 
         if goal.returned_goals.len() > 0 {
-            let f = &mut *self.f;
-            writeln!(f, "NESTED GOALS ADDED TO CALLER: [")?;
-            let mut f = self.nested();
-            for goal in goal.returned_goals.iter() {
-                writeln!(f, "ADDED GOAL: {:?},", goal)?;
-            }
+            writeln!(self.f, "NESTED GOALS ADDED TO CALLER: [")?;
+            self.nested(|this| {
+                for goal in goal.returned_goals.iter() {
+                    writeln!(this.f, "ADDED GOAL: {:?},", goal)?;
+                }
+                Ok(())
+            })?;
+
             writeln!(self.f, "]")?;
         }
 
@@ -72,58 +83,53 @@ impl ProofTreeFormatter<'_, '_> {
         &mut self,
         evaluation_step: &GoalEvaluationStep<'_>,
     ) -> std::fmt::Result {
-        let f = &mut *self.f;
-        writeln!(f, "INSTANTIATED: {:?}", evaluation_step.instantiated_goal)?;
+        writeln!(self.f, "INSTANTIATED: {:?}", evaluation_step.instantiated_goal)?;
 
         for candidate in &evaluation_step.candidates {
-            let mut f = self.nested();
-            f.format_candidate(candidate)?;
+            self.nested(|this| this.format_candidate(candidate))?;
         }
-        for nested_goal_evaluation in &evaluation_step.nested_goal_evaluations {
-            let mut f = self.nested();
-            f.format_nested_goal_evaluation(nested_goal_evaluation)?;
+        for nested in &evaluation_step.nested_goal_evaluations {
+            self.nested(|this| this.format_nested_goal_evaluation(nested))?;
         }
 
         Ok(())
     }
 
     pub(super) fn format_candidate(&mut self, candidate: &GoalCandidate<'_>) -> std::fmt::Result {
-        let f = &mut *self.f;
-
         match &candidate.kind {
             CandidateKind::NormalizedSelfTyAssembly => {
-                writeln!(f, "NORMALIZING SELF TY FOR ASSEMBLY:")
+                writeln!(self.f, "NORMALIZING SELF TY FOR ASSEMBLY:")
             }
             CandidateKind::Candidate { name, result } => {
-                writeln!(f, "CANDIDATE {}: {:?}", name, result)
+                writeln!(self.f, "CANDIDATE {}: {:?}", name, result)
             }
         }?;
 
-        let mut f = self.nested();
-        for candidate in &candidate.candidates {
-            f.format_candidate(candidate)?;
-        }
-        for nested_evaluations in &candidate.nested_goal_evaluations {
-            f.format_nested_goal_evaluation(nested_evaluations)?;
-        }
-
-        Ok(())
+        self.nested(|this| {
+            for candidate in &candidate.candidates {
+                this.format_candidate(candidate)?;
+            }
+            for nested in &candidate.nested_goal_evaluations {
+                this.format_nested_goal_evaluation(nested)?;
+            }
+            Ok(())
+        })
     }
 
     pub(super) fn format_nested_goal_evaluation(
         &mut self,
         nested_goal_evaluation: &AddedGoalsEvaluation<'_>,
     ) -> std::fmt::Result {
-        let f = &mut *self.f;
-        writeln!(f, "TRY_EVALUATE_ADDED_GOALS: {:?}", nested_goal_evaluation.result)?;
+        writeln!(self.f, "TRY_EVALUATE_ADDED_GOALS: {:?}", nested_goal_evaluation.result)?;
 
         for (n, revision) in nested_goal_evaluation.evaluations.iter().enumerate() {
-            let f = &mut *self.f;
-            writeln!(f, "REVISION {n}")?;
-            let mut f = self.nested();
-            for goal_evaluation in revision {
-                f.format_goal_evaluation(goal_evaluation)?;
-            }
+            writeln!(self.f, "REVISION {n}")?;
+            self.nested(|this| {
+                for goal_evaluation in revision {
+                    this.format_goal_evaluation(goal_evaluation)?;
+                }
+                Ok(())
+            })?;
         }
 
         Ok(())

--- a/compiler/rustc_middle/src/traits/solve/inspect/format.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect/format.rs
@@ -4,7 +4,7 @@ pub(super) struct ProofTreeFormatter<'a, 'b> {
     f: &'a mut (dyn Write + 'b),
 }
 
-/// A formatter which adds 4 spaces of identation to its input before
+/// A formatter which adds 4 spaces of indentation to its input before
 /// passing it on to its nested formatter.
 ///
 /// We can use this for arbitrary levels of indentation by nesting it.

--- a/compiler/rustc_smir/src/lib.rs
+++ b/compiler/rustc_smir/src/lib.rs
@@ -1,6 +1,6 @@
 //! The WIP stable interface to rustc internals.
 //!
-//! For more information see https://github.com/rust-lang/project-stable-mir
+//! For more information see <https://github.com/rust-lang/project-stable-mir>
 //!
 //! # Note
 //!

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -116,7 +116,8 @@ impl NestedGoals<'_> {
 #[derive(PartialEq, Eq, Debug, Hash, HashStable, Clone, Copy)]
 pub enum GenerateProofTree {
     Yes(UseGlobalCache),
-    No,
+    IfEnabled,
+    Never,
 }
 
 #[derive(PartialEq, Eq, Debug, Hash, HashStable, Clone, Copy)]
@@ -202,7 +203,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
             (&tree, infcx.tcx.sess.opts.unstable_opts.dump_solver_proof_tree)
         {
             let mut lock = std::io::stdout().lock();
-            let _ = lock.write_fmt(format_args!("{tree:?}"));
+            let _ = lock.write_fmt(format_args!("{tree:?}\n"));
             let _ = lock.flush();
         }
 

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
@@ -40,7 +40,7 @@ impl<'tcx> InferCtxtSelectExt<'tcx> for InferCtxt<'tcx> {
             self.instantiate_binder_with_placeholders(obligation.predicate),
         );
 
-        let (result, _) = EvalCtxt::enter_root(self, GenerateProofTree::No, |ecx| {
+        let (result, _) = EvalCtxt::enter_root(self, GenerateProofTree::Never, |ecx| {
             let goal = Goal::new(ecx.tcx(), trait_goal.param_env, trait_goal.predicate);
             let (orig_values, canonical_goal) = ecx.canonicalize_goal(goal);
             let mut candidates = ecx.compute_canonical_trait_candidates(canonical_goal);

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -57,7 +57,7 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
             .map(|obligation| {
                 let code = infcx.probe(|_| {
                     match infcx
-                        .evaluate_root_goal(obligation.clone().into(), GenerateProofTree::No)
+                        .evaluate_root_goal(obligation.clone().into(), GenerateProofTree::IfEnabled)
                         .0
                     {
                         Ok((_, Certainty::Maybe(MaybeCause::Ambiguity), _)) => {
@@ -96,7 +96,7 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
             for obligation in mem::take(&mut self.obligations) {
                 let goal = obligation.clone().into();
                 let (changed, certainty, nested_goals) =
-                    match infcx.evaluate_root_goal(goal, GenerateProofTree::No).0 {
+                    match infcx.evaluate_root_goal(goal, GenerateProofTree::IfEnabled).0 {
                         Ok(result) => result,
                         Err(NoSolution) => {
                             errors.push(FulfillmentError {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -3554,7 +3554,7 @@ pub fn dump_proof_tree<'tcx>(o: &Obligation<'tcx, ty::Predicate<'tcx>>, infcx: &
             .1
             .expect("proof tree should have been generated");
         let mut lock = std::io::stdout().lock();
-        let _ = lock.write_fmt(format_args!("{tree:?}"));
+        let _ = lock.write_fmt(format_args!("{tree:?}\n"));
         let _ = lock.flush();
     });
 }

--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -68,13 +68,17 @@ macro_rules! std {
 }
 
 macro_rules! doc_std {
-    ($host:ident => $target:ident, stage = $stage:literal) => {
+    ($host:ident => $target:ident, stage = $stage:literal) => {{
+        let config = configure("doc", &["A"], &["A"]);
+        let build = Build::new(config);
+        let builder = Builder::new(&build);
         doc::Std::new(
             $stage,
             TargetSelection::from_user(stringify!($target)),
+            &builder,
             DocumentationFormat::HTML,
         )
-    };
+    }};
 }
 
 macro_rules! rustc {

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -1,10 +1,8 @@
 //! Implementation of compiling the compiler and standard library, in "check"-based modes.
 
-use crate::builder::{crate_description, Builder, Kind, RunConfig, ShouldRun, Step};
+use crate::builder::{crate_description, Alias, Builder, Kind, RunConfig, ShouldRun, Step};
 use crate::cache::Interned;
-use crate::compile::{
-    add_to_sysroot, make_run_crates, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo,
-};
+use crate::compile::{add_to_sysroot, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo};
 use crate::config::TargetSelection;
 use crate::tool::{prepare_tool_cargo, SourceType};
 use crate::INTERNER;
@@ -89,7 +87,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = make_run_crates(&run, "library");
+        let crates = run.make_run_crates(Alias::Library);
         run.builder.ensure(Std { target: run.target, crates });
     }
 
@@ -140,7 +138,7 @@ impl Step for Std {
 
         // don't run on std twice with x.py clippy
         // don't check test dependencies if we haven't built libtest
-        if builder.kind == Kind::Clippy || !self.crates.is_empty() {
+        if builder.kind == Kind::Clippy || !self.crates.iter().any(|krate| krate == "test") {
             return;
         }
 
@@ -200,10 +198,11 @@ pub struct Rustc {
 
 impl Rustc {
     pub fn new(target: TargetSelection, builder: &Builder<'_>) -> Self {
-        let mut crates = vec![];
-        for krate in builder.in_tree_crates("rustc-main", None) {
-            crates.push(krate.name.to_string());
-        }
+        let crates = builder
+            .in_tree_crates("rustc-main", Some(target))
+            .into_iter()
+            .map(|krate| krate.name.to_string())
+            .collect();
         Self { target, crates: INTERNER.intern_list(crates) }
     }
 }
@@ -218,7 +217,7 @@ impl Step for Rustc {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = make_run_crates(&run, "compiler");
+        let crates = run.make_run_crates(Alias::Compiler);
         run.builder.ensure(Rustc { target: run.target, crates });
     }
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -55,17 +55,6 @@ impl Std {
     }
 }
 
-/// Given an `alias` selected by the `Step` and the paths passed on the command line,
-/// return a list of the crates that should be built.
-///
-/// Normally, people will pass *just* `library` if they pass it.
-/// But it's possible (although strange) to pass something like `library std core`.
-/// Build all crates anyway, as if they hadn't passed the other args.
-pub(crate) fn make_run_crates(run: &RunConfig<'_>, alias: &str) -> Interned<Vec<String>> {
-    let has_alias = run.paths.iter().any(|set| set.assert_single_path().path.ends_with(alias));
-    if has_alias { Default::default() } else { run.cargo_crates_in_set() }
-}
-
 impl Step for Std {
     type Output = ();
     const DEFAULT: bool = true;
@@ -80,10 +69,15 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
+        // If the paths include "library", build the entire standard library.
+        let has_alias =
+            run.paths.iter().any(|set| set.assert_single_path().path.ends_with("library"));
+        let crates = if has_alias { Default::default() } else { run.cargo_crates_in_set() };
+
         run.builder.ensure(Std {
             compiler: run.builder.compiler(run.builder.top_stage, run.build_triple()),
             target: run.target,
-            crates: make_run_crates(&run, "library"),
+            crates,
             force_recompile: false,
         });
     }

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -106,7 +106,12 @@ impl Step for JsonDocs {
     /// Builds the `rust-docs-json` installer component.
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
         let host = self.host;
-        builder.ensure(crate::doc::Std::new(builder.top_stage, host, DocumentationFormat::JSON));
+        builder.ensure(crate::doc::Std::new(
+            builder.top_stage,
+            host,
+            builder,
+            DocumentationFormat::JSON,
+        ));
 
         let dest = "share/doc/rust/json";
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1493,6 +1493,7 @@ impl Build {
                 }
             }
         }
+        ret.sort_unstable_by_key(|krate| krate.name); // reproducible order needed for tests
         ret
     }
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -907,6 +907,7 @@ impl Step for RustdocJSStd {
             builder.ensure(crate::doc::Std::new(
                 builder.top_stage,
                 self.target,
+                builder,
                 DocumentationFormat::HTML,
             ));
             builder.run(&mut command);

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -988,6 +988,11 @@ fn string_without_closing_tag<T: Display>(
                     )
                     .ok()
                     .map(|(url, _, _)| url),
+                    LinkFromSrc::Doc(def_id) => {
+                        format::href_with_root_path(*def_id, context, Some(&href_context.root_path))
+                            .ok()
+                            .map(|(doc_link, _, _)| doc_link)
+                    }
                 }
             })
         {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -349,7 +349,12 @@ impl<'tcx> Context<'tcx> {
                     let e = ExternalCrate { crate_num: cnum };
                     (e.name(self.tcx()), e.src_root(self.tcx()))
                 }
-                ExternalLocation::Unknown => return None,
+                ExternalLocation::Unknown => {
+                    let e = ExternalCrate { crate_num: cnum };
+                    let name = e.name(self.tcx());
+                    root = name.to_string();
+                    (name, e.src_root(self.tcx()))
+                }
             };
 
             let href = RefCell::new(PathBuf::new());

--- a/tests/rustdoc-gui/source-anchor-scroll.goml
+++ b/tests/rustdoc-gui/source-anchor-scroll.goml
@@ -7,11 +7,11 @@ set-window-size: (600, 800)
 // We check that the scroll is at the top first.
 assert-property: ("html", {"scrollTop": "0"})
 
-click: '//a[text() = "barbar"]'
+click: '//a[text() = "barbar" and @href="#5-7"]'
 assert-property: ("html", {"scrollTop": "149"})
-click: '//a[text() = "bar"]'
+click: '//a[text() = "bar" and @href="#28-36"]'
 assert-property: ("html", {"scrollTop": "180"})
-click: '//a[text() = "sub_fn"]'
+click: '//a[text() = "sub_fn" and @href="#2-4"]'
 assert-property: ("html", {"scrollTop": "77"})
 
 // We now check that clicking on lines doesn't change the scroll

--- a/tests/rustdoc/check-source-code-urls-to-def.rs
+++ b/tests/rustdoc/check-source-code-urls-to-def.rs
@@ -14,10 +14,10 @@ extern crate source_code;
 #[path = "auxiliary/source-code-bar.rs"]
 pub mod bar;
 
-// @count - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#5"]' 4
+// @count - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#5-7"]' 4
 use bar::Bar;
-// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#13"]' 'self'
-// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14"]' 'Trait'
+// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#13-17"]' 'self'
+// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14-16"]' 'Trait'
 use bar::sub::{self, Trait};
 
 pub struct Foo;
@@ -32,7 +32,8 @@ fn babar() {}
 // @has - '//pre[@class="rust"]//a/@href' '/primitive.u32.html'
 // @has - '//pre[@class="rust"]//a/@href' '/primitive.str.html'
 // @count - '//pre[@class="rust"]//a[@href="#23"]' 5
-// @has - '//pre[@class="rust"]//a[@href="../../source_code/struct.SourceCode.html"]' 'source_code::SourceCode'
+// @has - '//pre[@class="rust"]//a[@href="../../source_code/struct.SourceCode.html"]' \
+//        'source_code::SourceCode'
 pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar, f: source_code::SourceCode) {
     let x = 12;
     let y: Foo = Foo;
@@ -42,15 +43,15 @@ pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar, f: source_code::Sour
     y.hello();
 }
 
-// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14"]' 'bar::sub::Trait'
-// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14"]' 'Trait'
+// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14-16"]' 'bar::sub::Trait'
+// @has - '//pre[@class="rust"]//a[@href="auxiliary/source-code-bar.rs.html#14-16"]' 'Trait'
 pub fn foo2<T: bar::sub::Trait, V: Trait>(t: &T, v: &V, b: bool) {}
 
 pub trait AnotherTrait {}
 pub trait WhyNot {}
 
-// @has - '//pre[@class="rust"]//a[@href="#49"]' 'AnotherTrait'
-// @has - '//pre[@class="rust"]//a[@href="#50"]' 'WhyNot'
+// @has - '//pre[@class="rust"]//a[@href="#50"]' 'AnotherTrait'
+// @has - '//pre[@class="rust"]//a[@href="#51"]' 'WhyNot'
 pub fn foo3<T, V>(t: &T, v: &V)
 where
     T: AnotherTrait,
@@ -59,7 +60,7 @@ where
 
 pub trait AnotherTrait2 {}
 
-// @has - '//pre[@class="rust"]//a[@href="#60"]' 'AnotherTrait2'
+// @has - '//pre[@class="rust"]//a[@href="#61"]' 'AnotherTrait2'
 pub fn foo4() {
     let x: Vec<AnotherTrait2> = Vec::new();
 }

--- a/tests/rustdoc/jump-to-def-doc-links.rs
+++ b/tests/rustdoc/jump-to-def-doc-links.rs
@@ -1,0 +1,51 @@
+// compile-flags: -Zunstable-options --generate-link-to-definition
+
+#![crate_name = "foo"]
+
+// @has 'src/foo/jump-to-def-doc-links.rs.html'
+
+// @has - '//a[@href="../../foo/struct.Bar.html"]' 'Bar'
+// @has - '//a[@href="../../foo/struct.Foo.html"]' 'Foo'
+pub struct Bar; pub struct Foo;
+
+// @has - '//a[@href="../../foo/enum.Enum.html"]' 'Enum'
+pub enum Enum {
+    Variant1(String),
+    Variant2(u8),
+}
+
+// @has - '//a[@href="../../foo/struct.Struct.html"]' 'Struct'
+pub struct Struct {
+    pub a: u8,
+    b: Foo,
+}
+
+impl Struct {
+    pub fn foo() {}
+    pub fn foo2(&self) {}
+    fn bar() {}
+    fn bar(&self) {}
+}
+
+// @has - '//a[@href="../../foo/trait.Trait.html"]' 'Trait'
+pub trait Trait {
+    fn foo();
+}
+
+impl Trait for Struct {
+    fn foo() {}
+}
+
+// @has - '//a[@href="../../foo/union.Union.html"]' 'Union'
+pub union Union {
+    pub a: u16,
+    pub f: u32,
+}
+
+// @has - '//a[@href="../../foo/fn.bar.html"]' 'bar'
+pub fn bar(b: Bar) {
+     let x = Foo;
+}
+
+// @has - '//a[@href="../../foo/bar/index.html"]' 'bar'
+pub mod bar {}

--- a/tests/ui/inference/need_type_info/infer-var-for-self-param.rs
+++ b/tests/ui/inference/need_type_info/infer-var-for-self-param.rs
@@ -1,0 +1,7 @@
+// Regression test for #113610 where we ICEd when trying to print
+// inference variables created by instantiating the self type parameter.
+
+fn main() {
+    let _ = (Default::default(),);
+    //~^ ERROR cannot call associated function on trait
+}

--- a/tests/ui/inference/need_type_info/infer-var-for-self-param.stderr
+++ b/tests/ui/inference/need_type_info/infer-var-for-self-param.stderr
@@ -1,0 +1,14 @@
+error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
+  --> $DIR/infer-var-for-self-param.rs:5:14
+   |
+LL |     let _ = (Default::default(),);
+   |              ^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |
+help: use a fully-qualified path to a specific available implementation (271 found)
+   |
+LL |     let _ = (</* self type */ as Default>::default(),);
+   |              +++++++++++++++++++        +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0790`.


### PR DESCRIPTION
Successful merges:

 - #112982 (bootstrap: update defaults for `compiler` and `library` aliases)
 - #113536 (avoid building proof trees in select)
 - #113558 (Only use max_line_length = 100 for *.rs)
 - #113570 (refactor proof tree formatting)
 - #113623 (Add jump to doc)
 - #113631 (make MCP510 behavior opt-in to avoid conflicts between the CLI and target flavors)
 - #113651 (self type param infer, avoid ICE)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112982,113536,113558,113570,113623,113631,113651)
<!-- homu-ignore:end -->