### PR TITLE
Make privacy visitor use types more (instead of HIR)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4374,6 +4374,7 @@ dependencies = [
  "rustc_middle",
  "rustc_session",
  "rustc_span",
+ "rustc_ty_utils",
  "tracing",
 ]
 

--- a/compiler/rustc_privacy/Cargo.toml
+++ b/compiler/rustc_privacy/Cargo.toml
@@ -16,5 +16,6 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_middle = { path = "../rustc_middle" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
+rustc_ty_utils = { path = "../rustc_ty_utils" }
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -21,7 +21,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId, CRATE_DEF_ID};
 use rustc_hir::intravisit::{self, Visitor};
-use rustc_hir::{AssocItemKind, ForeignItemKind, ItemId, PatKind};
+use rustc_hir::{AssocItemKind, ForeignItemKind, ItemId, ItemKind, PatKind};
 use rustc_middle::middle::privacy::{EffectiveVisibilities, EffectiveVisibility, Level};
 use rustc_middle::query::Providers;
 use rustc_middle::ty::GenericArgs;
@@ -172,6 +172,10 @@ where
     V: DefIdVisitor<'tcx> + ?Sized,
 {
     type BreakTy = V::BreakTy;
+
+    fn visit_predicate(&mut self, p: ty::Predicate<'tcx>) -> ControlFlow<Self::BreakTy> {
+        self.visit_clause(p.as_clause().unwrap())
+    }
 
     fn visit_ty(&mut self, ty: Ty<'tcx>) -> ControlFlow<V::BreakTy> {
         let tcx = self.def_id_visitor.tcx();
@@ -1076,6 +1080,14 @@ impl<'tcx> TypePrivacyVisitor<'tcx> {
     }
 }
 
+impl<'tcx> rustc_ty_utils::sig_types::SpannedTypeVisitor<'tcx> for TypePrivacyVisitor<'tcx> {
+    type BreakTy = ();
+    fn visit(&mut self, span: Span, value: impl TypeVisitable<TyCtxt<'tcx>>) -> ControlFlow<()> {
+        self.span = span;
+        value.visit_with(&mut self.skeleton())
+    }
+}
+
 impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
     fn visit_nested_body(&mut self, body_id: hir::BodyId) {
         let old_maybe_typeck_results =
@@ -1086,18 +1098,15 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
 
     fn visit_ty(&mut self, hir_ty: &'tcx hir::Ty<'tcx>) {
         self.span = hir_ty.span;
-        if let Some(typeck_results) = self.maybe_typeck_results {
-            // Types in bodies.
-            if self.visit(typeck_results.node_type(hir_ty.hir_id)).is_break() {
-                return;
-            }
-        } else {
-            // Types in signatures.
-            // FIXME: This is very ineffective. Ideally each HIR type should be converted
-            // into a semantic type only once and the result should be cached somehow.
-            if self.visit(rustc_hir_analysis::hir_ty_to_ty(self.tcx, hir_ty)).is_break() {
-                return;
-            }
+        if self
+            .visit(
+                self.maybe_typeck_results
+                    .unwrap_or_else(|| span_bug!(hir_ty.span, "`hir::Ty` outside of a body"))
+                    .node_type(hir_ty.hir_id),
+            )
+            .is_break()
+        {
+            return;
         }
 
         intravisit::walk_ty(self, hir_ty);
@@ -1105,52 +1114,23 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
 
     fn visit_infer(&mut self, inf: &'tcx hir::InferArg) {
         self.span = inf.span;
-        if let Some(typeck_results) = self.maybe_typeck_results {
-            if let Some(ty) = typeck_results.node_type_opt(inf.hir_id) {
-                if self.visit(ty).is_break() {
-                    return;
-                }
-            } else {
-                // FIXME: check types of const infers here.
+        if let Some(ty) = self
+            .maybe_typeck_results
+            .unwrap_or_else(|| span_bug!(inf.span, "`hir::InferArg` outside of a body"))
+            .node_type_opt(inf.hir_id)
+        {
+            if self.visit(ty).is_break() {
+                return;
             }
         } else {
-            span_bug!(self.span, "`hir::InferArg` outside of a body");
+            // FIXME: check types of const infers here.
         }
         intravisit::walk_inf(self, inf);
     }
 
     fn visit_trait_ref(&mut self, trait_ref: &'tcx hir::TraitRef<'tcx>) {
         self.span = trait_ref.path.span;
-        if self.maybe_typeck_results.is_some() {
-            // Privacy of traits in bodies is checked as a part of trait object types.
-        } else {
-            let bounds = rustc_hir_analysis::hir_trait_to_predicates(
-                self.tcx,
-                trait_ref,
-                // NOTE: This isn't really right, but the actual type doesn't matter here. It's
-                // just required by `ty::TraitRef`.
-                self.tcx.types.never,
-            );
-
-            for (clause, _) in bounds.clauses() {
-                match clause.kind().skip_binder() {
-                    ty::ClauseKind::Trait(trait_predicate) => {
-                        if self.visit_trait(trait_predicate.trait_ref).is_break() {
-                            return;
-                        }
-                    }
-                    ty::ClauseKind::Projection(proj_predicate) => {
-                        let term = self.visit(proj_predicate.term);
-                        if term.is_break()
-                            || self.visit_projection_ty(proj_predicate.projection_ty).is_break()
-                        {
-                            return;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
+        // Privacy of traits in bodies is checked as a part of trait object types.
 
         intravisit::walk_trait_ref(self, trait_ref);
     }
@@ -1727,7 +1707,26 @@ fn check_mod_privacy(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
     // inferred types of expressions and patterns.
     let span = tcx.def_span(module_def_id);
     let mut visitor = TypePrivacyVisitor { tcx, module_def_id, maybe_typeck_results: None, span };
-    tcx.hir().visit_item_likes_in_module(module_def_id, &mut visitor);
+
+    let module = tcx.hir_module_items(module_def_id);
+    for def_id in module.definitions() {
+        rustc_ty_utils::sig_types::walk_types(tcx, def_id, &mut visitor);
+
+        if let Some(body_id) = tcx.hir().maybe_body_owned_by(def_id) {
+            visitor.visit_nested_body(body_id);
+        }
+    }
+
+    for id in module.items() {
+        if let ItemKind::Impl(i) = tcx.hir().item(id).kind {
+            if let Some(item) = i.of_trait {
+                let trait_ref = tcx.impl_trait_ref(id.owner_id.def_id).unwrap();
+                let trait_ref = trait_ref.instantiate_identity();
+                visitor.span = item.path.span;
+                visitor.visit_def_id(trait_ref.def_id, "trait", &trait_ref.print_only_trait_path());
+            }
+        }
+    }
 }
 
 fn effective_visibilities(tcx: TyCtxt<'_>, (): ()) -> &EffectiveVisibilities {

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -98,9 +98,6 @@ trait DefIdVisitor<'tcx> {
     fn visit_trait(&mut self, trait_ref: TraitRef<'tcx>) -> ControlFlow<Self::BreakTy> {
         self.skeleton().visit_trait(trait_ref)
     }
-    fn visit_projection_ty(&mut self, projection: ty::AliasTy<'tcx>) -> ControlFlow<Self::BreakTy> {
-        self.skeleton().visit_projection_ty(projection)
-    }
     fn visit_predicates(
         &mut self,
         predicates: ty::GenericPredicates<'tcx>,

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1128,13 +1128,6 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
         intravisit::walk_inf(self, inf);
     }
 
-    fn visit_trait_ref(&mut self, trait_ref: &'tcx hir::TraitRef<'tcx>) {
-        self.span = trait_ref.path.span;
-        // Privacy of traits in bodies is checked as a part of trait object types.
-
-        intravisit::walk_trait_ref(self, trait_ref);
-    }
-
     // Check types of expressions
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
         if self.check_expr_pat_type(expr.hir_id, expr.span) {

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -37,7 +37,7 @@ mod layout_sanity_check;
 mod needs_drop;
 mod opaque_types;
 mod representability;
-mod sig_types;
+pub mod sig_types;
 mod structural_match;
 mod ty;
 

--- a/compiler/rustc_ty_utils/src/sig_types.rs
+++ b/compiler/rustc_ty_utils/src/sig_types.rs
@@ -42,11 +42,10 @@ pub(crate) fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
         DefKind::TyAlias {..} | DefKind::AssocTy |
         // Walk over the type of the item
         DefKind::Static(_) | DefKind::Const | DefKind::AssocConst | DefKind::AnonConst => {
-            let span = match tcx.hir_node_by_def_id(item).ty() {
-                Some(ty) => ty.span,
-                _ => tcx.def_span(item),
-            };
-            visitor.visit(span, tcx.type_of(item).instantiate_identity());
+            if let Some(ty) = tcx.hir_node_by_def_id(item).ty() {
+                // Associated types in traits don't necessarily have a type that we can visit
+                visitor.visit(ty.span, tcx.type_of(item).instantiate_identity())?;
+            }
             for (pred, span) in tcx.predicates_of(item).instantiate_identity(tcx) {
                 visitor.visit(span, pred)?;
             }

--- a/compiler/rustc_ty_utils/src/sig_types.rs
+++ b/compiler/rustc_ty_utils/src/sig_types.rs
@@ -8,7 +8,7 @@ use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::Span;
 use rustc_type_ir::visit::TypeVisitable;
 
-pub(crate) trait SpannedTypeVisitor<'tcx> {
+pub trait SpannedTypeVisitor<'tcx> {
     type BreakTy = !;
     fn visit(
         &mut self,
@@ -17,7 +17,7 @@ pub(crate) trait SpannedTypeVisitor<'tcx> {
     ) -> ControlFlow<Self::BreakTy>;
 }
 
-pub(crate) fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
+pub fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
     tcx: TyCtxt<'tcx>,
     item: LocalDefId,
     visitor: &mut V,

--- a/compiler/rustc_ty_utils/src/sig_types.rs
+++ b/compiler/rustc_ty_utils/src/sig_types.rs
@@ -88,7 +88,6 @@ pub(crate) fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
             }
         }
         | DefKind::Variant
-        | DefKind::ForeignTy
         | DefKind::TyParam
         | DefKind::ConstParam
         | DefKind::Ctor(_, _)
@@ -102,6 +101,7 @@ pub(crate) fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
         // These don't have any types.
         | DefKind::ExternCrate
         | DefKind::ForeignMod
+        | DefKind::ForeignTy
         | DefKind::Macro(_)
         | DefKind::GlobalAsm
         | DefKind::Mod

--- a/tests/ui/dyn-keyword/dyn-2018-edition-lint.rs
+++ b/tests/ui/dyn-keyword/dyn-2018-edition-lint.rs
@@ -6,14 +6,6 @@ fn function(x: &SomeTrait, y: Box<SomeTrait>) {
     //~| WARN this is accepted in the current edition
     //~| ERROR trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
-    //~| ERROR trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition
-    //~| ERROR trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition
-    //~| ERROR trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition
-    //~| ERROR trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition
     let _x: &SomeTrait = todo!();
     //~^ ERROR trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition

--- a/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -30,7 +30,7 @@ LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
    |                                   +++
 
 error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/dyn-2018-edition-lint.rs:17:14
+  --> $DIR/dyn-2018-edition-lint.rs:9:14
    |
 LL |     let _x: &SomeTrait = todo!();
    |              ^^^^^^^^^
@@ -42,61 +42,5 @@ help: use `dyn`
 LL |     let _x: &dyn SomeTrait = todo!();
    |              +++
 
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/dyn-2018-edition-lint.rs:4:17
-   |
-LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-   |                 ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   |                 +++
-
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/dyn-2018-edition-lint.rs:4:17
-   |
-LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-   |                 ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   |                 +++
-
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/dyn-2018-edition-lint.rs:4:35
-   |
-LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-   |                                   ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   |                                   +++
-
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/dyn-2018-edition-lint.rs:4:35
-   |
-LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-   |                                   ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   |                                   +++
-
-error: aborting due to 7 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.rs
+++ b/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.rs
@@ -4,10 +4,6 @@
 
 fn ice() -> impl AsRef<Fn(&())> {
     //~^ WARN trait objects without an explicit `dyn` are deprecated
-    //~| WARN trait objects without an explicit `dyn` are deprecated
-    //~| WARN trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-    //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     Foo
 }

--- a/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
+++ b/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
@@ -12,33 +12,5 @@ help: use `dyn`
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {
    |                        +++
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/fresh-lifetime-from-bare-trait-obj-114664.rs:5:24
-   |
-LL | fn ice() -> impl AsRef<Fn(&())> {
-   |                        ^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | fn ice() -> impl AsRef<dyn Fn(&())> {
-   |                        +++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/fresh-lifetime-from-bare-trait-obj-114664.rs:5:24
-   |
-LL | fn ice() -> impl AsRef<Fn(&())> {
-   |                        ^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | fn ice() -> impl AsRef<dyn Fn(&())> {
-   |                        +++
-
-warning: 3 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.rs
+++ b/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.rs
@@ -10,9 +10,5 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -12,33 +12,5 @@ help: use `dyn`
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: 3 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/lint/force-warn/cap-lints-allow.rs
+++ b/tests/ui/lint/force-warn/cap-lints-allow.rs
@@ -8,9 +8,5 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/tests/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/tests/ui/lint/force-warn/cap-lints-allow.stderr
@@ -12,33 +12,5 @@ help: use `dyn`
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/cap-lints-allow.rs:8:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/cap-lints-allow.rs:8:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: 3 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.rs
+++ b/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.rs
@@ -8,9 +8,5 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -13,33 +13,5 @@ help: use `dyn`
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: 3 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/lint/force-warn/lint-group-allowed-lint-group.rs
+++ b/tests/ui/lint/force-warn/lint-group-allowed-lint-group.rs
@@ -10,9 +10,5 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -13,33 +13,5 @@ help: use `dyn`
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/lint-group-allowed-lint-group.rs:10:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/lint-group-allowed-lint-group.rs:10:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: 3 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.rs
+++ b/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.rs
@@ -10,9 +10,5 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -13,33 +13,5 @@ help: use `dyn`
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
-   |
-LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | pub fn function(_x: Box<dyn SomeTrait>) {}
-   |                         +++
-
-warning: 3 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/lint/lint-stability-deprecated.rs
+++ b/tests/ui/lint/lint-stability-deprecated.rs
@@ -96,13 +96,10 @@ mod cross_crate {
         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
         //~^ WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
-        //~| WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
         type A = dyn TraitWithAssociatedTypes<
             TypeUnstable = u8,
             TypeDeprecated = u16,
             //~^ WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`
-            //~| WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`
-            //~| WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`
         >;
 
         let _ = DeprecatedStruct { //~ WARN use of deprecated struct `lint_stability::DeprecatedStruct`

--- a/tests/ui/lint/lint-stability-deprecated.stderr
+++ b/tests/ui/lint/lint-stability-deprecated.stderr
@@ -77,241 +77,241 @@ LL | ...   <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated struct `lint_stability::DeprecatedStruct`: text
-  --> $DIR/lint-stability-deprecated.rs:108:17
+  --> $DIR/lint-stability-deprecated.rs:105:17
    |
 LL |         let _ = DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated struct `lint_stability::DeprecatedUnstableStruct`: text
-  --> $DIR/lint-stability-deprecated.rs:111:17
+  --> $DIR/lint-stability-deprecated.rs:108:17
    |
 LL |         let _ = DeprecatedUnstableStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated unit struct `lint_stability::DeprecatedUnitStruct`: text
-  --> $DIR/lint-stability-deprecated.rs:118:17
+  --> $DIR/lint-stability-deprecated.rs:115:17
    |
 LL |         let _ = DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated unit struct `lint_stability::DeprecatedUnstableUnitStruct`: text
-  --> $DIR/lint-stability-deprecated.rs:119:17
+  --> $DIR/lint-stability-deprecated.rs:116:17
    |
 LL |         let _ = DeprecatedUnstableUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated unit variant `lint_stability::Enum::DeprecatedVariant`: text
-  --> $DIR/lint-stability-deprecated.rs:123:23
+  --> $DIR/lint-stability-deprecated.rs:120:23
    |
 LL |         let _ = Enum::DeprecatedVariant;
    |                       ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated unit variant `lint_stability::Enum::DeprecatedUnstableVariant`: text
-  --> $DIR/lint-stability-deprecated.rs:124:23
+  --> $DIR/lint-stability-deprecated.rs:121:23
    |
 LL |         let _ = Enum::DeprecatedUnstableVariant;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated tuple struct `lint_stability::DeprecatedTupleStruct`: text
-  --> $DIR/lint-stability-deprecated.rs:128:17
+  --> $DIR/lint-stability-deprecated.rs:125:17
    |
 LL |         let _ = DeprecatedTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated tuple struct `lint_stability::DeprecatedUnstableTupleStruct`: text
-  --> $DIR/lint-stability-deprecated.rs:129:17
+  --> $DIR/lint-stability-deprecated.rs:126:17
    |
 LL |         let _ = DeprecatedUnstableTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated function `lint_stability::deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:138:25
+  --> $DIR/lint-stability-deprecated.rs:135:25
    |
 LL |         macro_test_arg!(deprecated_text());
    |                         ^^^^^^^^^^^^^^^
 
 warning: use of deprecated function `lint_stability::deprecated_unstable_text`: text
-  --> $DIR/lint-stability-deprecated.rs:139:25
+  --> $DIR/lint-stability-deprecated.rs:136:25
    |
 LL |         macro_test_arg!(deprecated_unstable_text());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated function `lint_stability::deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:140:41
+  --> $DIR/lint-stability-deprecated.rs:137:41
    |
 LL |         macro_test_arg!(macro_test_arg!(deprecated_text()));
    |                                         ^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:145:16
+  --> $DIR/lint-stability-deprecated.rs:142:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:147:25
+  --> $DIR/lint-stability-deprecated.rs:144:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |                         ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:149:16
+  --> $DIR/lint-stability-deprecated.rs:146:16
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:151:25
+  --> $DIR/lint-stability-deprecated.rs:148:25
    |
 LL |         <Foo as Trait>::trait_deprecated_text(&foo);
    |                         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
-  --> $DIR/lint-stability-deprecated.rs:153:16
+  --> $DIR/lint-stability-deprecated.rs:150:16
    |
 LL |         Trait::trait_deprecated_unstable(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
-  --> $DIR/lint-stability-deprecated.rs:155:25
+  --> $DIR/lint-stability-deprecated.rs:152:25
    |
 LL | ...   <Foo as Trait>::trait_deprecated_unstable(&foo);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
-  --> $DIR/lint-stability-deprecated.rs:157:16
+  --> $DIR/lint-stability-deprecated.rs:154:16
    |
 LL | ...   Trait::trait_deprecated_unstable_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
-  --> $DIR/lint-stability-deprecated.rs:159:25
+  --> $DIR/lint-stability-deprecated.rs:156:25
    |
 LL | ...   <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated trait `lint_stability::DeprecatedTrait`: text
-  --> $DIR/lint-stability-deprecated.rs:187:10
+  --> $DIR/lint-stability-deprecated.rs:184:10
    |
 LL |     impl DeprecatedTrait for S {}
    |          ^^^^^^^^^^^^^^^
 
 warning: use of deprecated trait `lint_stability::DeprecatedTrait`: text
-  --> $DIR/lint-stability-deprecated.rs:189:25
+  --> $DIR/lint-stability-deprecated.rs:186:25
    |
 LL |     trait LocalTrait2 : DeprecatedTrait { }
    |                         ^^^^^^^^^^^^^^^
 
 warning: use of deprecated function `inheritance::inherited_stability::unstable_mod::deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:208:23
+  --> $DIR/lint-stability-deprecated.rs:205:23
    |
 LL |         unstable_mod::deprecated();
    |                       ^^^^^^^^^^
 
 warning: use of deprecated function `this_crate::deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:330:9
+  --> $DIR/lint-stability-deprecated.rs:327:9
    |
 LL |         deprecated();
    |         ^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:335:16
+  --> $DIR/lint-stability-deprecated.rs:332:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:337:25
+  --> $DIR/lint-stability-deprecated.rs:334:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |                         ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated function `this_crate::deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:339:9
+  --> $DIR/lint-stability-deprecated.rs:336:9
    |
 LL |         deprecated_text();
    |         ^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:344:16
+  --> $DIR/lint-stability-deprecated.rs:341:16
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:346:25
+  --> $DIR/lint-stability-deprecated.rs:343:25
    |
 LL |         <Foo as Trait>::trait_deprecated_text(&foo);
    |                         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated struct `this_crate::DeprecatedStruct`: text
-  --> $DIR/lint-stability-deprecated.rs:384:17
+  --> $DIR/lint-stability-deprecated.rs:381:17
    |
 LL |         let _ = DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated unit struct `this_crate::DeprecatedUnitStruct`: text
-  --> $DIR/lint-stability-deprecated.rs:391:17
+  --> $DIR/lint-stability-deprecated.rs:388:17
    |
 LL |         let _ = DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated unit variant `this_crate::Enum::DeprecatedVariant`: text
-  --> $DIR/lint-stability-deprecated.rs:395:23
+  --> $DIR/lint-stability-deprecated.rs:392:23
    |
 LL |         let _ = Enum::DeprecatedVariant;
    |                       ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated tuple struct `this_crate::DeprecatedTupleStruct`: text
-  --> $DIR/lint-stability-deprecated.rs:399:17
+  --> $DIR/lint-stability-deprecated.rs:396:17
    |
 LL |         let _ = DeprecatedTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:406:16
+  --> $DIR/lint-stability-deprecated.rs:403:16
    |
 LL |         Trait::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:408:25
+  --> $DIR/lint-stability-deprecated.rs:405:25
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |                         ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:410:16
+  --> $DIR/lint-stability-deprecated.rs:407:16
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:412:25
+  --> $DIR/lint-stability-deprecated.rs:409:25
    |
 LL |         <Foo as Trait>::trait_deprecated_text(&foo);
    |                         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated function `this_crate::test_fn_body::fn_in_body`: text
-  --> $DIR/lint-stability-deprecated.rs:439:9
+  --> $DIR/lint-stability-deprecated.rs:436:9
    |
 LL |         fn_in_body();
    |         ^^^^^^^^^^
 
 warning: use of deprecated trait `this_crate::DeprecatedTrait`: text
-  --> $DIR/lint-stability-deprecated.rs:459:10
+  --> $DIR/lint-stability-deprecated.rs:456:10
    |
 LL |     impl DeprecatedTrait for S { }
    |          ^^^^^^^^^^^^^^^
 
 warning: use of deprecated trait `this_crate::DeprecatedTrait`: text
-  --> $DIR/lint-stability-deprecated.rs:461:24
+  --> $DIR/lint-stability-deprecated.rs:458:24
    |
 LL |     trait LocalTrait : DeprecatedTrait { }
    |                        ^^^^^^^^^^^^^^^
 
 warning: use of deprecated function `this_crate::MethodTester::test_method_body::fn_in_body`: text
-  --> $DIR/lint-stability-deprecated.rs:447:13
+  --> $DIR/lint-stability-deprecated.rs:444:13
    |
 LL |             fn_in_body();
    |             ^^^^^^^^^^
@@ -323,7 +323,7 @@ LL |         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
    |                                                ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:102:13
+  --> $DIR/lint-stability-deprecated.rs:101:13
    |
 LL |             TypeDeprecated = u16,
    |             ^^^^^^^^^^^^^^^^^^^^
@@ -449,214 +449,190 @@ LL | ...   <Foo>::trait_deprecated_unstable_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated field `lint_stability::DeprecatedStruct::i`: text
-  --> $DIR/lint-stability-deprecated.rs:109:13
+  --> $DIR/lint-stability-deprecated.rs:106:13
    |
 LL |             i: 0
    |             ^^^^
 
 warning: use of deprecated field `lint_stability::DeprecatedUnstableStruct::i`: text
-  --> $DIR/lint-stability-deprecated.rs:113:13
+  --> $DIR/lint-stability-deprecated.rs:110:13
    |
 LL |             i: 0
    |             ^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:144:13
+  --> $DIR/lint-stability-deprecated.rs:141:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:146:16
+  --> $DIR/lint-stability-deprecated.rs:143:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:148:13
+  --> $DIR/lint-stability-deprecated.rs:145:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:150:16
+  --> $DIR/lint-stability-deprecated.rs:147:16
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
-  --> $DIR/lint-stability-deprecated.rs:152:13
+  --> $DIR/lint-stability-deprecated.rs:149:13
    |
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
-  --> $DIR/lint-stability-deprecated.rs:154:16
+  --> $DIR/lint-stability-deprecated.rs:151:16
    |
 LL |         <Foo>::trait_deprecated_unstable(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
-  --> $DIR/lint-stability-deprecated.rs:156:13
+  --> $DIR/lint-stability-deprecated.rs:153:13
    |
 LL | ...   foo.trait_deprecated_unstable_text();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
-  --> $DIR/lint-stability-deprecated.rs:158:16
+  --> $DIR/lint-stability-deprecated.rs:155:16
    |
 LL | ...   <Foo>::trait_deprecated_unstable_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:175:13
+  --> $DIR/lint-stability-deprecated.rs:172:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:176:13
+  --> $DIR/lint-stability-deprecated.rs:173:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable`: text
-  --> $DIR/lint-stability-deprecated.rs:177:13
+  --> $DIR/lint-stability-deprecated.rs:174:13
    |
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated_unstable_text`: text
-  --> $DIR/lint-stability-deprecated.rs:178:13
+  --> $DIR/lint-stability-deprecated.rs:175:13
    |
 LL | ...   foo.trait_deprecated_unstable_text();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::MethodTester::method_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:331:13
+  --> $DIR/lint-stability-deprecated.rs:328:13
    |
 LL |         foo.method_deprecated();
    |             ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::MethodTester::method_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:332:14
+  --> $DIR/lint-stability-deprecated.rs:329:14
    |
 LL |         Foo::method_deprecated(&foo);
    |              ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::MethodTester::method_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:333:16
+  --> $DIR/lint-stability-deprecated.rs:330:16
    |
 LL |         <Foo>::method_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:334:13
+  --> $DIR/lint-stability-deprecated.rs:331:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:336:16
+  --> $DIR/lint-stability-deprecated.rs:333:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:340:13
+  --> $DIR/lint-stability-deprecated.rs:337:13
    |
 LL |         foo.method_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:341:14
+  --> $DIR/lint-stability-deprecated.rs:338:14
    |
 LL |         Foo::method_deprecated_text(&foo);
    |              ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::MethodTester::method_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:342:16
+  --> $DIR/lint-stability-deprecated.rs:339:16
    |
 LL |         <Foo>::method_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:343:13
+  --> $DIR/lint-stability-deprecated.rs:340:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:345:16
+  --> $DIR/lint-stability-deprecated.rs:342:16
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated field `this_crate::DeprecatedStruct::i`: text
-  --> $DIR/lint-stability-deprecated.rs:386:13
+  --> $DIR/lint-stability-deprecated.rs:383:13
    |
 LL |             i: 0
    |             ^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:405:13
+  --> $DIR/lint-stability-deprecated.rs:402:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:407:16
+  --> $DIR/lint-stability-deprecated.rs:404:16
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |                ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:409:13
+  --> $DIR/lint-stability-deprecated.rs:406:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:411:16
+  --> $DIR/lint-stability-deprecated.rs:408:16
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
    |                ^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:428:13
+  --> $DIR/lint-stability-deprecated.rs:425:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
 warning: use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
-  --> $DIR/lint-stability-deprecated.rs:429:13
+  --> $DIR/lint-stability-deprecated.rs:426:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:97:48
-   |
-LL |         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
-   |                                                ^^^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:102:13
-   |
-LL |             TypeDeprecated = u16,
-   |             ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:102:13
-   |
-LL |             TypeDeprecated = u16,
-   |             ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: 108 warnings emitted
+warning: 105 warnings emitted
 

--- a/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.rs
+++ b/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.rs
@@ -8,8 +8,6 @@ trait Foo {
 
 fn foo(_: &dyn Foo<Bar = ()>) {}
 //~^ WARN: unnecessary associated type bound for not object safe associated type
-//~| WARN: unnecessary associated type bound for not object safe associated type
-//~| WARN: unnecessary associated type bound for not object safe associated type
 
 #[allow(unused_associated_type_bounds)]
 fn bar(_: &dyn Foo<Bar = ()>) {}

--- a/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.stderr
@@ -7,23 +7,5 @@ LL | fn foo(_: &dyn Foo<Bar = ()>) {}
    = note: this associated type has a `where Self: Sized` bound. Thus, while the associated type can be specified, it cannot be used in any way, because trait objects are not `Sized`.
    = note: `#[warn(unused_associated_type_bounds)]` on by default
 
-warning: unnecessary associated type bound for not object safe associated type
-  --> $DIR/assoc_type_bounds_sized_unnecessary.rs:9:20
-   |
-LL | fn foo(_: &dyn Foo<Bar = ()>) {}
-   |                    ^^^^^^^^ help: remove this bound
-   |
-   = note: this associated type has a `where Self: Sized` bound. Thus, while the associated type can be specified, it cannot be used in any way, because trait objects are not `Sized`.
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: unnecessary associated type bound for not object safe associated type
-  --> $DIR/assoc_type_bounds_sized_unnecessary.rs:9:20
-   |
-LL | fn foo(_: &dyn Foo<Bar = ()>) {}
-   |                    ^^^^^^^^ help: remove this bound
-   |
-   = note: this associated type has a `where Self: Sized` bound. Thus, while the associated type can be specified, it cannot be used in any way, because trait objects are not `Sized`.
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: 3 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/privacy/associated-item-privacy-trait.stderr
+++ b/tests/ui/privacy/associated-item-privacy-trait.stderr
@@ -75,17 +75,6 @@ LL |     priv_trait::mac!();
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: trait `PrivTr` is private
-  --> $DIR/associated-item-privacy-trait.rs:29:14
-   |
-LL |         impl PrivTr for u8 {}
-   |              ^^^^^^ private trait
-...
-LL |     priv_trait::mac!();
-   |     ------------------ in this macro invocation
-   |
-   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:46:21
    |
@@ -327,6 +316,17 @@ LL |     priv_parent_substs::mac!();
    |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: trait `PrivTr` is private
+  --> $DIR/associated-item-privacy-trait.rs:29:14
+   |
+LL |         impl PrivTr for u8 {}
+   |              ^^^^^^ private trait
+...
+LL |     priv_trait::mac!();
+   |     ------------------ in this macro invocation
+   |
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 30 previous errors
 

--- a/tests/ui/privacy/associated-item-privacy-type-binding.stderr
+++ b/tests/ui/privacy/associated-item-privacy-type-binding.stderr
@@ -32,10 +32,10 @@ LL |     priv_trait::mac1!();
    = note: this error originates in the macro `priv_trait::mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
-  --> $DIR/associated-item-privacy-type-binding.rs:16:31
+  --> $DIR/associated-item-privacy-type-binding.rs:16:37
    |
 LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^ private trait
+   |                                     ^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac1!();
    |     ------------------- in this macro invocation
@@ -164,10 +164,10 @@ LL |     priv_parent_substs::mac!();
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `Priv` is private
-  --> $DIR/associated-item-privacy-type-binding.rs:56:31
+  --> $DIR/associated-item-privacy-type-binding.rs:56:37
    |
 LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
-   |                               ^^^^^^^^^^^^^^^^^^^ private type
+   |                                     ^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     -------------------------- in this macro invocation

--- a/tests/ui/privacy/private-type-in-interface.stderr
+++ b/tests/ui/privacy/private-type-in-interface.stderr
@@ -47,10 +47,10 @@ LL | fn g() -> impl Tr2<m::Alias> { 0 }
    |           ^^^^^^^^^^^^^^^^^^ private type
 
 error: type `Priv` is private
-  --> $DIR/private-type-in-interface.rs:28:16
+  --> $DIR/private-type-in-interface.rs:28:11
    |
 LL | fn g() -> impl Tr2<m::Alias> { 0 }
-   |                ^^^^^^^^^^^^^ private type
+   |           ^^^^^^^^^^^^^^^^^^ private type
 
 error: type `ext::Priv` is private
   --> $DIR/private-type-in-interface.rs:30:15
@@ -59,10 +59,10 @@ LL | fn g_ext() -> impl Tr2<ext::Alias> { 0 }
    |               ^^^^^^^^^^^^^^^^^^^^ private type
 
 error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:30:20
+  --> $DIR/private-type-in-interface.rs:30:15
    |
 LL | fn g_ext() -> impl Tr2<ext::Alias> { 0 }
-   |                    ^^^^^^^^^^^^^^^ private type
+   |               ^^^^^^^^^^^^^^^^^^^^ private type
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/privacy/projections.rs
+++ b/tests/ui/privacy/projections.rs
@@ -1,0 +1,60 @@
+mod m {
+    struct Priv;
+    pub type Leak = Priv; //~ WARN: `Priv` is more private than the item `Leak`
+}
+
+trait Trait {
+    type A<T>;
+}
+
+impl Trait for u8 {
+    type A<T> = u8;
+}
+
+fn check() -> <u8 as Trait>::A<m::Leak> {
+    //~^ ERROR: `Priv` is private
+    0
+}
+
+trait Trait2 {
+    type A<T>;
+}
+
+impl Trait2 for u8 {
+    type A<T> = m::Leak;
+    //~^ ERROR: `Priv` is private
+    //~| ERROR: private type `Priv` in public interface
+}
+
+fn check2() -> <u8 as Trait2>::A<u32> {
+    //~^ ERROR: `Priv` is private
+    todo!()
+}
+
+trait Trait3 {
+    type A<T: Trait>;
+}
+
+impl Trait3 for u8 {
+    type A<T: Trait> = T::A<m::Leak>;
+    //~^ ERROR: `Priv` is private
+    //~| ERROR: private type `Priv` in public interface
+}
+
+fn check3() -> <u8 as Trait3>::A<u8> {
+    todo!()
+}
+
+trait Trait4 {
+    type A<T: Trait3>;
+}
+
+impl Trait4 for u8 {
+    type A<T: Trait3> = T::A<u8>;
+}
+
+fn check4() -> <u8 as Trait4>::A<u8> {
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/privacy/projections.stderr
+++ b/tests/ui/privacy/projections.stderr
@@ -1,0 +1,62 @@
+warning: type `Priv` is more private than the item `Leak`
+  --> $DIR/projections.rs:3:5
+   |
+LL |     pub type Leak = Priv;
+   |     ^^^^^^^^^^^^^ type alias `Leak` is reachable at visibility `pub(crate)`
+   |
+note: but type `Priv` is only usable at visibility `pub(self)`
+  --> $DIR/projections.rs:2:5
+   |
+LL |     struct Priv;
+   |     ^^^^^^^^^^^
+   = note: `#[warn(private_interfaces)]` on by default
+
+error[E0446]: private type `Priv` in public interface
+  --> $DIR/projections.rs:24:5
+   |
+LL |     struct Priv;
+   |     ----------- `Priv` declared as private
+...
+LL |     type A<T> = m::Leak;
+   |     ^^^^^^^^^ can't leak private type
+
+error[E0446]: private type `Priv` in public interface
+  --> $DIR/projections.rs:39:5
+   |
+LL |     struct Priv;
+   |     ----------- `Priv` declared as private
+...
+LL |     type A<T: Trait> = T::A<m::Leak>;
+   |     ^^^^^^^^^^^^^^^^ can't leak private type
+
+error: type `Priv` is private
+  --> $DIR/projections.rs:14:15
+   |
+LL | fn check() -> <u8 as Trait>::A<m::Leak> {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
+
+error: type `Priv` is private
+  --> $DIR/projections.rs:29:39
+   |
+LL |   fn check2() -> <u8 as Trait2>::A<u32> {
+   |  _______________________________________^
+LL | |
+LL | |     todo!()
+LL | | }
+   | |_^ private type
+
+error: type `Priv` is private
+  --> $DIR/projections.rs:24:17
+   |
+LL |     type A<T> = m::Leak;
+   |                 ^^^^^^^ private type
+
+error: type `Priv` is private
+  --> $DIR/projections.rs:39:24
+   |
+LL |     type A<T: Trait> = T::A<m::Leak>;
+   |                        ^^^^^^^^^^^^^ private type
+
+error: aborting due to 6 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0446`.

--- a/tests/ui/privacy/projections2.rs
+++ b/tests/ui/privacy/projections2.rs
@@ -1,0 +1,38 @@
+mod m {
+    use super::*;
+    struct Priv;
+    pub type Leak = Priv; //~ WARN: `Priv` is more private than the item `Leak`
+
+    trait Trait3 {
+        type A<T: Trait>;
+    }
+
+    impl Trait3 for u8 {
+        type A<T: Trait> = T::A<Leak>;
+    }
+
+    pub trait Trait4 {
+        type A<T: Trait>;
+    }
+
+    impl Trait4 for u8 {
+        type A<T: Trait> = <u8 as Trait3>::A<T>;
+        //~^ ERROR: private associated type `Trait3::A` in public interface
+        //~| ERROR: private trait `Trait3` in public interface
+    }
+}
+
+pub trait Trait {
+    type A<T>;
+}
+
+impl Trait for u8 {
+    type A<T> = u8;
+}
+use m::*;
+
+fn check4() -> <u8 as Trait4>::A<u8> {
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/privacy/projections2.stderr
+++ b/tests/ui/privacy/projections2.stderr
@@ -1,0 +1,34 @@
+warning: type `Priv` is more private than the item `Leak`
+  --> $DIR/projections2.rs:4:5
+   |
+LL |     pub type Leak = Priv;
+   |     ^^^^^^^^^^^^^ type alias `Leak` is reachable at visibility `pub(crate)`
+   |
+note: but type `Priv` is only usable at visibility `pub(self)`
+  --> $DIR/projections2.rs:3:5
+   |
+LL |     struct Priv;
+   |     ^^^^^^^^^^^
+   = note: `#[warn(private_interfaces)]` on by default
+
+error[E0446]: private associated type `Trait3::A` in public interface
+  --> $DIR/projections2.rs:19:9
+   |
+LL |         type A<T: Trait>;
+   |         ---------------- `Trait3::A` declared as private
+...
+LL |         type A<T: Trait> = <u8 as Trait3>::A<T>;
+   |         ^^^^^^^^^^^^^^^^ can't leak private associated type
+
+error[E0446]: private trait `Trait3` in public interface
+  --> $DIR/projections2.rs:19:9
+   |
+LL |     trait Trait3 {
+   |     ------------ `Trait3` declared as private
+...
+LL |         type A<T: Trait> = <u8 as Trait3>::A<T>;
+   |         ^^^^^^^^^^^^^^^^ can't leak private trait
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0446`.

--- a/tests/ui/privacy/struct-field-type.rs
+++ b/tests/ui/privacy/struct-field-type.rs
@@ -1,0 +1,10 @@
+mod m {
+    struct Priv;
+    pub type Leak = Priv; //~ WARN: `Priv` is more private than the item `Leak`
+}
+
+struct S {
+    field: m::Leak, //~ ERROR: `Priv` is private
+}
+
+fn main() {}

--- a/tests/ui/privacy/struct-field-type.stderr
+++ b/tests/ui/privacy/struct-field-type.stderr
@@ -1,0 +1,21 @@
+warning: type `Priv` is more private than the item `Leak`
+  --> $DIR/struct-field-type.rs:3:5
+   |
+LL |     pub type Leak = Priv;
+   |     ^^^^^^^^^^^^^ type alias `Leak` is reachable at visibility `pub(crate)`
+   |
+note: but type `Priv` is only usable at visibility `pub(self)`
+  --> $DIR/struct-field-type.rs:2:5
+   |
+LL |     struct Priv;
+   |     ^^^^^^^^^^^
+   = note: `#[warn(private_interfaces)]` on by default
+
+error: type `Priv` is private
+  --> $DIR/struct-field-type.rs:7:5
+   |
+LL |     field: m::Leak,
+   |     ^^^^^ private type
+
+error: aborting due to 1 previous error; 1 warning emitted
+

--- a/tests/ui/suggestions/issue-61963.rs
+++ b/tests/ui/suggestions/issue-61963.rs
@@ -18,19 +18,9 @@ pub struct Qux<T>(T);
 pub struct Foo {
     //~^ ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARN this is accepted in the current edition
-    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
-    //~| WARN this is accepted in the current edition
-    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
-    //~| WARN this is accepted in the current edition
-    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
-    //~| WARN this is accepted in the current edition
     qux: Qux<Qux<Baz>>,
     bar: Box<Bar>,
     //~^ ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
-    //~| WARN this is accepted in the current edition
-    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
-    //~| WARN this is accepted in the current edition
-    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARN this is accepted in the current edition
 }
 

--- a/tests/ui/suggestions/issue-61963.stderr
+++ b/tests/ui/suggestions/issue-61963.stderr
@@ -1,5 +1,5 @@
 error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-61963.rs:28:14
+  --> $DIR/issue-61963.rs:22:14
    |
 LL |     bar: Box<Bar>,
    |              ^^^
@@ -29,75 +29,5 @@ help: use `dyn`
 LL | dyn pub struct Foo {
    | +++
 
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-61963.rs:28:14
-   |
-LL |     bar: Box<Bar>,
-   |              ^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL |     bar: Box<dyn Bar>,
-   |              +++
-
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-61963.rs:28:14
-   |
-LL |     bar: Box<Bar>,
-   |              ^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL |     bar: Box<dyn Bar>,
-   |              +++
-
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-61963.rs:18:1
-   |
-LL | pub struct Foo {
-   | ^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | dyn pub struct Foo {
-   | +++
-
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-61963.rs:18:1
-   |
-LL | pub struct Foo {
-   | ^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | dyn pub struct Foo {
-   | +++
-
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-61963.rs:18:1
-   |
-LL | pub struct Foo {
-   | ^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use `dyn`
-   |
-LL | dyn pub struct Foo {
-   | +++
-
-error: aborting due to 7 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.rs
+++ b/tests/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.rs
@@ -31,10 +31,7 @@ impl Tr for E {
     type V = u8;
     fn f() -> Self::V { 0 }
     //~^ ERROR ambiguous associated item
-    //~| ERROR ambiguous associated item
     //~| WARN this was previously accepted
-    //~| WARN this was previously accepted
-    //~| HELP use fully-qualified syntax
     //~| HELP use fully-qualified syntax
 }
 

--- a/tests/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
@@ -18,25 +18,5 @@ LL |     type V;
    |     ^^^^^^
    = note: `#[deny(ambiguous_associated_items)]` on by default
 
-error: ambiguous associated item
-  --> $DIR/enum-variant-priority-lint-ambiguous_associated_items.rs:32:15
-   |
-LL |     fn f() -> Self::V { 0 }
-   |               ^^^^^^^ help: use fully-qualified syntax: `<E as Tr>::V`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
-note: `V` could refer to the variant defined here
-  --> $DIR/enum-variant-priority-lint-ambiguous_associated_items.rs:22:5
-   |
-LL |     V
-   |     ^
-note: `V` could also refer to the associated type defined here
-  --> $DIR/enum-variant-priority-lint-ambiguous_associated_items.rs:26:5
-   |
-LL |     type V;
-   |     ^^^^^^
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 


### PR DESCRIPTION
r? @petrochenkov 

This is a prerequisite to normalizing projections, as otherwise we have too many invalid bound vars (hir_ty_to_ty is creating types that have bound vars, but no binder).

The commits are still chaotic, I'm gonna clean them up, but I just wanted to let you know about the general direction and wondering if we could land this before adding normalization, as normalization is where behavioral changes happen, and I'd like to keep that part as minimal as possible.

[context can be found on zulip](https://rust-lang.zulipchat.com/#narrow/stream/315482-t-compiler.2Fetc.2Fopaque-types/topic/weak.20type.20aliases.20and.20privacy)