### PR TITLE
Match scrutinee need necessary parentheses for structs

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -666,6 +666,24 @@ trait UnusedDelimLint {
         if !followed_by_block {
             return false;
         }
+
+        // Check if we need parens for `match &( Struct { feild:  }) {}`.
+        {
+            let mut innermost = inner;
+            loop {
+                innermost = match &innermost.kind {
+                    ExprKind::AddrOf(_, _, expr) => expr,
+                    _ => {
+                        if parser::contains_exterior_struct_lit(&innermost) {
+                            return true;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
         let mut innermost = inner;
         loop {
             innermost = match &innermost.kind {

--- a/tests/ui/lint/lint-struct-necessary.rs
+++ b/tests/ui/lint/lint-struct-necessary.rs
@@ -1,0 +1,31 @@
+#![allow(dead_code)]
+#![deny(unused_parens)]
+
+enum State {
+    Waiting { start_at: u64 }
+}
+struct Foo {}
+
+fn main() {
+    let e = &mut State::Waiting { start_at: 0u64 };
+    match (&mut State::Waiting { start_at: 0u64 }) {
+        _ => {}
+    }
+
+    match (e) {
+        //~^ ERROR unnecessary parentheses around `match` scrutinee expression
+        _ => {}
+    }
+
+    match &(State::Waiting { start_at: 0u64 }) {
+        _ => {}
+    }
+
+    match (State::Waiting { start_at: 0u64 }) {
+        _ => {}
+    }
+
+    match (&&Foo {}) {
+        _ => {}
+    }
+}

--- a/tests/ui/lint/lint-struct-necessary.stderr
+++ b/tests/ui/lint/lint-struct-necessary.stderr
@@ -1,0 +1,19 @@
+error: unnecessary parentheses around `match` scrutinee expression
+  --> $DIR/lint-struct-necessary.rs:15:11
+   |
+LL |     match (e) {
+   |           ^ ^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-struct-necessary.rs:2:9
+   |
+LL | #![deny(unused_parens)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     match (e) {
+LL +     match e {
+   |
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #113459