### PR TITLE
Print artifact sizes in `opt-dist`

### DIFF
--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -7,7 +7,9 @@ use crate::tests::run_tests;
 use crate::timer::Timer;
 use crate::training::{gather_llvm_bolt_profiles, gather_llvm_profiles, gather_rustc_profiles};
 use crate::utils::io::reset_directory;
-use crate::utils::{clear_llvm_files, format_env_variables, print_free_disk_space};
+use crate::utils::{
+    clear_llvm_files, format_env_variables, print_binary_sizes, print_free_disk_space,
+};
 
 mod environment;
 mod exec;
@@ -170,6 +172,8 @@ fn main() -> anyhow::Result<()> {
     log::info!("Timer results\n{}", timer.format_stats());
 
     print_free_disk_space()?;
+    result.context("Optimized build pipeline has failed")?;
+    print_binary_sizes(env.as_ref())?;
 
-    result.context("Optimized build pipeline has failed")
+    Ok(())
 }

--- a/src/tools/opt-dist/src/utils/io.rs
+++ b/src/tools/opt-dist/src/utils/io.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use fs_extra::dir::CopyOptions;
 use std::fs::File;
 
@@ -45,4 +45,18 @@ pub fn unpack_archive(path: &Utf8Path, dest_dir: &Utf8Path) -> anyhow::Result<()
     let mut archive = tar::Archive::new(file);
     archive.unpack(dest_dir.as_std_path())?;
     Ok(())
+}
+
+/// Returns paths in the given `dir` (non-recursively), optionally with the given `suffix`.
+/// The `suffix` should contain the leading dot.
+pub fn get_files_from_dir(
+    dir: &Utf8Path,
+    suffix: Option<&str>,
+) -> anyhow::Result<Vec<Utf8PathBuf>> {
+    let path = format!("{dir}/*{}", suffix.unwrap_or(""));
+
+    Ok(glob::glob(&path)?
+        .into_iter()
+        .map(|p| p.map(|p| Utf8PathBuf::from_path_buf(p).unwrap()))
+        .collect::<Result<Vec<_>, _>>()?)
 }


### PR DESCRIPTION
The Python PGO script printed a nice table of artifact sizes (`librustc_driver.so`, `libLLVM.so`, ...) at the end of the CI run, which was useful to quickly see the sizes of important files. I forgot to port this functionality into the Rust (`opt-dist`) version in https://github.com/rust-lang/rust/pull/112235. This PR fixes that.

r? bootstrap