### PR TITLE
Add #[inline] to core debug assertion helpers

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2524,12 +2524,14 @@ pub(crate) use assert_unsafe_precondition;
 
 /// Checks whether `ptr` is properly aligned with respect to
 /// `align_of::<T>()`.
+#[inline]
 pub(crate) fn is_aligned_and_not_null<T>(ptr: *const T) -> bool {
     !ptr.is_null() && ptr.is_aligned()
 }
 
 /// Checks whether an allocation of `len` instances of `T` exceeds
 /// the maximum allowed allocation size.
+#[inline]
 pub(crate) fn is_valid_allocation_size<T>(len: usize) -> bool {
     let max_len = const {
         let size = crate::mem::size_of::<T>();
@@ -2540,6 +2542,7 @@ pub(crate) fn is_valid_allocation_size<T>(len: usize) -> bool {
 
 /// Checks whether the regions of memory starting at `src` and `dst` of size
 /// `count * size_of::<T>()` do *not* overlap.
+#[inline]
 pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -> bool {
     let src_usize = src.addr();
     let dst_usize = dst.addr();

--- a/tests/mir-opt/pre-codegen/mem_replace.mem_replace.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_replace.mem_replace.PreCodegen.after.mir
@@ -10,22 +10,16 @@ fn mem_replace(_1: &mut u32, _2: u32) -> u32 {
         scope 2 {
             scope 3 {
                 debug result => _0;
-                scope 7 (inlined std::ptr::write::<u32>) {
+                scope 6 (inlined std::ptr::write::<u32>) {
                     debug dst => _1;
                     debug src => _2;
-                    scope 8 {
-                        scope 9 (inlined std::ptr::write::runtime::<u32>) {
-                            debug dst => _1;
-                        }
+                    scope 7 {
                     }
                 }
             }
             scope 4 (inlined std::ptr::read::<u32>) {
                 debug src => _1;
                 scope 5 {
-                    scope 6 (inlined std::ptr::read::runtime::<u32>) {
-                        debug src => _1;
-                    }
                 }
             }
         }


### PR DESCRIPTION
These functions are called a lot and not inlined by default in a dev compiler. Adding `#[inline]` should improve things in a dev workflow and be irrelevant in the distributed library.