### PR TITLE
llvm-wrapper: update for LLVM API change

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
@@ -7,6 +7,7 @@
 // * https://github.com/llvm/llvm-project/blob/8ef3e895ad8ab1724e2b87cabad1dacdc7a397a3/llvm/include/llvm/Object/ArchiveWriter.h
 // * https://github.com/llvm/llvm-project/blob/8ef3e895ad8ab1724e2b87cabad1dacdc7a397a3/llvm/lib/Object/ArchiveWriter.cpp
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Object/ObjectFile.h"
 


### PR DESCRIPTION
No functional changes intended.

Adds an include for `llvm::SmallString`. Previously, this must have been implicitly provided by some of the existing headers. With recent LLVM changes, not anymore:
https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/20776#01895448-44a4-4a1e-8407-9d41d0186132/209-690