### PR TITLE
allow opaques to be defined by trait queries, again

### DIFF
--- a/tests/ui/impl-trait/defined-by-trait-resolution.rs
+++ b/tests/ui/impl-trait/defined-by-trait-resolution.rs
@@ -1,0 +1,12 @@
+//! The trait query `foo: Fn() -> u8` is a valid defining use of RPIT.
+
+// build-pass
+
+fn returns_u8(_: impl Fn() -> u8) {}
+
+pub fn foo() -> impl Sized {
+    returns_u8(foo);
+    0u8
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/defined-by-user-annotation.rs
+++ b/tests/ui/type-alias-impl-trait/defined-by-user-annotation.rs
@@ -1,0 +1,19 @@
+// User type annotation in fn bodies is a a valid defining site for opaque types.
+// check-pass
+#![feature(type_alias_impl_trait)]
+
+trait Equate { type Proj; }
+impl<T> Equate for T { type Proj = T; }
+
+trait Indirect { type Ty; }
+impl<A, B: Equate<Proj = A>> Indirect for (A, B) { type Ty = (); }
+
+type Opq = impl Sized;
+fn define_1(_: Opq) {
+    let _ = None::<<(Opq, u8) as Indirect>::Ty>;
+}
+fn define_2() -> Opq {
+    0u8
+}
+
+fn main() {}


### PR DESCRIPTION
This basically reverts #112963.

Moreover, all call-sites of `enter_canonical_trait_query` can now define opaque types, see the ui test `defined-by-user-annotation.rs`.

Fixes #113689

r? @compiler-errors @oli-obk