### PR TITLE
tests: adapt for removal of -opaque-pointers in LLVM 17

### DIFF
--- a/tests/ui/dyn-star/llvm-old-style-ptrs.rs
+++ b/tests/ui/dyn-star/llvm-old-style-ptrs.rs
@@ -3,6 +3,8 @@
 
 // (opaque-pointers flag is called force-opaque-pointers in LLVM 13...)
 // min-llvm-version: 14.0
+// (the ability to disable opaque pointers has been removed in LLVM 17)
+// ignore-llvm-version: 17 - 99
 
 // This test can be removed once non-opaque pointers are gone from LLVM, maybe.
 


### PR DESCRIPTION
The commit https://github.com/llvm/llvm-project/commit/53717cabf837a589dd54a47dd8b4b3b9677f0b85 removed the flag from LLVM.

Found via our experimental rust + LLVM@HEAD bot: https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/20777#01895454-40b2-4e2f-978b-1294a83e1cce