### PR TITLE
Re-export core::ffi::FromBytesUntilNulError in std::ffi

### DIFF
--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -156,6 +156,8 @@
 
 #[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub use alloc::ffi::{CString, FromVecWithNulError, IntoStringError, NulError};
+#[stable(feature = "cstr_from_bytes_until_nul", since = "CURRENT_RUSTC_VERSION")]
+pub use core::ffi::FromBytesUntilNulError;
 #[stable(feature = "core_c_str", since = "1.64.0")]
 pub use core::ffi::{CStr, FromBytesWithNulError};
 


### PR DESCRIPTION
Like the other CStr and CString error types, make a re-export for std::ffi::FromBytesUntilNulError.

This seems to have slipped through the cracks in the cstr_from_bytes_until_nul implementation and core_c_str migration.

Tracking Issue: #95027