### PR TITLE
Make RPITITs inherit the `assumed_wf_types` of their parent method

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -284,6 +284,17 @@ fn check_trait_item(tcx: TyCtxt<'_>, trait_item: &hir::TraitItem<'_>) {
     };
     check_object_unsafe_self_trait_by_name(tcx, trait_item);
     check_associated_item(tcx, def_id, span, method_sig);
+
+    if matches!(trait_item.kind, hir::TraitItemKind::Fn(..)) {
+        for &assoc_ty_def_id in tcx.associated_types_for_impl_traits_in_associated_fn(def_id) {
+            check_associated_item(
+                tcx,
+                assoc_ty_def_id.expect_local(),
+                tcx.def_span(assoc_ty_def_id),
+                None,
+            );
+        }
+    }
 }
 
 /// Require that the user writes where clauses on GATs for the implicit
@@ -1466,13 +1477,6 @@ fn check_fn_or_method<'tcx>(
 
     check_where_clauses(wfcx, span, def_id);
 
-    check_return_position_impl_trait_in_trait_bounds(
-        wfcx,
-        def_id,
-        sig.output(),
-        hir_decl.output.span(),
-    );
-
     if sig.abi == Abi::RustCall {
         let span = tcx.def_span(def_id);
         let has_implicit_self = hir_decl.implicit_self != hir::ImplicitSelfKind::None;
@@ -1504,87 +1508,6 @@ fn check_fn_or_method<'tcx>(
                 "functions with the \"rust-call\" ABI must take a single non-self tuple argument",
             );
         }
-    }
-}
-
-/// Basically `check_associated_type_bounds`, but separated for now and should be
-/// deduplicated when RPITITs get lowered into real associated items.
-#[tracing::instrument(level = "trace", skip(wfcx))]
-fn check_return_position_impl_trait_in_trait_bounds<'tcx>(
-    wfcx: &WfCheckingCtxt<'_, 'tcx>,
-    fn_def_id: LocalDefId,
-    fn_output: Ty<'tcx>,
-    span: Span,
-) {
-    let tcx = wfcx.tcx();
-    let Some(assoc_item) = tcx.opt_associated_item(fn_def_id.to_def_id()) else {
-        return;
-    };
-    if assoc_item.container != ty::AssocItemContainer::TraitContainer {
-        return;
-    }
-    fn_output.visit_with(&mut ImplTraitInTraitFinder {
-        wfcx,
-        fn_def_id,
-        depth: ty::INNERMOST,
-        seen: FxHashSet::default(),
-    });
-}
-
-// FIXME(-Zlower-impl-trait-in-trait-to-assoc-ty): Even with the new lowering
-// strategy, we can't just call `check_associated_item` on the new RPITITs,
-// because tests like `tests/ui/async-await/in-trait/implied-bounds.rs` will fail.
-// That's because we need to check that the bounds of the RPITIT hold using
-// the special args that we create during opaque type lowering, otherwise we're
-// getting a bunch of early bound and free regions mixed up... Haven't looked too
-// deep into this, though.
-struct ImplTraitInTraitFinder<'a, 'tcx> {
-    wfcx: &'a WfCheckingCtxt<'a, 'tcx>,
-    fn_def_id: LocalDefId,
-    depth: ty::DebruijnIndex,
-    seen: FxHashSet<DefId>,
-}
-impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
-    type BreakTy = !;
-
-    fn visit_ty(&mut self, ty: Ty<'tcx>) -> ControlFlow<!> {
-        let tcx = self.wfcx.tcx();
-        if let ty::Alias(ty::Opaque, unshifted_opaque_ty) = *ty.kind()
-            && self.seen.insert(unshifted_opaque_ty.def_id)
-            && let Some(opaque_def_id) = unshifted_opaque_ty.def_id.as_local()
-            && let origin = tcx.opaque_type_origin(opaque_def_id)
-            && let hir::OpaqueTyOrigin::FnReturn(source) | hir::OpaqueTyOrigin::AsyncFn(source) = origin
-            && source == self.fn_def_id
-        {
-            let opaque_ty = tcx.fold_regions(unshifted_opaque_ty, |re, _depth| {
-                match re.kind() {
-                    ty::ReEarlyBound(_) | ty::ReFree(_) | ty::ReError(_) | ty::ReStatic => re,
-                    r => bug!("unexpected region: {r:?}"),
-                }
-            });
-            for (bound, bound_span) in tcx
-                .explicit_item_bounds(opaque_ty.def_id)
-                .iter_instantiated_copied(tcx, opaque_ty.args)
-            {
-                let bound = self.wfcx.normalize(bound_span, None, bound);
-                self.wfcx.register_obligations(traits::wf::predicate_obligations(
-                    self.wfcx.infcx,
-                    self.wfcx.param_env,
-                    self.wfcx.body_def_id,
-                    bound.as_predicate(),
-                    bound_span,
-                ));
-                // Set the debruijn index back to innermost here, since we already eagerly
-                // shifted the args that we use to generate these bounds. This is unfortunately
-                // subtly different behavior than the `ImplTraitInTraitFinder` we use in `param_env`,
-                // but that function doesn't actually need to normalize the bound it's visiting
-                // (whereas we have to do so here)...
-                let old_depth = std::mem::replace(&mut self.depth, ty::INNERMOST);
-                bound.visit_with(self);
-                self.depth = old_depth;
-            }
-        }
-        ty.super_visit_with(self)
     }
 }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -246,6 +246,7 @@ provide! { tcx, def_id, other, cdata,
         debug_assert_eq!(tcx.def_kind(def_id), DefKind::OpaqueTy);
         cdata.root.tables.is_type_alias_impl_trait.get(cdata, def_id.index)
     }
+    assumed_wf_types_for_rpitit => { table }
     collect_return_position_impl_trait_in_trait_tys => {
         Ok(cdata
             .root

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1560,6 +1560,12 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         }
         if let Some(rpitit_info) = item.opt_rpitit_info {
             record!(self.tables.opt_rpitit_info[def_id] <- rpitit_info);
+            if matches!(rpitit_info, ty::ImplTraitInTraitData::Trait { .. }) {
+                record_array!(
+                    self.tables.assumed_wf_types_for_rpitit[def_id]
+                        <- self.tcx.assumed_wf_types_for_rpitit(def_id)
+                );
+            }
         }
     }
 

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -457,6 +457,7 @@ define_tables! {
     trait_impl_trait_tys: Table<DefIndex, LazyValue<FxHashMap<DefId, ty::EarlyBinder<Ty<'static>>>>>,
     doc_link_resolutions: Table<DefIndex, LazyValue<DocLinkResMap>>,
     doc_link_traits_in_scope: Table<DefIndex, LazyArray<DefId>>,
+    assumed_wf_types_for_rpitit: Table<DefIndex, LazyArray<(Ty<'static>, Span)>>,
 }
 
 #[derive(TyEncodable, TyDecodable)]

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -885,6 +885,13 @@ rustc_queries! {
         desc { |tcx| "computing the implied bounds of `{}`", tcx.def_path_str(key) }
     }
 
+    /// We need to store the assumed_wf_types for an RPITIT so that impls of foreign
+    /// traits with return-position impl trait in traits can inherit the right wf types.
+    query assumed_wf_types_for_rpitit(key: DefId) -> &'tcx [(Ty<'tcx>, Span)] {
+        desc { |tcx| "computing the implied bounds of `{}`", tcx.def_path_str(key) }
+        separate_provide_extern
+    }
+
     /// Computes the signature of the function.
     query fn_sig(key: DefId) -> ty::EarlyBinder<ty::PolyFnSig<'tcx>> {
         desc { |tcx| "computing function signature of `{}`", tcx.def_path_str(key) }

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(assert_matches)]
 #![feature(iterator_try_collect)]
 #![feature(let_chains)]
+#![feature(if_let_guard)]
 #![feature(never_type)]
 #![feature(box_patterns)]
 #![recursion_limit = "256"]

--- a/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
+++ b/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
@@ -4,11 +4,11 @@ error[E0311]: the parameter type `U` may not live long enough
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
    |                            ^^^^^^^
    |
-note: the parameter type `U` must be valid for the anonymous lifetime defined here...
+note: the parameter type `U` must be valid for the anonymous lifetime as defined here...
   --> $DIR/async-generics-and-bounds.rs:12:18
    |
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
-   |                  ^^^^^
+   |                  ^
 note: ...so that the reference type `&(T, U)` does not outlive the data it points at
   --> $DIR/async-generics-and-bounds.rs:12:28
    |
@@ -21,11 +21,11 @@ error[E0311]: the parameter type `T` may not live long enough
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
    |                            ^^^^^^^
    |
-note: the parameter type `T` must be valid for the anonymous lifetime defined here...
+note: the parameter type `T` must be valid for the anonymous lifetime as defined here...
   --> $DIR/async-generics-and-bounds.rs:12:18
    |
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
-   |                  ^^^^^
+   |                  ^
 note: ...so that the reference type `&(T, U)` does not outlive the data it points at
   --> $DIR/async-generics-and-bounds.rs:12:28
    |

--- a/tests/ui/async-await/in-trait/async-generics.stderr
+++ b/tests/ui/async-await/in-trait/async-generics.stderr
@@ -4,11 +4,11 @@ error[E0311]: the parameter type `U` may not live long enough
 LL |     async fn foo(&self) -> &(T, U);
    |                            ^^^^^^^
    |
-note: the parameter type `U` must be valid for the anonymous lifetime defined here...
+note: the parameter type `U` must be valid for the anonymous lifetime as defined here...
   --> $DIR/async-generics.rs:9:18
    |
 LL |     async fn foo(&self) -> &(T, U);
-   |                  ^^^^^
+   |                  ^
 note: ...so that the reference type `&(T, U)` does not outlive the data it points at
   --> $DIR/async-generics.rs:9:28
    |
@@ -21,11 +21,11 @@ error[E0311]: the parameter type `T` may not live long enough
 LL |     async fn foo(&self) -> &(T, U);
    |                            ^^^^^^^
    |
-note: the parameter type `T` must be valid for the anonymous lifetime defined here...
+note: the parameter type `T` must be valid for the anonymous lifetime as defined here...
   --> $DIR/async-generics.rs:9:18
    |
 LL |     async fn foo(&self) -> &(T, U);
-   |                  ^^^^^
+   |                  ^
 note: ...so that the reference type `&(T, U)` does not outlive the data it points at
   --> $DIR/async-generics.rs:9:28
    |

--- a/tests/ui/impl-trait/in-trait/assumed-wf-bounds-in-impl.rs
+++ b/tests/ui/impl-trait/in-trait/assumed-wf-bounds-in-impl.rs
@@ -1,0 +1,29 @@
+// check-pass
+// edition: 2021
+// issue: 113796
+
+#![feature(async_fn_in_trait)]
+
+trait AsyncLendingIterator {
+    type Item<'a>
+    where
+        Self: 'a;
+
+    async fn next(&mut self) -> Option<Self::Item<'_>>;
+}
+
+struct Lend<I>(I);
+impl<I> AsyncLendingIterator for Lend<I> {
+    type Item<'a> = &'a I
+    where
+        Self: 'a;
+
+    // Checking that the synthetic `<Self as AsyncLendingIterator>::next()` GAT
+    // is well-formed requires being able to assume the WF types of `next`.
+
+    async fn next(&mut self) -> Option<Self::Item<'_>> {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
@@ -17,7 +17,6 @@ impl<'a, I: 'a + Iterable> Iterable for &'a I {
     //~^ ERROR impl has stricter requirements than trait
 
     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
-        //~^ ERROR the type `&'a I` does not fulfill the required lifetime
         (*self).iter()
     }
 }

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -12,19 +12,6 @@ help: copy the `where` clause predicates from the trait
 LL |     where Self: 'b;
    |     ~~~~~~~~~~~~~~
 
-error[E0477]: the type `&'a I` does not fulfill the required lifetime
-  --> $DIR/bad-item-bound-within-rpitit.rs:19:23
-   |
-LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: type must outlive the anonymous lifetime as defined here
-  --> $DIR/bad-item-bound-within-rpitit.rs:10:28
-   |
-LL |     fn iter(&self) -> impl '_ + Iterator<Item = Self::Item<'_>>;
-   |                            ^^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0276, E0477.
-For more information about an error, try `rustc --explain E0276`.
+For more information about this error, try `rustc --explain E0276`.

--- a/tests/ui/impl-trait/in-trait/wf-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/wf-bounds.stderr
@@ -47,10 +47,6 @@ note: required by a bound in `NeedsDisplay`
    |
 LL | struct NeedsDisplay<T: Display>(T);
    |                        ^^^^^^^ required by this bound in `NeedsDisplay`
-help: consider restricting type parameter `T`
-   |
-LL |     fn nya4<T: std::fmt::Display>() -> impl Wf<NeedsDisplay<T>>;
-   |              +++++++++++++++++++
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
... and then move the RPITIT well-formedness check to just use the regular logic of wfchecking an associated type.

---

We need to inherit the `assumed_wf_types` of the RPITIT's parent function in order for the given code to be considered well-formed:

```rust
trait Foo {
  fn bar<'a, T>(_: &'a T) -> impl Iterator<Output = &'a T>;
}
```

Since for `&'a T` to be WF, we need `T: 'a`.

In order for this to work for late-bound lifetimes, we need to do some additional mapping of any late-bound lifetimes captured by these assumed wf types. This is because within the body of the function (and thus in the `assumed_wf_types`), they're represented as `ReFree` variants of the original late-bound lifetimes declared in the function's generics, but in the RPITIT's GAT, they're represented as "reified" `ReEarlyBound` vars (duplicated during opaque type lowering). Luckily, the mapping between these two is already [stored in the opaque](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/struct.OpaqueTy.html#structfield.lifetime_mapping).

Fixes #113796