### PR TITLE
Fix compiletest windows path finding with spaces

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -4149,8 +4149,8 @@ impl<'test> TestCx<'test> {
                   # Match paths that don't include spaces.
                   (?:\\[\pL\pN\.\-_']+)+\.\pL+
                 |
-                  # If the path starts with a well-known root, then allow spaces.
-                  \$(?:DIR|SRC_DIR|TEST_BUILD_DIR|BUILD_DIR|LIB_DIR)(?:\\[\pL\pN\.\-_' ]+)+
+                  # If the path starts with a well-known root, then allow spaces and no file extension.
+                  \$(?:DIR|SRC_DIR|TEST_BUILD_DIR|BUILD_DIR|LIB_DIR)(?:\\[\pL\pN\.\-_'\ ]+)+
                 )"#,
             )
             .unwrap()

--- a/src/tools/compiletest/src/runtest/tests.rs
+++ b/src/tools/compiletest/src/runtest/tests.rs
@@ -8,8 +8,8 @@ fn normalize_platform_differences() {
         "$BUILD_DIR/../parser.rs"
     );
     assert_eq!(
-        TestCx::normalize_platform_differences(r"$DIR\bar.rs hello\nworld"),
-        r"$DIR/bar.rs hello\nworld"
+        TestCx::normalize_platform_differences(r"$DIR\bar.rs: hello\nworld"),
+        r"$DIR/bar.rs: hello\nworld"
     );
     assert_eq!(
         TestCx::normalize_platform_differences(r"either bar\baz.rs or bar\baz\mod.rs"),
@@ -27,8 +27,8 @@ fn normalize_platform_differences() {
     );
     assert_eq!(TestCx::normalize_platform_differences(r"$DIR\foo.rs:12:11"), "$DIR/foo.rs:12:11",);
     assert_eq!(
-        TestCx::normalize_platform_differences(r"$DIR\path with spaces 'n' quotes"),
-        "$DIR/path with spaces 'n' quotes",
+        TestCx::normalize_platform_differences(r"$DIR\path with\spaces 'n' quotes"),
+        "$DIR/path with/spaces 'n' quotes",
     );
     assert_eq!(
         TestCx::normalize_platform_differences(r"$DIR\file_with\no_extension"),


### PR DESCRIPTION
With `(?x)` enabled spaces are ignored unless you escape them, so the space wasn't being added to the character class

I don't think this makes any difference to the current test suite, but it could save someone a headache in the future