### PR TITLE
Use SHA256 source file checksums by default when targeting MSVC

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1420,7 +1420,7 @@ pub fn build_session(
     let loader = file_loader.unwrap_or_else(|| Box::new(RealFileLoader));
     let hash_kind = sopts.unstable_opts.src_hash_algorithm.unwrap_or_else(|| {
         if target_cfg.is_like_msvc {
-            SourceFileHashAlgorithm::Sha1
+            SourceFileHashAlgorithm::Sha256
         } else {
             SourceFileHashAlgorithm::Md5
         }


### PR DESCRIPTION
Currently, when targeting Windows (more specifically, the MSVC toolchain), Rust will use SHA1 source file checksums by default.  SHA1 has been superseded by SHA256, and Microsoft recommends migrating to SHA256.

As of Visual Studio 2022, MSVC defaults to SHA256.  This change aligns Rust and MSVC.

LLVM can already use SHA256 checksums, so this does not require any change to LLVM.

MSVC docs on source file checksums: https://learn.microsoft.com/en-us/cpp/build/reference/zh?view=msvc-170
