### PR TITLE
Fix ICE when trying to convert `ConstKind::Error` to usize

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -35,7 +35,15 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let tcx = self.tcx;
         let (min_length, exact_size) = if let Some(place_resolved) = place.try_to_place(self) {
             match place_resolved.ty(&self.local_decls, tcx).ty.kind() {
-                ty::Array(_, length) => (length.eval_target_usize(tcx, self.param_env), true),
+                ty::Array(_, length) => {
+                    let evaluated_const = length.eval(tcx, self.param_env);
+                    let min_length = match evaluated_const.kind() {
+                        ty::ConstKind::Error(_) => return,
+                        ty::ConstKind::Value(value) => value.try_to_target_usize(tcx).unwrap(),
+                        _ => unreachable!(),
+                    };
+                    (min_length, true)
+                }
                 _ => ((prefix.len() + suffix.len()).try_into().unwrap(), false),
             }
         } else {

--- a/tests/ui/const-generics/generic_const_exprs/match-with-error-length.rs
+++ b/tests/ui/const-generics/generic_const_exprs/match-with-error-length.rs
@@ -1,0 +1,30 @@
+// edition:2018
+// https://github.com/rust-lang/rust/issues/113021
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub async fn a(path: &[(); Abc]) {
+    //~^ ERROR cannot find value `Abc` in this scope
+    match path {
+        [] | _ => (),
+    }
+}
+
+pub async fn b(path: &[(); Abc]) {
+    //~^ ERROR cannot find value `Abc` in this scope
+    match path {
+        &[] | _ => (),
+    }
+}
+
+pub async fn c(path: &[[usize; N_ISLANDS]; PrivateStruct]) -> usize {
+    //~^ ERROR cannot find value `N_ISLANDS` in this scope
+    //~| ERROR cannot find value `PrivateStruct` in this scope
+    match path {
+        [] | _ => 0,
+    }
+}
+
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/match-with-error-length.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/match-with-error-length.stderr
@@ -1,0 +1,27 @@
+error[E0425]: cannot find value `Abc` in this scope
+  --> $DIR/match-with-error-length.rs:7:28
+   |
+LL | pub async fn a(path: &[(); Abc]) {
+   |                            ^^^ not found in this scope
+
+error[E0425]: cannot find value `Abc` in this scope
+  --> $DIR/match-with-error-length.rs:14:28
+   |
+LL | pub async fn b(path: &[(); Abc]) {
+   |                            ^^^ not found in this scope
+
+error[E0425]: cannot find value `N_ISLANDS` in this scope
+  --> $DIR/match-with-error-length.rs:21:32
+   |
+LL | pub async fn c(path: &[[usize; N_ISLANDS]; PrivateStruct]) -> usize {
+   |                                ^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `PrivateStruct` in this scope
+  --> $DIR/match-with-error-length.rs:21:44
+   |
+LL | pub async fn c(path: &[[usize; N_ISLANDS]; PrivateStruct]) -> usize {
+   |                                            ^^^^^^^^^^^^^ not found in this scope
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes an ICE (#113021) caused by trying to convert a `ConstKind::Error` to a usize.

Instead of panicking in the call to `eval_target_usize` in `prefix_slice_suffix`, `prefix_slice_suffix` now bails and does nothing. If it sees a `ConstKind::Error`, then there has already been an error reported so not doing anything shouldn't be a problem.

Closes #113021.

r? @matthiaskrgr