### PR TITLE
miri: fail when calling a function that requires an unavailable target feature

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -399,6 +399,9 @@ const_eval_unallowed_mutable_refs_raw =
 const_eval_unallowed_op_in_const_context =
     {$msg}
 
+const_eval_unavailable_target_features_for_fn =
+    calling a function that requires unavailable target features: {$unavailable_feats}
+
 const_eval_undefined_behavior =
     it is undefined behavior to use this value
 

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -503,24 +503,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     }
                 }
 
-                let attrs = self.tcx.codegen_fn_attrs(instance.def_id());
-                let missing_features: Vec<_> = attrs
-                    .target_features
-                    .iter()
-                    .copied()
-                    .filter(|feature| !self.tcx.sess.target_features.contains(feature))
-                    .collect();
-                if !missing_features.is_empty() {
-                    let mut missing_features_str = String::from(missing_features[0].as_str());
-                    for missing_feature in missing_features[1..].iter() {
-                        missing_features_str.push(',');
-                        missing_features_str.push_str(missing_feature.as_str());
-                    }
-                    throw_ub_custom!(
-                        fluent::const_eval_unavailable_target_features_for_fn,
-                        unavailable_feats = missing_features_str,
-                    );
-                }
+                // Check that all target features required by the callee (i.e., from
+                // the attribute `#[target_feature(enable = ...)]`) are enabled at
+                // compile time.
+                self.check_fn_target_features(instance)?;
 
                 if !callee_fn_abi.can_unwind {
                     // The callee cannot unwind, so force the `Unreachable` unwind handling.
@@ -803,6 +789,31 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 )
             }
         }
+    }
+
+    fn check_fn_target_features(&self, instance: ty::Instance<'tcx>) -> InterpResult<'tcx, ()> {
+        let attrs = self.tcx.codegen_fn_attrs(instance.def_id());
+        if attrs
+            .target_features
+            .iter()
+            .any(|feature| !self.tcx.sess.target_features.contains(feature))
+        {
+            throw_ub_custom!(
+                fluent::const_eval_unavailable_target_features_for_fn,
+                unavailable_feats = attrs
+                    .target_features
+                    .iter()
+                    .filter(|&feature| !self.tcx.sess.target_features.contains(feature))
+                    .fold(String::new(), |mut s, feature| {
+                        if !s.is_empty() {
+                            s.push_str(", ");
+                        }
+                        s.push_str(feature.as_str());
+                        s
+                    }),
+            );
+        }
+        Ok(())
     }
 
     fn drop_in_place(

--- a/src/tools/miri/tests/fail/function_calls/target_feature.rs
+++ b/src/tools/miri/tests/fail/function_calls/target_feature.rs
@@ -1,0 +1,11 @@
+//@only-target-x86_64: uses x86 target features
+
+fn main() {
+    assert!(!is_x86_feature_detected!("ssse3"));
+    unsafe {
+        ssse3_fn(); //~ ERROR: calling a function that requires unavailable target features: ssse3
+    }
+}
+
+#[target_feature(enable = "ssse3")]
+unsafe fn ssse3_fn() {}

--- a/src/tools/miri/tests/fail/function_calls/target_feature.stderr
+++ b/src/tools/miri/tests/fail/function_calls/target_feature.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: calling a function that requires unavailable target features: ssse3
+  --> $DIR/target_feature.rs:LL:CC
+   |
+LL |         ssse3_fn();
+   |         ^^^^^^^^^^ calling a function that requires unavailable target features: ssse3
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/target_feature.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/src/tools/miri/tests/pass/function_calls/target_feature.rs
+++ b/src/tools/miri/tests/pass/function_calls/target_feature.rs
@@ -1,0 +1,12 @@
+//@only-target-x86_64: uses x86 target features
+//@compile-flags: -C target-feature=+ssse3
+
+fn main() {
+    assert!(is_x86_feature_detected!("ssse3"));
+    unsafe {
+        ssse3_fn();
+    }
+}
+
+#[target_feature(enable = "ssse3")]
+unsafe fn ssse3_fn() {}

--- a/tests/ui/consts/const-eval/const_fn_target_feature.rs
+++ b/tests/ui/consts/const-eval/const_fn_target_feature.rs
@@ -1,0 +1,17 @@
+// only-x86_64
+// compile-flags:-C target-feature=+ssse3
+
+#![crate_type = "lib"]
+
+// ok (ssse3 enabled at compile time)
+const A: () = unsafe { ssse3_fn() };
+
+// error (avx2 not enabled at compile time)
+const B: () = unsafe { avx2_fn() };
+//~^ ERROR evaluation of constant value failed
+
+#[target_feature(enable = "ssse3")]
+const unsafe fn ssse3_fn() {}
+
+#[target_feature(enable = "avx2")]
+const unsafe fn avx2_fn() {}

--- a/tests/ui/consts/const-eval/const_fn_target_feature.stderr
+++ b/tests/ui/consts/const-eval/const_fn_target_feature.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const_fn_target_feature.rs:10:24
+   |
+LL | const B: () = unsafe { avx2_fn() };
+   |                        ^^^^^^^^^ calling a function that requires unavailable target features: avx2
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
miri will report an UB when calling a function that has a `#[target_feature(enable = ...)]` attribute is called and the required feature is not available.

"Available features" are the same that `is_x86_feature_detected!` (or equivalent) reports to be available during miri execution (which can be enabled or disabled with the `-C target-feature` flag).