### PR TITLE
Resurrect: rustc_llvm: Add a -Z `print-codegen-stats` option to expose LLVM statistics.

### DIFF
--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -239,6 +239,10 @@ impl WriteBackendMethods for GccCodegenBackend {
         unimplemented!();
     }
 
+    fn print_statistics(&self) {
+        unimplemented!()
+    }
+
     unsafe fn optimize(_cgcx: &CodegenContext<Self>, _diag_handler: &Handler, module: &ModuleCodegen<Self::Module>, config: &ModuleConfig) -> Result<(), FatalError> {
         module.module_llvm.context.set_optimization_level(to_gcc_opt_level(config.opt_level));
         Ok(())

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -181,6 +181,11 @@ impl WriteBackendMethods for LlvmCodegenBackend {
             llvm::LLVMRustPrintPassTimings();
         }
     }
+    fn print_statistics(&self) {
+        unsafe {
+            llvm::LLVMRustPrintStatistics();
+        }
+    }
     fn run_link(
         cgcx: &CodegenContext<Self>,
         diag_handler: &Handler,

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -177,14 +177,32 @@ impl WriteBackendMethods for LlvmCodegenBackend {
     type ThinData = back::lto::ThinData;
     type ThinBuffer = back::lto::ThinBuffer;
     fn print_pass_timings(&self) {
-        unsafe {
-            llvm::LLVMRustPrintPassTimings();
-        }
+        let msg = unsafe {
+            let cstr = llvm::LLVMRustPrintPassTimings();
+            if cstr.is_null() {
+                "failed to get pass timings".into()
+            } else {
+                let timings = CStr::from_ptr(cstr).to_bytes();
+                let timings = String::from_utf8_lossy(timings).to_string();
+                libc::free(cstr as *mut _);
+                timings
+            }
+        };
+        println!("{}", msg);
     }
     fn print_statistics(&self) {
-        unsafe {
-            llvm::LLVMRustPrintStatistics();
-        }
+        let msg = unsafe {
+            let cstr = llvm::LLVMRustPrintStatistics();
+            if cstr.is_null() {
+                "failed to get stats".into()
+            } else {
+                let stats = CStr::from_ptr(cstr).to_bytes();
+                let stats = String::from_utf8_lossy(stats).to_string();
+                libc::free(cstr as *mut _);
+                stats
+            }
+        };
+        println!("{}", msg);
     }
     fn run_link(
         cgcx: &CodegenContext<Self>,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1868,10 +1868,10 @@ extern "C" {
     pub fn LLVMRustGetLastError() -> *const c_char;
 
     /// Print the pass timings since static dtors aren't picking them up.
-    pub fn LLVMRustPrintPassTimings() -> *const c_char;
+    pub fn LLVMRustPrintPassTimings(size: *const size_t) -> *const c_char;
 
     /// Print the statistics since static dtors aren't picking them up.
-    pub fn LLVMRustPrintStatistics() -> *const c_char;
+    pub fn LLVMRustPrintStatistics(size: *const size_t) -> *const c_char;
 
     pub fn LLVMStructCreateNamed(C: &Context, Name: *const c_char) -> &Type;
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1868,10 +1868,10 @@ extern "C" {
     pub fn LLVMRustGetLastError() -> *const c_char;
 
     /// Print the pass timings since static dtors aren't picking them up.
-    pub fn LLVMRustPrintPassTimings();
+    pub fn LLVMRustPrintPassTimings() -> *const c_char;
 
     /// Print the statistics since static dtors aren't picking them up.
-    pub fn LLVMRustPrintStatistics();
+    pub fn LLVMRustPrintStatistics() -> *const c_char;
 
     pub fn LLVMStructCreateNamed(C: &Context, Name: *const c_char) -> &Type;
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1870,6 +1870,9 @@ extern "C" {
     /// Print the pass timings since static dtors aren't picking them up.
     pub fn LLVMRustPrintPassTimings();
 
+    /// Print the statistics since static dtors aren't picking them up.
+    pub fn LLVMRustPrintStatistics();
+
     pub fn LLVMStructCreateNamed(C: &Context, Name: *const c_char) -> &Type;
 
     pub fn LLVMStructSetBody<'a>(

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -110,6 +110,10 @@ unsafe fn configure_llvm(sess: &Session) {
         // Use non-zero `import-instr-limit` multiplier for cold callsites.
         add("-import-cold-multiplier=0.1", false);
 
+        if sess.print_llvm_stats() {
+            add("-stats", false);
+        }
+
         for arg in sess_args {
             add(&(*arg), true);
         }

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1945,6 +1945,10 @@ impl<B: ExtraBackendMethods> OngoingCodegen<B> {
             self.backend.print_pass_timings()
         }
 
+        if sess.print_llvm_stats() {
+            self.backend.print_statistics()
+        }
+
         (
             CodegenResults {
                 metadata: self.metadata,

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -35,6 +35,7 @@ pub trait WriteBackendMethods: 'static + Sized + Clone {
         cached_modules: Vec<(SerializedModule<Self::ModuleBuffer>, WorkProduct)>,
     ) -> Result<(Vec<LtoModuleCodegen<Self>>, Vec<WorkProduct>), FatalError>;
     fn print_pass_timings(&self);
+    fn print_statistics(&self);
     unsafe fn optimize(
         cgcx: &CodegenContext<Self>,
         diag_handler: &Handler,

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -715,6 +715,7 @@ fn test_unstable_options_tracking_hash() {
     // `pre_link_arg` is omitted because it just forwards to `pre_link_args`.
     untracked!(pre_link_args, vec![String::from("abc"), String::from("def")]);
     untracked!(print_llvm_passes, true);
+    untracked!(print_llvm_stats, true);
     untracked!(print_mono_items, Some(String::from("abc")));
     untracked!(print_type_sizes, true);
     untracked!(proc_macro_backtrace, true);

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -714,8 +714,8 @@ fn test_unstable_options_tracking_hash() {
     untracked!(perf_stats, true);
     // `pre_link_arg` is omitted because it just forwards to `pre_link_args`.
     untracked!(pre_link_args, vec![String::from("abc"), String::from("def")]);
+    untracked!(print_codegen_stats, true);
     untracked!(print_llvm_passes, true);
-    untracked!(print_llvm_stats, true);
     untracked!(print_mono_items, Some(String::from("abc")));
     untracked!(print_type_sizes, true);
     untracked!(proc_macro_backtrace, true);

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1,4 +1,5 @@
 #include "LLVMWrapper.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/DiagnosticHandler.h"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -114,6 +115,11 @@ extern "C" void LLVMRustSetNormalizedTarget(LLVMModuleRef M,
 extern "C" void LLVMRustPrintPassTimings() {
   raw_fd_ostream OS(2, false); // stderr.
   TimerGroup::printAll(OS);
+}
+
+extern "C" void LLVMRustPrintStatistics() {
+  raw_fd_ostream OS(2, false); // stderr.
+  llvm::PrintStatistics(OS);
 }
 
 extern "C" LLVMValueRef LLVMRustGetNamedValue(LLVMModuleRef M, const char *Name,

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -112,23 +112,25 @@ extern "C" void LLVMRustSetNormalizedTarget(LLVMModuleRef M,
   unwrap(M)->setTargetTriple(Triple::normalize(Triple));
 }
 
-extern "C" const char *LLVMRustPrintPassTimings(void) {
+extern "C" const char *LLVMRustPrintPassTimings(size_t *Len) {
   std::string buf;
   raw_string_ostream SS(buf);
   TimerGroup::printAll(SS);
   SS.flush();
-  char* CStr = (char*) malloc((buf.length() + 1) * sizeof(char));
-  strcpy(CStr, buf.c_str());
+  *Len = buf.length();
+  char *CStr = (char *)malloc(*Len);
+  memcpy(CStr, buf.c_str(), *Len);
   return CStr;
 }
 
-extern "C" const char *LLVMRustPrintStatistics(void) {
+extern "C" const char *LLVMRustPrintStatistics(size_t *Len) {
   std::string buf;
   raw_string_ostream SS(buf);
   llvm::PrintStatistics(SS);
   SS.flush();
-  char* CStr = (char*) malloc((buf.length() + 1) * sizeof(char));
-  strcpy(CStr, buf.c_str());
+  *Len = buf.length();
+  char *CStr = (char *)malloc(*Len);
+  memcpy(CStr, buf.c_str(), *Len);
   return CStr;
 }
 

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -112,14 +112,24 @@ extern "C" void LLVMRustSetNormalizedTarget(LLVMModuleRef M,
   unwrap(M)->setTargetTriple(Triple::normalize(Triple));
 }
 
-extern "C" void LLVMRustPrintPassTimings() {
-  raw_fd_ostream OS(2, false); // stderr.
-  TimerGroup::printAll(OS);
+extern "C" const char *LLVMRustPrintPassTimings(void) {
+  std::string buf;
+  raw_string_ostream SS(buf);
+  TimerGroup::printAll(SS);
+  SS.flush();
+  char* CStr = (char*) malloc((buf.length() + 1) * sizeof(char));
+  strcpy(CStr, buf.c_str());
+  return CStr;
 }
 
-extern "C" void LLVMRustPrintStatistics() {
-  raw_fd_ostream OS(2, false); // stderr.
-  llvm::PrintStatistics(OS);
+extern "C" const char *LLVMRustPrintStatistics(void) {
+  std::string buf;
+  raw_string_ostream SS(buf);
+  llvm::PrintStatistics(SS);
+  SS.flush();
+  char* CStr = (char*) malloc((buf.length() + 1) * sizeof(char));
+  strcpy(CStr, buf.c_str());
+  return CStr;
 }
 
 extern "C" LLVMValueRef LLVMRustGetNamedValue(LLVMModuleRef M, const char *Name,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1673,7 +1673,7 @@ options! {
     print_llvm_passes: bool = (false, parse_bool, [UNTRACKED],
         "print the LLVM optimization passes being run (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::print_llvm_stats` instead of this field")]
-    print_llvm_stats: bool = (true, parse_bool, [UNTRACKED],
+    print_llvm_stats: bool = (false, parse_bool, [UNTRACKED],
         "print LLVM statistics (default: no)"),
     print_mono_items: Option<String> = (None, parse_opt_string, [UNTRACKED],
         "print the result of the monomorphization collection pass"),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1668,13 +1668,13 @@ options! {
         "use a more precise version of drop elaboration for matches on enums (default: yes). \
         This results in better codegen, but has caused miscompilations on some tier 2 platforms. \
         See #77382 and #74551."),
+    #[rustc_lint_opt_deny_field_access("use `Session::print_codegen_stats` instead of this field")]
+    print_codegen_stats: bool = (false, parse_bool, [UNTRACKED],
+        "print codegen statistics (default: no)"),
     print_fuel: Option<String> = (None, parse_opt_string, [TRACKED],
         "make rustc print the total optimization fuel used by a crate"),
     print_llvm_passes: bool = (false, parse_bool, [UNTRACKED],
         "print the LLVM optimization passes being run (default: no)"),
-    #[rustc_lint_opt_deny_field_access("use `Session::print_llvm_stats` instead of this field")]
-    print_llvm_stats: bool = (false, parse_bool, [UNTRACKED],
-        "print LLVM statistics (default: no)"),
     print_mono_items: Option<String> = (None, parse_opt_string, [UNTRACKED],
         "print the result of the monomorphization collection pass"),
     print_type_sizes: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1672,6 +1672,9 @@ options! {
         "make rustc print the total optimization fuel used by a crate"),
     print_llvm_passes: bool = (false, parse_bool, [UNTRACKED],
         "print the LLVM optimization passes being run (default: no)"),
+    #[rustc_lint_opt_deny_field_access("use `Session::print_llvm_stats` instead of this field")]
+    print_llvm_stats: bool = (true, parse_bool, [UNTRACKED],
+        "print LLVM statistics (default: no)"),
     print_mono_items: Option<String> = (None, parse_opt_string, [UNTRACKED],
         "print the result of the monomorphization collection pass"),
     print_type_sizes: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1058,7 +1058,7 @@ impl Session {
     }
 
     pub fn print_llvm_stats(&self) -> bool {
-        self.opts.unstable_opts.print_llvm_stats
+        self.opts.unstable_opts.print_codegen_stats
     }
 
     pub fn verify_llvm_ir(&self) -> bool {

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1057,6 +1057,10 @@ impl Session {
         self.opts.unstable_opts.verbose
     }
 
+    pub fn print_llvm_stats(&self) -> bool {
+        self.opts.unstable_opts.print_llvm_stats
+    }
+
     pub fn verify_llvm_ir(&self) -> bool {
         self.opts.unstable_opts.verify_llvm_ir || option_env!("RUSTC_VERIFY_LLVM_IR").is_some()
     }


### PR DESCRIPTION
This resurrects PR https://github.com/rust-lang/rust/pull/104000, which has sat idle for a while. And I want to see the effect of stack-move optimizations on LLVM (like https://reviews.llvm.org/D153453) :).

I have applied the changes requested by @oli-obk and @nagisa  https://github.com/rust-lang/rust/pull/104000#discussion_r1014625377 and https://github.com/rust-lang/rust/pull/104000#discussion_r1014642482 in the latest commits.

r? @oli-obk 

-----

LLVM has a neat [statistics](https://llvm.org/docs/ProgrammersManual.html#the-statistic-class-stats-option) feature that tracks how often optimizations kick in. It's very handy for optimization work. Since we expose the LLVM pass timings, I thought it made sense to expose the LLVM statistics too.



-----
(Edit: fix broken link
(Edit2: fix segmentation fault and use malloc 

If `rustc` is built with 
```toml
[llvm]
assertions = true
```
Then you can see like 
```
rustc +stage1 -Z print-codegen-stats -C opt-level=3  tmp.rs
===-------------------------------------------------------------------------===
                          ... Statistics Collected ...
===-------------------------------------------------------------------------===
         3 aa                           - Number of MayAlias results
       193 aa                           - Number of MustAlias results
       531 aa                           - Number of NoAlias results
...
```

And the current default build emits only 
```
$ rustc +stage1 -Z print-codegen-stats -C opt-level=3  tmp.rs
===-------------------------------------------------------------------------===
                          ... Statistics Collected ...
===-------------------------------------------------------------------------===
$ 
```
This might be better to emit the message to tell assertion flag necessity, but now I can't find how to do that...
