### PR TITLE
Move MinGW linker dist option to proper section

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -690,10 +690,6 @@ changelog-seen = 2
 # Build compiler with the optimization enabled and -Zvalidate-mir, currently only for `std`
 #validate-mir-opts = 3
 
-# Copy the linker, DLLs, and various libraries from MinGW into the rustc toolchain.
-# Only applies when the host or target is pc-windows-gnu.
-#include-mingw-linker = true
-
 # =============================================================================
 # Options for specific targets
 #
@@ -844,3 +840,7 @@ changelog-seen = 2
 #
 # Available options: fast, balanced, best
 #compression-profile = "fast"
+
+# Copy the linker, DLLs, and various libraries from MinGW into the rustc toolchain.
+# Only applies when the host or target is pc-windows-gnu.
+#include-mingw-linker = true


### PR DESCRIPTION
Using this option currently results in the error:
```
failed to parse TOML configuration 'config.toml': unknown field `include-mingw-linker`, expected one of `optimize`, `debug`, `codegen-units`, `codegen-units-std`, `debug-assertions`, `debug-assertions-std`, `overflow-checks`, `overflow-checks-std`, `debug-logging`, `debuginfo-level`, `debuginfo-level-rustc`, `debuginfo-level-std`, `debuginfo-level-tools`, `debuginfo-level-tests`, `split-debuginfo`, `run-dsymutil`, `backtrace`, `incremental`, `parallel-compiler`, `default-linker`, `channel`, `description`, `musl-root`, `rpath`, `verbose-tests`, `optimize-tests`, `codegen-tests`, `omit-git-hash`, `dist-src`, `save-toolstates`, `codegen-backends`, `lld`, `use-lld`, `llvm-tools`, `deny-warnings`, `backtrace-on-ice`, `verify-llvm-ir`, `thin-lto-import-instr-limit`, `remap-debuginfo`, `jemalloc`, `test-compare-mode`, `llvm-libunwind`, `control-flow-guard`, `new-symbol-mangling`, `profile-generate`, `profile-use`, `download-rustc`, `lto`, `validate-mir-opts` for key `rust`
```
That's because the option [belongs to `dist` section](https://github.com/rust-lang/rust/blob/bef6ff618f17398775e9d8cd23a6f47d983869dc/src/bootstrap/config.rs#L861).

cc #108581