### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -299,10 +299,14 @@ Joseph T. Lyons <JosephTLyons@gmail.com> <JosephTLyons@users.noreply.github.com>
 Josh Cotton <jcotton42@outlook.com>
 Josh Driver <keeperofdakeys@gmail.com>
 Josh Holmer <jholmer.in@gmail.com>
-Joshua Nelson <jyn514@gmail.com> <joshua@yottadb.com>
 Julian Knodt <julianknodt@gmail.com>
 jumbatm <jumbatm@gmail.com> <30644300+jumbatm@users.noreply.github.com>
 Junyoung Cho <june0.cho@samsung.com>
+Jynn Nelson <github@jyn.dev> <jyn514@gmail.com>
+Jynn Nelson <github@jyn.dev> <joshua@yottadb.com>
+Jynn Nelson <github@jyn.dev> <jyn.nelson@redjack.com>
+Jynn Nelson <github@jyn.dev> <jnelson@cloudflare.com>
+Jynn Nelson <github@jyn.dev>
 Jyun-Yan You <jyyou.tw@gmail.com> <jyyou@cs.nctu.edu.tw>
 Kalita Alexey <kalita.alexey@outlook.com>
 Kampfkarren <boynedmaster@gmail.com>

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1742,6 +1742,18 @@ impl Config {
         }
     }
 
+    /// Runs a command, printing out nice contextual information if it fails.
+    /// Exits if the command failed to execute at all, otherwise returns its
+    /// `status.success()`.
+    #[deprecated = "use `Builder::try_run` instead where possible"]
+    pub(crate) fn try_run(&self, cmd: &mut Command) -> Result<(), ()> {
+        if self.dry_run() {
+            return Ok(());
+        }
+        self.verbose(&format!("running: {:?}", cmd));
+        build_helper::util::try_run(cmd, self.is_verbose())
+    }
+
     /// A git invocation which runs inside the source directory.
     ///
     /// Use this rather than `Command::new("git")` in order to support out-of-tree builds.

--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -7,7 +7,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use build_helper::{ci::CiEnv, util::try_run};
+use build_helper::ci::CiEnv;
 use once_cell::sync::OnceCell;
 use xz2::bufread::XzDecoder;
 
@@ -20,6 +20,12 @@ use crate::{
 };
 
 static SHOULD_FIX_BINS_AND_DYLIBS: OnceCell<bool> = OnceCell::new();
+
+/// `Config::try_run` wrapper for this module to avoid warnings on `try_run`, since we don't have access to a `builder` yet.
+fn try_run(config: &Config, cmd: &mut Command) -> Result<(), ()> {
+    #[allow(deprecated)]
+    config.try_run(cmd)
+}
 
 /// Generic helpers that are useful anywhere in bootstrap.
 impl Config {
@@ -49,17 +55,6 @@ impl Config {
         let tmp = self.out.join("tmp");
         t!(fs::create_dir_all(&tmp));
         tmp
-    }
-
-    /// Runs a command, printing out nice contextual information if it fails.
-    /// Exits if the command failed to execute at all, otherwise returns its
-    /// `status.success()`.
-    pub(crate) fn try_run(&self, cmd: &mut Command) -> Result<(), ()> {
-        if self.dry_run() {
-            return Ok(());
-        }
-        self.verbose(&format!("running: {:?}", cmd));
-        try_run(cmd, self.is_verbose())
     }
 
     /// Runs a command, printing out nice contextual information if it fails.
@@ -156,14 +151,16 @@ impl Config {
                 ];
             }
             ";
-            nix_build_succeeded = self
-                .try_run(Command::new("nix-build").args(&[
+            nix_build_succeeded = try_run(
+                self,
+                Command::new("nix-build").args(&[
                     Path::new("-E"),
                     Path::new(NIX_EXPR),
                     Path::new("-o"),
                     &nix_deps_dir,
-                ]))
-                .is_ok();
+                ]),
+            )
+            .is_ok();
             nix_deps_dir
         });
         if !nix_build_succeeded {
@@ -188,7 +185,7 @@ impl Config {
             patchelf.args(&["--set-interpreter", dynamic_linker.trim_end()]);
         }
 
-        let _ = self.try_run(patchelf.arg(fname));
+        let _ = try_run(self, patchelf.arg(fname));
     }
 
     fn download_file(&self, url: &str, dest_path: &Path, help_on_error: &str) {
@@ -236,7 +233,7 @@ impl Config {
             if self.build.contains("windows-msvc") {
                 eprintln!("Fallback to PowerShell");
                 for _ in 0..3 {
-                    if self.try_run(Command::new("PowerShell.exe").args(&[
+                    if try_run(self, Command::new("PowerShell.exe").args(&[
                         "/nologo",
                         "-Command",
                         "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;",

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -981,7 +981,7 @@ impl Build {
     }
 
     /// Runs a command, printing out contextual info if it fails, and delaying errors until the build finishes.
-    pub(crate) fn try_run(&self, cmd: &mut Command) -> bool {
+    pub(crate) fn run_delaying_failure(&self, cmd: &mut Command) -> bool {
         if !self.fail_fast {
             #[allow(deprecated)] // can't use Build::try_run, that's us
             if self.config.try_run(cmd).is_err() {

--- a/src/bootstrap/run.rs
+++ b/src/bootstrap/run.rs
@@ -24,8 +24,7 @@ impl Step for ExpandYamlAnchors {
     /// anchors in them, since GitHub Actions doesn't support them.
     fn run(self, builder: &Builder<'_>) {
         builder.info("Expanding YAML anchors in the GitHub Actions configuration");
-        try_run(
-            builder,
+        builder.try_run(
             &mut builder.tool_cmd(Tool::ExpandYamlAnchors).arg("generate").arg(&builder.src),
         );
     }
@@ -37,19 +36,6 @@ impl Step for ExpandYamlAnchors {
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(ExpandYamlAnchors);
     }
-}
-
-fn try_run(builder: &Builder<'_>, cmd: &mut Command) -> bool {
-    if !builder.fail_fast {
-        if builder.try_run(cmd).is_err() {
-            let mut failures = builder.delayed_failures.borrow_mut();
-            failures.push(format!("{:?}", cmd));
-            return false;
-        }
-    } else {
-        builder.run(cmd);
-    }
-    true
 }
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/bootstrap/run.rs
+++ b/src/bootstrap/run.rs
@@ -24,7 +24,7 @@ impl Step for ExpandYamlAnchors {
     /// anchors in them, since GitHub Actions doesn't support them.
     fn run(self, builder: &Builder<'_>) {
         builder.info("Expanding YAML anchors in the GitHub Actions configuration");
-        builder.try_run(
+        builder.run_delaying_failure(
             &mut builder.tool_cmd(Tool::ExpandYamlAnchors).arg("generate").arg(&builder.src),
         );
     }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -48,19 +48,6 @@ const MIR_OPT_BLESS_TARGET_MAPPING: &[(&str, &str)] = &[
     // build for, so there is no entry for "aarch64-apple-darwin" here.
 ];
 
-fn try_run_quiet(builder: &Builder<'_>, cmd: &mut Command) -> bool {
-    if !builder.fail_fast {
-        if !builder.try_run_quiet(cmd) {
-            let mut failures = builder.delayed_failures.borrow_mut();
-            failures.push(format!("{:?}", cmd));
-            return false;
-        }
-    } else {
-        builder.run_quiet(cmd);
-    }
-    true
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct CrateBootstrap {
     path: Interned<PathBuf>,
@@ -2134,7 +2121,7 @@ fn markdown_test(builder: &Builder<'_>, compiler: Compiler, markdown: &Path) -> 
     if builder.config.verbose_tests {
         builder.run_delaying_failure(&mut cmd)
     } else {
-        try_run_quiet(builder, &mut cmd)
+        builder.run_quiet_delaying_failure(&mut cmd)
     }
 }
 

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -108,7 +108,8 @@ impl Step for ToolBuild {
         );
 
         let mut cargo = Command::from(cargo);
-        let is_expected = builder.try_run(&mut cargo).is_ok();
+        #[allow(deprecated)] // we check this in `is_optional_tool` in a second
+        let is_expected = builder.config.try_run(&mut cargo).is_ok();
 
         builder.save_toolstate(
             tool,

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -153,16 +153,6 @@ pub fn symlink_dir(config: &Config, original: &Path, link: &Path) -> io::Result<
     }
 }
 
-/// The CI environment rustbuild is running in. This mainly affects how the logs
-/// are printed.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum CiEnv {
-    /// Not a CI environment.
-    None,
-    /// The GitHub Actions environment, for Linux (including Docker), Windows and macOS builds.
-    GitHubActions,
-}
-
 pub fn forcing_clang_based_tests() -> bool {
     if let Some(var) = env::var_os("RUSTBUILD_FORCE_CLANG_BASED_TESTS") {
         match &var.to_string_lossy().to_lowercase()[..] {


### PR DESCRIPTION
Successful merges:

 - #113643 (bootstrap: Clean up try_run)
 - #113731 (Remove unused `bootstrap::util::CiEnv` enum)
 - #113737 (update mailmap for myself)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113643,113731,113737)
<!-- homu-ignore:end -->