### PR TITLE
Don't install default projection bound for return-position `impl Trait` in trait methods with no body

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1144,13 +1144,7 @@ fn should_encode_type(tcx: TyCtxt<'_>, def_id: LocalDefId, def_kind: DefKind) ->
             let assoc_item = tcx.associated_item(def_id);
             match assoc_item.container {
                 ty::AssocItemContainer::ImplContainer => true,
-                // Always encode RPITITs, since we need to be able to project
-                // from an RPITIT associated item to an opaque when installing
-                // the default projection predicates in default trait methods
-                // with RPITITs.
-                ty::AssocItemContainer::TraitContainer => {
-                    assoc_item.defaultness(tcx).has_value() || assoc_item.is_impl_trait_in_trait()
-                }
+                ty::AssocItemContainer::TraitContainer => assoc_item.defaultness(tcx).has_value(),
             }
         }
         DefKind::TyParam => {

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -129,7 +129,9 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
     // sure that this will succeed without errors anyway.
 
     if tcx.def_kind(def_id) == DefKind::AssocFn
-        && tcx.associated_item(def_id).container == ty::AssocItemContainer::TraitContainer
+        && let assoc_item = tcx.associated_item(def_id)
+        && assoc_item.container == ty::AssocItemContainer::TraitContainer
+        && assoc_item.defaultness(tcx).has_value()
     {
         let sig = tcx.fn_sig(def_id).instantiate_identity();
         // We accounted for the binder of the fn sig, so skip the binder.

--- a/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.rs
@@ -1,0 +1,10 @@
+#![feature(return_position_impl_trait_in_trait)]
+
+struct Wrapper<G: Send>(G);
+
+trait Foo {
+    fn bar() -> Wrapper<impl Sized>;
+    //~^ ERROR `impl Sized` cannot be sent between threads safely
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.stderr
@@ -1,0 +1,16 @@
+error[E0277]: `impl Sized` cannot be sent between threads safely
+  --> $DIR/check-wf-on-non-defaulted-rpitit.rs:6:17
+   |
+LL |     fn bar() -> Wrapper<impl Sized>;
+   |                 ^^^^^^^^^^^^^^^^^^^ `impl Sized` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `impl Sized`
+note: required by a bound in `Wrapper`
+  --> $DIR/check-wf-on-non-defaulted-rpitit.rs:3:19
+   |
+LL | struct Wrapper<G: Send>(G);
+   |                   ^^^^ required by this bound in `Wrapper`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This ensures that we never try to project to an opaque type in a trait method that has no body to infer its hidden type, which means we never later call `type_of` on that opaque. This is because opaque types try to reveal their hidden type when proving auto traits.

I thought about this a lot, and I think this is a fix that's less likely to introduce other strange downstream ICEs than #113461.

Fixes #113434

r? @spastorino