### PR TITLE
impl Not, Bit{And,Or}{,Assign} for IP addresses

### DIFF
--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -2171,29 +2171,6 @@ impl Not for &'_ Ipv6Addr {
     }
 }
 
-#[stable(feature = "ip_bitops", since = "CURRENT_RUSTC_VERSION")]
-impl Not for IpAddr {
-    type Output = IpAddr;
-
-    #[inline]
-    fn not(self) -> IpAddr {
-        match self {
-            IpAddr::V4(v4) => IpAddr::V4(!v4),
-            IpAddr::V6(v6) => IpAddr::V6(!v6),
-        }
-    }
-}
-
-#[stable(feature = "ip_bitops", since = "CURRENT_RUSTC_VERSION")]
-impl Not for &'_ IpAddr {
-    type Output = IpAddr;
-
-    #[inline]
-    fn not(self) -> IpAddr {
-        !*self
-    }
-}
-
 macro_rules! bitop_impls {
     ($(
         $(#[$attr:meta])*


### PR DESCRIPTION
ACP: rust-lang/libs-team#235

Note: since these are insta-stable, these require an FCP.

Implements, where `N` is either `4` or `6`:

```rust
impl Not for IpvNAddr
impl Not for &IpvNAddr

impl BitAnd<IpvNAddr> for IpvNAddr
impl BitAnd<&IpvNAddr> for IpvNAddr
impl BitAnd<IpvNAddr> for &IpvNAddr
impl BitAnd<&IpvNAddr> for &IpvNAddr

impl BitAndAssign<IpvNAddr> for IpvNAddr
impl BitAndAssign<&IpvNAddr> for IpvNAddr

impl BitOr<IpvNAddr> for IpvNAddr
impl BitOr<&IpvNAddr> for IpvNAddr
impl BitOr<IpvNAddr> for &IpvNAddr
impl BitOr<&IpvNAddr> for &IpvNAddr

impl BitOrAssign<IpvNAddr> for IpvNAddr
impl BitOrAssign<&IpvNAddr> for IpvNAddr
```