### PR TITLE
Use log groups in `opt-dist`

### DIFF
--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -9,6 +9,7 @@ use crate::training::{gather_llvm_bolt_profiles, gather_llvm_profiles, gather_ru
 use crate::utils::io::reset_directory;
 use crate::utils::{
     clear_llvm_files, format_env_variables, print_binary_sizes, print_free_disk_space,
+    with_log_group,
 };
 
 mod environment;
@@ -29,7 +30,8 @@ fn execute_pipeline(
     dist_args: Vec<String>,
 ) -> anyhow::Result<()> {
     reset_directory(&env.opt_artifacts())?;
-    env.prepare_rustc_perf()?;
+
+    with_log_group("Building rustc-perf", || env.prepare_rustc_perf())?;
 
     // Stage 1: Build PGO instrumented rustc
     // We use a normal build of LLVM, because gathering PGO profiles for LLVM and `rustc` at the
@@ -141,12 +143,17 @@ fn main() -> anyhow::Result<()> {
         .init();
 
     let mut build_args: Vec<String> = std::env::args().skip(1).collect();
-    log::info!("Running optimized build pipeline with args `{}`", build_args.join(" "));
-    log::info!("Environment values\n{}", format_env_variables());
+    println!("Running optimized build pipeline with args `{}`", build_args.join(" "));
 
-    if let Ok(config) = std::fs::read_to_string("config.toml") {
-        log::info!("Contents of `config.toml`:\n{config}");
-    }
+    with_log_group("Environment values", || {
+        println!("Environment values\n{}", format_env_variables());
+    });
+
+    with_log_group("Printing config.toml", || {
+        if let Ok(config) = std::fs::read_to_string("config.toml") {
+            println!("Contents of `config.toml`:\n{config}");
+        }
+    });
 
     // Skip components that are not needed for try builds to speed them up
     if is_try_build() {

--- a/src/tools/opt-dist/src/utils/mod.rs
+++ b/src/tools/opt-dist/src/utils/mod.rs
@@ -56,3 +56,20 @@ pub fn clear_llvm_files(env: &dyn Environment) -> anyhow::Result<()> {
     delete_directory(&env.build_artifacts().join("lld"))?;
     Ok(())
 }
+
+/// Wraps all output produced within the `func` closure in a CI output group, if we're running in
+/// CI.
+pub fn with_log_group<F: FnOnce() -> R, R>(group: &str, func: F) -> R {
+    if is_in_ci() {
+        println!("::group::{group}");
+        let result = func();
+        println!("::endgroup::");
+        result
+    } else {
+        func()
+    }
+}
+
+fn is_in_ci() -> bool {
+    std::env::var("GITHUB_ACTIONS").is_ok()
+}


### PR DESCRIPTION
Some of the output was quite verbose in CI logs, this should help with that.

r? bootstrap