### PR TITLE
Simplify timers and query forcing in `analysis` query

### DIFF
--- a/compiler/rustc_interface/src/lib.rs
+++ b/compiler/rustc_interface/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(internal_output_capture)]
 #![feature(thread_spawn_unchecked)]
 #![feature(lazy_cell)]
+#![feature(let_chains)]
 #![feature(try_blocks)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -822,19 +822,15 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
     parallel!(
         {
             tcx.ensure().effective_visibilities(());
-
-            parallel!(
-                {
-                    tcx.ensure().check_private_in_public(());
-                },
-                {
-                    tcx.hir()
-                        .par_for_each_module(|module| tcx.ensure().check_mod_deathness(module));
-                },
-                {
-                    rustc_lint::check_crate(tcx, rustc_lint::BuiltinCombinedLateLintPass::new);
-                }
-            );
+        },
+        {
+            tcx.ensure().check_private_in_public(());
+        },
+        {
+            tcx.hir().par_for_each_module(|module| tcx.ensure().check_mod_deathness(module));
+        },
+        {
+            rustc_lint::check_crate(tcx, rustc_lint::BuiltinCombinedLateLintPass::new);
         },
         {
             tcx.hir().par_for_each_module(|module| tcx.ensure().check_mod_privacy(module));

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -746,11 +746,10 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
     rustc_passes::hir_id_validator::check_crate(tcx);
 
     let sess = tcx.sess;
-    let mut entry_point = None;
 
     parallel!(
         {
-            entry_point = tcx.entry_fn(());
+            tcx.ensure().entry_fn(());
 
             tcx.ensure().proc_macro_decls_static(());
 
@@ -846,7 +845,7 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
 
     // This check has to be run after all lints are done processing. We don't
     // define a lint filter, as all lint checks should have finished at this point.
-    let _ = tcx.check_expectations(None);
+    tcx.ensure().check_expectations(None);
 
     if sess.opts.unstable_opts.print_vtable_sizes {
         let traits = tcx.traits(LOCAL_CRATE);

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -833,6 +833,9 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
             rustc_lint::check_crate(tcx, rustc_lint::BuiltinCombinedLateLintPass::new);
         },
         {
+            tcx.hir().par_for_each_module(|module| tcx.ensure().lint_mod(module));
+        },
+        {
             tcx.hir().par_for_each_module(|module| tcx.ensure().check_mod_privacy(module));
         }
     );

--- a/compiler/rustc_passes/src/layout_test.rs
+++ b/compiler/rustc_passes/src/layout_test.rs
@@ -11,6 +11,8 @@ use rustc_target::abi::{HasDataLayout, TargetDataLayout};
 use crate::errors::{Abi, Align, HomogeneousAggregate, LayoutOf, Size, UnrecognizedField};
 
 pub fn test_layout(tcx: TyCtxt<'_>) {
+    let _prof_timer = tcx.sess.timer("layout_testing");
+
     if tcx.features().rustc_attrs {
         // if the `rustc_attrs` feature is not enabled, don't bother testing layout
         for id in tcx.hir().items() {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -931,6 +931,8 @@ impl<'tcx> Visitor<'tcx> for CheckTraitImplStable<'tcx> {
 /// were expected to be library features), and the list of features used from
 /// libraries, identify activated features that don't exist and error about them.
 pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
+    let _prof_timer = tcx.sess.timer("unused_lib_feature_checking");
+
     let is_staged_api =
         tcx.sess.opts.unstable_opts.force_unstable_if_unmarked || tcx.features().staged_api;
     if is_staged_api {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -327,6 +327,7 @@ pub(crate) fn run_global_ctxt(
     tcx.sess.time("missing_docs", || {
         rustc_lint::check_crate(tcx, rustc_lint::builtin::MissingDoc::new);
     });
+    tcx.hir().par_for_each_module(|module| tcx.ensure().lint_mod(module));
     tcx.sess.time("check_mod_attrs", || {
         tcx.hir().for_each_module(|module| tcx.ensure().check_mod_attrs(module))
     });


### PR DESCRIPTION
`sess.time` is not useful around queries, as they are timed by the query system itself.

Other uses of `sess.time` are replaced by `sess.timer`, to reduce callback pollution and simplify code.

cc @SparrowLii as this changes the parallelization pattern.