### PR TITLE
Normalize lazy type aliases when probing for ADTs

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -302,7 +302,9 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
         match ty.kind() {
             ty::Adt(adt_def, _) => Some(*adt_def),
             // FIXME(#104767): Should we handle bound regions here?
-            ty::Alias(ty::Projection | ty::Inherent, _) if !ty.has_escaping_bound_vars() => {
+            ty::Alias(ty::Projection | ty::Inherent | ty::Weak, _)
+                if !ty.has_escaping_bound_vars() =>
+            {
                 self.normalize(span, ty).ty_adt_def()
             }
             _ => None,

--- a/tests/ui/type-alias/lazy-type-alias-enum-variant.rs
+++ b/tests/ui/type-alias/lazy-type-alias-enum-variant.rs
@@ -1,0 +1,17 @@
+// Regression test for issue #113736.
+// check-pass
+
+#![feature(lazy_type_alias)]
+
+enum Enum {
+    Unit,
+    Tuple(),
+    Struct {},
+}
+
+fn main() {
+    type Alias = Enum;
+    let _ = Alias::Unit;
+    let _ = Alias::Tuple();
+    let _ = Alias::Struct {};
+}


### PR DESCRIPTION
Fixes #113736.

r? @oli-obk