### PR TITLE
Add `if-identical` mode for `download-ci-llvm`

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1105,7 +1105,7 @@ impl<'a> Builder<'a> {
         let mut dylib_dirs = vec![self.rustc_libdir(compiler)];
 
         // Ensure that the downloaded LLVM libraries can be found.
-        if self.config.llvm.from_ci {
+        if self.config.llvm_from_ci {
             let ci_llvm_lib = self.out.join(&*compiler.host.triple).join("ci-llvm").join("lib");
             dylib_dirs.push(ci_llvm_lib);
         }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -827,6 +827,7 @@ impl<'a> Builder<'a> {
                 dist::Miri,
                 dist::LlvmTools,
                 dist::RustDev,
+                dist::RustDevConfig,
                 dist::Bootstrap,
                 dist::Extended,
                 // It seems that PlainSourceTarball somehow changes how some of the tools

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1104,7 +1104,7 @@ impl<'a> Builder<'a> {
         let mut dylib_dirs = vec![self.rustc_libdir(compiler)];
 
         // Ensure that the downloaded LLVM libraries can be found.
-        if self.config.llvm_from_ci {
+        if self.config.llvm.from_ci {
             let ci_llvm_lib = self.out.join(&*compiler.host.triple).join("ci-llvm").join("lib");
             dylib_dirs.push(ci_llvm_lib);
         }
@@ -1872,7 +1872,7 @@ impl<'a> Builder<'a> {
         //
         // FIXME: the guard against msvc shouldn't need to be here
         if target.contains("msvc") {
-            if let Some(ref cl) = self.config.llvm_clang_cl {
+            if let Some(ref cl) = self.config.llvm.clang_cl {
                 cargo.env("CC", cl).env("CXX", cl);
             }
         } else {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -469,7 +469,7 @@ impl Step for Rustc {
             t!(fs::create_dir_all(&dst_dir));
 
             // Copy over lld if it's there
-            if builder.config.lld_enabled {
+            if builder.config.llvm.lld_enabled {
                 let src_dir = builder.sysroot_libdir(compiler, host).parent().unwrap().join("bin");
                 let rust_lld = exe("rust-lld", compiler.host);
                 builder.copy(&src_dir.join(&rust_lld), &dst_dir.join(&rust_lld));
@@ -1968,7 +1968,7 @@ fn install_llvm_file(builder: &Builder<'_>, source: &Path, destination: &Path) {
 /// Returns whether the files were actually copied.
 fn maybe_install_llvm(builder: &Builder<'_>, target: TargetSelection, dst_libdir: &Path) -> bool {
     if let Some(config) = builder.config.target_config.get(&target) {
-        if config.llvm_config.is_some() && !builder.config.llvm_from_ci {
+        if config.llvm_config.is_some() && !builder.config.llvm.from_ci {
             // If the LLVM was externally provided, then we don't currently copy
             // artifacts into the sysroot. This is not necessarily the right
             // choice (in particular, it will require the LLVM dylib to be in
@@ -2090,7 +2090,7 @@ impl Step for BoltInstrument {
             return self.file.clone();
         }
 
-        if builder.build.config.llvm_from_ci {
+        if builder.build.config.llvm.from_ci {
             println!("warning: trying to use BOLT with LLVM from CI, this will probably not work");
         }
 
@@ -2142,7 +2142,7 @@ impl Step for BoltOptimize {
             return self.file.clone();
         }
 
-        if builder.build.config.llvm_from_ci {
+        if builder.build.config.llvm.from_ci {
             println!("warning: trying to use BOLT with LLVM from CI, this will probably not work");
         }
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1968,7 +1968,7 @@ fn install_llvm_file(builder: &Builder<'_>, source: &Path, destination: &Path) {
 /// Returns whether the files were actually copied.
 fn maybe_install_llvm(builder: &Builder<'_>, target: TargetSelection, dst_libdir: &Path) -> bool {
     if let Some(config) = builder.config.target_config.get(&target) {
-        if config.llvm_config.is_some() && !builder.config.llvm.from_ci {
+        if config.llvm_config.is_some() && !builder.config.llvm_from_ci {
             // If the LLVM was externally provided, then we don't currently copy
             // artifacts into the sysroot. This is not necessarily the right
             // choice (in particular, it will require the LLVM dylib to be in
@@ -2090,7 +2090,7 @@ impl Step for BoltInstrument {
             return self.file.clone();
         }
 
-        if builder.build.config.llvm.from_ci {
+        if builder.build.config.llvm_from_ci {
             println!("warning: trying to use BOLT with LLVM from CI, this will probably not work");
         }
 
@@ -2142,7 +2142,7 @@ impl Step for BoltOptimize {
             return self.file.clone();
         }
 
-        if builder.build.config.llvm.from_ci {
+        if builder.build.config.llvm_from_ci {
             println!("warning: trying to use BOLT with LLVM from CI, this will probably not work");
         }
 

--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -425,7 +425,7 @@ impl Config {
         self.download_toolchain(
             &version,
             "ci-rustc",
-            &format!("{commit}-{}", self.llvm_assertions),
+            &format!("{commit}-{}", self.llvm.assertions),
             &extra_components,
             Self::download_ci_component,
         );
@@ -530,14 +530,14 @@ impl Config {
         let tarball = cache_dir.join(&filename);
         let (base_url, url, should_verify) = match mode {
             DownloadSource::CI => {
-                let dist_server = if self.llvm_assertions {
+                let dist_server = if self.llvm.assertions {
                     self.stage0_metadata.config.artifacts_with_llvm_assertions_server.clone()
                 } else {
                     self.stage0_metadata.config.artifacts_server.clone()
                 };
                 let url = format!(
                     "{}/{filename}",
-                    key.strip_suffix(&format!("-{}", self.llvm_assertions)).unwrap()
+                    key.strip_suffix(&format!("-{}", self.llvm.assertions)).unwrap()
                 );
                 (dist_server, url, false)
             }
@@ -602,13 +602,13 @@ download-rustc = false
     }
 
     pub(crate) fn maybe_download_ci_llvm(&self) {
-        if !self.llvm_from_ci {
+        if !self.llvm.from_ci {
             return;
         }
         let llvm_root = self.ci_llvm_root();
         let llvm_stamp = llvm_root.join(".llvm-stamp");
         let llvm_sha = detect_llvm_sha(&self, self.rust_info.is_managed_git_subrepository());
-        let key = format!("{}{}", llvm_sha, self.llvm_assertions);
+        let key = format!("{}{}", llvm_sha, self.llvm.assertions);
         if program_out_of_date(&llvm_stamp, &key) && !self.dry_run() {
             self.download_ci_llvm(&llvm_sha);
             if self.should_fix_bins_and_dylibs() {
@@ -644,7 +644,7 @@ download-rustc = false
     }
 
     fn download_ci_llvm(&self, llvm_sha: &str) {
-        let llvm_assertions = self.llvm_assertions;
+        let llvm_assertions = self.llvm.assertions;
 
         let cache_prefix = format!("llvm-{}-{}", llvm_sha, llvm_assertions);
         let cache_dst = self.out.join("cache");

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -868,7 +868,7 @@ impl Build {
             Some(Target { llvm_config, .. }) => {
                 // If the user set llvm-config we assume Rust is not patched,
                 // but first check to see if it was configured by llvm-from-ci.
-                (self.config.llvm.from_ci && target == self.config.build) || llvm_config.is_none()
+                (self.config.llvm_from_ci && target == self.config.build) || llvm_config.is_none()
             }
             None => true,
         }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -868,7 +868,7 @@ impl Build {
             Some(Target { llvm_config, .. }) => {
                 // If the user set llvm-config we assume Rust is not patched,
                 // but first check to see if it was configured by llvm-from-ci.
-                (self.config.llvm_from_ci && target == self.config.build) || llvm_config.is_none()
+                (self.config.llvm.from_ci && target == self.config.build) || llvm_config.is_none()
             }
             None => true,
         }
@@ -902,8 +902,8 @@ impl Build {
         } else {
             let base = self.llvm_out(target).join("build");
             let base = if !self.ninja() && target.contains("msvc") {
-                if self.config.llvm_optimize {
-                    if self.config.llvm_release_debuginfo {
+                if self.config.llvm.optimize {
+                    if self.config.llvm.release_debuginfo {
                         base.join("RelWithDebInfo")
                     } else {
                         base.join("Release")
@@ -1252,7 +1252,7 @@ impl Build {
             && !target.contains("msvc")
         {
             Some(self.cc(target))
-        } else if self.config.use_lld && !self.is_fuse_ld_lld(target) && self.build == target {
+        } else if self.config.llvm.use_lld && !self.is_fuse_ld_lld(target) && self.build == target {
             Some(self.initial_lld.clone())
         } else {
             None
@@ -1262,13 +1262,13 @@ impl Build {
     // LLD is used through `-fuse-ld=lld` rather than directly.
     // Only MSVC targets use LLD directly at the moment.
     fn is_fuse_ld_lld(&self, target: TargetSelection) -> bool {
-        self.config.use_lld && !target.contains("msvc")
+        self.config.llvm.use_lld && !target.contains("msvc")
     }
 
     fn lld_flags(&self, target: TargetSelection) -> impl Iterator<Item = String> {
         let mut options = [None, None];
 
-        if self.config.use_lld {
+        if self.config.llvm.use_lld {
             if self.is_fuse_ld_lld(target) {
                 options[0] = Some("-Clink-arg=-fuse-ld=lld".to_string());
             }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1738,7 +1738,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
 
             if !builder.config.dry_run() && matches!(suite, "run-make" | "run-make-fulldeps") {
                 // If LLD is available, add it to the PATH
-                if builder.config.lld_enabled {
+                if builder.config.llvm.lld_enabled {
                     let lld_install_root =
                         builder.ensure(llvm::Lld { target: builder.config.build });
 


### PR DESCRIPTION
This PR tries to modify the `download-ci-llvm` logic so that it can support more use-cases, primarily downloading of LLVM from CI in `dist` CI builders. Currently, LLVM can be downloaded from CI only if you do not set any LLVM flags on `config.toml` (apart from assertions) - because it is not possible to find out the options that were used to compile LLVM from the dist archive stored on S3.

This means that `dist` builders have to build LLVM on every merge, even though the LLVM source code (nor its compilation options/parameters) have changed. It usually does not take too long to build LLVM thanks to `sccache` (usually about 10 - 20 minutes), but it's still a nontrivial cost when multiplied by the number of dist builders.

This PR proposes a new workflow:
1) When a dist builder builds LLVM and uploads it to CI, it also uploads a separate archive that contains a JSON representation of the LLVM config (opts) used for compiling LLVM. An alternative to a separate archive is to just store this information directly within `rust-dev`, but then we would have to download this rather large archive when `if-identical` is used. I'm not sure if it would be that big of a deal, this mode is designed for CI, and most of the time it should be a "cache hit", when the LLVM options will be the same, and we will thus want to download LLVM anyway.
2) A new `if-identical` mode for `download-ci-llvm` is added. When used, it will try to download the LLVM opts from CI, and compare them to the local options. If they are identical, it will download LLVM from CI. This means that a `dist` builder can use this option to download a previous LLVM build without rebuilding it from scratch if nothing related to LLVM has changed.

The logic of `if-identical` is now a bit weird in that it always unconditionally tries to download the configuration from CI, which means that it does this e.g. even if I just run `python3 x.py fmt`, which is definitely not something that we should do. I'm not sure how to resolve this though - maybe the logic of this mode should be "lazy", similarly as to how the value of `llvm_link_shared` is resolved lazily, based on data downloaded from CI?

I'm opening this PR mostly for discussion, it's not clear to me if this is the right direction. One counter-argument to this could be that we should actually run the dist LLVM builds on every commit, just to check more often that it still works. If this is the case, I would still like to do something like this at least for try builds, which are latency-bounds, possibly with some ad-hoc way and without using `download-ci-llvm`.

Related issue: https://github.com/rust-lang/rust/issues/112011
Zulip discussion: https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/Downloading.20LLVM.20from.20CI.20in.20dist.20builders

r? jyn514