### PR TITLE
Fix typo

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -749,7 +749,7 @@ impl<T, E> Result<T, E> {
     }
 
     /// Returns the provided default (if [`Err`]), or
-    /// applies a function to the contained value (if [`Ok`]),
+    /// applies a function to the contained value (if [`Ok`]).
     ///
     /// Arguments passed to `map_or` are eagerly evaluated; if you are passing
     /// the result of a function call, it is recommended to use [`map_or_else`],


### PR DESCRIPTION
Typo in a docstring, noticed [here](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or).