### PR TITLE
Don't attempt to compute layout of type referencing error

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -138,7 +138,10 @@ where
         err_inval!(Layout(LayoutError::Unknown(_))) | err_inval!(TooGeneric) => {
             ErrorHandled::TooGeneric
         }
-        err_inval!(AlreadyReported(error_reported)) => ErrorHandled::Reported(error_reported),
+        err_inval!(AlreadyReported(guar)) => ErrorHandled::Reported(guar),
+        err_inval!(Layout(LayoutError::ReferencesError(guar))) => {
+            ErrorHandled::Reported(guar.into())
+        }
         err_inval!(Layout(layout_error @ LayoutError::SizeOverflow(_))) => {
             // We must *always* hard error on these, even if the caller wants just a lint.
             // The `message` makes little sense here, this is a more serious error than the

--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -122,14 +122,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         } else {
             err.note(format!("source type: `{}` ({})", from, skeleton_string(from, sk_from)))
                 .note(format!("target type: `{}` ({})", to, skeleton_string(to, sk_to)));
-            let mut should_delay_as_bug = false;
-            if let Err(LayoutError::Unknown(bad_from)) = sk_from && bad_from.references_error() {
-                should_delay_as_bug = true;
-            }
-            if let Err(LayoutError::Unknown(bad_to)) = sk_to && bad_to.references_error() {
-                should_delay_as_bug = true;
-            }
-            if should_delay_as_bug {
+            if let Err(LayoutError::ReferencesError(_)) = sk_from {
+                err.delay_as_bug();
+            } else if let Err(LayoutError::ReferencesError(_)) = sk_to {
                 err.delay_as_bug();
             }
         }

--- a/compiler/rustc_middle/messages.ftl
+++ b/compiler/rustc_middle/messages.ftl
@@ -52,6 +52,9 @@ middle_drop_check_overflow =
     overflow while adding drop-check rules for {$ty}
     .note = overflowed on {$overflow_ty}
 
+middle_layout_references_error =
+    the type has an unknown layout
+
 middle_limit_invalid =
     `limit` must be a non-negative integer
     .label = {$error_str}

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -132,6 +132,9 @@ pub enum LayoutError<'tcx> {
 
     #[diag(middle_cycle)]
     Cycle,
+
+    #[diag(middle_layout_references_error)]
+    ReferencesError,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -10,7 +10,7 @@ use rustc_hir::def_id::DefId;
 use rustc_index::IndexVec;
 use rustc_session::config::OptLevel;
 use rustc_span::symbol::{sym, Symbol};
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{ErrorGuaranteed, Span, DUMMY_SP};
 use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::*;
 use rustc_target::spec::{abi::Abi as SpecAbi, HasTargetSpec, PanicStrategy, Target};
@@ -212,6 +212,7 @@ pub enum LayoutError<'tcx> {
     Unknown(Ty<'tcx>),
     SizeOverflow(Ty<'tcx>),
     NormalizationFailure(Ty<'tcx>, NormalizationError<'tcx>),
+    ReferencesError(ErrorGuaranteed),
     Cycle,
 }
 
@@ -224,6 +225,7 @@ impl<'tcx> LayoutError<'tcx> {
             SizeOverflow(_) => middle_values_too_big,
             NormalizationFailure(_, _) => middle_cannot_be_normalized,
             Cycle => middle_cycle,
+            ReferencesError(_) => middle_layout_references_error,
         }
     }
 
@@ -237,6 +239,7 @@ impl<'tcx> LayoutError<'tcx> {
                 E::NormalizationFailure { ty, failure_ty: e.get_type_for_failure() }
             }
             Cycle => E::Cycle,
+            ReferencesError(_) => E::ReferencesError,
         }
     }
 }
@@ -257,6 +260,7 @@ impl<'tcx> fmt::Display for LayoutError<'tcx> {
                 e.get_type_for_failure()
             ),
             LayoutError::Cycle => write!(f, "a cycle occurred during layout computation"),
+            LayoutError::ReferencesError(_) => write!(f, "the type has an unknown layout"),
         }
     }
 }
@@ -323,7 +327,8 @@ impl<'tcx> SizeSkeleton<'tcx> {
             Err(
                 e @ LayoutError::Cycle
                 | e @ LayoutError::SizeOverflow(_)
-                | e @ LayoutError::NormalizationFailure(..),
+                | e @ LayoutError::NormalizationFailure(..)
+                | e @ LayoutError::ReferencesError(_),
             ) => return Err(e),
         };
 

--- a/compiler/rustc_transmute/src/layout/tree.rs
+++ b/compiler/rustc_transmute/src/layout/tree.rs
@@ -195,7 +195,7 @@ pub(crate) mod rustc {
     impl<'tcx> From<&LayoutError<'tcx>> for Err {
         fn from(err: &LayoutError<'tcx>) -> Self {
             match err {
-                LayoutError::Unknown(..) => Self::UnknownLayout,
+                LayoutError::Unknown(..) | LayoutError::ReferencesError(..) => Self::UnknownLayout,
                 err => unimplemented!("{:?}", err),
             }
         }

--- a/src/librustdoc/html/templates/type_layout.html
+++ b/src/librustdoc/html/templates/type_layout.html
@@ -44,6 +44,11 @@
             <strong>Note:</strong> Encountered an error during type layout; {#+ #}
             the type was too big. {# #}
         </p> {# #}
+        {% when Err(LayoutError::ReferencesError(_)) %}
+        <p> {# #}
+            <strong>Note:</strong> Encountered an error during type layout; {#+ #}
+            the type references errors. {# #}
+        </p> {# #}
         {% when Err(LayoutError::NormalizationFailure(_, _)) %}
         <p> {# #}
             <strong>Note:</strong> Encountered an error during type layout; {#+ #}

--- a/tests/ui/layout/malformed-unsized-type-in-union.rs
+++ b/tests/ui/layout/malformed-unsized-type-in-union.rs
@@ -1,0 +1,8 @@
+// issue: 113760
+
+union W { s: dyn Iterator<Item = Missing> }
+//~^ ERROR cannot find type `Missing` in this scope
+
+static ONCE: W = todo!();
+
+fn main() {}

--- a/tests/ui/layout/malformed-unsized-type-in-union.stderr
+++ b/tests/ui/layout/malformed-unsized-type-in-union.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/malformed-unsized-type-in-union.rs:3:34
+   |
+LL | union W { s: dyn Iterator<Item = Missing> }
+   |                                  ^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Leads to more ICEs and strange diagnostics than are worth it.

Fixes #113760