### PR TITLE
Build the first LLVM without LTO in try builds

### DIFF
--- a/src/tools/opt-dist/src/environment/linux.rs
+++ b/src/tools/opt-dist/src/environment/linux.rs
@@ -41,6 +41,10 @@ impl Environment for LinuxEnvironment {
         true
     }
 
+    fn supports_shared_llvm(&self) -> bool {
+        true
+    }
+
     fn executable_extension(&self) -> &'static str {
         ""
     }

--- a/src/tools/opt-dist/src/environment/mod.rs
+++ b/src/tools/opt-dist/src/environment/mod.rs
@@ -60,6 +60,8 @@ pub trait Environment {
 
     fn supports_bolt(&self) -> bool;
 
+    fn supports_shared_llvm(&self) -> bool;
+
     /// What is the extension of binary executables in this environment?
     fn executable_extension(&self) -> &'static str;
 

--- a/src/tools/opt-dist/src/environment/windows.rs
+++ b/src/tools/opt-dist/src/environment/windows.rs
@@ -65,6 +65,10 @@ impl Environment for WindowsEnvironment {
         false
     }
 
+    fn supports_shared_llvm(&self) -> bool {
+        false
+    }
+
     fn executable_extension(&self) -> &'static str {
         ".exe"
     }

--- a/src/tools/opt-dist/src/exec.rs
+++ b/src/tools/opt-dist/src/exec.rs
@@ -139,6 +139,16 @@ impl Bootstrap {
         self
     }
 
+    pub fn without_llvm_lto(mut self) -> Self {
+        self.cmd = self
+            .cmd
+            .arg("--set")
+            .arg("llvm.thin-lto=false")
+            .arg("--set")
+            .arg("llvm.link-shared=true");
+        self
+    }
+
     pub fn rustc_pgo_optimize(mut self, profile: &RustcPGOProfile) -> Self {
         self.cmd = self.cmd.arg("--rust-profile-use").arg(profile.0.as_str());
         self

--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -38,7 +38,17 @@ fn execute_pipeline(
         let rustc_profile_dir_root = env.opt_artifacts().join("rustc-pgo");
 
         stage.section("Build PGO instrumented rustc and LLVM", |section| {
-            Bootstrap::build(env).rustc_pgo_instrument(&rustc_profile_dir_root).run(section)
+            let mut builder = Bootstrap::build(env).rustc_pgo_instrument(&rustc_profile_dir_root);
+
+            if env.supports_shared_llvm() {
+                // This first LLVM that we build will be thrown away after this stage, and it
+                // doesn't really need LTO. Without LTO, it builds in ~1 minute thanks to sccache,
+                // with LTO it takes almost 10 minutes. It makes the followup Rustc PGO
+                // instrumented/optimized build a bit slower, but it seems to be worth it.
+                builder = builder.without_llvm_lto();
+            }
+
+            builder.run(section)
         })?;
 
         let profile = stage


### PR DESCRIPTION
Currently, we perform three LLVM builds in the Linux x64 dist builder, which is used for `try` builds:
1) "Normal" LLVM - takes ~5s to compile thanks to `sccache`, but ~8 minutes to link because of ThinLTO
2) PGO instrumented LLVM - same timings as 1)
3) PGO optimized LLVM - takes about 20 minutes to build

When I tried to disable LTO for build 1), it suddenly takes only about a minute to build, because the linking step is much faster. The first LLVM doesn't really need LTO all that much. Without it, it will be a bit slower to build `rustc` in two subsequent steps, but it seems that the ~7 minutes saved on linking it do win that back.

Btw, we can't use the host LLVM for build 1), because this LLVM then builds `rustc` in PGO instrumented mode, and we need the same compiler when later PGO optimizing `rustc`. And we want to use our in-house LLVM for that I think.