### PR TITLE
Disable dist tests on beta/stable

### DIFF
--- a/src/ci/stage-build.py
+++ b/src/ci/stage-build.py
@@ -22,7 +22,7 @@ from typing import Callable, ContextManager, Dict, Iterable, Iterator, List, Opt
     Tuple, Union
 
 PGO_HOST = os.environ["PGO_HOST"]
-CHANNEL = os.environ["RUST_RELEASE_CHANNEL"]
+CHANNEL = os.environ.get("RUST_RELEASE_CHANNEL", "")
 
 LOGGER = logging.getLogger("stage-build")
 
@@ -993,9 +993,10 @@ def execute_build_pipeline(timer: Timer, pipeline: Pipeline, runner: BenchmarkRu
         record_metrics(pipeline, final_stage)
 
     # Try builds can be in various broken states, so we don't want to gatekeep them with tests
-    if not is_try_build():
-        with timer.section("Run tests"):
-            run_tests(pipeline)
+    # Do not run tests, as they are broken for beta/stable versions in this script
+    # if not is_try_build():
+    #     with timer.section("Run tests"):
+    #         run_tests(pipeline)
 
 
 def run(runner: BenchmarkRunner):


### PR DESCRIPTION
Should resolve the beta/stable part of https://github.com/rust-lang/rust/issues/113784. To be extra safe, I also made the read of `RUST_RELEASE_CHANNEL` optional, just in case it was missing.

r? @Mark-Simulacrum