### PR TITLE
Update documentation for std::process::Command's new method

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -558,6 +558,14 @@ impl Command {
     /// but this has some implementation limitations on Windows
     /// (see issue #37519).
     ///
+    /// # Platform-specific behavior
+    ///
+    /// Note on Windows: For executable files with the .exe extension,
+    /// it can be omitted when specifying the program for this Command.
+    /// However, if the file has a different extension,
+    /// a filename including the extension needs to be provided,
+    /// otherwise the file won't be found.
+    ///
     /// # Examples
     ///
     /// Basic usage:


### PR DESCRIPTION
In the current documentation, it's not specified that when creating a Command, the .exe extension can be omitted for Windows executables. However, for other types of executable files like .bat or .cmd, the complete filename including the extension must be provided.

I encountered it by noticing that `Command::new("wt").spawn().unwrap()` succeeds on my machine while `Command::new("code").spawn().unwrap()` panics. Turns out VS Code's entrypoint is .cmd file.

`resolve_exe` method mentions this behaviour in [a comment](https://github.com/rust-lang/rust/blob/e7fda447e7d05b6ca431fc8fe8f489b1fda810bc/library/std/src/sys/windows/process.rs#L425), but it makes sense to mention it at a more visible place.

I've added this clarification to the documentation, which should make it more accurate and helpful for Rust developers working on the Windows platform.