### PR TITLE
Bump compiler_builtins to 0.1.96

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.95"
+version = "0.1.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6866e0f3638013234db3c89ead7a14d278354338e7237257407500009012b23f"
+checksum = "9dfb2e4b73f566e464e0d614dc2bf7bf7cefe44ef9ba6d1195cdb2ad0b0aed14"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
 libc = { version = "0.2.146", default-features = false, features = ['rustc-dep-of-std'], public = true }
-compiler_builtins = { version = "0.1.95" }
+compiler_builtins = { version = "0.1.96" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = ['rustc-dep-of-std'] }


### PR DESCRIPTION
This fixes a build failure on big-endian AArch64 (https://github.com/rust-lang/compiler-builtins/pull/539).