### PR TITLE
Tests crash from inappropriate use of common linkage

### DIFF
--- a/tests/ui/linkage-attr/common-linkage-non-zero-init.rs
+++ b/tests/ui/linkage-attr/common-linkage-non-zero-init.rs
@@ -1,0 +1,14 @@
+// build-fail
+// failure-status: 101
+// known-bug: #109681
+
+// This test verifies that we continue to hit the LLVM error for common linkage with non-zero
+// initializers, since it generates invalid LLVM IR.
+// Linkages are internal features marked as perma-unstable, so we don't need to fix the issue
+// for now.
+#![crate_type="lib"]
+#![feature(linkage)]
+
+#[linkage = "common"]
+#[no_mangle]
+pub static TEST: bool = true;

--- a/tests/ui/linkage-attr/common-linkage-non-zero-init.stderr
+++ b/tests/ui/linkage-attr/common-linkage-non-zero-init.stderr
@@ -1,0 +1,3 @@
+'common' global must have a zero initializer!
+ptr @TEST
+LLVM ERROR: Broken module found, compilation aborted!


### PR DESCRIPTION
Follows up my proposal under the [tracking issue for the linkage feature](https://github.com/rust-lang/rust/issues/29603#issuecomment-1597662999). Adds test for [issue 109681](https://github.com/rust-lang/rust/issues/109681).