### PR TITLE
fix CI skipping weekly `cargo update`

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,16 +25,16 @@ env:
 
 jobs:
   not-waiting-on-bors:
-    if: github.repository_owner == 'rust-lang'
+    if: github.repository_owner == 'rust-lang-ci'
     name: skip if S-waiting-on-bors
     runs-on: ubuntu-latest
     steps:
       - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CARGO_UPDATE_TOKEN }}
         run: |
           # Fetch state and labels of PR
           # Or exit successfully if PR does not exist
-          JSON=$(gh pr view cargo_update --repo $GITHUB_REPOSITORY --json labels,state || exit 0)
+          JSON=$(gh pr view cargo_update --repo rust-lang/rust --json labels,state || exit 0)
           STATE=$(echo "$JSON" | jq -r '.state')
           WAITING_ON_BORS=$(echo "$JSON" | jq '.labels[] | any(.name == "S-waiting-on-bors"; .)')
 
@@ -44,7 +44,7 @@ jobs:
           fi
 
   update:
-    if: github.repository_owner == 'rust-lang'
+    if: github.repository_owner == 'rust-lang-ci'
     name: update dependencies
     needs: not-waiting-on-bors
     runs-on: ubuntu-latest
@@ -78,13 +78,12 @@ jobs:
           retention-days: 1
 
   pr:
-    if: github.repository_owner == 'rust-lang'
+    if: github.repository_owner == 'rust-lang-ci'
     name: amend PR
     needs: update
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - name: checkout the source code
         uses: actions/checkout@v3
@@ -124,19 +123,19 @@ jobs:
         # Don't fail job if we need to open new PR
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CARGO_UPDATE_TOKEN }}
         run: |
           # Exit with error if PR is closed
-          STATE=$(gh pr view cargo_update --repo $GITHUB_REPOSITORY --json state --jq '.state')
+          STATE=$(gh pr view cargo_update --repo rust-lang/rust --json state --jq '.state')
           if [[ "$STATE" != "OPEN" ]]; then
             exit 1
           fi
 
-          gh pr edit cargo_update --title "${PR_TITLE}" --body-file body.md --repo $GITHUB_REPOSITORY
+          gh pr edit cargo_update --title "${PR_TITLE}" --body-file body.md --repo rust-lang/rust
 
       - name: open new pull request
         # Only run if there wasn't an existing PR
         if: steps.edit.outcome != 'success'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr create --title "${PR_TITLE}" --body-file body.md --repo $GITHUB_REPOSITORY
+          GITHUB_TOKEN: ${{ secrets.CARGO_UPDATE_TOKEN }}
+        run: gh pr create --title "${PR_TITLE}" --body-file body.md --repo rust-lang/rust

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,6 +16,8 @@ defaults:
 env:
   # So cargo doesn't complain about unstable features
   RUSTC_BOOTSTRAP: 1
+
+  # User-facing text
   PR_TITLE: Weekly `cargo update`
   PR_MESSAGE: |
     Automation to keep dependencies in `Cargo.lock` current.
@@ -23,8 +25,14 @@ env:
     The following is the output from `cargo update`:
   COMMIT_MESSAGE: "cargo update \n\n"
 
+  # Name to use for the branch
+  BRANCH: cargo_update
+  # Github repository to open the PR on
+  BASE_REPO: pitaj/rust
+
 jobs:
   not-waiting-on-bors:
+    # Only run workflow if on rust-lang-ci
     if: github.repository_owner == 'pitaj-rust-lang-ci'
     name: skip if S-waiting-on-bors
     runs-on: ubuntu-latest
@@ -34,7 +42,7 @@ jobs:
         run: |
           # Fetch state and labels of PR
           # Or exit successfully if PR does not exist
-          JSON=$(gh pr view cargo_update --repo pitaj/rust --json labels,state || exit 0)
+          JSON=$(gh pr view "${GITHUB_REPOSITORY_OWNER}:${BRANCH}" --repo "$BASE_REPO" --json labels,state || exit 0)
           STATE=$(echo "$JSON" | jq -r '.state')
           WAITING_ON_BORS=$(echo "$JSON" | jq '.labels[] | any(.name == "S-waiting-on-bors"; .)')
 
@@ -44,7 +52,6 @@ jobs:
           fi
 
   update:
-    if: github.repository_owner == 'pitaj-rust-lang-ci'
     name: update dependencies
     needs: not-waiting-on-bors
     runs-on: ubuntu-latest
@@ -78,7 +85,6 @@ jobs:
           retention-days: 1
 
   pr:
-    if: github.repository_owner == 'pitaj-rust-lang-ci'
     name: amend PR
     needs: update
     runs-on: ubuntu-latest
@@ -111,12 +117,12 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git switch --force-create cargo_update
+          git switch --force-create "$BRANCH"
           git add ./Cargo.lock
           git commit --no-verify --file=commit.txt
 
       - name: push
-        run: git push --no-verify --force --set-upstream origin cargo_update
+        run: git push --no-verify --force --set-upstream origin "$BRANCH"
 
       - name: edit existing open pull request
         id: edit
@@ -126,16 +132,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CARGO_UPDATE_TOKEN }}
         run: |
           # Exit with error if PR is closed
-          STATE=$(gh pr view cargo_update --repo pitaj/rust --json state --jq '.state')
+          STATE=$(gh pr view "${GITHUB_REPOSITORY_OWNER}:${BRANCH}" --repo "$BASE_REPO" --json state --jq '.state')
           if [[ "$STATE" != "OPEN" ]]; then
             exit 1
           fi
 
-          gh pr edit cargo_update --title "${PR_TITLE}" --body-file body.md --repo pitaj/rust
+          gh pr edit "${GITHUB_REPOSITORY_OWNER}:${BRANCH}" --title "${PR_TITLE}" --body-file body.md --repo "$BASE_REPO"
 
       - name: open new pull request
         # Only run if there wasn't an existing PR
         if: steps.edit.outcome != 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.CARGO_UPDATE_TOKEN }}
-        run: gh pr create --title "${PR_TITLE}" --body-file body.md --repo pitaj/rust
+        run: gh pr create --title "${PR_TITLE}" --body-file body.md --repo "$BASE_REPO"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,7 +1,7 @@
 # Automatically run `cargo update` periodically
 #
-# Requires setting a `CARGO_UPDATE_TOKEN` Actions Repository secret
-# to a Github API access token.
+# Requires setting a `CARGO_UPDATE_TOKEN` Actions Repository secret to a
+# Github access token with write access for "Contents" and "Pull requests".
 
 ---
 name: Bump dependencies in Cargo.lock
@@ -125,7 +125,17 @@ jobs:
           git commit --no-verify --file=commit.txt
 
       - name: push
-        run: git push --no-verify --force --set-upstream origin "$BRANCH"
+        env:
+          GITHUB_TOKEN: ${{ secrets.CARGO_UPDATE_TOKEN }}
+        # Need to use our own token for pushing, otherwise pushing will
+        # not initiate a new CI run.
+        run: |
+          # Remove existing token added by default within Github Actions
+          git config --unset-all http.https://github.com/.extraheader
+          # Set remote with custom token
+          git remote set-url origin "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git push --no-verify --force --set-upstream origin "$BRANCH"
 
       - name: edit existing open pull request
         id: edit

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -31,12 +31,12 @@ env:
   # Name to use for the branch
   BRANCH: cargo_update
   # Github repository to open the PR on
-  BASE_REPO: rust-lang/rust
+  BASE_REPO: pitaj/rust
 
 jobs:
   not-waiting-on-bors:
     # Only run workflow if on rust-lang-ci
-    if: github.repository_owner == 'rust-lang-ci'
+    if: github.repository_owner == 'pitaj-rust-lang-ci'
     name: skip if S-waiting-on-bors
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   not-waiting-on-bors:
-    if: github.repository_owner == 'rust-lang-ci'
+    if: github.repository_owner == 'pitaj-rust-lang-ci'
     name: skip if S-waiting-on-bors
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: |
           # Fetch state and labels of PR
           # Or exit successfully if PR does not exist
-          JSON=$(gh pr view cargo_update --repo rust-lang/rust --json labels,state || exit 0)
+          JSON=$(gh pr view cargo_update --repo pitaj/rust --json labels,state || exit 0)
           STATE=$(echo "$JSON" | jq -r '.state')
           WAITING_ON_BORS=$(echo "$JSON" | jq '.labels[] | any(.name == "S-waiting-on-bors"; .)')
 
@@ -44,7 +44,7 @@ jobs:
           fi
 
   update:
-    if: github.repository_owner == 'rust-lang-ci'
+    if: github.repository_owner == 'pitaj-rust-lang-ci'
     name: update dependencies
     needs: not-waiting-on-bors
     runs-on: ubuntu-latest
@@ -78,7 +78,7 @@ jobs:
           retention-days: 1
 
   pr:
-    if: github.repository_owner == 'rust-lang-ci'
+    if: github.repository_owner == 'pitaj-rust-lang-ci'
     name: amend PR
     needs: update
     runs-on: ubuntu-latest
@@ -126,16 +126,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CARGO_UPDATE_TOKEN }}
         run: |
           # Exit with error if PR is closed
-          STATE=$(gh pr view cargo_update --repo rust-lang/rust --json state --jq '.state')
+          STATE=$(gh pr view cargo_update --repo pitaj/rust --json state --jq '.state')
           if [[ "$STATE" != "OPEN" ]]; then
             exit 1
           fi
 
-          gh pr edit cargo_update --title "${PR_TITLE}" --body-file body.md --repo rust-lang/rust
+          gh pr edit cargo_update --title "${PR_TITLE}" --body-file body.md --repo pitaj/rust
 
       - name: open new pull request
         # Only run if there wasn't an existing PR
         if: steps.edit.outcome != 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.CARGO_UPDATE_TOKEN }}
-        run: gh pr create --title "${PR_TITLE}" --body-file body.md --repo rust-lang/rust
+        run: gh pr create --title "${PR_TITLE}" --body-file body.md --repo pitaj/rust

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,4 +1,7 @@
 # Automatically run `cargo update` periodically
+#
+# Requires setting a `CARGO_UPDATE_TOKEN` Actions Repository secret
+# to a Github API access token.
 
 ---
 name: Bump dependencies in Cargo.lock
@@ -28,12 +31,12 @@ env:
   # Name to use for the branch
   BRANCH: cargo_update
   # Github repository to open the PR on
-  BASE_REPO: pitaj/rust
+  BASE_REPO: rust-lang/rust
 
 jobs:
   not-waiting-on-bors:
     # Only run workflow if on rust-lang-ci
-    if: github.repository_owner == 'pitaj-rust-lang-ci'
+    if: github.repository_owner == 'rust-lang-ci'
     name: skip if S-waiting-on-bors
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This resolves the issue where CI will not run on PRs opened by the existing workflow, due to Github automatically preventing tasks performed by `GITHUB_TOKEN` from initiating more workflow runs.

r? infra