### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1619,13 +1619,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 debug!(?hir_bounds);
 
                 let lifetime_mapping = if in_trait {
-                    self.arena.alloc_from_iter(
-                        collected_lifetime_mapping
-                            .iter()
-                            .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                    Some(
+                        &*self.arena.alloc_from_iter(
+                            collected_lifetime_mapping
+                                .iter()
+                                .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                        ),
                     )
                 } else {
-                    &mut []
+                    None
                 };
 
                 let opaque_ty_item = hir::OpaqueTy {
@@ -2090,13 +2092,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 debug!("lower_async_fn_ret_ty: generic_params={:#?}", generic_params);
 
                 let lifetime_mapping = if in_trait {
-                    self.arena.alloc_from_iter(
-                        collected_lifetime_mapping
-                            .iter()
-                            .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                    Some(
+                        &*self.arena.alloc_from_iter(
+                            collected_lifetime_mapping
+                                .iter()
+                                .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                        ),
                     )
                 } else {
-                    &mut []
+                    None
                 };
 
                 let opaque_ty_item = hir::OpaqueTy {

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -335,6 +335,10 @@ pub fn from_fn_attrs<'ll, 'tcx>(
     to_add.extend(probestack_attr(cx));
     to_add.extend(stackprotector_attr(cx));
 
+    if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::NO_BUILTINS) {
+        to_add.push(llvm::CreateAttrString(cx.llcx, "no-builtins"));
+    }
+
     if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::COLD) {
         to_add.push(AttributeKind::Cold.create_attr(cx.llcx));
     }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2664,10 +2664,19 @@ pub struct OpaqueTy<'hir> {
     pub generics: &'hir Generics<'hir>,
     pub bounds: GenericBounds<'hir>,
     pub origin: OpaqueTyOrigin,
-    // Opaques have duplicated lifetimes, this mapping connects the original lifetime with the copy
-    // so we can later generate bidirectional outlives predicates to enforce that these lifetimes
-    // stay in sync.
-    pub lifetime_mapping: &'hir [(Lifetime, LocalDefId)],
+    /// Return-position impl traits (and async futures) must "reify" any late-bound
+    /// lifetimes that are captured from the function signature they originate from.
+    ///
+    /// This is done by generating a new early-bound lifetime parameter local to the
+    /// opaque which is substituted in the function signature with the late-bound
+    /// lifetime.
+    ///
+    /// This mapping associated a captured lifetime (first parameter) with the new
+    /// early-bound lifetime that was generated for the opaque.
+    pub lifetime_mapping: Option<&'hir [(Lifetime, LocalDefId)]>,
+    /// Whether the opaque is a return-position impl trait (or async future)
+    /// originating from a trait method. This makes it so that the opaque is
+    /// lowered as an associated type.
     pub in_trait: bool,
 }
 

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -66,7 +66,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
             let opaque_ty_id = tcx.hir().local_def_id_to_hir_id(opaque_def_id.expect_local());
             let opaque_ty_node = tcx.hir().get(opaque_ty_id);
             let Node::Item(&Item {
-                kind: ItemKind::OpaqueTy(OpaqueTy { lifetime_mapping, .. }),
+                kind: ItemKind::OpaqueTy(OpaqueTy { lifetime_mapping: Some(lifetime_mapping), .. }),
                 ..
             }) = opaque_ty_node
             else {

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -100,6 +100,8 @@ bitflags! {
         const REALLOCATOR               = 1 << 18;
         /// `#[rustc_allocator_zeroed]`: a hint to LLVM that the function only allocates zeroed memory.
         const ALLOCATOR_ZEROED          = 1 << 19;
+        /// `#[no_builtins]`: indicates that disable implicit builtin knowledge of functions for the function.
+        const NO_BUILTINS               = 1 << 20;
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -119,7 +119,9 @@ impl<'tcx> Tables<'tcx> {
                 TyKind::RigidTy(RigidTy::Array(self.intern_ty(*ty), opaque(constant)))
             }
             ty::Slice(ty) => TyKind::RigidTy(RigidTy::Slice(self.intern_ty(*ty))),
-            ty::RawPtr(_) => todo!(),
+            ty::RawPtr(ty::TypeAndMut { ty, mutbl }) => {
+                TyKind::RigidTy(RigidTy::RawPtr(self.intern_ty(*ty), mutbl.stable()))
+            }
             ty::Ref(_, _, _) => todo!(),
             ty::FnDef(_, _) => todo!(),
             ty::FnPtr(_) => todo!(),

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -122,7 +122,9 @@ impl<'tcx> Tables<'tcx> {
             ty::RawPtr(ty::TypeAndMut { ty, mutbl }) => {
                 TyKind::RigidTy(RigidTy::RawPtr(self.intern_ty(*ty), mutbl.stable()))
             }
-            ty::Ref(_, _, _) => todo!(),
+            ty::Ref(region, ty, mutbl) => {
+                TyKind::RigidTy(RigidTy::Ref(opaque(region), self.intern_ty(*ty), mutbl.stable()))
+            }
             ty::FnDef(_, _) => todo!(),
             ty::FnPtr(_) => todo!(),
             ty::Dynamic(_, _, _) => todo!(),

--- a/compiler/rustc_smir/src/stable_mir/mir/body.rs
+++ b/compiler/rustc_smir/src/stable_mir/mir/body.rs
@@ -1,4 +1,4 @@
-use crate::rustc_internal::Opaque;
+use crate::stable_mir::ty::Region;
 use crate::stable_mir::{self, ty::Ty};
 
 #[derive(Clone, Debug)]
@@ -136,8 +136,6 @@ pub enum Statement {
     Assign(Place, Rvalue),
     Nop,
 }
-
-type Region = Opaque;
 
 // FIXME this is incomplete
 #[derive(Clone, Debug)]

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -20,6 +20,8 @@ pub enum TyKind {
     RigidTy(RigidTy),
 }
 
+type Region = Opaque;
+
 #[derive(Clone, Debug)]
 pub enum RigidTy {
     Bool,
@@ -31,6 +33,7 @@ pub enum RigidTy {
     Str,
     Array(Ty, Const),
     Slice(Ty),
+    RawPtr(Ty, Mutability),
     Tuple(Vec<Ty>),
 }
 

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -1,7 +1,5 @@
-use super::{with, DefId};
+use super::{mir::Mutability, with, DefId};
 use crate::rustc_internal::Opaque;
-
-type Const = Opaque;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Ty(pub usize);
@@ -13,14 +11,12 @@ impl Ty {
 }
 
 type Const = Opaque;
-type Region = Opaque;
+pub(crate) type Region = Opaque;
 
 #[derive(Clone, Debug)]
 pub enum TyKind {
     RigidTy(RigidTy),
 }
-
-type Region = Opaque;
 
 #[derive(Clone, Debug)]
 pub enum RigidTy {
@@ -34,6 +30,7 @@ pub enum RigidTy {
     Array(Ty, Const),
     Slice(Ty),
     RawPtr(Ty, Mutability),
+    Ref(Region, Ty, Mutability),
     Tuple(Vec<Ty>),
 }
 

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -1,6 +1,8 @@
 use super::{with, DefId};
 use crate::rustc_internal::Opaque;
 
+type Const = Opaque;
+
 #[derive(Copy, Clone, Debug)]
 pub struct Ty(pub usize);
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -4149,8 +4149,8 @@ impl<'test> TestCx<'test> {
                   # Match paths that don't include spaces.
                   (?:\\[\pL\pN\.\-_']+)+\.\pL+
                 |
-                  # If the path starts with a well-known root, then allow spaces.
-                  \$(?:DIR|SRC_DIR|TEST_BUILD_DIR|BUILD_DIR|LIB_DIR)(?:\\[\pL\pN\.\-_' ]+)+
+                  # If the path starts with a well-known root, then allow spaces and no file extension.
+                  \$(?:DIR|SRC_DIR|TEST_BUILD_DIR|BUILD_DIR|LIB_DIR)(?:\\[\pL\pN\.\-_'\ ]+)+
                 )"#,
             )
             .unwrap()

--- a/src/tools/compiletest/src/runtest/tests.rs
+++ b/src/tools/compiletest/src/runtest/tests.rs
@@ -8,8 +8,8 @@ fn normalize_platform_differences() {
         "$BUILD_DIR/../parser.rs"
     );
     assert_eq!(
-        TestCx::normalize_platform_differences(r"$DIR\bar.rs hello\nworld"),
-        r"$DIR/bar.rs hello\nworld"
+        TestCx::normalize_platform_differences(r"$DIR\bar.rs: hello\nworld"),
+        r"$DIR/bar.rs: hello\nworld"
     );
     assert_eq!(
         TestCx::normalize_platform_differences(r"either bar\baz.rs or bar\baz\mod.rs"),
@@ -27,8 +27,8 @@ fn normalize_platform_differences() {
     );
     assert_eq!(TestCx::normalize_platform_differences(r"$DIR\foo.rs:12:11"), "$DIR/foo.rs:12:11",);
     assert_eq!(
-        TestCx::normalize_platform_differences(r"$DIR\path with spaces 'n' quotes"),
-        "$DIR/path with spaces 'n' quotes",
+        TestCx::normalize_platform_differences(r"$DIR\path with\spaces 'n' quotes"),
+        "$DIR/path with/spaces 'n' quotes",
     );
     assert_eq!(
         TestCx::normalize_platform_differences(r"$DIR\file_with\no_extension"),

--- a/tests/codegen/no_builtins-at-crate.rs
+++ b/tests/codegen/no_builtins-at-crate.rs
@@ -1,0 +1,23 @@
+// compile-flags: -C opt-level=1
+
+#![no_builtins]
+#![crate_type = "lib"]
+
+// CHECK: define void @__aeabi_memcpy
+// CHECK-SAME: #0
+#[no_mangle]
+pub unsafe extern "C" fn __aeabi_memcpy(dest: *mut u8, src: *const u8, size: usize) {
+    // CHECK: call
+    // CHECK-SAME: @memcpy(
+    memcpy(dest, src, size);
+}
+
+// CHECK: declare
+// CHECK-SAME: @memcpy
+// CHECK-SAME: #0
+extern "C" {
+    pub fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
+}
+
+// CHECK: attributes #0
+// CHECK-SAME: "no-builtins"

--- a/tests/run-make/no-builtins-attribute/Makefile
+++ b/tests/run-make/no-builtins-attribute/Makefile
@@ -1,0 +1,9 @@
+include ../tools.mk
+
+# We want to check if `no-builtins` is also added to the function declarations in the used crate.
+
+all:
+	$(RUSTC) no_builtins.rs --emit=link
+	$(RUSTC) main.rs --emit=llvm-ir
+
+	cat "$(TMPDIR)"/main.ll | "$(LLVM_FILECHECK)" filecheck.main.txt

--- a/tests/run-make/no-builtins-attribute/filecheck.main.txt
+++ b/tests/run-make/no-builtins-attribute/filecheck.main.txt
@@ -1,0 +1,5 @@
+CHECK: declare void @foo()
+CHECK-SAME: #[[ATTR_3:[0-9]+]]
+
+CHECK: attributes #[[ATTR_3]] 
+CHECK-SAME: no-builtins

--- a/tests/run-make/no-builtins-attribute/main.rs
+++ b/tests/run-make/no-builtins-attribute/main.rs
@@ -1,0 +1,10 @@
+extern crate no_builtins;
+
+#[no_mangle]
+fn call_foo() {
+    no_builtins::foo();
+}
+
+fn main() {
+    call_foo();
+}

--- a/tests/run-make/no-builtins-attribute/no_builtins.rs
+++ b/tests/run-make/no-builtins-attribute/no_builtins.rs
@@ -1,0 +1,5 @@
+#![crate_type = "lib"]
+#![no_builtins]
+
+#[no_mangle]
+pub fn foo() {}


### PR DESCRIPTION
Successful merges:

 - #113659 (Add ty convs for smir refs and ptrs)
 - #113706 (Fix compiletest windows path finding with spaces)
 - #113716 (Add the `no-builtins` attribute to functions when `no_builtins` is applied at the crate level.)
 - #113795 (Properly document `lifetime_mapping` in `OpaqueTy`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113659,113706,113716,113795)
<!-- homu-ignore:end -->