### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -92,7 +92,6 @@ Cargo
 -----
 - [Allow named debuginfo options in `Cargo.toml`.](https://github.com/rust-lang/cargo/pull/11958/)
 - [Add `workspace_default_members` to the output of `cargo metadata`.](https://github.com/rust-lang/cargo/pull/11978/)
-- [`cargo add` now considers `rust-version` when selecting packages.](https://github.com/rust-lang/cargo/pull/12078/)
 - [Automatically inherit workspace fields when running `cargo new`/`cargo init`.](https://github.com/rust-lang/cargo/pull/12069/)
 
 <a id="1.71.0-Rustdoc"></a>

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1619,13 +1619,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 debug!(?hir_bounds);
 
                 let lifetime_mapping = if in_trait {
-                    self.arena.alloc_from_iter(
-                        collected_lifetime_mapping
-                            .iter()
-                            .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                    Some(
+                        &*self.arena.alloc_from_iter(
+                            collected_lifetime_mapping
+                                .iter()
+                                .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                        ),
                     )
                 } else {
-                    &mut []
+                    None
                 };
 
                 let opaque_ty_item = hir::OpaqueTy {
@@ -2090,13 +2092,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 debug!("lower_async_fn_ret_ty: generic_params={:#?}", generic_params);
 
                 let lifetime_mapping = if in_trait {
-                    self.arena.alloc_from_iter(
-                        collected_lifetime_mapping
-                            .iter()
-                            .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                    Some(
+                        &*self.arena.alloc_from_iter(
+                            collected_lifetime_mapping
+                                .iter()
+                                .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                        ),
                     )
                 } else {
-                    &mut []
+                    None
                 };
 
                 let opaque_ty_item = hir::OpaqueTy {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2664,10 +2664,19 @@ pub struct OpaqueTy<'hir> {
     pub generics: &'hir Generics<'hir>,
     pub bounds: GenericBounds<'hir>,
     pub origin: OpaqueTyOrigin,
-    // Opaques have duplicated lifetimes, this mapping connects the original lifetime with the copy
-    // so we can later generate bidirectional outlives predicates to enforce that these lifetimes
-    // stay in sync.
-    pub lifetime_mapping: &'hir [(Lifetime, LocalDefId)],
+    /// Return-position impl traits (and async futures) must "reify" any late-bound
+    /// lifetimes that are captured from the function signature they originate from.
+    ///
+    /// This is done by generating a new early-bound lifetime parameter local to the
+    /// opaque which is substituted in the function signature with the late-bound
+    /// lifetime.
+    ///
+    /// This mapping associated a captured lifetime (first parameter) with the new
+    /// early-bound lifetime that was generated for the opaque.
+    pub lifetime_mapping: Option<&'hir [(Lifetime, LocalDefId)]>,
+    /// Whether the opaque is a return-position impl trait (or async future)
+    /// originating from a trait method. This makes it so that the opaque is
+    /// lowered as an associated type.
     pub in_trait: bool,
 }
 

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -66,7 +66,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
             let opaque_ty_id = tcx.hir().local_def_id_to_hir_id(opaque_def_id.expect_local());
             let opaque_ty_node = tcx.hir().get(opaque_ty_id);
             let Node::Item(&Item {
-                kind: ItemKind::OpaqueTy(OpaqueTy { lifetime_mapping, .. }),
+                kind: ItemKind::OpaqueTy(OpaqueTy { lifetime_mapping: Some(lifetime_mapping), .. }),
                 ..
             }) = opaque_ty_node
             else {

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -956,11 +956,11 @@ pub trait LintContext: Sized {
                     db.span_note(glob_reexport_span, format!("the name `{}` in the {} namespace is supposed to be publicly re-exported here", name, namespace));
                     db.span_note(private_item_span, "but the private item here shadows it".to_owned());
                 }
-                BuiltinLintDiagnostics::UnusedQualifications { path_span, unqualified_path } => {
+                BuiltinLintDiagnostics::UnusedQualifications { removal_span } => {
                     db.span_suggestion_verbose(
-                        path_span,
-                        "replace it with the unqualified path",
-                        unqualified_path,
+                        removal_span,
+                        "remove the unnecessary path segments",
+                        "",
                         Applicability::MachineApplicable
                     );
                 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -551,10 +551,8 @@ pub enum BuiltinLintDiagnostics {
         private_item_span: Span,
     },
     UnusedQualifications {
-        /// The span of the unnecessarily-qualified path.
-        path_span: Span,
-        /// The replacement unqualified path.
-        unqualified_path: Ident,
+        /// The span of the unnecessarily-qualified path to remove.
+        removal_span: Span,
     },
 }
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3911,8 +3911,9 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
             && path[0].ident.name != kw::PathRoot
             && path[0].ident.name != kw::DollarCrate
         {
+            let last_segment = *path.last().unwrap();
             let unqualified_result = {
-                match self.resolve_path(&[*path.last().unwrap()], Some(ns), None) {
+                match self.resolve_path(&[last_segment], Some(ns), None) {
                     PathResult::NonModule(path_res) => path_res.expect_full_res(),
                     PathResult::Module(ModuleOrUniformRoot::Module(module)) => {
                         module.res().unwrap()
@@ -3928,8 +3929,7 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                     finalize.path_span,
                     "unnecessary qualification",
                     lint::BuiltinLintDiagnostics::UnusedQualifications {
-                        path_span: finalize.path_span,
-                        unqualified_path: path.last().unwrap().ident
+                        removal_span: finalize.path_span.until(last_segment.ident.span),
                     }
                 )
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -90,6 +90,19 @@ pub(crate) fn clean_doc_module<'tcx>(doc: &DocModule<'tcx>, cx: &mut DocContext<
         }
         v
     }));
+    items.extend(doc.inlined_foreigns.values().flat_map(|(res, renamed, local_import_id)| {
+        let Some(def_id) = res.opt_def_id() else { return Vec::new() };
+        let name = renamed.unwrap_or_else(|| cx.tcx.item_name(def_id));
+        let import = cx.tcx.hir().expect_item(*local_import_id);
+        match import.kind {
+            hir::ItemKind::Use(path, kind) => {
+                let hir::UsePath { segments, span, .. } = *path;
+                let path = hir::Path { segments, res: *res, span };
+                clean_use_statement_inner(import, name, &path, kind, cx, &mut Default::default())
+            }
+            _ => unreachable!(),
+        }
+    }));
     items.extend(doc.items.values().flat_map(|(item, renamed, _)| {
         // Now we actually lower the imports, skipping everything else.
         if let hir::ItemKind::Use(path, hir::UseKind::Glob) = item.kind {
@@ -2652,9 +2665,6 @@ fn clean_use_statement<'tcx>(
     let mut items = Vec::new();
     let hir::UsePath { segments, ref res, span } = *path;
     for &res in res {
-        if let Res::Def(DefKind::Ctor(..), _) | Res::SelfCtor(..) = res {
-            continue;
-        }
         let path = hir::Path { segments, res, span };
         items.append(&mut clean_use_statement_inner(import, name, &path, kind, cx, inlined_names));
     }
@@ -2669,6 +2679,9 @@ fn clean_use_statement_inner<'tcx>(
     cx: &mut DocContext<'tcx>,
     inlined_names: &mut FxHashSet<(ItemType, Symbol)>,
 ) -> Vec<Item> {
+    if let Res::Def(DefKind::Ctor(..), _) | Res::SelfCtor(..) = path.res {
+        return Vec::new();
+    }
     // We need this comparison because some imports (for std types for example)
     // are "inserted" as well but directly by the compiler and they should not be
     // taken into account.

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -90,7 +90,7 @@ pub(crate) fn clean_doc_module<'tcx>(doc: &DocModule<'tcx>, cx: &mut DocContext<
         }
         v
     }));
-    items.extend(doc.inlined_foreigns.values().flat_map(|(res, renamed, local_import_id)| {
+    items.extend(doc.inlined_foreigns.iter().flat_map(|((_, renamed), (res, local_import_id))| {
         let Some(def_id) = res.opt_def_id() else { return Vec::new() };
         let name = renamed.unwrap_or_else(|| cx.tcx.item_name(def_id));
         let import = cx.tcx.hir().expect_item(*local_import_id);

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -36,8 +36,7 @@ pub(crate) struct Module<'hir> {
         (&'hir hir::Item<'hir>, Option<Symbol>, Option<LocalDefId>),
     >,
     /// Same as for `items`.
-    pub(crate) inlined_foreigns:
-        FxIndexMap<(DefId, Option<Symbol>), (Res, Option<Symbol>, LocalDefId)>,
+    pub(crate) inlined_foreigns: FxIndexMap<(DefId, Option<Symbol>), (Res, LocalDefId)>,
     pub(crate) foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Symbol>)>,
 }
 
@@ -295,7 +294,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 .last_mut()
                 .unwrap()
                 .inlined_foreigns
-                .insert((ori_res_did, renamed), (res, renamed, def_id));
+                .insert((ori_res_did, renamed), (res, def_id));
             return true;
         };
 

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -35,6 +35,9 @@ pub(crate) struct Module<'hir> {
         (LocalDefId, Option<Symbol>),
         (&'hir hir::Item<'hir>, Option<Symbol>, Option<LocalDefId>),
     >,
+    /// Same as for `items`.
+    pub(crate) inlined_foreigns:
+        FxIndexMap<(DefId, Option<Symbol>), (Res, Option<Symbol>, LocalDefId)>,
     pub(crate) foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Symbol>)>,
 }
 
@@ -54,6 +57,7 @@ impl Module<'_> {
             import_id,
             mods: Vec::new(),
             items: FxIndexMap::default(),
+            inlined_foreigns: FxIndexMap::default(),
             foreigns: Vec::new(),
         }
     }
@@ -272,21 +276,30 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             return false;
         }
 
-        // For cross-crate impl inlining we need to know whether items are
-        // reachable in documentation -- a previously unreachable item can be
-        // made reachable by cross-crate inlining which we're checking here.
-        // (this is done here because we need to know this upfront).
-        if !ori_res_did.is_local() && !is_no_inline {
-            crate::visit_lib::lib_embargo_visit_item(self.cx, ori_res_did);
-            return false;
-        }
-
+        let is_hidden = !document_hidden && tcx.is_doc_hidden(ori_res_did);
         let Some(res_did) = ori_res_did.as_local() else {
-            return false;
+            // For cross-crate impl inlining we need to know whether items are
+            // reachable in documentation -- a previously unreachable item can be
+            // made reachable by cross-crate inlining which we're checking here.
+            // (this is done here because we need to know this upfront).
+            crate::visit_lib::lib_embargo_visit_item(self.cx, ori_res_did);
+            if is_hidden {
+                return false;
+            }
+            // We store inlined foreign items otherwise, it'd mean that the `use` item would be kept
+            // around. It's not a problem unless this `use` imports both a local AND a foreign item.
+            // If a local item is inlined, its `use` is not supposed to still be around in `clean`,
+            // which would make appear the `use` in the generated documentation like the local item
+            // was not inlined even though it actually was.
+            self.modules
+                .last_mut()
+                .unwrap()
+                .inlined_foreigns
+                .insert((ori_res_did, renamed), (res, renamed, def_id));
+            return true;
         };
 
         let is_private = !self.cx.cache.effective_visibilities.is_directly_public(tcx, ori_res_did);
-        let is_hidden = !document_hidden && tcx.is_doc_hidden(ori_res_did);
         let item = tcx.hir().get_by_def_id(res_did);
 
         if !please_inline {
@@ -314,7 +327,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             return false;
         }
 
-        let inlined = match tcx.hir().get_by_def_id(res_did) {
+        let inlined = match item {
             // Bang macros are handled a bit on their because of how they are handled by the
             // compiler. If they have `#[doc(hidden)]` and the re-export doesn't have
             // `#[doc(inline)]`, then we don't inline it.
@@ -346,7 +359,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         };
         self.view_item_stack.remove(&res_did);
         if inlined {
-            self.cx.cache.inlined_items.insert(res_did.to_def_id());
+            self.cx.cache.inlined_items.insert(ori_res_did);
         }
         inlined
     }
@@ -483,7 +496,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                             continue;
                         }
                     }
-
                     self.add_to_current_mod(item, renamed, import_id);
                 }
             }

--- a/tests/rustdoc/issue-105735-overlapping-reexport-2.rs
+++ b/tests/rustdoc/issue-105735-overlapping-reexport-2.rs
@@ -1,0 +1,25 @@
+// Regression test to ensure that both `AtomicU8` items are displayed but not the re-export.
+
+#![crate_name = "foo"]
+#![no_std]
+
+// @has 'foo/index.html'
+// @has - '//*[@class="item-name"]/a[@class="type"]' 'AtomicU8'
+// @has - '//*[@class="item-name"]/a[@class="constant"]' 'AtomicU8'
+// We also ensure we don't have another item displayed.
+// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 2
+// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Type Definitions'
+// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Constants'
+
+mod other {
+    pub type AtomicU8 = ();
+}
+
+mod thing {
+    pub use crate::other::AtomicU8;
+
+    #[allow(non_upper_case_globals)]
+    pub const AtomicU8: () = ();
+}
+
+pub use crate::thing::AtomicU8;

--- a/tests/rustdoc/issue-105735-overlapping-reexport.rs
+++ b/tests/rustdoc/issue-105735-overlapping-reexport.rs
@@ -1,0 +1,21 @@
+// Regression test to ensure that both `AtomicU8` items are displayed but not the re-export.
+
+#![crate_name = "foo"]
+#![no_std]
+
+// @has 'foo/index.html'
+// @has - '//*[@class="item-name"]/a[@class="struct"]' 'AtomicU8'
+// @has - '//*[@class="item-name"]/a[@class="constant"]' 'AtomicU8'
+// We also ensure we don't have another item displayed.
+// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 2
+// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Structs'
+// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Constants'
+
+mod thing {
+    pub use core::sync::atomic::AtomicU8;
+
+    #[allow(non_upper_case_globals)]
+    pub const AtomicU8: () = ();
+}
+
+pub use crate::thing::AtomicU8;

--- a/tests/ui/lint/lint-qualification.fixed
+++ b/tests/ui/lint/lint-qualification.fixed
@@ -8,7 +8,7 @@ mod foo {
 
 fn main() {
     use foo::bar;
-    foo::bar(); //~ ERROR: unnecessary qualification
+    bar(); //~ ERROR: unnecessary qualification
     bar();
 
     let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345

--- a/tests/ui/lint/lint-qualification.stderr
+++ b/tests/ui/lint/lint-qualification.stderr
@@ -1,18 +1,19 @@
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:10:5
+  --> $DIR/lint-qualification.rs:11:5
    |
 LL |     foo::bar();
    |     ^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/lint-qualification.rs:1:9
+  --> $DIR/lint-qualification.rs:2:9
    |
 LL | #![deny(unused_qualifications)]
    |         ^^^^^^^^^^^^^^^^^^^^^
-help: replace it with the unqualified path
+help: remove the unnecessary path segments
    |
-LL |     bar();
-   |     ~~~
+LL -     foo::bar();
+LL +     bar();
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.fixed
+++ b/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.fixed
@@ -1,0 +1,31 @@
+// run-rustfix
+
+#![deny(unused_qualifications)]
+#![feature(unsized_fn_params)]
+
+#[allow(unused_imports)]
+use std::ops;
+use std::ops::Index;
+
+pub struct A;
+
+impl Index<str> for A {
+    //~^ ERROR unnecessary qualification
+    type Output = ();
+    fn index(&self, _: str) -> &Self::Output {
+        &()
+    }
+}
+
+mod inner {
+    pub trait Trait<T> {}
+}
+
+// the import needs to be here for the lint to show up
+#[allow(unused_imports)]
+use inner::Trait;
+
+impl Trait<u8> for () {}
+//~^ ERROR unnecessary qualification
+
+fn main() {}

--- a/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.rs
+++ b/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.rs
@@ -1,0 +1,31 @@
+// run-rustfix
+
+#![deny(unused_qualifications)]
+#![feature(unsized_fn_params)]
+
+#[allow(unused_imports)]
+use std::ops;
+use std::ops::Index;
+
+pub struct A;
+
+impl ops::Index<str> for A {
+    //~^ ERROR unnecessary qualification
+    type Output = ();
+    fn index(&self, _: str) -> &Self::Output {
+        &()
+    }
+}
+
+mod inner {
+    pub trait Trait<T> {}
+}
+
+// the import needs to be here for the lint to show up
+#[allow(unused_imports)]
+use inner::Trait;
+
+impl inner::Trait<u8> for () {}
+//~^ ERROR unnecessary qualification
+
+fn main() {}

--- a/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.stderr
+++ b/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.stderr
@@ -1,0 +1,31 @@
+error: unnecessary qualification
+  --> $DIR/issue-113808-invalid-unused-qualifications-suggestion.rs:12:6
+   |
+LL | impl ops::Index<str> for A {
+   |      ^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-113808-invalid-unused-qualifications-suggestion.rs:3:9
+   |
+LL | #![deny(unused_qualifications)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+help: remove the unnecessary path segments
+   |
+LL - impl ops::Index<str> for A {
+LL + impl Index<str> for A {
+   |
+
+error: unnecessary qualification
+  --> $DIR/issue-113808-invalid-unused-qualifications-suggestion.rs:28:6
+   |
+LL | impl inner::Trait<u8> for () {}
+   |      ^^^^^^^^^^^^^^^^
+   |
+help: remove the unnecessary path segments
+   |
+LL - impl inner::Trait<u8> for () {}
+LL + impl Trait<u8> for () {}
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/resolve/unused-qualifications-suggestion.stderr
+++ b/tests/ui/resolve/unused-qualifications-suggestion.stderr
@@ -9,10 +9,11 @@ note: the lint level is defined here
    |
 LL | #![deny(unused_qualifications)]
    |         ^^^^^^^^^^^^^^^^^^^^^
-help: replace it with the unqualified path
+help: remove the unnecessary path segments
    |
-LL |     bar();
-   |     ~~~
+LL -     foo::bar();
+LL +     bar();
+   |
 
 error: unnecessary qualification
   --> $DIR/unused-qualifications-suggestion.rs:21:5
@@ -20,10 +21,11 @@ error: unnecessary qualification
 LL |     baz::qux::quux();
    |     ^^^^^^^^^^^^^^
    |
-help: replace it with the unqualified path
+help: remove the unnecessary path segments
    |
-LL |     quux();
-   |     ~~~~
+LL -     baz::qux::quux();
+LL +     quux();
+   |
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #113785 (Fix invalid display of inlined re-export when both local and foreign items are inlined)
 - #113795 (Properly document `lifetime_mapping` in `OpaqueTy`)
 - #113811 (Fix removal span calculation of `unused_qualifications` suggestion)
 - #113812 (docs(release): Remove nightly-only cargo item)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113785,113795,113811,113812)
<!-- homu-ignore:end -->