### PR TITLE
Estimate size of shims the same as other functions.

### DIFF
--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -61,19 +61,14 @@ impl<'tcx> MonoItem<'tcx> {
     pub fn size_estimate(&self, tcx: TyCtxt<'tcx>) -> usize {
         match *self {
             MonoItem::Fn(instance) => {
-                match instance.def {
-                    // "Normal" functions size estimate: the number of
-                    // statements, plus one for the terminator.
-                    InstanceDef::Item(..) | InstanceDef::DropGlue(..) => {
-                        let mir = tcx.instance_mir(instance.def);
-                        mir.basic_blocks.iter().map(|bb| bb.statements.len() + 1).sum()
-                    }
-                    // Other compiler-generated shims size estimate: 1
-                    _ => 1,
-                }
+                // Function size estimate: the number of statements, plus one
+                // for the terminator.
+                let mir = tcx.instance_mir(instance.def);
+                mir.basic_blocks.iter().map(|bb| bb.statements.len() + 1).sum()
             }
-            // Conservatively estimate the size of a static declaration or
-            // assembly item to be 1.
+            // Static declarations and asm item are hard to compare in size
+            // with functions, but they're quite rare so the exact value
+            // doesn't matter much.
             MonoItem::Static(_) | MonoItem::GlobalAsm(_) => 1,
         }
     }

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -375,9 +375,9 @@ fn merge_codegen_units<'tcx>(
     // Having multiple CGUs can drastically speed up compilation. But for
     // non-incremental builds, tiny CGUs slow down compilation *and* result in
     // worse generated code. So we don't allow CGUs smaller than this (unless
-    // there is just one CGU, of course). Note that CGU sizes of 100,000+ are
+    // there is just one CGU, of course). Note that CGU sizes of 200,000+ are
     // common in larger programs, so this isn't all that large.
-    const NON_INCR_MIN_CGU_SIZE: usize = 1800;
+    const NON_INCR_MIN_CGU_SIZE: usize = 4050;
 
     // Repeatedly merge the two smallest codegen units as long as: it's a
     // non-incremental build, and the user didn't specify a CGU count, and


### PR DESCRIPTION
LLVM still has to process them, so there is no obvious reason to treat them differently. They typically are small, with 2 and 6 being common sizes.

r? @ghost