### PR TITLE
aarch64-msvc: remove CI hack for bad Windows SDK version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,6 @@ jobs:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=aarch64-pc-windows-msvc --enable-full-tools --enable-profiler"
               SCRIPT: python x.py dist bootstrap --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
-              WINDOWS_SDK_20348_HACK: 1
             os: windows-2019-8core-32gb
           - name: dist-i686-mingw
             env:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -668,9 +668,6 @@ jobs:
                 --enable-profiler
               SCRIPT: python x.py dist bootstrap --include-default-paths
               DIST_REQUIRE_ALL_TOOLS: 1
-              # Hack around this SDK version, because it doesn't work with clang.
-              # See https://github.com/rust-lang/rust/issues/88796
-              WINDOWS_SDK_20348_HACK: 1
             <<: *job-windows-8c
 
           - name: dist-i686-mingw

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -39,11 +39,6 @@ if isMacOS; then
     ciCommandSetEnv AR "ar"
 elif isWindows && [[ ${CUSTOM_MINGW-0} -ne 1 ]]; then
 
-    if [[ ${WINDOWS_SDK_20348_HACK-0} -eq 1 ]]; then
-        rm -rf '/c/Program Files (x86)/Windows Kits/10/include/10.0.20348.0'
-        mv '/c/Program Files (x86)/Windows Kits/10/include/'10.0.{19041,20348}.0
-    fi
-
     # If we're compiling for MSVC then we, like most other distribution builders,
     # switch to clang as the compiler. This'll allow us eventually to enable LTO
     # amongst LLVM and rustc. Note that we only do this on MSVC as I don't think


### PR DESCRIPTION
This removes hack which manually replaced windows sdk version, as it looks like useless now, as CI uses newer version: https://github.com/rust-lang-ci/rust/actions/runs/5596259246/jobs/10233070602#step:24:929
`C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\corecrt_io.h` (look at version)

related https://github.com/rust-lang/rust/issues/88796

It's nice to have some way to assert bad version, but i don't see anything except checking env https://github.com/rust-lang/cc-rs/pull/646