### PR TITLE
Refactor vtable encoding and optimize it for the case of multiple marker traits

### DIFF
--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -25,6 +25,13 @@ impl<'tcx> PredicateSet<'tcx> {
         Self { tcx, set: Default::default() }
     }
 
+    /// Adds a predicate to the set.
+    ///
+    /// Returns whether the predicate was newly inserted. That is:
+    /// - If the set did not previously contain this predicate, `true` is returned.
+    /// - If the set already contained this predicate, `false` is returned,
+    ///   and the set is not modified: original predicate is not replaced,
+    ///   and the predicate passed as argument is dropped.
     pub fn insert(&mut self, pred: ty::Predicate<'tcx>) -> bool {
         // We have to be careful here because we want
         //

--- a/compiler/rustc_trait_selection/src/traits/vtable.rs
+++ b/compiler/rustc_trait_selection/src/traits/vtable.rs
@@ -92,7 +92,7 @@ fn prepare_vtable_segments_inner<'tcx, T>(
 
     // the main traversal loop:
     // basically we want to cut the inheritance directed graph into a few non-overlapping slices of nodes
-    // that each node is emitted after all its descendents have been emitted.
+    // such that each node is emitted after all its descendants have been emitted.
     // so we convert the directed graph into a tree by skipping all previously visited nodes using a visited set.
     // this is done on the fly.
     // Each loop run emits a slice - it starts by find a "childless" unvisited node, backtracking upwards, and it

--- a/tests/ui/traits/object/print_vtable_sizes.rs
+++ b/tests/ui/traits/object/print_vtable_sizes.rs
@@ -10,8 +10,9 @@ trait C {
     fn x() {} // not object safe, shouldn't be reported
 }
 
-// This ideally should not have any upcasting cost,
-// but currently does due to a bug
+// This does not have any upcasting cost,
+// because both `Send` and `Sync` are traits
+// with no methods
 trait D: Send + Sync + help::MarkerWithSuper {}
 
 // This can't have no cost without reordering,

--- a/tests/ui/traits/object/print_vtable_sizes.stdout
+++ b/tests/ui/traits/object/print_vtable_sizes.stdout
@@ -1,8 +1,8 @@
-print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "D", "entries": "7", "entries_ignoring_upcasting": "4", "entries_for_upcasting": "3", "upcasting_cost_percent": "75" }
 print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "E", "entries": "6", "entries_ignoring_upcasting": "4", "entries_for_upcasting": "2", "upcasting_cost_percent": "50" }
 print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "G", "entries": "14", "entries_ignoring_upcasting": "11", "entries_for_upcasting": "3", "upcasting_cost_percent": "27.27272727272727" }
 print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "A", "entries": "6", "entries_ignoring_upcasting": "5", "entries_for_upcasting": "1", "upcasting_cost_percent": "20" }
 print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "B", "entries": "4", "entries_ignoring_upcasting": "4", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
+print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "D", "entries": "4", "entries_ignoring_upcasting": "4", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
 print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "F", "entries": "6", "entries_ignoring_upcasting": "6", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
 print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "_::S", "entries": "3", "entries_ignoring_upcasting": "3", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }
 print-vtable-sizes { "crate_name": "<UNKNOWN_CRATE>", "trait_name": "_::S", "entries": "3", "entries_ignoring_upcasting": "3", "entries_for_upcasting": "0", "upcasting_cost_percent": "0" }

--- a/tests/ui/traits/vtable/multiple-markers.rs
+++ b/tests/ui/traits/vtable/multiple-markers.rs
@@ -1,0 +1,47 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/113840>
+//
+// This test makes sure that multiple marker (method-less) traits can reuse the
+// same pointer for upcasting.
+//
+// build-fail
+#![crate_type = "lib"]
+#![feature(rustc_attrs)]
+
+// Markers
+trait M0 {}
+trait M1 {}
+trait M2 {}
+
+// Just a trait with a method
+trait T {
+    fn method(&self) {}
+}
+
+#[rustc_dump_vtable]
+trait A: M0 + M1 + M2 + T {} //~ error: vtable entries for `<S as A>`:
+
+#[rustc_dump_vtable]
+trait B: M0 + M1 + T + M2 {} //~ error: vtable entries for `<S as B>`:
+
+#[rustc_dump_vtable]
+trait C: M0 + T + M1 + M2 {} //~ error: vtable entries for `<S as C>`:
+
+#[rustc_dump_vtable]
+trait D: T + M0 + M1 + M2 {} //~ error: vtable entries for `<S as D>`:
+
+struct S;
+
+impl M0 for S {}
+impl M1 for S {}
+impl M2 for S {}
+impl T for S {}
+impl A for S {}
+impl B for S {}
+impl C for S {}
+impl D for S {}
+
+pub fn require_vtables() {
+    fn require_vtables(_: &dyn A, _: &dyn B, _: &dyn C, _: &dyn D) {}
+
+    require_vtables(&S, &S, &S, &S)
+}

--- a/tests/ui/traits/vtable/multiple-markers.stderr
+++ b/tests/ui/traits/vtable/multiple-markers.stderr
@@ -1,0 +1,58 @@
+error: vtable entries for `<S as A>`: [
+           MetadataDropInPlace,
+           MetadataSize,
+           MetadataAlign,
+           TraitVPtr(<S as M1>),
+           TraitVPtr(<S as M2>),
+           Method(<S as T>::method),
+           TraitVPtr(<S as T>),
+       ]
+  --> $DIR/multiple-markers.rs:21:1
+   |
+LL | trait A: M0 + M1 + M2 + T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: vtable entries for `<S as B>`: [
+           MetadataDropInPlace,
+           MetadataSize,
+           MetadataAlign,
+           TraitVPtr(<S as M1>),
+           Method(<S as T>::method),
+           TraitVPtr(<S as T>),
+           TraitVPtr(<S as M2>),
+       ]
+  --> $DIR/multiple-markers.rs:24:1
+   |
+LL | trait B: M0 + M1 + T + M2 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: vtable entries for `<S as C>`: [
+           MetadataDropInPlace,
+           MetadataSize,
+           MetadataAlign,
+           Method(<S as T>::method),
+           TraitVPtr(<S as T>),
+           TraitVPtr(<S as M1>),
+           TraitVPtr(<S as M2>),
+       ]
+  --> $DIR/multiple-markers.rs:27:1
+   |
+LL | trait C: M0 + T + M1 + M2 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: vtable entries for `<S as D>`: [
+           MetadataDropInPlace,
+           MetadataSize,
+           MetadataAlign,
+           Method(<S as T>::method),
+           TraitVPtr(<S as M0>),
+           TraitVPtr(<S as M1>),
+           TraitVPtr(<S as M2>),
+       ]
+  --> $DIR/multiple-markers.rs:30:1
+   |
+LL | trait D: T + M0 + M1 + M2 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/traits/vtable/multiple-markers.stderr
+++ b/tests/ui/traits/vtable/multiple-markers.stderr
@@ -2,10 +2,7 @@ error: vtable entries for `<S as A>`: [
            MetadataDropInPlace,
            MetadataSize,
            MetadataAlign,
-           TraitVPtr(<S as M1>),
-           TraitVPtr(<S as M2>),
            Method(<S as T>::method),
-           TraitVPtr(<S as T>),
        ]
   --> $DIR/multiple-markers.rs:21:1
    |
@@ -16,9 +13,7 @@ error: vtable entries for `<S as B>`: [
            MetadataDropInPlace,
            MetadataSize,
            MetadataAlign,
-           TraitVPtr(<S as M1>),
            Method(<S as T>::method),
-           TraitVPtr(<S as T>),
            TraitVPtr(<S as M2>),
        ]
   --> $DIR/multiple-markers.rs:24:1
@@ -31,7 +26,6 @@ error: vtable entries for `<S as C>`: [
            MetadataSize,
            MetadataAlign,
            Method(<S as T>::method),
-           TraitVPtr(<S as T>),
            TraitVPtr(<S as M1>),
            TraitVPtr(<S as M2>),
        ]


### PR DESCRIPTION
This PR does two things
- Refactor `prepare_vtable_segments` (this was motivated by the other change, `prepare_vtable_segments` was quite hard to understand and while trying to edit it I've refactored it)
  - Mostly remove `loop`s labeled `break`s/`continue`s whenever there is a simpler solution
  - Also use `?`
- Make vtable format a bit more efficient wrt to marker traits
  - See the tests for an example

Fixes https://github.com/rust-lang/rust/issues/113840
cc @crlf0710 

----

Review wise it's probably best to review each commit individually, as then it's more clear why the refactoring is correct.

I can split the last two commits (which change behavior) into a separate PR if it makes reviewing easier