### PR TITLE
Add tests for `--document-hidden-items` option

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -274,6 +274,8 @@ def get_commands(template):
                 args = shlex.split(args)
             except UnicodeEncodeError:
                 args = [arg.decode('utf-8') for arg in shlex.split(args.encode('utf-8'))]
+            except Exception as exc:
+                raise Exception("line {}: {}".format(lineno + 1, exc)) from None
             yield Command(negated=negated, cmd=cmd, args=args, lineno=lineno+1, context=line)
 
 

--- a/tests/rustdoc/display-hidden-items.rs
+++ b/tests/rustdoc/display-hidden-items.rs
@@ -1,0 +1,71 @@
+// Test to ensure that the `--document-hidden-items` option is working as expected.
+// compile-flags: -Z unstable-options --document-hidden-items
+// ignore-tidy-linelength
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+// @has - '//*[@id="reexport.hidden_reexport"]/code' 'pub use hidden::inside_hidden as hidden_reexport;'
+#[doc(hidden)]
+pub use hidden::inside_hidden as hidden_reexport;
+
+// @has - '//*[@class="item-name"]/a[@class="trait"]' 'TraitHidden'
+// @has 'foo/trait.TraitHidden.html'
+#[doc(hidden)]
+pub trait TraitHidden {}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="trait"]' 'Trait'
+pub trait Trait {
+    // @has 'foo/trait.Trait.html'
+    // @has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' 'const BAR: u32 = 0u32'
+    #[doc(hidden)]
+    const BAR: u32 = 0;
+
+    // @has - '//*[@id="method.foo"]/*[@class="code-header"]' 'fn foo()'
+    #[doc(hidden)]
+    fn foo() {}
+}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="struct"]' 'Struct'
+// @has 'foo/struct.Struct.html'
+pub struct Struct {
+    // @has - '//*[@id="structfield.a"]/code' 'a: u32'
+    #[doc(hidden)]
+    pub a: u32,
+}
+
+impl Struct {
+    // @has - '//*[@id="method.new"]/*[@class="code-header"]' 'pub fn new() -> Self'
+    #[doc(hidden)]
+    pub fn new() -> Self { Self { a: 0 } }
+}
+
+impl Trait for Struct {
+    // @has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' 'const BAR: u32 = 0u32'
+    // @has - '//*[@id="method.foo"]/*[@class="code-header"]' 'fn foo()'
+}
+// @has - '//*[@id="impl-TraitHidden-for-Struct"]/*[@class="code-header"]' 'impl TraitHidden for Struct'
+impl TraitHidden for Struct {}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="enum"]' 'HiddenEnum'
+// @has 'foo/enum.HiddenEnum.html'
+#[doc(hidden)]
+pub enum HiddenEnum {
+    A,
+}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="enum"]' 'Enum'
+pub enum Enum {
+    // @has 'foo/enum.Enum.html' '//*[@id="variant.A"]/*[@class="code-header"]' 'A'
+    #[doc(hidden)]
+    A,
+}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="mod"]' 'hidden'
+#[doc(hidden)]
+pub mod hidden {
+    // @has 'foo/hidden/index.html'
+    // @has - '//*[@class="item-name"]/a[@class="fn"]' 'inside_hidden'
+    // @has 'foo/hidden/fn.inside_hidden.html'
+    pub fn inside_hidden() {}
+}


### PR DESCRIPTION
Since `--document-hidden-items` was greatly fixed/improved in https://github.com/rust-lang/rust/pull/113574, thought it might be worth adding some more tests for it to prevent new regressions.

As for the first commit, it allows to go from:

```
Traceback (most recent call last):
  File "/home/imperio/rust/rust/src/etc/htmldocck.py", line 706, in <module>
    check(sys.argv[1], get_commands(rust_test_path))
  File "/home/imperio/rust/rust/src/etc/htmldocck.py", line 689, in check
    for c in commands:
  File "/home/imperio/rust/rust/src/etc/htmldocck.py", line 274, in get_commands
    args = shlex.split(args)
  File "/usr/lib/python3.10/shlex.py", line 315, in split
    return list(lex)
  File "/usr/lib/python3.10/shlex.py", line 300, in __next__
    token = self.get_token()
  File "/usr/lib/python3.10/shlex.py", line 109, in get_token
    raw = self.read_token()
  File "/usr/lib/python3.10/shlex.py", line 191, in read_token
    raise ValueError("No closing quotation")
ValueError: No closing quotation
```

to:

```
Traceback (most recent call last):
  File "/home/imperio/rust/rust/src/etc/htmldocck.py", line 708, in <module>
    check(sys.argv[1], get_commands(rust_test_path))
  File "/home/imperio/rust/rust/src/etc/htmldocck.py", line 691, in check
    for c in commands:
  File "/home/imperio/rust/rust/src/etc/htmldocck.py", line 278, in get_commands
    raise Exception("line {}: {}".format(lineno + 1, exc)) from None
Exception: line 57: No closing quotation
```

Having the line where the error occurred is quite useful.

r? @notriddle 