### PR TITLE
Always const-prop scalars and scalar pairs

### DIFF
--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -810,12 +810,7 @@ impl<'tcx> MutVisitor<'tcx> for ConstPropagator<'_, 'tcx> {
 
     fn visit_operand(&mut self, operand: &mut Operand<'tcx>, location: Location) {
         self.super_operand(operand, location);
-
-        // Only const prop copies and moves on `mir_opt_level=3` as doing so
-        // currently slightly increases compile time in some cases.
-        if self.tcx.sess.mir_opt_level() >= 3 {
-            self.propagate_operand(operand)
-        }
+        self.propagate_operand(operand)
     }
 
     fn process_projection_elem(

--- a/tests/mir-opt/const_prop/aggregate.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/aggregate.main.ConstProp.panic-abort.diff
@@ -26,8 +26,9 @@
           StorageLive(_4);
           StorageLive(_5);
 -         _5 = _1;
+-         _4 = foo(move _5) -> [return: bb1, unwind unreachable];
 +         _5 = const 1_u8;
-          _4 = foo(move _5) -> [return: bb1, unwind unreachable];
++         _4 = foo(const 1_u8) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/aggregate.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/aggregate.main.ConstProp.panic-unwind.diff
@@ -26,8 +26,9 @@
           StorageLive(_4);
           StorageLive(_5);
 -         _5 = _1;
+-         _4 = foo(move _5) -> [return: bb1, unwind continue];
 +         _5 = const 1_u8;
-          _4 = foo(move _5) -> [return: bb1, unwind continue];
++         _4 = foo(const 1_u8) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/aggregate.main.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/const_prop/aggregate.main.PreCodegen.after.panic-abort.mir
@@ -23,7 +23,7 @@ fn main() -> () {
         StorageLive(_4);
         StorageLive(_5);
         _5 = const 1_u8;
-        _4 = foo(move _5) -> [return: bb1, unwind unreachable];
+        _4 = foo(const 1_u8) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/const_prop/aggregate.main.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/const_prop/aggregate.main.PreCodegen.after.panic-unwind.mir
@@ -23,7 +23,7 @@ fn main() -> () {
         StorageLive(_4);
         StorageLive(_5);
         _5 = const 1_u8;
-        _4 = foo(move _5) -> [return: bb1, unwind continue];
+        _4 = foo(const 1_u8) -> [return: bb1, unwind continue];
     }
 
     bb1: {

--- a/tests/mir-opt/const_prop/array_index.main.ConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/array_index.main.ConstProp.32bit.panic-abort.diff
@@ -23,7 +23,7 @@
 -         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind unreachable];
 +         _4 = const 4_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind unreachable];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/array_index.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/array_index.main.ConstProp.32bit.panic-unwind.diff
@@ -23,7 +23,7 @@
 -         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
 +         _4 = const 4_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/array_index.main.ConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/array_index.main.ConstProp.64bit.panic-abort.diff
@@ -23,7 +23,7 @@
 -         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind unreachable];
 +         _4 = const 4_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind unreachable];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/array_index.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/array_index.main.ConstProp.64bit.panic-unwind.diff
@@ -23,7 +23,7 @@
 -         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
 +         _4 = const 4_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.panic-abort.diff
@@ -38,11 +38,12 @@
 +         _5 = const false;
 +         _6 = const false;
 +         _7 = const false;
-+         assert(!const false, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> [success: bb2, unwind unreachable];
++         assert(!const false, "attempt to compute `{} / {}`, which would overflow", const 1_i32, const 0_i32) -> [success: bb2, unwind unreachable];
       }
   
       bb2: {
-          _2 = Div(const 1_i32, move _3);
+-         _2 = Div(const 1_i32, move _3);
++         _2 = Div(const 1_i32, const 0_i32);
           StorageDead(_3);
           _0 = const ();
           StorageDead(_2);

--- a/tests/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.panic-unwind.diff
@@ -38,11 +38,12 @@
 +         _5 = const false;
 +         _6 = const false;
 +         _7 = const false;
-+         assert(!const false, "attempt to compute `{} / {}`, which would overflow", const 1_i32, _3) -> [success: bb2, unwind continue];
++         assert(!const false, "attempt to compute `{} / {}`, which would overflow", const 1_i32, const 0_i32) -> [success: bb2, unwind continue];
       }
   
       bb2: {
-          _2 = Div(const 1_i32, move _3);
+-         _2 = Div(const 1_i32, move _3);
++         _2 = Div(const 1_i32, const 0_i32);
           StorageDead(_3);
           _0 = const ();
           StorageDead(_2);

--- a/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.panic-abort.diff
@@ -38,11 +38,12 @@
 +         _5 = const false;
 +         _6 = const false;
 +         _7 = const false;
-+         assert(!const false, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> [success: bb2, unwind unreachable];
++         assert(!const false, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, const 0_i32) -> [success: bb2, unwind unreachable];
       }
   
       bb2: {
-          _2 = Rem(const 1_i32, move _3);
+-         _2 = Rem(const 1_i32, move _3);
++         _2 = Rem(const 1_i32, const 0_i32);
           StorageDead(_3);
           _0 = const ();
           StorageDead(_2);

--- a/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.panic-unwind.diff
@@ -38,11 +38,12 @@
 +         _5 = const false;
 +         _6 = const false;
 +         _7 = const false;
-+         assert(!const false, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, _3) -> [success: bb2, unwind continue];
++         assert(!const false, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, const 0_i32) -> [success: bb2, unwind continue];
       }
   
       bb2: {
-          _2 = Rem(const 1_i32, move _3);
+-         _2 = Rem(const 1_i32, move _3);
++         _2 = Rem(const 1_i32, const 0_i32);
           StorageDead(_3);
           _0 = const ();
           StorageDead(_2);

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.panic-abort.diff
@@ -38,7 +38,7 @@
 -         _8 = Lt(_6, _7);
 -         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind unreachable];
 +         _8 = const false;
-+         assert(const false, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind unreachable];
++         assert(const false, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 3_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.panic-unwind.diff
@@ -38,7 +38,7 @@
 -         _8 = Lt(_6, _7);
 -         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
 +         _8 = const false;
-+         assert(const false, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
++         assert(const false, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 3_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.panic-abort.diff
@@ -38,7 +38,7 @@
 -         _8 = Lt(_6, _7);
 -         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind unreachable];
 +         _8 = const false;
-+         assert(const false, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind unreachable];
++         assert(const false, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 3_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.panic-unwind.diff
@@ -38,7 +38,7 @@
 -         _8 = Lt(_6, _7);
 -         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
 +         _8 = const false;
-+         assert(const false, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
++         assert(const false, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 3_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/boxes.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/boxes.main.ConstProp.panic-abort.diff
@@ -24,9 +24,10 @@
           StorageLive(_3);
 -         _4 = SizeOf(i32);
 -         _5 = AlignOf(i32);
+-         _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> [return: bb1, unwind unreachable];
 +         _4 = const 4_usize;
 +         _5 = const 4_usize;
-          _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> [return: bb1, unwind unreachable];
++         _6 = alloc::alloc::exchange_malloc(const 4_usize, const 4_usize) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/boxes.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/boxes.main.ConstProp.panic-unwind.diff
@@ -24,9 +24,10 @@
           StorageLive(_3);
 -         _4 = SizeOf(i32);
 -         _5 = AlignOf(i32);
+-         _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> [return: bb1, unwind continue];
 +         _4 = const 4_usize;
 +         _5 = const 4_usize;
-          _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> [return: bb1, unwind continue];
++         _6 = alloc::alloc::exchange_malloc(const 4_usize, const 4_usize) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.panic-abort.diff
@@ -8,8 +8,9 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+-         _1 = const _;
 -         switchInt(move _1) -> [0: bb2, otherwise: bb1];
++         _1 = const false;
 +         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }
   

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.panic-unwind.diff
@@ -8,8 +8,9 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+-         _1 = const _;
 -         switchInt(move _1) -> [0: bb2, otherwise: bb1];
++         _1 = const false;
 +         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }
   

--- a/tests/mir-opt/const_prop/indirect.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/indirect.main.ConstProp.panic-abort.diff
@@ -18,7 +18,7 @@
 -         assert(!move (_3.1: bool), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> [success: bb1, unwind unreachable];
 +         _2 = const 2_u8;
 +         _3 = const (3_u8, false);
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> [success: bb1, unwind unreachable];
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u8, const 1_u8) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/indirect.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/indirect.main.ConstProp.panic-unwind.diff
@@ -18,7 +18,7 @@
 -         assert(!move (_3.1: bool), "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> [success: bb1, unwind continue];
 +         _2 = const 2_u8;
 +         _3 = const (3_u8, false);
-+         assert(!const false, "attempt to compute `{} + {}`, which would overflow", move _2, const 1_u8) -> [success: bb1, unwind continue];
++         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u8, const 1_u8) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-abort.diff
@@ -23,7 +23,7 @@
 -         _4 = CheckedAdd(_2, _3);
 -         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind unreachable];
 +         _4 = const (0_u8, true);
-+         assert(!const true, "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind unreachable];
++         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-unwind.diff
@@ -23,7 +23,7 @@
 -         _4 = CheckedAdd(_2, _3);
 -         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind continue];
 +         _4 = const (0_u8, true);
-+         assert(!const true, "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind continue];
++         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/tests/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -43,8 +43,9 @@
           StorageLive(_5);
           _5 = InvalidTag { int: const 4_u32 };
 -         _4 = (_5.1: E);
+-         _3 = [move _4];
 +         _4 = const Scalar(0x00000004): E;
-          _3 = [move _4];
++         _3 = [const Scalar(0x00000004): E];
           StorageDead(_4);
           StorageDead(_5);
           nop;

--- a/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-abort.diff
@@ -8,8 +8,10 @@
   
       bb0: {
           StorageLive(_2);
-          _2 = (const (), const 0_u8, const 0_u8);
-          _1 = encode(move _2) -> [return: bb1, unwind unreachable];
+-         _2 = (const (), const 0_u8, const 0_u8);
+-         _1 = encode(move _2) -> [return: bb1, unwind unreachable];
++         _2 = const ((), 0_u8, 0_u8);
++         _1 = encode(const ((), 0_u8, 0_u8)) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/issue_66971.main.ConstProp.panic-unwind.diff
@@ -8,8 +8,10 @@
   
       bb0: {
           StorageLive(_2);
-          _2 = (const (), const 0_u8, const 0_u8);
-          _1 = encode(move _2) -> [return: bb1, unwind continue];
+-         _2 = (const (), const 0_u8, const 0_u8);
+-         _1 = encode(move _2) -> [return: bb1, unwind continue];
++         _2 = const ((), 0_u8, 0_u8);
++         _1 = encode(const ((), 0_u8, 0_u8)) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-abort.diff
@@ -13,9 +13,10 @@
 -         _3 = (const 1_u8, const 2_u8);
 -         _2 = (move _3,);
 +         _3 = const (1_u8, 2_u8);
-+         _2 = (const (1_u8, 2_u8),);
++         _2 = const ((1_u8, 2_u8),);
           StorageDead(_3);
-          _1 = test(move _2) -> [return: bb1, unwind unreachable];
+-         _1 = test(move _2) -> [return: bb1, unwind unreachable];
++         _1 = test(const ((1_u8, 2_u8),)) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-abort.diff
@@ -11,8 +11,9 @@
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = (const 1_u8, const 2_u8);
+-         _2 = (move _3,);
 +         _3 = const (1_u8, 2_u8);
-          _2 = (move _3,);
++         _2 = (const (1_u8, 2_u8),);
           StorageDead(_3);
           _1 = test(move _2) -> [return: bb1, unwind unreachable];
       }

--- a/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-unwind.diff
@@ -13,9 +13,10 @@
 -         _3 = (const 1_u8, const 2_u8);
 -         _2 = (move _3,);
 +         _3 = const (1_u8, 2_u8);
-+         _2 = (const (1_u8, 2_u8),);
++         _2 = const ((1_u8, 2_u8),);
           StorageDead(_3);
-          _1 = test(move _2) -> [return: bb1, unwind continue];
+-         _1 = test(move _2) -> [return: bb1, unwind continue];
++         _1 = test(const ((1_u8, 2_u8),)) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/issue_67019.main.ConstProp.panic-unwind.diff
@@ -11,8 +11,9 @@
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = (const 1_u8, const 2_u8);
+-         _2 = (move _3,);
 +         _3 = const (1_u8, 2_u8);
-          _2 = (move _3,);
++         _2 = (const (1_u8, 2_u8),);
           StorageDead(_3);
           _1 = test(move _2) -> [return: bb1, unwind continue];
       }

--- a/tests/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.panic-abort.diff
@@ -23,7 +23,7 @@
 -         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind unreachable];
 +         _4 = const 5000_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind unreachable];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.panic-unwind.diff
@@ -23,7 +23,7 @@
 -         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
 +         _4 = const 5000_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.panic-abort.diff
@@ -23,7 +23,7 @@
 -         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind unreachable];
 +         _4 = const 5000_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind unreachable];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.panic-unwind.diff
@@ -23,7 +23,7 @@
 -         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
 +         _4 = const 5000_usize;
 +         _5 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind continue];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-abort.diff
@@ -28,8 +28,9 @@
           StorageLive(_1);
           StorageLive(_2);
 -         _2 = OffsetOf(Alpha, [0]);
+-         _1 = must_use::<usize>(move _2) -> [return: bb1, unwind unreachable];
 +         _2 = const 4_usize;
-          _1 = must_use::<usize>(move _2) -> [return: bb1, unwind unreachable];
++         _1 = must_use::<usize>(const 4_usize) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
@@ -37,8 +38,9 @@
           StorageLive(_3);
           StorageLive(_4);
 -         _4 = OffsetOf(Alpha, [1]);
+-         _3 = must_use::<usize>(move _4) -> [return: bb2, unwind unreachable];
 +         _4 = const 0_usize;
-          _3 = must_use::<usize>(move _4) -> [return: bb2, unwind unreachable];
++         _3 = must_use::<usize>(const 0_usize) -> [return: bb2, unwind unreachable];
       }
   
       bb2: {
@@ -46,8 +48,9 @@
           StorageLive(_5);
           StorageLive(_6);
 -         _6 = OffsetOf(Alpha, [2, 0]);
+-         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind unreachable];
 +         _6 = const 2_usize;
-          _5 = must_use::<usize>(move _6) -> [return: bb3, unwind unreachable];
++         _5 = must_use::<usize>(const 2_usize) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {
@@ -55,8 +58,9 @@
           StorageLive(_7);
           StorageLive(_8);
 -         _8 = OffsetOf(Alpha, [2, 1]);
+-         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind unreachable];
 +         _8 = const 3_usize;
-          _7 = must_use::<usize>(move _8) -> [return: bb4, unwind unreachable];
++         _7 = must_use::<usize>(const 3_usize) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {

--- a/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-unwind.diff
@@ -28,8 +28,9 @@
           StorageLive(_1);
           StorageLive(_2);
 -         _2 = OffsetOf(Alpha, [0]);
+-         _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
 +         _2 = const 4_usize;
-          _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
++         _1 = must_use::<usize>(const 4_usize) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -37,8 +38,9 @@
           StorageLive(_3);
           StorageLive(_4);
 -         _4 = OffsetOf(Alpha, [1]);
+-         _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
 +         _4 = const 0_usize;
-          _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
++         _3 = must_use::<usize>(const 0_usize) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -46,8 +48,9 @@
           StorageLive(_5);
           StorageLive(_6);
 -         _6 = OffsetOf(Alpha, [2, 0]);
+-         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
 +         _6 = const 2_usize;
-          _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
++         _5 = must_use::<usize>(const 2_usize) -> [return: bb3, unwind continue];
       }
   
       bb3: {
@@ -55,8 +58,9 @@
           StorageLive(_7);
           StorageLive(_8);
 -         _8 = OffsetOf(Alpha, [2, 1]);
+-         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
 +         _8 = const 3_usize;
-          _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
++         _7 = must_use::<usize>(const 3_usize) -> [return: bb4, unwind continue];
       }
   
       bb4: {

--- a/tests/mir-opt/const_prop/repeat.main.ConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/repeat.main.ConstProp.32bit.panic-abort.diff
@@ -25,7 +25,7 @@
 -         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind unreachable];
 +         _5 = const 8_usize;
 +         _6 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind unreachable];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/repeat.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/repeat.main.ConstProp.32bit.panic-unwind.diff
@@ -25,7 +25,7 @@
 -         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind continue];
 +         _5 = const 8_usize;
 +         _6 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind continue];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/repeat.main.ConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/repeat.main.ConstProp.64bit.panic-abort.diff
@@ -25,7 +25,7 @@
 -         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind unreachable];
 +         _5 = const 8_usize;
 +         _6 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind unreachable];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/repeat.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/repeat.main.ConstProp.64bit.panic-unwind.diff
@@ -25,7 +25,7 @@
 -         assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind continue];
 +         _5 = const 8_usize;
 +         _6 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _5, _4) -> [success: bb1, unwind continue];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.panic-abort.diff
@@ -16,8 +16,9 @@
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = _1;
+-         _2 = consume(move _3) -> [return: bb1, unwind unreachable];
 +         _3 = const 1_u32;
-          _2 = consume(move _3) -> [return: bb1, unwind unreachable];
++         _2 = consume(const 1_u32) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.panic-unwind.diff
@@ -16,8 +16,9 @@
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = _1;
+-         _2 = consume(move _3) -> [return: bb1, unwind continue];
 +         _3 = const 1_u32;
-          _2 = consume(move _3) -> [return: bb1, unwind continue];
++         _2 = consume(const 1_u32) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/slice_len.main.ConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.ConstProp.32bit.panic-abort.diff
@@ -30,7 +30,7 @@
 -         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind unreachable];
 +         _7 = const 3_usize;
 +         _8 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind unreachable];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/slice_len.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.ConstProp.32bit.panic-unwind.diff
@@ -30,7 +30,7 @@
 -         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
 +         _7 = const 3_usize;
 +         _8 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/slice_len.main.ConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.ConstProp.64bit.panic-abort.diff
@@ -30,7 +30,7 @@
 -         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind unreachable];
 +         _7 = const 3_usize;
 +         _8 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind unreachable];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> [success: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/slice_len.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.ConstProp.64bit.panic-unwind.diff
@@ -30,7 +30,7 @@
 -         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
 +         _7 = const 3_usize;
 +         _8 = const true;
-+         assert(const true, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb1, unwind continue];
++         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> [success: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.panic-abort.diff
@@ -17,8 +17,9 @@
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = _1;
+-         _2 = consume(move _3) -> [return: bb1, unwind unreachable];
 +         _3 = const (1_u32, 2_u32);
-          _2 = consume(move _3) -> [return: bb1, unwind unreachable];
++         _2 = consume(const (1_u32, 2_u32)) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.panic-unwind.diff
@@ -17,8 +17,9 @@
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = _1;
+-         _2 = consume(move _3) -> [return: bb1, unwind continue];
 +         _3 = const (1_u32, 2_u32);
-          _2 = consume(move _3) -> [return: bb1, unwind continue];
++         _2 = consume(const (1_u32, 2_u32)) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
@@ -12,7 +12,6 @@
 +         debug rhs => _4;
 +         let mut _5: u16;
 +         let mut _6: bool;
-+         let mut _7: u32;
 +         scope 2 {
 +         }
 +     }
@@ -28,10 +27,7 @@
 -     bb1: {
 +         StorageLive(_5);
 +         StorageLive(_6);
-+         StorageLive(_7);
-+         _7 = const 65535_u32;
-+         _6 = Le(_4, move _7);
-+         StorageDead(_7);
++         _6 = Le(_4, const 65535_u32);
 +         assume(move _6);
 +         StorageDead(_6);
 +         _5 = _4 as u16 (IntToInt);

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
@@ -12,7 +12,6 @@
 +         debug rhs => _4;
 +         let mut _5: u16;
 +         let mut _6: bool;
-+         let mut _7: u32;
 +         scope 2 {
 +         }
 +     }
@@ -28,10 +27,7 @@
 -     bb1: {
 +         StorageLive(_5);
 +         StorageLive(_6);
-+         StorageLive(_7);
-+         _7 = const 65535_u32;
-+         _6 = Le(_4, move _7);
-+         StorageDead(_7);
++         _6 = Le(_4, const 65535_u32);
 +         assume(move _6);
 +         StorageDead(_6);
 +         _5 = _4 as u16 (IntToInt);

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-abort.mir
@@ -7,25 +7,21 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
     scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
         debug self => _1;
         debug rhs => _2;
-        let mut _3: u32;
-        let mut _4: bool;
-        let mut _5: u16;
+        let mut _3: bool;
+        let mut _4: u16;
         scope 2 {
         }
     }
 
     bb0: {
-        StorageLive(_5);
         StorageLive(_4);
         StorageLive(_3);
-        _3 = const 65535_u32;
-        _4 = Le(_2, move _3);
+        _3 = Le(_2, const 65535_u32);
+        assume(move _3);
         StorageDead(_3);
-        assume(move _4);
+        _4 = _2 as u16 (IntToInt);
+        _0 = ShlUnchecked(_1, move _4);
         StorageDead(_4);
-        _5 = _2 as u16 (IntToInt);
-        _0 = ShlUnchecked(_1, move _5);
-        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-unwind.mir
@@ -7,25 +7,21 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
     scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
         debug self => _1;
         debug rhs => _2;
-        let mut _3: u32;
-        let mut _4: bool;
-        let mut _5: u16;
+        let mut _3: bool;
+        let mut _4: u16;
         scope 2 {
         }
     }
 
     bb0: {
-        StorageLive(_5);
         StorageLive(_4);
         StorageLive(_3);
-        _3 = const 65535_u32;
-        _4 = Le(_2, move _3);
+        _3 = Le(_2, const 65535_u32);
+        assume(move _3);
         StorageDead(_3);
-        assume(move _4);
+        _4 = _2 as u16 (IntToInt);
+        _0 = ShlUnchecked(_1, move _4);
         StorageDead(_4);
-        _5 = _2 as u16 (IntToInt);
-        _0 = ShlUnchecked(_1, move _5);
-        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-abort.diff
@@ -12,7 +12,6 @@
 +         debug rhs => _4;
 +         let mut _5: i16;
 +         let mut _6: bool;
-+         let mut _7: u32;
 +         scope 2 {
 +         }
 +     }
@@ -28,10 +27,7 @@
 -     bb1: {
 +         StorageLive(_5);
 +         StorageLive(_6);
-+         StorageLive(_7);
-+         _7 = const 32767_u32;
-+         _6 = Le(_4, move _7);
-+         StorageDead(_7);
++         _6 = Le(_4, const 32767_u32);
 +         assume(move _6);
 +         StorageDead(_6);
 +         _5 = _4 as i16 (IntToInt);

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-unwind.diff
@@ -12,7 +12,6 @@
 +         debug rhs => _4;
 +         let mut _5: i16;
 +         let mut _6: bool;
-+         let mut _7: u32;
 +         scope 2 {
 +         }
 +     }
@@ -28,10 +27,7 @@
 -     bb1: {
 +         StorageLive(_5);
 +         StorageLive(_6);
-+         StorageLive(_7);
-+         _7 = const 32767_u32;
-+         _6 = Le(_4, move _7);
-+         StorageDead(_7);
++         _6 = Le(_4, const 32767_u32);
 +         assume(move _6);
 +         StorageDead(_6);
 +         _5 = _4 as i16 (IntToInt);

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-abort.mir
@@ -7,25 +7,21 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
     scope 1 (inlined core::num::<impl i16>::unchecked_shr) {
         debug self => _1;
         debug rhs => _2;
-        let mut _3: u32;
-        let mut _4: bool;
-        let mut _5: i16;
+        let mut _3: bool;
+        let mut _4: i16;
         scope 2 {
         }
     }
 
     bb0: {
-        StorageLive(_5);
         StorageLive(_4);
         StorageLive(_3);
-        _3 = const 32767_u32;
-        _4 = Le(_2, move _3);
+        _3 = Le(_2, const 32767_u32);
+        assume(move _3);
         StorageDead(_3);
-        assume(move _4);
+        _4 = _2 as i16 (IntToInt);
+        _0 = ShrUnchecked(_1, move _4);
         StorageDead(_4);
-        _5 = _2 as i16 (IntToInt);
-        _0 = ShrUnchecked(_1, move _5);
-        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-unwind.mir
@@ -7,25 +7,21 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
     scope 1 (inlined core::num::<impl i16>::unchecked_shr) {
         debug self => _1;
         debug rhs => _2;
-        let mut _3: u32;
-        let mut _4: bool;
-        let mut _5: i16;
+        let mut _3: bool;
+        let mut _4: i16;
         scope 2 {
         }
     }
 
     bb0: {
-        StorageLive(_5);
         StorageLive(_4);
         StorageLive(_3);
-        _3 = const 32767_u32;
-        _4 = Le(_2, move _3);
+        _3 = Le(_2, const 32767_u32);
+        assume(move _3);
         StorageDead(_3);
-        assume(move _4);
+        _4 = _2 as i16 (IntToInt);
+        _0 = ShrUnchecked(_1, move _4);
         StorageDead(_4);
-        _5 = _2 as i16 (IntToInt);
-        _0 = ShrUnchecked(_1, move _5);
-        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
@@ -7,25 +7,24 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
     scope 1 (inlined core::num::<impl u32>::checked_shl) {
         debug self => _1;
         debug rhs => _2;
-        let mut _7: bool;
+        let mut _6: bool;
         scope 2 {
-            debug a => _5;
-            debug b => _6;
+            debug a => _4;
+            debug b => _5;
         }
         scope 3 (inlined core::num::<impl u32>::overflowing_shl) {
             debug self => _1;
             debug rhs => _2;
-            let mut _5: u32;
-            let mut _6: bool;
+            let mut _4: u32;
+            let mut _5: bool;
             scope 4 (inlined core::num::<impl u32>::wrapping_shl) {
                 debug self => _1;
                 debug rhs => _2;
                 let mut _3: u32;
-                let mut _4: u32;
                 scope 5 {
                     scope 6 (inlined core::num::<impl u32>::unchecked_shl) {
                         debug self => _1;
-                        debug rhs => _4;
+                        debug rhs => _3;
                         scope 7 {
                         }
                     }
@@ -35,26 +34,23 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
     }
 
     bb0: {
-        StorageLive(_5);
-        StorageLive(_6);
         StorageLive(_4);
+        StorageLive(_5);
         StorageLive(_3);
-        _3 = const 31_u32;
-        _4 = BitAnd(_2, move _3);
+        _3 = BitAnd(_2, const 31_u32);
+        _4 = ShlUnchecked(_1, _3);
         StorageDead(_3);
-        _5 = ShlUnchecked(_1, _4);
-        StorageDead(_4);
-        _6 = Ge(_2, const _);
-        StorageLive(_7);
-        _7 = unlikely(move _6) -> [return: bb1, unwind unreachable];
+        _5 = Ge(_2, const _);
+        StorageLive(_6);
+        _6 = unlikely(move _5) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        switchInt(move _7) -> [0: bb2, otherwise: bb3];
+        switchInt(move _6) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _0 = Option::<u32>::Some(_5);
+        _0 = Option::<u32>::Some(_4);
         goto -> bb4;
     }
 
@@ -64,9 +60,9 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
     }
 
     bb4: {
-        StorageDead(_7);
         StorageDead(_6);
         StorageDead(_5);
+        StorageDead(_4);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/intrinsics.f_u64.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/intrinsics.f_u64.PreCodegen.after.mir
@@ -2,22 +2,18 @@
 
 fn f_u64() -> () {
     let mut _0: ();
-    let mut _1: u64;
     scope 1 (inlined f_dispatch::<u64>) {
         debug t => const 0_u64;
-        let _2: ();
+        let _1: ();
         scope 2 (inlined std::mem::size_of::<u64>) {
         }
     }
 
     bb0: {
-        StorageLive(_1);
-        _1 = const 0_u64;
-        _2 = f_non_zst::<u64>(move _1) -> [return: bb1, unwind unreachable];
+        _1 = f_non_zst::<u64>(const 0_u64) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        StorageDead(_1);
         return;
     }
 }


### PR DESCRIPTION
This removes some complexity from the pass.

The limitation to propagate ScalarPairs only for tuple comes from https://github.com/rust-lang/rust/pull/67015, when ScalarPair constant were modeled using `Rvalue::Aggregate`. Nowadays, we use `ConstValue::ByRef`, which does not care about the underlying type.

The justification for not propagating in all cases was perf. This seems not to be a clear cut any more: https://github.com/rust-lang/rust/pull/113858#issuecomment-1642396746