### PR TITLE
Add note that Vec::as_mut_ptr() does not materialize a reference to the internal buffer

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1220,7 +1220,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// This method guarantees that for the purpose of the aliasing model, this method
     /// does not materialize a reference to the underlying slice, and thus the returned pointer
-    /// will remain valid when mixed with other calls to [`as_ptr`] and [`as_mut_ptr`],
+    /// will remain valid when mixed with other calls to [`as_ptr`] and [`as_mut_ptr`].
     /// Note that calling other methods that materialize mutable references to the slice,
     /// or references to specific elements you are planning on accessing through this pointer,
     /// may still invalidate this pointer.

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1249,7 +1249,8 @@ impl<T, A: Allocator> Vec<T, A> {
     ///     let _ = ptr1.read();
     ///     let ptr2 = v.as_mut_ptr().offset(2);
     ///     ptr2.write(2);
-    ///     // Notably, the write to `ptr2` did *not* invalidate `ptr1`:
+    ///     // Notably, the write to `ptr2` did *not* invalidate `ptr1`
+    ///     // because it mutated a different element:
     ///     let _ = ptr1.read();
     /// }
     /// ```

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1274,7 +1274,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// This method guarantees that for the purpose of the aliasing model, this method
     /// does not materialize a reference to the underlying slice, and thus the returned pointer
-    /// will remain valid when mixed with other calls to [`as_ptr`] and [`as_mut_ptr`],
+    /// will remain valid when mixed with other calls to [`as_ptr`] and [`as_mut_ptr`].
     /// Note that calling other methods that materialize references to the slice,
     /// or references to specific elements you are planning on accessing through this pointer,
     /// may still invalidate this pointer.

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1223,7 +1223,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// will remain valid when mixed with other calls to [`as_ptr`] and [`as_mut_ptr`].
     /// Note that calling other methods that materialize mutable references to the slice,
     /// or mutable references to specific elements you are planning on accessing through this pointer,
-    /// may still invalidate this pointer.
+    /// as well as writing to those elements, may still invalidate this pointer.
     /// See the second example below for how this guarantee can be used.
     ///
     ///

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1222,7 +1222,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// does not materialize a reference to the underlying slice, and thus the returned pointer
     /// will remain valid when mixed with other calls to [`as_ptr`] and [`as_mut_ptr`].
     /// Note that calling other methods that materialize mutable references to the slice,
-    /// or references to specific elements you are planning on accessing through this pointer,
+    /// or mutable references to specific elements you are planning on accessing through this pointer,
     /// may still invalidate this pointer.
     /// See the second example below for how this guarantee can be used.
     ///
@@ -1244,10 +1244,10 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// ```rust
     /// unsafe {
-    ///     let mut v = vec![0];
+    ///     let mut v = vec![0, 1, 2];
     ///     let ptr1 = v.as_ptr();
     ///     let _ = ptr1.read();
-    ///     let ptr2 = v.as_mut_ptr();
+    ///     let ptr2 = v.as_mut_ptr().offset(2);
     ///     ptr2.write(2);
     ///     // Notably, the write to `ptr2` did *not* invalidate `ptr1`:
     ///     let _ = ptr1.read();

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1218,6 +1218,12 @@ impl<T, A: Allocator> Vec<T, A> {
     /// is never written to (except inside an `UnsafeCell`) using this pointer or any pointer
     /// derived from it. If you need to mutate the contents of the slice, use [`as_mut_ptr`].
     ///
+    /// This method guarantees that when it is called multiple times without
+    /// the buffer being reallocated in the mean time, the returned pointer will
+    /// always be exactly the same, even for the purpose of the aliasing model, where
+    /// pointers may be invalidated even when the actual memory does not move.
+    /// See the second example below for how this can be used.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1231,6 +1237,16 @@ impl<T, A: Allocator> Vec<T, A> {
     /// }
     /// ```
     ///
+    /// The validity guarantee works out this way:
+    ///
+    /// ```rust
+    /// let mut v = vec![0];
+    /// let ptr = v.as_ptr();
+    /// let x = ptr.read();
+    /// v[0] = 5;
+    /// // Notably, the write above did *not* invalidate `ptr1`:
+    /// let x = ptr.read();
+    /// ```
     /// [`as_mut_ptr`]: Vec::as_mut_ptr
     #[stable(feature = "vec_as_ptr", since = "1.37.0")]
     #[inline]
@@ -1248,6 +1264,13 @@ impl<T, A: Allocator> Vec<T, A> {
     /// Modifying the vector may cause its buffer to be reallocated,
     /// which would also make any pointers to it invalid.
     ///
+    /// This method guarantees that when it is called multiple times without
+    /// the buffer being reallocated in the mean time, the returned pointer will
+    /// always be exactly the same, even for the purpose of the aliasing model, where
+    /// pointers may be invalidated even when the actual memory does not move.
+    /// See the second example below for how this can be used.
+    ///
+    ///
     /// # Examples
     ///
     /// ```
@@ -1264,6 +1287,18 @@ impl<T, A: Allocator> Vec<T, A> {
     ///     x.set_len(size);
     /// }
     /// assert_eq!(&*x, &[0, 1, 2, 3]);
+    /// ```
+    ///
+    /// The validity guarantee works out this way:
+    ///
+    /// ```rust
+    /// let mut v = vec![0];
+    /// let ptr1 = v.as_mut_ptr();
+    /// ptr1.write(1);
+    /// let ptr2 = v.as_mut_ptr();
+    /// ptr2.write(2);
+    /// // Notably, the write to `ptr2` did *not* invalidate `ptr1`:
+    /// ptr1.write(3);
     /// ```
     #[stable(feature = "vec_as_ptr", since = "1.37.0")]
     #[inline]


### PR DESCRIPTION
See discussion on https://github.com/thomcc/rust-typed-arena/issues/62 and [t-opsem](https://rust-lang.zulipchat.com/#narrow/stream/136281-t-opsem/topic/is.20this.20typed_arena.20code.20sound.20under.20stacked.2Ftree.20borrows.3F)

This method already does the correct thing here, but it is worth guaranteeing that it does so it can be used more freely in unsafe code without having to worry about potential Stacked/Tree Borrows violations. This moves one more unsafe usage pattern from the "very likely sound but technically not fully defined" box into "definitely sound", and currently our surface area of the latter is woefully small.

I'm not sure how best to word this, opening this PR as a way to start discussion.