### PR TITLE
Safe Transmute: Add test for ICE that has since been fixed

### DIFF
--- a/tests/ui/transmutability/issue-112433.rs
+++ b/tests/ui/transmutability/issue-112433.rs
@@ -1,0 +1,7 @@
+// check-fail
+// This was originally causing an ICE in `rustc_transmute::maybe_transmutable`
+#![crate_type="lib"]
+#[repr(C, packed)] //~ ERROR attribute should be applied to a struct or union
+enum V0usize {
+    V,
+}

--- a/tests/ui/transmutability/issue-112433.stderr
+++ b/tests/ui/transmutability/issue-112433.stderr
@@ -1,0 +1,13 @@
+error[E0517]: attribute should be applied to a struct or union
+  --> $DIR/issue-112433.rs:4:11
+   |
+LL |   #[repr(C, packed)]
+   |             ^^^^^^
+LL | / enum V0usize {
+LL | |     V,
+LL | | }
+   | |_- not a struct or union
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0517`.


### PR DESCRIPTION
This just makes sure that the ICE in #112433 doesn't regress.