### PR TITLE
Use the correct span for displaying the line following a derive sugge…

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1982,7 +1982,7 @@ impl EmitterWriter {
                 // We special case `#[derive(_)]\n` and other attribute suggestions, because those
                 // are the ones where context is most useful.
                 let file_lines = sm
-                    .span_to_lines(span.primary_span().unwrap().shrink_to_hi())
+                    .span_to_lines(parts[0].span.shrink_to_hi())
                     .expect("span_to_lines failed when emitting suggestion");
                 let line_num = sm.lookup_char_pos(parts[0].span.lo()).line;
                 if let Some(line) = file_lines.file.get_line(line_num - 1) {

--- a/tests/ui/modules/issue-107649.stderr
+++ b/tests/ui/modules/issue-107649.stderr
@@ -11,7 +11,7 @@ help: consider annotating `Dummy` with `#[derive(Debug)]`
    --> $DIR/auxiliary/dummy_lib.rs:2:1
     |
 2   + #[derive(Debug)]
-3   | #[path = "auxiliary/dummy_lib.rs"]
+3   | pub struct Dummy;
     |
 
 error: aborting due to previous error


### PR DESCRIPTION
`span` here is the main span of the diagnostic. In the linked issue's case, this belongs to `main.rs`. However, the line numbers (and line we are trying to display) are in `name.rs`, so using `span_to_lines` gives us the wrong `FileLines`.

Use `parts[0].span` (the span of the suggestion) here like the rest of the code does to get the right file.

Not sure if this needs a dedicated test because this fixes an existing error in the UI suite

Fixes #113844