### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1619,13 +1619,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 debug!(?hir_bounds);
 
                 let lifetime_mapping = if in_trait {
-                    self.arena.alloc_from_iter(
-                        collected_lifetime_mapping
-                            .iter()
-                            .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                    Some(
+                        &*self.arena.alloc_from_iter(
+                            collected_lifetime_mapping
+                                .iter()
+                                .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                        ),
                     )
                 } else {
-                    &mut []
+                    None
                 };
 
                 let opaque_ty_item = hir::OpaqueTy {
@@ -2090,13 +2092,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 debug!("lower_async_fn_ret_ty: generic_params={:#?}", generic_params);
 
                 let lifetime_mapping = if in_trait {
-                    self.arena.alloc_from_iter(
-                        collected_lifetime_mapping
-                            .iter()
-                            .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                    Some(
+                        &*self.arena.alloc_from_iter(
+                            collected_lifetime_mapping
+                                .iter()
+                                .map(|(lifetime, def_id)| (**lifetime, *def_id)),
+                        ),
                     )
                 } else {
-                    &mut []
+                    None
                 };
 
                 let opaque_ty_item = hir::OpaqueTy {

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1982,7 +1982,7 @@ impl EmitterWriter {
                 // We special case `#[derive(_)]\n` and other attribute suggestions, because those
                 // are the ones where context is most useful.
                 let file_lines = sm
-                    .span_to_lines(span.primary_span().unwrap().shrink_to_hi())
+                    .span_to_lines(parts[0].span.shrink_to_hi())
                     .expect("span_to_lines failed when emitting suggestion");
                 let line_num = sm.lookup_char_pos(parts[0].span.lo()).line;
                 if let Some(line) = file_lines.file.get_line(line_num - 1) {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2664,10 +2664,19 @@ pub struct OpaqueTy<'hir> {
     pub generics: &'hir Generics<'hir>,
     pub bounds: GenericBounds<'hir>,
     pub origin: OpaqueTyOrigin,
-    // Opaques have duplicated lifetimes, this mapping connects the original lifetime with the copy
-    // so we can later generate bidirectional outlives predicates to enforce that these lifetimes
-    // stay in sync.
-    pub lifetime_mapping: &'hir [(Lifetime, LocalDefId)],
+    /// Return-position impl traits (and async futures) must "reify" any late-bound
+    /// lifetimes that are captured from the function signature they originate from.
+    ///
+    /// This is done by generating a new early-bound lifetime parameter local to the
+    /// opaque which is substituted in the function signature with the late-bound
+    /// lifetime.
+    ///
+    /// This mapping associated a captured lifetime (first parameter) with the new
+    /// early-bound lifetime that was generated for the opaque.
+    pub lifetime_mapping: Option<&'hir [(Lifetime, LocalDefId)]>,
+    /// Whether the opaque is a return-position impl trait (or async future)
+    /// originating from a trait method. This makes it so that the opaque is
+    /// lowered as an associated type.
     pub in_trait: bool,
 }
 

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -66,7 +66,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
             let opaque_ty_id = tcx.hir().local_def_id_to_hir_id(opaque_def_id.expect_local());
             let opaque_ty_node = tcx.hir().get(opaque_ty_id);
             let Node::Item(&Item {
-                kind: ItemKind::OpaqueTy(OpaqueTy { lifetime_mapping, .. }),
+                kind: ItemKind::OpaqueTy(OpaqueTy { lifetime_mapping: Some(lifetime_mapping), .. }),
                 ..
             }) = opaque_ty_node
             else {

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -558,6 +558,14 @@ impl Command {
     /// but this has some implementation limitations on Windows
     /// (see issue #37519).
     ///
+    /// # Platform-specific behavior
+    ///
+    /// Note on Windows: For executable files with the .exe extension,
+    /// it can be omitted when specifying the program for this Command.
+    /// However, if the file has a different extension,
+    /// a filename including the extension needs to be provided,
+    /// otherwise the file won't be found.
+    ///
     /// # Examples
     ///
     /// Basic usage:

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1644,6 +1644,7 @@ impl<'a> Builder<'a> {
         // fun to pass a flag to a tool to pass a flag to pass a flag to a tool
         // to change a flag in a binary?
         if self.config.rpath_enabled(target) && util::use_host_linker(target) {
+            let libdir = self.sysroot_libdir_relative(compiler).to_str().unwrap();
             let rpath = if target.contains("apple") {
                 // Note that we need to take one extra step on macOS to also pass
                 // `-Wl,-instal_name,@rpath/...` to get things to work right. To
@@ -1651,10 +1652,10 @@ impl<'a> Builder<'a> {
                 // so. Note that this is definitely a hack, and we should likely
                 // flesh out rpath support more fully in the future.
                 rustflags.arg("-Zosx-rpath-install-name");
-                Some("-Wl,-rpath,@loader_path/../lib")
+                Some(format!("-Wl,-rpath,@loader_path/../{}", libdir))
             } else if !target.contains("windows") && !target.contains("aix") {
                 rustflags.arg("-Clink-args=-Wl,-z,origin");
-                Some("-Wl,-rpath,$ORIGIN/../lib")
+                Some(format!("-Wl,-rpath,$ORIGIN/../{}", libdir))
             } else {
                 None
             };

--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -274,6 +274,8 @@ def get_commands(template):
                 args = shlex.split(args)
             except UnicodeEncodeError:
                 args = [arg.decode('utf-8') for arg in shlex.split(args.encode('utf-8'))]
+            except Exception as exc:
+                raise Exception("line {}: {}".format(lineno + 1, exc)) from None
             yield Command(negated=negated, cmd=cmd, args=args, lineno=lineno+1, context=line)
 
 

--- a/tests/rustdoc/display-hidden-items.rs
+++ b/tests/rustdoc/display-hidden-items.rs
@@ -1,0 +1,71 @@
+// Test to ensure that the `--document-hidden-items` option is working as expected.
+// compile-flags: -Z unstable-options --document-hidden-items
+// ignore-tidy-linelength
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+// @has - '//*[@id="reexport.hidden_reexport"]/code' 'pub use hidden::inside_hidden as hidden_reexport;'
+#[doc(hidden)]
+pub use hidden::inside_hidden as hidden_reexport;
+
+// @has - '//*[@class="item-name"]/a[@class="trait"]' 'TraitHidden'
+// @has 'foo/trait.TraitHidden.html'
+#[doc(hidden)]
+pub trait TraitHidden {}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="trait"]' 'Trait'
+pub trait Trait {
+    // @has 'foo/trait.Trait.html'
+    // @has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' 'const BAR: u32 = 0u32'
+    #[doc(hidden)]
+    const BAR: u32 = 0;
+
+    // @has - '//*[@id="method.foo"]/*[@class="code-header"]' 'fn foo()'
+    #[doc(hidden)]
+    fn foo() {}
+}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="struct"]' 'Struct'
+// @has 'foo/struct.Struct.html'
+pub struct Struct {
+    // @has - '//*[@id="structfield.a"]/code' 'a: u32'
+    #[doc(hidden)]
+    pub a: u32,
+}
+
+impl Struct {
+    // @has - '//*[@id="method.new"]/*[@class="code-header"]' 'pub fn new() -> Self'
+    #[doc(hidden)]
+    pub fn new() -> Self { Self { a: 0 } }
+}
+
+impl Trait for Struct {
+    // @has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' 'const BAR: u32 = 0u32'
+    // @has - '//*[@id="method.foo"]/*[@class="code-header"]' 'fn foo()'
+}
+// @has - '//*[@id="impl-TraitHidden-for-Struct"]/*[@class="code-header"]' 'impl TraitHidden for Struct'
+impl TraitHidden for Struct {}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="enum"]' 'HiddenEnum'
+// @has 'foo/enum.HiddenEnum.html'
+#[doc(hidden)]
+pub enum HiddenEnum {
+    A,
+}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="enum"]' 'Enum'
+pub enum Enum {
+    // @has 'foo/enum.Enum.html' '//*[@id="variant.A"]/*[@class="code-header"]' 'A'
+    #[doc(hidden)]
+    A,
+}
+
+// @has 'foo/index.html' '//*[@class="item-name"]/a[@class="mod"]' 'hidden'
+#[doc(hidden)]
+pub mod hidden {
+    // @has 'foo/hidden/index.html'
+    // @has - '//*[@class="item-name"]/a[@class="fn"]' 'inside_hidden'
+    // @has 'foo/hidden/fn.inside_hidden.html'
+    pub fn inside_hidden() {}
+}

--- a/tests/ui/modules/issue-107649.stderr
+++ b/tests/ui/modules/issue-107649.stderr
@@ -11,7 +11,7 @@ help: consider annotating `Dummy` with `#[derive(Debug)]`
    --> $DIR/auxiliary/dummy_lib.rs:2:1
     |
 2   + #[derive(Debug)]
-3   | #[path = "auxiliary/dummy_lib.rs"]
+3   | pub struct Dummy;
     |
 
 error: aborting due to previous error


### PR DESCRIPTION
Successful merges:

 - #113710 (Fix rpath for libdir is specified)
 - #113787 (Update documentation for std::process::Command's new method)
 - #113795 (Properly document `lifetime_mapping` in `OpaqueTy`)
 - #113857 (Add tests for `--document-hidden-items` option)
 - #113871 (Use the correct span for displaying the line following a derive sugge…)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113710,113787,113795,113857,113871)
<!-- homu-ignore:end -->