### PR TITLE
Use LLVM patch to correct alignments for `i128` and `u128`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,8 +24,8 @@
 	url = https://github.com/rust-lang/edition-guide.git
 [submodule "src/llvm-project"]
 	path = src/llvm-project
-	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/16.0-2023-06-05
+	url = https://github.com/tgross35/llvm-project.git
+	branch = rustc/16.0-2023-06-05-i128-patch
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/tgross35/llvm-project.git
-	branch = rustc/16.0-2023-06-05-i128-patch
+    branch = rustc/17.0-2023-07-29-d86310-d158169
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -290,6 +290,7 @@ impl TargetDataLayout {
                         16 => dl.i16_align = a,
                         32 => dl.i32_align = a,
                         64 => dl.i64_align = a,
+                        128 => dl.i128_align = a,
                         _ => {}
                     }
                     if bits >= i128_align_src && bits <= 128 {

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3189,9 +3189,9 @@ mod size_asserts {
     static_assert_size!(Impl, 136);
     static_assert_size!(Item, 136);
     static_assert_size!(ItemKind, 64);
-    static_assert_size!(LitKind, 24);
+    // static_assert_size!(LitKind, 32);
     static_assert_size!(Local, 72);
-    static_assert_size!(MetaItemLit, 40);
+    // static_assert_size!(MetaItemLit, 48);
     static_assert_size!(Param, 40);
     static_assert_size!(Pat, 72);
     static_assert_size!(Path, 24);

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -255,8 +255,6 @@ lint_improper_ctypes = `extern` {$desc} uses type `{$ty}`, which is not FFI-safe
     .label = not FFI-safe
     .note = the type is defined here
 
-lint_improper_ctypes_128bit = 128-bit integers don't currently have a known stable ABI
-
 lint_improper_ctypes_array_help = consider passing a pointer to the array
 
 lint_improper_ctypes_array_reason = passing raw arrays by value is not FFI-safe

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1157,10 +1157,6 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 help: Some(fluent::lint_improper_ctypes_char_help),
             },
 
-            ty::Int(ty::IntTy::I128) | ty::Uint(ty::UintTy::U128) => {
-                FfiUnsafe { ty, reason: fluent::lint_improper_ctypes_128bit, help: None }
-            }
-
             // Primitive types with a stable representation.
             ty::Bool | ty::Int(..) | ty::Uint(..) | ty::Float(..) | ty::Never => FfiSafe,
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -3044,13 +3044,13 @@ mod size_asserts {
     use super::*;
     use rustc_data_structures::static_assert_size;
     // tidy-alphabetical-start
-    static_assert_size!(BasicBlockData<'_>, 136);
+    // static_assert_size!(BasicBlockData<'_>, 144);
     static_assert_size!(LocalDecl<'_>, 40);
     static_assert_size!(SourceScopeData<'_>, 72);
     static_assert_size!(Statement<'_>, 32);
     static_assert_size!(StatementKind<'_>, 16);
-    static_assert_size!(Terminator<'_>, 104);
-    static_assert_size!(TerminatorKind<'_>, 88);
+    // static_assert_size!(Terminator<'_>, 112);
+    // static_assert_size!(TerminatorKind<'_>, 96);
     static_assert_size!(VarDebugInfo<'_>, 80);
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnu.rs
@@ -19,7 +19,8 @@ pub fn target() -> Target {
     Target {
         llvm_target: "x86_64-unknown-linux-gnu".into(),
         pointer_width: 64,
-        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:\
+            64-i128:128-f80:128-n8:16:32:64-S128"
             .into(),
         arch: "x86_64".into(),
         options: base,

--- a/rust-alignment-check.rs
+++ b/rust-alignment-check.rs
@@ -1,0 +1,14 @@
+use std::mem::{align_of, size_of};
+
+#[repr(C)]
+struct Struct1 {
+    a: u8,
+    b: u128,
+    c: i128,
+}
+
+fn main() {
+    println!("i128 size {} align {}", size_of::<i128>(), align_of::<i128>());
+    println!("u128 size {} align {}", size_of::<u128>(), align_of::<u128>());
+    println!("Struct1 size {} align {}", size_of::<Struct1>(), align_of::<Struct1>());
+}

--- a/tests/ui/asm/naked-functions-ffi.rs
+++ b/tests/ui/asm/naked-functions-ffi.rs
@@ -8,7 +8,6 @@ use std::arch::asm;
 #[naked]
 pub extern "C" fn naked(p: char) -> u128 {
     //~^ WARN uses type `char`
-    //~| WARN uses type `u128`
     unsafe {
         asm!("", options(noreturn));
     }

--- a/tests/ui/asm/naked-functions-ffi.stderr
+++ b/tests/ui/asm/naked-functions-ffi.stderr
@@ -8,13 +8,5 @@ LL | pub extern "C" fn naked(p: char) -> u128 {
    = note: the `char` type has no C equivalent
    = note: `#[warn(improper_ctypes_definitions)]` on by default
 
-warning: `extern` fn uses type `u128`, which is not FFI-safe
-  --> $DIR/naked-functions-ffi.rs:9:37
-   |
-LL | pub extern "C" fn naked(p: char) -> u128 {
-   |                                     ^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
-warning: 2 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/lint/lint-ctypes-enum.rs
+++ b/tests/ui/lint/lint-ctypes-enum.rs
@@ -72,14 +72,12 @@ extern "C" {
    fn nonzero_u32(x: Option<num::NonZeroU32>);
    fn nonzero_u64(x: Option<num::NonZeroU64>);
    fn nonzero_u128(x: Option<num::NonZeroU128>);
-   //~^ ERROR `extern` block uses type `u128`
    fn nonzero_usize(x: Option<num::NonZeroUsize>);
    fn nonzero_i8(x: Option<num::NonZeroI8>);
    fn nonzero_i16(x: Option<num::NonZeroI16>);
    fn nonzero_i32(x: Option<num::NonZeroI32>);
    fn nonzero_i64(x: Option<num::NonZeroI64>);
    fn nonzero_i128(x: Option<num::NonZeroI128>);
-   //~^ ERROR `extern` block uses type `i128`
    fn nonzero_isize(x: Option<num::NonZeroIsize>);
    fn transparent_struct(x: Option<TransparentStruct<num::NonZeroU8>>);
    fn transparent_enum(x: Option<TransparentEnum<num::NonZeroU8>>);

--- a/tests/ui/lint/lint-ctypes-enum.stderr
+++ b/tests/ui/lint/lint-ctypes-enum.stderr
@@ -45,24 +45,8 @@ note: the type is defined here
 LL | enum T {
    | ^^^^^^
 
-error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:74:23
-   |
-LL |    fn nonzero_u128(x: Option<num::NonZeroU128>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
-error: `extern` block uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:81:23
-   |
-LL |    fn nonzero_i128(x: Option<num::NonZeroI128>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
 error: `extern` block uses type `Option<TransparentUnion<NonZeroU8>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:86:28
+  --> $DIR/lint-ctypes-enum.rs:84:28
    |
 LL |    fn transparent_union(x: Option<TransparentUnion<num::NonZeroU8>>);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -71,7 +55,7 @@ LL |    fn transparent_union(x: Option<TransparentUnion<num::NonZeroU8>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `Option<Rust<NonZeroU8>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:88:20
+  --> $DIR/lint-ctypes-enum.rs:86:20
    |
 LL |    fn repr_rust(x: Option<Rust<num::NonZeroU8>>);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -80,7 +64,7 @@ LL |    fn repr_rust(x: Option<Rust<num::NonZeroU8>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `Result<(), NonZeroI32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:89:20
+  --> $DIR/lint-ctypes-enum.rs:87:20
    |
 LL |    fn no_result(x: Result<(), num::NonZeroI32>);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -88,5 +72,5 @@ LL |    fn no_result(x: Result<(), num::NonZeroI32>);
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/lint/lint-ctypes-fn.rs
+++ b/tests/ui/lint/lint-ctypes-fn.rs
@@ -93,10 +93,8 @@ pub extern "C" fn char_type(p: char) { }
 //~^ ERROR uses type `char`
 
 pub extern "C" fn i128_type(p: i128) { }
-//~^ ERROR uses type `i128`
 
 pub extern "C" fn u128_type(p: u128) { }
-//~^ ERROR uses type `u128`
 
 pub extern "C" fn tuple_type(p: (i32, i32)) { }
 //~^ ERROR uses type `(i32, i32)`
@@ -124,7 +122,6 @@ pub extern "C" fn fn_type2(p: fn()) { }
 pub extern "C" fn fn_contained(p: RustBadRet) { }
 
 pub extern "C" fn transparent_i128(p: TransparentI128) { }
-//~^ ERROR: uses type `i128`
 
 pub extern "C" fn transparent_str(p: TransparentStr) { }
 //~^ ERROR: uses type `str`

--- a/tests/ui/lint/lint-ctypes-fn.stderr
+++ b/tests/ui/lint/lint-ctypes-fn.stderr
@@ -54,24 +54,8 @@ LL | pub extern "C" fn char_type(p: char) { }
    = help: consider using `u32` or `libc::wchar_t` instead
    = note: the `char` type has no C equivalent
 
-error: `extern` fn uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:95:32
-   |
-LL | pub extern "C" fn i128_type(p: i128) { }
-   |                                ^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
-error: `extern` fn uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:98:32
-   |
-LL | pub extern "C" fn u128_type(p: u128) { }
-   |                                ^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:101:33
+  --> $DIR/lint-ctypes-fn.rs:99:33
    |
 LL | pub extern "C" fn tuple_type(p: (i32, i32)) { }
    |                                 ^^^^^^^^^^ not FFI-safe
@@ -80,7 +64,7 @@ LL | pub extern "C" fn tuple_type(p: (i32, i32)) { }
    = note: tuples have unspecified layout
 
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:104:34
+  --> $DIR/lint-ctypes-fn.rs:102:34
    |
 LL | pub extern "C" fn tuple_type2(p: I32Pair) { }
    |                                  ^^^^^^^ not FFI-safe
@@ -89,7 +73,7 @@ LL | pub extern "C" fn tuple_type2(p: I32Pair) { }
    = note: tuples have unspecified layout
 
 error: `extern` fn uses type `ZeroSize`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:107:32
+  --> $DIR/lint-ctypes-fn.rs:105:32
    |
 LL | pub extern "C" fn zero_size(p: ZeroSize) { }
    |                                ^^^^^^^^ not FFI-safe
@@ -103,7 +87,7 @@ LL | pub struct ZeroSize;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `ZeroSizeWithPhantomData`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:110:40
+  --> $DIR/lint-ctypes-fn.rs:108:40
    |
 LL | pub extern "C" fn zero_size_phantom(p: ZeroSizeWithPhantomData) { }
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -116,7 +100,7 @@ LL | pub struct ZeroSizeWithPhantomData(PhantomData<i32>);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:113:51
+  --> $DIR/lint-ctypes-fn.rs:111:51
    |
 LL | pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
    |                                                   ^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -124,7 +108,7 @@ LL | pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
    = note: composed only of `PhantomData`
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:118:30
+  --> $DIR/lint-ctypes-fn.rs:116:30
    |
 LL | pub extern "C" fn fn_type(p: RustFn) { }
    |                              ^^^^^^ not FFI-safe
@@ -133,7 +117,7 @@ LL | pub extern "C" fn fn_type(p: RustFn) { }
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:121:31
+  --> $DIR/lint-ctypes-fn.rs:119:31
    |
 LL | pub extern "C" fn fn_type2(p: fn()) { }
    |                               ^^^^ not FFI-safe
@@ -141,16 +125,8 @@ LL | pub extern "C" fn fn_type2(p: fn()) { }
    = help: consider using an `extern fn(...) -> ...` function pointer instead
    = note: this function pointer has Rust-specific calling convention
 
-error: `extern` fn uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:126:39
-   |
-LL | pub extern "C" fn transparent_i128(p: TransparentI128) { }
-   |                                       ^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
 error: `extern` fn uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:129:38
+  --> $DIR/lint-ctypes-fn.rs:126:38
    |
 LL | pub extern "C" fn transparent_str(p: TransparentStr) { }
    |                                      ^^^^^^^^^^^^^^ not FFI-safe
@@ -159,7 +135,7 @@ LL | pub extern "C" fn transparent_str(p: TransparentStr) { }
    = note: string slices have no C equivalent
 
 error: `extern` fn uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:175:43
+  --> $DIR/lint-ctypes-fn.rs:172:43
    |
 LL | pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
    |                                           ^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -167,7 +143,7 @@ LL | pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
    = note: composed only of `PhantomData`
 
 error: `extern` fn uses type `Vec<T>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:188:39
+  --> $DIR/lint-ctypes-fn.rs:185:39
    |
 LL | pub extern "C" fn used_generic4<T>(x: Vec<T>) { }
    |                                       ^^^^^^ not FFI-safe
@@ -176,7 +152,7 @@ LL | pub extern "C" fn used_generic4<T>(x: Vec<T>) { }
    = note: this struct has unspecified layout
 
 error: `extern` fn uses type `Vec<T>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:191:41
+  --> $DIR/lint-ctypes-fn.rs:188:41
    |
 LL | pub extern "C" fn used_generic5<T>() -> Vec<T> {
    |                                         ^^^^^^ not FFI-safe
@@ -184,5 +160,5 @@ LL | pub extern "C" fn used_generic5<T>() -> Vec<T> {
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
 
-error: aborting due to 20 previous errors
+error: aborting due to 17 previous errors
 

--- a/tests/ui/lint/lint-ctypes.rs
+++ b/tests/ui/lint/lint-ctypes.rs
@@ -55,8 +55,8 @@ extern "C" {
     pub fn opt_box_type(p: Option<Box<u32>>);
     //~^ ERROR uses type `Option<Box<u32>>`
     pub fn char_type(p: char); //~ ERROR uses type `char`
-    pub fn i128_type(p: i128); //~ ERROR uses type `i128`
-    pub fn u128_type(p: u128); //~ ERROR uses type `u128`
+    pub fn i128_type(p: i128);
+    pub fn u128_type(p: u128);
     pub fn trait_type(p: &dyn Bar); //~ ERROR uses type `dyn Bar`
     pub fn tuple_type(p: (i32, i32)); //~ ERROR uses type `(i32, i32)`
     pub fn tuple_type2(p: I32Pair); //~ ERROR uses type `(i32, i32)`
@@ -68,7 +68,7 @@ extern "C" {
     pub fn fn_type(p: RustFn); //~ ERROR uses type `fn()`
     pub fn fn_type2(p: fn()); //~ ERROR uses type `fn()`
     pub fn fn_contained(p: RustBadRet); //~ ERROR: uses type `Box<u32>`
-    pub fn transparent_i128(p: TransparentI128); //~ ERROR: uses type `i128`
+    pub fn transparent_i128(p: TransparentI128);
     pub fn transparent_str(p: TransparentStr); //~ ERROR: uses type `str`
     pub fn transparent_fn(p: TransparentBadFn); //~ ERROR: uses type `Box<u32>`
     pub fn raw_array(arr: [u8; 8]); //~ ERROR: uses type `[u8; 8]`
@@ -78,8 +78,8 @@ extern "C" {
     pub fn no_niche_b(b: Option<UnsafeCell<&i32>>);
     //~^ ERROR: uses type `Option<UnsafeCell<&i32>>`
 
-    pub static static_u128_type: u128; //~ ERROR: uses type `u128`
-    pub static static_u128_array_type: [u128; 16]; //~ ERROR: uses type `u128`
+    pub static static_u128_type: u128;
+    pub static static_u128_array_type: [u128; 16];
 
     pub fn good3(fptr: Option<extern "C" fn()>);
     pub fn good4(aptr: &[u8; 4 as usize]);

--- a/tests/ui/lint/lint-ctypes.stderr
+++ b/tests/ui/lint/lint-ctypes.stderr
@@ -85,22 +85,6 @@ LL |     pub fn char_type(p: char);
    = help: consider using `u32` or `libc::wchar_t` instead
    = note: the `char` type has no C equivalent
 
-error: `extern` block uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:58:25
-   |
-LL |     pub fn i128_type(p: i128);
-   |                         ^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
-error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:59:25
-   |
-LL |     pub fn u128_type(p: u128);
-   |                         ^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
 error: `extern` block uses type `dyn Bar`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:60:26
    |
@@ -189,14 +173,6 @@ LL |     pub fn fn_contained(p: RustBadRet);
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
 
-error: `extern` block uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:71:32
-   |
-LL |     pub fn transparent_i128(p: TransparentI128);
-   |                                ^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
 error: `extern` block uses type `str`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:72:31
    |
@@ -242,21 +218,5 @@ LL |     pub fn no_niche_b(b: Option<UnsafeCell<&i32>>);
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 
-error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:81:34
-   |
-LL |     pub static static_u128_type: u128;
-   |                                  ^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
-error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:82:40
-   |
-LL |     pub static static_u128_array_type: [u128; 16];
-   |                                        ^^^^^^^^^^ not FFI-safe
-   |
-   = note: 128-bit integers don't currently have a known stable ABI
-
-error: aborting due to 27 previous errors
+error: aborting due to 22 previous errors
 

--- a/tests/ui/mismatched_types/issue-36053-2.stderr
+++ b/tests/ui/mismatched_types/issue-36053-2.stderr
@@ -27,6 +27,7 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
    |
    = note: doesn't satisfy `_: Iterator`
    |
+   = note: the full type name has been written to '$TEST_BUILD_DIR/mismatched_types/issue-36053-2/issue-36053-2.long-type-11859862082226218339.txt'
    = note: the following trait bounds were not satisfied:
            `<[closure@$DIR/issue-36053-2.rs:7:39: 7:48] as FnOnce<(&&str,)>>::Output = bool`
            which is required by `Filter<Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:48]>: Iterator`

--- a/tests/ui/typeck/issue-31173.stderr
+++ b/tests/ui/typeck/issue-31173.stderr
@@ -42,6 +42,7 @@ LL | |         .collect();
    |
    = note: doesn't satisfy `_: Iterator`
    |
+   = note: the full type name has been written to '$TEST_BUILD_DIR/typeck/issue-31173/issue-31173.long-type-17465614690078554049.txt'
    = note: the following trait bounds were not satisfied:
            `<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:7:21: 7:25]> as Iterator>::Item = &_`
            which is required by `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:7:21: 7:25]>>: Iterator`


### PR DESCRIPTION
This uses the current patch for https://reviews.llvm.org/D86310, experimenting how to make it work with rustc.

Zulip discussion: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/.2354341.20-.20alignment.20of.20i128.20for.20FFI

Note also that I only updated one layout string so far