### PR TITLE
new solver: add a separate cache for coherence

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -569,6 +569,7 @@ pub struct GlobalCtxt<'tcx> {
 
     /// Caches the results of goal evaluation in the new solver.
     pub new_solver_evaluation_cache: solve::EvaluationCache<'tcx>,
+    pub new_solver_coherence_evaluation_cache: solve::EvaluationCache<'tcx>,
 
     /// Data layout specification for the current target.
     pub data_layout: TargetDataLayout,
@@ -680,10 +681,12 @@ impl<'tcx> TyCtxt<'tcx> {
         value.lift_to_tcx(self)
     }
 
-    /// Creates a type context and call the closure with a `TyCtxt` reference
-    /// to the context. The closure enforces that the type context and any interned
-    /// value (types, args, etc.) can only be used while `ty::tls` has a valid
-    /// reference to the context, to allow formatting values that need it.
+    /// Creates a type context. To use the context call `fn enter` which
+    /// provides a `TyCtxt`.
+    ///
+    /// By only providing the `TyCtxt` inside of the closure we enforce that the type
+    /// context and any interned alue (types, args, etc.) can only be used while `ty::tls`
+    /// has a valid reference to the context, to allow formatting values that need it.
     pub fn create_global_ctxt(
         s: &'tcx Session,
         lint_store: Lrc<dyn Any + sync::DynSend + sync::DynSync>,
@@ -721,6 +724,7 @@ impl<'tcx> TyCtxt<'tcx> {
             selection_cache: Default::default(),
             evaluation_cache: Default::default(),
             new_solver_evaluation_cache: Default::default(),
+            new_solver_coherence_evaluation_cache: Default::default(),
             data_layout,
             alloc_map: Lock::new(interpret::AllocMap::new()),
         }


### PR DESCRIPTION
based on #113835

`typenum` now compiles with `-Ztrait-solver=next-coherence`. Because we disable caching once we encounter the recursion limit it is still really slow, but at least it passes and I will deal with overflow handling afterwards.

`typenum` previously hanged. The top 10 goals were
```rust
1749948 counts
(  1)   601056 (34.3%, 34.3%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: ProjectionPredicate(AliasTy { args: [^1_0], def_id: DefId(0:1196 ~ typenum[0ab6]::type_operators::Len::Output) }, Term::Ty(^1_1)), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
(  2)   240422 (13.7%, 48.1%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: ProjectionPredicate(AliasTy { args: [<^1_0 as type_operators::Len>::Output, bit::B1], def_id: DefId(1:2752 ~ core[a405]::ops::arith::Add::Output) }, Term::Ty(^1_1)), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
(  3)   198367 (11.3%, 59.4%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: TraitPredicate(<^1_0 as core::marker::Sized>, polarity:Positive), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
(  4)    96168 ( 5.5%, 64.9%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: ProjectionPredicate(AliasTy { args: [<^1_0 as type_operators::Len>::Output, bit::B1], def_id: DefId(1:2752 ~ core[a405]::ops::arith::Add::Output) }, Term::Ty(<<^1_0 as type_operators::Len>::Output as core::ops::Add<bit::B1>>::Output)), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
(  5)    78155 ( 4.5%, 69.4%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: TraitPredicate(<^1_0 as marker_traits::Unsigned>, polarity:Positive), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
(  6)    72140 ( 4.1%, 73.5%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: TraitPredicate(<^1_0 as marker_traits::Bit>, polarity:Positive), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
(  7)    60107 ( 3.4%, 76.9%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: TraitPredicate(<^1_0 as type_operators::Len>, polarity:Positive), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
(  8)    60106 ( 3.4%, 80.4%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: ProjectionPredicate(AliasTy { args: [uint::UInt<^1_0, ^1_1>], def_id: DefId(0:1196 ~ typenum[0ab6]::type_operators::Len::Output) }, Term::Ty(^1_2)), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }, CanonicalVarInfo { kind: Ty(General(U0)) }] }
(  9)    60106 ( 3.4%, 83.8%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: TraitPredicate(<<<^1_0 as type_operators::Len>::Output as core::ops::Add<bit::B1>>::Output as marker_traits::Unsigned>, polarity:Positive), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
( 10)    60106 ( 3.4%, 87.2%): Canonical { value: QueryInput { goal: Goal { predicate: Binder { value: TraitPredicate(<<^1_0 as type_operators::Len>::Output as core::ops::Add<bit::B1>>, polarity:Positive), bound_vars: [] }, param_env: ParamEnv { caller_bounds: [], reveal: UserFacing, constness: NotConst } }, anchor: Bubble, predefined_opaques_in_body: PredefinedOpaques(PredefinedOpaquesData { opaque_types: [] }) }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
```

r? @compiler-errors 