### PR TITLE
Add RUSTC_PROGRESS env var to show the current queries and their arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b297dc40733f23a0e52728a58fa9489a5b7638a324932de16b41adc3ef80730"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
 dependencies = [
  "console",
  "instant",
@@ -4467,6 +4467,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags 2.4.1",
  "getopts",
+ "indicatif",
  "libc",
  "rustc_ast",
  "rustc_data_structures",

--- a/compiler/rustc_session/Cargo.toml
+++ b/compiler/rustc_session/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # tidy-alphabetical-start
 bitflags = "2.4.1"
 getopts = "0.2"
+indicatif = "0.17.7"
 rustc_ast = { path = "../rustc_ast" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -26,6 +26,8 @@ pub mod config;
 pub mod cstore;
 pub mod filesearch;
 mod options;
+mod progress;
+pub use progress::*;
 pub mod search_paths;
 
 mod session;

--- a/compiler/rustc_session/src/progress.rs
+++ b/compiler/rustc_session/src/progress.rs
@@ -1,0 +1,88 @@
+use std::{
+    cell::RefCell,
+    sync::mpsc::{Sender, TryRecvError},
+    thread::ThreadId,
+    time::Duration,
+};
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use rustc_data_structures::{fx::FxHashMap, sync::IntoDynSyncSend};
+
+use crate::Session;
+
+thread_local! {
+    static CURRENT_SPINNER: RefCell<Option<(ProgressBar, usize)>> = RefCell::new(None);
+}
+
+pub struct ProgressBars {
+    sender: IntoDynSyncSend<Sender<Msg>>,
+}
+
+enum Msg {
+    Pop { thread: ThreadId },
+    Push { thread: ThreadId, name: &'static str },
+}
+
+impl Session {
+    /// Starts up a thread that makes sure all the threads' messages are collected and processed
+    /// in one central location, and thus rendered correctly.
+    pub(crate) fn init_progress_bars() -> ProgressBars {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let bars = MultiProgress::new();
+            let mut threads: FxHashMap<ThreadId, Vec<_>> = FxHashMap::default();
+            'outer: loop {
+                std::thread::sleep(Duration::from_millis(100));
+                loop {
+                    match receiver.try_recv() {
+                        Ok(val) => match val {
+                            Msg::Pop { thread } => {
+                                threads.get_mut(&thread).unwrap().pop();
+                            }
+                            Msg::Push { thread, name } => {
+                                let stack = threads.entry(thread).or_default();
+
+                                let mut template = String::new();
+                                use std::fmt::Write;
+                                if !stack.is_empty() {
+                                    for _ in 1..stack.len() {
+                                        write!(template, " ").unwrap();
+                                    }
+                                    write!(template, "└").unwrap();
+                                }
+                                write!(template, "{{spinner}} {{msg}}").unwrap();
+
+                                let spinner = ProgressBar::new_spinner()
+                                    .with_message(name)
+                                    .with_style(ProgressStyle::with_template(&template).unwrap());
+                                let spinner = bars.add(spinner);
+                                stack.push(spinner)
+                            }
+                        },
+                        Err(TryRecvError::Disconnected) => break 'outer,
+                        Err(TryRecvError::Empty) => break,
+                    }
+                }
+                for thread in threads.values() {
+                    for spinner in thread {
+                        spinner.tick()
+                    }
+                }
+            }
+        });
+        ProgressBars { sender: IntoDynSyncSend(sender) }
+    }
+
+    /// Append a new spinner to the current stack
+    pub fn push_spinner(&self, bars: &ProgressBars, name: &'static str) -> impl Sized {
+        let thread = std::thread::current().id();
+        bars.sender.send(Msg::Push { thread, name }).unwrap();
+        struct Spinner(Sender<Msg>, ThreadId);
+        impl Drop for Spinner {
+            fn drop(&mut self) {
+                self.0.send(Msg::Pop { thread: self.1 }).unwrap();
+            }
+        }
+        Spinner(bars.sender.0.clone(), thread)
+    }
+}

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -204,6 +204,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "cc",
     "cfg-if",
     "compiler_builtins",
+    "console",      // Dependency of indicatif
     "convert_case", // dependency of derive_more
     "cpufeatures",
     "crc32fast",
@@ -226,6 +227,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "either",
     "elsa",
     "ena",
+    "encode_unicode", // Dependency of indicatif
     "equivalent",
     "errno",
     "expect-test",
@@ -255,6 +257,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "icu_provider_macros",
     "ident_case",
     "indexmap",
+    "indicatif",
     "intl-memoizer",
     "intl_pluralrules",
     "is-terminal",
@@ -278,6 +281,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "miniz_oxide",
     "nu-ansi-term",
     "num_cpus",
+    "number_prefix", // Dependency of indicatif
     "object",
     "odht",
     "once_cell",
@@ -288,7 +292,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "perf-event-open-sys",
     "pin-project-lite",
     "polonius-engine",
-    "portable-atomic", // dependency for platforms doesn't support `AtomicU64` in std
+    "portable-atomic", // dependency for platforms doesn't support `AtomicU64` in std, and indicatif
     "ppv-lite86",
     "proc-macro-hack",
     "proc-macro2",


### PR DESCRIPTION
This should make debugging hangs much simpler, as you know in which query it's happening.

If compilation progresses, but slowly, this can also be used to actually follow that progress. Most of the time it's too fast and the displayed progress spinners disappear and get replaced by new ones.

The spinners look like the ones from the first example in https://crates.io/crates/indicatif

r? @bjorn3 

cc @cjgillot 