### PR TITLE
Add more syscall doc aliases to std docs

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1922,7 +1922,7 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///     Ok(())
 /// }
 /// ```
-#[doc(alias = "stat")]
+#[doc(alias = "stat", alias = "GetFileAttributes", alias = "GetFileAttributesEx")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     fs_imp::stat(path.as_ref()).map(Metadata)
@@ -1957,7 +1957,7 @@ pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 ///     Ok(())
 /// }
 /// ```
-#[doc(alias = "lstat")]
+#[doc(alias = "lstat", alias = "GetFileAttributes", alias = "GetFileAttributesEx")]
 #[stable(feature = "symlink_metadata", since = "1.1.0")]
 pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     fs_imp::lstat(path.as_ref()).map(Metadata)
@@ -2061,6 +2061,7 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> 
 /// }
 /// ```
 #[doc(alias = "cp")]
+#[doc(alias = "copy_file_range")]
 #[doc(alias = "CopyFile", alias = "CopyFileEx")]
 #[doc(alias = "fclonefileat", alias = "fcopyfile")]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -2107,7 +2108,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
 ///     Ok(())
 /// }
 /// ```
-#[doc(alias = "CreateHardLink", alias = "linkat")]
+#[doc(alias = "ln", alias = "CreateHardLink", alias = "linkat")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
     fs_imp::link(original.as_ref(), link.as_ref())
@@ -2303,6 +2304,7 @@ pub fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///     Ok(())
 /// }
 /// ```
+#[doc(alias = "mkdir", alias = "CreateDirectory")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     DirBuilder::new().recursive(true).create(path.as_ref())
@@ -2386,6 +2388,7 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///     Ok(())
 /// }
 /// ```
+#[doc(alias = "rm")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     fs_imp::remove_dir_all(path.as_ref())

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2108,7 +2108,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
 ///     Ok(())
 /// }
 /// ```
-#[doc(alias = "ln", alias = "CreateHardLink", alias = "linkat")]
+#[doc(alias = "CreateHardLink", alias = "linkat")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
     fs_imp::link(original.as_ref(), link.as_ref())

--- a/library/std/src/io/copy.rs
+++ b/library/std/src/io/copy.rs
@@ -57,6 +57,7 @@ mod tests;
 /// Note that platform-specific behavior [may change in the future][changes].
 ///
 /// [changes]: crate::io#platform-specific-behavior
+#[doc(alias = "copy_file_range", alias = "sendfile", alias = "splice")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> Result<u64>
 where

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -577,6 +577,7 @@ impl FileTimesExt for fs::FileTimes {
 /// the process as an administrator.
 ///
 /// [symlink-security]: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links
+#[doc(alias = "CreateSymbolicLink", alias = "CreateSymbolicLinkW")]
 #[stable(feature = "symlink", since = "1.1.0")]
 pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
     sys::fs::symlink_inner(original.as_ref(), link.as_ref(), false)
@@ -616,6 +617,7 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io:
 /// the process as an administrator.
 ///
 /// [symlink-security]: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links
+#[doc(alias = "CreateSymbolicLink", alias = "CreateSymbolicLinkW")]
 #[stable(feature = "symlink", since = "1.1.0")]
 pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
     sys::fs::symlink_inner(original.as_ref(), link.as_ref(), true)

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -151,12 +151,6 @@ pub use core::time::TryFromFloatSecsError;
 /// [`checked_duration_since`]: Instant::checked_duration_since
 ///
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc(alias = "insecure_time")]
-#[doc(alias = "clock_gettime")]
-#[doc(alias = "mach_absolute_time")]
-#[doc(alias = "get_tim")]
-#[doc(alias = "__wasi_clock_time_get")]
-#[doc(alias = "QueryPerformanceCounter")]
 #[stable(feature = "time2", since = "1.8.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Instant")]
 pub struct Instant(time::Instant);
@@ -250,12 +244,6 @@ pub struct Instant(time::Instant);
 ///
 /// [`add`]: SystemTime::add
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc(alias = "insecure_time")]
-#[doc(alias = "clock_gettime")]
-#[doc(alias = "gettimeofday")]
-#[doc(alias = "SOLID_RTC_ReadTime")]
-#[doc(alias = "__wasi_clock_time_get")]
-#[doc(alias = "GetSystemTimePreciseAsFileTime")]
 #[stable(feature = "time2", since = "1.8.0")]
 pub struct SystemTime(time::SystemTime);
 

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -151,6 +151,12 @@ pub use core::time::TryFromFloatSecsError;
 /// [`checked_duration_since`]: Instant::checked_duration_since
 ///
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc(alias = "insecure_time")]
+#[doc(alias = "clock_gettime")]
+#[doc(alias = "mach_absolute_time")]
+#[doc(alias = "get_tim")]
+#[doc(alias = "__wasi_clock_time_get")]
+#[doc(alias = "QueryPerformanceCounter")]
 #[stable(feature = "time2", since = "1.8.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Instant")]
 pub struct Instant(time::Instant);
@@ -244,6 +250,12 @@ pub struct Instant(time::Instant);
 ///
 /// [`add`]: SystemTime::add
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc(alias = "insecure_time")]
+#[doc(alias = "clock_gettime")]
+#[doc(alias = "gettimeofday")]
+#[doc(alias = "SOLID_RTC_ReadTime")]
+#[doc(alias = "__wasi_clock_time_get")]
+#[doc(alias = "GetSystemTimePreciseAsFileTime")]
 #[stable(feature = "time2", since = "1.8.0")]
 pub struct SystemTime(time::SystemTime);
 


### PR DESCRIPTION
Some of these are quite trivial but we should optimize for the user not having to think about it.

Blocked on https://github.com/rust-lang/std-dev-guide/pull/64