### PR TITLE
rustc_target: drop duplicate code

### DIFF
--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -140,24 +140,3 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         offset
     }
 }
-
-impl<'a, Ty> TyAndLayout<'a, Ty> {
-    /// Returns `true` if the layout corresponds to an unsized type.
-    pub fn is_unsized(&self) -> bool {
-        self.abi.is_unsized()
-    }
-
-    #[inline]
-    pub fn is_sized(&self) -> bool {
-        self.abi.is_sized()
-    }
-
-    /// Returns `true` if the type is a ZST and not unsized.
-    pub fn is_zst(&self) -> bool {
-        match self.abi {
-            Abi::Scalar(_) | Abi::ScalarPair(..) | Abi::Vector { .. } => false,
-            Abi::Uninhabited => self.size.bytes() == 0,
-            Abi::Aggregate { sized } => sized && self.size.bytes() == 0,
-        }
-    }
-}


### PR DESCRIPTION
Drop duplicate helper methods on `Layout`, which are already implemented on `LayoutS`. Note that `Layout` has a `Deref` implementation to `LayoutS`, so all accessors are automatically redirected.

The methods are identical and have been copied to `rustc_abi` in:

    commit 390a637e296ccfaac4c6abd1291b0523e8a8e00b
    Author: hamidreza kalbasi <hamidrezakalbasi@protonmail.com>
    Date:   Mon Nov 7 00:36:11 2022 +0330

        move things from rustc_target::abi to rustc_abi

This commit left behind the original implementation. Drop it now.

(originally moved by @HKalbasi)