### PR TITLE
blame the furthest statement in borrowck errors

### DIFF
--- a/tests/ui/associated-types/associated-types-project-from-hrtb-in-fn-body.stderr
+++ b/tests/ui/associated-types/associated-types-project-from-hrtb-in-fn-body.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/associated-types-project-from-hrtb-in-fn-body.rs:22:29
+  --> $DIR/associated-types-project-from-hrtb-in-fn-body.rs:22:40
    |
 LL | fn bar<'a, 'b, I : for<'x> Foo<&'x isize>>(
    |        --  -- lifetime `'b` defined here
@@ -7,7 +7,7 @@ LL | fn bar<'a, 'b, I : for<'x> Foo<&'x isize>>(
    |        lifetime `'a` defined here
 ...
 LL |     let z: I::A = if cond { x } else { y };
-   |                             ^ assignment requires that `'a` must outlive `'b`
+   |                                        ^ assignment requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/tests/ui/associated-types/cache/project-fn-ret-invariant.oneuse.stderr
+++ b/tests/ui/associated-types/cache/project-fn-ret-invariant.oneuse.stderr
@@ -1,12 +1,12 @@
 error: lifetime may not live long enough
-  --> $DIR/project-fn-ret-invariant.rs:40:13
+  --> $DIR/project-fn-ret-invariant.rs:41:13
    |
 LL | fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    |        --  -- lifetime `'b` defined here
    |        |
    |        lifetime `'a` defined here
-LL |     let f = foo; // <-- No consistent type can be inferred for `f` here.
-LL |     let a = bar(f, x);
+...
+LL |     let b = bar(f, y);
    |             ^^^^^^^^^ argument requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
@@ -15,7 +15,7 @@ LL |     let a = bar(f, x);
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/project-fn-ret-invariant.rs:42:13
+  --> $DIR/project-fn-ret-invariant.rs:41:13
    |
 LL | fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    |        --  -- lifetime `'b` defined here
@@ -26,8 +26,8 @@ LL |     let b = bar(f, y);
    |             ^^^^^^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of the type `Type<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `Type<'a>` is invariant over the parameter `'a`
+   = note: requirement occurs because of a function pointer to `foo`
+   = note: the function `foo` is invariant over the parameter `'a`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 help: `'a` and `'b` must be the same: replace one with the other

--- a/tests/ui/associated-types/cache/project-fn-ret-invariant.rs
+++ b/tests/ui/associated-types/cache/project-fn-ret-invariant.rs
@@ -38,9 +38,9 @@ fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
 fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
     let f = foo; // <-- No consistent type can be inferred for `f` here.
     let a = bar(f, x);
-    //[oneuse]~^ ERROR lifetime may not live long enough
     let b = bar(f, y);
     //[oneuse]~^ ERROR lifetime may not live long enough
+    //[oneuse]~| ERROR lifetime may not live long enough
     (a, b)
 }
 

--- a/tests/ui/borrowck/issue-102209.stderr
+++ b/tests/ui/borrowck/issue-102209.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/issue-102209.rs:10:29
+  --> $DIR/issue-102209.rs:10:15
    |
 LL | impl NfaBuilder<'_> {
    |                 -- lifetime `'2` appears in the `impl`'s self type
@@ -7,16 +7,20 @@ LL |     pub fn with<R, F: FnOnce(NfaBuilder<'_>) -> R>(f: F) -> R {
 LL |         Brand::with(|brand| {
    |                      ----- has type `Brand<'1>`
 LL |             f(Self { brand: brand.lt })
-   |                             ^^^^^^^^ this usage requires that `'1` must outlive `'2`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'1` must outlive `'2`
+   |
+   = note: requirement occurs because of the type `NfaBuilder<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `NfaBuilder<'brand>` is invariant over the parameter `'brand`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/issue-102209.rs:10:29
+  --> $DIR/issue-102209.rs:10:15
    |
 LL | impl NfaBuilder<'_> {
    |                 -- lifetime `'1` appears in the `impl`'s self type
 ...
 LL |             f(Self { brand: brand.lt })
-   |                             ^^^^^^^^ this usage requires that `'1` must outlive `'static`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'1` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/two-phase-surprise-no-conflict.stderr
+++ b/tests/ui/borrowck/two-phase-surprise-no-conflict.stderr
@@ -72,11 +72,11 @@ LL | fn register_plugins<'a>(mk_reg: impl Fn() -> &'a mut Registry<'a>) {
    |                     -- lifetime `'a` defined here
 ...
 LL |     reg.register_univ(Box::new(CapturePass::new(&reg.sess_mut)));
-   |     ^^^^^^^^^^^^^^^^^^-----------------------------------------^
-   |     |                 |                         |
-   |     |                 |                         immutable borrow occurs here
-   |     |                 cast requires that `reg.sess_mut` is borrowed for `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------^^^
+   |     |                                           |
+   |     |                                           immutable borrow occurs here
    |     mutable borrow occurs here
+   |     argument requires that `reg.sess_mut` is borrowed for `'a`
 
 error[E0502]: cannot borrow `*reg` as mutable because it is also borrowed as immutable
   --> $DIR/two-phase-surprise-no-conflict.rs:144:5
@@ -114,11 +114,11 @@ LL | fn register_plugins<'a>(mk_reg: impl Fn() -> &'a mut Registry<'a>) {
    |                     -- lifetime `'a` defined here
 ...
 LL |     reg.register_univ(Box::new(CapturePass::new_mut(&mut reg.sess_mut)));
-   |     ^^^^^^^^^^^^^^^^^^-------------------------------------------------^
-   |     |                 |                             |
-   |     |                 |                             first mutable borrow occurs here
-   |     |                 cast requires that `reg.sess_mut` is borrowed for `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------^^^
+   |     |                                               |
+   |     |                                               first mutable borrow occurs here
    |     second mutable borrow occurs here
+   |     argument requires that `reg.sess_mut` is borrowed for `'a`
 
 error[E0499]: cannot borrow `reg.sess_mut` as mutable more than once at a time
   --> $DIR/two-phase-surprise-no-conflict.rs:158:53

--- a/tests/ui/c-variadic/variadic-ffi-4.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-4.stderr
@@ -120,28 +120,28 @@ LL | }
    | - `ap1` dropped here while still borrowed
 
 error: lifetime may not live long enough
-  --> $DIR/variadic-ffi-4.rs:35:12
+  --> $DIR/variadic-ffi-4.rs:35:5
    |
 LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
    |                                               -------                   ------- has type `VaListImpl<'2>`
    |                                               |
    |                                               has type `&mut VaListImpl<'1>`
 LL |     *ap0 = ap1.clone();
-   |            ^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^^ assignment requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of the type `VaListImpl<'_>`, which makes the generic argument `'_` invariant
    = note: the struct `VaListImpl<'f>` is invariant over the parameter `'f`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variadic-ffi-4.rs:35:12
+  --> $DIR/variadic-ffi-4.rs:35:5
    |
 LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
    |                                               -------                   ------- has type `VaListImpl<'2>`
    |                                               |
    |                                               has type `&mut VaListImpl<'1>`
 LL |     *ap0 = ap1.clone();
-   |            ^^^^^^^^^^^ argument requires that `'2` must outlive `'1`
+   |     ^^^^ assignment requires that `'2` must outlive `'1`
    |
    = note: requirement occurs because of the type `VaListImpl<'_>`, which makes the generic argument `'_` invariant
    = note: the struct `VaListImpl<'f>` is invariant over the parameter `'f`

--- a/tests/ui/dropck/dropck_trait_cycle_checked.stderr
+++ b/tests/ui/dropck/dropck_trait_cycle_checked.stderr
@@ -2,10 +2,13 @@ error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:111:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |              -- binding `o2` declared here                          -------- cast requires that `o2` is borrowed for `'static`
+   |              -- binding `o2` declared here
 LL |     o1.set0(&o2);
    |             ^^^ borrowed value does not live long enough
 ...
+LL |     o3.set0(&o1);
+   |     ------------ argument requires that `o2` is borrowed for `'static`
+LL |     o3.set1(&o2);
 LL | }
    | - `o2` dropped here while still borrowed
 
@@ -13,11 +16,14 @@ error[E0597]: `o3` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:112:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |                  -- binding `o3` declared here                      -------- cast requires that `o3` is borrowed for `'static`
+   |                  -- binding `o3` declared here
 LL |     o1.set0(&o2);
 LL |     o1.set1(&o3);
    |             ^^^ borrowed value does not live long enough
 ...
+LL |     o3.set0(&o1);
+   |     ------------ argument requires that `o3` is borrowed for `'static`
+LL |     o3.set1(&o2);
 LL | }
    | - `o3` dropped here while still borrowed
 
@@ -25,10 +31,13 @@ error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:113:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |              -- binding `o2` declared here                                    -------- cast requires that `o2` is borrowed for `'static`
+   |              -- binding `o2` declared here
 ...
 LL |     o2.set0(&o2);
-   |             ^^^ borrowed value does not live long enough
+   |     --------^^^-
+   |     |       |
+   |     |       borrowed value does not live long enough
+   |     argument requires that `o2` is borrowed for `'static`
 ...
 LL | }
    | - `o2` dropped here while still borrowed
@@ -37,10 +46,13 @@ error[E0597]: `o3` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:114:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |                  -- binding `o3` declared here                                -------- cast requires that `o3` is borrowed for `'static`
+   |                  -- binding `o3` declared here
 ...
 LL |     o2.set1(&o3);
-   |             ^^^ borrowed value does not live long enough
+   |     --------^^^-
+   |     |       |
+   |     |       borrowed value does not live long enough
+   |     argument requires that `o3` is borrowed for `'static`
 ...
 LL | }
    | - `o3` dropped here while still borrowed
@@ -49,10 +61,13 @@ error[E0597]: `o1` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:115:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |          -- binding `o1` declared here                                                  -------- cast requires that `o1` is borrowed for `'static`
+   |          -- binding `o1` declared here
 ...
 LL |     o3.set0(&o1);
-   |             ^^^ borrowed value does not live long enough
+   |     --------^^^-
+   |     |       |
+   |     |       borrowed value does not live long enough
+   |     argument requires that `o1` is borrowed for `'static`
 LL |     o3.set1(&o2);
 LL | }
    | - `o1` dropped here while still borrowed
@@ -61,10 +76,13 @@ error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:116:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |              -- binding `o2` declared here                                              -------- cast requires that `o2` is borrowed for `'static`
+   |              -- binding `o2` declared here
 ...
 LL |     o3.set1(&o2);
-   |             ^^^ borrowed value does not live long enough
+   |     --------^^^-
+   |     |       |
+   |     |       borrowed value does not live long enough
+   |     argument requires that `o2` is borrowed for `'static`
 LL | }
    | - `o2` dropped here while still borrowed
 

--- a/tests/ui/lifetimes/issue-69314.stderr
+++ b/tests/ui/lifetimes/issue-69314.stderr
@@ -17,8 +17,8 @@ LL |         let mut buf = [0; 512];
 LL |         let m2 = &buf[..];
    |                   ^^^ borrowed value does not live long enough
 LL |         let m = Self::g(m2).await;
-   |                 ----------- argument requires that `buf` is borrowed for `'static`
 LL |         Self::f2(m).await;
+   |         ----------- argument requires that `buf` is borrowed for `'static`
 LL |     }
    |     - `buf` dropped here while still borrowed
 

--- a/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.rs
+++ b/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.rs
@@ -7,9 +7,9 @@ fn inner(mut foo: &[u8]) {
     let refcell = RefCell::new(&mut foo);
     //~^ ERROR `foo` does not live long enough
     let read = &refcell as &RefCell<dyn Read>;
-    //~^ ERROR lifetime may not live long enough
 
     read_thing(read);
+    //~^ ERROR borrowed data escapes outside of function [E0521]
 }
 
 fn read_thing(refcell: &RefCell<dyn Read>) {}

--- a/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.stderr
+++ b/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.stderr
@@ -5,22 +5,32 @@ LL | fn inner(mut foo: &[u8]) {
    |          ------- binding `foo` declared here
 LL |     let refcell = RefCell::new(&mut foo);
    |                                ^^^^^^^^ borrowed value does not live long enough
-LL |
-LL |     let read = &refcell as &RefCell<dyn Read>;
-   |                -------- cast requires that `foo` is borrowed for `'static`
 ...
+LL |     read_thing(read);
+   |     ---------------- argument requires that `foo` is borrowed for `'static`
+LL |
 LL | }
    |  - `foo` dropped here while still borrowed
 
-error: lifetime may not live long enough
-  --> $DIR/issue-90600-expected-return-static-indirect.rs:9:16
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/issue-90600-expected-return-static-indirect.rs:11:5
    |
 LL | fn inner(mut foo: &[u8]) {
-   |                   - let's call the lifetime of this reference `'1`
+   |          -------  - let's call the lifetime of this reference `'1`
+   |          |
+   |          `foo` is a reference that is only valid in the function body
 ...
-LL |     let read = &refcell as &RefCell<dyn Read>;
-   |                ^^^^^^^^ cast requires that `'1` must outlive `'static`
+LL |     read_thing(read);
+   |     ^^^^^^^^^^^^^^^^
+   |     |
+   |     `foo` escapes the function body here
+   |     argument requires that `'1` must outlive `'static`
+   |
+   = note: requirement occurs because of the type `RefCell<(dyn std::io::Read + 'static)>`, which makes the generic argument `(dyn std::io::Read + 'static)` invariant
+   = note: the struct `RefCell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+Some errors have detailed explanations: E0521, E0597.
+For more information about an error, try `rustc --explain E0521`.

--- a/tests/ui/nll/blame-furthest-statement.rs
+++ b/tests/ui/nll/blame-furthest-statement.rs
@@ -1,0 +1,48 @@
+// Make sure we blame the furthest statment in lifetime errors.
+
+fn id<X>(x: X) -> X { x }
+fn relate<X>(_: &X, _: &X) {}
+struct Inv<'a>(*mut &'a u8);
+
+fn test_static(a: Inv<'_>, b: Inv<'static>) {
+    let a = id(a);
+    let b = id(b);
+    relate(&a, &b);
+    //~^ ERROR
+}
+
+fn test1(a: Inv<'_>, b: Inv<'_>) {
+    let a = id(a);
+    let b = id(b);
+    relate(&a, &b);
+    //~^ ERROR
+    //~| ERROR
+}
+
+fn test2(cond: bool, a: Inv<'_>, b: Inv<'_>) {
+    let mut x = None::<Inv<'_>>;
+    let mut y = None::<Inv<'_>>;
+    if cond {
+        relate(&x, &y);
+    } else {
+        x.replace(a);
+        y.replace(b);
+        //~^ ERROR
+        //~| ERROR
+    }
+}
+
+fn test3(cond: bool, a: Inv<'_>, b: Inv<'_>) {
+    let mut x = None::<Inv<'_>>;
+    let mut y = None::<Inv<'_>>;
+    if cond {
+        x.replace(a);
+        y.replace(b);
+    } else {
+        relate(&x, &y);
+        //~^ ERROR
+        //~| ERROR
+    }
+}
+
+fn main() {}

--- a/tests/ui/nll/blame-furthest-statement.stderr
+++ b/tests/ui/nll/blame-furthest-statement.stderr
@@ -1,0 +1,112 @@
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/blame-furthest-statement.rs:10:5
+   |
+LL | fn test_static(a: Inv<'_>, b: Inv<'static>) {
+   |                -           - `b` declared here, outside of the function body
+   |                |
+   |                `a` is a reference that is only valid in the function body
+   |                has type `Inv<'1>`
+...
+LL |     relate(&a, &b);
+   |     ^^^^^^^^^^^^^^
+   |     |
+   |     `a` escapes the function body here
+   |     argument requires that `'1` must outlive `'static`
+   |
+   = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `Inv<'a>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/blame-furthest-statement.rs:17:5
+   |
+LL | fn test1(a: Inv<'_>, b: Inv<'_>) {
+   |          -           - has type `Inv<'2>`
+   |          |
+   |          has type `Inv<'1>`
+...
+LL |     relate(&a, &b);
+   |     ^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |
+   = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `Inv<'a>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/blame-furthest-statement.rs:17:5
+   |
+LL | fn test1(a: Inv<'_>, b: Inv<'_>) {
+   |          -           - has type `Inv<'2>`
+   |          |
+   |          has type `Inv<'1>`
+...
+LL |     relate(&a, &b);
+   |     ^^^^^^^^^^^^^^ argument requires that `'2` must outlive `'1`
+   |
+   = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `Inv<'a>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/blame-furthest-statement.rs:29:9
+   |
+LL | fn test2(cond: bool, a: Inv<'_>, b: Inv<'_>) {
+   |                      -           - has type `Inv<'2>`
+   |                      |
+   |                      has type `Inv<'1>`
+...
+LL |         y.replace(b);
+   |         ^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |
+   = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `Inv<'a>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/blame-furthest-statement.rs:29:9
+   |
+LL | fn test2(cond: bool, a: Inv<'_>, b: Inv<'_>) {
+   |                      -           - has type `Inv<'2>`
+   |                      |
+   |                      has type `Inv<'1>`
+...
+LL |         y.replace(b);
+   |         ^^^^^^^^^^^^ argument requires that `'2` must outlive `'1`
+   |
+   = note: requirement occurs because of a mutable reference to `Option<Inv<'_>>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/blame-furthest-statement.rs:42:9
+   |
+LL | fn test3(cond: bool, a: Inv<'_>, b: Inv<'_>) {
+   |                      -           - has type `Inv<'2>`
+   |                      |
+   |                      has type `Inv<'1>`
+...
+LL |         relate(&x, &y);
+   |         ^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |
+   = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `Inv<'a>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/blame-furthest-statement.rs:42:9
+   |
+LL | fn test3(cond: bool, a: Inv<'_>, b: Inv<'_>) {
+   |                      -           - has type `Inv<'2>`
+   |                      |
+   |                      has type `Inv<'1>`
+...
+LL |         relate(&x, &y);
+   |         ^^^^^^^^^^^^^^ argument requires that `'2` must outlive `'1`
+   |
+   = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `Inv<'a>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0521`.

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -40,7 +40,7 @@ LL | |     });
    | |______`cell_a` escapes the function body here
    |        argument requires that `'a` must outlive `'static`
    |
-   = note: requirement occurs because of the type `Cell<&'?9 u32>`, which makes the generic argument `&'?9 u32` invariant
+   = note: requirement occurs because of the type `Cell<&'?10 &'?51 u32>`, which makes the generic argument `&'?10 &'?51 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -40,7 +40,7 @@ LL | |     });
    | |______`cell_a` escapes the function body here
    |        argument requires that `'a` must outlive `'static`
    |
-   = note: requirement occurs because of the type `Cell<&'?10 u32>`, which makes the generic argument `&'?10 u32` invariant
+   = note: requirement occurs because of the type `Cell<&'?12 &'?59 u32>`, which makes the generic argument `&'?12 &'?59 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/tests/ui/nll/issue-46036.stderr
+++ b/tests/ui/nll/issue-46036.stderr
@@ -4,10 +4,10 @@ error[E0597]: `a` does not live long enough
 LL |     let a = 3;
    |         - binding `a` declared here
 LL |     let foo = Foo { x: &a };
-   |                        ^^
-   |                        |
-   |                        borrowed value does not live long enough
-   |                        this usage requires that `a` is borrowed for `'static`
+   |               ---------^^--
+   |               |        |
+   |               |        borrowed value does not live long enough
+   |               requires that `a` is borrowed for `'static`
 LL |     loop { }
 LL | }
    | - `a` dropped here while still borrowed

--- a/tests/ui/nll/issue-54779-anon-static-lifetime.rs
+++ b/tests/ui/nll/issue-54779-anon-static-lifetime.rs
@@ -29,7 +29,8 @@ impl DebugWith<dyn DebugContext> for Foo {
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
         let Foo { bar } = self;
-        bar.debug_with(cx); //~ ERROR: lifetime may not live long enough
+        bar.debug_with(cx);
+        //~^ ERROR: borrowed data escapes outside of method [E0521]
         Ok(())
     }
 }

--- a/tests/ui/nll/issue-54779-anon-static-lifetime.stderr
+++ b/tests/ui/nll/issue-54779-anon-static-lifetime.stderr
@@ -1,11 +1,17 @@
-error: lifetime may not live long enough
-  --> $DIR/issue-54779-anon-static-lifetime.rs:32:24
+error[E0521]: borrowed data escapes outside of method
+  --> $DIR/issue-54779-anon-static-lifetime.rs:32:9
    |
 LL |         cx: &dyn DebugContext,
-   |             - let's call the lifetime of this reference `'1`
+   |         --  - let's call the lifetime of this reference `'1`
+   |         |
+   |         `cx` is a reference that is only valid in the method body
 ...
 LL |         bar.debug_with(cx);
-   |                        ^^ cast requires that `'1` must outlive `'static`
+   |         ^^^^^^^^^^^^^^^^^^
+   |         |
+   |         `cx` escapes the method body here
+   |         argument requires that `'1` must outlive `'static`
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0521`.

--- a/tests/ui/nll/issue-62007-assign-const-index.stderr
+++ b/tests/ui/nll/issue-62007-assign-const-index.stderr
@@ -17,10 +17,9 @@ LL | fn to_refs<T>(mut list: [&mut List<T>; 2]) -> Vec<&mut T> {
    |                          - let's call the lifetime of this reference `'1`
 ...
 LL |         if let Some(n) = list[0].next.as_mut() {
-   |                          ^^^^^^^^^^^^---------
-   |                          |
-   |                          `list[_].next` was mutably borrowed here in the previous iteration of the loop
-   |                          argument requires that `list[_].next` is borrowed for `'1`
+   |                          ^^^^^^^^^^^^ `list[_].next` was mutably borrowed here in the previous iteration of the loop
+LL |             list[0] = n;
+   |             ----------- assignment requires that `list[_].next` is borrowed for `'1`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/issue-62007-assign-differing-fields.stderr
+++ b/tests/ui/nll/issue-62007-assign-differing-fields.stderr
@@ -17,10 +17,9 @@ LL | fn to_refs<'a, T>(mut list: (&'a mut List<T>, &'a mut List<T>)) -> Vec<&'a 
    |            -- lifetime `'a` defined here
 ...
 LL |         if let Some(n) = (list.0).next.as_mut() {
-   |                          ^^^^^^^^^^^^^---------
-   |                          |
-   |                          `list.0.next` was mutably borrowed here in the previous iteration of the loop
-   |                          argument requires that `list.0.next` is borrowed for `'a`
+   |                          ^^^^^^^^^^^^^ `list.0.next` was mutably borrowed here in the previous iteration of the loop
+LL |             list.1 = n;
+   |             ---------- assignment requires that `list.0.next` is borrowed for `'a`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/issue-98170.stderr
+++ b/tests/ui/nll/issue-98170.stderr
@@ -9,14 +9,25 @@ LL |         Self { field }
    |         ^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
-  --> $DIR/issue-98170.rs:7:16
+  --> $DIR/issue-98170.rs:7:9
    |
 LL | impl MyStruct<'_> {
    |               -- lifetime `'1` appears in the `impl`'s self type
 LL |     pub fn new<'a>(field: &'a [u32]) -> MyStruct<'a> {
    |                -- lifetime `'a` defined here
 LL |         Self { field }
-   |                ^^^^^ this usage requires that `'a` must outlive `'1`
+   |         ^^^^^^^^^^^^^^ requires that `'a` must outlive `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-98170.rs:19:9
+   |
+LL | impl<'a> Trait<'a> for MyStruct<'_> {
+   |      --                         -- lifetime `'1` appears in the `impl`'s self type
+   |      |
+   |      lifetime `'a` defined here
+LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
+LL |         Self { field }
+   |         ^^^^^^^^^^^^^^ requires that `'a` must outlive `'1`
 
 error: lifetime may not live long enough
   --> $DIR/issue-98170.rs:19:9
@@ -28,17 +39,6 @@ LL | impl<'a> Trait<'a> for MyStruct<'_> {
 LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
 LL |         Self { field }
    |         ^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
-
-error: lifetime may not live long enough
-  --> $DIR/issue-98170.rs:19:16
-   |
-LL | impl<'a> Trait<'a> for MyStruct<'_> {
-   |      --                         -- lifetime `'1` appears in the `impl`'s self type
-   |      |
-   |      lifetime `'a` defined here
-LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
-LL |         Self { field }
-   |                ^^^^^ this usage requires that `'a` must outlive `'1`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/nll/issue-98589-closures-relate-named-regions.stderr
+++ b/tests/ui/nll/issue-98589-closures-relate-named-regions.stderr
@@ -11,14 +11,14 @@ LL |     || { None::<&'a &'b ()>; };
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/issue-98589-closures-relate-named-regions.rs:15:10
+  --> $DIR/issue-98589-closures-relate-named-regions.rs:15:5
    |
 LL | fn test_early_late<'a: 'a, 'b>() {
    |                    --      -- lifetime `'b` defined here
    |                    |
    |                    lifetime `'a` defined here
 LL |     || { None::<&'a &'b ()>; };
-   |          ^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/tests/ui/nll/outlives-suggestion-simple.stderr
+++ b/tests/ui/nll/outlives-suggestion-simple.stderr
@@ -99,6 +99,10 @@ LL |     fn get_bar(&self) -> Bar2 {
    |                - let's call the lifetime of this reference `'1`
 LL |         Bar2::new(&self)
    |         ^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'a`
+   |
+   = note: requirement occurs because of the type `Foo2<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `Foo2<'a>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/nll/polonius/assignment-to-differing-field.stderr
+++ b/tests/ui/nll/polonius/assignment-to-differing-field.stderr
@@ -17,10 +17,10 @@ LL | fn assignment_to_field_projection<'a, T>(
    |                                   -- lifetime `'a` defined here
 ...
 LL |         if let Some(n) = (list.0).next.as_mut() {
-   |                          ^^^^^^^^^^^^^---------
-   |                          |
-   |                          `list.0.next` was mutably borrowed here in the previous iteration of the loop
-   |                          argument requires that `list.0.next` is borrowed for `'a`
+   |                          ^^^^^^^^^^^^^ `list.0.next` was mutably borrowed here in the previous iteration of the loop
+LL |
+LL |             list.1 = n;
+   |             ---------- assignment requires that `list.0.next` is borrowed for `'a`
 
 error[E0499]: cannot borrow `list.0.0.0.0.0.value` as mutable more than once at a time
   --> $DIR/assignment-to-differing-field.rs:37:21
@@ -41,10 +41,10 @@ LL | fn assignment_through_projection_chain<'a, T>(
    |                                        -- lifetime `'a` defined here
 ...
 LL |         if let Some(n) = ((((list.0).0).0).0).0.next.as_mut() {
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^---------
-   |                          |
-   |                          `list.0.0.0.0.0.next` was mutably borrowed here in the previous iteration of the loop
-   |                          argument requires that `list.0.0.0.0.0.next` is borrowed for `'a`
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `list.0.0.0.0.0.next` was mutably borrowed here in the previous iteration of the loop
+LL |
+LL |             *((((list.0).0).0).0).1 = n;
+   |             --------------------------- assignment requires that `list.0.0.0.0.0.next` is borrowed for `'a`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -178,7 +178,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of the type `Cell<&'?8 ()>`, which makes the generic argument `&'?8 ()` invariant
+   = note: requirement occurs because of the type `Cell<&'?6 ()>`, which makes the generic argument `&'?6 ()` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/tests/ui/nll/type-check-pointer-comparisons.stderr
+++ b/tests/ui/nll/type-check-pointer-comparisons.stderr
@@ -6,7 +6,7 @@ LL | fn compare_const<'a, 'b>(x: *const &mut &'a i32, y: *const &mut &'b i32) {
    |                  |
    |                  lifetime `'a` defined here
 LL |     x == y;
-   |     ^ requires that `'a` must outlive `'b`
+   |     ^^^^^^ requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to `&i32`
@@ -14,14 +14,14 @@ LL |     x == y;
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/type-check-pointer-comparisons.rs:4:10
+  --> $DIR/type-check-pointer-comparisons.rs:4:5
    |
 LL | fn compare_const<'a, 'b>(x: *const &mut &'a i32, y: *const &mut &'b i32) {
    |                  --  -- lifetime `'b` defined here
    |                  |
    |                  lifetime `'a` defined here
 LL |     x == y;
-   |          ^ requires that `'b` must outlive `'a`
+   |     ^^^^^^ requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `&i32`
@@ -38,7 +38,7 @@ LL | fn compare_mut<'a, 'b>(x: *mut &'a i32, y: *mut &'b i32) {
    |                |
    |                lifetime `'a` defined here
 LL |     x == y;
-   |     ^ requires that `'a` must outlive `'b`
+   |     ^^^^^^ requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable pointer to `&i32`
@@ -46,14 +46,14 @@ LL |     x == y;
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/type-check-pointer-comparisons.rs:10:10
+  --> $DIR/type-check-pointer-comparisons.rs:10:5
    |
 LL | fn compare_mut<'a, 'b>(x: *mut &'a i32, y: *mut &'b i32) {
    |                --  -- lifetime `'b` defined here
    |                |
    |                lifetime `'a` defined here
 LL |     x == y;
-   |          ^ requires that `'b` must outlive `'a`
+   |     ^^^^^^ requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable pointer to `&i32`
@@ -70,7 +70,7 @@ LL | fn compare_fn_ptr<'a, 'b, 'c>(f: fn(&'c mut &'a i32), g: fn(&'c mut &'b i32
    |                   |
    |                   lifetime `'a` defined here
 LL |     f == g;
-   |     ^ requires that `'a` must outlive `'b`
+   |     ^^^^^^ requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to `&i32`
@@ -78,14 +78,14 @@ LL |     f == g;
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/type-check-pointer-comparisons.rs:16:10
+  --> $DIR/type-check-pointer-comparisons.rs:16:5
    |
 LL | fn compare_fn_ptr<'a, 'b, 'c>(f: fn(&'c mut &'a i32), g: fn(&'c mut &'b i32)) {
    |                   --  -- lifetime `'b` defined here
    |                   |
    |                   lifetime `'a` defined here
 LL |     f == g;
-   |          ^ requires that `'b` must outlive `'a`
+   |     ^^^^^^ requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `&i32`

--- a/tests/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/tests/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -4,10 +4,10 @@ error[E0597]: `c` does not live long enough
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
-   |                                                ^^
-   |                                                |
-   |                                                borrowed value does not live long enough
-   |                                                this usage requires that `c` is borrowed for `'static`
+   |     -------------------------------------------^^--
+   |     |                                          |
+   |     |                                          borrowed value does not live long enough
+   |     requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 

--- a/tests/ui/nll/user-annotations/adt-brace-structs.stderr
+++ b/tests/ui/nll/user-annotations/adt-brace-structs.stderr
@@ -4,10 +4,10 @@ error[E0597]: `c` does not live long enough
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     SomeStruct::<&'static u32> { t: &c };
-   |                                     ^^
-   |                                     |
-   |                                     borrowed value does not live long enough
-   |                                     this usage requires that `c` is borrowed for `'static`
+   |     --------------------------------^^--
+   |     |                               |
+   |     |                               borrowed value does not live long enough
+   |     requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 

--- a/tests/ui/nll/user-annotations/adt-tuple-enums.stderr
+++ b/tests/ui/nll/user-annotations/adt-tuple-enums.stderr
@@ -4,10 +4,10 @@ error[E0597]: `c` does not live long enough
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     SomeEnum::SomeVariant::<&'static u32>(&c);
-   |                                           ^^
-   |                                           |
-   |                                           borrowed value does not live long enough
-   |                                           this usage requires that `c` is borrowed for `'static`
+   |     --------------------------------------^^-
+   |     |                                     |
+   |     |                                     borrowed value does not live long enough
+   |     requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 

--- a/tests/ui/nll/user-annotations/adt-tuple-struct.stderr
+++ b/tests/ui/nll/user-annotations/adt-tuple-struct.stderr
@@ -4,10 +4,10 @@ error[E0597]: `c` does not live long enough
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     SomeStruct::<&'static u32>(&c);
-   |                                ^^
-   |                                |
-   |                                borrowed value does not live long enough
-   |                                this usage requires that `c` is borrowed for `'static`
+   |     ---------------------------^^-
+   |     |                          |
+   |     |                          borrowed value does not live long enough
+   |     requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 

--- a/tests/ui/nll/user-annotations/normalization-default.stderr
+++ b/tests/ui/nll/user-annotations/normalization-default.stderr
@@ -1,10 +1,10 @@
 error: lifetime may not live long enough
-  --> $DIR/normalization-default.rs:8:22
+  --> $DIR/normalization-default.rs:8:5
    |
 LL | fn test_tuple(x: &(), y: &()) {
    |                  - let's call the lifetime of this reference `'1`
 LL |     MyTuple::<_>((), x);
-   |                      ^ this usage requires that `'1` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^ requires that `'1` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/normalization-default.rs:10:12
@@ -16,12 +16,12 @@ LL |     let _: MyTuple::<_> = MyTuple((), y);
    |            ^^^^^^^^^^^^ type annotation requires that `'2` must outlive `'static`
 
 error: lifetime may not live long enough
-  --> $DIR/normalization-default.rs:16:26
+  --> $DIR/normalization-default.rs:16:5
    |
 LL | fn test_struct(x: &(), y: &()) {
    |                   - let's call the lifetime of this reference `'1`
 LL |     MyStruct::<_> { val: ((), x) };
-   |                          ^^^^^^^ this usage requires that `'1` must outlive `'static`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'1` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/normalization-default.rs:18:12

--- a/tests/ui/nll/user-annotations/normalization-infer.stderr
+++ b/tests/ui/nll/user-annotations/normalization-infer.stderr
@@ -90,10 +90,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/normalization-infer.rs:33:27
    |
 LL |     Some::<Alias<_, _>>((&temp(), 0u8));
-   |                         --^^^^^^------ - temporary value is freed at the end of this statement
-   |                         | |
-   |                         | creates a temporary value which is freed while still in use
-   |                         this usage requires that borrow lasts for `'static`
+   |     ----------------------^^^^^^-------- temporary value is freed at the end of this statement
+   |     |                     |
+   |     |                     creates a temporary value which is freed while still in use
+   |     requires that borrow lasts for `'static`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/nll/user-annotations/normalization-self.stderr
+++ b/tests/ui/nll/user-annotations/normalization-self.stderr
@@ -1,10 +1,10 @@
 error: lifetime may not live long enough
-  --> $DIR/normalization-self.rs:9:14
+  --> $DIR/normalization-self.rs:9:9
    |
 LL |     fn test(x: &(), y: &()) {
    |                - let's call the lifetime of this reference `'1`
 LL |         Self(x);
-   |              ^ this usage requires that `'1` must outlive `'static`
+   |         ^^^^^^^ requires that `'1` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/normalization-self.rs:11:16
@@ -16,12 +16,12 @@ LL |         let _: Self = MyTuple(y);
    |                ^^^^ type annotation requires that `'2` must outlive `'static`
 
 error: lifetime may not live long enough
-  --> $DIR/normalization-self.rs:19:21
+  --> $DIR/normalization-self.rs:19:9
    |
 LL |     fn test(x: &(), y: &()) {
    |                - let's call the lifetime of this reference `'1`
 LL |         Self { val: x };
-   |                     ^ this usage requires that `'1` must outlive `'static`
+   |         ^^^^^^^^^^^^^^^ requires that `'1` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/normalization-self.rs:21:16

--- a/tests/ui/regions/region-invariant-static-error-reporting.rs
+++ b/tests/ui/regions/region-invariant-static-error-reporting.rs
@@ -3,7 +3,7 @@
 // over time, but this test used to exhibit some pretty bogus messages
 // that were not remotely helpful.
 
-// error-pattern:argument requires that `'a` must outlive `'static`
+// error-pattern:assignment requires that `'a` must outlive `'static`
 
 struct Invariant<'a>(Option<&'a mut &'a mut ()>);
 
@@ -11,9 +11,10 @@ fn mk_static() -> Invariant<'static> { Invariant(None) }
 
 fn unify<'a>(x: Option<Invariant<'a>>, f: fn(Invariant<'a>)) {
     let bad = if x.is_some() {
-        x.unwrap() //~ ERROR borrowed data escapes outside of function [E0521]
+        x.unwrap()
     } else {
-        mk_static()
+        mk_static() //~ ERROR lifetime may not live long enough
+
     };
     f(bad);
 }

--- a/tests/ui/regions/region-invariant-static-error-reporting.stderr
+++ b/tests/ui/regions/region-invariant-static-error-reporting.stderr
@@ -1,16 +1,11 @@
-error[E0521]: borrowed data escapes outside of function
-  --> $DIR/region-invariant-static-error-reporting.rs:14:9
+error: lifetime may not live long enough
+  --> $DIR/region-invariant-static-error-reporting.rs:16:9
    |
 LL | fn unify<'a>(x: Option<Invariant<'a>>, f: fn(Invariant<'a>)) {
-   |          --  - `x` is a reference that is only valid in the function body
-   |          |
-   |          lifetime `'a` defined here
-LL |     let bad = if x.is_some() {
-LL |         x.unwrap()
-   |         ^^^^^^^^^^
-   |         |
-   |         `x` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |          -- lifetime `'a` defined here
+...
+LL |         mk_static()
+   |         ^^^^^^^^^^^ assignment requires that `'a` must outlive `'static`
    |
    = note: requirement occurs because of the type `Invariant<'_>`, which makes the generic argument `'_` invariant
    = note: the struct `Invariant<'a>` is invariant over the parameter `'a`
@@ -18,4 +13,3 @@ LL |         x.unwrap()
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0521`.

--- a/tests/ui/self/issue-61882-2.stderr
+++ b/tests/ui/self/issue-61882-2.stderr
@@ -4,10 +4,10 @@ error[E0597]: `x` does not live long enough
 LL |         let x = 0;
    |             - binding `x` declared here
 LL |         Self(&x);
-   |              ^^
-   |              |
-   |              borrowed value does not live long enough
-   |              this usage requires that `x` is borrowed for `'static`
+   |         -----^^-
+   |         |    |
+   |         |    borrowed value does not live long enough
+   |         requires that `x` is borrowed for `'static`
 LL |
 LL |     }
    |     - `x` dropped here while still borrowed

--- a/tests/ui/traits/coercion-generic-regions.stderr
+++ b/tests/ui/traits/coercion-generic-regions.stderr
@@ -4,11 +4,9 @@ error[E0597]: `person` does not live long enough
 LL |     let person = "Fred".to_string();
    |         ------ binding `person` declared here
 LL |     let person: &str = &person;
-   |                        ^^^^^^^
-   |                        |
-   |                        borrowed value does not live long enough
-   |                        assignment requires that `person` is borrowed for `'static`
+   |                        ^^^^^^^ borrowed value does not live long enough
 LL |     let s: Box<dyn Trait<&'static str>> = Box::new(Struct { person: person });
+   |                                                    ------------------------- requires that `person` is borrowed for `'static`
 LL | }
    | - `person` dropped here while still borrowed
 


### PR DESCRIPTION
This should generate a more correct span for lifetime errors.
Fixes #113041

r? @estebank 