### PR TITLE
lint/ctypes: only try normalize

### DIFF
--- a/tests/ui/lint/lint-ctypes-113900.rs
+++ b/tests/ui/lint/lint-ctypes-113900.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+// Extending `improper_ctypes` to check external-ABI fn-ptrs means that it can encounter
+// projections which cannot be normalized - unsurprisingly, this shouldn't crash the compiler.
+
+trait Bar {
+    type Assoc;
+}
+
+type Foo<T> = extern "C" fn() -> <T as Bar>::Assoc;
+
+fn main() {}


### PR DESCRIPTION
Fixes #113900.

Now that this lint runs on any external-ABI fn-ptr, normalization won't always succeed, so use `try_normalize_erasing_regions` instead.