### PR TITLE
rust-installer: Use env(1) in the shebang.

### DIFF
--- a/src/tools/rust-installer/install-template.sh
+++ b/src/tools/rust-installer/install-template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # No undefined variables
 set -u


### PR DESCRIPTION
This fixes the case (e.g. *BSD) where bash is installed on the host system, but not at the typical location of /bin.