### PR TITLE
Add regression test for issue #113941 - naive layout isn't refined

### DIFF
--- a/tests/ui/layout/issue-113941.rs
+++ b/tests/ui/layout/issue-113941.rs
@@ -1,0 +1,13 @@
+// build-pass
+// revisions: normal randomize-layout
+// [randomize-layout]compile-flags: -Zrandomize-layout
+
+enum Void {}
+
+pub struct Struct([*const (); 0], Void);
+
+pub enum Enum {
+    Variant(Struct),
+}
+
+fn main() {}


### PR DESCRIPTION
This PR adds a regression test for issue #113941 - `the naive layout isn't refined by the actual layout` based on the minimized repro https://github.com/rust-lang/rust/issues/113941#issuecomment-1646446769.