### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2353,7 +2353,12 @@ impl Param {
     /// Builds a `Param` object from `ExplicitSelf`.
     pub fn from_self(attrs: AttrVec, eself: ExplicitSelf, eself_ident: Ident) -> Param {
         let span = eself.span.to(eself_ident.span);
-        let infer_ty = P(Ty { id: DUMMY_NODE_ID, kind: TyKind::ImplicitSelf, span, tokens: None });
+        let infer_ty = P(Ty {
+            id: DUMMY_NODE_ID,
+            kind: TyKind::ImplicitSelf,
+            span: eself_ident.span,
+            tokens: None,
+        });
         let (mutbl, ty) = match eself.node {
             SelfKind::Explicit(ty, mutbl) => (mutbl, ty),
             SelfKind::Value(mutbl) => (mutbl, infer_ty),

--- a/compiler/rustc_trait_selection/messages.ftl
+++ b/compiler/rustc_trait_selection/messages.ftl
@@ -1,3 +1,13 @@
+trait_selection_adjust_signature_borrow = consider adjusting the signature so it borrows its {$len ->
+        [one] argument
+        *[other] arguments
+    }
+
+trait_selection_adjust_signature_remove_borrow = consider adjusting the signature so it does not borrow its {$len ->
+        [one] argument
+        *[other] arguments
+    }
+
 trait_selection_dump_vtable_entries = vtable entries for `{$trait_ref}`: {$entries}
 
 trait_selection_empty_on_clause_in_rustc_on_unimplemented = empty `on`-clause in `#[rustc_on_unimplemented]`

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3959,6 +3959,10 @@ fn hint_missing_borrow<'tcx>(
     found_node: Node<'_>,
     err: &mut Diagnostic,
 ) {
+    if matches!(found_node, Node::TraitItem(..)) {
+        return;
+    }
+
     let found_args = match found.kind() {
         ty::FnPtr(f) => infcx.instantiate_binder_with_placeholders(*f).inputs().iter(),
         kind => {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -5,6 +5,7 @@ use super::{
     PredicateObligation,
 };
 
+use crate::errors;
 use crate::infer::InferCtxt;
 use crate::traits::{NormalizeExt, ObligationCtxt};
 
@@ -4032,19 +4033,11 @@ fn hint_missing_borrow<'tcx>(
     }
 
     if !to_borrow.is_empty() {
-        err.multipart_suggestion_verbose(
-            "consider adjusting the signature so it borrows its argument",
-            to_borrow,
-            Applicability::MaybeIncorrect,
-        );
+        err.subdiagnostic(errors::AdjustSignatureBorrow::Borrow { to_borrow });
     }
 
     if !remove_borrow.is_empty() {
-        err.multipart_suggestion_verbose(
-            "consider adjusting the signature so it does not borrow its argument",
-            remove_borrow,
-            Applicability::MaybeIncorrect,
-        );
+        err.subdiagnostic(errors::AdjustSignatureBorrow::RemoveBorrow { remove_borrow });
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -4029,7 +4029,7 @@ fn hint_missing_borrow<'tcx>(
 
     if !to_borrow.is_empty() {
         err.multipart_suggestion_verbose(
-            "consider borrowing the argument",
+            "consider adjusting the signature so it borrows its argument",
             to_borrow,
             Applicability::MaybeIncorrect,
         );
@@ -4037,7 +4037,7 @@ fn hint_missing_borrow<'tcx>(
 
     if !remove_borrow.is_empty() {
         err.multipart_suggestion_verbose(
-            "do not borrow the argument",
+            "consider adjusting the signature so it does not borrow its argument",
             remove_borrow,
             Applicability::MaybeIncorrect,
         );

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -2043,6 +2043,13 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Zinline-mir");
         }
 
+        // set rustc args passed from command line
+        let rustc_args =
+            self.config.cmd.rustc_args().iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        if !rustc_args.is_empty() {
+            cargo.env("RUSTFLAGS", &rustc_args.join(" "));
+        }
+
         Cargo { command: cargo, rustflags, rustdocflags, allow_features }
     }
 

--- a/tests/rustdoc-gui/item-decl-colors.goml
+++ b/tests/rustdoc-gui/item-decl-colors.goml
@@ -20,6 +20,7 @@ define-function: (
     block {
         go-to: "file://" + |DOC_PATH| + "/test_docs/struct.WithGenerics.html"
         show-text: true
+
         set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
         reload:
         assert-css: (".item-decl .code-attribute", {"color": |attr_color|}, ALL)
@@ -40,41 +41,41 @@ call-function: (
     "check-colors",
     {
         "theme": "ayu",
-        "attr_color": "rgb(153, 153, 153)",
-        "trait_color": "rgb(57, 175, 215)",
-        "struct_color": "rgb(255, 160, 165)",
-        "enum_color": "rgb(255, 160, 165)",
-        "primitive_color": "rgb(255, 160, 165)",
-        "constant_color": "rgb(57, 175, 215)",
-        "fn_color": "rgb(253, 214, 135)",
-        "assoc_type_color": "rgb(57, 175, 215)",
+        "attr_color": "#999",
+        "trait_color": "#39afd7",
+        "struct_color": "#ffa0a5",
+        "enum_color": "#ffa0a5",
+        "primitive_color": "#ffa0a5",
+        "constant_color": "#39afd7",
+        "fn_color": "#fdd687",
+        "assoc_type_color": "#39afd7",
     },
 )
 call-function: (
     "check-colors",
     {
         "theme": "dark",
-        "attr_color": "rgb(153, 153, 153)",
-        "trait_color": "rgb(183, 140, 242)",
-        "struct_color": "rgb(45, 191, 184)",
-        "enum_color": "rgb(45, 191, 184)",
-        "primitive_color": "rgb(45, 191, 184)",
-        "constant_color": "rgb(210, 153, 29)",
-        "fn_color": "rgb(43, 171, 99)",
-        "assoc_type_color": "rgb(210, 153, 29)",
+        "attr_color": "#999",
+        "trait_color": "#b78cf2",
+        "struct_color": "#2dbfb8",
+        "enum_color": "#2dbfb8",
+        "primitive_color": "#2dbfb8",
+        "constant_color": "#d2991d",
+        "fn_color": "#2bab63",
+        "assoc_type_color": "#d2991d",
     },
 )
 call-function: (
     "check-colors",
     {
         "theme": "light",
-        "attr_color": "rgb(153, 153, 153)",
-        "trait_color": "rgb(110, 79, 201)",
-        "struct_color": "rgb(173, 55, 138)",
-        "enum_color": "rgb(173, 55, 138)",
-        "primitive_color": "rgb(173, 55, 138)",
-        "constant_color": "rgb(56, 115, 173)",
-        "fn_color": "rgb(173, 124, 55)",
-        "assoc_type_color": "rgb(56, 115, 173)",
+        "attr_color": "#999",
+        "trait_color": "#6e4fc9",
+        "struct_color": "#ad378a",
+        "enum_color": "#ad378a",
+        "primitive_color": "#ad378a",
+        "constant_color": "#3873ad",
+        "fn_color": "#ad7c37",
+        "assoc_type_color": "#3873ad",
     },
 )

--- a/tests/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/tests/ui/anonymous-higher-ranked-lifetime.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `f1`
    |
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
    |                         ^^^^^^^^^^^^ required by this bound in `f1`
-help: consider adjusting the signature so it borrows its argument
+help: consider adjusting the signature so it borrows its arguments
    |
 LL |     f1(|_: &(), _: &()| {});
    |            +       +
@@ -33,7 +33,7 @@ note: required by a bound in `f2`
    |
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f2`
-help: consider adjusting the signature so it borrows its argument
+help: consider adjusting the signature so it borrows its arguments
    |
 LL |     f2(|_: &(), _: &()| {});
    |            +       +
@@ -53,7 +53,7 @@ note: required by a bound in `f3`
    |
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
    |                             ^^^^^^^^^^^^^^^ required by this bound in `f3`
-help: consider adjusting the signature so it borrows its argument
+help: consider adjusting the signature so it borrows its arguments
    |
 LL |     f3(|_: &(), _: &()| {});
    |            +       +
@@ -73,7 +73,7 @@ note: required by a bound in `f4`
    |
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f4`
-help: consider adjusting the signature so it borrows its argument
+help: consider adjusting the signature so it borrows its arguments
    |
 LL |     f4(|_: &(), _: &()| {});
    |            +       +
@@ -93,7 +93,7 @@ note: required by a bound in `f5`
    |
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f5`
-help: consider adjusting the signature so it borrows its argument
+help: consider adjusting the signature so it borrows its arguments
    |
 LL |     f5(|_: &(), _: &()| {});
    |            +       +
@@ -193,7 +193,7 @@ note: required by a bound in `h1`
    |
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h1`
-help: consider adjusting the signature so it borrows its argument
+help: consider adjusting the signature so it borrows its arguments
    |
 LL |     h1(|_: &(), _: (), _: &(), _: ()| {});
    |            +              +
@@ -213,7 +213,7 @@ note: required by a bound in `h2`
    |
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h2`
-help: consider adjusting the signature so it borrows its argument
+help: consider adjusting the signature so it borrows its arguments
    |
 LL |     h2(|_: &(), _: (), _: &(), _: ()| {});
    |            +              +

--- a/tests/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/tests/ui/anonymous-higher-ranked-lifetime.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `f1`
    |
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
    |                         ^^^^^^^^^^^^ required by this bound in `f1`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     f1(|_: &(), _: &()| {});
    |            +       +
@@ -33,7 +33,7 @@ note: required by a bound in `f2`
    |
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f2`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     f2(|_: &(), _: &()| {});
    |            +       +
@@ -53,7 +53,7 @@ note: required by a bound in `f3`
    |
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
    |                             ^^^^^^^^^^^^^^^ required by this bound in `f3`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     f3(|_: &(), _: &()| {});
    |            +       +
@@ -73,7 +73,7 @@ note: required by a bound in `f4`
    |
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f4`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     f4(|_: &(), _: &()| {});
    |            +       +
@@ -93,7 +93,7 @@ note: required by a bound in `f5`
    |
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f5`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     f5(|_: &(), _: &()| {});
    |            +       +
@@ -113,7 +113,7 @@ note: required by a bound in `g1`
    |
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g1`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     g1(|_: &(), _: ()| {});
    |            +
@@ -133,7 +133,7 @@ note: required by a bound in `g2`
    |
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
    |                         ^^^^^^^^^^^^^^^^ required by this bound in `g2`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     g2(|_: &(), _: ()| {});
    |            +
@@ -153,7 +153,7 @@ note: required by a bound in `g3`
    |
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g3`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     g3(|_: &(), _: ()| {});
    |            +
@@ -173,7 +173,7 @@ note: required by a bound in `g4`
    |
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g4`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     g4(|_: &(), _: ()| {});
    |            +
@@ -193,7 +193,7 @@ note: required by a bound in `h1`
    |
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h1`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     h1(|_: &(), _: (), _: &(), _: ()| {});
    |            +              +
@@ -213,7 +213,7 @@ note: required by a bound in `h2`
    |
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h2`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     h2(|_: &(), _: (), _: &(), _: ()| {});
    |            +              +

--- a/tests/ui/closures/multiple-fn-bounds.stderr
+++ b/tests/ui/closures/multiple-fn-bounds.stderr
@@ -18,7 +18,7 @@ note: required by a bound in `foo`
    |
 LL | fn foo<F: Fn(&char) -> bool + Fn(char) -> bool>(f: F) {
    |                               ^^^^^^^^^^^^^^^^ required by this bound in `foo`
-help: do not borrow the argument
+help: consider adjusting the signature so it does not borrow its argument
    |
 LL |     foo(move |char| v);
    |               ~~~~

--- a/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
@@ -15,10 +15,10 @@ LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply
    |                 ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/explicit-drop-bounds.rs:32:13
+  --> $DIR/explicit-drop-bounds.rs:32:18
    |
 LL |     fn drop(&mut self) {}
-   |             ^^^^^^^^^ the trait `Copy` is not implemented for `T`
+   |                  ^^^^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `DropMe`
   --> $DIR/explicit-drop-bounds.rs:7:18

--- a/tests/ui/dropck/explicit-drop-bounds.bad2.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad2.stderr
@@ -15,10 +15,10 @@ LL | impl<T: std::marker::Copy> Drop for DropMe<T>
    |       +++++++++++++++++++
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/explicit-drop-bounds.rs:40:13
+  --> $DIR/explicit-drop-bounds.rs:40:18
    |
 LL |     fn drop(&mut self) {}
-   |             ^^^^^^^^^ the trait `Copy` is not implemented for `T`
+   |                  ^^^^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `DropMe`
   --> $DIR/explicit-drop-bounds.rs:7:18

--- a/tests/ui/layout/issue-113941.rs
+++ b/tests/ui/layout/issue-113941.rs
@@ -1,0 +1,13 @@
+// build-pass
+// revisions: normal randomize-layout
+// [randomize-layout]compile-flags: -Zrandomize-layout
+
+enum Void {}
+
+pub struct Struct([*const (); 0], Void);
+
+pub enum Enum {
+    Variant(Struct),
+}
+
+fn main() {}

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.stderr
@@ -10,7 +10,7 @@ LL |     let _ = (-10..=10).find(|x: i32| x.signum() == 0);
               found closure signature `fn(i32) -> _`
 note: required by a bound in `find`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     let _ = (-10..=10).find(|x: &i32| x.signum() == 0);
    |                                 +
@@ -27,7 +27,7 @@ LL |     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
               found closure signature `for<'a, 'b, 'c> fn(&'a &'b &'c i32) -> _`
 note: required by a bound in `find`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
-help: do not borrow the argument
+help: consider adjusting the signature so it does not borrow its argument
    |
 LL -     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
 LL +     let _ = (-10..=10).find(|x: &i32| x.signum() == 0);

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -10,7 +10,7 @@ LL |     a.iter().map(|_: (u32, u32)| 45);
               found closure signature `fn((u32, u32)) -> _`
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     a.iter().map(|_: &(u32, u32)| 45);
    |                      +

--- a/tests/ui/mismatched_types/issue-36053-2.stderr
+++ b/tests/ui/mismatched_types/issue-36053-2.stderr
@@ -10,7 +10,7 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
               found closure signature `for<'a> fn(&'a str) -> _`
 note: required by a bound in `filter`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     once::<&str>("str").fuse().filter(|a: &&str| true).count();
    |                                           +

--- a/tests/ui/mismatched_types/suggest-option-asderef-inference-var.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef-inference-var.stderr
@@ -13,7 +13,7 @@ LL |     let _has_inference_vars: Option<i32> = Some(0).map(deref_int);
               found function signature `for<'a> fn(&'a i32) -> _`
 note: required by a bound in `Option::<T>::map`
   --> $SRC_DIR/core/src/option.rs:LL:COL
-help: do not borrow the argument
+help: consider adjusting the signature so it does not borrow its argument
    |
 LL - fn deref_int(a: &i32) -> i32 {
 LL + fn deref_int(a: i32) -> i32 {

--- a/tests/ui/mismatched_types/suggest-option-asderef.fixed
+++ b/tests/ui/mismatched_types/suggest-option-asderef.fixed
@@ -17,7 +17,7 @@ fn generic<T>(_: T) -> Option<()> {
 }
 
 fn generic_ref<T>(_: T) -> Option<()> {
-    //~^ HELP do not borrow the argument
+    //~^ HELP consider adjusting the signature so it does not borrow its argument
     Some(())
 }
 

--- a/tests/ui/mismatched_types/suggest-option-asderef.rs
+++ b/tests/ui/mismatched_types/suggest-option-asderef.rs
@@ -17,7 +17,7 @@ fn generic<T>(_: T) -> Option<()> {
 }
 
 fn generic_ref<T>(_: &T) -> Option<()> {
-    //~^ HELP do not borrow the argument
+    //~^ HELP consider adjusting the signature so it does not borrow its argument
     Some(())
 }
 

--- a/tests/ui/mismatched_types/suggest-option-asderef.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef.stderr
@@ -73,7 +73,7 @@ LL |     let _ = produces_string().and_then(generic_ref);
               found function signature `for<'a> fn(&'a _) -> _`
 note: required by a bound in `Option::<T>::and_then`
   --> $SRC_DIR/core/src/option.rs:LL:COL
-help: do not borrow the argument
+help: consider adjusting the signature so it does not borrow its argument
    |
 LL - fn generic_ref<T>(_: &T) -> Option<()> {
 LL + fn generic_ref<T>(_: T) -> Option<()> {

--- a/tests/ui/specialization/min_specialization/issue-79224.stderr
+++ b/tests/ui/specialization/min_specialization/issue-79224.stderr
@@ -11,10 +11,10 @@ LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
 
 error[E0277]: the trait bound `B: Clone` is not satisfied
-  --> $DIR/issue-79224.rs:20:12
+  --> $DIR/issue-79224.rs:20:13
    |
 LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-   |            ^^^^^ the trait `Clone` is not implemented for `B`
+   |             ^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
 help: consider further restricting this bound

--- a/tests/ui/suggestions/late-bound-in-borrow-closure-sugg.stderr
+++ b/tests/ui/suggestions/late-bound-in-borrow-closure-sugg.stderr
@@ -16,7 +16,7 @@ note: required by a bound in `Trader::<'a>::set_closure`
    |
 LL |     pub fn set_closure(&mut self, function: impl Fn(&mut Trader) + 'a) {
    |                                                  ^^^^^^^^^^^^^^^ required by this bound in `Trader::<'a>::set_closure`
-help: consider borrowing the argument
+help: consider adjusting the signature so it borrows its argument
    |
 LL |     let closure = |trader : &mut Trader| {
    |                             ++++

--- a/tests/ui/typeck/mismatched-map-under-self.rs
+++ b/tests/ui/typeck/mismatched-map-under-self.rs
@@ -1,0 +1,17 @@
+pub trait Insertable {
+    type Values;
+
+    fn values(&self) -> Self::Values;
+}
+
+impl<T> Insertable for Option<T> {
+    type Values = ();
+
+    fn values(self) -> Self::Values {
+        //~^ ERROR method `values` has an incompatible type for trait
+        self.map(Insertable::values).unwrap_or_default()
+        //~^ ERROR type mismatch in function arguments
+    }
+}
+
+fn main() {}

--- a/tests/ui/typeck/mismatched-map-under-self.stderr
+++ b/tests/ui/typeck/mismatched-map-under-self.stderr
@@ -1,0 +1,42 @@
+error[E0053]: method `values` has an incompatible type for trait
+  --> $DIR/mismatched-map-under-self.rs:10:15
+   |
+LL |     fn values(self) -> Self::Values {
+   |               ^^^^
+   |               |
+   |               expected `&Option<T>`, found `Option<T>`
+   |               help: change the self-receiver type to match the trait: `&self`
+   |
+note: type in trait
+  --> $DIR/mismatched-map-under-self.rs:4:15
+   |
+LL |     fn values(&self) -> Self::Values;
+   |               ^^^^^
+   = note: expected signature `fn(&Option<T>)`
+              found signature `fn(Option<T>)`
+
+error[E0631]: type mismatch in function arguments
+  --> $DIR/mismatched-map-under-self.rs:12:18
+   |
+LL |     fn values(&self) -> Self::Values;
+   |     --------------------------------- found signature defined here
+...
+LL |         self.map(Insertable::values).unwrap_or_default()
+   |              --- ^^^^^^^^^^^^^^^^^^ expected due to this
+   |              |
+   |              required by a bound introduced by this call
+   |
+   = note: expected function signature `fn(T) -> _`
+              found function signature `for<'a> fn(&'a _) -> _`
+note: required by a bound in `Option::<T>::map`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+help: consider adjusting the signature so it does not borrow its argument
+   |
+LL -     fn values(&self) -> Self::Values;
+LL +     fn values(self) -> Self::Values;
+   |
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0053, E0631.
+For more information about an error, try `rustc --explain E0053`.

--- a/tests/ui/typeck/mismatched-map-under-self.stderr
+++ b/tests/ui/typeck/mismatched-map-under-self.stderr
@@ -30,11 +30,6 @@ LL |         self.map(Insertable::values).unwrap_or_default()
               found function signature `for<'a> fn(&'a _) -> _`
 note: required by a bound in `Option::<T>::map`
   --> $SRC_DIR/core/src/option.rs:LL:COL
-help: consider adjusting the signature so it does not borrow its argument
-   |
-LL -     fn values(&self) -> Self::Values;
-LL +     fn values(self) -> Self::Values;
-   |
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #112508 (Tweak spans for self arg, fix borrow suggestion for signature mismatch)
 - #113901 (Get rid of subst-relate incompleteness in new solver)
 - #113948 (Fix rustc-args passing issue in bootstrap)
 - #113950 (Remove Scope::Elision from bound-vars resolution.)
 - #113957 (Add regression test for issue #113941 - naive layout isn't refined)
 - #113959 (Migrate GUI colors test to original CSS color format)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112508,113901,113948,113950,113957,113959)
<!-- homu-ignore:end -->