### PR TITLE
Migrate GUI colors test to original CSS color format

### DIFF
--- a/tests/rustdoc-gui/label-next-to-symbol.goml
+++ b/tests/rustdoc-gui/label-next-to-symbol.goml
@@ -10,11 +10,11 @@ assert: (".stab.portability")
 // make sure that deprecated and portability have the right colors
 assert-css: (
     ".item-table .item-name .stab.deprecated",
-    { "background-color": "rgb(255, 245, 214)" },
+    { "background-color": "#fff5d6" },
 )
 assert-css: (
     ".item-table .item-name .stab.portability",
-    { "background-color": "rgb(255, 245, 214)" },
+    { "background-color": "#fff5d6" },
 )
 
 // table like view


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/111459.

r? @notriddle