### PR TITLE
fix(resolve): skip panic when resolution is dummy

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -989,17 +989,17 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             initial_binding.res()
                         });
                         let res = binding.res();
+                        if res == Res::Err || !this.ambiguity_errors.is_empty() {
+                            this.tcx
+                                .sess
+                                .delay_span_bug(import.span, "some error happened for an import");
+                            return;
+                        }
                         if let Ok(initial_res) = initial_res {
-                            if res != initial_res
-                                && this.ambiguity_errors.is_empty()
-                                && res != Res::Err
-                            {
+                            if res != initial_res {
                                 span_bug!(import.span, "inconsistent resolution for an import");
                             }
-                        } else if res != Res::Err
-                            && this.ambiguity_errors.is_empty()
-                            && this.privacy_errors.is_empty()
-                        {
+                        } else if this.privacy_errors.is_empty() {
                             this.tcx
                                 .sess
                                 .create_err(CannotDetermineImportResolution { span: import.span })

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -990,7 +990,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         });
                         let res = binding.res();
                         if let Ok(initial_res) = initial_res {
-                            if res != initial_res && this.ambiguity_errors.is_empty() {
+                            if res != initial_res
+                                && this.ambiguity_errors.is_empty()
+                                && res != Res::Err
+                            {
                                 span_bug!(import.span, "inconsistent resolution for an import");
                             }
                         } else if res != Res::Err

--- a/tests/ui/imports/issue-113953.rs
+++ b/tests/ui/imports/issue-113953.rs
@@ -1,0 +1,6 @@
+// edition: 2021
+use u8 as imported_u8;
+use unresolved as u8;
+//~^ ERROR unresolved import `unresolved`
+
+fn main() {}

--- a/tests/ui/imports/issue-113953.stderr
+++ b/tests/ui/imports/issue-113953.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `unresolved`
+  --> $DIR/issue-113953.rs:3:5
+   |
+LL | use unresolved as u8;
+   |     ^^^^^^^^^^^^^^^^ no external crate `unresolved`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
Fixes #113953 

Skip the panic when the binding refers to a dummy node during the finalization.

r? @petrochenkov 