### PR TITLE
Add a visibility suggestion in private-in-public errors

### DIFF
--- a/compiler/rustc_privacy/messages.ftl
+++ b/compiler/rustc_privacy/messages.ftl
@@ -8,6 +8,8 @@ privacy_from_private_dep_in_public_interface =
 privacy_in_public_interface = {$vis_descr} {$kind} `{$descr}` in public interface
     .label = can't leak {$vis_descr} {$kind}
     .visibility_label = `{$descr}` declared as {$vis_descr}
+    .help = - Either remove the `pub` from the function
+            - Or add `pub` to `{$descr}`
 
 privacy_item_is_private = {$kind} `{$descr}` is private
     .label = private {$kind}

--- a/compiler/rustc_privacy/messages.ftl
+++ b/compiler/rustc_privacy/messages.ftl
@@ -8,7 +8,7 @@ privacy_from_private_dep_in_public_interface =
 privacy_in_public_interface = {$vis_descr} {$kind} `{$descr}` in public interface
     .label = can't leak {$vis_descr} {$kind}
     .visibility_label = `{$descr}` declared as {$vis_descr}
-    .suggestion = consider adding `pub` in front of it
+    .suggestion = consider adding `{$vis_sugg}` in front of it
 
 privacy_item_is_private = {$kind} `{$descr}` is private
     .label = private {$kind}

--- a/compiler/rustc_privacy/messages.ftl
+++ b/compiler/rustc_privacy/messages.ftl
@@ -8,8 +8,7 @@ privacy_from_private_dep_in_public_interface =
 privacy_in_public_interface = {$vis_descr} {$kind} `{$descr}` in public interface
     .label = can't leak {$vis_descr} {$kind}
     .visibility_label = `{$descr}` declared as {$vis_descr}
-    .help = - Either remove the `pub` from the function
-            - Or add `pub` to `{$descr}`
+    .suggestion = consider adding `pub` in front of it
 
 privacy_item_is_private = {$kind} `{$descr}` is private
     .label = private {$kind}

--- a/compiler/rustc_privacy/src/errors.rs
+++ b/compiler/rustc_privacy/src/errors.rs
@@ -56,6 +56,7 @@ pub struct InPublicInterface<'a> {
     pub span: Span,
     pub vis_descr: &'static str,
     pub kind: &'a str,
+    pub vis_sugg: &'static str,
     pub descr: DiagArgFromDisplay<'a>,
     #[label(privacy_visibility_label)]
     pub vis_span: Span,

--- a/compiler/rustc_privacy/src/errors.rs
+++ b/compiler/rustc_privacy/src/errors.rs
@@ -48,6 +48,7 @@ pub struct UnnamedItemIsPrivate {
 }
 
 #[derive(Diagnostic)]
+#[help]
 #[diag(privacy_in_public_interface, code = E0446)]
 pub struct InPublicInterface<'a> {
     #[primary_span]

--- a/compiler/rustc_privacy/src/errors.rs
+++ b/compiler/rustc_privacy/src/errors.rs
@@ -59,7 +59,7 @@ pub struct InPublicInterface<'a> {
     pub descr: DiagArgFromDisplay<'a>,
     #[label(privacy_visibility_label)]
     pub vis_span: Span,
-    #[suggestion(code="", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect")]
     pub suggestion: Span,
 }
 

--- a/compiler/rustc_privacy/src/errors.rs
+++ b/compiler/rustc_privacy/src/errors.rs
@@ -59,6 +59,8 @@ pub struct InPublicInterface<'a> {
     pub descr: DiagArgFromDisplay<'a>,
     #[label(privacy_visibility_label)]
     pub vis_span: Span,
+    #[suggestion(code="", applicability = "maybe-incorrect")]
+    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_privacy/src/errors.rs
+++ b/compiler/rustc_privacy/src/errors.rs
@@ -56,12 +56,12 @@ pub struct InPublicInterface<'a> {
     pub span: Span,
     pub vis_descr: &'static str,
     pub kind: &'a str,
-    pub vis_sugg: &'static str,
     pub descr: DiagArgFromDisplay<'a>,
     #[label(privacy_visibility_label)]
     pub vis_span: Span,
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
-    pub suggestion: Span,
+    #[suggestion(code = "{vis_sugg}", applicability = "maybe-incorrect", style = "verbose")]
+    pub data: Span,
+    pub vis_sugg: &'static str,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1337,12 +1337,31 @@ impl SearchInterfaceForPrivateItemsVisitor<'_> {
                 }
             };
 
+            // FIXME: this code was adapted from the above `vis_descr` computation,
+            //        but it's not clear if it's correct.
+            let vis_sugg = match self.required_visibility {
+                ty::Visibility::Public => "pub",
+                ty::Visibility::Restricted(vis_def_id) => {
+                    if vis_def_id
+                        == self.tcx.parent_module_from_def_id(local_def_id).to_local_def_id()
+                    {
+                        "???FIXME???"
+                    } else if vis_def_id.is_top_level_module() {
+                        "pub(crate)"
+                    } else {
+                        "???FIXME???"
+                    }
+                }
+            };
+
             self.tcx.dcx().emit_err(InPublicInterface {
                 span,
                 vis_descr,
                 kind,
+                vis_sugg,
                 descr: descr.into(),
                 vis_span,
+                suggestion: vis_span,
             });
             return false;
         }

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1358,10 +1358,10 @@ impl SearchInterfaceForPrivateItemsVisitor<'_> {
                 span,
                 vis_descr,
                 kind,
-                vis_sugg,
                 descr: descr.into(),
                 vis_span,
-                suggestion: vis_span,
+                data: vis_span,
+                vis_sugg,
             });
             return false;
         }

--- a/tests/ui/const-generics/generic_const_exprs/eval-privacy.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/eval-privacy.stderr
@@ -5,10 +5,12 @@ LL |     type AssocTy = Const<{ my_const_fn(U) }>;
    |     ^^^^^^^^^^^^ can't leak private type
 ...
 LL | const fn my_const_fn(val: u8) -> u8 {
-   | -----------------------------------
-   | |
-   | `fn(u8) -> u8 {my_const_fn}` declared as private
-   | help: consider adding `pub` in front of it
+   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   |
+help: consider adding `pub` in front of it
+   |
+LL | pub {
+   | ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/eval-privacy.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/eval-privacy.stderr
@@ -5,7 +5,10 @@ LL |     type AssocTy = Const<{ my_const_fn(U) }>;
    |     ^^^^^^^^^^^^ can't leak private type
 ...
 LL | const fn my_const_fn(val: u8) -> u8 {
-   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   | -----------------------------------
+   | |
+   | `fn(u8) -> u8 {my_const_fn}` declared as private
+   | help: consider adding `pub` in front of it
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0446.stderr
+++ b/tests/ui/error-codes/E0446.stderr
@@ -2,25 +2,29 @@ error[E0446]: private type `Bar` in public interface
   --> $DIR/E0446.rs:10:5
    |
 LL | struct Bar;
-   | ----------
-   | |
-   | `Bar` declared as private
-   | help: consider adding `pub` in front of it
+   | ---------- `Bar` declared as private
 ...
 LL |     type Alias1 = Bar;
    |     ^^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL | pub;
+   | ~~~
 
 error[E0446]: private trait `PrivTr` in public interface
   --> $DIR/E0446.rs:11:5
    |
 LL | trait PrivTr {}
-   | ------------
-   | |
-   | `PrivTr` declared as private
-   | help: consider adding `pub` in front of it
+   | ------------ `PrivTr` declared as private
 ...
 LL |     type Alias2 = Box<dyn PrivTr>;
    |     ^^^^^^^^^^^ can't leak private trait
+   |
+help: consider adding `pub` in front of it
+   |
+LL | pub {}
+   | ~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0446.stderr
+++ b/tests/ui/error-codes/E0446.stderr
@@ -2,7 +2,10 @@ error[E0446]: private type `Bar` in public interface
   --> $DIR/E0446.rs:10:5
    |
 LL | struct Bar;
-   | ---------- `Bar` declared as private
+   | ----------
+   | |
+   | `Bar` declared as private
+   | help: consider adding `pub` in front of it
 ...
 LL |     type Alias1 = Bar;
    |     ^^^^^^^^^^^ can't leak private type
@@ -11,7 +14,10 @@ error[E0446]: private trait `PrivTr` in public interface
   --> $DIR/E0446.rs:11:5
    |
 LL | trait PrivTr {}
-   | ------------ `PrivTr` declared as private
+   | ------------
+   | |
+   | `PrivTr` declared as private
+   | help: consider adding `pub` in front of it
 ...
 LL |     type Alias2 = Box<dyn PrivTr>;
    |     ^^^^^^^^^^^ can't leak private trait

--- a/tests/ui/privacy/issue-30079.stderr
+++ b/tests/ui/privacy/issue-30079.stderr
@@ -15,7 +15,10 @@ error[E0446]: private type `m2::Priv` in public interface
   --> $DIR/issue-30079.rs:17:9
    |
 LL |     struct Priv;
-   |     ----------- `m2::Priv` declared as private
+   |     -----------
+   |     |
+   |     `m2::Priv` declared as private
+   |     help: consider adding `pub` in front of it
 LL |     impl ::std::ops::Deref for ::SemiPriv {
 LL |         type Target = Priv;
    |         ^^^^^^^^^^^ can't leak private type
@@ -24,7 +27,10 @@ error[E0446]: private type `m3::Priv` in public interface
   --> $DIR/issue-30079.rs:34:9
    |
 LL |     struct Priv;
-   |     ----------- `m3::Priv` declared as private
+   |     -----------
+   |     |
+   |     `m3::Priv` declared as private
+   |     help: consider adding `pub` in front of it
 LL |     impl ::SemiPrivTrait for () {
 LL |         type Assoc = Priv;
    |         ^^^^^^^^^^ can't leak private type

--- a/tests/ui/privacy/issue-30079.stderr
+++ b/tests/ui/privacy/issue-30079.stderr
@@ -15,25 +15,29 @@ error[E0446]: private type `m2::Priv` in public interface
   --> $DIR/issue-30079.rs:17:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `m2::Priv` declared as private
-   |     help: consider adding `pub(crate)` in front of it
+   |     ----------- `m2::Priv` declared as private
 LL |     impl ::std::ops::Deref for ::SemiPriv {
 LL |         type Target = Priv;
    |         ^^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub(crate)` in front of it
+   |
+LL |     pub(crate);
+   |     ~~~~~~~~~~
 
 error[E0446]: private type `m3::Priv` in public interface
   --> $DIR/issue-30079.rs:34:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `m3::Priv` declared as private
-   |     help: consider adding `pub(crate)` in front of it
+   |     ----------- `m3::Priv` declared as private
 LL |     impl ::SemiPrivTrait for () {
 LL |         type Assoc = Priv;
    |         ^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub(crate)` in front of it
+   |
+LL |     pub(crate);
+   |     ~~~~~~~~~~
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/privacy/issue-30079.stderr
+++ b/tests/ui/privacy/issue-30079.stderr
@@ -18,7 +18,7 @@ LL |     struct Priv;
    |     -----------
    |     |
    |     `m2::Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     help: consider adding `pub(crate)` in front of it
 LL |     impl ::std::ops::Deref for ::SemiPriv {
 LL |         type Target = Priv;
    |         ^^^^^^^^^^^ can't leak private type
@@ -30,7 +30,7 @@ LL |     struct Priv;
    |     -----------
    |     |
    |     `m3::Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     help: consider adding `pub(crate)` in front of it
 LL |     impl ::SemiPrivTrait for () {
 LL |         type Assoc = Priv;
    |         ^^^^^^^^^^ can't leak private type

--- a/tests/ui/privacy/private-in-public-assoc-ty.stderr
+++ b/tests/ui/privacy/private-in-public-assoc-ty.stderr
@@ -75,7 +75,10 @@ error[E0446]: private trait `PrivTr` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:41:9
    |
 LL |     trait PrivTr {}
-   |     ------------ `PrivTr` declared as private
+   |     ------------
+   |     |
+   |     `PrivTr` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Exist = impl PrivTr;
    |         ^^^^^^^^^^ can't leak private trait

--- a/tests/ui/privacy/private-in-public-assoc-ty.stderr
+++ b/tests/ui/privacy/private-in-public-assoc-ty.stderr
@@ -2,13 +2,15 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:17:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `Priv` declared as private
 ...
 LL |         type A = Priv;
    |         ^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 warning: trait `PrivTr` is more private than the item `PubTr::Alias1`
   --> $DIR/private-in-public-assoc-ty.rs:24:9
@@ -51,37 +53,43 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:31:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `Priv` declared as private
 ...
 LL |         type Alias4 = Priv;
    |         ^^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:38:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `Priv` declared as private
 ...
 LL |         type Alias1 = Priv;
    |         ^^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error[E0446]: private trait `PrivTr` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:41:9
    |
 LL |     trait PrivTr {}
-   |     ------------
-   |     |
-   |     `PrivTr` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ------------ `PrivTr` declared as private
 ...
 LL |         type Exist = impl PrivTr;
    |         ^^^^^^^^^^ can't leak private trait
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub {}
+   |     ~~~
 
 error: aborting due to 4 previous errors; 3 warnings emitted
 

--- a/tests/ui/privacy/private-in-public-assoc-ty.stderr
+++ b/tests/ui/privacy/private-in-public-assoc-ty.stderr
@@ -2,7 +2,10 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:17:9
    |
 LL |     struct Priv;
-   |     ----------- `Priv` declared as private
+   |     -----------
+   |     |
+   |     `Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type A = Priv;
    |         ^^^^^^ can't leak private type
@@ -48,7 +51,10 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:31:9
    |
 LL |     struct Priv;
-   |     ----------- `Priv` declared as private
+   |     -----------
+   |     |
+   |     `Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Alias4 = Priv;
    |         ^^^^^^^^^^^ can't leak private type
@@ -57,7 +63,10 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:38:9
    |
 LL |     struct Priv;
-   |     ----------- `Priv` declared as private
+   |     -----------
+   |     |
+   |     `Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Alias1 = Priv;
    |         ^^^^^^^^^^^ can't leak private type

--- a/tests/ui/privacy/private-in-public-warn.stderr
+++ b/tests/ui/privacy/private-in-public-warn.stderr
@@ -55,7 +55,10 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:22:9
    |
 LL |     struct Priv;
-   |     ----------- `types::Priv` declared as private
+   |     -----------
+   |     |
+   |     `types::Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Alias = Priv;
    |         ^^^^^^^^^^ can't leak private type
@@ -124,7 +127,10 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:32:9
    |
 LL |     struct Priv;
-   |     ----------- `types::Priv` declared as private
+   |     -----------
+   |     |
+   |     `types::Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Alias = Priv;
    |         ^^^^^^^^^^ can't leak private type
@@ -306,7 +312,10 @@ error[E0446]: private type `impls::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:109:9
    |
 LL |     struct Priv;
-   |     ----------- `impls::Priv` declared as private
+   |     -----------
+   |     |
+   |     `impls::Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Alias = Priv;
    |         ^^^^^^^^^^ can't leak private type
@@ -327,7 +336,10 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:183:9
    |
 LL |     struct Priv;
-   |     ----------- `aliases_pub::Priv` declared as private
+   |     -----------
+   |     |
+   |     `aliases_pub::Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type
@@ -336,7 +348,10 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:186:9
    |
 LL |     struct Priv;
-   |     ----------- `aliases_pub::Priv` declared as private
+   |     -----------
+   |     |
+   |     `aliases_pub::Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type
@@ -345,7 +360,10 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:189:9
    |
 LL |     struct Priv;
-   |     ----------- `aliases_pub::Priv` declared as private
+   |     -----------
+   |     |
+   |     `aliases_pub::Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type
@@ -354,7 +372,10 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:192:9
    |
 LL |     struct Priv;
-   |     ----------- `aliases_pub::Priv` declared as private
+   |     -----------
+   |     |
+   |     `aliases_pub::Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type

--- a/tests/ui/privacy/private-in-public-warn.stderr
+++ b/tests/ui/privacy/private-in-public-warn.stderr
@@ -55,13 +55,15 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:22:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `types::Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `types::Priv` declared as private
 ...
 LL |         type Alias = Priv;
    |         ^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error: type `types::Priv` is more private than the item `Tr::f1`
   --> $DIR/private-in-public-warn.rs:23:9
@@ -127,13 +129,15 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:32:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `types::Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `types::Priv` declared as private
 ...
 LL |         type Alias = Priv;
    |         ^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error: trait `traits::PrivTr` is more private than the item `traits::Alias`
   --> $DIR/private-in-public-warn.rs:41:5
@@ -312,13 +316,15 @@ error[E0446]: private type `impls::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:109:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `impls::Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `impls::Priv` declared as private
 ...
 LL |         type Alias = Priv;
    |         ^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error: type `aliases_pub::Priv` is more private than the item `aliases_pub::<impl Pub2>::f`
   --> $DIR/private-in-public-warn.rs:180:9
@@ -336,49 +342,57 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:183:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `aliases_pub::Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `aliases_pub::Priv` declared as private
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:186:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `aliases_pub::Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `aliases_pub::Priv` declared as private
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:189:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `aliases_pub::Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `aliases_pub::Priv` declared as private
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:192:9
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `aliases_pub::Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `aliases_pub::Priv` declared as private
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error: trait `PrivTr1` is more private than the item `aliases_priv::Tr1`
   --> $DIR/private-in-public-warn.rs:222:5

--- a/tests/ui/privacy/private-inferred-type.stderr
+++ b/tests/ui/privacy/private-inferred-type.stderr
@@ -2,7 +2,10 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-inferred-type.rs:61:36
    |
 LL |     struct Priv;
-   |     ----------- `Priv` declared as private
+   |     -----------
+   |     |
+   |     `Priv` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |     impl TraitWithAssocTy for u8 { type AssocTy = Priv; }
    |                                    ^^^^^^^^^^^^ can't leak private type
@@ -11,7 +14,10 @@ error[E0446]: private type `S2` in public interface
   --> $DIR/private-inferred-type.rs:83:9
    |
 LL |     struct S2;
-   |     --------- `S2` declared as private
+   |     ---------
+   |     |
+   |     `S2` declared as private
+   |     help: consider adding `pub` in front of it
 ...
 LL |         type Target = S2Alias;
    |         ^^^^^^^^^^^ can't leak private type

--- a/tests/ui/privacy/private-inferred-type.stderr
+++ b/tests/ui/privacy/private-inferred-type.stderr
@@ -2,25 +2,29 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-inferred-type.rs:61:36
    |
 LL |     struct Priv;
-   |     -----------
-   |     |
-   |     `Priv` declared as private
-   |     help: consider adding `pub` in front of it
+   |     ----------- `Priv` declared as private
 ...
 LL |     impl TraitWithAssocTy for u8 { type AssocTy = Priv; }
    |                                    ^^^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error[E0446]: private type `S2` in public interface
   --> $DIR/private-inferred-type.rs:83:9
    |
 LL |     struct S2;
-   |     ---------
-   |     |
-   |     `S2` declared as private
-   |     help: consider adding `pub` in front of it
+   |     --------- `S2` declared as private
 ...
 LL |         type Target = S2Alias;
    |         ^^^^^^^^^^^ can't leak private type
+   |
+help: consider adding `pub` in front of it
+   |
+LL |     pub;
+   |     ~~~
 
 error: type `Priv` is private
   --> $DIR/private-inferred-type.rs:97:9

--- a/tests/ui/privacy/where-priv-type.stderr
+++ b/tests/ui/privacy/where-priv-type.stderr
@@ -75,7 +75,10 @@ LL |     type AssocTy = Const<{ my_const_fn(U) }>;
    |     ^^^^^^^^^^^^ can't leak private type
 ...
 LL | const fn my_const_fn(val: u8) -> u8 {
-   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   | -----------------------------------
+   | |
+   | `fn(u8) -> u8 {my_const_fn}` declared as private
+   | help: consider adding `pub` in front of it
 
 error: aborting due to 1 previous error; 5 warnings emitted
 

--- a/tests/ui/privacy/where-priv-type.stderr
+++ b/tests/ui/privacy/where-priv-type.stderr
@@ -75,10 +75,12 @@ LL |     type AssocTy = Const<{ my_const_fn(U) }>;
    |     ^^^^^^^^^^^^ can't leak private type
 ...
 LL | const fn my_const_fn(val: u8) -> u8 {
-   | -----------------------------------
-   | |
-   | `fn(u8) -> u8 {my_const_fn}` declared as private
-   | help: consider adding `pub` in front of it
+   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   |
+help: consider adding `pub` in front of it
+   |
+LL | pub {
+   | ~~~
 
 error: aborting due to 1 previous error; 5 warnings emitted
 


### PR DESCRIPTION
This modifies the original #112540 by @aryan-debug to fix #112284

This PR introduces a new field `vis_sugg` to suggest the proper visibility for the error.

TODO:   What should the `TODO` values be here?  Note that not a single test anywhere has used these `???TODO???` values, so it is unclear how they can be generated.  Maybe this whole match should be simplified to map `Restricted(_) => "pub(crate)"` ?

```rust
let vis_sugg = match self.required_visibility {
    ty::Visibility::Public => "pub",
    ty::Visibility::Restricted(vis_def_id) => {
        if vis_def_id == self.tcx.parent_module(hir_id) {
            "???TODO???"
        } else if vis_def_id.is_top_level_module() {
            "pub(crate)"
        } else {
            "???TODO???"
        }
    }
};
```