### PR TITLE
[experiment] `-Ztrait-solver=next-coherence` but hacks that make things not fail anymore

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -843,7 +843,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(thir_unsafeck, true);
     tracked!(tiny_const_eval_limit, true);
     tracked!(tls_model, Some(TlsModel::GeneralDynamic));
-    tracked!(trait_solver, TraitSolver::NextCoherence);
+    tracked!(trait_solver, TraitSolver::Next);
     tracked!(translate_remapped_path_to_local_path, false);
     tracked!(trap_unreachable, Some(false));
     tracked!(treat_err_as_bug, NonZeroUsize::new(1));

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -989,7 +989,7 @@ mod parse {
             Some("next") => *slot = TraitSolver::Next,
             Some("next-coherence") => *slot = TraitSolver::NextCoherence,
             // default trait solver is subject to change..
-            Some("default") => *slot = TraitSolver::Classic,
+            Some("default") => *slot = TraitSolver::NextCoherence,
             _ => return false,
         }
         true
@@ -1817,8 +1817,8 @@ written to standard error output)"),
         "for every macro invocation, print its name and arguments (default: no)"),
     track_diagnostics: bool = (false, parse_bool, [UNTRACKED],
         "tracks where in rustc a diagnostic was emitted"),
-    trait_solver: TraitSolver = (TraitSolver::Classic, parse_trait_solver, [TRACKED],
-        "specify the trait solver mode used by rustc (default: classic)"),
+    trait_solver: TraitSolver = (TraitSolver::NextCoherence, parse_trait_solver, [TRACKED],
+        "specify the trait solver mode used by rustc (default: next-coherence)"),
     // Diagnostics are considered side-effects of a query (see `QuerySideEffects`) and are saved
     // alongside query results and changes to translation options can affect diagnostics - so
     // translation options should be tracked.

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt.rs
@@ -373,6 +373,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
             && has_changed
             && is_normalizes_to_hack == IsNormalizesToHack::No
             && !self.search_graph.in_cycle()
+            && false
         {
             debug!("rerunning goal to check result is stable");
             let (_orig_values, canonical_goal) = self.canonicalize_goal(goal);

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -89,7 +89,12 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
         let mut errors = Vec::new();
         for i in 0.. {
             if !infcx.tcx.recursion_limit().value_within_limit(i) {
-                unimplemented!("overflowed on pending obligations: {:?}", self.obligations);
+                let obligation = self.obligations.first().cloned().unwrap();
+                return vec![FulfillmentError {
+                    root_obligation: obligation.clone(),
+                    obligation,
+                    code: FulfillmentErrorCode::CodeAmbiguity { overflow: true },
+                }];
             }
 
             let mut has_changed = false;

--- a/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
@@ -9,9 +9,8 @@ use cache::ProvisionalCache;
 use overflow::OverflowData;
 use rustc_index::IndexVec;
 use rustc_middle::dep_graph::DepKind;
-use rustc_middle::traits::solve::{
-    CanonicalInput, Certainty, EvaluationCache, MaybeCause, QueryResult,
-};
+use rustc_middle::traits::query::NoSolution;
+use rustc_middle::traits::solve::{CanonicalInput, Certainty, EvaluationCache, QueryResult};
 use rustc_middle::ty::TyCtxt;
 use std::{collections::hash_map::Entry, mem};
 
@@ -146,11 +145,7 @@ impl<'tcx> SearchGraph<'tcx> {
                 {
                     Err(cache.provisional_result(entry_index))
                 } else {
-                    Err(super::response_no_constraints(
-                        tcx,
-                        input,
-                        Certainty::Maybe(MaybeCause::Overflow),
-                    ))
+                    Err(Err(NoSolution))
                 }
             }
         }


### PR DESCRIPTION
i am not endorsing this, just checking how many of these failures are due to inductive cycles being treated as ["may not apply"](https://github.com/rust-lang/rust/blob/8771282d4e7a5c4569e49d1f878fb3ba90a974d0/compiler/rustc_middle/src/traits/select.rs#L276) 06409c806e58432eb6a4398792e924a693a4a6b0.

also skipping aliases in `assemble_coherence_unknowable_candidates` (let's just try the self type first, 57443cdd353eeb27dfb4d9955a0c63ae0f3cc63c)

r? @ghost