### PR TITLE
arm-none fixups

### DIFF
--- a/compiler/rustc_target/src/spec/armebv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armebv7r_none_eabi.rs
@@ -5,7 +5,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, Targ
 
 pub fn target() -> Target {
     Target {
-        llvm_target: "armebv7r-unknown-none-eabi".into(),
+        llvm_target: "armebv7r-none-eabi".into(),
         pointer_width: 32,
         data_layout: "E-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: "arm".into(),

--- a/compiler/rustc_target/src/spec/armebv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armebv7r_none_eabi.rs
@@ -18,7 +18,7 @@ pub fn target() -> Target {
             panic_strategy: PanicStrategy::Abort,
             max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
-            // GCC and Clang default to 8 for arm-none here
+            // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
             ..Default::default()
         },

--- a/compiler/rustc_target/src/spec/armebv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armebv7r_none_eabihf.rs
@@ -19,7 +19,7 @@ pub fn target() -> Target {
             features: "+vfp3,-d32,-fp16".into(),
             max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
-            // GCC and Clang default to 8 for arm-none here
+            // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
             ..Default::default()
         },

--- a/compiler/rustc_target/src/spec/armebv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armebv7r_none_eabihf.rs
@@ -5,7 +5,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, Targ
 
 pub fn target() -> Target {
     Target {
-        llvm_target: "armebv7r-unknown-none-eabihf".into(),
+        llvm_target: "armebv7r-none-eabihf".into(),
         pointer_width: 32,
         data_layout: "E-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: "arm".into(),

--- a/compiler/rustc_target/src/spec/armv4t_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv4t_none_eabi.rs
@@ -39,9 +39,9 @@ pub fn target() -> Target {
             has_thumb_interworking: true,
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
-            // from thumb_base, rust-lang/rust#44993.
+            // From thumb_base, rust-lang/rust#44993.
             emit_debug_gdb_scripts: false,
-            // from thumb_base, apparently gcc/clang give enums a minimum of 8 bits on no-os targets
+            // From thumb_base, GCC gives enums a minimum of 8 bits on no-os targets.
             c_enum_min_bits: Some(8),
             ..Default::default()
         },

--- a/compiler/rustc_target/src/spec/armv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7a_none_eabihf.rs
@@ -18,7 +18,7 @@ pub fn target() -> Target {
         max_atomic_width: Some(64),
         panic_strategy: PanicStrategy::Abort,
         emit_debug_gdb_scripts: false,
-        // GCC and Clang default to 8 for arm-none here
+        // GCC defaults to 8 for arm-none here.
         c_enum_min_bits: Some(8),
         ..Default::default()
     };

--- a/compiler/rustc_target/src/spec/armv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv7r_none_eabi.rs
@@ -17,7 +17,7 @@ pub fn target() -> Target {
             panic_strategy: PanicStrategy::Abort,
             max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
-            // GCC and Clang default to 8 for arm-none here
+            // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
             ..Default::default()
         },

--- a/compiler/rustc_target/src/spec/armv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv7r_none_eabi.rs
@@ -4,7 +4,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, Targ
 
 pub fn target() -> Target {
     Target {
-        llvm_target: "armv7r-unknown-none-eabi".into(),
+        llvm_target: "armv7r-none-eabi".into(),
         pointer_width: 32,
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: "arm".into(),

--- a/compiler/rustc_target/src/spec/armv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7r_none_eabihf.rs
@@ -4,7 +4,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, Targ
 
 pub fn target() -> Target {
     Target {
-        llvm_target: "armv7r-unknown-none-eabihf".into(),
+        llvm_target: "armv7r-none-eabihf".into(),
         pointer_width: 32,
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: "arm".into(),

--- a/compiler/rustc_target/src/spec/armv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7r_none_eabihf.rs
@@ -18,7 +18,7 @@ pub fn target() -> Target {
             features: "+vfp3,-d32,-fp16".into(),
             max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
-            // GCC and Clang default to 8 for arm-none here
+            // GCC defaults to 8 for arm-none here.
             c_enum_min_bits: Some(8),
             ..Default::default()
         },

--- a/compiler/rustc_target/src/spec/thumb_base.rs
+++ b/compiler/rustc_target/src/spec/thumb_base.rs
@@ -52,7 +52,7 @@ pub fn opts() -> TargetOptions {
         // breaks debugging. Preserve LR by default to prevent that from happening.
         frame_pointer: FramePointer::Always,
         // ARM supports multiple ABIs for enums, the linux one matches the default of 32 here
-        // but any arm-none or thumb-none target will be defaulted to 8 on GCC and clang
+        // but any arm-none or thumb-none target will be defaulted to 8 on GCC.
         c_enum_min_bits: Some(8),
         ..Default::default()
     }

--- a/compiler/rustc_target/src/spec/thumbv4t_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/thumbv4t_none_eabi.rs
@@ -45,8 +45,6 @@ pub fn target() -> Target {
             relocation_model: RelocModel::Static,
             // suggested from thumb_base, rust-lang/rust#44993.
             emit_debug_gdb_scripts: false,
-            // suggested from thumb_base, with no-os gcc/clang use 8-bit enums
-            c_enum_min_bits: Some(8),
             frame_pointer: FramePointer::MayOmit,
 
             main_needs_argc_argv: false,


### PR DESCRIPTION
- Remove "-unknown" from `llvm_target` for arm\*v7r-none-eabi\* targets.
- Remove redundant `c_enum_min_bits` option from the thumbv4t-none-eabi target.
- Fix comments about GCC/Clang's enum width for arm-none targets.

Previously part of #110482, which is a larger change to add a new target.
These nits were found along the way.
