### PR TITLE
Define CMAKE_SYSTEM_NAME on a cross build targeting DragonFly.

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/112931
+Last change is for: https://github.com/rust-lang/rust/pull/113996

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -559,6 +559,8 @@ fn configure_cmake(
 
         if target.contains("netbsd") {
             cfg.define("CMAKE_SYSTEM_NAME", "NetBSD");
+        } else if target.contains("dragonfly") {
+            cfg.define("CMAKE_SYSTEM_NAME", "DragonFly");
         } else if target.contains("freebsd") {
             cfg.define("CMAKE_SYSTEM_NAME", "FreeBSD");
         } else if target.contains("windows") {
@@ -569,7 +571,12 @@ fn configure_cmake(
             cfg.define("CMAKE_SYSTEM_NAME", "SunOS");
         } else if target.contains("linux") {
             cfg.define("CMAKE_SYSTEM_NAME", "Linux");
+        } else {
+            builder.info(
+                "could not determine CMAKE_SYSTEM_NAME from the target `{target}`, build may fail",
+            );
         }
+
         // When cross-compiling we should also set CMAKE_SYSTEM_VERSION, but in
         // that case like CMake we cannot easily determine system version either.
         //


### PR DESCRIPTION
Without `CMAKE_SYSTEM_NAME` set to the target  a cross compile will generally fail.  Related to #109170.