### PR TITLE
compiler: be more clear about transparent layout violations

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0690.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0690.md
@@ -5,8 +5,8 @@ Erroneous code example:
 
 ```compile_fail,E0690
 #[repr(transparent)]
-struct LengthWithUnit<U> { // error: transparent struct needs at most one
-    value: f32,            //        non-zero-sized field, but has 2
+struct LengthWithUnit<U> { // error: transparent struct needs at most one field
+    value: f32,            //        with non-trivial layout, but has 2
     unit: U,
 }
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0690.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0690.md
@@ -1,5 +1,5 @@
 A struct with the representation hint `repr(transparent)` had two or more fields
-that were not guaranteed to be zero-sized.
+that were not guaranteed to be zero-sized or have an alignment of 1.
 
 Erroneous code example:
 
@@ -17,7 +17,8 @@ it is not clear how the struct should be represented.
 Note that fields of zero-sized types (e.g., `PhantomData`) can also exist
 alongside the field that contains the actual data, they do not count for this
 error. When generic types are involved (as in the above example), an error is
-reported because the type parameter could be non-zero-sized.
+reported because the type parameter could be non-zero-sized, or it could raise
+the alignment requirements of the type.
 
 To combine `repr(transparent)` with type parameters, `PhantomData` may be
 useful:

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -270,13 +270,15 @@ hir_analysis_transparent_enum_variant = transparent enum needs exactly one varia
     .many_label = too many variants in `{$path}`
     .multi_label = variant here
 
-hir_analysis_transparent_non_zero_sized = transparent {$desc} needs at most one non-zero-sized field, but has {$field_count}
-    .label = needs at most one non-zero-sized field, but has {$field_count}
-    .labels = this field is non-zero-sized
+hir_analysis_transparent_layout = transparent {$desc} needs at most one field of non-zero size or alignment larger than 1, but has {$field_count}
+    .label = needs at most one field of non-zero size or alignment larger than 1, but has {$field_count}
+    .non_layout_labels = this field may have an alignment larger than 1
+    .non_zst_labels = this field is non-zero-sized
 
-hir_analysis_transparent_non_zero_sized_enum = the variant of a transparent {$desc} needs at most one non-zero-sized field, but has {$field_count}
-    .label = needs at most one non-zero-sized field, but has {$field_count}
-    .labels = this field is non-zero-sized
+hir_analysis_transparent_layout_enum = the variant of a transparent {$desc} needs at most one field of non-zero size or alignment larger than 1, but has {$field_count}
+    .label = needs at most one field of non-zero size or alignment larger than 1, but has {$field_count}
+    .non_layout_labels = this field may have an alignment larger than 1
+    .non_zst_labels = this field is non-zero-sized
 
 hir_analysis_typeof_reserved_keyword_used =
     `typeof` is a reserved keyword but unimplemented

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -270,15 +270,17 @@ hir_analysis_transparent_enum_variant = transparent enum needs exactly one varia
     .many_label = too many variants in `{$path}`
     .multi_label = variant here
 
-hir_analysis_transparent_layout = transparent {$desc} needs at most one field of non-zero size or alignment larger than 1, but has {$field_count}
-    .label = needs at most one field of non-zero size or alignment larger than 1, but has {$field_count}
+hir_analysis_transparent_layout = transparent {$desc} needs at most one field with non-trivial layout, but has {$field_count}
+    .label = needs at most one field with non-trivial layout, but has {$field_count}
     .non_layout_labels = this field may have an alignment larger than 1
     .non_zst_labels = this field is non-zero-sized
+    .note = a layout is trivial if, any only if, it is zero-sized with an alignment of 1
 
-hir_analysis_transparent_layout_enum = the variant of a transparent {$desc} needs at most one field of non-zero size or alignment larger than 1, but has {$field_count}
-    .label = needs at most one field of non-zero size or alignment larger than 1, but has {$field_count}
+hir_analysis_transparent_layout_enum = the variant of a transparent {$desc} needs at most one field with non-trivial layout, but has {$field_count}
+    .label = needs at most one field with non-trivial layout, but has {$field_count}
     .non_layout_labels = this field may have an alignment larger than 1
     .non_zst_labels = this field is non-zero-sized
+    .note = a layout is trivial if, any only if, it is zero-sized with an alignment of 1
 
 hir_analysis_typeof_reserved_keyword_used =
     `typeof` is a reserved keyword but unimplemented

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1130,7 +1130,7 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
         return;
     }
 
-    // For each field, figure out if it's known to be a ZST and align(1), with "known"
+    // For each field, figure out if it's known to be a ZST with layout, with "known"
     // respecting #[non_exhaustive] attributes.
     let field_infos = adt.all_fields().map(|field| {
         let ty = field.ty(tcx, GenericArgs::identity_for_item(tcx, field.did));
@@ -1139,9 +1139,8 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
         // We are currently checking the type this field came from, so it must be local
         let span = tcx.hir().span_if_local(field.did).unwrap();
         let zst = layout.is_ok_and(|layout| layout.is_zst());
-        let align = layout.ok().map(|layout| layout.align.abi.bytes());
         if !zst {
-            return (span, zst, align, None);
+            return (span, zst, layout, None);
         }
 
         fn check_non_exhaustive<'tcx>(
@@ -1176,12 +1175,12 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
             }
         }
 
-        (span, zst, align, check_non_exhaustive(tcx, ty).break_value())
+        (span, zst, layout, check_non_exhaustive(tcx, ty).break_value())
     });
 
     let non_zst_fields = field_infos
         .clone()
-        .filter_map(|(span, zst, _align, _non_exhaustive)| if !zst { Some(span) } else { None });
+        .filter_map(|(span, zst, _layout, _non_exhaustive)| if !zst { Some(span) } else { None });
     let non_zst_count = non_zst_fields.clone().count();
     if non_zst_count >= 2 {
         bad_non_zero_sized_fields(tcx, adt, non_zst_count, non_zst_fields, tcx.def_span(adt.did()));
@@ -1189,7 +1188,8 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
     let incompatible_zst_fields =
         field_infos.clone().filter(|(_, _, _, opt)| opt.is_some()).count();
     let incompat = incompatible_zst_fields + non_zst_count >= 2 && non_zst_count < 2;
-    for (span, zst, align, non_exhaustive) in field_infos {
+    for (span, zst, layout, non_exhaustive) in field_infos {
+        let align = layout.ok().map(|layout| layout.align.abi.bytes());
         if zst && align != Some(1) {
             let mut err = struct_span_err!(
                 tcx.sess,

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -516,7 +516,7 @@ fn bad_variant_count<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>, sp: Span, d
     });
 }
 
-/// Emit an error when encountering two or more fields without layout or non-zero size
+/// Emit an error when encountering two or more fields with non-trivial layout
 /// in a transparent Adt.
 fn bad_transparent_layout<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -533,6 +533,7 @@ fn bad_transparent_layout<'tcx>(
             non_zst_spans: non_zst_spans.collect(),
             field_count,
             desc: adt.descr(),
+            note: (),
         });
     } else {
         tcx.sess.emit_err(errors::TransparentLayout {
@@ -541,6 +542,7 @@ fn bad_transparent_layout<'tcx>(
             non_zst_spans: non_zst_spans.collect(),
             field_count,
             desc: adt.descr(),
+            note: (),
         });
     }
 }

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -516,26 +516,29 @@ fn bad_variant_count<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>, sp: Span, d
     });
 }
 
-/// Emit an error when encountering two or more non-zero-sized fields in a transparent
-/// enum.
-fn bad_non_zero_sized_fields<'tcx>(
+/// Emit an error when encountering two or more fields without layout or non-zero size
+/// in a transparent Adt.
+fn bad_transparent_layout<'tcx>(
     tcx: TyCtxt<'tcx>,
     adt: ty::AdtDef<'tcx>,
     field_count: usize,
-    field_spans: impl Iterator<Item = Span>,
+    non_layout_spans: impl Iterator<Item = Span>,
+    non_zst_spans: impl Iterator<Item = Span>,
     sp: Span,
 ) {
     if adt.is_enum() {
-        tcx.sess.emit_err(errors::TransparentNonZeroSizedEnum {
+        tcx.sess.emit_err(errors::TransparentLayoutEnum {
             span: sp,
-            spans: field_spans.collect(),
+            non_layout_spans: non_layout_spans.collect(),
+            non_zst_spans: non_zst_spans.collect(),
             field_count,
             desc: adt.descr(),
         });
     } else {
-        tcx.sess.emit_err(errors::TransparentNonZeroSized {
+        tcx.sess.emit_err(errors::TransparentLayout {
             span: sp,
-            spans: field_spans.collect(),
+            non_layout_spans: non_layout_spans.collect(),
+            non_zst_spans: non_zst_spans.collect(),
             field_count,
             desc: adt.descr(),
         });

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -788,6 +788,8 @@ pub(crate) struct TransparentLayoutEnum<'a> {
     pub non_zst_spans: Vec<Span>,
     pub field_count: usize,
     pub desc: &'a str,
+    #[note]
+    pub note: (),
 }
 
 #[derive(Diagnostic)]
@@ -802,6 +804,8 @@ pub(crate) struct TransparentLayout<'a> {
     pub non_zst_spans: Vec<Span>,
     pub field_count: usize,
     pub desc: &'a str,
+    #[note]
+    pub note: (),
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -777,25 +777,29 @@ pub(crate) struct TransparentEnumVariant {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_transparent_non_zero_sized_enum, code = "E0690")]
-pub(crate) struct TransparentNonZeroSizedEnum<'a> {
+#[diag(hir_analysis_transparent_layout_enum, code = "E0690")]
+pub(crate) struct TransparentLayoutEnum<'a> {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(hir_analysis_labels)]
-    pub spans: Vec<Span>,
+    #[label(hir_analysis_non_layout_labels)]
+    pub non_layout_spans: Vec<Span>,
+    #[label(hir_analysis_non_zst_labels)]
+    pub non_zst_spans: Vec<Span>,
     pub field_count: usize,
     pub desc: &'a str,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_transparent_non_zero_sized, code = "E0690")]
-pub(crate) struct TransparentNonZeroSized<'a> {
+#[diag(hir_analysis_transparent_layout, code = "E0690")]
+pub(crate) struct TransparentLayout<'a> {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[label(hir_analysis_labels)]
-    pub spans: Vec<Span>,
+    #[label(hir_analysis_non_layout_labels)]
+    pub non_layout_spans: Vec<Span>,
+    #[label(hir_analysis_non_zst_labels)]
+    pub non_zst_spans: Vec<Span>,
     pub field_count: usize,
     pub desc: &'a str,
 }

--- a/tests/ui/repr/repr-transparent.rs
+++ b/tests/ui/repr/repr-transparent.rs
@@ -24,14 +24,14 @@ struct ContainsZstAndNonZst((), [i32; 2]);
 
 #[repr(transparent)]
 struct MultipleNonZst(u8, u8);
-//~^ ERROR needs at most one field of non-zero size or alignment larger than 1
+//~^ ERROR needs at most one field with non-trivial layout
 
 trait Mirror { type It: ?Sized; }
 impl<T: ?Sized> Mirror for T { type It = Self; }
 
 #[repr(transparent)]
 pub struct StructWithProjection(f32, <f32 as Mirror>::It);
-//~^ ERROR needs at most one field of non-zero size or alignment larger than 1
+//~^ ERROR needs at most one field with non-trivial layout
 
 #[repr(transparent)]
 struct NontrivialAlignZst(u32, [u16; 0]); //~ ERROR alignment larger than 1
@@ -59,7 +59,7 @@ enum UnitFieldEnum {
 enum TooManyFieldsEnum {
     Foo(u32, String),
 }
-//~^^^ ERROR needs at most one field of non-zero size or alignment larger than 1, but has 2
+//~^^^ ERROR needs at most one field with non-trivial layout, but has 2
 
 #[repr(transparent)]
 enum MultipleVariants { //~ ERROR transparent enum needs exactly one variant, but has 2
@@ -87,6 +87,6 @@ union TooManyFields {
     u: u32,
     s: i32
 }
-//~^^^^ ERROR transparent union needs at most one field of non-zero size or alignment larger than 1, but has 2
+//~^^^^ ERROR transparent union needs at most one field with non-trivial layout, but has 2
 
 fn main() {}

--- a/tests/ui/repr/repr-transparent.rs
+++ b/tests/ui/repr/repr-transparent.rs
@@ -23,14 +23,15 @@ struct ContainsMultipleZst(PhantomData<*const i32>, NoFields);
 struct ContainsZstAndNonZst((), [i32; 2]);
 
 #[repr(transparent)]
-struct MultipleNonZst(u8, u8); //~ ERROR needs at most one non-zero-sized field
+struct MultipleNonZst(u8, u8);
+//~^ ERROR needs at most one field of non-zero size or alignment larger than 1
 
 trait Mirror { type It: ?Sized; }
 impl<T: ?Sized> Mirror for T { type It = Self; }
 
 #[repr(transparent)]
 pub struct StructWithProjection(f32, <f32 as Mirror>::It);
-//~^ ERROR needs at most one non-zero-sized field
+//~^ ERROR needs at most one field of non-zero size or alignment larger than 1
 
 #[repr(transparent)]
 struct NontrivialAlignZst(u32, [u16; 0]); //~ ERROR alignment larger than 1
@@ -58,7 +59,7 @@ enum UnitFieldEnum {
 enum TooManyFieldsEnum {
     Foo(u32, String),
 }
-//~^^^ ERROR transparent enum needs at most one non-zero-sized field, but has 2
+//~^^^ ERROR needs at most one field of non-zero size or alignment larger than 1, but has 2
 
 #[repr(transparent)]
 enum MultipleVariants { //~ ERROR transparent enum needs exactly one variant, but has 2
@@ -82,9 +83,10 @@ union UnitUnion {
 }
 
 #[repr(transparent)]
-union TooManyFields { //~ ERROR transparent union needs at most one non-zero-sized field, but has 2
+union TooManyFields {
     u: u32,
     s: i32
 }
+//~^^^^ ERROR transparent union needs at most one field of non-zero size or alignment larger than 1, but has 2
 
 fn main() {}

--- a/tests/ui/repr/repr-transparent.stderr
+++ b/tests/ui/repr/repr-transparent.stderr
@@ -1,35 +1,35 @@
-error[E0690]: transparent struct needs at most one non-zero-sized field, but has 2
+error[E0690]: transparent struct needs at most one field of non-zero size or alignment larger than 1, but has 2
   --> $DIR/repr-transparent.rs:26:1
    |
 LL | struct MultipleNonZst(u8, u8);
    | ^^^^^^^^^^^^^^^^^^^^^ --  -- this field is non-zero-sized
    | |                     |
    | |                     this field is non-zero-sized
-   | needs at most one non-zero-sized field, but has 2
+   | needs at most one field of non-zero size or alignment larger than 1, but has 2
 
-error[E0690]: transparent struct needs at most one non-zero-sized field, but has 2
-  --> $DIR/repr-transparent.rs:32:1
+error[E0690]: transparent struct needs at most one field of non-zero size or alignment larger than 1, but has 2
+  --> $DIR/repr-transparent.rs:33:1
    |
 LL | pub struct StructWithProjection(f32, <f32 as Mirror>::It);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---  ------------------- this field is non-zero-sized
    | |                               |
    | |                               this field is non-zero-sized
-   | needs at most one non-zero-sized field, but has 2
+   | needs at most one field of non-zero size or alignment larger than 1, but has 2
 
 error[E0691]: zero-sized field in transparent struct has alignment larger than 1
-  --> $DIR/repr-transparent.rs:36:32
+  --> $DIR/repr-transparent.rs:37:32
    |
 LL | struct NontrivialAlignZst(u32, [u16; 0]);
    |                                ^^^^^^^^ has alignment of 2, which is larger than 1
 
 error[E0691]: zero-sized field in transparent struct has alignment larger than 1
-  --> $DIR/repr-transparent.rs:42:24
+  --> $DIR/repr-transparent.rs:43:24
    |
 LL | struct GenericAlign<T>(ZstAlign32<T>, u32);
    |                        ^^^^^^^^^^^^^ has alignment of 32, which is larger than 1
 
 error[E0084]: unsupported representation for zero-variant enum
-  --> $DIR/repr-transparent.rs:44:1
+  --> $DIR/repr-transparent.rs:45:1
    |
 LL | #[repr(transparent)]
    | ^^^^^^^^^^^^^^^^^^^^
@@ -37,23 +37,23 @@ LL | enum Void {}
    | --------- zero-variant enum
 
 error[E0731]: transparent enum needs exactly one variant, but has 0
-  --> $DIR/repr-transparent.rs:45:1
+  --> $DIR/repr-transparent.rs:46:1
    |
 LL | enum Void {}
    | ^^^^^^^^^ needs exactly one variant, but has 0
 
-error[E0690]: the variant of a transparent enum needs at most one non-zero-sized field, but has 2
-  --> $DIR/repr-transparent.rs:58:1
+error[E0690]: the variant of a transparent enum needs at most one field of non-zero size or alignment larger than 1, but has 2
+  --> $DIR/repr-transparent.rs:59:1
    |
 LL | enum TooManyFieldsEnum {
-   | ^^^^^^^^^^^^^^^^^^^^^^ needs at most one non-zero-sized field, but has 2
+   | ^^^^^^^^^^^^^^^^^^^^^^ needs at most one field of non-zero size or alignment larger than 1, but has 2
 LL |     Foo(u32, String),
    |         ---  ------ this field is non-zero-sized
    |         |
    |         this field is non-zero-sized
 
 error[E0731]: transparent enum needs exactly one variant, but has 2
-  --> $DIR/repr-transparent.rs:64:1
+  --> $DIR/repr-transparent.rs:65:1
    |
 LL | enum MultipleVariants {
    | ^^^^^^^^^^^^^^^^^^^^^ needs exactly one variant, but has 2
@@ -63,22 +63,22 @@ LL |     Bar,
    |     --- too many variants in `MultipleVariants`
 
 error[E0691]: zero-sized field in transparent enum has alignment larger than 1
-  --> $DIR/repr-transparent.rs:71:14
+  --> $DIR/repr-transparent.rs:72:14
    |
 LL |     Foo(u32, [u16; 0]),
    |              ^^^^^^^^ has alignment of 2, which is larger than 1
 
 error[E0691]: zero-sized field in transparent enum has alignment larger than 1
-  --> $DIR/repr-transparent.rs:76:11
+  --> $DIR/repr-transparent.rs:77:11
    |
 LL |     Foo { bar: ZstAlign32<T>, baz: u32 }
    |           ^^^^^^^^^^^^^^^^^^ has alignment of 32, which is larger than 1
 
-error[E0690]: transparent union needs at most one non-zero-sized field, but has 2
-  --> $DIR/repr-transparent.rs:85:1
+error[E0690]: transparent union needs at most one field of non-zero size or alignment larger than 1, but has 2
+  --> $DIR/repr-transparent.rs:86:1
    |
 LL | union TooManyFields {
-   | ^^^^^^^^^^^^^^^^^^^ needs at most one non-zero-sized field, but has 2
+   | ^^^^^^^^^^^^^^^^^^^ needs at most one field of non-zero size or alignment larger than 1, but has 2
 LL |     u: u32,
    |     ------ this field is non-zero-sized
 LL |     s: i32

--- a/tests/ui/repr/repr-transparent.stderr
+++ b/tests/ui/repr/repr-transparent.stderr
@@ -1,20 +1,24 @@
-error[E0690]: transparent struct needs at most one field of non-zero size or alignment larger than 1, but has 2
+error[E0690]: transparent struct needs at most one field with non-trivial layout, but has 2
   --> $DIR/repr-transparent.rs:26:1
    |
 LL | struct MultipleNonZst(u8, u8);
    | ^^^^^^^^^^^^^^^^^^^^^ --  -- this field is non-zero-sized
    | |                     |
    | |                     this field is non-zero-sized
-   | needs at most one field of non-zero size or alignment larger than 1, but has 2
+   | needs at most one field with non-trivial layout, but has 2
+   |
+   = note: a layout is trivial if, any only if, it is zero-sized with an alignment of 1
 
-error[E0690]: transparent struct needs at most one field of non-zero size or alignment larger than 1, but has 2
+error[E0690]: transparent struct needs at most one field with non-trivial layout, but has 2
   --> $DIR/repr-transparent.rs:33:1
    |
 LL | pub struct StructWithProjection(f32, <f32 as Mirror>::It);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---  ------------------- this field is non-zero-sized
    | |                               |
    | |                               this field is non-zero-sized
-   | needs at most one field of non-zero size or alignment larger than 1, but has 2
+   | needs at most one field with non-trivial layout, but has 2
+   |
+   = note: a layout is trivial if, any only if, it is zero-sized with an alignment of 1
 
 error[E0691]: zero-sized field in transparent struct has alignment larger than 1
   --> $DIR/repr-transparent.rs:37:32
@@ -42,15 +46,17 @@ error[E0731]: transparent enum needs exactly one variant, but has 0
 LL | enum Void {}
    | ^^^^^^^^^ needs exactly one variant, but has 0
 
-error[E0690]: the variant of a transparent enum needs at most one field of non-zero size or alignment larger than 1, but has 2
+error[E0690]: the variant of a transparent enum needs at most one field with non-trivial layout, but has 2
   --> $DIR/repr-transparent.rs:59:1
    |
 LL | enum TooManyFieldsEnum {
-   | ^^^^^^^^^^^^^^^^^^^^^^ needs at most one field of non-zero size or alignment larger than 1, but has 2
+   | ^^^^^^^^^^^^^^^^^^^^^^ needs at most one field with non-trivial layout, but has 2
 LL |     Foo(u32, String),
    |         ---  ------ this field is non-zero-sized
    |         |
    |         this field is non-zero-sized
+   |
+   = note: a layout is trivial if, any only if, it is zero-sized with an alignment of 1
 
 error[E0731]: transparent enum needs exactly one variant, but has 2
   --> $DIR/repr-transparent.rs:65:1
@@ -74,15 +80,17 @@ error[E0691]: zero-sized field in transparent enum has alignment larger than 1
 LL |     Foo { bar: ZstAlign32<T>, baz: u32 }
    |           ^^^^^^^^^^^^^^^^^^ has alignment of 32, which is larger than 1
 
-error[E0690]: transparent union needs at most one field of non-zero size or alignment larger than 1, but has 2
+error[E0690]: transparent union needs at most one field with non-trivial layout, but has 2
   --> $DIR/repr-transparent.rs:86:1
    |
 LL | union TooManyFields {
-   | ^^^^^^^^^^^^^^^^^^^ needs at most one field of non-zero size or alignment larger than 1, but has 2
+   | ^^^^^^^^^^^^^^^^^^^ needs at most one field with non-trivial layout, but has 2
 LL |     u: u32,
    |     ------ this field is non-zero-sized
 LL |     s: i32
    |     ------ this field is non-zero-sized
+   |
+   = note: a layout is trivial if, any only if, it is zero-sized with an alignment of 1
 
 error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Extend the error-messages of rustc to distinguish between non-zero-sized fields and fields without layout when annotating `repr(transparent)` violations.

When compiling `repr(transparent)` structures, the compiler checks that there is at most one field with non-zero size *OR* having unknown layout. However, the error message treats both conditions as the same, thus always annotating them as;

    a: u32,
    ------ this field is non-zero-sized

In most situations, this is reasonable. However, if you consider generic fields, this can easily become confusing. Consider the following error message:

    a: [T; 0],
    --------- this field is non-zero-sized

This field is clearly zero-sized, yet the compiler is correct to refuse it. This is because the field might raise the alignment requirements of the transparent field, thus change the overall layout.

This patch changes the error message to distinguish non-zero-sized fields _with_ known layout from fields with _unknown_ layout. The logic _when_ to emit errors is not changed. Before this patch, it would emit an error when `non_zst_count >= 2` (but `non_zst_count` counted fields without layout *AND* fields with guaranteed non-zero layout). After this patch, `non_zst_count` is changed to only count fields with guaranteed non-zero layout, but `non_layout_count` counts fields without layout. The new `non_transparent_count` is the sum of both and should be equivalent to the previous `non_zst_count`.

Long story short, the new error output looks like this:

    error[E0690]: transparent struct needs at most one field of non-zero size or alignment larger than 1, but has 2
     --> src/foobar.rs:2:1
      |
    2 | struct Test<T: Sized> {
      | ^^^^^^^^^^^^^^^^^^^^^ needs at most one field of non-zero size or alignment larger than 1, but has 2
    3 |     a: u32,
      |     ------ this field is non-zero-sized
    4 |     b: [T; 0],
      |     --------- this field may have alignment larger than 1

Previously, any field without known layout was annotated as "non-zero size", now this is changed to annotate those fields as "may have alignment larger than 1". This is a catch-all that is, to my knowledge, true for all generic fields without layout, since one cannot control their alignment. This might need refinement in the future, when other cases of layout-violation occur.

One might even argue that the entire error-message could be made more generic, ala:

    transparent struct needs at most one field with non-trivial layout

However, I think the current error-message is much more helpful in stating the 2 obvious violations: non-ZST and non-alignment-of-1 Hence, this commit retains the original error-message style and simply extends it with the alignment-violation notice.

Originally reported in: #98064