### PR TITLE
Hide `ToString` implementations that specialize the default one

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2527,6 +2527,7 @@ impl<T: fmt::Display + ?Sized> ToString for T {
     }
 }
 
+#[doc(hidden)]
 #[cfg(not(no_global_oom_handling))]
 #[unstable(feature = "ascii_char", issue = "110998")]
 impl ToString for core::ascii::Char {
@@ -2536,6 +2537,7 @@ impl ToString for core::ascii::Char {
     }
 }
 
+#[doc(hidden)]
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "char_to_string_specialization", since = "1.46.0")]
 impl ToString for char {
@@ -2545,6 +2547,7 @@ impl ToString for char {
     }
 }
 
+#[doc(hidden)]
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "bool_to_string_specialization", since = "1.68.0")]
 impl ToString for bool {
@@ -2554,6 +2557,7 @@ impl ToString for bool {
     }
 }
 
+#[doc(hidden)]
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "u8_to_string_specialization", since = "1.54.0")]
 impl ToString for u8 {
@@ -2574,6 +2578,7 @@ impl ToString for u8 {
     }
 }
 
+#[doc(hidden)]
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "i8_to_string_specialization", since = "1.54.0")]
 impl ToString for i8 {
@@ -2597,6 +2602,7 @@ impl ToString for i8 {
     }
 }
 
+#[doc(hidden)]
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "str_to_string_specialization", since = "1.9.0")]
 impl ToString for str {
@@ -2606,6 +2612,7 @@ impl ToString for str {
     }
 }
 
+#[doc(hidden)]
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "cow_str_to_string_specialization", since = "1.17.0")]
 impl ToString for Cow<'_, str> {
@@ -2615,6 +2622,7 @@ impl ToString for Cow<'_, str> {
     }
 }
 
+#[doc(hidden)]
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "string_to_string_specialization", since = "1.17.0")]
 impl ToString for String {
@@ -2624,6 +2632,7 @@ impl ToString for String {
     }
 }
 
+#[doc(hidden)]
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "fmt_arguments_to_string_specialization", since = "1.71.0")]
 impl ToString for fmt::Arguments<'_> {

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -177,6 +177,7 @@ impl FromStr for TokenStream {
 
 // N.B., the bridge only provides `to_string`, implement `fmt::Display`
 // based on it (the reverse of the usual relationship between the two).
+#[doc(hidden)]
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl ToString for TokenStream {
     fn to_string(&self) -> String {
@@ -738,6 +739,7 @@ impl From<Literal> for TokenTree {
 
 // N.B., the bridge only provides `to_string`, implement `fmt::Display`
 // based on it (the reverse of the usual relationship between the two).
+#[doc(hidden)]
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl ToString for TokenTree {
     fn to_string(&self) -> String {
@@ -872,6 +874,7 @@ impl Group {
 
 // N.B., the bridge only provides `to_string`, implement `fmt::Display`
 // based on it (the reverse of the usual relationship between the two).
+#[doc(hidden)]
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl ToString for Group {
     fn to_string(&self) -> String {
@@ -981,6 +984,7 @@ impl Punct {
     }
 }
 
+#[doc(hidden)]
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl ToString for Punct {
     fn to_string(&self) -> String {
@@ -1083,8 +1087,7 @@ impl Ident {
     }
 }
 
-/// Converts the identifier to a string that should be losslessly convertible
-/// back into the same identifier.
+#[doc(hidden)]
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl ToString for Ident {
     fn to_string(&self) -> String {
@@ -1423,6 +1426,7 @@ impl FromStr for Literal {
     }
 }
 
+#[doc(hidden)]
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl ToString for Literal {
     fn to_string(&self) -> String {


### PR DESCRIPTION
The status quo is highly confusing, since the overlap is not apparent, and specialization is not a feature of Rust. This change addresses #87545; I'm not certain if it closes/fixes it entirely, since that issue might also be tracking the question of a *general* solution for hiding the documentation for specializing impls automatically.

Before
![Screenshot_20230724_234210](https://github.com/rust-lang/rust/assets/3986214/54bbe659-1790-4e95-a5d8-5426e710ceb8)


After
![Screenshot_20230724_234255](https://github.com/rust-lang/rust/assets/3986214/ee645d6e-c1c0-40c0-a0d3-a5c5f3dae65e)
