### PR TITLE
Warn on inductive cycle in coherence leading to impls being considered not overlapping

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4463,7 +4463,10 @@ declare_lint! {
     ///
     /// The manual impl of `PartialEq` impl overlaps with the `derive`, since
     /// if we replace `Q = Interval<T>`, then the second impl leads to a cycle:
-    /// `PartialOrd for Interval<T> where Interval<T>: Partial`.
+    /// `PartialOrd for Interval<T> where Interval<T>: PartialOrd`. This cycle
+    /// currently causes the compiler to consider `Interval<T>: PartialOrd` to not
+    /// hold, causing the two implementations to be disjoint. This will change in
+    /// a future release.
     pub COINDUCTIVE_OVERLAP_IN_COHERENCE,
     Warn,
     "impls that are not considered to overlap may be considered to \

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4431,6 +4431,8 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,compile_fail
+    /// #![deny(coinductive_overlap_in_coherence)]
+    ///
     /// use std::borrow::Borrow;
     /// use std::cmp::Ordering;
     /// use std::marker::PhantomData;

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -238,7 +238,7 @@ pub struct ImplHeader<'tcx> {
     pub impl_def_id: DefId,
     pub self_ty: Ty<'tcx>,
     pub trait_ref: Option<TraitRef<'tcx>>,
-    pub predicates: Vec<Predicate<'tcx>>,
+    pub predicates: Vec<(Predicate<'tcx>, Span)>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, TypeFoldable, TypeVisitable)]

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -741,7 +741,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                 return Ok(EvaluatedToOk);
                             } else {
                                 match self.treat_inductive_cycle {
-                                    TreatInductiveCycleAs::Ambig => return Ok(EvaluatedToAmbig),
+                                    TreatInductiveCycleAs::Ambig => return Ok(EvaluatedToUnknown),
                                     TreatInductiveCycleAs::Recur => return Ok(EvaluatedToRecur),
                                 }
                             }
@@ -862,7 +862,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         }
                         ProjectAndUnifyResult::FailedNormalization => Ok(EvaluatedToAmbig),
                         ProjectAndUnifyResult::Recursive => match self.treat_inductive_cycle {
-                            TreatInductiveCycleAs::Ambig => return Ok(EvaluatedToAmbig),
+                            TreatInductiveCycleAs::Ambig => return Ok(EvaluatedToUnknown),
                             TreatInductiveCycleAs::Recur => return Ok(EvaluatedToRecur),
                         },
                         ProjectAndUnifyResult::MismatchedProjectionTypes(_) => Ok(EvaluatedToErr),
@@ -1179,7 +1179,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             } else {
                 debug!("evaluate_stack --> recursive, inductive");
                 match self.treat_inductive_cycle {
-                    TreatInductiveCycleAs::Ambig => Some(EvaluatedToAmbig),
+                    TreatInductiveCycleAs::Ambig => Some(EvaluatedToUnknown),
                     TreatInductiveCycleAs::Recur => Some(EvaluatedToRecur),
                 }
             }

--- a/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.rs
+++ b/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.rs
@@ -11,7 +11,7 @@ pub(crate) struct Interval<T>(PhantomData<T>);
 // `Interval<?1>: PartialOrd<Interval<?1>>` candidate which results
 // in a - currently inductive - cycle.
 impl<T, Q> PartialEq<Q> for Interval<T>
-//~^ ERROR impls that are not considered to overlap may be considered to overlap in the future
+//~^ ERROR implementations of `PartialEq<Interval<_>>` for `Interval<_>` will conflict in the future
 //~| WARN this was previously accepted by the compiler but is being phased out
 where
     T: Borrow<Q>,

--- a/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.rs
+++ b/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.rs
@@ -1,0 +1,35 @@
+#![deny(coinductive_overlap_in_coherence)]
+
+use std::borrow::Borrow;
+use std::cmp::Ordering;
+use std::marker::PhantomData;
+
+#[derive(PartialEq, Default)]
+pub(crate) struct Interval<T>(PhantomData<T>);
+
+// This impl overlaps with the `derive` unless we reject the nested
+// `Interval<?1>: PartialOrd<Interval<?1>>` candidate which results
+// in an inductive cycle right now.
+impl<T, Q> PartialEq<Q> for Interval<T>
+//~^ ERROR impls that are not considered to overlap may be considered to overlap in the future
+//~| WARN this was previously accepted by the compiler but is being phased out
+where
+    T: Borrow<Q>,
+    Q: ?Sized + PartialOrd,
+{
+    fn eq(&self, _: &Q) -> bool {
+        true
+    }
+}
+
+impl<T, Q> PartialOrd<Q> for Interval<T>
+where
+    T: Borrow<Q>,
+    Q: ?Sized + PartialOrd,
+{
+    fn partial_cmp(&self, _: &Q) -> Option<Ordering> {
+        None
+    }
+}
+
+fn main() {}

--- a/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.rs
+++ b/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.rs
@@ -9,7 +9,7 @@ pub(crate) struct Interval<T>(PhantomData<T>);
 
 // This impl overlaps with the `derive` unless we reject the nested
 // `Interval<?1>: PartialOrd<Interval<?1>>` candidate which results
-// in an inductive cycle right now.
+// in a - currently inductive - cycle.
 impl<T, Q> PartialEq<Q> for Interval<T>
 //~^ ERROR impls that are not considered to overlap may be considered to overlap in the future
 //~| WARN this was previously accepted by the compiler but is being phased out

--- a/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.stderr
+++ b/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.stderr
@@ -1,4 +1,4 @@
-error: impls that are not considered to overlap may be considered to overlap in the future
+error: implementations of `PartialEq<Interval<_>>` for `Interval<_>` will conflict in the future
   --> $DIR/warn-when-cycle-is-error-in-coherence.rs:13:1
    |
 LL | #[derive(PartialEq, Default)]
@@ -8,10 +8,11 @@ LL | impl<T, Q> PartialEq<Q> for Interval<T>
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the first impl is here
 ...
 LL |     Q: ?Sized + PartialOrd,
-   |                 ---------- this where-clause causes a cycle, but it may be treated as possibly holding in the future, causing the impls to overlap
+   |                 ---------- `Interval<_>: PartialOrd` may be considered to hold in future releases, causing the impls to overlap
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #114040 <https://github.com/rust-lang/rust/issues/114040>
+   = note: impls that are not considered to overlap may be considered to overlap in the future
 note: the lint level is defined here
   --> $DIR/warn-when-cycle-is-error-in-coherence.rs:1:9
    |

--- a/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.stderr
+++ b/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.stderr
@@ -1,0 +1,22 @@
+error: impls that are not considered to overlap may be considered to overlap in the future
+  --> $DIR/warn-when-cycle-is-error-in-coherence.rs:13:1
+   |
+LL | #[derive(PartialEq, Default)]
+   |          --------- the second impl is here
+...
+LL | impl<T, Q> PartialEq<Q> for Interval<T>
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the first impl is here
+...
+LL |     Q: ?Sized + PartialOrd,
+   |                 ---------- this where-clause causes a cycle, but it may be treated as possibly holding in the future, causing the impls to overlap
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114040 <https://github.com/rust-lang/rust/issues/114040>
+note: the lint level is defined here
+  --> $DIR/warn-when-cycle-is-error-in-coherence.rs:1:9
+   |
+LL | #![deny(coinductive_overlap_in_coherence)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/traits/issue-105231.rs
+++ b/tests/ui/traits/issue-105231.rs
@@ -1,9 +1,9 @@
-//~ ERROR overflow evaluating the requirement `A<A<A<A<A<A<A<...>>>>>>>: Send`
 struct A<T>(B<T>);
 //~^ ERROR recursive types `A` and `B` have infinite size
 struct B<T>(A<A<T>>);
 trait Foo {}
 impl<T> Foo for T where T: Send {}
+//~^ ERROR overflow evaluating the requirement `A<A<A<A<A<A<A<...>>>>>>>: Send`
 impl Foo for B<u8> {}
 
 fn main() {}

--- a/tests/ui/traits/issue-105231.stderr
+++ b/tests/ui/traits/issue-105231.stderr
@@ -1,5 +1,5 @@
 error[E0072]: recursive types `A` and `B` have infinite size
-  --> $DIR/issue-105231.rs:2:1
+  --> $DIR/issue-105231.rs:1:1
    |
 LL | struct A<T>(B<T>);
    | ^^^^^^^^^^^ ---- recursive without indirection
@@ -15,10 +15,14 @@ LL ~ struct B<T>(Box<A<A<T>>>);
    |
 
 error[E0275]: overflow evaluating the requirement `A<A<A<A<A<A<A<...>>>>>>>: Send`
+  --> $DIR/issue-105231.rs:5:28
+   |
+LL | impl<T> Foo for T where T: Send {}
+   |                            ^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_105231`)
 note: required because it appears within the type `B<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<u8>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`
-  --> $DIR/issue-105231.rs:4:8
+  --> $DIR/issue-105231.rs:3:8
    |
 LL | struct B<T>(A<A<T>>);
    |        ^

--- a/tests/ui/traits/solver-cycles/cycle-via-builtin-auto-trait-impl.rs
+++ b/tests/ui/traits/solver-cycles/cycle-via-builtin-auto-trait-impl.rs
@@ -1,4 +1,3 @@
-//~ ERROR overflow
 // A regression test for #111729 checking that we correctly
 // track recursion depth for obligations returned by confirmation.
 use std::panic::RefUnwindSafe;
@@ -15,6 +14,7 @@ struct RootDatabase {
 }
 
 impl<T: RefUnwindSafe> Database for T {
+    //~^ ERROR overflow
     type Storage = SalsaStorage;
 }
 impl Database for RootDatabase {

--- a/tests/ui/traits/solver-cycles/cycle-via-builtin-auto-trait-impl.stderr
+++ b/tests/ui/traits/solver-cycles/cycle-via-builtin-auto-trait-impl.stderr
@@ -1,13 +1,17 @@
 error[E0275]: overflow evaluating the requirement `Runtime<RootDatabase>: RefUnwindSafe`
+  --> $DIR/cycle-via-builtin-auto-trait-impl.rs:16:9
+   |
+LL | impl<T: RefUnwindSafe> Database for T {
+   |         ^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`cycle_via_builtin_auto_trait_impl`)
 note: required because it appears within the type `RootDatabase`
-  --> $DIR/cycle-via-builtin-auto-trait-impl.rs:13:8
+  --> $DIR/cycle-via-builtin-auto-trait-impl.rs:12:8
    |
 LL | struct RootDatabase {
    |        ^^^^^^^^^^^^
 note: required for `RootDatabase` to implement `Database`
-  --> $DIR/cycle-via-builtin-auto-trait-impl.rs:17:24
+  --> $DIR/cycle-via-builtin-auto-trait-impl.rs:16:24
    |
 LL | impl<T: RefUnwindSafe> Database for T {
    |         -------------  ^^^^^^^^     ^


### PR DESCRIPTION
This PR implements a `coinductive_overlap_in_coherence` lint (#114040), which warns users against cases where two impls are considered **not** to overlap during coherence due to an inductive cycle disproving one of the predicates after unifying the two impls. 

Cases where this lint fires will become an overlap error if we ever move to coinduction, so I'd like to make this a warning to avoid having more crates take advantage of this behavior in the mean time. Also, since the new trait solver treats inductive cycles as ambiguity, not an error, this is a blocker for landing the new trait solver in coherence.