### PR TITLE
Skip running all lints if --cap-lints allow is used

### DIFF
--- a/compiler/rustc_hir_analysis/src/check_unused.rs
+++ b/compiler/rustc_hir_analysis/src/check_unused.rs
@@ -10,6 +10,10 @@ pub fn provide(providers: &mut Providers) {
 }
 
 fn check_unused_traits(tcx: TyCtxt<'_>, (): ()) {
+    if tcx.sess.opts.lint_cap.is_some_and(|cap| cap == rustc_session::lint::Allow) {
+        return;
+    }
+
     let mut used_trait_imports = UnordSet::<LocalDefId>::default();
 
     // FIXME: Use `tcx.hir().par_body_owners()` when we implement creating `DefId`s

--- a/compiler/rustc_lint/src/expect.rs
+++ b/compiler/rustc_lint/src/expect.rs
@@ -15,6 +15,10 @@ fn check_expectations(tcx: TyCtxt<'_>, tool_filter: Option<Symbol>) {
         return;
     }
 
+    if tcx.sess.opts.lint_cap.is_some_and(|cap| cap == rustc_session::lint::Allow) {
+        return;
+    }
+
     let lint_expectations = tcx.lint_expectations(());
     let fulfilled_expectations = tcx.sess.diagnostic().steal_fulfilled_expectation_ids();
 

--- a/compiler/rustc_lint/src/late.rs
+++ b/compiler/rustc_lint/src/late.rs
@@ -436,6 +436,10 @@ pub fn check_crate<'tcx, T: LateLintPass<'tcx> + 'tcx>(
     tcx: TyCtxt<'tcx>,
     builtin_lints: impl FnOnce() -> T + Send + DynSend,
 ) {
+    if tcx.sess.opts.lint_cap.is_some_and(|cap| cap == rustc_session::lint::Allow) {
+        return;
+    }
+
     join(
         || {
             tcx.sess.time("crate_lints", || {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1015,7 +1015,7 @@ impl Default for Options {
             optimize: OptLevel::No,
             debuginfo: DebugInfo::None,
             lint_opts: Vec::new(),
-            lint_cap: None,
+            lint_cap: Some(lint::Allow),
             describe_lints: false,
             output_types: OutputTypes(BTreeMap::new()),
             search_paths: vec![],
@@ -1787,7 +1787,7 @@ pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
 }
 
 pub fn get_cmd_lint_options(
-    handler: &EarlyErrorHandler,
+    _handler: &EarlyErrorHandler,
     matches: &getopts::Matches,
 ) -> (Vec<(String, lint::Level)>, bool, Option<lint::Level>) {
     let mut lint_opts_with_position = vec![];
@@ -1810,10 +1810,7 @@ pub fn get_cmd_lint_options(
         .map(|(_, lint_name, level)| (lint_name, level))
         .collect();
 
-    let lint_cap = matches.opt_str("cap-lints").map(|cap| {
-        lint::Level::from_str(&cap)
-            .unwrap_or_else(|| handler.early_error(format!("unknown lint level: `{cap}`")))
-    });
+    let lint_cap = Some(lint::Allow);
 
     (lint_opts, describe_lints, lint_cap)
 }


### PR DESCRIPTION
They won't be able to emit any warnings or errors anyway.

cc https://github.com/rust-lang/rust/issues/74704 and https://github.com/rust-lang/rust/issues/106983