### PR TITLE
Update cargo

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1085,13 +1085,6 @@ impl Step for Cargo {
         tarball.add_dir(etc.join("man"), "share/man/man1");
         tarball.add_legal_and_readme_to("share/doc/cargo");
 
-        for dirent in fs::read_dir(cargo.parent().unwrap()).expect("read_dir") {
-            let dirent = dirent.expect("read dir entry");
-            if dirent.file_name().to_str().expect("utf8").starts_with("cargo-credential-") {
-                tarball.add_file(&dirent.path(), "libexec", 0o755);
-            }
-        }
-
         Some(tarball.generate())
     }
 }

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -894,19 +894,10 @@ tool_doc!(
         "-p",
         "cargo-credential",
         "-p",
-        "cargo-credential-1password",
-        "-p",
         "mdman",
         // FIXME: this trips a license check in tidy.
         // "-p",
         // "resolver-tests",
-        // FIXME: we should probably document these, but they're different per-platform so we can't use `tool_doc`.
-        // "-p",
-        // "cargo-credential-gnome-secret",
-        // "-p",
-        // "cargo-credential-macos-keychain",
-        // "-p",
-        // "cargo-credential-wincred",
     ]
 );
 tool_doc!(Tidy, "tidy", "src/tools/tidy", rustc_tool = false, ["-p", "tidy"]);

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -558,39 +558,6 @@ impl Step for Cargo {
                 allow_features: "",
             })
             .expect("expected to build -- essential tool");
-
-        let build_cred = |name, path| {
-            // These credential helpers are currently experimental.
-            // Any build failures will be ignored.
-            let _ = builder.ensure(ToolBuild {
-                compiler: self.compiler,
-                target: self.target,
-                tool: name,
-                mode: Mode::ToolRustc,
-                path,
-                is_optional_tool: true,
-                source_type: SourceType::Submodule,
-                extra_features: Vec::new(),
-                allow_features: "",
-            });
-        };
-
-        if self.target.contains("windows") {
-            build_cred(
-                "cargo-credential-wincred",
-                "src/tools/cargo/credential/cargo-credential-wincred",
-            );
-        }
-        if self.target.contains("apple-darwin") {
-            build_cred(
-                "cargo-credential-macos-keychain",
-                "src/tools/cargo/credential/cargo-credential-macos-keychain",
-            );
-        }
-        build_cred(
-            "cargo-credential-1password",
-            "src/tools/cargo/credential/cargo-credential-1password",
-        );
         cargo_bin_path
     }
 }


### PR DESCRIPTION
8 commits in 1b15556767f4b78a64e868eedf4073c423f02b93..7ac9416d82cd4fc5e707c9ec3574d22dff6466e5
2023-07-18 14:44:47 +0000 to 2023-07-24 14:29:38 +0000
- fix(cargo-credential): should enable feature `serde/derive` (rust-lang/cargo#12396)
- fix: encode URL params correctly for SourceId in Cargo.lock (rust-lang/cargo#12280)
- docs: format config override caveat as a note (rust-lang/cargo#12392)
- credential provider implementation (rust-lang/cargo#12334)
- feat(crates-io): expose HTTP headers and Error type (rust-lang/cargo#12310)
- chore: Don't update test data (rust-lang/cargo#12380)
- fix: only skip mtime check on `~/.cargo/{git,registry}` (rust-lang/cargo#12369)
- Update docs for artifact JSON debuginfo levels. (rust-lang/cargo#12376)

Since rust-lang/cargo#12334 makes built-in credential providers part of the cargo binary, it's no longer needed to build them in bootstrap.