### PR TITLE
Explain more clearly why `fn() -> T` can't be `#[derive(Clone)]`

### DIFF
--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -86,6 +86,46 @@
 /// }
 /// ```
 ///
+/// If we `derive`:
+///
+/// ```
+/// #[derive(Copy, Clone)]
+/// struct Generate<T>(fn() -> T);
+/// ```
+///
+/// the auto-derived implementations will have unnecessary `T: Copy` and `T: Clone` bounds:
+///
+/// ```
+/// # struct Generate<T>(fn() -> T);
+///
+/// // Automatically derived
+/// impl<T: Copy> Copy for Generate<T> { }
+///
+/// // Automatically derived
+/// impl<T: Clone> Clone for Generate<T> {
+///     fn clone(&self) -> Generate<T> {
+///         Generate(Clone::clone(&self.0))
+///     }
+/// }
+/// ```
+///
+/// The bounds are unnecessary because clearly the function itself should be
+/// copy- and cloneable even if its return type is not:
+///
+/// ```compile_fail,E0599
+/// #[derive(Copy, Clone)]
+/// struct Generate<T>(fn() -> T);
+///
+/// struct NotCloneable;
+///
+/// fn generate_not_cloneable() -> NotCloneable {
+///     NotCloneable
+/// }
+///
+/// Generate(generate_not_cloneable).clone(); // error: trait bounds were not satisfied
+/// // Note: With the manual implementations the above line will compile.
+/// ```
+///
 /// ## Additional implementors
 ///
 /// In addition to the [implementors listed below][impls],


### PR DESCRIPTION
Closes #73480

The derived impls were generated with `rustc -Z unpretty=expanded main.rs` and the raw output is:

```rust
struct Generate<T>(fn() -> T);
#[automatically_derived]
impl<T: ::core::marker::Copy> ::core::marker::Copy for Generate<T> { }
#[automatically_derived]
impl<T: ::core::clone::Clone> ::core::clone::Clone for Generate<T> {
    #[inline]
    fn clone(&self) -> Generate<T> {
        Generate(::core::clone::Clone::clone(&self.0))
    }
}
```

