### PR TITLE
core library: Disable fpmath tests for i586 ...

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -800,7 +800,7 @@ impl f32 {
     /// let angle = std::f32::consts::PI;
     ///
     /// let abs_difference = (angle.to_degrees() - 180.0).abs();
-    ///
+    /// # #[cfg(any(not(target_arch = "x86"), target_feature = "sse2"))]
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[must_use = "this returns the result of the operation, \


### PR DESCRIPTION
This patch disables the floating-point epsilon test for i586 since x87 registers are too imprecise and can't produce the expected results.