### PR TITLE
Add regression test for invalid "unused const" in method

### DIFF
--- a/tests/ui/lint/unused/const-local-var.rs
+++ b/tests/ui/lint/unused/const-local-var.rs
@@ -1,0 +1,23 @@
+// regression test for https://github.com/rust-lang/rust/issues/69016
+// check-pass
+
+#![warn(unused)]
+#![deny(warnings)]
+
+fn _unused1(x: i32) -> i32 {
+    const F: i32 = 2;
+    let g = 1;
+    x * F + g
+}
+
+pub struct Foo {}
+
+impl Foo {
+    fn _unused2(x: i32) -> i32 {
+        const F: i32 = 2;
+        let g = 1;
+        x * F + g
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
The warning can be reproduced with 1.63 but not with 1.64.

    $ rustc +1.63 tests/ui/lint/unused/const-local-var.rs
    warning: constant `F` is never used
      --> tests/ui/lint/unused/const-local-var.rs:14:9
       |
    14 |         const F: i32 = 2;
       |         ^^^^^^^^^^^^^^^^^
       |
       = note: `#[warn(dead_code)]` on by default
    $ rustc +1.64 tests/ui/lint/unused/const-local-var.rs

Add a regression test to prevent the problem from re-appearing.

Closes #69016