### PR TITLE
Suggest `{Option,Result}::as_ref()` instead of `cloned()` in some cases

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -53,7 +53,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             || self.suggest_no_capture_closure(err, expected, expr_ty)
             || self.suggest_boxing_when_appropriate(err, expr.span, expr.hir_id, expected, expr_ty)
             || self.suggest_block_to_brackets_peeling_refs(err, expr, expr_ty, expected)
-            || self.suggest_copied_or_cloned(err, expr, expr_ty, expected)
+            || self.suggest_copied_cloned_or_as_ref(err, expr, expr_ty, expected, expected_ty_expr)
             || self.suggest_clone_for_ref(err, expr, expr_ty, expected)
             || self.suggest_into(err, expr, expr_ty, expected)
             || self.suggest_floating_point_literal(err, expr, expected)

--- a/tests/ui/associated-types/dont-suggest-cyclic-constraint.fixed
+++ b/tests/ui/associated-types/dont-suggest-cyclic-constraint.fixed
@@ -6,7 +6,7 @@ pub fn foo<I: Iterator>(mut iter: I, value: &I::Item)
 where
     I::Item: Eq + Debug,
 {
-    debug_assert_eq!(iter.next(), Some(value));
+    debug_assert_eq!(iter.next().as_ref(), Some(value));
     //~^ ERROR mismatched types
 }
 

--- a/tests/ui/associated-types/dont-suggest-cyclic-constraint.stderr
+++ b/tests/ui/associated-types/dont-suggest-cyclic-constraint.stderr
@@ -1,11 +1,15 @@
 error[E0308]: mismatched types
-  --> $DIR/dont-suggest-cyclic-constraint.rs:7:35
+  --> $DIR/dont-suggest-cyclic-constraint.rs:9:35
    |
 LL |     debug_assert_eq!(iter.next(), Some(value));
    |                                   ^^^^^^^^^^^ expected `Option<<I as Iterator>::Item>`, found `Option<&<I as Iterator>::Item>`
    |
    = note: expected enum `Option<<I as Iterator>::Item>`
               found enum `Option<&<I as Iterator>::Item>`
+help: use `Option::as_ref()` to convert `Option<<I as Iterator>::Item>` to `Option<&<I as Iterator>::Item>`
+   |
+LL |     debug_assert_eq!(iter.next().as_ref(), Some(value));
+   |                                 +++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/copied-and-cloned.fixed
+++ b/tests/ui/suggestions/copied-and-cloned.fixed
@@ -20,4 +20,12 @@ fn main() {
     expect::<Result<String, ()>>(x.cloned());
     //~^ ERROR mismatched types
     //~| HELP use `Result::cloned` to clone the value inside the `Result`
+
+    let s = String::new();
+    let x = Some(s.clone());
+    let y = Some(&s);
+    println!("{}", x.as_ref() == y);
+    //~^ ERROR mismatched types
+    //~| HELP use `Option::as_ref()` to convert `Option<String>` to `Option<&String>`
+
 }

--- a/tests/ui/suggestions/copied-and-cloned.rs
+++ b/tests/ui/suggestions/copied-and-cloned.rs
@@ -20,4 +20,12 @@ fn main() {
     expect::<Result<String, ()>>(x);
     //~^ ERROR mismatched types
     //~| HELP use `Result::cloned` to clone the value inside the `Result`
+
+    let s = String::new();
+    let x = Some(s.clone());
+    let y = Some(&s);
+    println!("{}", x == y);
+    //~^ ERROR mismatched types
+    //~| HELP use `Option::as_ref()` to convert `Option<String>` to `Option<&String>`
+
 }

--- a/tests/ui/suggestions/copied-and-cloned.stderr
+++ b/tests/ui/suggestions/copied-and-cloned.stderr
@@ -78,6 +78,19 @@ help: use `Result::cloned` to clone the value inside the `Result`
 LL |     expect::<Result<String, ()>>(x.cloned());
    |                                   +++++++++
 
-error: aborting due to 4 previous errors
+error[E0308]: mismatched types
+  --> $DIR/copied-and-cloned.rs:27:25
+   |
+LL |     println!("{}", x == y);
+   |                         ^ expected `Option<String>`, found `Option<&String>`
+   |
+   = note: expected enum `Option<String>`
+              found enum `Option<&String>`
+help: use `Option::as_ref()` to convert `Option<String>` to `Option<&String>`
+   |
+LL |     println!("{}", x.as_ref() == y);
+   |                     +++++++++
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #114050

When we have an expr available that produces the type expectation, we can suggest appending `.as_ref()` to the span, instead of cloning the expr producing the mismatch