### PR TITLE
rustdoc: fix cross-crate `impl Sized` & `impl ?Sized`

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1219,15 +1219,24 @@ pub(crate) enum GenericBound {
 }
 
 impl GenericBound {
+    pub(crate) fn sized(cx: &mut DocContext<'_>) -> GenericBound {
+        Self::sized_with(cx, hir::TraitBoundModifier::None)
+    }
+
     pub(crate) fn maybe_sized(cx: &mut DocContext<'_>) -> GenericBound {
+        Self::sized_with(cx, hir::TraitBoundModifier::Maybe)
+    }
+
+    fn sized_with(cx: &mut DocContext<'_>, modifier: hir::TraitBoundModifier) -> GenericBound {
         let did = cx.tcx.require_lang_item(LangItem::Sized, None);
         let empty = ty::Binder::dummy(ty::GenericArgs::empty());
         let path = external_path(cx, did, false, ThinVec::new(), empty);
         inline::record_extern_fqn(cx, did, ItemType::Trait);
-        GenericBound::TraitBound(
-            PolyTrait { trait_: path, generic_params: Vec::new() },
-            hir::TraitBoundModifier::Maybe,
-        )
+        GenericBound::TraitBound(PolyTrait { trait_: path, generic_params: Vec::new() }, modifier)
+    }
+
+    pub(crate) fn is_trait_bound(&self) -> bool {
+        matches!(self, Self::TraitBound(..))
     }
 
     pub(crate) fn is_sized_bound(&self, cx: &DocContext<'_>) -> bool {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1094,22 +1094,35 @@ fn fmt_type<'cx>(
             };
             let m = mutability.print_with_space();
             let amp = if f.alternate() { "&" } else { "&amp;" };
-            match **ty {
+
+            if let clean::Generic(name) = **ty {
+                return primitive_link(
+                    f,
+                    PrimitiveType::Reference,
+                    &format!("{amp}{lt}{m}{name}"),
+                    cx,
+                );
+            }
+
+            write!(f, "{amp}{lt}{m}")?;
+
+            let needs_parens = match **ty {
                 clean::DynTrait(ref bounds, ref trait_lt)
                     if bounds.len() > 1 || trait_lt.is_some() =>
                 {
-                    write!(f, "{}{}{}(", amp, lt, m)?;
-                    fmt_type(ty, f, use_absolute, cx)?;
-                    write!(f, ")")
+                    true
                 }
-                clean::Generic(name) => {
-                    primitive_link(f, PrimitiveType::Reference, &format!("{amp}{lt}{m}{name}"), cx)
-                }
-                _ => {
-                    write!(f, "{}{}{}", amp, lt, m)?;
-                    fmt_type(ty, f, use_absolute, cx)
-                }
+                clean::ImplTrait(ref bounds) if bounds.len() > 1 => true,
+                _ => false,
+            };
+            if needs_parens {
+                f.write_str("(")?;
             }
+            fmt_type(ty, f, use_absolute, cx)?;
+            if needs_parens {
+                f.write_str(")")?;
+            }
+            Ok(())
         }
         clean::ImplTrait(ref bounds) => {
             if f.alternate() {

--- a/tests/rustdoc/extern-impl-trait.rs
+++ b/tests/rustdoc/extern-impl-trait.rs
@@ -7,5 +7,5 @@ extern crate extern_impl_trait;
 // @has 'foo/struct.X.html' '//h4[@class="code-header"]' "impl Foo<Associated = ()> + 'a"
 pub use extern_impl_trait::X;
 
-// @has 'foo/struct.Y.html' '//h4[@class="code-header"]' "impl ?Sized + Foo<Associated = ()> + 'a"
+// @has 'foo/struct.Y.html' '//h4[@class="code-header"]' "impl Foo<Associated = ()> + ?Sized + 'a"
 pub use extern_impl_trait::Y;

--- a/tests/rustdoc/impl-everywhere.rs
+++ b/tests/rustdoc/impl-everywhere.rs
@@ -25,6 +25,6 @@ pub fn foo_foo() -> impl Foo + Foo2 {
     Bar
 }
 
-// @has foo/fn.foo_foo_foo.html '//section[@id="main-content"]//pre' "x: &'x impl Foo + Foo2"
+// @has foo/fn.foo_foo_foo.html '//section[@id="main-content"]//pre' "x: &'x (impl Foo + Foo2)"
 pub fn foo_foo_foo<'x>(_x: &'x (impl Foo + Foo2)) {
 }

--- a/tests/rustdoc/inline_cross/auxiliary/impl-sized.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/impl-sized.rs
@@ -1,0 +1,21 @@
+use std::fmt::Debug;
+
+pub fn sized(x: impl Sized) -> impl Sized {
+    x
+}
+
+pub fn sized_outlives<'a>(x: impl Sized + 'a) -> impl Sized + 'a {
+    x
+}
+
+pub fn maybe_sized(x: &impl ?Sized) -> &impl ?Sized {
+    x
+}
+
+pub fn debug_maybe_sized(x: &(impl Debug + ?Sized)) -> &(impl Debug + ?Sized) {
+    x
+}
+
+pub fn maybe_sized_outlives<'t>(x: &(impl ?Sized + 't)) -> &(impl ?Sized + 't) {
+    x
+}

--- a/tests/rustdoc/inline_cross/impl-sized.rs
+++ b/tests/rustdoc/inline_cross/impl-sized.rs
@@ -1,0 +1,27 @@
+#![crate_name = "user"]
+
+// aux-crate:impl_sized=impl-sized.rs
+// edition:2021
+
+// @has user/fn.sized.html
+// @has - '//pre[@class="rust item-decl"]' "sized(x: impl Sized) -> impl Sized"
+pub use impl_sized::sized;
+
+// @has user/fn.sized_outlives.html
+// @has - '//pre[@class="rust item-decl"]' \
+//     "sized_outlives<'a>(x: impl Sized + 'a) -> impl Sized + 'a"
+pub use impl_sized::sized_outlives;
+
+// @has user/fn.maybe_sized.html
+// @has - '//pre[@class="rust item-decl"]' "maybe_sized(x: &impl ?Sized) -> &impl ?Sized"
+pub use impl_sized::maybe_sized;
+
+// @has user/fn.debug_maybe_sized.html
+// @has - '//pre[@class="rust item-decl"]' \
+//     "debug_maybe_sized(x: &(impl Debug + ?Sized)) -> &(impl Debug + ?Sized)"
+pub use impl_sized::debug_maybe_sized;
+
+// @has user/fn.maybe_sized_outlives.html
+// @has - '//pre[@class="rust item-decl"]' \
+//     "maybe_sized_outlives<'t>(x: &(impl ?Sized + 't)) -> &(impl ?Sized + 't)"
+pub use impl_sized::maybe_sized_outlives;


### PR DESCRIPTION
Previously, cross-crate impl-Trait (APIT, RPIT, etc.) that only consists of a single `Sized` bound (modulo outlives-bounds) and ones that are `?Sized` were incorrectly rendered. To give you a taste (before vs. after):

```diff
- fn sized(x: impl ) -> impl 
+ fn sized(x: impl Sized) -> impl Sized

- fn sized_outlives<'a>(x: impl 'a) -> impl 'a
+ fn sized_outlives<'a>(x: impl Sized + 'a) -> impl Sized + 'a

- fn maybe_sized(x: &impl ) -> &impl 
+ fn maybe_sized(x: &impl ?Sized) -> &impl ?Sized

- fn debug_maybe_sized(x: &impl Debug) -> &impl ?Sized + Debug
+ fn debug_maybe_sized(x: &(impl Debug + ?Sized)) -> &(impl Debug + ?Sized)
```

Moreover, we now surround impl-Trait that has multiple bounds with parentheses if they're the pointee of a reference or raw pointer type. This affects both local and cross-crate docs. The current output isn't correct (rustc would emit the error *ambiguous `+` in a type* if we fed the rendered code back to it).

---

Best reviewed commit by commit :)

@rustbot label A-cross-crate-reexports