### PR TITLE
Ignore host C++ runtime in a cross build scenario

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -343,6 +343,8 @@ fn main() {
     } else if target.contains("netbsd") && llvm_static_stdcpp.is_some() {
         // NetBSD uses a separate library when relocation is required
         "stdc++_p"
+    } else if target.contains("dragonfly") {
+        "stdc++"
     } else if llvm_use_libcxx.is_some() {
         "c++"
     } else {

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -382,7 +382,11 @@ fn main() {
             } else {
                 println!("cargo:rustc-link-lib=static={stdcppname}");
             }
-        } else if cxxflags.contains("stdlib=libc++") {
+        } else if !is_crossed && cxxflags.contains("stdlib=libc++") {
+            // If we're in a cross build these flags come from the host
+            // compiler and not the target compiler. In the case of an
+            // Apple to non-Apple cross build, there's a good chance we
+            // don't want libc++.
             println!("cargo:rustc-link-lib=c++");
         } else {
             println!("cargo:rustc-link-lib={stdcppname}");

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -189,6 +189,18 @@ fn main() {
             continue;
         }
 
+        // In the cross compiling case we pick up the C++ runtime flags from the host compiler
+        // and not the target.  This breaks the build in the case of the host and target using
+        // different runtimes.
+        if is_crossed && flag.starts_with("-stdlib") {
+            println!("cargo:warning=Skipping attempt to set C++ library to {flag:?} on target {target:?}");
+
+            // Most targets these days seem to use libc+, but DragonFly uses GNU libstdc++ for sure
+            if target.contains("dragonfly") {
+                continue;
+            }
+        }
+
         // -Wdate-time is not supported by the netbsd cross compiler
         if is_crossed && target.contains("netbsd") && flag.contains("date-time") {
             continue;


### PR DESCRIPTION
I'm not quite sure how this will play out for other cross builds, but in the case of macOS to DragonFly one of the big problems I was running into was the insistence on linking against a non-existent `libc++`.  It turned out that the flags were coming in from the `llvm-config` built for the host, which at first blush seems like the wrong behavior.