### PR TITLE
Add regression test for `echo 'mod unknown;' | rustc -`

### DIFF
--- a/tests/run-make/unknown-mod-stdin/Makefile
+++ b/tests/run-make/unknown-mod-stdin/Makefile
@@ -1,0 +1,13 @@
+include ../tools.mk
+
+all:
+	echo 'mod unknown;' | $(RUSTC) --crate-type rlib - >$(TMPDIR)/unknown-mod.stdout 2>$(TMPDIR)/unknown-mod.stderr || echo "failed successfully"
+
+# Bless like this: RUSTC_BLESS_TEST=1 ./x.py test tests/run-make/unknown-mod-stdin
+ifdef RUSTC_BLESS_TEST
+	cp "$(TMPDIR)"/unknown-mod.stdout unknown-mod.stdout
+	cp "$(TMPDIR)"/unknown-mod.stderr unknown-mod.stderr
+else
+	$(DIFF) unknown-mod.stdout "$(TMPDIR)"/unknown-mod.stdout
+	$(DIFF) unknown-mod.stderr "$(TMPDIR)"/unknown-mod.stderr
+endif

--- a/tests/run-make/unknown-mod-stdin/Makefile
+++ b/tests/run-make/unknown-mod-stdin/Makefile
@@ -1,3 +1,5 @@
+# ignore-windows
+
 include ../tools.mk
 
 all:

--- a/tests/run-make/unknown-mod-stdin/unknown-mod.stderr
+++ b/tests/run-make/unknown-mod-stdin/unknown-mod.stderr
@@ -1,0 +1,11 @@
+error[E0583]: file not found for module `unknown`
+ --> <anon>:1:1
+  |
+1 | mod unknown;
+  | ^^^^^^^^^^^^
+  |
+  = help: to create the module `unknown`, create file "unknown.rs" or "unknown/mod.rs"
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0583`.


### PR DESCRIPTION
Closes #65601

The bug is fixed since long ago, probably by #69838 (see https://github.com/rust-lang/rust/issues/65601#issuecomment-1650508071 for more details).
Add a regression test so we can close the issue.