### PR TITLE
Don't try to prove opaque type bounds twice on the same types

### DIFF
--- a/src/tools/clippy/tests/ui/new_ret_no_self_overflow.stderr
+++ b/src/tools/clippy/tests/ui/new_ret_no_self_overflow.stderr
@@ -1,9 +1,20 @@
-error[E0275]: overflow evaluating the requirement `<i32 as std::ops::Add>::Output == issue10041::X`
-  --> $DIR/new_ret_no_self_overflow.rs:20:25
+error: methods called `new` usually return `Self`
+  --> $DIR/new_ret_no_self_overflow.rs:9:9
    |
-LL |         pub fn new() -> X {
-   |                         ^
+LL | /         pub fn new() -> impl PartialOrd {
+LL | |             0i32
+LL | |         }
+   | |_________^
+   |
+   = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
 
-error: aborting due to previous error
+error: methods called `new` usually return `Self`
+  --> $DIR/new_ret_no_self_overflow.rs:20:9
+   |
+LL | /         pub fn new() -> X {
+LL | |             0i32
+LL | |         }
+   | |_________^
 
-For more information about this error, try `rustc --explain E0275`.
+error: aborting due to 2 previous errors
+

--- a/tests/ui/async-await/suggest-missing-await.stderr
+++ b/tests/ui/async-await/suggest-missing-await.stderr
@@ -24,6 +24,8 @@ LL |     take_u32(x.await)
 error[E0308]: mismatched types
   --> $DIR/suggest-missing-await.rs:22:5
    |
+LL | async fn suggest_await_in_async_fn_return() {
+   |                                             - expected `()` because of return type
 LL |     dummy()
    |     ^^^^^^^ expected `()`, found future
    |

--- a/tests/ui/parser/expr-as-stmt.stderr
+++ b/tests/ui/parser/expr-as-stmt.stderr
@@ -81,9 +81,16 @@ error[E0308]: mismatched types
   --> $DIR/expr-as-stmt.rs:64:7
    |
 LL |     { foo() } || { true }
-   |       ^^^^^- help: consider using a semicolon here: `;`
-   |       |
-   |       expected `()`, found `i32`
+   |       ^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |     { foo(); } || { true }
+   |            +
+help: you might have meant to return this value
+   |
+LL |     { return foo(); } || { true }
+   |       ++++++      +
 
 error[E0308]: mismatched types
   --> $DIR/expr-as-stmt.rs:8:6

--- a/tests/ui/type-alias-impl-trait/issue-63279.rs
+++ b/tests/ui/type-alias-impl-trait/issue-63279.rs
@@ -7,7 +7,6 @@ fn c() -> Closure {
     || -> Closure { || () }
     //~^ ERROR: mismatched types
     //~| ERROR: mismatched types
-    //~| ERROR: expected a `FnOnce<()>` closure, found `()`
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-63279.stderr
@@ -7,15 +7,6 @@ LL | fn c() -> Closure {
    = help: the trait `FnOnce<()>` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
 
-error[E0277]: expected a `FnOnce<()>` closure, found `()`
-  --> $DIR/issue-63279.rs:7:11
-   |
-LL |     || -> Closure { || () }
-   |           ^^^^^^^ expected an `FnOnce<()>` closure, found `()`
-   |
-   = help: the trait `FnOnce<()>` is not implemented for `()`
-   = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
-
 error[E0308]: mismatched types
   --> $DIR/issue-63279.rs:7:21
    |
@@ -32,6 +23,9 @@ LL |     || -> Closure { (|| ())() }
 error[E0308]: mismatched types
   --> $DIR/issue-63279.rs:7:5
    |
+LL | fn c() -> Closure {
+   |           ------- expected `()` because of return type
+LL |
 LL |     || -> Closure { || () }
    |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found closure
    |
@@ -42,7 +36,7 @@ help: use parentheses to call this closure
 LL |     (|| -> Closure { || () })()
    |     +                       +++
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.next.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.next.stderr
@@ -1,5 +1,5 @@
 error: unconstrained opaque type
-  --> $DIR/self-referential-in-fn-trait.rs:3:16
+  --> $DIR/self-referential-in-fn-trait.rs:13:16
    |
 LL | type Foo<'a> = impl Fn() -> Foo<'a>;
    |                ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.old.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.old.stderr
@@ -1,0 +1,10 @@
+error: unconstrained opaque type
+  --> $DIR/self-referential-in-fn-trait.rs:13:16
+   |
+LL | type Foo<'a> = impl Fn() -> Foo<'a>;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Foo` must be used in combination with a concrete type within the same module
+
+error: aborting due to previous error
+

--- a/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.rs
@@ -1,0 +1,10 @@
+#![feature(type_alias_impl_trait)]
+
+type Foo<'a> = impl Fn() -> Foo<'a>;
+
+fn crash<'a>(_: &'a (), x: Foo<'a>) -> Foo<'a> {
+    //~^ ERROR: overflow evaluating the requirement `<Foo<'a> as FnOnce<()>>::Output == Foo<'a>
+    x
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.rs
@@ -1,9 +1,9 @@
 #![feature(type_alias_impl_trait)]
 
 type Foo<'a> = impl Fn() -> Foo<'a>;
+//~^ ERROR: unconstrained opaque type
 
 fn crash<'a>(_: &'a (), x: Foo<'a>) -> Foo<'a> {
-    //~^ ERROR: overflow evaluating the requirement `<Foo<'a> as FnOnce<()>>::Output == Foo<'a>
     x
 }
 

--- a/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.rs
@@ -1,10 +1,25 @@
+//! This test checks that we do not
+//! end up with an infinite recursion,
+//! a cycle error or an overflow when
+//! encountering an opaque type that has
+//! an associated type that is just itself
+//! again.
+
 #![feature(type_alias_impl_trait)]
+// revisions: next old working
+//[next] compile-flags: -Ztrait-solver=next
+//[working] check-pass
 
 type Foo<'a> = impl Fn() -> Foo<'a>;
-//~^ ERROR: unconstrained opaque type
+//[old,next]~^ ERROR: unconstrained opaque type
 
 fn crash<'a>(_: &'a (), x: Foo<'a>) -> Foo<'a> {
     x
+}
+
+#[cfg(working)]
+fn foo<'a>() -> Foo<'a> {
+    foo
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.stderr
@@ -1,0 +1,9 @@
+error[E0275]: overflow evaluating the requirement `<Foo<'a> as FnOnce<()>>::Output == Foo<'a>`
+  --> $DIR/self-referential-in-fn-trait.rs:5:40
+   |
+LL | fn crash<'a>(_: &'a (), x: Foo<'a>) -> Foo<'a> {
+   |                                        ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-in-fn-trait.stderr
@@ -1,9 +1,10 @@
-error[E0275]: overflow evaluating the requirement `<Foo<'a> as FnOnce<()>>::Output == Foo<'a>`
-  --> $DIR/self-referential-in-fn-trait.rs:5:40
+error: unconstrained opaque type
+  --> $DIR/self-referential-in-fn-trait.rs:3:16
    |
-LL | fn crash<'a>(_: &'a (), x: Foo<'a>) -> Foo<'a> {
-   |                                        ^^^^^^^
+LL | type Foo<'a> = impl Fn() -> Foo<'a>;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Foo` must be used in combination with a concrete type within the same module
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/typeck/issue-90027-async-fn-return-suggestion.stderr
+++ b/tests/ui/typeck/issue-90027-async-fn-return-suggestion.stderr
@@ -10,13 +10,18 @@ error[E0308]: mismatched types
   --> $DIR/issue-90027-async-fn-return-suggestion.rs:9:5
    |
 LL | async fn world() -> () {
-   |                     -- expected `()` because of return type
+   |                     --
+   |                     |
+   |                     expected `()` because of return type
+   |                     expected `()` because of return type
 LL |     0
    |     ^ expected `()`, found integer
 
 error[E0308]: mismatched types
   --> $DIR/issue-90027-async-fn-return-suggestion.rs:14:5
    |
+LL | async fn suggest_await_in_async_fn_return() {
+   |                                             - expected `()` because of return type
 LL |     hello()
    |     ^^^^^^^ expected `()`, found future
    |


### PR DESCRIPTION
fixes #109268

The other alternative I came up with was to filter obligations out by trying to prove them on their own first. Basically `<Foo<'_> as Fn() -> Foo<'_>>::Output = Foo<'_>` should always hold without needing to reveal the opaque type or without trying to register a hidden type for it.

r? @compiler-errors cc @lcnr 