### PR TITLE
privacy: no nominal visibility for assoc fns 

### DIFF
--- a/tests/ui/privacy/issue-113860-1.rs
+++ b/tests/ui/privacy/issue-113860-1.rs
@@ -1,0 +1,16 @@
+#![feature(staged_api)]
+//~^ ERROR module has missing stability attribute
+
+pub trait Trait {
+    //~^ ERROR trait has missing stability attribute
+    fn fun() {}
+    //~^ ERROR associated function has missing stability attribute
+}
+
+impl Trait for u8 {
+    //~^ ERROR implementation has missing stability attribute
+    pub(self) fn fun() {}
+    //~^ ERROR visibility qualifiers are not permitted here [E0449]
+}
+
+fn main() {}

--- a/tests/ui/privacy/issue-113860-1.stderr
+++ b/tests/ui/privacy/issue-113860-1.stderr
@@ -1,0 +1,49 @@
+error[E0449]: visibility qualifiers are not permitted here
+  --> $DIR/issue-113860-1.rs:12:5
+   |
+LL |     pub(self) fn fun() {}
+   |     ^^^^^^^^^
+   |
+   = note: trait items always share the visibility of their trait
+
+error: module has missing stability attribute
+  --> $DIR/issue-113860-1.rs:1:1
+   |
+LL | / #![feature(staged_api)]
+LL | |
+LL | |
+LL | | pub trait Trait {
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: trait has missing stability attribute
+  --> $DIR/issue-113860-1.rs:4:1
+   |
+LL | / pub trait Trait {
+LL | |
+LL | |     fn fun() {}
+LL | |
+LL | | }
+   | |_^
+
+error: implementation has missing stability attribute
+  --> $DIR/issue-113860-1.rs:10:1
+   |
+LL | / impl Trait for u8 {
+LL | |
+LL | |     pub(self) fn fun() {}
+LL | |
+LL | | }
+   | |_^
+
+error: associated function has missing stability attribute
+  --> $DIR/issue-113860-1.rs:6:5
+   |
+LL |     fn fun() {}
+   |     ^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0449`.

--- a/tests/ui/privacy/issue-113860-2.rs
+++ b/tests/ui/privacy/issue-113860-2.rs
@@ -1,0 +1,16 @@
+#![feature(staged_api)]
+//~^ ERROR module has missing stability attribute
+
+pub trait Trait {
+    //~^ ERROR trait has missing stability attribute
+    type X;
+    //~^ ERROR associated type has missing stability attribute
+}
+
+impl Trait for u8 {
+    //~^ ERROR implementation has missing stability attribute
+    pub(self) type X = Self;
+    //~^ ERROR visibility qualifiers are not permitted here [E0449]
+}
+
+fn main() {}

--- a/tests/ui/privacy/issue-113860-2.stderr
+++ b/tests/ui/privacy/issue-113860-2.stderr
@@ -1,0 +1,49 @@
+error[E0449]: visibility qualifiers are not permitted here
+  --> $DIR/issue-113860-2.rs:12:5
+   |
+LL |     pub(self) type X = Self;
+   |     ^^^^^^^^^
+   |
+   = note: trait items always share the visibility of their trait
+
+error: module has missing stability attribute
+  --> $DIR/issue-113860-2.rs:1:1
+   |
+LL | / #![feature(staged_api)]
+LL | |
+LL | |
+LL | | pub trait Trait {
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: trait has missing stability attribute
+  --> $DIR/issue-113860-2.rs:4:1
+   |
+LL | / pub trait Trait {
+LL | |
+LL | |     type X;
+LL | |
+LL | | }
+   | |_^
+
+error: implementation has missing stability attribute
+  --> $DIR/issue-113860-2.rs:10:1
+   |
+LL | / impl Trait for u8 {
+LL | |
+LL | |     pub(self) type X = Self;
+LL | |
+LL | | }
+   | |_^
+
+error: associated type has missing stability attribute
+  --> $DIR/issue-113860-2.rs:6:5
+   |
+LL |     type X;
+   |     ^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0449`.

--- a/tests/ui/privacy/issue-113860.rs
+++ b/tests/ui/privacy/issue-113860.rs
@@ -1,0 +1,16 @@
+#![feature(staged_api)]
+//~^ ERROR module has missing stability attribute
+
+pub trait Trait {
+    //~^ ERROR trait has missing stability attribute
+    const X: u32;
+    //~^ ERROR associated constant has missing stability attribute
+}
+
+impl Trait for u8 {
+    //~^ ERROR implementation has missing stability attribute
+    pub(self) const X: u32 = 3;
+    //~^ ERROR visibility qualifiers are not permitted here [E0449]
+}
+
+fn main() {}

--- a/tests/ui/privacy/issue-113860.stderr
+++ b/tests/ui/privacy/issue-113860.stderr
@@ -1,0 +1,49 @@
+error[E0449]: visibility qualifiers are not permitted here
+  --> $DIR/issue-113860.rs:12:5
+   |
+LL |     pub(self) const X: u32 = 3;
+   |     ^^^^^^^^^
+   |
+   = note: trait items always share the visibility of their trait
+
+error: module has missing stability attribute
+  --> $DIR/issue-113860.rs:1:1
+   |
+LL | / #![feature(staged_api)]
+LL | |
+LL | |
+LL | | pub trait Trait {
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: trait has missing stability attribute
+  --> $DIR/issue-113860.rs:4:1
+   |
+LL | / pub trait Trait {
+LL | |
+LL | |     const X: u32;
+LL | |
+LL | | }
+   | |_^
+
+error: implementation has missing stability attribute
+  --> $DIR/issue-113860.rs:10:1
+   |
+LL | / impl Trait for u8 {
+LL | |
+LL | |     pub(self) const X: u32 = 3;
+LL | |
+LL | | }
+   | |_^
+
+error: associated constant has missing stability attribute
+  --> $DIR/issue-113860.rs:6:5
+   |
+LL |     const X: u32;
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0449`.


### PR DESCRIPTION
Fixes #113860.

When `staged_api` is enabled, effective visibilities are computed earlier and this can trigger an ICE in some cases.

In particular, if a impl of a trait method has a visibility then an error will be reported for that, but when privacy invariants are being checked, the effective visibility will still be greater than the nominal visbility and that will trigger a `span_bug!`.

However, this invariant - that effective visibilites are limited to nominal visibility - doesn't make sense for associated functions.
