### PR TITLE
Dont pass `-Zwrite-long-types-to-disk=no` for `ui-fulldeps --stage=1`

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2330,7 +2330,14 @@ impl<'test> TestCx<'test> {
                 // Hide line numbers to reduce churn
                 rustc.arg("-Zui-testing");
                 rustc.arg("-Zdeduplicate-diagnostics=no");
-                rustc.arg("-Zwrite-long-types-to-disk=no");
+                // #[cfg(not(bootstrap)] unconditionally pass flag after beta bump
+                // since `ui-fulldeps --stage=1` builds using the stage 0 compiler,
+                // which doesn't have this flag.
+                if !(self.config.stage_id.starts_with("stage1-")
+                    && self.config.suite == "ui-fulldeps")
+                {
+                    rustc.arg("-Zwrite-long-types-to-disk=no");
+                }
                 // FIXME: use this for other modes too, for perf?
                 rustc.arg("-Cstrip=debuginfo");
             }


### PR DESCRIPTION
Due to this hack:

https://github.com/rust-lang/rust/blob/601a34de8c10458b72a7781eb0b44a7981e4a2b1/src/bootstrap/test.rs#L1473-L1484

We use the stage 0 compiler to build the stage 1 fulldeps tests. That means that we don't have `-Zwrite-long-types-to-disk=no` which was added in #113893.

Add a temporary hack to fix this (https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Some.20tests.20failing.20with.20--stage.201) until the next beta bump.