### PR TITLE
Docs: Fix URL for `rmatches`

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1666,7 +1666,7 @@ impl str {
     /// If the pattern allows a reverse search but its results might differ
     /// from a forward search, the [`rmatches`] method can be used.
     ///
-    /// [`rmatches`]: str::matches
+    /// [`rmatches`]: str::rmatches
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This PR fixes a link to `str::rmatches()` by pointing it to the correct URL.