### PR TITLE
Always add LC_BUILD_VERSION for metadata object files

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -858,11 +858,9 @@ fn print_crate_info(
                 use rustc_target::spec::current_apple_deployment_target;
 
                 if sess.target.is_like_osx {
-                    println_info!(
-                        "deployment_target={}",
-                        current_apple_deployment_target(&sess.target)
-                            .expect("unknown Apple target OS")
-                    )
+                    let (major, minor) = current_apple_deployment_target(&sess.target)
+                        .expect("unknown Apple target OS");
+                    println_info!("deployment_target={}", format!("{major}.{minor}"))
                 } else {
                     handler
                         .early_error("only Apple targets currently support deployment version info")

--- a/compiler/rustc_target/src/spec/apple_base.rs
+++ b/compiler/rustc_target/src/spec/apple_base.rs
@@ -193,31 +193,15 @@ pub fn sdk_version(platform: u32) -> Option<(u32, u32)> {
 }
 
 pub fn platform(target: &Target) -> Option<u32> {
-    Some(match &*target.os {
-        "macos" => object::macho::PLATFORM_MACOS,
-        "ios" => {
-            if target.llvm_target.ends_with("-macabi") {
-                object::macho::PLATFORM_MACCATALYST
-            } else if target.llvm_target.ends_with("-simulator") {
-                object::macho::PLATFORM_IOSSIMULATOR
-            } else {
-                object::macho::PLATFORM_IOS
-            }
-        }
-        "watchos" => {
-            if target.llvm_target.ends_with("-simulator") {
-                object::macho::PLATFORM_WATCHOSSIMULATOR
-            } else {
-                object::macho::PLATFORM_WATCHOS
-            }
-        }
-        "tvos" => {
-            if target.llvm_target.ends_with("-simulator") {
-                object::macho::PLATFORM_TVOSSIMULATOR
-            } else {
-                object::macho::PLATFORM_TVOS
-            }
-        }
+    Some(match (&*target.os, &*target.abi) {
+        ("macos", _) => object::macho::PLATFORM_MACOS,
+        ("ios", "macabi") => object::macho::PLATFORM_MACCATALYST,
+        ("ios", "sim") => object::macho::PLATFORM_IOSSIMULATOR,
+        ("ios", _) => object::macho::PLATFORM_IOS,
+        ("watchos", "sim") => object::macho::PLATFORM_WATCHOSSIMULATOR,
+        ("watchos", _) => object::macho::PLATFORM_WATCHOS,
+        ("tvos", "sim") => object::macho::PLATFORM_TVOSSIMULATOR,
+        ("tvos", _) => object::macho::PLATFORM_TVOS,
         _ => return None,
     })
 }
@@ -229,7 +213,7 @@ pub fn deployment_target(target: &Target) -> Option<(u32, u32)> {
             let arch = if target.arch == "x86" || target.arch == "x86_64" { X86_64 } else { Arm64 };
             macos_deployment_target(arch)
         }
-        "ios" => match &*target.options.abi {
+        "ios" => match &*target.abi {
             "macabi" => mac_catalyst_deployment_target(),
             _ => ios_deployment_target(),
         },

--- a/compiler/rustc_target/src/spec/apple_base.rs
+++ b/compiler/rustc_target/src/spec/apple_base.rs
@@ -180,6 +180,8 @@ pub fn opts(os: &'static str, arch: Arch) -> TargetOptions {
 }
 
 pub fn sdk_version(platform: u32) -> Option<(u32, u32)> {
+    // NOTE: These values are from an arbitrary point in time but shouldn't make it into the final
+    // binary since the final link command will have the current SDK version passed to it.
     match platform {
         object::macho::PLATFORM_MACOS => Some((13, 1)),
         object::macho::PLATFORM_IOS

--- a/compiler/rustc_target/src/spec/apple_base.rs
+++ b/compiler/rustc_target/src/spec/apple_base.rs
@@ -179,20 +179,66 @@ pub fn opts(os: &'static str, arch: Arch) -> TargetOptions {
     }
 }
 
-pub fn deployment_target(target: &Target) -> Option<String> {
+pub fn sdk_version(platform: u32) -> Option<(u32, u32)> {
+    match platform {
+        object::macho::PLATFORM_MACOS => Some((13, 1)),
+        object::macho::PLATFORM_IOS
+        | object::macho::PLATFORM_IOSSIMULATOR
+        | object::macho::PLATFORM_TVOS
+        | object::macho::PLATFORM_TVOSSIMULATOR
+        | object::macho::PLATFORM_MACCATALYST => Some((16, 2)),
+        object::macho::PLATFORM_WATCHOS | object::macho::PLATFORM_WATCHOSSIMULATOR => Some((9, 1)),
+        _ => None,
+    }
+}
+
+pub fn platform(target: &Target) -> Option<u32> {
+    Some(match &*target.os {
+        "macos" => object::macho::PLATFORM_MACOS,
+        "ios" => {
+            if target.llvm_target.ends_with("-macabi") {
+                object::macho::PLATFORM_MACCATALYST
+            } else if target.llvm_target.ends_with("-simulator") {
+                object::macho::PLATFORM_IOSSIMULATOR
+            } else {
+                object::macho::PLATFORM_IOS
+            }
+        }
+        "watchos" => {
+            if target.llvm_target.ends_with("-simulator") {
+                object::macho::PLATFORM_WATCHOSSIMULATOR
+            } else {
+                object::macho::PLATFORM_WATCHOS
+            }
+        }
+        "tvos" => {
+            if target.llvm_target.ends_with("-simulator") {
+                object::macho::PLATFORM_TVOSSIMULATOR
+            } else {
+                object::macho::PLATFORM_TVOS
+            }
+        }
+        _ => return None,
+    })
+}
+
+pub fn deployment_target(target: &Target) -> Option<(u32, u32)> {
     let (major, minor) = match &*target.os {
         "macos" => {
             // This does not need to be specific. It just needs to handle x86 vs M1.
             let arch = if target.arch == "x86" || target.arch == "x86_64" { X86_64 } else { Arm64 };
             macos_deployment_target(arch)
         }
-        "ios" => ios_deployment_target(),
+        "ios" => match &*target.options.abi {
+            "macabi" => mac_catalyst_deployment_target(),
+            _ => ios_deployment_target(),
+        },
         "watchos" => watchos_deployment_target(),
         "tvos" => tvos_deployment_target(),
         _ => return None,
     };
 
-    Some(format!("{major}.{minor}"))
+    Some((major, minor))
 }
 
 fn from_set_deployment_target(var_name: &str) -> Option<(u32, u32)> {
@@ -272,6 +318,11 @@ fn link_env_remove(arch: Arch, os: &'static str) -> StaticCow<[StaticCow<str>]> 
 fn ios_deployment_target() -> (u32, u32) {
     // If you are looking for the default deployment target, prefer `rustc --print deployment-target`.
     from_set_deployment_target("IPHONEOS_DEPLOYMENT_TARGET").unwrap_or((7, 0))
+}
+
+fn mac_catalyst_deployment_target() -> (u32, u32) {
+    // If you are looking for the default deployment target, prefer `rustc --print deployment-target`.
+    from_set_deployment_target("IPHONEOS_DEPLOYMENT_TARGET").unwrap_or((14, 0))
 }
 
 pub fn ios_llvm_target(arch: Arch) -> String {

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -61,6 +61,8 @@ mod aix_base;
 mod android_base;
 mod apple_base;
 pub use apple_base::deployment_target as current_apple_deployment_target;
+pub use apple_base::platform as current_apple_platform;
+pub use apple_base::sdk_version as current_apple_sdk_version;
 mod avr_gnu_base;
 pub use avr_gnu_base::ef_avr_arch;
 mod bpf_base;


### PR DESCRIPTION
As of Xcode 15 Apple's linker has become a bit more strict about the warnings it produces. One of those new warnings requires all valid Mach-O object files in an archive to have a LC_BUILD_VERSION load command:

```
ld: warning: no platform load command found in 'ARCHIVE[arm64][2106](lib.rmeta)', assuming: iOS-simulator
```

This was already being done for Mac Catalyst so this change expands this logic to include it for all Apple platforms. I filed this behavior change as FB12546320 and was told it was the new intentional behavior.