### PR TITLE
Experiment with removing cold from rawvec

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -280,7 +280,6 @@ impl<T, A: Allocator> RawVec<T, A> {
         // Therefore, we move all the resizing and error-handling logic from grow_amortized and
         // handle_reserve behind a call, while making sure that this function is likely to be
         // inlined as just a comparison and a call if the comparison fails.
-        #[cold]
         fn do_reserve_and_handle<T, A: Allocator>(
             slf: &mut RawVec<T, A>,
             len: usize,


### PR DESCRIPTION
This is mostly a perf experiment, but this function is always called on pushing to empty vecs, which can cause the compiler to incorrectly estimate likelihood of callers, so if it's not perf-negative I'd like to remove the attribute.