### PR TITLE
tests/ui/hello_world/main.rs: Remove FIXME (#62277)

### DIFF
--- a/tests/ui/hello_world/main.rs
+++ b/tests/ui/hello_world/main.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 // Test that compiling hello world succeeds with no output of any kind.
 


### PR DESCRIPTION
The purpose of the test is to make sure that compiling hello world produces no compiler output. To properly test that, we need to run the entire compiler pipeline. We don't want the test to pass if codegen accidentally starts writing to stdout. So keep it as build-pass.

Part of #62277