### PR TITLE
tests/ui/proc-macro/*: Migrate FIXMEs to check-pass

### DIFF
--- a/tests/ui/proc-macro/derive-helper-shadowed.rs
+++ b/tests/ui/proc-macro/derive-helper-shadowed.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 // aux-build:derive-helper-shadowed-2.rs
 

--- a/tests/ui/proc-macro/derive-in-mod.rs
+++ b/tests/ui/proc-macro/derive-in-mod.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 extern crate test_macros;

--- a/tests/ui/proc-macro/edition-imports-2018.rs
+++ b/tests/ui/proc-macro/edition-imports-2018.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2018
 // aux-build:edition-imports-2015.rs
 

--- a/tests/ui/proc-macro/extern-prelude-extern-crate-proc-macro.rs
+++ b/tests/ui/proc-macro/extern-prelude-extern-crate-proc-macro.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2018
 
 extern crate proc_macro;

--- a/tests/ui/proc-macro/helper-attr-blocked-by-import.rs
+++ b/tests/ui/proc-macro/helper-attr-blocked-by-import.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 #[macro_use(Empty)]

--- a/tests/ui/proc-macro/issue-53481.rs
+++ b/tests/ui/proc-macro/issue-53481.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 #[macro_use]

--- a/tests/ui/proc-macro/macro-use-attr.rs
+++ b/tests/ui/proc-macro/macro-use-attr.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 #[macro_use]

--- a/tests/ui/proc-macro/macro-use-bang.rs
+++ b/tests/ui/proc-macro/macro-use-bang.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 #[macro_use]


### PR DESCRIPTION
proc-macros are processed early in the compiler pipeline. There is no need to involve codegen. So change to check-pass.

I have also looked through each changed test and to me it is sufficiently clear that codegen is not needed for the purpose of the test.

I skipped changing `tests/ui/proc-macro/no-missing-docs.rs` in this commit because it was not clear to me that it can be changed to check-pass.

Part of #62277