### PR TITLE
When flushing delayed span bugs, write to the ICE dump file even if it doesn't exist

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1673,11 +1673,11 @@ impl HandlerInner {
         let backtrace = std::env::var_os("RUST_BACKTRACE").map_or(true, |x| &x != "0");
         for bug in bugs {
             if let Some(file) = self.ice_file.as_ref()
-                && let Ok(mut out) = std::fs::File::options().append(true).open(file)
+                && let Ok(mut out) = std::fs::File::options().create(true).append(true).open(file)
             {
                 let _ = write!(
                     &mut out,
-                    "\n\ndelayed span bug: {}\n{}",
+                    "delayed span bug: {}\n{}\n",
                     bug.inner.styled_message().iter().filter_map(|(msg, _)| msg.as_str()).collect::<String>(),
                     &bug.note
                 );

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -300,7 +300,7 @@ pub fn panic_hook_with_disk_dump(info: &PanicInfo<'_>, path: Option<&crate::path
     };
 
     if let Some(path) = path
-        && let Ok(mut out) = crate::fs::File::options().create(true).write(true).open(&path)
+        && let Ok(mut out) = crate::fs::File::options().create(true).append(true).open(&path)
     {
         write(&mut out, BacktraceStyle::full());
     }


### PR DESCRIPTION
Fix #113881.