### PR TITLE
Make `--print` with path unstable

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2151,6 +2151,12 @@ fn collect_print_requests(
     prints.extend(matches.opt_strs("print").into_iter().map(|req| {
         let (req, out) = split_out_file_name(&req);
 
+        if out.is_some() && !unstable_opts.unstable_options {
+            handler.early_error(
+                "the `-Z unstable-options` flag must also be passed to \
+                 enable the path print option",
+            );
+        }
         let kind = match PRINT_KINDS.iter().find(|&&(name, _)| name == req) {
             Some((_, PrintKind::TargetSpec)) => {
                 if unstable_opts.unstable_options {

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -260,10 +260,6 @@ The valid types of print values are:
   This returns rustc's minimum supported deployment target if no `*_DEPLOYMENT_TARGET` variable
   is present in the environment, or otherwise returns the variable's parsed value.
 
-A filepath may optionally be specified for each requested information kind, in
-the format `--print KIND=PATH`, just like for `--emit`. When a path is
-specified, information will be written there instead of to stdout.
-
 [conditional compilation]: ../reference/conditional-compilation.html
 [deployment target]: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html
 

--- a/src/doc/unstable-book/src/compiler-flags/path-options.md
+++ b/src/doc/unstable-book/src/compiler-flags/path-options.md
@@ -1,0 +1,11 @@
+# `--print` Options
+
+The behavior of the `--print` flag can be modified by optionally be specifiying a filepath
+for each requested information kind, in the format `--print KIND=PATH`, just like for
+`--emit`. When a path is specified, information will be written there instead of to stdout.
+
+This is unstable feature, so you have to provide `-Zunstable-options` to enable it.
+
+## Examples
+
+`rustc main.rs -Z unstable-options --print cfg=cfgs.txt`

--- a/tests/run-make/print-cfg/Makefile
+++ b/tests/run-make/print-cfg/Makefile
@@ -13,19 +13,19 @@ all: default output_to_file
 
 output_to_file:
 	# Backend-independent, printed by rustc_driver_impl/src/lib.rs
-	$(RUSTC) --target x86_64-pc-windows-gnu --print cfg=$(TMPDIR)/cfg.txt
+	$(RUSTC) --target x86_64-pc-windows-gnu --print cfg=$(TMPDIR)/cfg.txt -Z unstable-options
 	$(CGREP) windows < $(TMPDIR)/cfg.txt
 
 	# Printed from CodegenBackend trait impl in rustc_codegen_llvm/src/lib.rs
-	$(RUSTC) --print relocation-models=$(TMPDIR)/relocation-models.txt
+	$(RUSTC) --print relocation-models=$(TMPDIR)/relocation-models.txt -Z unstable-options
 	$(CGREP) dynamic-no-pic < $(TMPDIR)/relocation-models.txt
 
 	# Printed by compiler/rustc_codegen_llvm/src/llvm_util.rs
-	$(RUSTC) --target wasm32-unknown-unknown --print target-features=$(TMPDIR)/target-features.txt
+	$(RUSTC) --target wasm32-unknown-unknown --print target-features=$(TMPDIR)/target-features.txt -Z unstable-options
 	$(CGREP) reference-types < $(TMPDIR)/target-features.txt
 
 	# Printed by C++ code in rustc_llvm/llvm-wrapper/PassWrapper.cpp
-	$(RUSTC) --target wasm32-unknown-unknown --print target-cpus=$(TMPDIR)/target-cpus.txt
+	$(RUSTC) --target wasm32-unknown-unknown --print target-cpus=$(TMPDIR)/target-cpus.txt -Z unstable-options
 	$(CGREP) generic < $(TMPDIR)/target-cpus.txt
 
 ifdef IS_WINDOWS

--- a/tests/ui/feature-gates/print-with-path.cfg.stderr
+++ b/tests/ui/feature-gates/print-with-path.cfg.stderr
@@ -1,0 +1,2 @@
+error: the `-Z unstable-options` flag must also be passed to enable the path print option
+

--- a/tests/ui/feature-gates/print-with-path.rs
+++ b/tests/ui/feature-gates/print-with-path.rs
@@ -1,0 +1,7 @@
+// check-fail
+// revisions: cfg target-features target-cpus
+// [cfg]compile-flags: --print cfg=cfg.txt
+// [target-cpus]compile-flags: --print target-cpu=target_cpu.txt
+// [target-features]compile-flags: --print target-features=target_features.txt
+
+fn main() {}

--- a/tests/ui/feature-gates/print-with-path.target-cpus.stderr
+++ b/tests/ui/feature-gates/print-with-path.target-cpus.stderr
@@ -1,0 +1,2 @@
+error: the `-Z unstable-options` flag must also be passed to enable the path print option
+

--- a/tests/ui/feature-gates/print-with-path.target-features.stderr
+++ b/tests/ui/feature-gates/print-with-path.target-features.stderr
@@ -1,0 +1,2 @@
+error: the `-Z unstable-options` flag must also be passed to enable the path print option
+


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/113780 should have gone through an MCP+FCP but wasn't, but instead of reverting the original PR, this PR just make that new option unstable.

[Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202023-07-27/near/379199738)
cc @dtolnay