### PR TITLE
Change LLVM BOLT flags

### DIFF
--- a/src/bootstrap/bolt.rs
+++ b/src/bootstrap/bolt.rs
@@ -49,6 +49,8 @@ pub fn optimize_with_bolt(path: &Path, profile_path: &Path, output_path: &Path) 
         .arg("-icf=1")
         // Update DWARF debug info in the final binary
         .arg("-update-debug-sections")
+        // Try to reuse old text segments to reduce binary size
+        .arg("--use-old-text")
         // Print optimization statistics
         .arg("-dyno-stats")
         .status()


### PR DESCRIPTION
I talked to the BOLT maintainers about the binary size effect of BOLT. Currently, BOLTing LLVM increases its binary size from ~120 MiB to ~170 MiB, which is not ideal. Now we can track both runtime performance and (rustc, LLVM, ...) artifact sizes in perf.RLO, so I'd like to try experimenting with changing the flags to reduce `libLLVM.so` size without regressing the performance gains of BOLT too much. 

r? @ghost