### PR TITLE
Rename tests/ui/issues/issue-100605.rs to ../type/option-ref-advice.rs

### DIFF
--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
-const ISSUES_ENTRY_LIMIT: usize = 1893;
+const ISSUES_ENTRY_LIMIT: usize = 1891;
 const ROOT_ENTRY_LIMIT: usize = 866;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[

--- a/tests/ui/issues/issue-100605.rs
+++ b/tests/ui/issues/issue-100605.rs
@@ -1,9 +1,0 @@
-fn takes_option(_arg: Option<&String>) {}
-
-fn main() {
-    takes_option(&None); //~ ERROR 4:18: 4:23: mismatched types [E0308]
-
-    let x = String::from("x");
-    let res = Some(x);
-    takes_option(&res); //~ ERROR 8:18: 8:22: mismatched types [E0308]
-}

--- a/tests/ui/type/option-ref-advice.rs
+++ b/tests/ui/type/option-ref-advice.rs
@@ -1,0 +1,11 @@
+// Regression test for https://github.com/rust-lang/rust/issues/100605
+
+fn takes_option(_arg: Option<&String>) {}
+
+fn main() {
+    takes_option(&None); //~ ERROR 6:18: 6:23: mismatched types [E0308]
+
+    let x = String::from("x");
+    let res = Some(x);
+    takes_option(&res); //~ ERROR 10:18: 10:22: mismatched types [E0308]
+}

--- a/tests/ui/type/option-ref-advice.stderr
+++ b/tests/ui/type/option-ref-advice.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-100605.rs:4:18
+  --> $DIR/option-ref-advice.rs:6:18
    |
 LL |     takes_option(&None);
    |     ------------ ^^^^^ expected `Option<&String>`, found `&Option<_>`
@@ -9,7 +9,7 @@ LL |     takes_option(&None);
    = note:   expected enum `Option<&String>`
            found reference `&Option<_>`
 note: function defined here
-  --> $DIR/issue-100605.rs:1:4
+  --> $DIR/option-ref-advice.rs:3:4
    |
 LL | fn takes_option(_arg: Option<&String>) {}
    |    ^^^^^^^^^^^^ ---------------------
@@ -20,7 +20,7 @@ LL +     takes_option(None);
    |
 
 error[E0308]: mismatched types
-  --> $DIR/issue-100605.rs:8:18
+  --> $DIR/option-ref-advice.rs:10:18
    |
 LL |     takes_option(&res);
    |     ------------ ^^^^ expected `Option<&String>`, found `&Option<String>`
@@ -30,7 +30,7 @@ LL |     takes_option(&res);
    = note:   expected enum `Option<&String>`
            found reference `&Option<String>`
 note: function defined here
-  --> $DIR/issue-100605.rs:1:4
+  --> $DIR/option-ref-advice.rs:3:4
    |
 LL | fn takes_option(_arg: Option<&String>) {}
    |    ^^^^^^^^^^^^ ---------------------


### PR DESCRIPTION
The test is a regression test for a [bug ](https://github.com/rust-lang/rust/issues/100605) where the compiler gave bad advice for an `Option<&String>`. Rename the file appropriately.

Part of #73494