### PR TITLE
Skip reporting item name when checking RPITIT GAT's associated type bounds hold

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/note.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note.rs
@@ -243,12 +243,18 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             }
             infer::CheckAssociatedTypeBounds { impl_item_def_id, trait_item_def_id, parent } => {
                 let mut err = self.report_concrete_failure(*parent, sub, sup);
-                let trait_item_span = self.tcx.def_span(trait_item_def_id);
-                let item_name = self.tcx.item_name(impl_item_def_id.to_def_id());
-                err.span_label(
-                    trait_item_span,
-                    format!("definition of `{}` from trait", item_name),
-                );
+
+                // Don't mention the item name if it's an RPITIT, since that'll just confuse
+                // folks.
+                if !self.tcx.is_impl_trait_in_trait(impl_item_def_id.to_def_id()) {
+                    let trait_item_span = self.tcx.def_span(trait_item_def_id);
+                    let item_name = self.tcx.item_name(impl_item_def_id.to_def_id());
+                    err.span_label(
+                        trait_item_span,
+                        format!("definition of `{}` from trait", item_name),
+                    );
+                }
+
                 self.suggest_copy_trait_method_bounds(
                     trait_item_def_id,
                     impl_item_def_id,

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -346,8 +346,16 @@ fn associated_type_for_impl_trait_in_impl(
 ) -> LocalDefId {
     let impl_local_def_id = tcx.local_parent(impl_fn_def_id);
 
-    // FIXME fix the span, we probably want the def_id of the return type of the function
-    let span = tcx.def_span(impl_fn_def_id);
+    let decl = tcx
+        .hir()
+        .find_by_def_id(impl_fn_def_id)
+        .expect("expected item")
+        .fn_decl()
+        .expect("expected decl");
+    let span = match decl.output {
+        hir::FnRetTy::DefaultReturn(_) => tcx.def_span(impl_fn_def_id),
+        hir::FnRetTy::Return(ty) => ty.span,
+    };
     let impl_assoc_ty = tcx.at(span).create_def(impl_local_def_id, DefPathData::ImplTraitAssocTy);
 
     let local_def_id = impl_assoc_ty.def_id();

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.rs
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.rs
@@ -1,0 +1,11 @@
+// issue: 114146
+
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Foo {
+    fn bar<'other: 'a>() -> impl Sized + 'a {}
+    //~^ ERROR use of undeclared lifetime name `'a`
+    //~| ERROR use of undeclared lifetime name `'a`
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.stderr
@@ -1,0 +1,33 @@
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/bad-item-bound-within-rpitit-2.rs:6:20
+   |
+LL |     fn bar<'other: 'a>() -> impl Sized + 'a {}
+   |                    ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     fn bar<'a, 'other: 'a>() -> impl Sized + 'a {}
+   |            +++
+help: consider introducing lifetime `'a` here
+   |
+LL | trait Foo<'a> {
+   |          ++++
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/bad-item-bound-within-rpitit-2.rs:6:42
+   |
+LL |     fn bar<'other: 'a>() -> impl Sized + 'a {}
+   |                                          ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     fn bar<'a, 'other: 'a>() -> impl Sized + 'a {}
+   |            +++
+help: consider introducing lifetime `'a` here
+   |
+LL | trait Foo<'a> {
+   |          ++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
@@ -1,0 +1,25 @@
+// issue: 114145
+
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Iterable {
+    type Item<'a>
+    where
+        Self: 'a;
+
+    fn iter(&self) -> impl '_ + Iterator<Item = Self::Item<'_>>;
+}
+
+impl<'a, I: 'a + Iterable> Iterable for &'a I {
+    type Item<'b> = I::Item<'a>
+    where
+        'b: 'a;
+    //~^ ERROR impl has stricter requirements than trait
+
+    fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
+        //~^ ERROR the type `&'a I` does not fulfill the required lifetime
+        (*self).iter()
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -1,0 +1,30 @@
+error[E0276]: impl has stricter requirements than trait
+  --> $DIR/bad-item-bound-within-rpitit.rs:16:13
+   |
+LL |     type Item<'a>
+   |     ------------- definition of `Item` from trait
+...
+LL |         'b: 'a;
+   |             ^^ impl has extra requirement `'b: 'a`
+   |
+help: copy the `where` clause predicates from the trait
+   |
+LL |     where Self: 'b;
+   |     ~~~~~~~~~~~~~~
+
+error[E0477]: the type `&'a I` does not fulfill the required lifetime
+  --> $DIR/bad-item-bound-within-rpitit.rs:19:5
+   |
+LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type must outlive the anonymous lifetime as defined here
+  --> $DIR/bad-item-bound-within-rpitit.rs:10:28
+   |
+LL |     fn iter(&self) -> impl '_ + Iterator<Item = Self::Item<'_>>;
+   |                            ^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0276, E0477.
+For more information about an error, try `rustc --explain E0276`.

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -13,10 +13,10 @@ LL |     where Self: 'b;
    |     ~~~~~~~~~~~~~~
 
 error[E0477]: the type `&'a I` does not fulfill the required lifetime
-  --> $DIR/bad-item-bound-within-rpitit.rs:19:5
+  --> $DIR/bad-item-bound-within-rpitit.rs:19:23
    |
 LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: type must outlive the anonymous lifetime as defined here
   --> $DIR/bad-item-bound-within-rpitit.rs:10:28


### PR DESCRIPTION
Doesn't really make sense to label an item that has a name that users can't really mention. Fixes #114145. Also fixes #113794.

r? @spastorino