### PR TITLE
Insert RPITITs that were shadowed by missing ADTs that resolve to [type error]

### DIFF
--- a/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
+++ b/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
@@ -1,0 +1,18 @@
+// issue: 113903
+
+#![feature(return_position_impl_trait_in_trait)]
+
+use std::ops::Deref;
+
+pub trait Tr {
+    fn w() -> impl Deref<Target = Missing<impl Sized>>;
+    //~^ ERROR cannot find type `Missing` in this scope
+}
+
+impl Tr for () {
+    fn w() -> &'static () {
+        &()
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.stderr
+++ b/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/rpitit-shadowed-by-missing-adt.rs:8:35
+   |
+LL |     fn w() -> impl Deref<Target = Missing<impl Sized>>;
+   |                                   ^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Comment inline explains how this can happen.

Fixes #113903