### PR TITLE
style-guide: don't flatten match arms with macro call

### DIFF
--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -663,7 +663,8 @@ never use a block (unless the block is empty).
 
 If the right-hand side consists of multiple statements, or has line comments,
 or the start of the line does not fit on the same line as the left-hand side,
-use a block.
+use a block. Do not flatten a right-hand side block containing a single macro call
+because its expanded form could contain a trailing semicolon.
 
 Block-indent the body of a block arm.
 
@@ -686,6 +687,10 @@ match foo {
     bar => {}
     // Trailing comma on last item.
     foo => bar,
+    baz => qux!(),
+    lorem => {
+        ipsum!()
+    }
 }
 ```
 


### PR DESCRIPTION
This pulls forward the gist of the text that was added to the style guide in https://github.com/rust-lang/style-team/pull/159 to account for needing to tweak/soften rustfmt's behavior based on the style guide prescriptions.

There were a few options I considered, noted below, and although I don't particularly love any of them, I felt this was the lesser of the evils.

r? @joshtriplett 