### PR TITLE
Enable triagebot no-merges check

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -402,6 +402,10 @@ message_on_add = """\
 Issue #{number} "{title}" has been added.
 """
 
+[no-merges]
+exclude_titles = ["Rollup of", "subtree update"]
+labels = ["has-merge-commits", "S-waiting-on-author"]
+
 [github-releases]
 format = "rustc"
 project-name = "Rust"


### PR DESCRIPTION
Follow-up on https://github.com/rust-lang/triagebot/pull/1704

### Motivation

Occasionally, a merge commit like https://github.com/rust-lang/rust/commit/cb5c011670ce8d073d0aae8c45e73c20593bfa11 makes it past manual review and gets merged into master.

At one point, we tried adding a check to CI to prevent this from happening (https://github.com/rust-lang/rust/pull/105058), but that ended up [problematic](https://github.com/rust-lang/rust/pull/106319#issuecomment-1368144076) and was [reverted](https://github.com/rust-lang/rust/pull/106320). This kind of check is simply too fragile for CI, and there must be a way for a human to override the bot's decision.

The capability to detect and warn about merge commits has been present in triagebot for quite some time, but was never enabled at rust-lang/rust, possibly due to concerns about false positives on rollup and subtree sync PRs. This PR intends to alleviate those concerns.

### Configuration

This configuration will exclude rollup PRs and subtree sync PRs from merge commit detection, and it will post the default warning message and add the `has-merge-commits` and `S-waiting-on-author` labels when merge commits are detected on other PRs.

The eventual vision is to have bors refuse to merge if the `has-merge-commits` label is present. A reviewer can still force the merge by removing that label if they so wish.

### Note for contributors

The rollup tool should add that label automatically, but anyone performing subtree updates should begin including "subtree update" in the titles of those PRs, to avoid false positives.

r? infra

## Open Questions

1. This configuration uses the default message that's built into triagebot:

> There are merge commits (commits with multiple parents) in your changes. We have a [no merge policy](https://rustc-dev-guide.rust-lang.org/git.html#no-merge-policy) so these commits will need to be removed for this pull request to be merged.
>
> You can start a rebase with the following commands:
> ```shell-session
> $ # rebase
> $ git rebase -i master
> $ # delete any merge commits in the editor that appears
> $ git push --force-with-lease
> ```

Any changes to this are easy, I'll just have to add a `message` option. Should we mention the excluded titles in the message?