### PR TITLE
Add regression test for `--cap-lints allow` and trait bounds warning

### DIFF
--- a/tests/ui/lint/lint-cap-trait-bounds.rs
+++ b/tests/ui/lint/lint-cap-trait-bounds.rs
@@ -1,0 +1,8 @@
+// Regression test for https://github.com/rust-lang/rust/issues/43134
+
+// check-pass
+// compile-flags: --cap-lints allow
+
+type Foo<T: Clone> = Option<T>;
+
+fn main() {}


### PR DESCRIPTION
Closes #43134 

I have verified that the test fails if stderr begins to contain output by making sure the test fails when I add

    eprintln!("some output on stderr");

to the compiler (I added it to `fn build_session()`).