### PR TITLE
Add regression test for resolving `--extern libc=test.rlib`

### DIFF
--- a/tests/ui/imports/resolve-other-libc.rs
+++ b/tests/ui/imports/resolve-other-libc.rs
@@ -1,0 +1,14 @@
+// Regression test for https://github.com/rust-lang/rust/issues/26043
+
+// compile-flags: --extern libc=test.rlib
+
+// The error shall NOT be something similar to the following, because it
+// indicates that `libc` was wrongly resolved to `libc` shipped with the
+// compiler:
+//
+//   error[E0658]: use of unstable library feature 'rustc_private': \
+//           this crate is being loaded from the sysroot
+//
+extern crate libc; //~ ERROR: extern location for libc does not exist: test.rlib
+
+fn main() {}

--- a/tests/ui/imports/resolve-other-libc.stderr
+++ b/tests/ui/imports/resolve-other-libc.stderr
@@ -1,0 +1,8 @@
+error: extern location for libc does not exist: test.rlib
+  --> $DIR/resolve-other-libc.rs:12:1
+   |
+LL | extern crate libc;
+   | ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes #26043

I could not find a test for this particular use case. The closest I got was [`tests/ui/imports/issue-37887.rs`](https://github.com/rust-lang/rust/blob/master/tests/ui/imports/issue-37887.rs), but that is a regression test for a different use case (see https://github.com/rust-lang/rust/issues/37887).