### PR TITLE
Fix switch-stdout test for none unix/windows platforms

### DIFF
--- a/library/std/tests/switch-stdout.rs
+++ b/library/std/tests/switch-stdout.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_family = "unix", target_family = "windows"))]
+#![cfg(any(target_family = "unix", target_family = "windows"))]
 
 use std::fs::File;
 use std::io::{Read, Write};


### PR DESCRIPTION
PR #112390 moved tests to std. Unfortunately, there is a typo which causes issues on platforms other than unix and windows.