### PR TITLE
Fix issue_15149 test for the SGX target

### DIFF
--- a/library/std/tests/process_spawning.rs
+++ b/library/std/tests/process_spawning.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_env="sgx"))]
+
 use std::env;
 use std::fs;
 use std::process;


### PR DESCRIPTION
PR https://github.com/rust-lang/rust/pull/112390 moved tests to std. Unfortunately, this caused the `issue_15149` test to be enabled for the SGX target. This is incorrect as the SGX target does not support the `env::current_exe()` call.