### PR TITLE
Account for macros when suggesting a new let binding

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2133,13 +2133,14 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         self.current -= 1;
                     }
                     fn visit_expr(&mut self, expr: &hir::Expr<'tcx>) {
-                        if self.span == expr.span {
+                        if self.span == expr.span.source_callsite() {
                             self.found = self.current;
                         }
                         walk_expr(self, expr);
                     }
                 }
                 let source_info = self.body.source_info(location);
+                let proper_span = proper_span.source_callsite();
                 if let Some(scope) = self.body.source_scopes.get(source_info.scope)
                     && let ClearCrossCrate::Set(scope_data) = &scope.local_data
                     && let Some(node) = self.infcx.tcx.hir().find(scope_data.lint_root)

--- a/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
+++ b/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
@@ -8,8 +8,12 @@ LL |     let x = defer(&vec!["Goodbye", "world!"]);
 LL |     x.x[0];
    |     ------ borrow later used here
    |
-   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using a `let` binding to create a longer lived value
+   |
+LL ~     let binding = vec!["Goodbye", "world!"];
+LL ~     let x = defer(&binding);
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -9,8 +9,12 @@ LL |
 LL |     x.use_mut();
    |     - borrow later used here
    |
-   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using a `let` binding to create a longer lived value
+   |
+LL ~     let binding = vec![1];
+LL ~     let mut x = binding.iter();
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
+++ b/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
@@ -9,8 +9,12 @@ LL |
 LL |     stuff(phantom_pinned)
    |           -------------- borrow later used here
    |
-   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using a `let` binding to create a longer lived value
+   |
+LL ~     let binding = pin!(PhantomPinned);
+LL ~     let phantom_pinned = identity(binding);
+   |
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/lifetime_errors_on_promotion_misusage.rs:18:30


### PR DESCRIPTION
Provide a structured suggestion when the expression comes from a macro expansion:

```
error[E0716]: temporary value dropped while borrowed
  --> $DIR/borrowck-let-suggestion.rs:2:17
   |
LL |     let mut x = vec![1].iter();
   |                 ^^^^^^^       - temporary value is freed at the end of this statement
   |                 |
   |                 creates a temporary value which is freed while still in use
LL |
LL |     x.use_mut();
   |     - borrow later used here
   |
   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider using a `let` binding to create a longer lived value
   |
LL ~     let binding = vec![1];
LL ~     let mut x = binding.iter();
   |
```