### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1673,11 +1673,11 @@ impl HandlerInner {
         let backtrace = std::env::var_os("RUST_BACKTRACE").map_or(true, |x| &x != "0");
         for bug in bugs {
             if let Some(file) = self.ice_file.as_ref()
-                && let Ok(mut out) = std::fs::File::options().append(true).open(file)
+                && let Ok(mut out) = std::fs::File::options().create(true).append(true).open(file)
             {
                 let _ = write!(
                     &mut out,
-                    "\n\ndelayed span bug: {}\n{}",
+                    "delayed span bug: {}\n{}\n",
                     bug.inner.styled_message().iter().filter_map(|(msg, _)| msg.as_str()).collect::<String>(),
                     &bug.note
                 );

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -531,8 +531,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return;
             }
 
-            let up_to_rcvr_span = segment.ident.span.until(callee_expr.span);
-            let rest_span = callee_expr.span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
+            let Some(callee_expr_span) = callee_expr.span.find_ancestor_inside(call_expr.span)
+            else {
+                return;
+            };
+            let up_to_rcvr_span = segment.ident.span.until(callee_expr_span);
+            let rest_span = callee_expr_span.shrink_to_hi().to(call_expr.span.shrink_to_hi());
             let rest_snippet = if let Some(first) = rest.first() {
                 self.tcx
                     .sess

--- a/compiler/rustc_infer/src/infer/error_reporting/note.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note.rs
@@ -243,12 +243,18 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             }
             infer::CheckAssociatedTypeBounds { impl_item_def_id, trait_item_def_id, parent } => {
                 let mut err = self.report_concrete_failure(*parent, sub, sup);
-                let trait_item_span = self.tcx.def_span(trait_item_def_id);
-                let item_name = self.tcx.item_name(impl_item_def_id.to_def_id());
-                err.span_label(
-                    trait_item_span,
-                    format!("definition of `{}` from trait", item_name),
-                );
+
+                // Don't mention the item name if it's an RPITIT, since that'll just confuse
+                // folks.
+                if !self.tcx.is_impl_trait_in_trait(impl_item_def_id.to_def_id()) {
+                    let trait_item_span = self.tcx.def_span(trait_item_def_id);
+                    let item_name = self.tcx.item_name(impl_item_def_id.to_def_id());
+                    err.span_label(
+                        trait_item_span,
+                        format!("definition of `{}` from trait", item_name),
+                    );
+                }
+
                 self.suggest_copy_trait_method_bounds(
                     trait_item_def_id,
                     impl_item_def_id,

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -346,8 +346,16 @@ fn associated_type_for_impl_trait_in_impl(
 ) -> LocalDefId {
     let impl_local_def_id = tcx.local_parent(impl_fn_def_id);
 
-    // FIXME fix the span, we probably want the def_id of the return type of the function
-    let span = tcx.def_span(impl_fn_def_id);
+    let decl = tcx
+        .hir()
+        .find_by_def_id(impl_fn_def_id)
+        .expect("expected item")
+        .fn_decl()
+        .expect("expected decl");
+    let span = match decl.output {
+        hir::FnRetTy::DefaultReturn(_) => tcx.def_span(impl_fn_def_id),
+        hir::FnRetTy::Return(ty) => ty.span,
+    };
     let impl_assoc_ty = tcx.at(span).create_def(impl_local_def_id, DefPathData::ImplTraitAssocTy);
 
     let local_def_id = impl_assoc_ty.def_id();

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -300,7 +300,7 @@ pub fn panic_hook_with_disk_dump(info: &PanicInfo<'_>, path: Option<&crate::path
     };
 
     if let Some(path) = path
-        && let Ok(mut out) = crate::fs::File::options().create(true).write(true).open(&path)
+        && let Ok(mut out) = crate::fs::File::options().create(true).append(true).open(&path)
     {
         write(&mut out, BacktraceStyle::full());
     }

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.rs
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.rs
@@ -1,0 +1,11 @@
+// issue: 114146
+
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Foo {
+    fn bar<'other: 'a>() -> impl Sized + 'a {}
+    //~^ ERROR use of undeclared lifetime name `'a`
+    //~| ERROR use of undeclared lifetime name `'a`
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.stderr
@@ -1,0 +1,33 @@
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/bad-item-bound-within-rpitit-2.rs:6:20
+   |
+LL |     fn bar<'other: 'a>() -> impl Sized + 'a {}
+   |                    ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     fn bar<'a, 'other: 'a>() -> impl Sized + 'a {}
+   |            +++
+help: consider introducing lifetime `'a` here
+   |
+LL | trait Foo<'a> {
+   |          ++++
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/bad-item-bound-within-rpitit-2.rs:6:42
+   |
+LL |     fn bar<'other: 'a>() -> impl Sized + 'a {}
+   |                                          ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     fn bar<'a, 'other: 'a>() -> impl Sized + 'a {}
+   |            +++
+help: consider introducing lifetime `'a` here
+   |
+LL | trait Foo<'a> {
+   |          ++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
@@ -1,0 +1,25 @@
+// issue: 114145
+
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Iterable {
+    type Item<'a>
+    where
+        Self: 'a;
+
+    fn iter(&self) -> impl '_ + Iterator<Item = Self::Item<'_>>;
+}
+
+impl<'a, I: 'a + Iterable> Iterable for &'a I {
+    type Item<'b> = I::Item<'a>
+    where
+        'b: 'a;
+    //~^ ERROR impl has stricter requirements than trait
+
+    fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
+        //~^ ERROR the type `&'a I` does not fulfill the required lifetime
+        (*self).iter()
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -1,0 +1,30 @@
+error[E0276]: impl has stricter requirements than trait
+  --> $DIR/bad-item-bound-within-rpitit.rs:16:13
+   |
+LL |     type Item<'a>
+   |     ------------- definition of `Item` from trait
+...
+LL |         'b: 'a;
+   |             ^^ impl has extra requirement `'b: 'a`
+   |
+help: copy the `where` clause predicates from the trait
+   |
+LL |     where Self: 'b;
+   |     ~~~~~~~~~~~~~~
+
+error[E0477]: the type `&'a I` does not fulfill the required lifetime
+  --> $DIR/bad-item-bound-within-rpitit.rs:19:5
+   |
+LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type must outlive the anonymous lifetime as defined here
+  --> $DIR/bad-item-bound-within-rpitit.rs:10:28
+   |
+LL |     fn iter(&self) -> impl '_ + Iterator<Item = Self::Item<'_>>;
+   |                            ^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0276, E0477.
+For more information about an error, try `rustc --explain E0276`.

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -13,10 +13,10 @@ LL |     where Self: 'b;
    |     ~~~~~~~~~~~~~~
 
 error[E0477]: the type `&'a I` does not fulfill the required lifetime
-  --> $DIR/bad-item-bound-within-rpitit.rs:19:5
+  --> $DIR/bad-item-bound-within-rpitit.rs:19:23
    |
 LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: type must outlive the anonymous lifetime as defined here
   --> $DIR/bad-item-bound-within-rpitit.rs:10:28

--- a/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
+++ b/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
@@ -1,0 +1,18 @@
+// issue: 113903
+
+#![feature(return_position_impl_trait_in_trait)]
+
+use std::ops::Deref;
+
+pub trait Tr {
+    fn w() -> impl Deref<Target = Missing<impl Sized>>;
+    //~^ ERROR cannot find type `Missing` in this scope
+}
+
+impl Tr for () {
+    fn w() -> &'static () {
+        &()
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.stderr
+++ b/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/rpitit-shadowed-by-missing-adt.rs:8:35
+   |
+LL |     fn w() -> impl Deref<Target = Missing<impl Sized>>;
+   |                                   ^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/lint/lint-cap-trait-bounds.rs
+++ b/tests/ui/lint/lint-cap-trait-bounds.rs
@@ -1,0 +1,8 @@
+// Regression test for https://github.com/rust-lang/rust/issues/43134
+
+// check-pass
+// compile-flags: --cap-lints allow
+
+type Foo<T: Clone> = Option<T>;
+
+fn main() {}

--- a/tests/ui/methods/suggest-method-on-call-with-macro-rcvr.rs
+++ b/tests/ui/methods/suggest-method-on-call-with-macro-rcvr.rs
@@ -1,0 +1,6 @@
+// issue: 114131
+
+fn main() {
+    let hello = len(vec![]);
+    //~^ ERROR cannot find function `len` in this scope
+}

--- a/tests/ui/methods/suggest-method-on-call-with-macro-rcvr.stderr
+++ b/tests/ui/methods/suggest-method-on-call-with-macro-rcvr.stderr
@@ -1,0 +1,15 @@
+error[E0425]: cannot find function `len` in this scope
+  --> $DIR/suggest-method-on-call-with-macro-rcvr.rs:4:17
+   |
+LL |     let hello = len(vec![]);
+   |                 ^^^ not found in this scope
+   |
+help: use the `.` operator to call the method `len` on `&Vec<_>`
+   |
+LL -     let hello = len(vec![]);
+LL +     let hello = vec![].len();
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/privacy/issue-113860-1.rs
+++ b/tests/ui/privacy/issue-113860-1.rs
@@ -1,0 +1,16 @@
+#![feature(staged_api)]
+//~^ ERROR module has missing stability attribute
+
+pub trait Trait {
+    //~^ ERROR trait has missing stability attribute
+    fn fun() {}
+    //~^ ERROR associated function has missing stability attribute
+}
+
+impl Trait for u8 {
+    //~^ ERROR implementation has missing stability attribute
+    pub(self) fn fun() {}
+    //~^ ERROR visibility qualifiers are not permitted here [E0449]
+}
+
+fn main() {}

--- a/tests/ui/privacy/issue-113860-1.stderr
+++ b/tests/ui/privacy/issue-113860-1.stderr
@@ -1,0 +1,49 @@
+error[E0449]: visibility qualifiers are not permitted here
+  --> $DIR/issue-113860-1.rs:12:5
+   |
+LL |     pub(self) fn fun() {}
+   |     ^^^^^^^^^
+   |
+   = note: trait items always share the visibility of their trait
+
+error: module has missing stability attribute
+  --> $DIR/issue-113860-1.rs:1:1
+   |
+LL | / #![feature(staged_api)]
+LL | |
+LL | |
+LL | | pub trait Trait {
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: trait has missing stability attribute
+  --> $DIR/issue-113860-1.rs:4:1
+   |
+LL | / pub trait Trait {
+LL | |
+LL | |     fn fun() {}
+LL | |
+LL | | }
+   | |_^
+
+error: implementation has missing stability attribute
+  --> $DIR/issue-113860-1.rs:10:1
+   |
+LL | / impl Trait for u8 {
+LL | |
+LL | |     pub(self) fn fun() {}
+LL | |
+LL | | }
+   | |_^
+
+error: associated function has missing stability attribute
+  --> $DIR/issue-113860-1.rs:6:5
+   |
+LL |     fn fun() {}
+   |     ^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0449`.

--- a/tests/ui/privacy/issue-113860-2.rs
+++ b/tests/ui/privacy/issue-113860-2.rs
@@ -1,0 +1,16 @@
+#![feature(staged_api)]
+//~^ ERROR module has missing stability attribute
+
+pub trait Trait {
+    //~^ ERROR trait has missing stability attribute
+    type X;
+    //~^ ERROR associated type has missing stability attribute
+}
+
+impl Trait for u8 {
+    //~^ ERROR implementation has missing stability attribute
+    pub(self) type X = Self;
+    //~^ ERROR visibility qualifiers are not permitted here [E0449]
+}
+
+fn main() {}

--- a/tests/ui/privacy/issue-113860-2.stderr
+++ b/tests/ui/privacy/issue-113860-2.stderr
@@ -1,0 +1,49 @@
+error[E0449]: visibility qualifiers are not permitted here
+  --> $DIR/issue-113860-2.rs:12:5
+   |
+LL |     pub(self) type X = Self;
+   |     ^^^^^^^^^
+   |
+   = note: trait items always share the visibility of their trait
+
+error: module has missing stability attribute
+  --> $DIR/issue-113860-2.rs:1:1
+   |
+LL | / #![feature(staged_api)]
+LL | |
+LL | |
+LL | | pub trait Trait {
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: trait has missing stability attribute
+  --> $DIR/issue-113860-2.rs:4:1
+   |
+LL | / pub trait Trait {
+LL | |
+LL | |     type X;
+LL | |
+LL | | }
+   | |_^
+
+error: implementation has missing stability attribute
+  --> $DIR/issue-113860-2.rs:10:1
+   |
+LL | / impl Trait for u8 {
+LL | |
+LL | |     pub(self) type X = Self;
+LL | |
+LL | | }
+   | |_^
+
+error: associated type has missing stability attribute
+  --> $DIR/issue-113860-2.rs:6:5
+   |
+LL |     type X;
+   |     ^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0449`.

--- a/tests/ui/privacy/issue-113860.rs
+++ b/tests/ui/privacy/issue-113860.rs
@@ -1,0 +1,16 @@
+#![feature(staged_api)]
+//~^ ERROR module has missing stability attribute
+
+pub trait Trait {
+    //~^ ERROR trait has missing stability attribute
+    const X: u32;
+    //~^ ERROR associated constant has missing stability attribute
+}
+
+impl Trait for u8 {
+    //~^ ERROR implementation has missing stability attribute
+    pub(self) const X: u32 = 3;
+    //~^ ERROR visibility qualifiers are not permitted here [E0449]
+}
+
+fn main() {}

--- a/tests/ui/privacy/issue-113860.stderr
+++ b/tests/ui/privacy/issue-113860.stderr
@@ -1,0 +1,49 @@
+error[E0449]: visibility qualifiers are not permitted here
+  --> $DIR/issue-113860.rs:12:5
+   |
+LL |     pub(self) const X: u32 = 3;
+   |     ^^^^^^^^^
+   |
+   = note: trait items always share the visibility of their trait
+
+error: module has missing stability attribute
+  --> $DIR/issue-113860.rs:1:1
+   |
+LL | / #![feature(staged_api)]
+LL | |
+LL | |
+LL | | pub trait Trait {
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: trait has missing stability attribute
+  --> $DIR/issue-113860.rs:4:1
+   |
+LL | / pub trait Trait {
+LL | |
+LL | |     const X: u32;
+LL | |
+LL | | }
+   | |_^
+
+error: implementation has missing stability attribute
+  --> $DIR/issue-113860.rs:10:1
+   |
+LL | / impl Trait for u8 {
+LL | |
+LL | |     pub(self) const X: u32 = 3;
+LL | |
+LL | | }
+   | |_^
+
+error: associated constant has missing stability attribute
+  --> $DIR/issue-113860.rs:6:5
+   |
+LL |     const X: u32;
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0449`.


### PR DESCRIPTION
Successful merges:

 - #114099 (privacy: no nominal visibility for assoc fns )
 - #114128 (When flushing delayed span bugs, write to the ICE dump file even if it doesn't exist)
 - #114138 (Adjust spans correctly for fn -> method suggestion)
 - #114146 (Skip reporting item name when checking RPITIT GAT's associated type bounds hold)
 - #114147 (Insert RPITITs that were shadowed by missing ADTs that resolve to [type error])
 - #114155 (Replace a lazy `RefCell<Option<T>>` with `OnceCell<T>`)
 - #114164 (Add regression test for `--cap-lints allow` and trait bounds warning)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114099,114128,114138,114146,114147,114155,114164)
<!-- homu-ignore:end -->