### PR TITLE
Bubble up nested goals from equation in `predicates_for_object_candidate`

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
@@ -153,16 +153,12 @@ pub(super) trait GoalKind<'tcx>:
             let ty::Dynamic(bounds, _, _) = *goal.predicate.self_ty().kind() else {
                 bug!("expected object type in `consider_object_bound_candidate`");
             };
-            ecx.add_goals(
-                structural_traits::predicates_for_object_candidate(
-                    &ecx,
-                    goal.param_env,
-                    goal.predicate.trait_ref(tcx),
-                    bounds,
-                )
-                .into_iter()
-                .map(|pred| goal.with(tcx, pred)),
-            );
+            ecx.add_goals(structural_traits::predicates_for_object_candidate(
+                &ecx,
+                goal.param_env,
+                goal.predicate.trait_ref(tcx),
+                bounds,
+            ));
             ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
         })
     }

--- a/tests/ui/traits/new-solver/object-soundness-requires-generalization.rs
+++ b/tests/ui/traits/new-solver/object-soundness-requires-generalization.rs
@@ -1,0 +1,20 @@
+// compile-flags: -Ztrait-solver=next
+// ignore-test
+
+trait Trait {
+    type Gat<'lt>;
+}
+impl Trait for u8 {
+    type Gat<'lt> = u8;
+}
+
+fn test<T: Trait, F: FnOnce(<T as Trait>::Gat<'_>) -> S + ?Sized, S>() {}
+
+fn main() {
+    // Proving `dyn FnOnce: FnOnce` requires making sure that all of the supertraits
+    // of the trait and associated type bounds hold. We check this in
+    // `predicates_for_object_candidate`, and eagerly replace projections using equality
+    // which may generalize a type and emit a nested AliasRelate goal. Make sure that
+    // we don't ICE in that case, and bubble that goal up to the caller.
+    test::<u8, dyn FnOnce(<u8 as Trait>::Gat<'_>) + 'static, _>();
+}


### PR DESCRIPTION
This used to be needed for https://github.com/rust-lang/rust/pull/114036#discussion_r1273987510, but since it's no longer, I'm opening this as a separate PR. This also fixes one ICEing UI test: (`tests/ui/unboxed-closures/issue-53448.rs`)

r? @lcnr