### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -138,7 +138,10 @@ where
         err_inval!(Layout(LayoutError::Unknown(_))) | err_inval!(TooGeneric) => {
             ErrorHandled::TooGeneric
         }
-        err_inval!(AlreadyReported(error_reported)) => ErrorHandled::Reported(error_reported),
+        err_inval!(AlreadyReported(guar)) => ErrorHandled::Reported(guar),
+        err_inval!(Layout(LayoutError::ReferencesError(guar))) => {
+            ErrorHandled::Reported(guar.into())
+        }
         err_inval!(Layout(layout_error @ LayoutError::SizeOverflow(_))) => {
             // We must *always* hard error on these, even if the caller wants just a lint.
             // The `message` makes little sense here, this is a more serious error than the

--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -122,14 +122,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         } else {
             err.note(format!("source type: `{}` ({})", from, skeleton_string(from, sk_from)))
                 .note(format!("target type: `{}` ({})", to, skeleton_string(to, sk_to)));
-            let mut should_delay_as_bug = false;
-            if let Err(LayoutError::Unknown(bad_from)) = sk_from && bad_from.references_error() {
-                should_delay_as_bug = true;
-            }
-            if let Err(LayoutError::Unknown(bad_to)) = sk_to && bad_to.references_error() {
-                should_delay_as_bug = true;
-            }
-            if should_delay_as_bug {
+            if let Err(LayoutError::ReferencesError(_)) = sk_from {
+                err.delay_as_bug();
+            } else if let Err(LayoutError::ReferencesError(_)) = sk_to {
                 err.delay_as_bug();
             }
         }

--- a/compiler/rustc_middle/messages.ftl
+++ b/compiler/rustc_middle/messages.ftl
@@ -52,6 +52,9 @@ middle_drop_check_overflow =
     overflow while adding drop-check rules for {$ty}
     .note = overflowed on {$overflow_ty}
 
+middle_layout_references_error =
+    the type has an unknown layout
+
 middle_limit_invalid =
     `limit` must be a non-negative integer
     .label = {$error_str}

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -132,6 +132,9 @@ pub enum LayoutError<'tcx> {
 
     #[diag(middle_cycle)]
     Cycle,
+
+    #[diag(middle_layout_references_error)]
+    ReferencesError,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -10,7 +10,7 @@ use rustc_hir::def_id::DefId;
 use rustc_index::IndexVec;
 use rustc_session::config::OptLevel;
 use rustc_span::symbol::{sym, Symbol};
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{ErrorGuaranteed, Span, DUMMY_SP};
 use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::*;
 use rustc_target::spec::{abi::Abi as SpecAbi, HasTargetSpec, PanicStrategy, Target};
@@ -212,6 +212,7 @@ pub enum LayoutError<'tcx> {
     Unknown(Ty<'tcx>),
     SizeOverflow(Ty<'tcx>),
     NormalizationFailure(Ty<'tcx>, NormalizationError<'tcx>),
+    ReferencesError(ErrorGuaranteed),
     Cycle,
 }
 
@@ -224,6 +225,7 @@ impl<'tcx> LayoutError<'tcx> {
             SizeOverflow(_) => middle_values_too_big,
             NormalizationFailure(_, _) => middle_cannot_be_normalized,
             Cycle => middle_cycle,
+            ReferencesError(_) => middle_layout_references_error,
         }
     }
 
@@ -237,6 +239,7 @@ impl<'tcx> LayoutError<'tcx> {
                 E::NormalizationFailure { ty, failure_ty: e.get_type_for_failure() }
             }
             Cycle => E::Cycle,
+            ReferencesError(_) => E::ReferencesError,
         }
     }
 }
@@ -257,6 +260,7 @@ impl<'tcx> fmt::Display for LayoutError<'tcx> {
                 e.get_type_for_failure()
             ),
             LayoutError::Cycle => write!(f, "a cycle occurred during layout computation"),
+            LayoutError::ReferencesError(_) => write!(f, "the type has an unknown layout"),
         }
     }
 }
@@ -323,7 +327,8 @@ impl<'tcx> SizeSkeleton<'tcx> {
             Err(
                 e @ LayoutError::Cycle
                 | e @ LayoutError::SizeOverflow(_)
-                | e @ LayoutError::NormalizationFailure(..),
+                | e @ LayoutError::NormalizationFailure(..)
+                | e @ LayoutError::ReferencesError(_),
             ) => return Err(e),
         };
 

--- a/compiler/rustc_transmute/src/layout/tree.rs
+++ b/compiler/rustc_transmute/src/layout/tree.rs
@@ -195,7 +195,7 @@ pub(crate) mod rustc {
     impl<'tcx> From<&LayoutError<'tcx>> for Err {
         fn from(err: &LayoutError<'tcx>) -> Self {
             match err {
-                LayoutError::Unknown(..) => Self::UnknownLayout,
+                LayoutError::Unknown(..) | LayoutError::ReferencesError(..) => Self::UnknownLayout,
                 err => unimplemented!("{:?}", err),
             }
         }

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -613,8 +613,6 @@ impl<K, V> BTreeMap<K, V> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     ///
@@ -635,8 +633,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// Clears the map, removing all elements.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -660,8 +656,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// Makes a new empty BTreeMap with a reasonable choice for B.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// # #![feature(allocator_api)]
@@ -687,8 +681,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// on the borrowed form *must* match the ordering on the key type.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -743,8 +735,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// The key in this pair is the minimum key in the map.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -829,8 +819,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// The key in this pair is the maximum key in the map.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -917,8 +905,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     ///
@@ -942,8 +928,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// on the borrowed form *must* match the ordering on the key type.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -982,8 +966,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     ///
@@ -1017,8 +999,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// #![feature(map_try_insert)]
     ///
@@ -1051,8 +1031,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     ///
@@ -1077,8 +1055,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// on the borrowed form *must* match the ordering on the key type.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -1208,8 +1184,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     /// use std::ops::Bound::Included;
@@ -1251,8 +1225,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     ///
@@ -1282,8 +1254,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -1335,8 +1305,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// including the key.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -2388,8 +2356,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     ///
@@ -2419,8 +2385,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// Gets a mutable iterator over the entries of the map, sorted by key.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -2453,8 +2417,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     ///
@@ -2474,8 +2436,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     ///
@@ -2494,8 +2454,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// Gets a mutable iterator over the values of the map, in order by key.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -2521,8 +2479,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::collections::BTreeMap;
     ///
@@ -2545,8 +2501,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// Returns `true` if the map contains no elements.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::collections::BTreeMap;
@@ -2577,8 +2531,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// element of the map.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// #![feature(btree_cursors)]
@@ -2618,8 +2570,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// element of the map.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// #![feature(btree_cursors)]
@@ -2673,8 +2623,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// #![feature(btree_cursors)]
     ///
@@ -2713,8 +2661,6 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// element of the map.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// #![feature(btree_cursors)]

--- a/library/core/src/borrow.rs
+++ b/library/core/src/borrow.rs
@@ -22,7 +22,7 @@
 /// Types express that they can be borrowed as some type `T` by implementing
 /// `Borrow<T>`, providing a reference to a `T` in the trait’s
 /// [`borrow`] method. A type is free to borrow as several different types.
-/// If it wishes to mutably borrow as the type – allowing the underlying data
+/// If it wishes to mutably borrow as the type, allowing the underlying data
 /// to be modified, it can additionally implement [`BorrowMut<T>`].
 ///
 /// Further, when providing implementations for additional traits, it needs

--- a/library/std/tests/process_spawning.rs
+++ b/library/std/tests/process_spawning.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_env="sgx"))]
+
 use std::env;
 use std::fs;
 use std::process;

--- a/library/std/tests/switch-stdout.rs
+++ b/library/std/tests/switch-stdout.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_family = "unix", target_family = "windows"))]
+#![cfg(any(target_family = "unix", target_family = "windows"))]
 
 use std::fs::File;
 use std::io::{Read, Write};

--- a/src/librustdoc/html/templates/type_layout.html
+++ b/src/librustdoc/html/templates/type_layout.html
@@ -44,6 +44,11 @@
             <strong>Note:</strong> Encountered an error during type layout; {#+ #}
             the type was too big. {# #}
         </p> {# #}
+        {% when Err(LayoutError::ReferencesError(_)) %}
+        <p> {# #}
+            <strong>Note:</strong> Encountered an error during type layout; {#+ #}
+            the type references errors. {# #}
+        </p> {# #}
         {% when Err(LayoutError::NormalizationFailure(_, _)) %}
         <p> {# #}
             <strong>Note:</strong> Encountered an error during type layout; {#+ #}

--- a/tests/ui/layout/malformed-unsized-type-in-union.rs
+++ b/tests/ui/layout/malformed-unsized-type-in-union.rs
@@ -1,0 +1,8 @@
+// issue: 113760
+
+union W { s: dyn Iterator<Item = Missing> }
+//~^ ERROR cannot find type `Missing` in this scope
+
+static ONCE: W = todo!();
+
+fn main() {}

--- a/tests/ui/layout/malformed-unsized-type-in-union.stderr
+++ b/tests/ui/layout/malformed-unsized-type-in-union.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/malformed-unsized-type-in-union.rs:3:34
+   |
+LL | union W { s: dyn Iterator<Item = Missing> }
+   |                                  ^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/proc-macro/derive-helper-shadowed.rs
+++ b/tests/ui/proc-macro/derive-helper-shadowed.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 // aux-build:derive-helper-shadowed-2.rs
 

--- a/tests/ui/proc-macro/derive-in-mod.rs
+++ b/tests/ui/proc-macro/derive-in-mod.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 extern crate test_macros;

--- a/tests/ui/proc-macro/edition-imports-2018.rs
+++ b/tests/ui/proc-macro/edition-imports-2018.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2018
 // aux-build:edition-imports-2015.rs
 

--- a/tests/ui/proc-macro/extern-prelude-extern-crate-proc-macro.rs
+++ b/tests/ui/proc-macro/extern-prelude-extern-crate-proc-macro.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2018
 
 extern crate proc_macro;

--- a/tests/ui/proc-macro/helper-attr-blocked-by-import.rs
+++ b/tests/ui/proc-macro/helper-attr-blocked-by-import.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 #[macro_use(Empty)]

--- a/tests/ui/proc-macro/issue-53481.rs
+++ b/tests/ui/proc-macro/issue-53481.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 #[macro_use]

--- a/tests/ui/proc-macro/macro-use-attr.rs
+++ b/tests/ui/proc-macro/macro-use-attr.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 #[macro_use]

--- a/tests/ui/proc-macro/macro-use-bang.rs
+++ b/tests/ui/proc-macro/macro-use-bang.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:test-macros.rs
 
 #[macro_use]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -498,6 +498,7 @@ cc = ["@nnethercote"]
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
+users_on_vacation = ["jyn514"]
 
 [assign.adhoc_groups]
 compiler-team = [


### PR DESCRIPTION
Successful merges:

 - #113773 (Don't attempt to compute layout of type referencing error)
 - #114107 (Prevent people from assigning me as a PR reviewer)
 - #114124 (tests/ui/proc-macro/*: Migrate FIXMEs to check-pass)
 - #114171 (Fix switch-stdout test for none unix/windows platforms)
 - #114172 (Fix issue_15149 test for the SGX target)
 - #114173 (btree/map.rs: remove "Basic usage" text)
 - #114174 (doc: replace wrong punctuation mark)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113773,114107,114124,114171,114172,114173,114174)
<!-- homu-ignore:end -->