### PR TITLE
Don't unsize coerce infer vars in select in new solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
@@ -235,7 +235,10 @@ fn rematch_unsize<'tcx>(
         goal.param_env,
         &mut nested,
     );
+
     match (a_ty.kind(), b_ty.kind()) {
+        // Don't try to coerce `?0` to `dyn Trait`
+        (ty::Infer(ty::TyVar(_)), _) | (_, ty::Infer(ty::TyVar(_))) => Ok(None),
         // Stall any ambiguous upcasting goals, since we can't rematch those
         (ty::Dynamic(_, _, ty::Dyn), ty::Dynamic(_, _, ty::Dyn)) => match certainty {
             Certainty::Yes => Ok(Some(ImplSource::Builtin(source, nested))),

--- a/tests/ui/inference/type-infer-generalize-ty-var.rs
+++ b/tests/ui/inference/type-infer-generalize-ty-var.rs
@@ -1,4 +1,6 @@
-// run-pass
+// check-pass
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]

--- a/tests/ui/traits/new-solver/dont-coerce-infer-to-dyn.rs
+++ b/tests/ui/traits/new-solver/dont-coerce-infer-to-dyn.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+use std::fmt::Display;
+use std::rc::Rc;
+
+fn mk<T: ?Sized>(t: Option<&T>) -> Rc<T> {
+    todo!()
+}
+
+fn main() {
+    let mut x = None;
+    let y = mk(x);
+    // Don't treat the line below as a unsize coercion `Rc<?0> ~> Rc<dyn Display>`
+    let z: Rc<dyn Display> = y;
+    x = Some(&1 as &dyn Display);
+}


### PR DESCRIPTION
Otherwise we're too eagerly preferring the `T -> dyn Trait` branch during coercion.

r? @lcnr