### PR TITLE
[rustdoc] Remove unneeded `clone()` calls for `derive_id`

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -532,8 +532,6 @@ impl<'a, 'b, 'ids, I: Iterator<Item = SpannedEvent<'a>>> Iterator
             let start_tags = format!(
                 "<h{level} id=\"{id}\">\
                     <a href=\"#{id}\">",
-                id = id,
-                level = level
             );
             return Some((Event::Html(start_tags.into()), 0..0));
         }

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -38,7 +38,7 @@ fn test_unique_id() {
     ];
 
     let mut map = IdMap::new();
-    let actual: Vec<String> = input.iter().map(|s| map.derive(s.to_string())).collect();
+    let actual: Vec<String> = input.iter().map(|s| map.derive(s)).collect();
     assert_eq!(&actual[..], expected);
 }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -162,7 +162,7 @@ impl<'tcx> Context<'tcx> {
         self.shared.tcx.sess
     }
 
-    pub(super) fn derive_id(&mut self, id: String) -> String {
+    pub(super) fn derive_id<S: AsRef<str> + ToString>(&mut self, id: S) -> String {
         self.id_map.derive(id)
     }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1153,9 +1153,7 @@ fn render_assoc_items_inner(
             AssocItemRender::DerefFor { trait_, type_, deref_mut_ } => {
                 let id =
                     cx.derive_id(small_url_encode(format!("deref-methods-{:#}", type_.print(cx))));
-                if let Some(def_id) = type_.def_id(cx.cache()) {
-                    cx.deref_id_map.insert(def_id, id.clone());
-                }
+                let derived_id = cx.derive_id(&id);
                 write_impl_section_heading(
                     &mut tmp_buf,
                     &format!(
@@ -1165,11 +1163,10 @@ fn render_assoc_items_inner(
                     ),
                     &id,
                 );
-                (
-                    RenderMode::ForDeref { mut_: deref_mut_ },
-                    cx.derive_id(id),
-                    r#" class="impl-items""#,
-                )
+                if let Some(def_id) = type_.def_id(cx.cache()) {
+                    cx.deref_id_map.insert(def_id, id);
+                }
+                (RenderMode::ForDeref { mut_: deref_mut_ }, derived_id, r#" class="impl-items""#)
             }
         };
         let mut impls_buf = Buffer::html();
@@ -1579,7 +1576,7 @@ fn render_impl(
             kind @ (clean::TyAssocConstItem(generics, ty)
             | clean::AssocConstItem(generics, ty, _)) => {
                 let source_id = format!("{item_type}.{name}");
-                let id = cx.derive_id(source_id.clone());
+                let id = cx.derive_id(&source_id);
                 write!(w, "<section id=\"{id}\" class=\"{item_type}{in_trait_class}\">");
                 render_rightside(w, cx, item, containing_item, render_mode);
                 if trait_.is_some() {
@@ -1605,7 +1602,7 @@ fn render_impl(
             }
             clean::TyAssocTypeItem(generics, bounds) => {
                 let source_id = format!("{item_type}.{name}");
-                let id = cx.derive_id(source_id.clone());
+                let id = cx.derive_id(&source_id);
                 write!(w, "<section id=\"{id}\" class=\"{item_type}{in_trait_class}\">");
                 if trait_.is_some() {
                     // Anchors are only used on trait impls.
@@ -1626,7 +1623,7 @@ fn render_impl(
             }
             clean::AssocTypeItem(tydef, _bounds) => {
                 let source_id = format!("{item_type}.{name}");
-                let id = cx.derive_id(source_id.clone());
+                let id = cx.derive_id(&source_id);
                 write!(w, "<section id=\"{id}\" class=\"{item_type}{in_trait_class}\">");
                 if trait_.is_some() {
                     // Anchors are only used on trait impls.

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -433,7 +433,7 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
                     <a href=\"#{id}\">{name}</a>\
                  </h2>{}",
                 ITEM_TABLE_OPEN,
-                id = cx.derive_id(my_section.id().to_owned()),
+                id = cx.derive_id(my_section.id()),
                 name = my_section.name(),
             );
         }


### PR DESCRIPTION
I realized we were cloning values before passing them to `derive_id` where they are cloned again, which isn't great. Since they'll be cloned anyway, let's allow to pass both by reference and by value.

r? @notriddle 