### PR TITLE
Support enum variants in offset_of!

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1133,13 +1133,6 @@ rustc_index::newtype_index! {
     pub struct FieldIdx {}
 }
 
-/// `offset_of` can traverse fields and enum variants and should keep track of which is which.
-#[derive(Copy, Clone, Debug, Eq, Hash, HashStable_Generic, PartialEq, Encodable, Decodable)]
-pub enum OffsetOfIdx {
-    Field(FieldIdx),
-    Variant(VariantIdx),
-}
-
 /// Describes how the fields of a type are located in memory.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 #[cfg_attr(feature = "nightly", derive(HashStable_Generic))]

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1107,32 +1107,6 @@ impl Scalar {
 }
 
 // NOTE: This struct is generic over the FieldIdx for rust-analyzer usage.
-rustc_index::newtype_index! {
-    /// The *source-order* index of a field in a variant.
-    ///
-    /// This is how most code after type checking refers to fields, rather than
-    /// using names (as names have hygiene complications and more complex lookup).
-    ///
-    /// Particularly for `repr(Rust)` types, this may not be the same as *layout* order.
-    /// (It is for `repr(C)` `struct`s, however.)
-    ///
-    /// For example, in the following types,
-    /// ```rust
-    /// # enum Never {}
-    /// # #[repr(u16)]
-    /// enum Demo1 {
-    ///    Variant0 { a: Never, b: i32 } = 100,
-    ///    Variant1 { c: u8, d: u64 } = 10,
-    /// }
-    /// struct Demo2 { e: u8, f: u16, g: u8 }
-    /// ```
-    /// `b` is `FieldIdx(1)` in `VariantIdx(0)`,
-    /// `d` is `FieldIdx(1)` in `VariantIdx(1)`, and
-    /// `f` is `FieldIdx(1)` in `VariantIdx(0)`.
-    #[derive(HashStable_Generic)]
-    pub struct FieldIdx {}
-}
-
 /// Describes how the fields of a type are located in memory.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 #[cfg_attr(feature = "nightly", derive(HashStable_Generic))]

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1107,6 +1107,39 @@ impl Scalar {
 }
 
 // NOTE: This struct is generic over the FieldIdx for rust-analyzer usage.
+rustc_index::newtype_index! {
+    /// The *source-order* index of a field in a variant.
+    ///
+    /// This is how most code after type checking refers to fields, rather than
+    /// using names (as names have hygiene complications and more complex lookup).
+    ///
+    /// Particularly for `repr(Rust)` types, this may not be the same as *layout* order.
+    /// (It is for `repr(C)` `struct`s, however.)
+    ///
+    /// For example, in the following types,
+    /// ```rust
+    /// # enum Never {}
+    /// # #[repr(u16)]
+    /// enum Demo1 {
+    ///    Variant0 { a: Never, b: i32 } = 100,
+    ///    Variant1 { c: u8, d: u64 } = 10,
+    /// }
+    /// struct Demo2 { e: u8, f: u16, g: u8 }
+    /// ```
+    /// `b` is `FieldIdx(1)` in `VariantIdx(0)`,
+    /// `d` is `FieldIdx(1)` in `VariantIdx(1)`, and
+    /// `f` is `FieldIdx(1)` in `VariantIdx(0)`.
+    #[derive(HashStable_Generic)]
+    pub struct FieldIdx {}
+}
+
+/// `offset_of` can traverse fields and enum variants and should keep track of which is which.
+#[derive(Copy, Clone, Debug, Eq, Hash, HashStable_Generic, PartialEq, Encodable, Decodable)]
+pub enum OffsetOfIdx {
+    Field(FieldIdx),
+    Variant(VariantIdx),
+}
+
 /// Describes how the fields of a type are located in memory.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 #[cfg_attr(feature = "nightly", derive(HashStable_Generic))]

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -766,7 +766,7 @@ fn codegen_stmt<'tcx>(
                         NullOp::SizeOf => layout.size.bytes(),
                         NullOp::AlignOf => layout.align.abi.bytes(),
                         NullOp::OffsetOf(fields) => {
-                            layout.offset_of_subfield(fx, fields.iter().map(|f| f.index())).bytes()
+                            layout.offset_of_subfield(fx, fields.iter()).bytes()
                         }
                     };
                     let val = CValue::by_val(

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -680,7 +680,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         layout.align.abi.bytes()
                     }
                     mir::NullOp::OffsetOf(fields) => {
-                        layout.offset_of_subfield(bx.cx(), fields.iter().map(|f| f.index())).bytes()
+                        layout.offset_of_subfield(bx.cx(), fields.iter()).bytes()
                     }
                 };
                 let val = bx.cx().const_usize(val);

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -275,7 +275,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     mir::NullOp::SizeOf => layout.size.bytes(),
                     mir::NullOp::AlignOf => layout.align.abi.bytes(),
                     mir::NullOp::OffsetOf(fields) => {
-                        layout.offset_of_subfield(self, fields.iter().map(|f| f.index())).bytes()
+                        layout.offset_of_subfield(self, fields.iter()).bytes()
                     }
                 };
                 self.write_scalar(Scalar::from_target_usize(val, self), &dest)?;

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -514,6 +514,7 @@ E0791: include_str!("./error_codes/E0791.md"),
 E0792: include_str!("./error_codes/E0792.md"),
 E0793: include_str!("./error_codes/E0793.md"),
 E0794: include_str!("./error_codes/E0794.md"),
+E0795: include_str!("./error_codes/E0795.md"),
 }
 
 // Undocumented removed error codes. Note that many removed error codes are kept in the list above

--- a/compiler/rustc_error_codes/src/error_codes/E0795.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0795.md
@@ -1,0 +1,28 @@
+Invalid argument for the `offset_of!` macro.
+
+Erroneous code example:
+
+```compile_fail,E0795
+#![feature(offset_of)]
+
+let x = std::mem::offset_of!(Option<u8>, Some);
+```
+
+The `offset_of!` macro gives the offset of a field within a type. It can
+navigate through enum variants, but the final component of its second argument
+must be a field and not a variant.
+
+The offset of the contained `u8` in the `Option<u8>` can be found by specifying
+the field name `0`:
+
+```
+#![feature(offset_of)]
+
+let x: usize = std::mem::offset_of!(Option<u8>, Some.0);
+```
+
+The discriminant of an enumeration may be read with `core::mem::discriminant`,
+but this is not always a value physically present within the enum.
+
+Further information about enum layout may be found at
+https://rust-lang.github.io/unsafe-code-guidelines/layout/enums.html.

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -54,7 +54,7 @@ use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_span::source_map::{Span, Spanned};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
-use rustc_target::abi::FieldIdx;
+use rustc_target::abi::{FieldIdx, FIRST_VARIANT};
 use rustc_target::spec::abi::Abi::RustIntrinsic;
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::error_reporting::TypeErrCtxtExt;
@@ -3103,8 +3103,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         fields: &[Ident],
         expr: &'tcx hir::Expr<'tcx>,
     ) -> Ty<'tcx> {
-        use rustc_target::abi::OffsetOfIdx::*;
-
         let container = self.to_ty(container).normalized;
 
         let mut field_indices = Vec::with_capacity(fields.len());
@@ -3120,49 +3118,68 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let (ident, _def_scope) =
                         self.tcx.adjust_ident_and_get_scope(field, container_def.did(), block);
 
-                    if let Some((index, variant)) = container_def.variants()
+                    let Some((index, variant)) = container_def.variants()
                         .iter_enumerated()
-                        .find(|(_, v)| v.ident(self.tcx).normalize_to_macros_2_0() == ident)
-                    {
-                        let Some(&subfield) = fields.next() else {
-                            let mut err = type_error_struct!(
-                                self.tcx().sess,
-                                ident.span,
-                                container,
-                                E0795,
-                                "`{ident}` is an enum variant; expected field at end of `offset_of`",
-                                );
-                            err.span_label(field.span, "enum variant");
-                            err.emit();
-                            break;
-                        };
-                        let (subident, sub_def_scope) =
-                            self.tcx.adjust_ident_and_get_scope(subfield, variant.def_id, block);
+                        .find(|(_, v)| v.ident(self.tcx).normalize_to_macros_2_0() == ident) else {
+                        let mut err = type_error_struct!(
+                            self.tcx().sess,
+                            ident.span,
+                            container,
+                            E0599,
+                            "no variant named `{ident}` found for enum `{container}`",
+                            );
+                        err.span_label(field.span, "variant not found");
+                        err.emit();
+                        break;
+                    };
+                    let Some(&subfield) = fields.next() else {
+                        let mut err = type_error_struct!(
+                            self.tcx().sess,
+                            ident.span,
+                            container,
+                            E0795,
+                            "`{ident}` is an enum variant; expected field at end of `offset_of`",
+                            );
+                        err.span_label(field.span, "enum variant");
+                        err.emit();
+                        break;
+                    };
+                    let (subident, sub_def_scope) =
+                        self.tcx.adjust_ident_and_get_scope(subfield, variant.def_id, block);
 
-                        if let Some((subindex, field)) = variant.fields
-                            .iter_enumerated()
-                            .find(|(_, f)| f.ident(self.tcx).normalize_to_macros_2_0() == subident)
-                        {
-                            let field_ty = self.field_ty(expr.span, field, args);
+                    let Some((subindex, field)) = variant.fields
+                        .iter_enumerated()
+                        .find(|(_, f)| f.ident(self.tcx).normalize_to_macros_2_0() == subident) else {
+                        let mut err = type_error_struct!(
+                            self.tcx().sess,
+                            ident.span,
+                            container,
+                            E0609,
+                            "no field named `{subfield}` on enum variant `{container}::{ident}`",
+                            );
+                        err.span_label(field.span, "this enum variant...");
+                        err.span_label(subident.span, "...does not have this field");
+                        err.emit();
+                        break;
+                    };
 
-                            // FIXME: DSTs with static alignment should be allowed
-                            self.require_type_is_sized(field_ty, expr.span, traits::MiscObligation);
+                    let field_ty = self.field_ty(expr.span, field, args);
 
-                            if field.vis.is_accessible_from(sub_def_scope, self.tcx) {
-                                self.tcx.check_stability(field.did, Some(expr.hir_id), expr.span, None);
-                            } else {
-                                self.private_field_err(ident, container_def.did()).emit();
-                            }
+                    // FIXME: DSTs with static alignment should be allowed
+                    self.require_type_is_sized(field_ty, expr.span, traits::MiscObligation);
 
-                            // Save the index of all fields regardless of their visibility in case
-                            // of error recovery.
-                            field_indices.push(Variant(index));
-                            field_indices.push(Field(subindex));
-                            current_container = field_ty;
-
-                            continue;
-                        }
+                    if field.vis.is_accessible_from(sub_def_scope, self.tcx) {
+                        self.tcx.check_stability(field.did, Some(expr.hir_id), expr.span, None);
+                    } else {
+                        self.private_field_err(ident, container_def.did()).emit();
                     }
+
+                    // Save the index of all fields regardless of their visibility in case
+                    // of error recovery.
+                    field_indices.push((index, subindex));
+                    current_container = field_ty;
+
+                    continue;
                 }
                 ty::Adt(container_def, args) => {
                     let block = self.tcx.hir().local_def_id_to_hir_id(self.body_id);
@@ -3187,7 +3204,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                         // Save the index of all fields regardless of their visibility in case
                         // of error recovery.
-                        field_indices.push(Field(index));
+                        field_indices.push((FIRST_VARIANT, index));
                         current_container = field_ty;
 
                         continue;
@@ -3201,7 +3218,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.require_type_is_sized(ty, expr.span, traits::MiscObligation);
                         }
                         if let Some(&field_ty) = tys.get(index) {
-                            field_indices.push(Field(index.into()));
+                            field_indices.push((FIRST_VARIANT, index.into()));
                             current_container = field_ty;
 
                             continue;

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -17,7 +17,7 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{self as hir};
 use rustc_hir::{self, CoroutineKind};
 use rustc_index::IndexVec;
-use rustc_target::abi::{FieldIdx, VariantIdx};
+use rustc_target::abi::{FieldIdx, OffsetOfIdx, VariantIdx};
 
 use rustc_ast::Mutability;
 use rustc_span::def_id::LocalDefId;
@@ -1354,7 +1354,7 @@ pub enum NullOp<'tcx> {
     /// Returns the minimum alignment of a type
     AlignOf,
     /// Returns the offset of a field
-    OffsetOf(&'tcx List<FieldIdx>),
+    OffsetOf(&'tcx List<OffsetOfIdx>),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -17,7 +17,7 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{self as hir};
 use rustc_hir::{self, CoroutineKind};
 use rustc_index::IndexVec;
-use rustc_target::abi::{FieldIdx, OffsetOfIdx, VariantIdx};
+use rustc_target::abi::{FieldIdx, VariantIdx};
 
 use rustc_ast::Mutability;
 use rustc_span::def_id::LocalDefId;
@@ -1354,7 +1354,7 @@ pub enum NullOp<'tcx> {
     /// Returns the minimum alignment of a type
     AlignOf,
     /// Returns the offset of a field
-    OffsetOf(&'tcx List<OffsetOfIdx>),
+    OffsetOf(&'tcx List<(VariantIdx, FieldIdx)>),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -25,7 +25,8 @@ use rustc_middle::ty::{
 };
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{sym, ErrorGuaranteed, Span, Symbol, DUMMY_SP};
-use rustc_target::abi::{FieldIdx, VariantIdx};
+use rustc_span::{sym, Span, Symbol, DUMMY_SP};
+use rustc_target::abi::{FieldIdx, OffsetOfIdx, VariantIdx};
 use rustc_target::asm::InlineAsmRegOrRegClass;
 use std::fmt;
 use std::ops::Index;
@@ -490,7 +491,7 @@ pub enum ExprKind<'tcx> {
     /// Field offset (`offset_of!`)
     OffsetOf {
         container: Ty<'tcx>,
-        fields: &'tcx List<FieldIdx>,
+        fields: &'tcx List<OffsetOfIdx>,
     },
     /// An expression taking a reference to a thread local.
     ThreadLocalRef(DefId),

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -26,7 +26,7 @@ use rustc_middle::ty::{
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{sym, ErrorGuaranteed, Span, Symbol, DUMMY_SP};
 use rustc_span::{sym, Span, Symbol, DUMMY_SP};
-use rustc_target::abi::{FieldIdx, OffsetOfIdx, VariantIdx};
+use rustc_target::abi::{FieldIdx, VariantIdx};
 use rustc_target::asm::InlineAsmRegOrRegClass;
 use std::fmt;
 use std::ops::Index;
@@ -491,7 +491,7 @@ pub enum ExprKind<'tcx> {
     /// Field offset (`offset_of!`)
     OffsetOf {
         container: Ty<'tcx>,
-        fields: &'tcx List<OffsetOfIdx>,
+        fields: &'tcx List<(VariantIdx, FieldIdx)>,
     },
     /// An expression taking a reference to a thread local.
     ThreadLocalRef(DefId),

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -25,7 +25,6 @@ use rustc_middle::ty::{
 };
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{sym, ErrorGuaranteed, Span, Symbol, DUMMY_SP};
-use rustc_span::{sym, Span, Symbol, DUMMY_SP};
 use rustc_target::abi::{FieldIdx, VariantIdx};
 use rustc_target::asm::InlineAsmRegOrRegClass;
 use std::fmt;

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -19,7 +19,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::{Decodable, Encodable};
 use rustc_span::Span;
-use rustc_target::abi::FieldIdx;
+use rustc_target::abi::{FieldIdx, OffsetOfIdx};
 pub use rustc_type_ir::{TyDecoder, TyEncoder};
 use std::hash::Hash;
 use std::intrinsics;
@@ -414,6 +414,15 @@ impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> RefDecodable<'tcx, D> for ty::List<Fi
     }
 }
 
+impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> RefDecodable<'tcx, D> for ty::List<OffsetOfIdx> {
+    fn decode(decoder: &mut D) -> &'tcx Self {
+        let len = decoder.read_usize();
+        decoder
+            .interner()
+            .mk_offset_of_from_iter((0..len).map::<OffsetOfIdx, _>(|_| Decodable::decode(decoder)))
+    }
+}
+
 impl_decodable_via_ref! {
     &'tcx ty::TypeckResults<'tcx>,
     &'tcx ty::List<Ty<'tcx>>,
@@ -426,6 +435,7 @@ impl_decodable_via_ref! {
     &'tcx ty::List<ty::BoundVariableKind>,
     &'tcx ty::List<ty::Clause<'tcx>>,
     &'tcx ty::List<FieldIdx>,
+    &'tcx ty::List<OffsetOfIdx>,
 }
 
 #[macro_export]

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -19,7 +19,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::{Decodable, Encodable};
 use rustc_span::Span;
-use rustc_target::abi::{FieldIdx, OffsetOfIdx};
+use rustc_target::abi::{FieldIdx, VariantIdx};
 pub use rustc_type_ir::{TyDecoder, TyEncoder};
 use std::hash::Hash;
 use std::intrinsics;
@@ -414,12 +414,14 @@ impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> RefDecodable<'tcx, D> for ty::List<Fi
     }
 }
 
-impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> RefDecodable<'tcx, D> for ty::List<OffsetOfIdx> {
+impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> RefDecodable<'tcx, D>
+    for ty::List<(VariantIdx, FieldIdx)>
+{
     fn decode(decoder: &mut D) -> &'tcx Self {
         let len = decoder.read_usize();
-        decoder
-            .interner()
-            .mk_offset_of_from_iter((0..len).map::<OffsetOfIdx, _>(|_| Decodable::decode(decoder)))
+        decoder.interner().mk_offset_of_from_iter(
+            (0..len).map::<(VariantIdx, FieldIdx), _>(|_| Decodable::decode(decoder)),
+        )
     }
 }
 
@@ -435,7 +437,7 @@ impl_decodable_via_ref! {
     &'tcx ty::List<ty::BoundVariableKind>,
     &'tcx ty::List<ty::Clause<'tcx>>,
     &'tcx ty::List<FieldIdx>,
-    &'tcx ty::List<OffsetOfIdx>,
+    &'tcx ty::List<(VariantIdx, FieldIdx)>,
 }
 
 #[macro_export]

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -63,7 +63,7 @@ use rustc_session::{Limit, MetadataKind, Session};
 use rustc_span::def_id::{DefPathHash, StableCrateId};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
-use rustc_target::abi::{FieldIdx, Layout, LayoutS, OffsetOfIdx, TargetDataLayout, VariantIdx};
+use rustc_target::abi::{FieldIdx, Layout, LayoutS, TargetDataLayout, VariantIdx};
 use rustc_target::spec::abi;
 use rustc_type_ir::TyKind::*;
 use rustc_type_ir::WithCachedTypeInfo;
@@ -163,7 +163,7 @@ pub struct CtxtInterners<'tcx> {
     predefined_opaques_in_body: InternedSet<'tcx, PredefinedOpaquesData<'tcx>>,
     fields: InternedSet<'tcx, List<FieldIdx>>,
     local_def_ids: InternedSet<'tcx, List<LocalDefId>>,
-    offset_of: InternedSet<'tcx, List<OffsetOfIdx>>,
+    offset_of: InternedSet<'tcx, List<(VariantIdx, FieldIdx)>>,
 }
 
 impl<'tcx> CtxtInterners<'tcx> {
@@ -1589,7 +1589,7 @@ slice_interners!(
     bound_variable_kinds: pub mk_bound_variable_kinds(ty::BoundVariableKind),
     fields: pub mk_fields(FieldIdx),
     local_def_ids: intern_local_def_ids(LocalDefId),
-    offset_of: pub mk_offset_of(OffsetOfIdx),
+    offset_of: pub mk_offset_of((VariantIdx, FieldIdx)),
 );
 
 impl<'tcx> TyCtxt<'tcx> {
@@ -1920,7 +1920,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_offset_of_from_iter<I, T>(self, iter: I) -> T::Output
     where
         I: Iterator<Item = T>,
-        T: CollectAndApply<OffsetOfIdx, &'tcx List<OffsetOfIdx>>,
+        T: CollectAndApply<(VariantIdx, FieldIdx), &'tcx List<(VariantIdx, FieldIdx)>>,
     {
         T::collect_and_apply(iter, |xs| self.mk_offset_of(xs))
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -63,7 +63,7 @@ use rustc_session::{Limit, MetadataKind, Session};
 use rustc_span::def_id::{DefPathHash, StableCrateId};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
-use rustc_target::abi::{FieldIdx, Layout, LayoutS, TargetDataLayout, VariantIdx};
+use rustc_target::abi::{FieldIdx, Layout, LayoutS, OffsetOfIdx, TargetDataLayout, VariantIdx};
 use rustc_target::spec::abi;
 use rustc_type_ir::TyKind::*;
 use rustc_type_ir::WithCachedTypeInfo;
@@ -163,6 +163,7 @@ pub struct CtxtInterners<'tcx> {
     predefined_opaques_in_body: InternedSet<'tcx, PredefinedOpaquesData<'tcx>>,
     fields: InternedSet<'tcx, List<FieldIdx>>,
     local_def_ids: InternedSet<'tcx, List<LocalDefId>>,
+    offset_of: InternedSet<'tcx, List<OffsetOfIdx>>,
 }
 
 impl<'tcx> CtxtInterners<'tcx> {
@@ -189,6 +190,7 @@ impl<'tcx> CtxtInterners<'tcx> {
             predefined_opaques_in_body: Default::default(),
             fields: Default::default(),
             local_def_ids: Default::default(),
+            offset_of: Default::default(),
         }
     }
 
@@ -1587,6 +1589,7 @@ slice_interners!(
     bound_variable_kinds: pub mk_bound_variable_kinds(ty::BoundVariableKind),
     fields: pub mk_fields(FieldIdx),
     local_def_ids: intern_local_def_ids(LocalDefId),
+    offset_of: pub mk_offset_of(OffsetOfIdx),
 );
 
 impl<'tcx> TyCtxt<'tcx> {
@@ -1912,6 +1915,14 @@ impl<'tcx> TyCtxt<'tcx> {
         T: CollectAndApply<FieldIdx, &'tcx List<FieldIdx>>,
     {
         T::collect_and_apply(iter, |xs| self.mk_fields(xs))
+    }
+
+    pub fn mk_offset_of_from_iter<I, T>(self, iter: I) -> T::Output
+    where
+        I: Iterator<Item = T>,
+        T: CollectAndApply<OffsetOfIdx, &'tcx List<OffsetOfIdx>>,
+    {
+        T::collect_and_apply(iter, |xs| self.mk_offset_of(xs))
     }
 
     pub fn mk_args_trait(

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -24,7 +24,7 @@ use rustc_macros::HashStable;
 use rustc_middle::mir::FakeReadCause;
 use rustc_session::Session;
 use rustc_span::Span;
-use rustc_target::abi::{FieldIdx, OffsetOfIdx};
+use rustc_target::abi::{FieldIdx, VariantIdx};
 use std::{collections::hash_map::Entry, hash::Hash, iter};
 
 use super::RvalueScopes;
@@ -205,7 +205,7 @@ pub struct TypeckResults<'tcx> {
     pub closure_size_eval: LocalDefIdMap<ClosureSizeProfileData<'tcx>>,
 
     /// Container types and field indices of `offset_of!` expressions
-    offset_of_data: ItemLocalMap<(Ty<'tcx>, Vec<OffsetOfIdx>)>,
+    offset_of_data: ItemLocalMap<(Ty<'tcx>, Vec<(VariantIdx, FieldIdx)>)>,
 }
 
 impl<'tcx> TypeckResults<'tcx> {
@@ -464,13 +464,15 @@ impl<'tcx> TypeckResults<'tcx> {
         &self.coercion_casts
     }
 
-    pub fn offset_of_data(&self) -> LocalTableInContext<'_, (Ty<'tcx>, Vec<OffsetOfIdx>)> {
+    pub fn offset_of_data(
+        &self,
+    ) -> LocalTableInContext<'_, (Ty<'tcx>, Vec<(VariantIdx, FieldIdx)>)> {
         LocalTableInContext { hir_owner: self.hir_owner, data: &self.offset_of_data }
     }
 
     pub fn offset_of_data_mut(
         &mut self,
-    ) -> LocalTableInContextMut<'_, (Ty<'tcx>, Vec<OffsetOfIdx>)> {
+    ) -> LocalTableInContextMut<'_, (Ty<'tcx>, Vec<(VariantIdx, FieldIdx)>)> {
         LocalTableInContextMut { hir_owner: self.hir_owner, data: &mut self.offset_of_data }
     }
 }

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -24,7 +24,7 @@ use rustc_macros::HashStable;
 use rustc_middle::mir::FakeReadCause;
 use rustc_session::Session;
 use rustc_span::Span;
-use rustc_target::abi::FieldIdx;
+use rustc_target::abi::{FieldIdx, OffsetOfIdx};
 use std::{collections::hash_map::Entry, hash::Hash, iter};
 
 use super::RvalueScopes;
@@ -205,7 +205,7 @@ pub struct TypeckResults<'tcx> {
     pub closure_size_eval: LocalDefIdMap<ClosureSizeProfileData<'tcx>>,
 
     /// Container types and field indices of `offset_of!` expressions
-    offset_of_data: ItemLocalMap<(Ty<'tcx>, Vec<FieldIdx>)>,
+    offset_of_data: ItemLocalMap<(Ty<'tcx>, Vec<OffsetOfIdx>)>,
 }
 
 impl<'tcx> TypeckResults<'tcx> {
@@ -464,11 +464,13 @@ impl<'tcx> TypeckResults<'tcx> {
         &self.coercion_casts
     }
 
-    pub fn offset_of_data(&self) -> LocalTableInContext<'_, (Ty<'tcx>, Vec<FieldIdx>)> {
+    pub fn offset_of_data(&self) -> LocalTableInContext<'_, (Ty<'tcx>, Vec<OffsetOfIdx>)> {
         LocalTableInContext { hir_owner: self.hir_owner, data: &self.offset_of_data }
     }
 
-    pub fn offset_of_data_mut(&mut self) -> LocalTableInContextMut<'_, (Ty<'tcx>, Vec<FieldIdx>)> {
+    pub fn offset_of_data_mut(
+        &mut self,
+    ) -> LocalTableInContextMut<'_, (Ty<'tcx>, Vec<OffsetOfIdx>)> {
         LocalTableInContextMut { hir_owner: self.hir_owner, data: &mut self.offset_of_data }
     }
 }

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -670,7 +670,7 @@ impl<'tcx> Cx<'tcx> {
             hir::ExprKind::OffsetOf(_, _) => {
                 let data = self.typeck_results.offset_of_data();
                 let &(container, ref indices) = data.get(expr.hir_id).unwrap();
-                let fields = tcx.mk_fields_from_iter(indices.iter().copied());
+                let fields = tcx.mk_offset_of_from_iter(indices.iter().copied());
 
                 ExprKind::OffsetOf { container, fields }
             }

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -286,9 +286,9 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                 let val = match null_op {
                     NullOp::SizeOf if layout.is_sized() => layout.size.bytes(),
                     NullOp::AlignOf if layout.is_sized() => layout.align.abi.bytes(),
-                    NullOp::OffsetOf(fields) => layout
-                        .offset_of_subfield(&self.ecx, fields.iter())
-                        .bytes(),
+                    NullOp::OffsetOf(fields) => {
+                        layout.offset_of_subfield(&self.ecx, fields.iter()).bytes()
+                    }
                     _ => return ValueOrPlace::Value(FlatSet::Top),
                 };
                 FlatSet::Elem(Scalar::from_target_usize(val, &self.tcx))

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -287,7 +287,7 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                     NullOp::SizeOf if layout.is_sized() => layout.size.bytes(),
                     NullOp::AlignOf if layout.is_sized() => layout.align.abi.bytes(),
                     NullOp::OffsetOf(fields) => layout
-                        .offset_of_subfield(&self.ecx, fields.iter().map(|f| f.index()))
+                        .offset_of_subfield(&self.ecx, fields.iter())
                         .bytes(),
                     _ => return ValueOrPlace::Value(FlatSet::Top),
                 };

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -467,9 +467,9 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
                 let val = match null_op {
                     NullOp::SizeOf => layout.size.bytes(),
                     NullOp::AlignOf => layout.align.abi.bytes(),
-                    NullOp::OffsetOf(fields) => layout
-                        .offset_of_subfield(&self.ecx, fields.iter().map(|f| f.index()))
-                        .bytes(),
+                    NullOp::OffsetOf(fields) => {
+                        layout.offset_of_subfield(&self.ecx, fields.iter()).bytes()
+                    }
                 };
                 let usize_layout = self.ecx.layout_of(self.tcx.types.usize).unwrap();
                 let imm = ImmTy::try_from_uint(val, usize_layout)?;

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -248,8 +248,6 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
     }
 
     fn handle_offset_of(&mut self, expr: &'tcx hir::Expr<'tcx>) {
-        use rustc_target::abi::OffsetOfIdx::*;
-
         let data = self.typeck_results().offset_of_data();
         let &(container, ref indices) =
             data.get(expr.hir_id).expect("no offset_of_data for offset_of");
@@ -258,22 +256,10 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
         let param_env = self.tcx.param_env(body_did);
 
         let mut current_ty = container;
-        let mut indices = indices.into_iter();
 
-        while let Some(&index) = indices.next() {
-            match (current_ty.kind(), index) {
-                (ty::Adt(def, subst), Field(field)) if !def.is_enum() => {
-                    let field = &def.non_enum_variant().fields[field];
-
-                    self.insert_def_id(field.did);
-                    let field_ty = field.ty(self.tcx, subst);
-
-                    current_ty = self.tcx.normalize_erasing_regions(param_env, field_ty);
-                }
-                (ty::Adt(def, subst), Variant(variant)) if def.is_enum() => {
-                    let Some(&Field(field)) = indices.next() else {
-                        span_bug!(expr.span, "variant must be followed by field in offset_of")
-                    };
+        for &(variant, field) in indices {
+            match current_ty.kind() {
+                ty::Adt(def, subst) => {
                     let field = &def.variant(variant).fields[field];
 
                     self.insert_def_id(field.did);
@@ -283,12 +269,11 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                 }
                 // we don't need to mark tuple fields as live,
                 // but we may need to mark subfields
-                (ty::Tuple(tys), Field(field)) => {
+                ty::Tuple(tys) => {
                     current_ty =
                         self.tcx.normalize_erasing_regions(param_env, tys[field.as_usize()]);
                 }
-                (_, Field(_)) => span_bug!(expr.span, "named field access on non-ADT"),
-                (_, Variant(_)) => span_bug!(expr.span, "enum variant access on non-enum"),
+                _ => span_bug!(expr.span, "named field access on non-ADT"),
             }
         }
     }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -16,7 +16,7 @@ use rustc_middle::mir::interpret::{alloc_range, AllocId};
 use rustc_middle::mir::mono::MonoItem;
 use rustc_middle::ty::{self, Instance, ParamEnv, Ty, TyCtxt, Variance};
 use rustc_span::def_id::{CrateNum, DefId, LOCAL_CRATE};
-use rustc_target::abi::{FieldIdx, OffsetOfIdx};
+use rustc_target::abi::FieldIdx;
 use stable_mir::mir::mono::InstanceDef;
 use stable_mir::mir::{Body, CopyNonOverlapping, Statement, UserTypeProjection, VariantIdx};
 use stable_mir::ty::{
@@ -643,13 +643,10 @@ impl<'tcx> Stable<'tcx> for FieldIdx {
     }
 }
 
-impl<'tcx> Stable<'tcx> for OffsetOfIdx {
-    type T = usize;
+impl<'tcx> Stable<'tcx> for (rustc_target::abi::VariantIdx, FieldIdx) {
+    type T = (usize, usize);
     fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
-        match self {
-            OffsetOfIdx::Field(f) => f.as_usize(),
-            OffsetOfIdx::Variant(v) => v.as_usize(),
-        }
+        (self.0.as_usize(), self.1.as_usize())
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -16,7 +16,7 @@ use rustc_middle::mir::interpret::{alloc_range, AllocId};
 use rustc_middle::mir::mono::MonoItem;
 use rustc_middle::ty::{self, Instance, ParamEnv, Ty, TyCtxt, Variance};
 use rustc_span::def_id::{CrateNum, DefId, LOCAL_CRATE};
-use rustc_target::abi::FieldIdx;
+use rustc_target::abi::{FieldIdx, OffsetOfIdx};
 use stable_mir::mir::mono::InstanceDef;
 use stable_mir::mir::{Body, CopyNonOverlapping, Statement, UserTypeProjection, VariantIdx};
 use stable_mir::ty::{
@@ -640,6 +640,16 @@ impl<'tcx> Stable<'tcx> for FieldIdx {
     type T = usize;
     fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
         self.as_usize()
+    }
+}
+
+impl<'tcx> Stable<'tcx> for OffsetOfIdx {
+    type T = usize;
+    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            OffsetOfIdx::Field(f) => f.as_usize(),
+            OffsetOfIdx::Variant(v) => v.as_usize(),
+        }
     }
 }
 

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -514,7 +514,7 @@ pub enum NullOp {
     /// Returns the minimum alignment of a type.
     AlignOf,
     /// Returns the offset of a field.
-    OffsetOf(Vec<FieldIdx>),
+    OffsetOf(Vec<(VariantIdx, FieldIdx)>),
 }
 
 impl Operand {

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1292,11 +1292,15 @@ impl<T> SizedTypeProperties for T {}
 
 /// Expands to the offset in bytes of a field from the beginning of the given type.
 ///
-/// Only structs, unions and tuples are supported.
+/// Structs, enums, unions and tuples are supported.
 ///
 /// Nested field accesses may be used, but not array indexes like in `C`'s `offsetof`.
 ///
-/// Note that the output of this macro is not stable, except for `#[repr(C)]` types.
+/// Enum variants may be traversed as if they were fields. Variants themselves do
+/// not have an offset.
+///
+/// Note that type layout is, in general, [platform-specific, and subject to
+/// change](https://doc.rust-lang.org/reference/type-layout.html).
 ///
 /// # Examples
 ///
@@ -1324,6 +1328,8 @@ impl<T> SizedTypeProperties for T {}
 /// struct NestedB(u8);
 ///
 /// assert_eq!(mem::offset_of!(NestedA, b.0), 0);
+///
+/// assert_eq!(mem::offset_of!(Option<&u8>, Some.0), 0);
 /// ```
 #[unstable(feature = "offset_of", issue = "106655")]
 #[allow_internal_unstable(builtin_syntax, hint_must_use)]

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1329,6 +1329,7 @@ impl<T> SizedTypeProperties for T {}
 ///
 /// assert_eq!(mem::offset_of!(NestedA, b.0), 0);
 ///
+/// # #[cfg(not(bootstrap))]
 /// assert_eq!(mem::offset_of!(Option<&u8>, Some.0), 0);
 /// ```
 #[unstable(feature = "offset_of", issue = "106655")]

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1299,8 +1299,8 @@ impl<T> SizedTypeProperties for T {}
 /// Enum variants may be traversed as if they were fields. Variants themselves do
 /// not have an offset.
 ///
-/// Note that type layout is, in general, [platform-specific, and subject to
-/// change](https://doc.rust-lang.org/reference/type-layout.html).
+/// Note that type layout is, in general, [subject to change and
+/// platform-specific](https://doc.rust-lang.org/reference/type-layout.html).
 ///
 /// # Examples
 ///

--- a/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-abort.diff
@@ -42,7 +42,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
--         _2 = OffsetOf(Alpha, [Field(0)]);
+-         _2 = OffsetOf(Alpha, [(0, 0)]);
 -         _1 = must_use::<usize>(move _2) -> [return: bb1, unwind unreachable];
 +         _2 = const 4_usize;
 +         _1 = must_use::<usize>(const 4_usize) -> [return: bb1, unwind unreachable];
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
--         _4 = OffsetOf(Alpha, [Field(1)]);
+-         _4 = OffsetOf(Alpha, [(0, 1)]);
 -         _3 = must_use::<usize>(move _4) -> [return: bb2, unwind unreachable];
 +         _4 = const 0_usize;
 +         _3 = must_use::<usize>(const 0_usize) -> [return: bb2, unwind unreachable];
@@ -62,7 +62,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = OffsetOf(Alpha, [Field(2), Field(0)]);
+-         _6 = OffsetOf(Alpha, [(0, 2), (0, 0)]);
 -         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind unreachable];
 +         _6 = const 2_usize;
 +         _5 = must_use::<usize>(const 2_usize) -> [return: bb3, unwind unreachable];
@@ -72,7 +72,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
--         _8 = OffsetOf(Alpha, [Field(2), Field(1)]);
+-         _8 = OffsetOf(Alpha, [(0, 2), (0, 1)]);
 -         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind unreachable];
 +         _8 = const 3_usize;
 +         _7 = must_use::<usize>(const 3_usize) -> [return: bb4, unwind unreachable];
@@ -82,7 +82,7 @@
           StorageDead(_8);
           StorageLive(_9);
           StorageLive(_10);
--         _10 = OffsetOf(Epsilon, [Variant(0), Field(0)]);
+-         _10 = OffsetOf(Epsilon, [(0, 0)]);
 -         _9 = must_use::<usize>(move _10) -> [return: bb5, unwind unreachable];
 +         _10 = const 1_usize;
 +         _9 = must_use::<usize>(const 1_usize) -> [return: bb5, unwind unreachable];
@@ -92,7 +92,7 @@
           StorageDead(_10);
           StorageLive(_11);
           StorageLive(_12);
--         _12 = OffsetOf(Epsilon, [Variant(0), Field(1)]);
+-         _12 = OffsetOf(Epsilon, [(0, 1)]);
 -         _11 = must_use::<usize>(move _12) -> [return: bb6, unwind unreachable];
 +         _12 = const 2_usize;
 +         _11 = must_use::<usize>(const 2_usize) -> [return: bb6, unwind unreachable];
@@ -102,7 +102,7 @@
           StorageDead(_12);
           StorageLive(_13);
           StorageLive(_14);
--         _14 = OffsetOf(Epsilon, [Variant(2), Field(0)]);
+-         _14 = OffsetOf(Epsilon, [(2, 0)]);
 -         _13 = must_use::<usize>(move _14) -> [return: bb7, unwind unreachable];
 +         _14 = const 4_usize;
 +         _13 = must_use::<usize>(const 4_usize) -> [return: bb7, unwind unreachable];

--- a/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-abort.diff
@@ -8,6 +8,9 @@
       let mut _4: usize;
       let mut _6: usize;
       let mut _8: usize;
+      let mut _10: usize;
+      let mut _12: usize;
+      let mut _14: usize;
       scope 1 {
           debug x => _1;
           let _3: usize;
@@ -19,6 +22,18 @@
                   let _7: usize;
                   scope 4 {
                       debug z1 => _7;
+                      let _9: usize;
+                      scope 5 {
+                          debug eA0 => _9;
+                          let _11: usize;
+                          scope 6 {
+                              debug eA1 => _11;
+                              let _13: usize;
+                              scope 7 {
+                                  debug eC => _13;
+                              }
+                          }
+                      }
                   }
               }
           }
@@ -27,7 +42,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
--         _2 = OffsetOf(Alpha, [0]);
+-         _2 = OffsetOf(Alpha, [Field(0)]);
 -         _1 = must_use::<usize>(move _2) -> [return: bb1, unwind unreachable];
 +         _2 = const 4_usize;
 +         _1 = must_use::<usize>(const 4_usize) -> [return: bb1, unwind unreachable];
@@ -37,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
--         _4 = OffsetOf(Alpha, [1]);
+-         _4 = OffsetOf(Alpha, [Field(1)]);
 -         _3 = must_use::<usize>(move _4) -> [return: bb2, unwind unreachable];
 +         _4 = const 0_usize;
 +         _3 = must_use::<usize>(const 0_usize) -> [return: bb2, unwind unreachable];
@@ -47,7 +62,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = OffsetOf(Alpha, [2, 0]);
+-         _6 = OffsetOf(Alpha, [Field(2), Field(0)]);
 -         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind unreachable];
 +         _6 = const 2_usize;
 +         _5 = must_use::<usize>(const 2_usize) -> [return: bb3, unwind unreachable];
@@ -57,7 +72,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
--         _8 = OffsetOf(Alpha, [2, 1]);
+-         _8 = OffsetOf(Alpha, [Field(2), Field(1)]);
 -         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind unreachable];
 +         _8 = const 3_usize;
 +         _7 = must_use::<usize>(const 3_usize) -> [return: bb4, unwind unreachable];
@@ -65,7 +80,40 @@
   
       bb4: {
           StorageDead(_8);
+          StorageLive(_9);
+          StorageLive(_10);
+-         _10 = OffsetOf(Epsilon, [Variant(0), Field(0)]);
+-         _9 = must_use::<usize>(move _10) -> [return: bb5, unwind unreachable];
++         _10 = const 1_usize;
++         _9 = must_use::<usize>(const 1_usize) -> [return: bb5, unwind unreachable];
+      }
+  
+      bb5: {
+          StorageDead(_10);
+          StorageLive(_11);
+          StorageLive(_12);
+-         _12 = OffsetOf(Epsilon, [Variant(0), Field(1)]);
+-         _11 = must_use::<usize>(move _12) -> [return: bb6, unwind unreachable];
++         _12 = const 2_usize;
++         _11 = must_use::<usize>(const 2_usize) -> [return: bb6, unwind unreachable];
+      }
+  
+      bb6: {
+          StorageDead(_12);
+          StorageLive(_13);
+          StorageLive(_14);
+-         _14 = OffsetOf(Epsilon, [Variant(2), Field(0)]);
+-         _13 = must_use::<usize>(move _14) -> [return: bb7, unwind unreachable];
++         _14 = const 4_usize;
++         _13 = must_use::<usize>(const 4_usize) -> [return: bb7, unwind unreachable];
+      }
+  
+      bb7: {
+          StorageDead(_14);
           _0 = const ();
+          StorageDead(_13);
+          StorageDead(_11);
+          StorageDead(_9);
           StorageDead(_7);
           StorageDead(_5);
           StorageDead(_3);

--- a/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-unwind.diff
@@ -42,7 +42,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
--         _2 = OffsetOf(Alpha, [Field(0)]);
+-         _2 = OffsetOf(Alpha, [(0, 0)]);
 -         _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
 +         _2 = const 4_usize;
 +         _1 = must_use::<usize>(const 4_usize) -> [return: bb1, unwind continue];
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
--         _4 = OffsetOf(Alpha, [Field(1)]);
+-         _4 = OffsetOf(Alpha, [(0, 1)]);
 -         _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
 +         _4 = const 0_usize;
 +         _3 = must_use::<usize>(const 0_usize) -> [return: bb2, unwind continue];
@@ -62,7 +62,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = OffsetOf(Alpha, [Field(2), Field(0)]);
+-         _6 = OffsetOf(Alpha, [(0, 2), (0, 0)]);
 -         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
 +         _6 = const 2_usize;
 +         _5 = must_use::<usize>(const 2_usize) -> [return: bb3, unwind continue];
@@ -72,7 +72,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
--         _8 = OffsetOf(Alpha, [Field(2), Field(1)]);
+-         _8 = OffsetOf(Alpha, [(0, 2), (0, 1)]);
 -         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
 +         _8 = const 3_usize;
 +         _7 = must_use::<usize>(const 3_usize) -> [return: bb4, unwind continue];
@@ -82,7 +82,7 @@
           StorageDead(_8);
           StorageLive(_9);
           StorageLive(_10);
--         _10 = OffsetOf(Epsilon, [Variant(0), Field(0)]);
+-         _10 = OffsetOf(Epsilon, [(0, 0)]);
 -         _9 = must_use::<usize>(move _10) -> [return: bb5, unwind continue];
 +         _10 = const 1_usize;
 +         _9 = must_use::<usize>(const 1_usize) -> [return: bb5, unwind continue];
@@ -92,7 +92,7 @@
           StorageDead(_10);
           StorageLive(_11);
           StorageLive(_12);
--         _12 = OffsetOf(Epsilon, [Variant(0), Field(1)]);
+-         _12 = OffsetOf(Epsilon, [(0, 1)]);
 -         _11 = must_use::<usize>(move _12) -> [return: bb6, unwind continue];
 +         _12 = const 2_usize;
 +         _11 = must_use::<usize>(const 2_usize) -> [return: bb6, unwind continue];
@@ -102,7 +102,7 @@
           StorageDead(_12);
           StorageLive(_13);
           StorageLive(_14);
--         _14 = OffsetOf(Epsilon, [Variant(2), Field(0)]);
+-         _14 = OffsetOf(Epsilon, [(2, 0)]);
 -         _13 = must_use::<usize>(move _14) -> [return: bb7, unwind continue];
 +         _14 = const 4_usize;
 +         _13 = must_use::<usize>(const 4_usize) -> [return: bb7, unwind continue];

--- a/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/offset_of.concrete.ConstProp.panic-unwind.diff
@@ -8,6 +8,9 @@
       let mut _4: usize;
       let mut _6: usize;
       let mut _8: usize;
+      let mut _10: usize;
+      let mut _12: usize;
+      let mut _14: usize;
       scope 1 {
           debug x => _1;
           let _3: usize;
@@ -19,6 +22,18 @@
                   let _7: usize;
                   scope 4 {
                       debug z1 => _7;
+                      let _9: usize;
+                      scope 5 {
+                          debug eA0 => _9;
+                          let _11: usize;
+                          scope 6 {
+                              debug eA1 => _11;
+                              let _13: usize;
+                              scope 7 {
+                                  debug eC => _13;
+                              }
+                          }
+                      }
                   }
               }
           }
@@ -27,7 +42,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
--         _2 = OffsetOf(Alpha, [0]);
+-         _2 = OffsetOf(Alpha, [Field(0)]);
 -         _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
 +         _2 = const 4_usize;
 +         _1 = must_use::<usize>(const 4_usize) -> [return: bb1, unwind continue];
@@ -37,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
--         _4 = OffsetOf(Alpha, [1]);
+-         _4 = OffsetOf(Alpha, [Field(1)]);
 -         _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
 +         _4 = const 0_usize;
 +         _3 = must_use::<usize>(const 0_usize) -> [return: bb2, unwind continue];
@@ -47,7 +62,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = OffsetOf(Alpha, [2, 0]);
+-         _6 = OffsetOf(Alpha, [Field(2), Field(0)]);
 -         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
 +         _6 = const 2_usize;
 +         _5 = must_use::<usize>(const 2_usize) -> [return: bb3, unwind continue];
@@ -57,7 +72,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
--         _8 = OffsetOf(Alpha, [2, 1]);
+-         _8 = OffsetOf(Alpha, [Field(2), Field(1)]);
 -         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
 +         _8 = const 3_usize;
 +         _7 = must_use::<usize>(const 3_usize) -> [return: bb4, unwind continue];
@@ -65,7 +80,40 @@
   
       bb4: {
           StorageDead(_8);
+          StorageLive(_9);
+          StorageLive(_10);
+-         _10 = OffsetOf(Epsilon, [Variant(0), Field(0)]);
+-         _9 = must_use::<usize>(move _10) -> [return: bb5, unwind continue];
++         _10 = const 1_usize;
++         _9 = must_use::<usize>(const 1_usize) -> [return: bb5, unwind continue];
+      }
+  
+      bb5: {
+          StorageDead(_10);
+          StorageLive(_11);
+          StorageLive(_12);
+-         _12 = OffsetOf(Epsilon, [Variant(0), Field(1)]);
+-         _11 = must_use::<usize>(move _12) -> [return: bb6, unwind continue];
++         _12 = const 2_usize;
++         _11 = must_use::<usize>(const 2_usize) -> [return: bb6, unwind continue];
+      }
+  
+      bb6: {
+          StorageDead(_12);
+          StorageLive(_13);
+          StorageLive(_14);
+-         _14 = OffsetOf(Epsilon, [Variant(2), Field(0)]);
+-         _13 = must_use::<usize>(move _14) -> [return: bb7, unwind continue];
++         _14 = const 4_usize;
++         _13 = must_use::<usize>(const 4_usize) -> [return: bb7, unwind continue];
+      }
+  
+      bb7: {
+          StorageDead(_14);
           _0 = const ();
+          StorageDead(_13);
+          StorageDead(_11);
+          StorageDead(_9);
           StorageDead(_7);
           StorageDead(_5);
           StorageDead(_3);

--- a/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-abort.diff
@@ -8,6 +8,9 @@
       let mut _4: usize;
       let mut _6: usize;
       let mut _8: usize;
+      let mut _10: usize;
+      let mut _12: usize;
+      let mut _14: usize;
       scope 1 {
           debug gx => _1;
           let _3: usize;
@@ -19,6 +22,18 @@
                   let _7: usize;
                   scope 4 {
                       debug dy => _7;
+                      let _9: usize;
+                      scope 5 {
+                          debug zA0 => _9;
+                          let _11: usize;
+                          scope 6 {
+                              debug zA1 => _11;
+                              let _13: usize;
+                              scope 7 {
+                                  debug zB => _13;
+                              }
+                          }
+                      }
                   }
               }
           }
@@ -27,7 +42,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = OffsetOf(Gamma<T>, [0]);
+          _2 = OffsetOf(Gamma<T>, [Field(0)]);
           _1 = must_use::<usize>(move _2) -> [return: bb1, unwind unreachable];
       }
   
@@ -35,7 +50,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _4 = OffsetOf(Gamma<T>, [1]);
+          _4 = OffsetOf(Gamma<T>, [Field(1)]);
           _3 = must_use::<usize>(move _4) -> [return: bb2, unwind unreachable];
       }
   
@@ -43,7 +58,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
-          _6 = OffsetOf(Delta<T>, [1]);
+          _6 = OffsetOf(Delta<T>, [Field(1)]);
           _5 = must_use::<usize>(move _6) -> [return: bb3, unwind unreachable];
       }
   
@@ -51,13 +66,40 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
-          _8 = OffsetOf(Delta<T>, [2]);
+          _8 = OffsetOf(Delta<T>, [Field(2)]);
           _7 = must_use::<usize>(move _8) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {
           StorageDead(_8);
+          StorageLive(_9);
+          StorageLive(_10);
+          _10 = OffsetOf(Zeta<T>, [Variant(0), Field(0)]);
+          _9 = must_use::<usize>(move _10) -> [return: bb5, unwind unreachable];
+      }
+  
+      bb5: {
+          StorageDead(_10);
+          StorageLive(_11);
+          StorageLive(_12);
+          _12 = OffsetOf(Zeta<T>, [Variant(0), Field(1)]);
+          _11 = must_use::<usize>(move _12) -> [return: bb6, unwind unreachable];
+      }
+  
+      bb6: {
+          StorageDead(_12);
+          StorageLive(_13);
+          StorageLive(_14);
+          _14 = OffsetOf(Zeta<T>, [Variant(1), Field(0)]);
+          _13 = must_use::<usize>(move _14) -> [return: bb7, unwind unreachable];
+      }
+  
+      bb7: {
+          StorageDead(_14);
           _0 = const ();
+          StorageDead(_13);
+          StorageDead(_11);
+          StorageDead(_9);
           StorageDead(_7);
           StorageDead(_5);
           StorageDead(_3);

--- a/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-abort.diff
@@ -42,7 +42,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = OffsetOf(Gamma<T>, [Field(0)]);
+          _2 = OffsetOf(Gamma<T>, [(0, 0)]);
           _1 = must_use::<usize>(move _2) -> [return: bb1, unwind unreachable];
       }
   
@@ -50,7 +50,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _4 = OffsetOf(Gamma<T>, [Field(1)]);
+          _4 = OffsetOf(Gamma<T>, [(0, 1)]);
           _3 = must_use::<usize>(move _4) -> [return: bb2, unwind unreachable];
       }
   
@@ -58,7 +58,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
-          _6 = OffsetOf(Delta<T>, [Field(1)]);
+          _6 = OffsetOf(Delta<T>, [(0, 1)]);
           _5 = must_use::<usize>(move _6) -> [return: bb3, unwind unreachable];
       }
   
@@ -66,7 +66,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
-          _8 = OffsetOf(Delta<T>, [Field(2)]);
+          _8 = OffsetOf(Delta<T>, [(0, 2)]);
           _7 = must_use::<usize>(move _8) -> [return: bb4, unwind unreachable];
       }
   
@@ -74,7 +74,7 @@
           StorageDead(_8);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = OffsetOf(Zeta<T>, [Variant(0), Field(0)]);
+          _10 = OffsetOf(Zeta<T>, [(0, 0)]);
           _9 = must_use::<usize>(move _10) -> [return: bb5, unwind unreachable];
       }
   
@@ -82,7 +82,7 @@
           StorageDead(_10);
           StorageLive(_11);
           StorageLive(_12);
-          _12 = OffsetOf(Zeta<T>, [Variant(0), Field(1)]);
+          _12 = OffsetOf(Zeta<T>, [(0, 1)]);
           _11 = must_use::<usize>(move _12) -> [return: bb6, unwind unreachable];
       }
   
@@ -90,7 +90,7 @@
           StorageDead(_12);
           StorageLive(_13);
           StorageLive(_14);
-          _14 = OffsetOf(Zeta<T>, [Variant(1), Field(0)]);
+          _14 = OffsetOf(Zeta<T>, [(1, 0)]);
           _13 = must_use::<usize>(move _14) -> [return: bb7, unwind unreachable];
       }
   

--- a/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-unwind.diff
@@ -8,6 +8,9 @@
       let mut _4: usize;
       let mut _6: usize;
       let mut _8: usize;
+      let mut _10: usize;
+      let mut _12: usize;
+      let mut _14: usize;
       scope 1 {
           debug gx => _1;
           let _3: usize;
@@ -19,6 +22,18 @@
                   let _7: usize;
                   scope 4 {
                       debug dy => _7;
+                      let _9: usize;
+                      scope 5 {
+                          debug zA0 => _9;
+                          let _11: usize;
+                          scope 6 {
+                              debug zA1 => _11;
+                              let _13: usize;
+                              scope 7 {
+                                  debug zB => _13;
+                              }
+                          }
+                      }
                   }
               }
           }
@@ -27,7 +42,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = OffsetOf(Gamma<T>, [0]);
+          _2 = OffsetOf(Gamma<T>, [Field(0)]);
           _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
       }
   
@@ -35,7 +50,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _4 = OffsetOf(Gamma<T>, [1]);
+          _4 = OffsetOf(Gamma<T>, [Field(1)]);
           _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
       }
   
@@ -43,7 +58,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
-          _6 = OffsetOf(Delta<T>, [1]);
+          _6 = OffsetOf(Delta<T>, [Field(1)]);
           _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
       }
   
@@ -51,13 +66,40 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
-          _8 = OffsetOf(Delta<T>, [2]);
+          _8 = OffsetOf(Delta<T>, [Field(2)]);
           _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
       }
   
       bb4: {
           StorageDead(_8);
+          StorageLive(_9);
+          StorageLive(_10);
+          _10 = OffsetOf(Zeta<T>, [Variant(0), Field(0)]);
+          _9 = must_use::<usize>(move _10) -> [return: bb5, unwind continue];
+      }
+  
+      bb5: {
+          StorageDead(_10);
+          StorageLive(_11);
+          StorageLive(_12);
+          _12 = OffsetOf(Zeta<T>, [Variant(0), Field(1)]);
+          _11 = must_use::<usize>(move _12) -> [return: bb6, unwind continue];
+      }
+  
+      bb6: {
+          StorageDead(_12);
+          StorageLive(_13);
+          StorageLive(_14);
+          _14 = OffsetOf(Zeta<T>, [Variant(1), Field(0)]);
+          _13 = must_use::<usize>(move _14) -> [return: bb7, unwind continue];
+      }
+  
+      bb7: {
+          StorageDead(_14);
           _0 = const ();
+          StorageDead(_13);
+          StorageDead(_11);
+          StorageDead(_9);
           StorageDead(_7);
           StorageDead(_5);
           StorageDead(_3);

--- a/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/offset_of.generic.ConstProp.panic-unwind.diff
@@ -42,7 +42,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = OffsetOf(Gamma<T>, [Field(0)]);
+          _2 = OffsetOf(Gamma<T>, [(0, 0)]);
           _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
       }
   
@@ -50,7 +50,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _4 = OffsetOf(Gamma<T>, [Field(1)]);
+          _4 = OffsetOf(Gamma<T>, [(0, 1)]);
           _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
       }
   
@@ -58,7 +58,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
-          _6 = OffsetOf(Delta<T>, [Field(1)]);
+          _6 = OffsetOf(Delta<T>, [(0, 1)]);
           _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
       }
   
@@ -66,7 +66,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
-          _8 = OffsetOf(Delta<T>, [Field(2)]);
+          _8 = OffsetOf(Delta<T>, [(0, 2)]);
           _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
       }
   
@@ -74,7 +74,7 @@
           StorageDead(_8);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = OffsetOf(Zeta<T>, [Variant(0), Field(0)]);
+          _10 = OffsetOf(Zeta<T>, [(0, 0)]);
           _9 = must_use::<usize>(move _10) -> [return: bb5, unwind continue];
       }
   
@@ -82,7 +82,7 @@
           StorageDead(_10);
           StorageLive(_11);
           StorageLive(_12);
-          _12 = OffsetOf(Zeta<T>, [Variant(0), Field(1)]);
+          _12 = OffsetOf(Zeta<T>, [(0, 1)]);
           _11 = must_use::<usize>(move _12) -> [return: bb6, unwind continue];
       }
   
@@ -90,7 +90,7 @@
           StorageDead(_12);
           StorageLive(_13);
           StorageLive(_14);
-          _14 = OffsetOf(Zeta<T>, [Variant(1), Field(0)]);
+          _14 = OffsetOf(Zeta<T>, [(1, 0)]);
           _13 = must_use::<usize>(move _14) -> [return: bb7, unwind continue];
       }
   

--- a/tests/mir-opt/const_prop/offset_of.rs
+++ b/tests/mir-opt/const_prop/offset_of.rs
@@ -28,12 +28,26 @@ struct Delta<T> {
     y: u16,
 }
 
+enum Epsilon {
+    A(u8, u16),
+    B,
+    C { c: u32 }
+}
+
+enum Zeta<T> {
+    A(T, bool),
+    B(char),
+}
+
 // EMIT_MIR offset_of.concrete.ConstProp.diff
 fn concrete() {
     let x = offset_of!(Alpha, x);
     let y = offset_of!(Alpha, y);
     let z0 = offset_of!(Alpha, z.0);
     let z1 = offset_of!(Alpha, z.1);
+    let eA0 = offset_of!(Epsilon, A.0);
+    let eA1 = offset_of!(Epsilon, A.1);
+    let eC = offset_of!(Epsilon, C.c);
 }
 
 // EMIT_MIR offset_of.generic.ConstProp.diff
@@ -42,6 +56,9 @@ fn generic<T>() {
     let gy = offset_of!(Gamma<T>, y);
     let dx = offset_of!(Delta<T>, x);
     let dy = offset_of!(Delta<T>, y);
+    let zA0 = offset_of!(Zeta<T>, A.0);
+    let zA1 = offset_of!(Zeta<T>, A.1);
+    let zB = offset_of!(Zeta<T>, B.0);
 }
 
 fn main() {

--- a/tests/mir-opt/dataflow-const-prop/offset_of.concrete.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/offset_of.concrete.DataflowConstProp.panic-abort.diff
@@ -27,7 +27,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
--         _2 = OffsetOf(Alpha, [0]);
+-         _2 = OffsetOf(Alpha, [(0, 0)]);
 -         _1 = must_use::<usize>(move _2) -> [return: bb1, unwind unreachable];
 +         _2 = const 4_usize;
 +         _1 = must_use::<usize>(const 4_usize) -> [return: bb1, unwind unreachable];
@@ -37,7 +37,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
--         _4 = OffsetOf(Alpha, [1]);
+-         _4 = OffsetOf(Alpha, [(0, 1)]);
 -         _3 = must_use::<usize>(move _4) -> [return: bb2, unwind unreachable];
 +         _4 = const 0_usize;
 +         _3 = must_use::<usize>(const 0_usize) -> [return: bb2, unwind unreachable];
@@ -47,7 +47,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = OffsetOf(Alpha, [2, 0]);
+-         _6 = OffsetOf(Alpha, [(0, 2), (0, 0)]);
 -         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind unreachable];
 +         _6 = const 2_usize;
 +         _5 = must_use::<usize>(const 2_usize) -> [return: bb3, unwind unreachable];
@@ -57,7 +57,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
--         _8 = OffsetOf(Alpha, [2, 1]);
+-         _8 = OffsetOf(Alpha, [(0, 2), (0, 1)]);
 -         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind unreachable];
 +         _8 = const 3_usize;
 +         _7 = must_use::<usize>(const 3_usize) -> [return: bb4, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/offset_of.concrete.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/offset_of.concrete.DataflowConstProp.panic-unwind.diff
@@ -27,7 +27,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
--         _2 = OffsetOf(Alpha, [0]);
+-         _2 = OffsetOf(Alpha, [(0, 0)]);
 -         _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
 +         _2 = const 4_usize;
 +         _1 = must_use::<usize>(const 4_usize) -> [return: bb1, unwind continue];
@@ -37,7 +37,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
--         _4 = OffsetOf(Alpha, [1]);
+-         _4 = OffsetOf(Alpha, [(0, 1)]);
 -         _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
 +         _4 = const 0_usize;
 +         _3 = must_use::<usize>(const 0_usize) -> [return: bb2, unwind continue];
@@ -47,7 +47,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = OffsetOf(Alpha, [2, 0]);
+-         _6 = OffsetOf(Alpha, [(0, 2), (0, 0)]);
 -         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
 +         _6 = const 2_usize;
 +         _5 = must_use::<usize>(const 2_usize) -> [return: bb3, unwind continue];
@@ -57,7 +57,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
--         _8 = OffsetOf(Alpha, [2, 1]);
+-         _8 = OffsetOf(Alpha, [(0, 2), (0, 1)]);
 -         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
 +         _8 = const 3_usize;
 +         _7 = must_use::<usize>(const 3_usize) -> [return: bb4, unwind continue];

--- a/tests/mir-opt/dataflow-const-prop/offset_of.generic.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/offset_of.generic.DataflowConstProp.panic-abort.diff
@@ -27,7 +27,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = OffsetOf(Gamma<T>, [0]);
+          _2 = OffsetOf(Gamma<T>, [(0, 0)]);
           _1 = must_use::<usize>(move _2) -> [return: bb1, unwind unreachable];
       }
   
@@ -35,7 +35,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _4 = OffsetOf(Gamma<T>, [1]);
+          _4 = OffsetOf(Gamma<T>, [(0, 1)]);
           _3 = must_use::<usize>(move _4) -> [return: bb2, unwind unreachable];
       }
   
@@ -43,7 +43,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = OffsetOf(Delta<T>, [1]);
+-         _6 = OffsetOf(Delta<T>, [(0, 1)]);
 -         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind unreachable];
 +         _6 = const 0_usize;
 +         _5 = must_use::<usize>(const 0_usize) -> [return: bb3, unwind unreachable];
@@ -53,7 +53,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
--         _8 = OffsetOf(Delta<T>, [2]);
+-         _8 = OffsetOf(Delta<T>, [(0, 2)]);
 -         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind unreachable];
 +         _8 = const 2_usize;
 +         _7 = must_use::<usize>(const 2_usize) -> [return: bb4, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/offset_of.generic.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/offset_of.generic.DataflowConstProp.panic-unwind.diff
@@ -27,7 +27,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = OffsetOf(Gamma<T>, [0]);
+          _2 = OffsetOf(Gamma<T>, [(0, 0)]);
           _1 = must_use::<usize>(move _2) -> [return: bb1, unwind continue];
       }
   
@@ -35,7 +35,7 @@
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _4 = OffsetOf(Gamma<T>, [1]);
+          _4 = OffsetOf(Gamma<T>, [(0, 1)]);
           _3 = must_use::<usize>(move _4) -> [return: bb2, unwind continue];
       }
   
@@ -43,7 +43,7 @@
           StorageDead(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = OffsetOf(Delta<T>, [1]);
+-         _6 = OffsetOf(Delta<T>, [(0, 1)]);
 -         _5 = must_use::<usize>(move _6) -> [return: bb3, unwind continue];
 +         _6 = const 0_usize;
 +         _5 = must_use::<usize>(const 0_usize) -> [return: bb3, unwind continue];
@@ -53,7 +53,7 @@
           StorageDead(_6);
           StorageLive(_7);
           StorageLive(_8);
--         _8 = OffsetOf(Delta<T>, [2]);
+-         _8 = OffsetOf(Delta<T>, [(0, 2)]);
 -         _7 = must_use::<usize>(move _8) -> [return: bb4, unwind continue];
 +         _8 = const 2_usize;
 +         _7 = must_use::<usize>(const 2_usize) -> [return: bb4, unwind continue];

--- a/tests/ui/offset-of/offset-of-enum.rs
+++ b/tests/ui/offset-of/offset-of-enum.rs
@@ -14,4 +14,5 @@ fn main() {
     offset_of!(Alpha, Two.1); //~ ERROR no field named `1` on enum variant `Alpha::Two`
     offset_of!(Alpha, Two.foo); //~ ERROR no field named `foo` on enum variant `Alpha::Two`
     offset_of!(Alpha, NonExistent); //~ ERROR no variant named `NonExistent` found for enum `Alpha`
+    offset_of!(Beta, One); //~ ERROR cannot find type `Beta` in this scope
 }

--- a/tests/ui/offset-of/offset-of-enum.rs
+++ b/tests/ui/offset-of/offset-of-enum.rs
@@ -9,5 +9,6 @@ enum Alpha {
 
 fn main() {
     offset_of!(Alpha::One, 0); //~ ERROR expected type, found variant `Alpha::One`
-    offset_of!(Alpha, Two.0); //~ ERROR no field `Two` on type `Alpha`
+    offset_of!(Alpha, One); //~ ERROR `One` is an enum variant; expected field at end of `offset_of`
+    offset_of!(Alpha, Two.0);
 }

--- a/tests/ui/offset-of/offset-of-enum.rs
+++ b/tests/ui/offset-of/offset-of-enum.rs
@@ -11,4 +11,7 @@ fn main() {
     offset_of!(Alpha::One, 0); //~ ERROR expected type, found variant `Alpha::One`
     offset_of!(Alpha, One); //~ ERROR `One` is an enum variant; expected field at end of `offset_of`
     offset_of!(Alpha, Two.0);
+    offset_of!(Alpha, Two.1); //~ ERROR no field named `1` on enum variant `Alpha::Two`
+    offset_of!(Alpha, Two.foo); //~ ERROR no field named `foo` on enum variant `Alpha::Two`
+    offset_of!(Alpha, NonExistent); //~ ERROR no variant named `NonExistent` found for enum `Alpha`
 }

--- a/tests/ui/offset-of/offset-of-enum.stderr
+++ b/tests/ui/offset-of/offset-of-enum.stderr
@@ -7,6 +7,12 @@ LL |     offset_of!(Alpha::One, 0);
    |                not a type
    |                help: try using the variant's enum: `Alpha`
 
+error[E0412]: cannot find type `Beta` in this scope
+  --> $DIR/offset-of-enum.rs:17:16
+   |
+LL |     offset_of!(Beta, One);
+   |                ^^^^ not found in this scope
+
 error[E0795]: `One` is an enum variant; expected field at end of `offset_of`
   --> $DIR/offset-of-enum.rs:12:23
    |
@@ -35,7 +41,7 @@ error[E0599]: no variant named `NonExistent` found for enum `Alpha`
 LL |     offset_of!(Alpha, NonExistent);
    |                       ^^^^^^^^^^^ variant not found
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0573, E0599, E0609, E0795.
-For more information about an error, try `rustc --explain E0573`.
+Some errors have detailed explanations: E0412, E0573, E0599, E0609, E0795.
+For more information about an error, try `rustc --explain E0412`.

--- a/tests/ui/offset-of/offset-of-enum.stderr
+++ b/tests/ui/offset-of/offset-of-enum.stderr
@@ -13,7 +13,29 @@ error[E0795]: `One` is an enum variant; expected field at end of `offset_of`
 LL |     offset_of!(Alpha, One);
    |                       ^^^ enum variant
 
-error: aborting due to 2 previous errors
+error[E0609]: no field named `1` on enum variant `Alpha::Two`
+  --> $DIR/offset-of-enum.rs:14:23
+   |
+LL |     offset_of!(Alpha, Two.1);
+   |                       ^^^ - ...does not have this field
+   |                       |
+   |                       this enum variant...
 
-Some errors have detailed explanations: E0573, E0795.
+error[E0609]: no field named `foo` on enum variant `Alpha::Two`
+  --> $DIR/offset-of-enum.rs:15:23
+   |
+LL |     offset_of!(Alpha, Two.foo);
+   |                       ^^^ --- ...does not have this field
+   |                       |
+   |                       this enum variant...
+
+error[E0599]: no variant named `NonExistent` found for enum `Alpha`
+  --> $DIR/offset-of-enum.rs:16:23
+   |
+LL |     offset_of!(Alpha, NonExistent);
+   |                       ^^^^^^^^^^^ variant not found
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0573, E0599, E0609, E0795.
 For more information about an error, try `rustc --explain E0573`.

--- a/tests/ui/offset-of/offset-of-enum.stderr
+++ b/tests/ui/offset-of/offset-of-enum.stderr
@@ -7,13 +7,13 @@ LL |     offset_of!(Alpha::One, 0);
    |                not a type
    |                help: try using the variant's enum: `Alpha`
 
-error[E0609]: no field `Two` on type `Alpha`
+error[E0795]: `One` is an enum variant; expected field at end of `offset_of`
   --> $DIR/offset-of-enum.rs:12:23
    |
-LL |     offset_of!(Alpha, Two.0);
-   |                       ^^^
+LL |     offset_of!(Alpha, One);
+   |                       ^^^ enum variant
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0573, E0609.
+Some errors have detailed explanations: E0573, E0795.
 For more information about an error, try `rustc --explain E0573`.

--- a/tests/ui/offset-of/offset-of-private.rs
+++ b/tests/ui/offset-of/offset-of-private.rs
@@ -8,12 +8,19 @@ mod m {
         pub public: u8,
         private: u8,
     }
+
     #[repr(C)]
     pub struct FooTuple(pub u8, u8);
+
     #[repr(C)]
     struct Bar {
         pub public: u8,
         private: u8,
+    }
+
+    pub enum Baz {
+        Var1(Foo),
+        Var2(u64),
     }
 }
 
@@ -25,4 +32,8 @@ fn main() {
     offset_of!(m::Bar, public); //~ ERROR struct `Bar` is private
     offset_of!(m::Bar, private); //~ ERROR struct `Bar` is private
     //~| ERROR field `private` of struct `Bar` is private
+
+    offset_of!(m::Baz, Var1.0.public);
+    offset_of!(m::Baz, Var1.0.private); //~ ERROR field `private` of struct `Foo` is private
+    offset_of!(m::Baz, Var2.0);
 }

--- a/tests/ui/offset-of/offset-of-private.stderr
+++ b/tests/ui/offset-of/offset-of-private.stderr
@@ -1,46 +1,52 @@
 error[E0603]: struct `Bar` is private
-  --> $DIR/offset-of-private.rs:25:19
+  --> $DIR/offset-of-private.rs:32:19
    |
 LL |     offset_of!(m::Bar, public);
    |                   ^^^ private struct
    |
 note: the struct `Bar` is defined here
-  --> $DIR/offset-of-private.rs:14:5
+  --> $DIR/offset-of-private.rs:16:5
    |
 LL |     struct Bar {
    |     ^^^^^^^^^^
 
 error[E0603]: struct `Bar` is private
-  --> $DIR/offset-of-private.rs:26:19
+  --> $DIR/offset-of-private.rs:33:19
    |
 LL |     offset_of!(m::Bar, private);
    |                   ^^^ private struct
    |
 note: the struct `Bar` is defined here
-  --> $DIR/offset-of-private.rs:14:5
+  --> $DIR/offset-of-private.rs:16:5
    |
 LL |     struct Bar {
    |     ^^^^^^^^^^
 
 error[E0616]: field `private` of struct `Foo` is private
-  --> $DIR/offset-of-private.rs:22:24
+  --> $DIR/offset-of-private.rs:29:24
    |
 LL |     offset_of!(m::Foo, private);
    |                        ^^^^^^^ private field
 
 error[E0616]: field `1` of struct `FooTuple` is private
-  --> $DIR/offset-of-private.rs:24:29
+  --> $DIR/offset-of-private.rs:31:29
    |
 LL |     offset_of!(m::FooTuple, 1);
    |                             ^ private field
 
 error[E0616]: field `private` of struct `Bar` is private
-  --> $DIR/offset-of-private.rs:26:24
+  --> $DIR/offset-of-private.rs:33:24
    |
 LL |     offset_of!(m::Bar, private);
    |                        ^^^^^^^ private field
 
-error: aborting due to 5 previous errors
+error[E0616]: field `private` of struct `Foo` is private
+  --> $DIR/offset-of-private.rs:37:31
+   |
+LL |     offset_of!(m::Baz, Var1.0.private);
+   |                               ^^^^^^^ private field
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0603, E0616.
 For more information about an error, try `rustc --explain E0603`.


### PR DESCRIPTION
This MR implements support for navigating through enum variants in `offset_of!`, placing the enum variant name in the second argument to `offset_of!`. The RFC placed it in the first argument, but I think it interacts better with nested field access in the second, as you can then write things like

```rust
offset_of!(Type, field.Variant.field)
```

Alternatively, a syntactic distinction could be made between variants and fields (e.g. `field::Variant.field`) but I'm not convinced this would be helpful.

[RFC 3308 # Enum Support](https://rust-lang.github.io/rfcs/3308-offset_of.html#enum-support-offset_ofsomeenumstructvariant-field_on_variant)
Tracking Issue #106655.