### PR TITLE
Mark `lazy_type_alias` as incomplete

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -449,7 +449,7 @@ declare_features! (
     // Allows setting the threshold for the `large_assignments` lint.
     (active, large_assignments, "1.52.0", Some(83518), None),
     /// Allow to have type alias types for inter-crate use.
-    (active, lazy_type_alias, "1.72.0", Some(112792), None),
+    (incomplete, lazy_type_alias, "1.72.0", Some(112792), None),
     /// Allows `if/while p && let q = r && ...` chains.
     (active, let_chains, "1.37.0", Some(53667), None),
     /// Allows using `reason` in lint attributes and the `#[expect(lint)]` lint check.

--- a/tests/rustdoc/alias-reexport.rs
+++ b/tests/rustdoc/alias-reexport.rs
@@ -3,6 +3,7 @@
 
 #![crate_name = "foo"]
 #![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
 
 extern crate alias_reexport2;
 

--- a/tests/rustdoc/alias-reexport2.rs
+++ b/tests/rustdoc/alias-reexport2.rs
@@ -3,6 +3,7 @@
 
 #![crate_name = "foo"]
 #![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
 
 extern crate alias_reexport;
 

--- a/tests/ui/type-alias/lazy-type-alias-enum-variant.rs
+++ b/tests/ui/type-alias/lazy-type-alias-enum-variant.rs
@@ -2,6 +2,7 @@
 // check-pass
 
 #![feature(lazy_type_alias)]
+//~^ WARN the feature `lazy_type_alias` is incomplete and may not be safe to use
 
 enum Enum {
     Unit,

--- a/tests/ui/type-alias/lazy-type-alias-enum-variant.stderr
+++ b/tests/ui/type-alias/lazy-type-alias-enum-variant.stderr
@@ -1,0 +1,11 @@
+warning: the feature `lazy_type_alias` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/lazy-type-alias-enum-variant.rs:4:12
+   |
+LL | #![feature(lazy_type_alias)]
+   |            ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
This feature is very not complete: https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+label%3AF-lazy_type_alias

r? types