### PR TITLE
Documentation: Fix Stilted Language in Vec->Indexing

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -213,7 +213,7 @@ mod spec_extend;
 ///
 /// # Indexing
 ///
-/// The `Vec` type allows to access values by index, because it implements the
+/// The `Vec` type allows access to values by index, because it implements the
 /// [`Index`] trait. An example will be more explicit:
 ///
 /// ```


### PR DESCRIPTION
Problem

Language in the Vec->Indexing documentation sounds stilted due to incorrect word ordering: "... type allows to access values by index."

Solution

Reorder words in the Vec->Indexing documentation to flow better: "... type allows access to values by index." The phrase "allows access to" also matches other existing documentation.