### PR TITLE
rustc_llvm: Link to libkstat on Solaris/SPARC

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -241,6 +241,11 @@ fn main() {
         cmd.arg("--system-libs");
     }
 
+    // We need libkstat for getHostCPUName on SPARC builds.
+    if target.starts_with("sparcv9") && target.contains("solaris") {
+        println!("cargo:rustc-link-lib=kstat");
+    }
+
     if (target.starts_with("arm") && !target.contains("freebsd"))
         || target.starts_with("mips-")
         || target.starts_with("mipsel-")

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -242,6 +242,7 @@ fn main() {
     }
 
     // We need libkstat for getHostCPUName on SPARC builds.
+    // See also: https://github.com/llvm/llvm-project/issues/64186
     if target.starts_with("sparcv9") && target.contains("solaris") {
         println!("cargo:rustc-link-lib=kstat");
     }


### PR DESCRIPTION
getHostCPUName calls into libkstat but as of
LLVM 16.0.6 libLLVMTargetParser is not explicitly
linked against libkstat causing builds to fail
due to undefined symbols.

See also: llvm/llvm-project#64186