### PR TITLE
Weaken unnameable_types lint

### DIFF
--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1941,7 +1941,7 @@ impl<'tcx> PrivateItemsInPublicInterfacesChecker<'tcx, '_> {
         let reexported_at_vis = effective_vis.at_level(Level::Reexported);
         let reachable_at_vis = effective_vis.at_level(Level::Reachable);
 
-        if reexported_at_vis != reachable_at_vis {
+        if reachable_at_vis.is_public() && reexported_at_vis != reachable_at_vis {
             let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
             let span = self.tcx.def_span(def_id.to_def_id());
             self.tcx.emit_spanned_lint(
@@ -1972,10 +1972,6 @@ impl<'tcx> PrivateItemsInPublicInterfacesChecker<'tcx, '_> {
             AssocItemKind::Const | AssocItemKind::Fn { .. } => (true, false),
             AssocItemKind::Type => (self.tcx.defaultness(def_id).has_value(), true),
         };
-
-        if is_assoc_ty {
-            self.check_unnameable(def_id, self.get(def_id));
-        }
 
         check.in_assoc_ty = is_assoc_ty;
         check.generics().predicates();

--- a/tests/ui/privacy/unnameable_types.rs
+++ b/tests/ui/privacy/unnameable_types.rs
@@ -11,12 +11,12 @@ mod m {
 
     pub trait PubTr { //~ ERROR trait `PubTr` is reachable but cannot be named
         const C : i32 = 0;
-        type Alias; //~ ERROR associated type `PubTr::Alias` is reachable but cannot be named
+        type Alias;
         fn f() {}
     }
 
     impl PubTr for PubStruct {
-        type Alias = i32; //~ ERROR associated type `<PubStruct as PubTr>::Alias` is reachable but cannot be named
+        type Alias = i32;
         fn f() {}
     }
 }

--- a/tests/ui/privacy/unnameable_types.stderr
+++ b/tests/ui/privacy/unnameable_types.stderr
@@ -22,17 +22,5 @@ error: trait `PubTr` is reachable but cannot be named
 LL |     pub trait PubTr {
    |     ^^^^^^^^^^^^^^^ reachable at visibility `pub`, but can only be named at visibility `pub(crate)`
 
-error: associated type `PubTr::Alias` is reachable but cannot be named
-  --> $DIR/unnameable_types.rs:14:9
-   |
-LL |         type Alias;
-   |         ^^^^^^^^^^ reachable at visibility `pub`, but can only be named at visibility `pub(crate)`
-
-error: associated type `<PubStruct as PubTr>::Alias` is reachable but cannot be named
-  --> $DIR/unnameable_types.rs:19:9
-   |
-LL |         type Alias = i32;
-   |         ^^^^^^^^^^ reachable at visibility `pub`, but can only be named at visibility `pub(crate)`
-
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
`unnameable_types` lint is no longer emitted for 
- associated types
- internal types

r? @petrochenkov