### PR TITLE
Make lint missing-copy-implementations honor negative `Copy` impls

### DIFF
--- a/tests/ui/lint/missing-copy-implementations-negative-copy.rs
+++ b/tests/ui/lint/missing-copy-implementations-negative-copy.rs
@@ -1,0 +1,15 @@
+// Regression test for issue #101980.
+// Ensure that we don't suggest impl'ing `Copy` for a type if it already impl's `!Copy`.
+
+// check-pass
+
+#![feature(negative_impls)]
+#![deny(missing_copy_implementations)]
+
+pub struct Struct {
+    pub field: i32,
+}
+
+impl !Copy for Struct {}
+
+fn main() {}


### PR DESCRIPTION
Fixes #101980.

@rustbot label A-lint F-negative_impls