### PR TITLE
Fix invalid suggestion for mismatched types in closure arguments

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -755,7 +755,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             match binding_parent {
                 // Check that there is explicit type (ie this is not a closure param with inferred type)
                 // so we don't suggest moving something to the type that does not exist
-                hir::Node::Param(hir::Param { ty_span, .. }) if binding.span != *ty_span => {
+                hir::Node::Param(hir::Param { ty_span, pat, .. }) if pat.span != *ty_span => {
                     err.multipart_suggestion_verbose(
                         format!("to take parameter `{binding}` by reference, move `&{mutability}` to the type"),
                         vec![

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2342,7 +2342,7 @@ impl<'a> Parser<'a> {
             let ty = if this.eat(&token::Colon) {
                 this.parse_ty()?
             } else {
-                this.mk_ty(this.prev_token.span, TyKind::Infer)
+                this.mk_ty(pat.span, TyKind::Infer)
             };
 
             Ok((

--- a/tests/ui/impl-trait/hidden-type-is-opaque-2.rs
+++ b/tests/ui/impl-trait/hidden-type-is-opaque-2.rs
@@ -6,7 +6,8 @@
 
 fn reify_as() -> Thunk<impl FnOnce(Continuation) -> Continuation> {
     Thunk::new(|mut cont| {
-        cont.reify_as(); //~ ERROR type annotations needed
+        //~^ ERROR type annotations needed
+        cont.reify_as();
         cont
     })
 }
@@ -15,7 +16,8 @@ type Tait = impl FnOnce(Continuation) -> Continuation;
 
 fn reify_as_tait() -> Thunk<Tait> {
     Thunk::new(|mut cont| {
-        cont.reify_as(); //~ ERROR type annotations needed
+        //~^ ERROR type annotations needed
+        cont.reify_as();
         cont
     })
 }

--- a/tests/ui/impl-trait/hidden-type-is-opaque-2.stderr
+++ b/tests/ui/impl-trait/hidden-type-is-opaque-2.stderr
@@ -1,14 +1,30 @@
 error[E0282]: type annotations needed
-  --> $DIR/hidden-type-is-opaque-2.rs:9:9
+  --> $DIR/hidden-type-is-opaque-2.rs:8:17
    |
+LL |     Thunk::new(|mut cont| {
+   |                 ^^^^^^^^
+LL |
 LL |         cont.reify_as();
-   |         ^^^^ cannot infer type
+   |         ---- type must be known at this point
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     Thunk::new(|mut cont: /* Type */| {
+   |                         ++++++++++++
 
 error[E0282]: type annotations needed
-  --> $DIR/hidden-type-is-opaque-2.rs:18:9
+  --> $DIR/hidden-type-is-opaque-2.rs:18:17
    |
+LL |     Thunk::new(|mut cont| {
+   |                 ^^^^^^^^
+LL |
 LL |         cont.reify_as();
-   |         ^^^^ cannot infer type
+   |         ---- type must be known at this point
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     Thunk::new(|mut cont: /* Type */| {
+   |                         ++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/mismatched_types/closure-ref-114180.rs
+++ b/tests/ui/mismatched_types/closure-ref-114180.rs
@@ -1,0 +1,8 @@
+// check-fail
+
+fn main() {
+    let mut v = vec![(1,)];
+    let compare = |(a,), (e,)| todo!();
+    v.sort_by(compare);
+    //~^ ERROR type mismatch in closure arguments
+}

--- a/tests/ui/mismatched_types/closure-ref-114180.stderr
+++ b/tests/ui/mismatched_types/closure-ref-114180.stderr
@@ -1,0 +1,22 @@
+error[E0631]: type mismatch in closure arguments
+  --> $DIR/closure-ref-114180.rs:6:15
+   |
+LL |     let compare = |(a,), (e,)| todo!();
+   |                   ------------ found signature defined here
+LL |     v.sort_by(compare);
+   |       ------- ^^^^^^^ expected due to this
+   |       |
+   |       required by a bound introduced by this call
+   |
+   = note: expected closure signature `for<'a, 'b> fn(&'a ({integer},), &'b ({integer},)) -> _`
+              found closure signature `fn((_,), (_,)) -> _`
+note: required by a bound in `slice::<impl [T]>::sort_by`
+  --> $SRC_DIR/alloc/src/slice.rs:LL:COL
+help: consider adjusting the signature so it borrows its arguments
+   |
+LL |     let compare = |&(a,), &(e,)| todo!();
+   |                    +      +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0631`.

--- a/tests/ui/mismatched_types/ref-pat-suggestions.stderr
+++ b/tests/ui/mismatched_types/ref-pat-suggestions.stderr
@@ -103,10 +103,10 @@ error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:11:23
    |
 LL |     let _: fn(u32) = |&_a| ();
-   |                       ^--
-   |                       ||
-   |                       |expected due to this
+   |                       ^^^
+   |                       |
    |                       expected `u32`, found `&_`
+   |                       expected due to this
    |
    = note:   expected type `u32`
            found reference `&_`
@@ -120,10 +120,10 @@ error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:12:23
    |
 LL |     let _: fn(u32) = |&mut _a| ();
-   |                       ^^^^^--
-   |                       |    |
-   |                       |    expected due to this
+   |                       ^^^^^^^
+   |                       |
    |                       expected `u32`, found `&mut _`
+   |                       expected due to this
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
@@ -142,10 +142,10 @@ error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:13:25
    |
 LL |     let _: fn(&u32) = |&&_a| ();
-   |                         ^--
-   |                         ||
-   |                         |expected due to this
-   |                         expected `u32`, found `&_`
+   |                        -^^^
+   |                        ||
+   |                        |expected `u32`, found `&_`
+   |                        expected due to this
    |
    = note:   expected type `u32`
            found reference `&_`
@@ -159,10 +159,10 @@ error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:14:33
    |
 LL |     let _: fn(&mut u32) = |&mut &_a| ();
-   |                                 ^--
-   |                                 ||
-   |                                 |expected due to this
-   |                                 expected `u32`, found `&_`
+   |                            -----^^^
+   |                            |    |
+   |                            |    expected `u32`, found `&_`
+   |                            expected due to this
    |
    = note:   expected type `u32`
            found reference `&_`
@@ -176,10 +176,10 @@ error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:15:25
    |
 LL |     let _: fn(&u32) = |&&mut _a| ();
-   |                         ^^^^^--
-   |                         |    |
-   |                         |    expected due to this
-   |                         expected `u32`, found `&mut _`
+   |                        -^^^^^^^
+   |                        ||
+   |                        |expected `u32`, found `&mut _`
+   |                        expected due to this
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
@@ -193,10 +193,10 @@ error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:16:33
    |
 LL |     let _: fn(&mut u32) = |&mut &mut _a| ();
-   |                                 ^^^^^--
-   |                                 |    |
-   |                                 |    expected due to this
-   |                                 expected `u32`, found `&mut _`
+   |                            -----^^^^^^^
+   |                            |    |
+   |                            |    expected `u32`, found `&mut _`
+   |                            expected due to this
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`


### PR DESCRIPTION
This PR fixes the invalid suggestion for mismatched types in closure arguments.

The invalid suggestion came from a wrongly created span in the parser for closure arguments that don't have a type specified. Specifically, the span in this case was the last token span, but in the case of tuples, the span represented the last parenthesis instead of the whole tuple, which is fixed by taking the more accurate span of the pattern.

There is one unfortunate downside of this fix, it worsens even more the diagnostic for mismatched types in closure args without an explicit type. This happens because there is no correct span for implied inferred type. I tried also fixing this but it's a rabbit hole.

Fixes https://github.com/rust-lang/rust/issues/114180