### PR TITLE
Allow stripping debuginfo from LLVM's shared library

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -56,6 +56,11 @@ changelog-seen = 2
 # Indicates whether an LLVM Release build should include debug info
 #release-debuginfo = false
 
+# When building LLVM as a dynamically linked library, and not explicitly
+# requesting debuginfo, strips the debuginfo it could contain (most often coming
+# from the C++ standard library).
+#strip-debuginfo = false
+
 # Indicates whether the LLVM assertions are enabled or not
 # NOTE: When assertions are disabled, bugs in the integration between rustc and LLVM can lead to
 # unsoundness (segfaults, etc.) in the rustc process itself, not just in the generated code.

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -173,6 +173,7 @@ pub struct Config {
     pub llvm_optimize: bool,
     pub llvm_thin_lto: bool,
     pub llvm_release_debuginfo: bool,
+    pub llvm_strip_debuginfo: bool,
     pub llvm_static_stdcpp: bool,
     /// `None` if `llvm_from_ci` is true and we haven't yet downloaded llvm.
     #[cfg(not(test))]
@@ -823,6 +824,7 @@ define_config! {
         optimize: Option<bool> = "optimize",
         thin_lto: Option<bool> = "thin-lto",
         release_debuginfo: Option<bool> = "release-debuginfo",
+        strip_debuginfo: Option<bool> = "strip-debuginfo",
         assertions: Option<bool> = "assertions",
         tests: Option<bool> = "tests",
         plugins: Option<bool> = "plugins",
@@ -1511,6 +1513,7 @@ impl Config {
             config.llvm_clang = llvm.clang.unwrap_or(false);
             config.llvm_enable_warnings = llvm.enable_warnings.unwrap_or(false);
             config.llvm_build_config = llvm.build_config.clone().unwrap_or(Default::default());
+            config.llvm_strip_debuginfo = llvm.strip_debuginfo.unwrap_or(false);
 
             let asserts = llvm_assertions.unwrap_or(false);
             config.llvm_from_ci = match llvm.download_ci_llvm {
@@ -1552,6 +1555,7 @@ impl Config {
                 check_ci_llvm!(llvm.clang);
                 check_ci_llvm!(llvm.build_config);
                 check_ci_llvm!(llvm.plugins);
+                check_ci_llvm!(llvm.strip_debuginfo);
             }
 
             // NOTE: can never be hit when downloading from CI, since we call `check_ci_llvm!(thin_lto)` above.

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1565,6 +1565,25 @@ impl Config {
                 // the link step) with each stage.
                 config.llvm_link_shared.set(Some(true));
             }
+
+            // Stripping LLVM's debuginfo is only accepted when:
+            // - using a shared library
+            // - not explicitly requesting debuginfo
+            if config.llvm_strip_debuginfo {
+                if config.llvm_release_debuginfo {
+                    panic!(
+                        "enabling `llvm.strip-debuginfo` is incompatible \
+                        with setting `llvm.release-debuginfo`"
+                    );
+                }
+                let llvm_link_shared = config.llvm_link_shared.get().unwrap_or(false);
+                if !llvm_link_shared {
+                    panic!(
+                        "enabling `llvm.strip-debuginfo` is incompatible \
+                        with statically linking LLVM"
+                    );
+                }
+            }
         } else {
             config.llvm_from_ci =
                 config.channel == "dev" && crate::llvm::is_ci_llvm_available(&config, false);

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -82,6 +82,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
+      --set llvm.strip-debuginfo=true \
       --set rust.jemalloc \
       --set rust.use-lld=true \
       --set rust.lto=thin


### PR DESCRIPTION
As seen in #114175, there's still some small amount of debuginfo in LLVM's shared library on linux, even when not requesting it (much like in `librustc_driver.so`), coming from `libstdc++`.

```
$ readelf --debug-dump=info .rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/libLLVM-16-rust-1.73.0-nightly.so | grep DW_TAG_compile_unit -A5 | grep DW_AT_comp_dir | cut -d ":" -f 2- | counts
101 counts
(  1)       39 (38.6%, 38.6%):  (indirect string, offset: 0x7): /tmp/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/libsupc++
(  2)       38 (37.6%, 76.2%):  (indirect string, offset: 0x43fb2): /tmp/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11
(  3)       23 (22.8%, 99.0%):  (indirect string, offset: 0x18ed8): /tmp/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++98
(  4)        1 ( 1.0%,100.0%):  (indirect string, offset: 0x53f04): /tmp/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/src
```

This PR adds a `llvm.strip-debuginfo` config to strip it away, when all of the following hold:
- this config option is explicitly set to true, the default is false
- `llvm.link-shared` is true
- `llvm.release-debuginfo` is false
- on a linux target (I don't know how to strip debuginfo from a dylib on mac): the BOLTed .so is huge, so this will help a little.

#114175 did the same thing unconditionally in `opt-dist`, prior to BOLTing LLVM. But this should be validated and used in conjunction with these other config options above, and which `opt-dist` doesn't know about. Therefore, it makes more sense as a dedicated option, to be used in bootstrap when building LLVM (and enabled in CI on e.g. the `dist-x86_64-linux` builder).

---

From the other PR, `libLLVM-16-rust-1.73.0-nightly.so` prior to #114141:

- master: 173.13 MiB
- stripped debuginfo: 165.12 MiB (-8MiB, -4%)

And from this PR, `libLLVM-16-rust-1.73.0-nightly.so` after #114141:
- master: 121.14 MiB
- stripped debuginfo: 113.14 MiB (still -8MiB, -6.5%)

---

(Draft while I do some try builds to ensure this is working as expected on CI, and until I ask e.g. cuviper whether it's a good idea 😓. Or if we could avoid emitting that debuginfo in the first place, if at all possible).

(After we validate whether it's interesting, I could add similar mechanism for `librustc_driver.so`, which also has some debuginfo from `libstdc++`, as well as `compiler_builtins`: I tested locally that removing that would reduce its size by about 10%.)

(I also don't know if it should be added to `src/bootstrap/configure.py`, I don't think so. And may also need its `check_ci_llvm!` to be removed, where CI needs `download-ci-llvm`...)
