### PR TITLE
Fix empty_write since rust version attribute

### DIFF
--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -100,7 +100,7 @@ impl SizeHint for Empty {
     }
 }
 
-#[stable(feature = "empty_write", since = "1.64.0")]
+#[stable(feature = "empty_write", since = "CURRENT_RUSTC_VERSION")]
 impl Write for Empty {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -124,7 +124,7 @@ impl Write for Empty {
     }
 }
 
-#[stable(feature = "empty_write", since = "1.64.0")]
+#[stable(feature = "empty_write", since = "CURRENT_RUSTC_VERSION")]
 impl Write for &Empty {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {


### PR DESCRIPTION
Fixup of https://github.com/rust-lang/rust/pull/98154 for the rust version.

r? @workingjubilee 