### PR TITLE
Update x64 Linux host compiler to LLVM 17

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-16.0.0
+LLVM=llvmorg-17.0.0-rc3
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
This PR updates the LLVM host compiler on 64-bit Linux to version 17.

r? @ghost