### PR TITLE
Don't check unnecessarily that impl trait is RPIT

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -552,8 +552,8 @@ fn gather_gat_bounds<'tcx, T: TypeFoldable<TyCtxt<'tcx>>>(
     for (region_a, region_a_idx) in &regions {
         // Ignore `'static` lifetimes for the purpose of this lint: it's
         // because we know it outlives everything and so doesn't give meaningful
-        // clues
-        if let ty::ReStatic = **region_a {
+        // clues. Also ignore `ReError`, to avoid knock-down errors.
+        if let ty::ReStatic | ty::ReError(_) = **region_a {
             continue;
         }
         // For each region argument (e.g., `'a` in our example), check for a
@@ -596,8 +596,9 @@ fn gather_gat_bounds<'tcx, T: TypeFoldable<TyCtxt<'tcx>>>(
         // on the GAT itself.
         for (region_b, region_b_idx) in &regions {
             // Again, skip `'static` because it outlives everything. Also, we trivially
-            // know that a region outlives itself.
-            if ty::ReStatic == **region_b || region_a == region_b {
+            // know that a region outlives itself. Also ignore `ReError`, to avoid
+            // knock-down errors.
+            if matches!(**region_b, ty::ReStatic | ty::ReError(_)) || region_a == region_b {
                 continue;
             }
             if region_known_to_outlive(

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2567,15 +2567,13 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     None,
                 );
                 if let Some(infer::RelateParamBound(_, t, _)) = origin {
-                    let return_impl_trait =
-                        self.tcx.return_type_impl_trait(generic_param_scope).is_some();
                     let t = self.resolve_vars_if_possible(t);
                     match t.kind() {
                         // We've got:
                         // fn get_later<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
                         // suggest:
                         // fn get_later<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
-                        ty::Closure(..) | ty::Alias(ty::Opaque, ..) if return_impl_trait => {
+                        ty::Closure(..) | ty::Alias(ty::Opaque, ..) => {
                             new_binding_suggestion(&mut err, type_param_span);
                         }
                         _ => {

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -942,6 +942,10 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
         generic_ty: Ty<'tcx>,
         min: ty::Region<'tcx>,
     ) -> bool {
+        if let ty::ReError(_) = *min {
+            return true;
+        }
+
         match bound {
             VerifyBound::IfEq(verify_if_eq_b) => {
                 let verify_if_eq_b = var_values.normalize(self.region_rels.tcx, *verify_if_eq_b);

--- a/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.rs
+++ b/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.rs
@@ -7,7 +7,6 @@ trait Iterable {
 
     fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
     //~^ ERROR use of undeclared lifetime name `'missing`
-    //~| ERROR the parameter type `Self` may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.rs
+++ b/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.rs
@@ -1,0 +1,13 @@
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Iterable {
+    type Item<'a>
+    where
+        Self: 'a;
+
+    fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
+    //~^ ERROR use of undeclared lifetime name `'missing`
+    //~| ERROR the parameter type `Self` may not live long enough
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.stderr
@@ -1,0 +1,38 @@
+error[E0261]: use of undeclared lifetime name `'missing`
+  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:8:55
+   |
+LL |     fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
+   |                                                       ^^^^^^^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'missing` lifetime
+   |
+LL |     fn iter(&self) -> impl for<'missing> Iterator<Item = Self::Item<'missing>>;
+   |                            +++++++++++++
+help: consider introducing lifetime `'missing` here
+   |
+LL |     fn iter<'missing>(&self) -> impl Iterator<Item = Self::Item<'missing>>;
+   |            ++++++++++
+help: consider introducing lifetime `'missing` here
+   |
+LL | trait Iterable<'missing> {
+   |               ++++++++++
+
+error[E0311]: the parameter type `Self` may not live long enough
+  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:8:37
+   |
+LL |     fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `Self: 'a`...
+   = note: ...so that the type `Self` will meet its required lifetime bounds...
+note: ...that is required by this bound
+  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:6:15
+   |
+LL |         Self: 'a;
+   |               ^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0261, E0311.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.stderr
@@ -18,21 +18,6 @@ help: consider introducing lifetime `'missing` here
 LL | trait Iterable<'missing> {
    |               ++++++++++
 
-error[E0311]: the parameter type `Self` may not live long enough
-  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:8:37
-   |
-LL |     fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `Self: 'a`...
-   = note: ...so that the type `Self` will meet its required lifetime bounds...
-note: ...that is required by this bound
-  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:6:15
-   |
-LL |         Self: 'a;
-   |               ^^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0261, E0311.
-For more information about an error, try `rustc --explain E0261`.
+For more information about this error, try `rustc --explain E0261`.


### PR DESCRIPTION
We have this random `return_type_impl_trait` function to detect if a function returns an RPIT which is used in outlives suggestions, but removing it doesn't actually change any diagnostics. Let's just remove it.

Also, suppress a spurious outlives error from a ReError.

Fixes #114274