### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,34 +1,45 @@
 [submodule "src/doc/nomicon"]
 	path = src/doc/nomicon
 	url = https://github.com/rust-lang/nomicon.git
+	shallow = true
 [submodule "src/tools/cargo"]
 	path = src/tools/cargo
 	url = https://github.com/rust-lang/cargo.git
+	shallow = true
 [submodule "src/doc/reference"]
 	path = src/doc/reference
 	url = https://github.com/rust-lang/reference.git
+	shallow = true
 [submodule "src/doc/book"]
 	path = src/doc/book
 	url = https://github.com/rust-lang/book.git
+	shallow = true
 [submodule "src/doc/rust-by-example"]
 	path = src/doc/rust-by-example
 	url = https://github.com/rust-lang/rust-by-example.git
+	shallow = true
 [submodule "library/stdarch"]
 	path = library/stdarch
 	url = https://github.com/rust-lang/stdarch.git
+	shallow = true
 [submodule "src/doc/rustc-dev-guide"]
 	path = src/doc/rustc-dev-guide
 	url = https://github.com/rust-lang/rustc-dev-guide.git
+	shallow = true
 [submodule "src/doc/edition-guide"]
 	path = src/doc/edition-guide
 	url = https://github.com/rust-lang/edition-guide.git
+	shallow = true
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
 	branch = rustc/16.0-2023-06-05
+	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git
+	shallow = true
 [submodule "library/backtrace"]
 	path = library/backtrace
 	url = https://github.com/rust-lang/backtrace-rs.git
+	shallow = true

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -709,7 +709,7 @@ impl<B: WriteBackendMethods> WorkItem<B> {
         fn desc(short: &str, _long: &str, name: &str) -> String {
             // The short label is three bytes, and is followed by a space. That
             // leaves 11 bytes for the CGU name. How we obtain those 11 bytes
-            // depends on the the CGU name form.
+            // depends on the CGU name form.
             //
             // - Non-incremental, e.g. `regex.f10ba03eb5ec7975-cgu.0`: the part
             //   before the `-cgu.0` is the same for every CGU, so use the

--- a/compiler/rustc_data_structures/src/sync/worker_local.rs
+++ b/compiler/rustc_data_structures/src/sync/worker_local.rs
@@ -116,7 +116,7 @@ pub struct WorkerLocal<T> {
 
 // This is safe because the `deref` call will return a reference to a `T` unique to each thread
 // or it will panic for threads without an associated local. So there isn't a need for `T` to do
-// it's own synchronization. The `verify` method on `RegistryId` has an issue where the the id
+// it's own synchronization. The `verify` method on `RegistryId` has an issue where the id
 // can be reused, but `WorkerLocal` has a reference to `Registry` which will prevent any reuse.
 #[cfg(parallel_compiler)]
 unsafe impl<T: Send> Sync for WorkerLocal<T> {}

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -475,15 +475,15 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         let indeterminate_imports = mem::take(&mut self.indeterminate_imports);
 
         for (is_indeterminate, import) in determined_imports
-            .into_iter()
+            .iter()
             .map(|i| (false, i))
-            .chain(indeterminate_imports.into_iter().map(|i| (true, i)))
+            .chain(indeterminate_imports.iter().map(|i| (true, i)))
         {
-            let unresolved_import_error = self.finalize_import(import);
+            let unresolved_import_error = self.finalize_import(*import);
 
             // If this import is unresolved then create a dummy import
             // resolution for it so that later resolve stages won't complain.
-            self.import_dummy_binding(import, is_indeterminate);
+            self.import_dummy_binding(*import, is_indeterminate);
 
             if let Some(err) = unresolved_import_error {
                 if let ImportKind::Single { source, ref source_bindings, .. } = import.kind {
@@ -505,27 +505,34 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     errors = vec![];
                 }
                 if seen_spans.insert(err.span) {
-                    errors.push((import, err));
+                    errors.push((*import, err));
                     prev_root_id = import.root_id;
                 }
-            } else if is_indeterminate {
-                let path = import_path_to_string(
-                    &import.module_path.iter().map(|seg| seg.ident).collect::<Vec<_>>(),
-                    &import.kind,
-                    import.span,
-                );
-                let err = UnresolvedImportError {
-                    span: import.span,
-                    label: None,
-                    note: None,
-                    suggestion: None,
-                    candidates: None,
-                };
-                // FIXME: there should be a better way of doing this than
-                // formatting this as a string then checking for `::`
-                if path.contains("::") {
-                    errors.push((import, err))
-                }
+            }
+        }
+
+        if !errors.is_empty() {
+            self.throw_unresolved_import_error(errors);
+            return;
+        }
+
+        for import in &indeterminate_imports {
+            let path = import_path_to_string(
+                &import.module_path.iter().map(|seg| seg.ident).collect::<Vec<_>>(),
+                &import.kind,
+                import.span,
+            );
+            let err = UnresolvedImportError {
+                span: import.span,
+                label: None,
+                note: None,
+                suggestion: None,
+                candidates: None,
+            };
+            // FIXME: there should be a better way of doing this than
+            // formatting this as a string then checking for `::`
+            if path.contains("::") {
+                errors.push((*import, err))
             }
         }
 

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1300,6 +1300,7 @@ supported_targets! {
     ("armv7-linux-androideabi", armv7_linux_androideabi),
     ("thumbv7neon-linux-androideabi", thumbv7neon_linux_androideabi),
     ("aarch64-linux-android", aarch64_linux_android),
+    ("riscv64-linux-android", riscv64_linux_android),
 
     ("aarch64-unknown-freebsd", aarch64_unknown_freebsd),
     ("armv6-unknown-freebsd", armv6_unknown_freebsd),

--- a/compiler/rustc_target/src/spec/riscv64_linux_android.rs
+++ b/compiler/rustc_target/src/spec/riscv64_linux_android.rs
@@ -1,0 +1,19 @@
+use crate::spec::{CodeModel, SanitizerSet, Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "riscv64-linux-android".into(),
+        pointer_width: 64,
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128".into(),
+        arch: "riscv64".into(),
+        options: TargetOptions {
+            code_model: Some(CodeModel::Medium),
+            cpu: "generic-rv64".into(),
+            features: "+m,+a,+f,+d,+c".into(),
+            llvm_abiname: "lp64d".into(),
+            supported_sanitizers: SanitizerSet::ADDRESS,
+            max_atomic_width: Some(64),
+            ..super::android_base::opts()
+        },
+    }
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -690,10 +690,6 @@ changelog-seen = 2
 # Build compiler with the optimization enabled and -Zvalidate-mir, currently only for `std`
 #validate-mir-opts = 3
 
-# Copy the linker, DLLs, and various libraries from MinGW into the rustc toolchain.
-# Only applies when the host or target is pc-windows-gnu.
-#include-mingw-linker = true
-
 # =============================================================================
 # Options for specific targets
 #
@@ -844,3 +840,7 @@ changelog-seen = 2
 #
 # Available options: fast, balanced, best
 #compression-profile = "fast"
+
+# Copy the linker, DLLs, and various libraries from MinGW into the rustc toolchain.
+# Only applies when the host or target is pc-windows-gnu.
+#include-mingw-linker = true

--- a/library/alloc/tests/string.rs
+++ b/library/alloc/tests/string.rs
@@ -368,29 +368,73 @@ fn remove_bad() {
 
 #[test]
 fn test_remove_matches() {
+    // test_single_pattern_occurrence
     let mut s = "abc".to_string();
-
     s.remove_matches('b');
     assert_eq!(s, "ac");
+    // repeat_test_single_pattern_occurrence
     s.remove_matches('b');
     assert_eq!(s, "ac");
 
+    // test_single_character_pattern
     let mut s = "abcb".to_string();
-
     s.remove_matches('b');
     assert_eq!(s, "ac");
 
+    // test_pattern_with_special_characters
     let mut s = "ศไทย中华Việt Nam; foobarศ".to_string();
     s.remove_matches('ศ');
     assert_eq!(s, "ไทย中华Việt Nam; foobar");
 
+    // test_pattern_empty_text_and_pattern
     let mut s = "".to_string();
     s.remove_matches("");
     assert_eq!(s, "");
 
+    // test_pattern_empty_text
+    let mut s = "".to_string();
+    s.remove_matches("something");
+    assert_eq!(s, "");
+
+    // test_empty_pattern
+    let mut s = "Testing with empty pattern.".to_string();
+    s.remove_matches("");
+    assert_eq!(s, "Testing with empty pattern.");
+
+    // test_multiple_consecutive_patterns_1
     let mut s = "aaaaa".to_string();
     s.remove_matches('a');
     assert_eq!(s, "");
+
+    // test_multiple_consecutive_patterns_2
+    let mut s = "Hello **world****today!**".to_string();
+    s.remove_matches("**");
+    assert_eq!(s, "Hello worldtoday!");
+
+    // test_case_insensitive_pattern
+    let mut s = "CASE ** SeNsItIvE ** PaTtErN.".to_string();
+    s.remove_matches("sEnSiTiVe");
+    assert_eq!(s, "CASE ** SeNsItIvE ** PaTtErN.");
+
+    // test_pattern_with_digits
+    let mut s = "123 ** 456 ** 789".to_string();
+    s.remove_matches("**");
+    assert_eq!(s, "123  456  789");
+
+    // test_pattern_occurs_after_empty_string
+    let mut s = "abc X defXghi".to_string();
+    s.remove_matches("X");
+    assert_eq!(s, "abc  defghi");
+
+    // test_large_pattern
+    let mut s = "aaaXbbbXcccXdddXeee".to_string();
+    s.remove_matches("X");
+    assert_eq!(s, "aaabbbcccdddeee");
+
+    // test_pattern_at_multiple_positions
+    let mut s = "Pattern ** found ** multiple ** times ** in ** text.".to_string();
+    s.remove_matches("**");
+    assert_eq!(s, "Pattern  found  multiple  times  in  text.");
 }
 
 #[test]

--- a/library/portable-simd/crates/core_simd/examples/dot_product.rs
+++ b/library/portable-simd/crates/core_simd/examples/dot_product.rs
@@ -130,7 +130,7 @@ pub fn dot_prod_simd_4(a: &[f32], b: &[f32]) -> f32 {
 }
 
 // This version allocates a single `XMM` register for accumulation, and the folds don't allocate on top of that.
-// Notice the the use of `mul_add`, which can do a multiply and an add operation ber iteration.
+// Notice the use of `mul_add`, which can do a multiply and an add operation ber iteration.
 pub fn dot_prod_simd_5(a: &[f32], b: &[f32]) -> f32 {
     a.array_chunks::<4>()
         .map(|&a| f32x4::from_array(a))

--- a/library/std/src/os/android/raw.rs
+++ b/library/std/src/os/android/raw.rs
@@ -89,7 +89,7 @@ mod arch {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 mod arch {
     use crate::os::raw::{c_int, c_long, c_uint, c_ulong};
     use crate::os::unix::raw::{gid_t, uid_t};

--- a/library/test/src/types.rs
+++ b/library/test/src/types.rs
@@ -224,7 +224,7 @@ impl TestDesc {
         }
     }
 
-    /// Returns None for ignored test or that that are just run, otherwise give a description of the type of test.
+    /// Returns None for ignored test or tests that are just run, otherwise returns a description of the type of test.
     /// Descriptions include "should panic", "compile fail" and "compile".
     pub fn test_mode(&self) -> Option<&'static str> {
         if self.ignore {

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -32,6 +32,7 @@ static SETTINGS_HASHES: &[&str] = &[
     "56e7bf011c71c5d81e0bf42e84938111847a810eee69d906bba494ea90b51922",
     "af1b5efe196aed007577899db9dae15d6dbc923d6fa42fa0934e68617ba9bbe0",
     "3468fea433c25fff60be6b71e8a215a732a7b1268b6a83bf10d024344e140541",
+    "47d227f424bf889b0d899b9cc992d5695e1b78c406e183cd78eafefbe5488923",
 ];
 static RUST_ANALYZER_SETTINGS: &str = include_str!("../etc/rust_analyzer_settings.json");
 

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -309,6 +309,7 @@ target | std | host | notes
 `riscv64gc-unknown-linux-musl` |   |   | RISC-V Linux (kernel 4.20, musl 1.2.0)
 [`riscv64gc-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | RISC-V NetBSD
 [`riscv64gc-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | OpenBSD/riscv64
+[`riscv64-linux-android`](platform-support/android.md) |   |   | RISC-V 64-bit Android
 `s390x-unknown-linux-musl` |  |  | S390x Linux (kernel 3.2, MUSL)
 `sparc-unknown-linux-gnu` | ✓ |  | 32-bit SPARC Linux
 [`sparc64-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | NetBSD/sparc64

--- a/src/etc/rust_analyzer_settings.json
+++ b/src/etc/rust_analyzer_settings.json
@@ -31,5 +31,8 @@
         "--json-output"
     ],
     "rust-analyzer.cargo.sysrootSrc": "./library",
-    "rust-analyzer.rustc.source": "./Cargo.toml"
+    "rust-analyzer.rustc.source": "./Cargo.toml",
+    "rust-analyzer.cargo.extraEnv": {
+        "RUSTC_BOOTSTRAP": "1"
+    }
 }

--- a/src/tools/miri/src/mono_hash_map.rs
+++ b/src/tools/miri/src/mono_hash_map.rs
@@ -2,7 +2,7 @@
 //! otherwise mutated. We also box items in the map. This means we can safely provide
 //! shared references into existing items in the `FxHashMap`, because they will not be dropped
 //! (from being removed) or moved (because they are boxed).
-//! The API is is completely tailored to what `memory.rs` needs. It is still in
+//! The API is completely tailored to what `memory.rs` needs. It is still in
 //! a separate file to minimize the amount of code that has to care about the unsafety.
 
 use std::borrow::Borrow;

--- a/tests/run-make/dump-ice-to-disk/Makefile
+++ b/tests/run-make/dump-ice-to-disk/Makefile
@@ -3,6 +3,7 @@ include ../tools.mk
 # ignore-windows
 
 export RUSTC := $(RUSTC_ORIGINAL)
+export LD_LIBRARY_PATH := $(HOST_RPATH_DIR)
 export TMPDIR := $(TMPDIR)
 
 all:

--- a/tests/run-make/short-ice/Makefile
+++ b/tests/run-make/short-ice/Makefile
@@ -3,6 +3,7 @@ include ../tools.mk
 # ignore-windows
 
 export RUSTC := $(RUSTC_ORIGINAL)
+export LD_LIBRARY_PATH := $(HOST_RPATH_DIR)
 export TMPDIR := $(TMPDIR)
 
 all:

--- a/tests/ui/imports/issue-81413.rs
+++ b/tests/ui/imports/issue-81413.rs
@@ -1,0 +1,23 @@
+pub const ITEM: Item = Item;
+
+pub struct Item;
+
+pub fn item() {}
+
+pub use doesnt_exist::*;
+//~^ ERROR unresolved import `doesnt_exist`
+mod a {
+    use crate::{item, Item, ITEM};
+}
+
+mod b {
+    use crate::item;
+    use crate::Item;
+    use crate::ITEM;
+}
+
+mod c {
+    use crate::item;
+}
+
+fn main() {}

--- a/tests/ui/imports/issue-81413.stderr
+++ b/tests/ui/imports/issue-81413.stderr
@@ -1,0 +1,11 @@
+error[E0432]: unresolved import `doesnt_exist`
+  --> $DIR/issue-81413.rs:7:9
+   |
+LL | pub use doesnt_exist::*;
+   |         ^^^^^^^^^^^^ maybe a missing crate `doesnt_exist`?
+   |
+   = help: consider adding `extern crate doesnt_exist` to use the `doesnt_exist` crate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
Successful merges:

 - #112858 (Update Android system definitions and add riscv-linux-android as tier 3 target)
 - #113717 (remove repetitive words)
 - #113725 (Move MinGW linker dist option to proper section)
 - #113740 (Update `.gitmodules` to use shallow submodule clones)
 - #113889 (Fix ice tests when librustc-driver is linked dynamically)
 - #113906 (etc: add `RUSTC_BOOTSTRAP` to rust-analyzer config)
 - #113920 (fix(resolve): report unresolved imports firstly)
 - #114111 (Improve test case for experimental API remove_matches)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112858,113717,113725,113740,113889,113906,113920,114111)
<!-- homu-ignore:end -->