### PR TITLE
Fix invalid slice coercion suggestion reported in turbofish

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -3034,6 +3034,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
             self.maybe_suggest_convert_to_slice(
                 err,
+                obligation,
                 trait_ref,
                 impl_candidates.as_slice(),
                 span,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -3032,7 +3032,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 self.report_similar_impl_candidates_for_root_obligation(&obligation, *trait_predicate, body_def_id, err);
             }
 
-            self.maybe_suggest_convert_to_slice(
+            self.suggest_convert_to_slice(
                 err,
                 obligation,
                 trait_ref,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -398,7 +398,7 @@ pub trait TypeErrCtxtExt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
     ) -> Vec<Option<(Span, (DefId, Ty<'tcx>))>>;
 
-    fn maybe_suggest_convert_to_slice(
+    fn suggest_convert_to_slice(
         &self,
         err: &mut Diagnostic,
         obligation: &PredicateObligation<'tcx>,
@@ -3955,7 +3955,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
     /// If the type that failed selection is an array or a reference to an array,
     /// but the trait is implemented for slices, suggest that the user converts
     /// the array into a slice.
-    fn maybe_suggest_convert_to_slice(
+    fn suggest_convert_to_slice(
         &self,
         err: &mut Diagnostic,
         obligation: &PredicateObligation<'tcx>,

--- a/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.rs
+++ b/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.rs
@@ -1,0 +1,13 @@
+trait Test {}
+impl Test for &[u8] {}
+
+fn needs_test<T: Test>() -> T {
+    panic!()
+}
+
+fn main() {
+    needs_test::<[u8; 1]>();
+    //~^ ERROR the trait bound
+    let x: [u8; 1] = needs_test();
+    //~^ ERROR the trait bound
+}

--- a/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `[u8; 1]: Test` is not satisfied
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:9:18
+   |
+LL |     needs_test::<[u8; 1]>();
+   |                  ^^^^^^^ the trait `Test` is not implemented for `[u8; 1]`
+   |
+   = help: the trait `Test` is implemented for `&[u8]`
+note: required by a bound in `needs_test`
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:4:18
+   |
+LL | fn needs_test<T: Test>() -> T {
+   |                  ^^^^ required by this bound in `needs_test`
+
+error[E0277]: the trait bound `[u8; 1]: Test` is not satisfied
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:11:22
+   |
+LL |     let x: [u8; 1] = needs_test();
+   |                      ^^^^^^^^^^ the trait `Test` is not implemented for `[u8; 1]`
+   |
+   = help: the trait `Test` is implemented for `&[u8]`
+note: required by a bound in `needs_test`
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:4:18
+   |
+LL | fn needs_test<T: Test>() -> T {
+   |                  ^^^^ required by this bound in `needs_test`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This PR fixes the invalid slice coercion suggestion reported in turbofish and inferred generics by not emitting them.

Fixes https://github.com/rust-lang/rust/issues/110063