### PR TITLE
[rustc_data_structures][base_n][perf] Remove unnecessary utf8 check.

### DIFF
--- a/compiler/rustc_data_structures/src/base_n.rs
+++ b/compiler/rustc_data_structures/src/base_n.rs
@@ -30,7 +30,10 @@ pub fn push_str(mut n: u128, base: usize, output: &mut String) {
         }
     }
 
-    output.push_str(str::from_utf8(&s[index..]).unwrap());
+    output.push_str(unsafe {
+        // SAFETY: `s` is populated using only valid utf8 characters from `BASE_64`
+        str::from_utf8_unchecked(&s[index..])
+    });
 }
 
 #[inline]


### PR DESCRIPTION
Since all output characters taken from `BASE_64` are valid UTF8 chars there is no need to waste cycles on validation.

Even though it's obviously a perf win, I've also used a [benchmark](https://gist.github.com/ttsugriy/e1e63c07927d8f31e71695a9c617bbf3) on M1 MacBook Air with following results:
```
Running benches/base_n_benchmark.rs (target/release/deps/base_n_benchmark-825fe5895b5c2693)
push_str/old            time:   [14.670 µs 14.852 µs 15.074 µs]
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
push_str/new            time:   [12.573 µs 12.674 µs 12.801 µs]
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
```