### PR TITLE
Use the correct `llvm-profdata` binary in `opt-dist`

### DIFF
--- a/src/tools/opt-dist/src/training.rs
+++ b/src/tools/opt-dist/src/training.rs
@@ -66,20 +66,32 @@ fn init_compiler_benchmarks(
     .workdir(&env.rustc_perf_dir())
 }
 
+/// Describes which `llvm-profdata` binary should be used for merging PGO profiles.
+enum LlvmProfdata {
+    /// Use llvm-profdata from the host toolchain (i.e. from LLVM provided externally).
+    Host,
+    /// Use llvm-profdata from the target toolchain (i.e. from LLVM built from `src/llvm-project`).
+    Target,
+}
+
 fn merge_llvm_profiles(
     env: &dyn Environment,
     merged_path: &Utf8Path,
     profile_dir: &Utf8Path,
+    profdata: LlvmProfdata,
 ) -> anyhow::Result<()> {
-    cmd(&[
-        env.downloaded_llvm_dir().join("bin/llvm-profdata").as_str(),
-        "merge",
-        "-o",
-        merged_path.as_str(),
-        profile_dir.as_str(),
-    ])
-    .run()
-    .context("Cannot merge LLVM profiles")?;
+    let llvm_profdata = match profdata {
+        LlvmProfdata::Host => env.downloaded_llvm_dir().join("bin/llvm-profdata"),
+        LlvmProfdata::Target => env
+            .build_artifacts()
+            .join("llvm")
+            .join("build")
+            .join(format!("bin/llvm-profdata{}", env.executable_extension())),
+    };
+
+    cmd(&[llvm_profdata.as_str(), "merge", "-o", merged_path.as_str(), profile_dir.as_str()])
+        .run()
+        .context("Cannot merge LLVM profiles")?;
     Ok(())
 }
 
@@ -118,7 +130,7 @@ pub fn gather_llvm_profiles(
     let merged_profile = env.opt_artifacts().join("llvm-pgo.profdata");
     log::info!("Merging LLVM PGO profiles to {merged_profile}");
 
-    merge_llvm_profiles(env, &merged_profile, profile_root)?;
+    merge_llvm_profiles(env, &merged_profile, profile_root, LlvmProfdata::Host)?;
     log_profile_stats("LLVM", &merged_profile, profile_root)?;
 
     // We don't need the individual .profraw files now that they have been merged
@@ -154,7 +166,7 @@ pub fn gather_rustc_profiles(
     let merged_profile = env.opt_artifacts().join("rustc-pgo.profdata");
     log::info!("Merging Rustc PGO profiles to {merged_profile}");
 
-    merge_llvm_profiles(env, &merged_profile, profile_root)?;
+    merge_llvm_profiles(env, &merged_profile, profile_root, LlvmProfdata::Target)?;
     log_profile_stats("Rustc", &merged_profile, profile_root)?;
 
     // We don't need the individual .profraw files now that they have been merged


### PR DESCRIPTION
Turns out that we were probably using the wrong `llvm-profdata` binary in the PGO script all along. This should resolve the performance regressions of switching the host LLVM to 17 ([host `llvm-profdata`](https://github.com/rust-lang/rust/pull/114297#issuecomment-1660521361), [target `llvm-profdata`](https://github.com/rust-lang/rust/pull/114297#issuecomment-1661127032)]).

r? @nikic