### PR TITLE
Provide prebuilt std for gnullvm targets

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -57,6 +57,9 @@ RUN ./install-mipsel-musl.sh
 COPY host-x86_64/dist-various-1/install-aarch64-none-elf.sh /build
 RUN ./install-aarch64-none-elf.sh
 
+COPY host-x86_64/dist-various-1/install-llvm-mingw.sh /build
+RUN ./install-llvm-mingw.sh
+
 # Suppress some warnings in the openwrt toolchains we downloaded
 ENV STAGING_DIR=/tmp
 
@@ -141,6 +144,8 @@ ENV TARGETS=$TARGETS,armv7r-none-eabi
 ENV TARGETS=$TARGETS,armv7r-none-eabihf
 ENV TARGETS=$TARGETS,thumbv7neon-unknown-linux-gnueabihf
 ENV TARGETS=$TARGETS,armv7a-none-eabi
+ENV TARGETS=$TARGETS,aarch64-pc-windows-gnullvm
+ENV TARGETS=$TARGETS,x86_64-pc-windows-gnullvm
 
 # riscv targets currently do not need a C compiler, as compiler_builtins
 # doesn't currently have it enabled, and the riscv gcc compiler is not
@@ -170,7 +175,9 @@ ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft
     CC_riscv32imc_unknown_none_elf=false \
     CC_riscv32imac_unknown_none_elf=false \
     CC_riscv64imac_unknown_none_elf=false \
-    CC_riscv64gc_unknown_none_elf=false
+    CC_riscv64gc_unknown_none_elf=false \
+    CC_aarch64_pc_windows_gnullvm=aarch64-w64-mingw32-clang \
+    CC_x86_64_pc_windows_gnullvm=x86_64-w64-mingw32-clang
 
 ENV RUST_CONFIGURE_ARGS \
       --musl-root-armv5te=/musl-armv5te \

--- a/src/ci/docker/host-x86_64/dist-various-1/install-llvm-mingw.sh
+++ b/src/ci/docker/host-x86_64/dist-various-1/install-llvm-mingw.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+curl -L https://github.com/mstorsjo/llvm-mingw/releases/download/20230614/llvm-mingw-20230614-ucrt-ubuntu-20.04-x86_64.tar.xz | \
+tar --extract --lzma --strip 1 --directory /usr/local

--- a/src/doc/rustc/src/platform-support/pc-windows-gnullvm.md
+++ b/src/doc/rustc/src/platform-support/pc-windows-gnullvm.md
@@ -14,7 +14,7 @@ Target triples available so far:
 
 ## Requirements
 
-The easiest way to obtain these targets is cross-compilation but native build from `x86_64-pc-windows-gnu` is possible with few hacks which I don't recommend.
+The easiest way to obtain these targets is cross-compilation, but native build from `x86_64-pc-windows-gnu` is possible with few hacks which I don't recommend.
 Std support is expected to be on pair with `*-pc-windows-gnu`.
 
 Binaries for this target should be at least on pair with `*-pc-windows-gnu` in terms of requirements and functionality.
@@ -25,15 +25,12 @@ Like with any other Windows target created binaries are in PE format.
 
 ## Building the target
 
-For cross-compilation I recommend using [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) toolchain, one change that seems necessary beside configuring cross compilers is disabling experimental `m86k` target. Otherwise LLVM build fails with `multiple definition ...` errors.
-Native bootstrapping builds require rather fragile hacks until host artifacts are available so I won't describe them here.
+For cross-compilation I recommend using [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) toolchain, one change that seems necessary beside configuring cross-compilers is disabling experimental `m86k` target. Otherwise, LLVM build fails with `multiple definition ...` errors.
+Native bootstrapping builds require rather fragile hacks until host artifacts are available, so I won't describe them here.
 
 ## Building Rust programs
 
-Rust does not yet ship pre-compiled artifacts for this target. To compile for
-this target, you will either need to build Rust with the target enabled (see
-"Building the target" above), or build your own copy of `core` by using
-`build-std` or similar.
+Rust does ship pre-compiled std library for those targets. That means one can cross-compile for those targets from other hosts.
 
 ## Testing
 


### PR DESCRIPTION
Don't know if we have CI capacity for providing prebuilt host toolchain for them but at least std is low cost and there was no breakage for past year.