### PR TITLE
cg_llvm: stop identifying ADTs in LLVM IR

### DIFF
--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -61,9 +61,6 @@ fn uncached_llvm_type<'a, 'tcx>(
             }
             Some(name)
         }
-        // Use identified structure types for ADT. Due to pointee types in LLVM IR their definition
-        // might be recursive. Other cases are non-recursive and we can use literal structure types.
-        ty::Adt(..) => Some(String::new()),
         _ => None,
     };
 


### PR DESCRIPTION
This is an extension of https://github.com/rust-lang/rust/pull/94107. It may be a minor perf win.

Fixes #96242.

Now that we use opaque pointers, ADTs can no longer be recursive, so we
do not need to name them. Previously, this would be necessary if you had
a struct like

```rs
struct Foo(Box<Foo>, u64, u64);
```

which would be represented with something like

```ll
%Foo = type { %Foo*, i64, i64 }
```

which is now just

```ll
{ ptr, i64, i64 }
```

r? @tmiasko