### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -28,7 +28,7 @@ pub fn rust_version_symbol() -> Symbol {
 }
 
 pub fn is_builtin_attr(attr: &Attribute) -> bool {
-    attr.is_doc_comment() || attr.ident().filter(|ident| is_builtin_attr_name(ident.name)).is_some()
+    attr.is_doc_comment() || attr.ident().is_some_and(|ident| is_builtin_attr_name(ident.name))
 }
 
 enum AttrError {

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2133,13 +2133,14 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         self.current -= 1;
                     }
                     fn visit_expr(&mut self, expr: &hir::Expr<'tcx>) {
-                        if self.span == expr.span {
+                        if self.span == expr.span.source_callsite() {
                             self.found = self.current;
                         }
                         walk_expr(self, expr);
                     }
                 }
                 let source_info = self.body.source_info(location);
+                let proper_span = proper_span.source_callsite();
                 if let Some(scope) = self.body.source_scopes.get(source_info.scope)
                     && let ClearCrossCrate::Set(scope_data) = &scope.local_data
                     && let Some(node) = self.infcx.tcx.hir().find(scope_data.lint_root)

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -1462,7 +1462,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     let traits: Vec<_> =
                         self.probe_traits_that_match_assoc_ty(qself_ty, assoc_ident);
 
-                    // Don't print `TyErr` to the user.
+                    // Don't print `ty::Error` to the user.
                     self.report_ambiguous_associated_type(
                         span,
                         &[qself_ty.to_string()],

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -552,8 +552,8 @@ fn gather_gat_bounds<'tcx, T: TypeFoldable<TyCtxt<'tcx>>>(
     for (region_a, region_a_idx) in &regions {
         // Ignore `'static` lifetimes for the purpose of this lint: it's
         // because we know it outlives everything and so doesn't give meaningful
-        // clues
-        if let ty::ReStatic = **region_a {
+        // clues. Also ignore `ReError`, to avoid knock-down errors.
+        if let ty::ReStatic | ty::ReError(_) = **region_a {
             continue;
         }
         // For each region argument (e.g., `'a` in our example), check for a
@@ -596,8 +596,9 @@ fn gather_gat_bounds<'tcx, T: TypeFoldable<TyCtxt<'tcx>>>(
         // on the GAT itself.
         for (region_b, region_b_idx) in &regions {
             // Again, skip `'static` because it outlives everything. Also, we trivially
-            // know that a region outlives itself.
-            if ty::ReStatic == **region_b || region_a == region_b {
+            // know that a region outlives itself. Also ignore `ReError`, to avoid
+            // knock-down errors.
+            if matches!(**region_b, ty::ReStatic | ty::ReError(_)) || region_a == region_b {
                 continue;
             }
             if region_known_to_outlive(

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -795,7 +795,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     /// Converts the types that the user supplied, in case that doing
     /// so should yield an error, but returns back a signature where
-    /// all parameters are of type `TyErr`.
+    /// all parameters are of type `ty::Error`.
     fn error_sig_of_closure(
         &self,
         decl: &hir::FnDecl<'_>,

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2567,15 +2567,13 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     None,
                 );
                 if let Some(infer::RelateParamBound(_, t, _)) = origin {
-                    let return_impl_trait =
-                        self.tcx.return_type_impl_trait(generic_param_scope).is_some();
                     let t = self.resolve_vars_if_possible(t);
                     match t.kind() {
                         // We've got:
                         // fn get_later<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
                         // suggest:
                         // fn get_later<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
-                        ty::Closure(..) | ty::Alias(ty::Opaque, ..) if return_impl_trait => {
+                        ty::Closure(..) | ty::Alias(ty::Opaque, ..) => {
                             new_binding_suggestion(&mut err, type_param_span);
                         }
                         _ => {

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -942,6 +942,10 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
         generic_ty: Ty<'tcx>,
         min: ty::Region<'tcx>,
     ) -> bool {
+        if let ty::ReError(_) = *min {
+            return true;
+        }
+
         match bound {
             VerifyBound::IfEq(verify_if_eq_b) => {
                 let verify_if_eq_b = var_values.normalize(self.region_rels.tcx, *verify_if_eq_b);

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -706,7 +706,7 @@ rustc_queries! {
         separate_provide_extern
     }
 
-    query adt_sized_constraint(key: DefId) -> &'tcx [Ty<'tcx>] {
+    query adt_sized_constraint(key: DefId) -> ty::EarlyBinder<&'tcx ty::List<Ty<'tcx>>> {
         desc { |tcx| "computing `Sized` constraints for `{}`", tcx.def_path_str(key) }
     }
 

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -572,8 +572,8 @@ impl<'tcx> AdtDef<'tcx> {
     ///
     /// Due to normalization being eager, this applies even if
     /// the associated type is behind a pointer (e.g., issue #31299).
-    pub fn sized_constraint(self, tcx: TyCtxt<'tcx>) -> ty::EarlyBinder<&'tcx [Ty<'tcx>]> {
-        ty::EarlyBinder::bind(tcx.adt_sized_constraint(self.did()))
+    pub fn sized_constraint(self, tcx: TyCtxt<'tcx>) -> ty::EarlyBinder<&'tcx ty::List<Ty<'tcx>>> {
+        tcx.adt_sized_constraint(self.did())
     }
 }
 

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -562,16 +562,8 @@ impl<'tcx> AdtDef<'tcx> {
         tcx.adt_destructor(self.did())
     }
 
-    /// Returns a list of types such that `Self: Sized` if and only
-    /// if that type is `Sized`, or `TyErr` if this type is recursive.
-    ///
-    /// Oddly enough, checking that the sized-constraint is `Sized` is
-    /// actually more expressive than checking all members:
-    /// the `Sized` trait is inductive, so an associated type that references
-    /// `Self` would prevent its containing ADT from being `Sized`.
-    ///
-    /// Due to normalization being eager, this applies even if
-    /// the associated type is behind a pointer (e.g., issue #31299).
+    /// Returns a list of types such that `Self: Sized` if and only if that
+    /// type is `Sized`, or `ty::Error` if this type has a recursive layout.
     pub fn sized_constraint(self, tcx: TyCtxt<'tcx>) -> ty::EarlyBinder<&'tcx ty::List<Ty<'tcx>>> {
         tcx.adt_sized_constraint(self.did())
     }

--- a/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
@@ -150,7 +150,7 @@ pub(in crate::solve) fn instantiate_constituent_tys_for_sized_trait<'tcx>(
 
         ty::Adt(def, args) => {
             let sized_crit = def.sized_constraint(ecx.tcx());
-            Ok(sized_crit.iter_instantiated_copied(ecx.tcx(), args).collect())
+            Ok(sized_crit.iter_instantiated(ecx.tcx(), args).collect())
         }
     }
 }

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
@@ -235,7 +235,10 @@ fn rematch_unsize<'tcx>(
         goal.param_env,
         &mut nested,
     );
+
     match (a_ty.kind(), b_ty.kind()) {
+        // Don't try to coerce `?0` to `dyn Trait`
+        (ty::Infer(ty::TyVar(_)), _) | (_, ty::Infer(ty::TyVar(_))) => Ok(None),
         // Stall any ambiguous upcasting goals, since we can't rematch those
         (ty::Dynamic(_, _, ty::Dyn), ty::Dynamic(_, _, ty::Dyn)) => match certainty {
             Certainty::Yes => Ok(Some(ImplSource::Builtin(source, nested))),

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -3034,6 +3034,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
             self.maybe_suggest_convert_to_slice(
                 err,
+                obligation,
                 trait_ref,
                 impl_candidates.as_slice(),
                 span,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -3032,7 +3032,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 self.report_similar_impl_candidates_for_root_obligation(&obligation, *trait_predicate, body_def_id, err);
             }
 
-            self.maybe_suggest_convert_to_slice(
+            self.suggest_convert_to_slice(
                 err,
                 obligation,
                 trait_ref,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -398,7 +398,7 @@ pub trait TypeErrCtxtExt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
     ) -> Vec<Option<(Span, (DefId, Ty<'tcx>))>>;
 
-    fn maybe_suggest_convert_to_slice(
+    fn suggest_convert_to_slice(
         &self,
         err: &mut Diagnostic,
         obligation: &PredicateObligation<'tcx>,
@@ -3955,7 +3955,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
     /// If the type that failed selection is an array or a reference to an array,
     /// but the trait is implemented for slices, suggest that the user converts
     /// the array into a slice.
-    fn maybe_suggest_convert_to_slice(
+    fn suggest_convert_to_slice(
         &self,
         err: &mut Diagnostic,
         obligation: &PredicateObligation<'tcx>,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2099,7 +2099,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
                 Where(
                     obligation
                         .predicate
-                        .rebind(sized_crit.iter_instantiated_copied(self.tcx(), args).collect()),
+                        .rebind(sized_crit.iter_instantiated(self.tcx(), args).collect()),
                 )
             }
 

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -42,7 +42,7 @@ fn sized_constraint_for_ty<'tcx>(
             let adt_tys = adt.sized_constraint(tcx);
             debug!("sized_constraint_for_ty({:?}) intermediate = {:?}", ty, adt_tys);
             adt_tys
-                .iter_instantiated_copied(tcx, args)
+                .iter_instantiated(tcx, args)
                 .flat_map(|ty| sized_constraint_for_ty(tcx, adtdef, ty))
                 .collect()
         }
@@ -92,10 +92,13 @@ fn defaultness(tcx: TyCtxt<'_>, def_id: LocalDefId) -> hir::Defaultness {
 ///     - a tuple of type parameters or projections, if there are multiple
 ///       such.
 ///     - an Error, if a type is infinitely sized
-fn adt_sized_constraint(tcx: TyCtxt<'_>, def_id: DefId) -> &[Ty<'_>] {
+fn adt_sized_constraint<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+) -> ty::EarlyBinder<&'tcx ty::List<Ty<'tcx>>> {
     if let Some(def_id) = def_id.as_local() {
         if matches!(tcx.representability(def_id), ty::Representability::Infinite) {
-            return tcx.mk_type_list(&[Ty::new_misc_error(tcx)]);
+            return ty::EarlyBinder::bind(tcx.mk_type_list(&[Ty::new_misc_error(tcx)]));
         }
     }
     let def = tcx.adt_def(def_id);
@@ -107,7 +110,7 @@ fn adt_sized_constraint(tcx: TyCtxt<'_>, def_id: DefId) -> &[Ty<'_>] {
 
     debug!("adt_sized_constraint: {:?} => {:?}", def, result);
 
-    result
+    ty::EarlyBinder::bind(result)
 }
 
 /// See `ParamEnv` struct definition for details.

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -62,7 +62,8 @@ fn sized_constraint_for_ty<'tcx>(
             let predicates = tcx.predicates_of(adtdef.did()).predicates;
             if predicates.iter().any(|(p, _)| {
                 p.as_trait_clause().is_some_and(|trait_pred| {
-                    trait_pred.def_id() == sized_trait_def_id && trait_pred.self_ty().skip_binder() == ty
+                    trait_pred.def_id() == sized_trait_def_id
+                        && trait_pred.self_ty().skip_binder() == ty
                 })
             }) {
                 vec![]

--- a/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
+++ b/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
@@ -8,8 +8,12 @@ LL |     let x = defer(&vec!["Goodbye", "world!"]);
 LL |     x.x[0];
    |     ------ borrow later used here
    |
-   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using a `let` binding to create a longer lived value
+   |
+LL ~     let binding = vec!["Goodbye", "world!"];
+LL ~     let x = defer(&binding);
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.rs
+++ b/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.rs
@@ -1,0 +1,13 @@
+trait Test {}
+impl Test for &[u8] {}
+
+fn needs_test<T: Test>() -> T {
+    panic!()
+}
+
+fn main() {
+    needs_test::<[u8; 1]>();
+    //~^ ERROR the trait bound
+    let x: [u8; 1] = needs_test();
+    //~^ ERROR the trait bound
+}

--- a/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `[u8; 1]: Test` is not satisfied
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:9:18
+   |
+LL |     needs_test::<[u8; 1]>();
+   |                  ^^^^^^^ the trait `Test` is not implemented for `[u8; 1]`
+   |
+   = help: the trait `Test` is implemented for `&[u8]`
+note: required by a bound in `needs_test`
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:4:18
+   |
+LL | fn needs_test<T: Test>() -> T {
+   |                  ^^^^ required by this bound in `needs_test`
+
+error[E0277]: the trait bound `[u8; 1]: Test` is not satisfied
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:11:22
+   |
+LL |     let x: [u8; 1] = needs_test();
+   |                      ^^^^^^^^^^ the trait `Test` is not implemented for `[u8; 1]`
+   |
+   = help: the trait `Test` is implemented for `&[u8]`
+note: required by a bound in `needs_test`
+  --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:4:18
+   |
+LL | fn needs_test<T: Test>() -> T {
+   |                  ^^^^ required by this bound in `needs_test`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.rs
+++ b/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.rs
@@ -7,7 +7,6 @@ trait Iterable {
 
     fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
     //~^ ERROR use of undeclared lifetime name `'missing`
-    //~| ERROR the parameter type `Self` may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.rs
+++ b/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.rs
@@ -1,0 +1,13 @@
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Iterable {
+    type Item<'a>
+    where
+        Self: 'a;
+
+    fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
+    //~^ ERROR use of undeclared lifetime name `'missing`
+    //~| ERROR the parameter type `Self` may not live long enough
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.stderr
@@ -1,0 +1,38 @@
+error[E0261]: use of undeclared lifetime name `'missing`
+  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:8:55
+   |
+LL |     fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
+   |                                                       ^^^^^^^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'missing` lifetime
+   |
+LL |     fn iter(&self) -> impl for<'missing> Iterator<Item = Self::Item<'missing>>;
+   |                            +++++++++++++
+help: consider introducing lifetime `'missing` here
+   |
+LL |     fn iter<'missing>(&self) -> impl Iterator<Item = Self::Item<'missing>>;
+   |            ++++++++++
+help: consider introducing lifetime `'missing` here
+   |
+LL | trait Iterable<'missing> {
+   |               ++++++++++
+
+error[E0311]: the parameter type `Self` may not live long enough
+  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:8:37
+   |
+LL |     fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `Self: 'a`...
+   = note: ...so that the type `Self` will meet its required lifetime bounds...
+note: ...that is required by this bound
+  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:6:15
+   |
+LL |         Self: 'a;
+   |               ^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0261, E0311.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-lt-outlives-in-rpitit-114274.stderr
@@ -18,21 +18,6 @@ help: consider introducing lifetime `'missing` here
 LL | trait Iterable<'missing> {
    |               ++++++++++
 
-error[E0311]: the parameter type `Self` may not live long enough
-  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:8:37
-   |
-LL |     fn iter(&self) -> impl Iterator<Item = Self::Item<'missing>>;
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider adding an explicit lifetime bound `Self: 'a`...
-   = note: ...so that the type `Self` will meet its required lifetime bounds...
-note: ...that is required by this bound
-  --> $DIR/missing-lt-outlives-in-rpitit-114274.rs:6:15
-   |
-LL |         Self: 'a;
-   |               ^^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0261, E0311.
-For more information about an error, try `rustc --explain E0261`.
+For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/inference/type-infer-generalize-ty-var.rs
+++ b/tests/ui/inference/type-infer-generalize-ty-var.rs
@@ -1,4 +1,6 @@
-// run-pass
+// check-pass
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -9,8 +9,12 @@ LL |
 LL |     x.use_mut();
    |     - borrow later used here
    |
-   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using a `let` binding to create a longer lived value
+   |
+LL ~     let binding = vec![1];
+LL ~     let mut x = binding.iter();
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
+++ b/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
@@ -9,8 +9,12 @@ LL |
 LL |     stuff(phantom_pinned)
    |           -------------- borrow later used here
    |
-   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using a `let` binding to create a longer lived value
+   |
+LL ~     let binding = pin!(PhantomPinned);
+LL ~     let phantom_pinned = identity(binding);
+   |
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/lifetime_errors_on_promotion_misusage.rs:18:30

--- a/tests/ui/traits/new-solver/dont-coerce-infer-to-dyn.rs
+++ b/tests/ui/traits/new-solver/dont-coerce-infer-to-dyn.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+use std::fmt::Display;
+use std::rc::Rc;
+
+fn mk<T: ?Sized>(t: Option<&T>) -> Rc<T> {
+    todo!()
+}
+
+fn main() {
+    let mut x = None;
+    let y = mk(x);
+    // Don't treat the line below as a unsize coercion `Rc<?0> ~> Rc<dyn Display>`
+    let z: Rc<dyn Display> = y;
+    x = Some(&1 as &dyn Display);
+}


### PR DESCRIPTION
Successful merges:

 - #114178 (Account for macros when suggesting a new let binding)
 - #114199 (Don't unsize coerce infer vars in select in new solver)
 - #114301 (Don't check unnecessarily that impl trait is RPIT)
 - #114314 (Tweaks to `adt_sized_constraint`)
 - #114322 (Fix invalid slice coercion suggestion reported in turbofish)
 - #114340 ([rustc_attr][nit] Replace `filter` + `is_some` with `map_or`.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114178,114199,114301,114314,114322,114340)
<!-- homu-ignore:end -->