### PR TITLE
[library/std] Replace condv while loop with `cvar.wait_while`.

### DIFF
--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -130,11 +130,8 @@ impl Barrier {
         let local_gen = lock.generation_id;
         lock.count += 1;
         if lock.count < self.num_threads {
-            // We need a while loop to guard against spurious wakeups.
-            // https://en.wikipedia.org/wiki/Spurious_wakeup
-            while local_gen == lock.generation_id {
-                lock = self.cvar.wait(lock).unwrap();
-            }
+            let _guard =
+                self.cvar.wait_while(lock, |state| local_gen == state.generation_id).unwrap();
             BarrierWaitResult(false)
         } else {
             lock.count = 0;


### PR DESCRIPTION
`wait_while` takes care of spurious wake-ups in centralized place, reducing chances for mistakes and potential future optimizations (who knows, maybe in future there will be no spurious wake-ups? :)