### PR TITLE
Avoid exporting __rust_alloc_error_handler_should_panic more than once.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -233,15 +233,6 @@ fn exported_symbols_provider_local(
             ));
         }
 
-        symbols.push((
-            ExportedSymbol::NoDefId(SymbolName::new(tcx, OomStrategy::SYMBOL)),
-            SymbolExportInfo {
-                level: SymbolExportLevel::Rust,
-                kind: SymbolExportKind::Text,
-                used: false,
-            },
-        ));
-
         let exported_symbol =
             ExportedSymbol::NoDefId(SymbolName::new(tcx, NO_ALLOC_SHIM_IS_UNSTABLE));
         symbols.push((


### PR DESCRIPTION
Exporting `__rust_alloc_error_handler_should_panic` multiple times causes `ld.gold` to balk with: `error: version script assignment of  to symbol __rust_alloc_error_handler_should_panic failed: symbol not defined`

Specifically this breaks builds of 1.70.0 and newer on DragonFly and YoctoProject with `ld.gold`.  Builds with `ld.bfd` and `lld` should be unaffected.

http://errors.yoctoproject.org/Errors/Details/708194/