### PR TITLE
test_get_dbpath_for_term(): handle non-utf8 paths (fix FIXME)

### DIFF
--- a/library/test/src/term/terminfo/searcher/tests.rs
+++ b/library/test/src/term/terminfo/searcher/tests.rs
@@ -6,14 +6,12 @@ fn test_get_dbpath_for_term() {
     // woefully inadequate test coverage
     // note: current tests won't work with non-standard terminfo hierarchies (e.g., macOS's)
     use std::env;
-    // FIXME (#9639): This needs to handle non-utf8 paths
-    fn x(t: &str) -> String {
-        let p = get_dbpath_for_term(t).expect("no terminfo entry found");
-        p.to_str().unwrap().to_string()
+    fn x(t: &str) -> PathBuf {
+        get_dbpath_for_term(t).expect(&format!("no terminfo entry found for {t:?}"))
     }
-    assert_eq!(x("screen"), "/usr/share/terminfo/s/screen");
+    assert_eq!(x("screen"), PathBuf::from("/usr/share/terminfo/s/screen"));
     assert_eq!(get_dbpath_for_term(""), None);
     env::set_var("TERMINFO_DIRS", ":");
-    assert_eq!(x("screen"), "/usr/share/terminfo/s/screen");
+    assert_eq!(x("screen"), PathBuf::from("/usr/share/terminfo/s/screen"));
     env::remove_var("TERMINFO_DIRS");
 }

--- a/library/test/src/term/terminfo/searcher/tests.rs
+++ b/library/test/src/term/terminfo/searcher/tests.rs
@@ -11,9 +11,9 @@ fn test_get_dbpath_for_term() {
         let p = get_dbpath_for_term(t).expect("no terminfo entry found");
         p.to_str().unwrap().to_string()
     }
-    assert!(x("screen") == "/usr/share/terminfo/s/screen");
-    assert!(get_dbpath_for_term("") == None);
+    assert_eq!(x("screen"), "/usr/share/terminfo/s/screen");
+    assert_eq!(get_dbpath_for_term(""), None);
     env::set_var("TERMINFO_DIRS", ":");
-    assert!(x("screen") == "/usr/share/terminfo/s/screen");
+    assert_eq!(x("screen"), "/usr/share/terminfo/s/screen");
     env::remove_var("TERMINFO_DIRS");
 }


### PR DESCRIPTION
Removes a FIXME for #9639

Part of #44366 which is E-help-wanted 

The remaining two FIXMEs for #9639 are considerably more complicated, so I will create separate PRs for them.