### PR TITLE
Command: also print removed env vars

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -789,7 +789,7 @@ impl Command {
     /// or [`Command::envs`]. In addition, it will prevent the spawned child process from inheriting
     /// any environment variable from its parent process.
     ///
-    /// After calling [`Command::env_remove`], the iterator from [`Command::get_envs`] will be
+    /// After calling [`Command::env_clear`], the iterator from [`Command::get_envs`] will be
     /// empty.
     ///
     /// You can use [`Command::env_remove`] to clear a single mapping.

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -563,6 +563,29 @@ fn debug_print() {
 {PIDFD}}}"#
         )
     );
+
+    let mut command_with_cleared_env = Command::new("boring-name");
+    command_with_cleared_env.env_clear().env("BAR", "val").env_remove("FOO");
+    assert_eq!(format!("{command_with_cleared_env:?}"), r#"env -i BAR="val" "boring-name""#);
+    assert_eq!(
+        format!("{command_with_cleared_env:#?}"),
+        format!(
+            r#"Command {{
+    program: "boring-name",
+    args: [
+        "boring-name",
+    ],
+    env: CommandEnv {{
+        clear: true,
+        vars: {{
+            "BAR": Some(
+                "val",
+            ),
+        }},
+    }},
+{PIDFD}}}"#
+        )
+    );
 }
 
 // See issue #91991

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -452,7 +452,7 @@ fn env_empty() {
 #[test]
 #[cfg(not(windows))]
 #[cfg_attr(any(target_os = "emscripten", target_env = "sgx"), ignore)]
-fn main() {
+fn debug_print() {
     const PIDFD: &'static str =
         if cfg!(target_os = "linux") { "    create_pidfd: false,\n" } else { "" };
 
@@ -538,6 +538,27 @@ fn main() {
     cwd: Some(
         "/some/path",
     ),
+{PIDFD}}}"#
+        )
+    );
+
+    let mut command_with_removed_env = Command::new("boring-name");
+    command_with_removed_env.env_remove("BAR");
+    assert_eq!(format!("{command_with_removed_env:?}"), r#"unset(BAR) "boring-name""#);
+    assert_eq!(
+        format!("{command_with_removed_env:#?}"),
+        format!(
+            r#"Command {{
+    program: "boring-name",
+    args: [
+        "boring-name",
+    ],
+    env: CommandEnv {{
+        clear: false,
+        vars: {{
+            "BAR": None,
+        }},
+    }},
 {PIDFD}}}"#
         )
     );

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -544,7 +544,7 @@ fn debug_print() {
 
     let mut command_with_removed_env = Command::new("boring-name");
     command_with_removed_env.env_remove("FOO").env_remove("BAR");
-    assert_eq!(format!("{command_with_removed_env:?}"), r#"unset BAR FOO && "boring-name""#);
+    assert_eq!(format!("{command_with_removed_env:?}"), r#"env -u BAR -u FOO "boring-name""#);
     assert_eq!(
         format!("{command_with_removed_env:#?}"),
         format!(

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -543,8 +543,8 @@ fn debug_print() {
     );
 
     let mut command_with_removed_env = Command::new("boring-name");
-    command_with_removed_env.env_remove("BAR");
-    assert_eq!(format!("{command_with_removed_env:?}"), r#"unset(BAR) "boring-name""#);
+    command_with_removed_env.env_remove("FOO").env_remove("BAR");
+    assert_eq!(format!("{command_with_removed_env:?}"), r#"unset BAR FOO && "boring-name""#);
     assert_eq!(
         format!("{command_with_removed_env:#?}"),
         format!(
@@ -557,6 +557,7 @@ fn debug_print() {
         clear: false,
         vars: {{
             "BAR": None,
+            "FOO": None,
         }},
     }},
 {PIDFD}}}"#

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -562,7 +562,7 @@ impl fmt::Debug for Command {
                 write!(f, "env -i ")?;
                 // Altered env vars will be printed next, that should exactly work as expected.
             } else {
-                // Removed env vars need the command to be wrappen in `env`.
+                // Removed env vars need the command to be wrapped in `env`.
                 let mut any_removed = false;
                 for (key, value_opt) in self.get_envs() {
                     if value_opt.is_none() {

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -562,20 +562,16 @@ impl fmt::Debug for Command {
                 write!(f, "env -i ")?;
                 // Altered env vars will be printed next, that should exactly work as expected.
             } else {
-                // Removed env vars need a separate command.
-                // We use a single `unset` command for all of them.
+                // Removed env vars need the command to be wrappen in `env`.
                 let mut any_removed = false;
                 for (key, value_opt) in self.get_envs() {
                     if value_opt.is_none() {
                         if !any_removed {
-                            write!(f, "unset ")?;
+                            write!(f, "env ")?;
                             any_removed = true;
                         }
-                        write!(f, "{} ", key.to_string_lossy())?;
+                        write!(f, "-u {} ", key.to_string_lossy())?;
                     }
-                }
-                if any_removed {
-                    write!(f, "&& ")?;
                 }
             }
             // Altered env vars can just be added in front of the program.

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -561,6 +561,8 @@ impl fmt::Debug for Command {
             for (key, value_opt) in self.get_envs() {
                 if let Some(value) = value_opt {
                     write!(f, "{}={value:?} ", key.to_string_lossy())?;
+                } else {
+                    write!(f, "unset({}) ", key.to_string_lossy())?;
                 }
             }
             if self.program != self.args[0] {

--- a/library/std/src/sys_common/process.rs
+++ b/library/std/src/sys_common/process.rs
@@ -80,6 +80,10 @@ impl CommandEnv {
         self.vars.clear();
     }
 
+    pub fn does_clear(&self) -> bool {
+        self.clear
+    }
+
     pub fn have_changed_path(&self) -> bool {
         self.saw_path || self.clear
     }


### PR DESCRIPTION
There is no real shell syntax for unsetting an env var so easily, so we have to make one up. But we already do that for showing the 'program' name so I hope that's okay here, too. No strong opinion on what that should look like, I went with `unset(VAR_NAME)` for now.