### PR TITLE
Temporarily eholk from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -502,7 +502,6 @@ compiler-team = [
 ]
 compiler-team-contributors = [
     "@compiler-errors",
-    "@eholk",
     "@jackh726",
     "@TaKO8Ki",
     "@WaffleLapkin",


### PR DESCRIPTION
I'm going to be out for the rest of this week and then all of next week, and I generally haven't had the bandwidth to do much in the way of reviewing lately anyway. I'm going to remove myself for the review queue at least until I'm back from vacation and have some time to get a few other things in better shape.

r? @wesleywiser 