### PR TITLE
[rustc_span][perf] Hoist lookup sorted by words out of the loop.

### DIFF
--- a/compiler/rustc_span/src/edit_distance.rs
+++ b/compiler/rustc_span/src/edit_distance.rs
@@ -238,8 +238,9 @@ fn find_best_match_for_name_impl(
 }
 
 fn find_match_by_sorted_words(iter_names: &[Symbol], lookup: &str) -> Option<Symbol> {
+    let lookup_sorted_by_words = sort_by_words(lookup);
     iter_names.iter().fold(None, |result, candidate| {
-        if sort_by_words(candidate.as_str()) == sort_by_words(lookup) {
+        if sort_by_words(candidate.as_str()) == lookup_sorted_by_words {
             Some(*candidate)
         } else {
             result


### PR DESCRIPTION
@lqd commented on https://github.com/rust-lang/rust/pull/114351 asking if `sort_by_words(lookup)` is computed repeatedly. I was assuming that rustc should have no difficulties to hoist it automatically outside of the loop to avoid repeated pure computation, but according to
 https://godbolt.org/z/frs8Kj1rq it seems like I was wrong:
original version seems to have 2 calls per loop iteration
```
.LBB16_3:
        mov     rbx, qword ptr [r13]
        mov     r14, qword ptr [r13 + 8]
        lea     rdi, [rsp + 40]
        mov     rsi, rbx
        mov     rdx, r14
        call    example::sort_by_words
        lea     rdi, [rsp + 64]
        mov     rsi, qword ptr [rsp + 8]
        mov     rdx, qword ptr [rsp + 16]
        call    example::sort_by_words
        mov     rdi, qword ptr [rsp + 40]
        mov     rdx, qword ptr [rsp + 56]
        mov     rsi, qword ptr [rsp + 64]
        cmp     rdx, qword ptr [rsp + 80]
        mov     qword ptr [rsp + 32], rdi
        mov     qword ptr [rsp + 24], rsi
        jne     .LBB16_5
        call    qword ptr [rip + bcmp@GOTPCREL]
        test    eax, eax
        sete    al
        mov     dword ptr [rsp + 4], eax
        mov     rsi, qword ptr [rsp + 72]
        test    rsi, rsi
        jne     .LBB16_8
        jmp     .LBB16_9
```
but the manually hoisted version just 1:
```
.LBB16_3:
        mov     r13, qword ptr [r15]
        mov     r14, qword ptr [r15 + 8]
        lea     rdi, [rsp + 64]
        mov     rsi, r13
        mov     rdx, r14
        call    example::sort_by_words
        mov     rdi, qword ptr [rsp + 64]
        mov     rdx, qword ptr [rsp + 16]
        cmp     qword ptr [rsp + 80], rdx
        mov     qword ptr [rsp + 32], rdi
        jne     .LBB16_5
        mov     rsi, qword ptr [rsp + 8]
        call    qword ptr [rip + bcmp@GOTPCREL]
        test    eax, eax
        sete    bpl
        mov     rsi, qword ptr [rsp + 72]
        test    rsi, rsi
        jne     .LBB16_8
        jmp     .LBB16_9
```
This code is probably not very hot, but there is no reason to leave such a low hanging fruit.