### PR TITLE
Add note when matching on tuples/ADTs containing non-exhaustive types

### DIFF
--- a/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
@@ -77,6 +77,8 @@ LL |     m!((0usize, true), (0..5, true) | (5..=usize::MAX, true) | (0..=usize::
    |        ^^^^^^^^^^^^^^ pattern `(_, _)` not covered
    |
    = note: the matched value is of type `(usize, bool)`
+   = note: `usize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL |         match $s { $($t)+ => {}, (_, _) => todo!() }
@@ -131,6 +133,8 @@ LL |     m!((0isize, true), (isize::MIN..5, true)
    |        ^^^^^^^^^^^^^^ pattern `(_, _)` not covered
    |
    = note: the matched value is of type `(isize, bool)`
+   = note: `isize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `isize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL |         match $s { $($t)+ => {}, (_, _) => todo!() }

--- a/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.rs
+++ b/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.rs
@@ -1,0 +1,67 @@
+struct A<T> {
+    a: T,
+}
+
+struct B<T, U>(T, U);
+
+fn main() {
+    match 0 {
+        //~^ ERROR non-exhaustive patterns: `_` not covered [E0004]
+        0 => (),
+        1..=usize::MAX => (),
+    }
+
+    match (0usize, 0usize) {
+        //~^ ERROR non-exhaustive patterns: `(_, _)` not covered [E0004]
+        (0, 0) => (),
+        (1..=usize::MAX, 1..=usize::MAX) => (),
+    }
+
+    match (0isize, 0usize) {
+        //~^ ERROR non-exhaustive patterns: `(_, _)` not covered [E0004]
+        (isize::MIN..=isize::MAX, 0) => (),
+        (isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
+    }
+
+    // Should not report note about usize not having fixed max value
+    match Some(1usize) {
+        //~^ ERROR non-exhaustive patterns: `Some(_)` not covered
+        None => {}
+    }
+
+    match Some(4) {
+        //~^ ERROR non-exhaustive patterns: `Some(_)` not covered
+        Some(0) => (),
+        Some(1..=usize::MAX) => (),
+        None => (),
+    }
+
+    match Some(Some(Some(0))) {
+        //~^ ERROR non-exhaustive patterns: `Some(Some(Some(_)))` not covered
+        Some(Some(Some(0))) => (),
+        Some(Some(Some(1..=usize::MAX))) => (),
+        Some(Some(None)) => (),
+        Some(None) => (),
+        None => (),
+    }
+
+    match (A { a: 0usize }) {
+        //~^ ERROR non-exhaustive patterns: `A { .. }` not covered [E0004]
+        A { a: 0 } => (),
+        A { a: 1..=usize::MAX } => (),
+    }
+
+    match B(0isize, 0usize) {
+        //~^ ERROR non-exhaustive patterns: `B(_, _)` not covered [E0004]
+        B(isize::MIN..=isize::MAX, 0) => (),
+        B(isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
+    }
+
+    // Should report only the note about usize not having fixed max value and not report
+    // report the note about isize
+    match B(0isize, 0usize) {
+        //~^ ERROR non-exhaustive patterns: `B(_, _)` not covered [E0004]
+        B(_, 0) => (),
+        B(_, 1..=usize::MAX) => (),
+    }
+}

--- a/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
+++ b/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
@@ -1,0 +1,170 @@
+error[E0004]: non-exhaustive patterns: `_` not covered
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:8:11
+   |
+LL |     match 0 {
+   |           ^ pattern `_` not covered
+   |
+   = note: the matched value is of type `usize`
+   = note: `usize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         1..=usize::MAX => (),
+LL ~         _ => todo!(),
+   |
+
+error[E0004]: non-exhaustive patterns: `(_, _)` not covered
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:14:11
+   |
+LL |     match (0usize, 0usize) {
+   |           ^^^^^^^^^^^^^^^^ pattern `(_, _)` not covered
+   |
+   = note: the matched value is of type `(usize, usize)`
+   = note: `usize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         (1..=usize::MAX, 1..=usize::MAX) => (),
+LL ~         (_, _) => todo!(),
+   |
+
+error[E0004]: non-exhaustive patterns: `(_, _)` not covered
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:20:11
+   |
+LL |     match (0isize, 0usize) {
+   |           ^^^^^^^^^^^^^^^^ pattern `(_, _)` not covered
+   |
+   = note: the matched value is of type `(isize, usize)`
+   = note: `isize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `isize` matching
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         (isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
+LL ~         (_, _) => todo!(),
+   |
+
+error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:27:11
+   |
+LL |     match Some(1usize) {
+   |           ^^^^^^^^^^^^ pattern `Some(_)` not covered
+   |
+note: `Option<usize>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<usize>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         None => {},
+LL +         Some(_) => todo!()
+   |
+
+error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:32:11
+   |
+LL |     match Some(4) {
+   |           ^^^^^^^ pattern `Some(_)` not covered
+   |
+note: `Option<usize>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<usize>`
+   = note: `usize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         None => (),
+LL ~         Some(_) => todo!(),
+   |
+
+error[E0004]: non-exhaustive patterns: `Some(Some(Some(_)))` not covered
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:39:11
+   |
+LL |     match Some(Some(Some(0))) {
+   |           ^^^^^^^^^^^^^^^^^^^ pattern `Some(Some(Some(_)))` not covered
+   |
+note: `Option<Option<Option<usize>>>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   |
+   = note: not covered
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<Option<Option<usize>>>`
+   = note: `usize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         None => (),
+LL ~         Some(Some(Some(_))) => todo!(),
+   |
+
+error[E0004]: non-exhaustive patterns: `A { .. }` not covered
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:48:11
+   |
+LL |     match (A { a: 0usize }) {
+   |           ^^^^^^^^^^^^^^^^^ pattern `A { .. }` not covered
+   |
+note: `A<usize>` defined here
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:1:8
+   |
+LL | struct A<T> {
+   |        ^
+   = note: the matched value is of type `A<usize>`
+   = note: `usize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         A { a: 1..=usize::MAX } => (),
+LL ~         A { .. } => todo!(),
+   |
+
+error[E0004]: non-exhaustive patterns: `B(_, _)` not covered
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:54:11
+   |
+LL |     match B(0isize, 0usize) {
+   |           ^^^^^^^^^^^^^^^^^ pattern `B(_, _)` not covered
+   |
+note: `B<isize, usize>` defined here
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:5:8
+   |
+LL | struct B<T, U>(T, U);
+   |        ^
+   = note: the matched value is of type `B<isize, usize>`
+   = note: `isize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `isize` matching
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         B(isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
+LL ~         B(_, _) => todo!(),
+   |
+
+error[E0004]: non-exhaustive patterns: `B(_, _)` not covered
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:62:11
+   |
+LL |     match B(0isize, 0usize) {
+   |           ^^^^^^^^^^^^^^^^^ pattern `B(_, _)` not covered
+   |
+note: `B<isize, usize>` defined here
+  --> $DIR/issue-85222-types-containing-non-exhaustive-types.rs:5:8
+   |
+LL | struct B<T, U>(T, U);
+   |        ^
+   = note: the matched value is of type `B<isize, usize>`
+   = note: `usize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         B(_, 1..=usize::MAX) => (),
+LL ~         B(_, _) => todo!(),
+   |
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
@@ -10,6 +10,8 @@ note: `Foo` defined here
 LL | struct Foo {
    |        ^^^
    = note: the matched value is of type `Foo`
+   = note: `usize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Foo { first: false, second: Some([1, 2, 3, 4]) } => (),

--- a/tests/ui/pattern/usefulness/tuple-struct-nonexhaustive.stderr
+++ b/tests/ui/pattern/usefulness/tuple-struct-nonexhaustive.stderr
@@ -10,6 +10,8 @@ note: `Foo` defined here
 LL | struct Foo(isize, isize);
    |        ^^^
    = note: the matched value is of type `Foo`
+   = note: `isize` does not have a fixed maximum value, so a wildcard `_` is necessary to match exhaustively
+   = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `isize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Foo(2, b) => println!("{}", b),


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/85222

r? @Nadrieril 