### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -494,6 +494,7 @@ Ryan Sullivant <rsulli55@gmail.com>
 Ryan Wiedemann <Ryan1729@gmail.com>
 S Pradeep Kumar <gohanpra@gmail.com>
 Sam Radhakrishnan <sk09idm@gmail.com>
+Samuel Tardieu <sam@rfc1149.net>
 Scott McMurray <scottmcm@users.noreply.github.com>
 Scott Olson <scott@solson.me> Scott Olson <scott@scott-olson.org>
 Sean Gillespie <sean.william.g@gmail.com> swgillespie <sean.william.g@gmail.com>

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -1,4 +1,4 @@
-//! Intrinsics and other functions that the miri engine executes without
+//! Intrinsics and other functions that the interpreter executes without
 //! looking at their MIR. Intrinsics/functions supported here are shared by CTFE
 //! and miri.
 

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -91,7 +91,7 @@ impl<'tcx, Other> FnVal<'tcx, Other> {
 // `Memory` has to depend on the `Machine` because some of its operations
 // (e.g., `get`) call a `Machine` hook.
 pub struct Memory<'mir, 'tcx, M: Machine<'mir, 'tcx>> {
-    /// Allocations local to this instance of the miri engine. The kind
+    /// Allocations local to this instance of the interpreter. The kind
     /// helps ensure that the same mechanism is used for allocation and
     /// deallocation. When an allocation is not found here, it is a
     /// global and looked up in the `tcx` for read access. Some machines may

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -155,7 +155,7 @@ impl<'tcx> InterpErrorInfo<'tcx> {
 }
 
 fn print_backtrace(backtrace: &Backtrace) {
-    eprintln!("\n\nAn error occurred in miri:\n{backtrace}");
+    eprintln!("\n\nAn error occurred in the MIR interpreter:\n{backtrace}");
 }
 
 impl From<ErrorGuaranteed> for InterpErrorInfo<'_> {

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -609,7 +609,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Panics in case the `AllocId` is dangling. Since that is impossible for `AllocId`s in
     /// constants (as all constants must pass interning and validation that check for dangling
     /// ids), this function is frequently used throughout rustc, but should not be used within
-    /// the miri engine.
+    /// the interpreter.
     pub fn global_alloc(self, id: AllocId) -> GlobalAlloc<'tcx> {
         match self.try_get_global_alloc(id) {
             Some(alloc) => alloc,

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -628,7 +628,8 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
                                         valtree, ty
                                     )
                                     });
-                                let s = std::str::from_utf8(slice).expect("non utf8 str from miri");
+                                let s = std::str::from_utf8(slice)
+                                    .expect("non utf8 str from MIR interpreter");
 
                                 self.push("e");
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -502,7 +502,6 @@ compiler-team = [
 ]
 compiler-team-contributors = [
     "@compiler-errors",
-    "@eholk",
     "@jackh726",
     "@TaKO8Ki",
     "@WaffleLapkin",


### PR DESCRIPTION
Successful merges:

 - #114363 (avoid 'miri' when refering to the shared interpreter)
 - #114371 (Add myself to mailmap)
 - #114387 (Temporarily eholk from review rotation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114363,114371,114387)
<!-- homu-ignore:end -->