### PR TITLE
Fix documentation of impl From<Vec<T>> for Rc<[T]>

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2491,9 +2491,9 @@ impl<T, A: Allocator> From<Vec<T, A>> for Rc<[T], A> {
     ///
     /// ```
     /// # use std::rc::Rc;
-    /// let original: Box<Vec<i32>> = Box::new(vec![1, 2, 3]);
-    /// let shared: Rc<Vec<i32>> = Rc::from(original);
-    /// assert_eq!(vec![1, 2, 3], *shared);
+    /// let unique: Vec<i32> = vec![1, 2, 3];
+    /// let shared: Rc<[i32]> = Rc::from(unique);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
     /// ```
     #[inline]
     fn from(v: Vec<T, A>) -> Rc<[T], A> {


### PR DESCRIPTION
The example in the documentation of `impl From<Vec<T>> for <Rc<[T]>` is irrelevant (likely was copied from `impl From<Box<T>> for <Rc<T>`). I suggest taking corresponding example from the documentation of `Arc` and replacing `Arc` with `Rc`.