### PR TITLE
Warn when #[macro_export] is applied on decl macros

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -428,6 +428,10 @@ passes_link_section =
 passes_macro_export =
     `#[macro_export]` only has an effect on macro definitions
 
+passes_macro_export_on_decl_macro =
+    `#[macro_export]` has no effect on declarative macro definitions
+    .note = declarative macros follow the same exporting rules as regular items
+
 passes_macro_use =
     `#[{$name}]` only has an effect on `extern crate` and modules
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -2133,6 +2133,20 @@ impl CheckAttrVisitor<'_> {
                     );
                 }
             }
+        } else {
+            // special case when `#[macro_export]` is applied to a macro 2.0
+            let (macro_definition, _) =
+                self.tcx.hir().find(hir_id).unwrap().expect_item().expect_macro();
+            let is_decl_macro = !macro_definition.macro_rules;
+
+            if is_decl_macro {
+                self.tcx.emit_spanned_lint(
+                    UNUSED_ATTRIBUTES,
+                    hir_id,
+                    attr.span,
+                    errors::MacroExport::OnDeclMacro,
+                );
+            }
         }
     }
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -690,6 +690,10 @@ pub enum MacroExport {
     #[diag(passes_macro_export)]
     Normal,
 
+    #[diag(passes_macro_export_on_decl_macro)]
+    #[note]
+    OnDeclMacro,
+
     #[diag(passes_invalid_macro_export_arguments)]
     UnknownItem { name: Symbol },
 

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -312,7 +312,6 @@ macro_rules! debug_assert_ne {
 /// let c = Ok("abc".to_string());
 /// debug_assert_matches!(c, Ok(x) | Err(x) if x.len() < 100);
 /// ```
-#[macro_export]
 #[unstable(feature = "assert_matches", issue = "82775")]
 #[allow_internal_unstable(assert_matches)]
 #[rustc_macro_transparency = "semitransparent"]

--- a/tests/ui/attributes/macro_export_on_decl_macro.rs
+++ b/tests/ui/attributes/macro_export_on_decl_macro.rs
@@ -1,0 +1,9 @@
+// Using #[macro_export] on a decl macro has no effect and should warn
+
+#![feature(decl_macro)]
+#![deny(unused)]
+
+#[macro_export] //~ ERROR `#[macro_export]` has no effect on declarative macro definitions
+pub macro foo() {}
+
+fn main() {}

--- a/tests/ui/attributes/macro_export_on_decl_macro.stderr
+++ b/tests/ui/attributes/macro_export_on_decl_macro.stderr
@@ -1,0 +1,16 @@
+error: `#[macro_export]` has no effect on declarative macro definitions
+  --> $DIR/macro_export_on_decl_macro.rs:6:1
+   |
+LL | #[macro_export]
+   | ^^^^^^^^^^^^^^^
+   |
+   = note: declarative macros follow the same exporting rules as regular items
+note: the lint level is defined here
+  --> $DIR/macro_export_on_decl_macro.rs:4:9
+   |
+LL | #![deny(unused)]
+   |         ^^^^^^
+   = note: `#[deny(unused_attributes)]` implied by `#[deny(unused)]`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
The existing code checks if `#[macro_export]` is being applied to an item other than a macro, and warns in that case, but fails to take into account macros 2.0/decl macros, despite the attribute having no effect on these macros.

This PR adds a special case for decl macros with the aforementioned attribute, so that the warning is a bit more precise. Instead of just saying "this attribute has no effect", hint towards the fact that decl macros get exported and resolved like regular items.
It also removes a `#[macro_export]` attribute which was applied on one of `core`'s decl macros.

- core: Remove #[macro_export] from `debug_assert_matches`
- check_attrs: Warn when #[macro_export] is used on macros 2.0
