### PR TITLE
Skip checking of `rustc_codegen_gcc` with vendoring enabled

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -307,6 +307,12 @@ impl Step for CodegenBackend {
     }
 
     fn run(self, builder: &Builder<'_>) {
+        // FIXME: remove once https://github.com/rust-lang/rust/issues/112393 is resolved
+        if builder.build.config.vendor && &self.backend == "gcc" {
+            println!("Skipping checking of `rustc_codegen_gcc` with vendoring enabled.");
+            return;
+        }
+
         let compiler = builder.compiler(builder.top_stage, builder.config.build);
         let target = self.target;
         let backend = self.backend;


### PR DESCRIPTION
`rustc_codegen_gcc` currently cannot be vendored, which [breaks](https://github.com/rust-lang/rust/issues/112393) `x.py check` with vendoring enabled. Until the vendoring issue is resolved, it would be nice if `x.py check` could succeed (and just skip `gcc`) with `vendor = true`. With this PR, it does.

Related issue: https://github.com/rust-lang/rust/issues/112393

r? bootstrap