### PR TITLE
bump parking_lot to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3416,7 +3416,7 @@ dependencies = [
  "libc",
  "measureme",
  "memmap2",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "rustc-hash",
  "rustc-rayon",
  "rustc-rayon-core",
@@ -4135,7 +4135,7 @@ dependencies = [
 name = "rustc_query_system"
 version = "0.0.0"
 dependencies = [
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "rustc-rayon-core",
  "rustc_ast",
  "rustc_data_structures",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -35,7 +35,7 @@ elsa = "=1.7.1"
 itertools = "0.10.1"
 
 [dependencies.parking_lot]
-version = "0.11"
+version = "0.12"
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.48.0"

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [lib]
 
 [dependencies]
-parking_lot = "0.11"
+parking_lot = "0.12"
 rustc_ast = { path = "../rustc_ast" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -1,4 +1,3 @@
-use parking_lot::Mutex;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
 use rustc_data_structures::profiling::{EventId, QueryInvocationId, SelfProfilerRef};
@@ -88,7 +87,7 @@ pub struct DepGraphData<K: DepKind> {
 
     colors: DepNodeColorMap,
 
-    processed_side_effects: Mutex<FxHashSet<DepNodeIndex>>,
+    processed_side_effects: Lock<FxHashSet<DepNodeIndex>>,
 
     /// When we load, there may be `.o` files, cached MIR, or other such
     /// things available to us. If we find that they are not dirty, we


### PR DESCRIPTION
Bumps parking_lot to 0.12, replaces few explicit uses of parking_lot with rustc_data_structures::sync ones.

<strike>cc @oli-obk this touches recent https://github.com/rust-lang/rust/pull/114283</strike>
cc @SparrowLii i've checked that this builds with parallel-compiler

measureme's bump https://github.com/rust-lang/measureme/pull/209
https://github.com/rust-lang/rust/blob/fcf3006e0133365ecd26894689c086387edcbecb/compiler/rustc_data_structures/src/sync.rs#L18-L34