### PR TITLE
Convert `Into<ExitStatus> for ExitStatusError` to `From<ExitStatusError> for ExitStatus` in `std::process`

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1738,9 +1738,9 @@ impl ExitStatusError {
 }
 
 #[unstable(feature = "exit_status_error", issue = "84908")]
-impl Into<ExitStatus> for ExitStatusError {
-    fn into(self) -> ExitStatus {
-        ExitStatus(self.0.into())
+impl From<ExitStatusError> for ExitStatus {
+    fn from(error: ExitStatusError) -> Self {
+        Self(error.0.into())
     }
 }
 


### PR DESCRIPTION
Implementing suggestion from https://github.com/rust-lang/rust/issues/84908#issuecomment-912352902:

> I believe the impl on ExitStatusError should be
>
> ```rust
> impl From<ExitStatusError> for ExitStatus
> ```
>
> rather than
>
> ```rust
> impl Into<ExitStatus> for ExitStatusError
> ```
>
> (there is generally never anything implemented as `Into` first, because implementing `From` reflexively provides `Into`)