### PR TITLE
Enable tests on rustc_codegen_ssa

### DIFF
--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -3,9 +3,6 @@ name = "rustc_codegen_ssa"
 version = "0.0.0"
 edition = "2021"
 
-[lib]
-test = false
-
 [dependencies]
 ar_archive_writer = "0.1.3"
 bitflags = "1.2.1"


### PR DESCRIPTION
This enables unittests in rustc_codegen_ssa. There are some tests, primarily in [`back/rpath/tests.rs`](https://github.com/rust-lang/rust/blob/HEAD/compiler/rustc_codegen_ssa/src/back/rpath/tests.rs) that haven't ever been running since the unittests are disabled. From what I can tell, this was just a consequence of how things evolved. When testing was initially added in https://github.com/rust-lang/rust/pull/33282, `librustc_trans` had test=false because it didn't have any tests. `rustc_codegen_ssa` eventually split off from that (https://github.com/rust-lang/rust/pull/55627), and the rpath module eventually got merged in too (from `librustc_back` where it used to live). That migration didn't enable the tests.

This also includes some fluent diagnostic tests, though I'm not sure what exactly they are testing.