### PR TITLE
(do not merge) Try some inline things with a skipped test

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -359,6 +359,7 @@ struct ArcInner<T: ?Sized> {
 }
 
 /// Calculate layout for `ArcInner<T>` using the inner value's layout
+#[inline]
 fn arcinner_layout_for_value_layout(layout: Layout) -> Layout {
     // Calculate layout using the given value layout.
     // Previously, layout was calculated on the expression

--- a/tests/codegen/issues/issue-111603.rs
+++ b/tests/codegen/issues/issue-111603.rs
@@ -1,5 +1,7 @@
 // compile-flags: -O
 
+// FIXME: DO NOT MERGE until these tests are re-enabled
+
 #![crate_type = "lib"]
 #![feature(get_mut_unchecked, new_uninit)]
 
@@ -20,8 +22,6 @@ pub fn new_from_array(x: u64) -> Arc<[u64]> {
 // CHECK-LABEL: @new_uninit
 #[no_mangle]
 pub fn new_uninit(x: u64) -> Arc<[u64; 1000]> {
-    // CHECK: call alloc::sync::arcinner_layout_for_value_layout
-    // CHECK-NOT: call alloc::sync::arcinner_layout_for_value_layout
     let mut arc = Arc::new_uninit();
     unsafe { Arc::get_mut_unchecked(&mut arc) }.write([x; 1000]);
     unsafe { arc.assume_init() }
@@ -30,8 +30,6 @@ pub fn new_uninit(x: u64) -> Arc<[u64; 1000]> {
 // CHECK-LABEL: @new_uninit_slice
 #[no_mangle]
 pub fn new_uninit_slice(x: u64) -> Arc<[u64]> {
-    // CHECK: call alloc::sync::arcinner_layout_for_value_layout
-    // CHECK-NOT: call alloc::sync::arcinner_layout_for_value_layout
     let mut arc = Arc::new_uninit_slice(1000);
     for elem in unsafe { Arc::get_mut_unchecked(&mut arc) } {
         elem.write(x);


### PR DESCRIPTION
`arcinner_layout_for_value_layout` is not currently being inlined, and we can't inline it since it is required by a test. Once figuring out how to rewrite the test we should be able to change this if the performance is worth it.

Zulip discussion: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Inline.20causing.20failed.20codegen.20test