### PR TITLE
Print GHA log groups to stdout instead of stderr

### DIFF
--- a/src/tools/build_helper/src/ci.rs
+++ b/src/tools/build_helper/src/ci.rs
@@ -82,15 +82,15 @@ pub mod gha {
 
     fn start_group(name: impl std::fmt::Display) {
         if is_in_gha() {
-            eprintln!("::group::{name}");
+            println!("::group::{name}");
         } else {
-            eprintln!("{name}")
+            println!("{name}")
         }
     }
 
     fn end_group() {
         if is_in_gha() {
-            eprintln!("::endgroup::");
+            println!("::endgroup::");
         }
     }
 


### PR DESCRIPTION
In all other places (e.g. `bootstrap.py`, `opt-dist`), we use stdout instead of stderr. I think that using stderr might be causing some discrepancies in the log, where sometimes the contents of a group "leak" outside the group. Let's see what happens if we use stdout instead. It's possible that it will be worse, since we print most stuff to stderr (?).

r? @ghost