### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -1620,8 +1620,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     .iter()
                                     .enumerate()
                                     .filter(|x| x.1.hir_id == *hir_id)
-                                    .map(|(i, _)| init_tup.get(i).unwrap())
-                                    .next()
+                                    .find_map(|(i, _)| init_tup.get(i))
                                 {
                                     self.note_type_is_not_clone_inner_expr(init)
                                 } else {

--- a/compiler/rustc_span/src/edit_distance.rs
+++ b/compiler/rustc_span/src/edit_distance.rs
@@ -247,9 +247,9 @@ fn find_match_by_sorted_words(iter_names: &[Symbol], lookup: &str) -> Option<Sym
     })
 }
 
-fn sort_by_words(name: &str) -> String {
+fn sort_by_words(name: &str) -> Vec<&str> {
     let mut split_words: Vec<&str> = name.split('_').collect();
     // We are sorting primitive &strs and can use unstable sort here.
     split_words.sort_unstable();
-    split_words.join("_")
+    split_words
 }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2987,6 +2987,14 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         unsatisfied_const: bool,
     ) {
         let body_def_id = obligation.cause.body_id;
+        let span = if let ObligationCauseCode::BinOp { rhs_span: Some(rhs_span), .. } =
+            obligation.cause.code()
+        {
+            *rhs_span
+        } else {
+            span
+        };
+
         // Try to report a help message
         if is_fn_trait
             && let Ok((implemented_kind, params)) = self.type_implements_fn_trait(

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3953,9 +3953,11 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         candidate_impls: &[ImplCandidate<'tcx>],
         span: Span,
     ) {
-        // We can only suggest the slice coersion for function arguments since the suggestion
-        // would make no sense in turbofish or call
-        let ObligationCauseCode::FunctionArgumentObligation { .. } = obligation.cause.code() else {
+        // We can only suggest the slice coersion for function and binary operation arguments,
+        // since the suggestion would make no sense in turbofish or call
+        let (ObligationCauseCode::BinOp { .. }
+        | ObligationCauseCode::FunctionArgumentObligation { .. }) = obligation.cause.code()
+        else {
             return;
         };
 

--- a/tests/ui/dst/issue-113447.fixed
+++ b/tests/ui/dst/issue-113447.fixed
@@ -1,0 +1,25 @@
+// run-rustfix
+
+pub struct Bytes;
+
+impl Bytes {
+    pub fn as_slice(&self) -> &[u8] {
+        todo!()
+    }
+}
+
+impl PartialEq<[u8]> for Bytes {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl PartialEq<Bytes> for &[u8] {
+    fn eq(&self, other: &Bytes) -> bool {
+        *other == **self
+    }
+}
+
+fn main() {
+    let _ = &[0u8] == &[0xAA][..]; //~ ERROR can't compare `&[u8; 1]` with `[{integer}; 1]`
+}

--- a/tests/ui/dst/issue-113447.rs
+++ b/tests/ui/dst/issue-113447.rs
@@ -1,0 +1,25 @@
+// run-rustfix
+
+pub struct Bytes;
+
+impl Bytes {
+    pub fn as_slice(&self) -> &[u8] {
+        todo!()
+    }
+}
+
+impl PartialEq<[u8]> for Bytes {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl PartialEq<Bytes> for &[u8] {
+    fn eq(&self, other: &Bytes) -> bool {
+        *other == **self
+    }
+}
+
+fn main() {
+    let _ = &[0u8] == [0xAA]; //~ ERROR can't compare `&[u8; 1]` with `[{integer}; 1]`
+}

--- a/tests/ui/dst/issue-113447.stderr
+++ b/tests/ui/dst/issue-113447.stderr
@@ -1,0 +1,25 @@
+error[E0277]: can't compare `&[u8; 1]` with `[{integer}; 1]`
+  --> $DIR/issue-113447.rs:24:20
+   |
+LL |     let _ = &[0u8] == [0xAA];
+   |                    ^^ no implementation for `&[u8; 1] == [{integer}; 1]`
+   |
+   = help: the trait `PartialEq<[{integer}; 1]>` is not implemented for `&[u8; 1]`
+   = help: the following other types implement trait `PartialEq<Rhs>`:
+             <[A; N] as PartialEq<[B; N]>>
+             <[A; N] as PartialEq<[B]>>
+             <[A; N] as PartialEq<&[B]>>
+             <[A; N] as PartialEq<&mut [B]>>
+             <[T] as PartialEq<Vec<U, A>>>
+             <[A] as PartialEq<[B]>>
+             <[B] as PartialEq<[A; N]>>
+             <&[u8] as PartialEq<Bytes>>
+           and 4 others
+help: convert the array to a `&[u8]` slice instead
+   |
+LL |     let _ = &[0u8] == &[0xAA][..];
+   |                       +      ++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/typeck/issue-114423.rs
+++ b/tests/ui/typeck/issue-114423.rs
@@ -1,0 +1,15 @@
+struct RGB {
+    g: f64,
+    b: f64,
+}
+
+fn main() {
+    let (r, alone_in_path, b): (f32, f32, f32) = (e.clone(), e.clone());
+    //~^ ERROR cannot find value `e` in this scope
+    //~| ERROR cannot find value `e` in this scope
+    //~| ERROR mismatched types
+    let _ = RGB { r, g, b };
+    //~^ ERROR cannot find value `g` in this scope
+    //~| ERROR struct `RGB` has no field named `r`
+    //~| ERROR mismatched types
+}

--- a/tests/ui/typeck/issue-114423.stderr
+++ b/tests/ui/typeck/issue-114423.stderr
@@ -1,0 +1,52 @@
+error[E0425]: cannot find value `e` in this scope
+  --> $DIR/issue-114423.rs:7:51
+   |
+LL |     let (r, alone_in_path, b): (f32, f32, f32) = (e.clone(), e.clone());
+   |                                                   ^ not found in this scope
+
+error[E0425]: cannot find value `e` in this scope
+  --> $DIR/issue-114423.rs:7:62
+   |
+LL |     let (r, alone_in_path, b): (f32, f32, f32) = (e.clone(), e.clone());
+   |                                                              ^ not found in this scope
+
+error[E0425]: cannot find value `g` in this scope
+  --> $DIR/issue-114423.rs:11:22
+   |
+LL |     let _ = RGB { r, g, b };
+   |                      ^ help: a local variable with a similar name exists: `b`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-114423.rs:7:50
+   |
+LL |     let (r, alone_in_path, b): (f32, f32, f32) = (e.clone(), e.clone());
+   |                                ---------------   ^^^^^^^^^^^^^^^^^^^^^^ expected a tuple with 3 elements, found one with 2 elements
+   |                                |
+   |                                expected due to this
+   |
+   = note: expected tuple `(f32, f32, f32)`
+              found tuple `(f32, f32)`
+
+error[E0560]: struct `RGB` has no field named `r`
+  --> $DIR/issue-114423.rs:11:19
+   |
+LL |     let _ = RGB { r, g, b };
+   |                   ^ `RGB` does not have this field
+   |
+   = note: all struct fields are already assigned
+
+error[E0308]: mismatched types
+  --> $DIR/issue-114423.rs:11:25
+   |
+LL |     let _ = RGB { r, g, b };
+   |                         ^ expected `f64`, found `f32`
+   |
+help: you can convert an `f32` to an `f64`
+   |
+LL |     let _ = RGB { r, g, b: b.into() };
+   |                         ++  +++++++
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0308, E0425, E0560.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #113945 (Fix wrong span for trait selection failure error reporting)
 - #114351 ([rustc_span][perf] Remove unnecessary string joins and allocs.)
 - #114461 (Fix unwrap on None)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113945,114351,114461)
<!-- homu-ignore:end -->