### PR TITLE
Detect method not found on arbitrary self type with different mutability

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -13,7 +13,7 @@ use crate::errors::{
     YieldExprOutsideOfGenerator,
 };
 use crate::fatally_break_rust;
-use crate::method::SelfSource;
+use crate::method::{MethodCallComponents, SelfSource};
 use crate::type_error_struct;
 use crate::Expectation::{self, ExpectCastableToType, ExpectHasType, NoExpectation};
 use crate::{
@@ -1293,7 +1293,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         segment.ident,
                         SelfSource::MethodCall(rcvr),
                         error,
-                        Some((rcvr, args, expr)),
+                        Some(MethodCallComponents { receiver: rcvr, args, full_expr: expr }),
                         expected,
                         false,
                     ) {

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1293,7 +1293,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         segment.ident,
                         SelfSource::MethodCall(rcvr),
                         error,
-                        Some((rcvr, args)),
+                        Some((rcvr, args, expr)),
                         expected,
                         false,
                     ) {

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -7,7 +7,7 @@ mod prelude2021;
 pub mod probe;
 mod suggest;
 
-pub use self::suggest::SelfSource;
+pub use self::suggest::{MethodCallComponents, SelfSource};
 pub use self::MethodError::*;
 
 use crate::errors::OpMethodGenericParams;

--- a/tests/ui/self/arbitrary_self_type_mut_difference.rs
+++ b/tests/ui/self/arbitrary_self_type_mut_difference.rs
@@ -1,0 +1,13 @@
+// Related to #57994.
+use std::pin::Pin;
+struct S;
+
+impl S {
+    fn x(self: Pin<&mut Self>) {} //~ NOTE method is available for `Pin<&mut S>`
+    fn y(self: Pin<&Self>) {} //~ NOTE method is available for `Pin<&S>`
+}
+
+fn main() {
+    Pin::new(&S).x(); //~ ERROR no method named `x` found for struct `Pin<&S>` in the current scope
+    Pin::new(&mut S).y(); //~ ERROR no method named `y` found for struct `Pin<&mut S>` in the current scope
+}

--- a/tests/ui/self/arbitrary_self_type_mut_difference.stderr
+++ b/tests/ui/self/arbitrary_self_type_mut_difference.stderr
@@ -1,0 +1,27 @@
+error[E0599]: no method named `x` found for struct `Pin<&S>` in the current scope
+  --> $DIR/arbitrary_self_type_mut_difference.rs:11:18
+   |
+LL |     Pin::new(&S).x();
+   |                  ^ help: there is a method with a similar name: `y`
+   |
+note: method is available for `Pin<&mut S>`
+  --> $DIR/arbitrary_self_type_mut_difference.rs:6:5
+   |
+LL |     fn x(self: Pin<&mut Self>) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0599]: no method named `y` found for struct `Pin<&mut S>` in the current scope
+  --> $DIR/arbitrary_self_type_mut_difference.rs:12:22
+   |
+LL |     Pin::new(&mut S).y();
+   |                      ^ help: there is a method with a similar name: `x`
+   |
+note: method is available for `Pin<&S>`
+  --> $DIR/arbitrary_self_type_mut_difference.rs:7:5
+   |
+LL |     fn y(self: Pin<&Self>) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/self/arbitrary_self_types_needing_box_or_arc_wrapping.fixed
+++ b/tests/ui/self/arbitrary_self_types_needing_box_or_arc_wrapping.fixed
@@ -1,0 +1,17 @@
+// run-rustfix
+#![allow(dead_code)]
+mod first {
+    trait Foo { fn m(self: Box<Self>); }
+    fn foo<T: Foo>(a: T) {
+        Box::new(a).m(); //~ ERROR no method named `m` found
+    }
+}
+mod second {
+    use std::sync::Arc;
+    trait Bar { fn m(self: Arc<Self>); }
+    fn bar(b: impl Bar) {
+        Arc::new(b).m(); //~ ERROR no method named `m` found
+    }
+}
+
+fn main() {}

--- a/tests/ui/self/arbitrary_self_types_needing_box_or_arc_wrapping.rs
+++ b/tests/ui/self/arbitrary_self_types_needing_box_or_arc_wrapping.rs
@@ -1,0 +1,17 @@
+// run-rustfix
+#![allow(dead_code)]
+mod first {
+    trait Foo { fn m(self: Box<Self>); }
+    fn foo<T: Foo>(a: T) {
+        a.m(); //~ ERROR no method named `m` found
+    }
+}
+mod second {
+    use std::sync::Arc;
+    trait Bar { fn m(self: Arc<Self>); }
+    fn bar(b: impl Bar) {
+        b.m(); //~ ERROR no method named `m` found
+    }
+}
+
+fn main() {}

--- a/tests/ui/self/arbitrary_self_types_needing_box_or_arc_wrapping.stderr
+++ b/tests/ui/self/arbitrary_self_types_needing_box_or_arc_wrapping.stderr
@@ -1,0 +1,43 @@
+error[E0599]: no method named `m` found for type parameter `T` in the current scope
+  --> $DIR/arbitrary_self_types_needing_box_or_arc_wrapping.rs:6:11
+   |
+LL |     trait Foo { fn m(self: Box<Self>); }
+   |                    -       --------- the method might not be found because of this arbitrary self type
+   |                    |
+   |                    the method is available for `Box<T>` here
+LL |     fn foo<T: Foo>(a: T) {
+   |            - method `m` not found for this type parameter
+LL |         a.m();
+   |           ^ method not found in `T`
+...
+LL |     trait Bar { fn m(self: Arc<Self>); }
+   |                            --------- the method might not be found because of this arbitrary self type
+   |
+help: consider wrapping the receiver expression with the appropriate type
+   |
+LL |         Box::new(a).m();
+   |         +++++++++ +
+
+error[E0599]: no method named `m` found for type parameter `impl Bar` in the current scope
+  --> $DIR/arbitrary_self_types_needing_box_or_arc_wrapping.rs:13:11
+   |
+LL |     trait Foo { fn m(self: Box<Self>); }
+   |                            --------- the method might not be found because of this arbitrary self type
+...
+LL |     trait Bar { fn m(self: Arc<Self>); }
+   |                    -       --------- the method might not be found because of this arbitrary self type
+   |                    |
+   |                    the method is available for `Arc<impl Bar>` here
+LL |     fn bar(b: impl Bar) {
+   |               -------- method `m` not found for this type parameter
+LL |         b.m();
+   |           ^ method not found in `impl Bar`
+   |
+help: consider wrapping the receiver expression with the appropriate type
+   |
+LL |         Arc::new(b).m();
+   |         +++++++++ +
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/self/arbitrary_self_types_needing_mut_pin.fixed
+++ b/tests/ui/self/arbitrary_self_types_needing_mut_pin.fixed
@@ -1,0 +1,12 @@
+// run-rustfix
+use std::pin::Pin;
+struct S;
+
+impl S {
+    fn x(self: Pin<&mut Self>) {
+    }
+}
+
+fn main() {
+    Pin::new(&mut S).x(); //~ ERROR no method named `x` found
+}

--- a/tests/ui/self/arbitrary_self_types_needing_mut_pin.rs
+++ b/tests/ui/self/arbitrary_self_types_needing_mut_pin.rs
@@ -1,0 +1,12 @@
+// run-rustfix
+use std::pin::Pin;
+struct S;
+
+impl S {
+    fn x(self: Pin<&mut Self>) {
+    }
+}
+
+fn main() {
+    S.x(); //~ ERROR no method named `x` found
+}

--- a/tests/ui/self/arbitrary_self_types_needing_mut_pin.stderr
+++ b/tests/ui/self/arbitrary_self_types_needing_mut_pin.stderr
@@ -1,0 +1,20 @@
+error[E0599]: no method named `x` found for struct `S` in the current scope
+  --> $DIR/arbitrary_self_types_needing_mut_pin.rs:11:7
+   |
+LL | struct S;
+   | -------- method `x` not found for this struct
+...
+LL |     fn x(self: Pin<&mut Self>) {
+   |        - the method is available for `Pin<&mut S>` here
+...
+LL |     S.x();
+   |       ^ method not found in `S`
+   |
+help: consider wrapping the receiver expression with the appropriate type
+   |
+LL |     Pin::new(&mut S).x();
+   |     +++++++++++++  +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/self/arbitrary_self_types_pin_needing_borrow.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_needing_borrow.rs
@@ -1,0 +1,13 @@
+use std::pin::Pin;
+struct S;
+
+impl S {
+    fn x(self: Pin<&mut Self>) {
+    }
+}
+
+fn main() {
+    Pin::new(S).x();
+    //~^ ERROR the trait bound `S: Deref` is not satisfied
+    //~| ERROR no method named `x` found for struct `Pin` in the current scope
+}

--- a/tests/ui/self/arbitrary_self_types_pin_needing_borrow.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_needing_borrow.stderr
@@ -1,0 +1,33 @@
+error[E0277]: the trait bound `S: Deref` is not satisfied
+  --> $DIR/arbitrary_self_types_pin_needing_borrow.rs:10:14
+   |
+LL |     Pin::new(S).x();
+   |     -------- ^ the trait `Deref` is not implemented for `S`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `Pin::<P>::new`
+  --> $SRC_DIR/core/src/pin.rs:LL:COL
+help: consider borrowing here
+   |
+LL |     Pin::new(&S).x();
+   |              +
+LL |     Pin::new(&mut S).x();
+   |              ++++
+
+error[E0599]: no method named `x` found for struct `Pin` in the current scope
+  --> $DIR/arbitrary_self_types_pin_needing_borrow.rs:10:17
+   |
+LL |     Pin::new(S).x();
+   |                 ^ method not found in `Pin<S>`
+   |
+note: method is available for `Pin<&mut S>`
+  --> $DIR/arbitrary_self_types_pin_needing_borrow.rs:5:5
+   |
+LL |     fn x(self: Pin<&mut Self>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
```
error[E0599]: no method named `x` found for struct `Pin<&S>` in the current scope
  --> $DIR/arbitrary_self_type_mut_difference.rs:11:18
   |
LL |     Pin::new(&S).x();
   |                  ^ help: there is a method with a similar name: `y`
   |
note: method is available for `Pin<&mut S>`
  --> $DIR/arbitrary_self_type_mut_difference.rs:6:5
   |
LL |     fn x(self: Pin<&mut Self>) {}
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Related to #57994, as one of the presented cases can lead to code like this.