### PR TITLE
Restrict linker version script of proc-macro crates to just its two symbols 

### DIFF
--- a/tests/ui/proc-macro/auxiliary/exports_no_mangle.rs
+++ b/tests/ui/proc-macro/auxiliary/exports_no_mangle.rs
@@ -1,0 +1,9 @@
+#![crate_type="lib"]
+
+// Issue 111888: this crate (1.) is imported by a proc-macro crate and (2.)
+// exports a no_mangle function; that combination of acts was broken for some
+// period of time. See further discussion in the test file that imports this
+// crate.
+
+#[no_mangle]
+pub fn some_no_mangle_function() { }

--- a/tests/ui/proc-macro/auxiliary/exports_no_mangle.rs
+++ b/tests/ui/proc-macro/auxiliary/exports_no_mangle.rs
@@ -1,3 +1,5 @@
+// force-host
+// no-prefer-dynamic
 #![crate_type="lib"]
 
 // Issue 111888: this crate (1.) is imported by a proc-macro crate and (2.)

--- a/tests/ui/proc-macro/no-mangle-in-proc-macro-issue-111888.rs
+++ b/tests/ui/proc-macro/no-mangle-in-proc-macro-issue-111888.rs
@@ -1,0 +1,20 @@
+// run-pass
+// aux-build:exports_no_mangle.rs
+#![crate_type = "proc-macro"]
+
+// Issue #111888: this proc-macro crate imports another crate that itself
+// exports a no_mangle function.
+//
+// That combination was broken for a period of time, because:
+//
+// In PR #99944 we *stopped* exporting no_mangle symbols from
+// proc-macro crates. The constructed linker version script still referred
+// to them, but resolving that discrepancy was left as a FIXME in the code.
+//
+// In PR #108017 we started telling the linker to check (via the
+// `--no-undefined-version` linker invocation flag) that every symbol referenced
+// in the "linker version script" is actually present in the linker input. So
+// the unresolved discrepancy from #99944 started surfacing as a compile-time
+// error.
+
+extern crate exports_no_mangle;

--- a/tests/ui/proc-macro/no-mangle-in-proc-macro-issue-111888.rs
+++ b/tests/ui/proc-macro/no-mangle-in-proc-macro-issue-111888.rs
@@ -1,4 +1,4 @@
-// run-pass
+// build-pass
 // aux-build:exports_no_mangle.rs
 #![crate_type = "proc-macro"]
 

--- a/tests/ui/proc-macro/no-mangle-in-proc-macro-issue-111888.rs
+++ b/tests/ui/proc-macro/no-mangle-in-proc-macro-issue-111888.rs
@@ -1,4 +1,6 @@
 // build-pass
+// force-host
+// no-prefer-dynamic
 // aux-build:exports_no_mangle.rs
 #![crate_type = "proc-macro"]
 


### PR DESCRIPTION
Restrict linker version script of proc-macro crates to just the two symbols of each proc-macro crate. 

The main known effect of doing this is to stop including `#[no_mangle]` symbols in the linker version script.

Background: 

The combination of a proc-macro crate with an import of another crate that itself exports a no_mangle function was broken for a period of time, because:

* In PR #99944 we stopped exporting no_mangle symbols from proc-macro crates; proc-macro crates have a very limited interface and are meant to be treated as a blackbox to everything except rustc itself. However: he constructed linker version script still referred to them, but resolving that discrepancy was left as a FIXME in the code, tagged with issue #99978.
* In PR #108017 we started telling the linker to check (via the`--no-undefined-version` linker invocation flag) that every symbol referenced in the "linker version script" is provided as linker input. So the unresolved discrepancy from #99978 started surfacing as a compile-time error (e.g. #111888).

Fix #111888 
Fix #99978.
