### PR TITLE
Migrate GUI colors test to original CSS color format

### DIFF
--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -68,7 +68,7 @@
 	--test-arrow-color: #dedede;
 	--test-arrow-background-color: rgba(78, 139, 202, 0.2);
 	--test-arrow-hover-color: #dedede;
-	--test-arrow-hover-background-color: #4e8bca;
+	--test-arrow-hover-background-color: rgb(78, 139, 202);
 	--target-background-color: #494a3d;
 	--target-border-color: #bb7410;
 	--kbd-color: #000;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -68,7 +68,7 @@
 	--test-arrow-color: #f5f5f5;
 	--test-arrow-background-color: rgba(78, 139, 202, 0.2);
 	--test-arrow-hover-color: #f5f5f5;
-	--test-arrow-hover-background-color: #4e8bca;
+	--test-arrow-hover-background-color: rgb(78, 139, 202);
 	--target-background-color: #fdffd3;
 	--target-border-color: #ad7c37;
 	--kbd-color: #000;

--- a/tests/rustdoc-gui/run-on-hover.goml
+++ b/tests/rustdoc-gui/run-on-hover.goml
@@ -33,22 +33,22 @@ define-function: (
 
 call-function: ("check-run-button", {
     "theme": "ayu",
-    "color": "rgb(120, 135, 151)",
+    "color": "#788797",
     "background": "rgba(57, 175, 215, 0.09)",
-    "hover_color": "rgb(197, 197, 197)",
+    "hover_color": "#c5c5c5",
     "hover_background": "rgba(57, 175, 215, 0.37)",
 })
 call-function: ("check-run-button", {
     "theme": "dark",
-    "color": "rgb(222, 222, 222)",
+    "color": "#dedede",
     "background": "rgba(78, 139, 202, 0.2)",
-    "hover_color": "rgb(222, 222, 222)",
+    "hover_color": "#dedede",
     "hover_background": "rgb(78, 139, 202)",
 })
 call-function: ("check-run-button", {
     "theme": "light",
-    "color": "rgb(245, 245, 245)",
+    "color": "#f5f5f5",
     "background": "rgba(78, 139, 202, 0.2)",
-    "hover_color": "rgb(245, 245, 245)",
+    "hover_color": "#f5f5f5",
     "hover_background": "rgb(78, 139, 202)",
 })


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/111459.

r? @notriddle