### PR TITLE
Account for `Rc` and `Arc` when suggesting to clone

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -751,9 +751,19 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 )
                 .must_apply_modulo_regions()
         {
+            let msg = if let ty::Adt(def, _) = ty.kind()
+                && [
+                    tcx.get_diagnostic_item(sym::Arc),
+                    tcx.get_diagnostic_item(sym::Rc),
+                ].contains(&Some(def.did()))
+            {
+                "clone the value to increment its reference count"
+            } else {
+                "consider cloning the value if the performance cost is acceptable"
+            };
             err.span_suggestion_verbose(
                 span.shrink_to_hi(),
-                "consider cloning the value if the performance cost is acceptable",
+                msg,
                 suggestion,
                 Applicability::MachineApplicable,
             );

--- a/tests/ui/moves/use_of_moved_value_clone_suggestions.stderr
+++ b/tests/ui/moves/use_of_moved_value_clone_suggestions.stderr
@@ -8,7 +8,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider cloning the value if the performance cost is acceptable
+help: clone the value to increment its reference count
    |
 LL |     (t.clone(), t)
    |       ++++++++


### PR DESCRIPTION
When suggesting to clone a reference-counted value, be less uncertain.