### PR TITLE
Fix ui-fulldeps missing the `internal_features` lint on stage 0

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2466,8 +2466,13 @@ impl<'test> TestCx<'test> {
             rustc.args(&["-A", "unused"]);
         }
 
-        // Allow tests to use internal features.
-        rustc.args(&["-A", "internal_features"]);
+        // #[cfg(not(bootstrap)] unconditionally pass flag after beta bump
+        // since `ui-fulldeps --stage=1` builds using the stage 0 compiler,
+        // which doesn't have this lint.
+        if !(self.config.stage_id.starts_with("stage1-") && self.config.suite == "ui-fulldeps") {
+            // Allow tests to use internal features.
+            rustc.args(&["-A", "internal_features"]);
+        }
 
         if self.props.force_host {
             self.maybe_add_external_args(&mut rustc, &self.config.host_rustcflags);


### PR DESCRIPTION
Similar to #114102, `ui-fulldeps --stage=1` builds using the the stage 0 compiler instead of the stage 1 compiler. That means that the new `internal_features` lint is referencing a lint that does not exist. Gate the flag it properly until the next feature bump.

Maybe we should just add ui-fulldeps stage 1 into CI somewhere so this is flagged before landing.