### PR TITLE
Make RPITITs capture all in-scope lifetimes

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -813,6 +813,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(TEST, rustc_insignificant_dtor, Normal, template!(Word), WarnFollowing),
     rustc_attr!(TEST, rustc_strict_coherence, Normal, template!(Word), WarnFollowing),
     rustc_attr!(TEST, rustc_variance, Normal, template!(Word), WarnFollowing),
+    rustc_attr!(TEST, rustc_variance_of_opaques, Normal, template!(Word), WarnFollowing),
     rustc_attr!(TEST, rustc_layout, Normal, template!(List: "field1, field2, ..."), WarnFollowing),
     rustc_attr!(TEST, rustc_abi, Normal, template!(List: "field1, field2, ..."), WarnFollowing),
     rustc_attr!(TEST, rustc_regions, Normal, template!(Word), WarnFollowing),

--- a/compiler/rustc_hir_analysis/src/variance/test.rs
+++ b/compiler/rustc_hir_analysis/src/variance/test.rs
@@ -1,9 +1,24 @@
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::CRATE_DEF_ID;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::symbol::sym;
 
 use crate::errors;
 
 pub fn test_variance(tcx: TyCtxt<'_>) {
+    if tcx.has_attr(CRATE_DEF_ID, sym::rustc_variance_of_opaques) {
+        for id in tcx.hir().items() {
+            if matches!(tcx.def_kind(id.owner_id), DefKind::OpaqueTy) {
+                let variances_of = tcx.variances_of(id.owner_id);
+
+                tcx.sess.emit_err(errors::VariancesOf {
+                    span: tcx.def_span(id.owner_id),
+                    variances_of: format!("{variances_of:?}"),
+                });
+            }
+        }
+    }
+
     // For unit testing: check for a special "rustc_variance"
     // attribute and report an error with various results if found.
     for id in tcx.hir().items() {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1366,6 +1366,7 @@ symbols! {
         rustc_trivial_field_reads,
         rustc_unsafe_specialization_marker,
         rustc_variance,
+        rustc_variance_of_opaques,
         rustdoc,
         rustdoc_internals,
         rustdoc_missing_doc_code_examples,

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -548,7 +548,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     obligation.cause.span,
                     "GATs in trait object shouldn't have been considered",
                 );
-                return Err(SelectionError::Unimplemented);
+                return Err(SelectionError::TraitNotObjectSafe(trait_predicate.trait_ref.def_id));
             }
 
             // This maybe belongs in wf, but that can't (doesn't) handle

--- a/tests/ui/impl-trait/in-trait/object-safety.rs
+++ b/tests/ui/impl-trait/in-trait/object-safety.rs
@@ -19,4 +19,5 @@ fn main() {
     //~| ERROR the trait `Foo` cannot be made into an object
     let s = i.baz();
     //~^ ERROR the trait `Foo` cannot be made into an object
+    //~| ERROR the trait bound `dyn Foo: Foo`
 }

--- a/tests/ui/impl-trait/in-trait/object-safety.rs
+++ b/tests/ui/impl-trait/in-trait/object-safety.rs
@@ -19,5 +19,5 @@ fn main() {
     //~| ERROR the trait `Foo` cannot be made into an object
     let s = i.baz();
     //~^ ERROR the trait `Foo` cannot be made into an object
-    //~| ERROR the trait bound `dyn Foo: Foo`
+    //~| ERROR the trait `Foo` cannot be made into an object
 }

--- a/tests/ui/impl-trait/in-trait/object-safety.stderr
+++ b/tests/ui/impl-trait/in-trait/object-safety.stderr
@@ -13,6 +13,14 @@ LL |     fn baz(&self) -> impl Debug;
    |                      ^^^^^^^^^^ ...because method `baz` references an `impl Trait` type in its return type
    = help: consider moving `baz` to another trait
 
+error[E0277]: the trait bound `dyn Foo: Foo` is not satisfied
+  --> $DIR/object-safety.rs:20:15
+   |
+LL |     let s = i.baz();
+   |               ^^^ the trait `Foo` is not implemented for `dyn Foo`
+   |
+   = help: the trait `Foo` is implemented for `u32`
+
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/object-safety.rs:20:13
    |
@@ -44,6 +52,7 @@ LL |     fn baz(&self) -> impl Debug;
    = help: consider moving `baz` to another trait
    = note: required for the cast from `Box<u32>` to `Box<dyn Foo>`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0038`.
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/in-trait/object-safety.stderr
+++ b/tests/ui/impl-trait/in-trait/object-safety.stderr
@@ -13,13 +13,20 @@ LL |     fn baz(&self) -> impl Debug;
    |                      ^^^^^^^^^^ ...because method `baz` references an `impl Trait` type in its return type
    = help: consider moving `baz` to another trait
 
-error[E0277]: the trait bound `dyn Foo: Foo` is not satisfied
+error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/object-safety.rs:20:15
    |
 LL |     let s = i.baz();
-   |               ^^^ the trait `Foo` is not implemented for `dyn Foo`
+   |               ^^^ `Foo` cannot be made into an object
    |
-   = help: the trait `Foo` is implemented for `u32`
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety.rs:7:22
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     fn baz(&self) -> impl Debug;
+   |                      ^^^^^^^^^^ ...because method `baz` references an `impl Trait` type in its return type
+   = help: consider moving `baz` to another trait
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/object-safety.rs:20:13
@@ -54,5 +61,4 @@ LL |     fn baz(&self) -> impl Debug;
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0038, E0277.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/in-trait/signature-mismatch.failure.stderr
+++ b/tests/ui/impl-trait/in-trait/signature-mismatch.failure.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/signature-mismatch.rs:56:10
+  --> $DIR/signature-mismatch.rs:77:10
    |
 LL |         &'a self,
    |         -------- this parameter and the return type are declared with different lifetimes...

--- a/tests/ui/impl-trait/in-trait/signature-mismatch.rs
+++ b/tests/ui/impl-trait/in-trait/signature-mismatch.rs
@@ -1,4 +1,6 @@
 // edition:2021
+// revisions: success failure
+//[success] check-pass
 
 #![feature(return_position_impl_trait_in_trait)]
 #![allow(incomplete_features)]
@@ -11,16 +13,25 @@ impl<T> Captures<'_> for T {}
 trait Captures2<'a, 'b> {}
 impl<T> Captures2<'_, '_> for T {}
 
-pub trait AsyncTrait {
+trait AsyncTrait {
+    #[cfg(success)]
     fn async_fn(&self, buff: &[u8]) -> impl Future<Output = Vec<u8>>;
+
+    #[cfg(success)]
     fn async_fn_early<'a: 'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>>;
+
+    #[cfg(success)]
     fn async_fn_multiple<'a>(&'a self, buff: &[u8])
-        -> impl Future<Output = Vec<u8>> + Captures<'a>;
+    -> impl Future<Output = Vec<u8>> + Captures<'a>;
+
+    #[cfg(failure)]
     fn async_fn_reduce_outlive<'a, T>(
         &'a self,
         buff: &[u8],
         t: T,
     ) -> impl Future<Output = Vec<u8>> + 'a;
+
+    #[cfg(success)]
     fn async_fn_reduce<'a, T>(
         &'a self,
         buff: &[u8],
@@ -31,38 +42,49 @@ pub trait AsyncTrait {
 pub struct Struct;
 
 impl AsyncTrait for Struct {
+    // Does not capture more lifetimes that trait def'n, since trait def'n
+    // implicitly captures all in-scope lifetimes.
+    #[cfg(success)]
     fn async_fn<'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
-        //~^ ERROR return type captures more lifetimes than trait definition
         async move { buff.to_vec() }
     }
 
+    // Does not capture more lifetimes that trait def'n, since trait def'n
+    // implicitly captures all in-scope lifetimes.
+    #[cfg(success)]
     fn async_fn_early<'a: 'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
-        //~^ ERROR return type captures more lifetimes than trait definition
         async move { buff.to_vec() }
     }
 
+    // Does not capture more lifetimes that trait def'n, since trait def'n
+    // implicitly captures all in-scope lifetimes.
+    #[cfg(success)]
     fn async_fn_multiple<'a, 'b>(
         &'a self,
         buff: &'b [u8],
     ) -> impl Future<Output = Vec<u8>> + Captures2<'a, 'b> {
-        //~^ ERROR return type captures more lifetimes than trait definition
         async move { buff.to_vec() }
     }
 
+    // This error message is awkward, but `impl Future<Output = Vec<u8>>`
+    // cannot outlive `'a` (from the trait signature) because it captures
+    // both `T` and `'b`.
+    #[cfg(failure)]
     fn async_fn_reduce_outlive<'a, 'b, T>(
         &'a self,
         buff: &'b [u8],
         t: T,
     ) -> impl Future<Output = Vec<u8>> {
-        //~^ ERROR the parameter type `T` may not live long enough
+        //[failure]~^ ERROR lifetime mismatch
         async move {
             let _t = t;
             vec![]
         }
     }
 
-    // OK: We remove the `Captures<'a>`, providing a guarantee that we don't capture `'a`,
-    // but we still fulfill the `Captures<'a>` trait bound.
+    // Does not capture fewer lifetimes that trait def'n (not that it matters),
+    // since impl also captures all in-scope lifetimes.
+    #[cfg(success)]
     fn async_fn_reduce<'a, 'b, T>(&'a self, buff: &'b [u8], t: T) -> impl Future<Output = Vec<u8>> {
         async move {
             let _t = t;

--- a/tests/ui/impl-trait/in-trait/signature-mismatch.stderr
+++ b/tests/ui/impl-trait/in-trait/signature-mismatch.stderr
@@ -1,61 +1,14 @@
-error: return type captures more lifetimes than trait definition
-  --> $DIR/signature-mismatch.rs:34:47
-   |
-LL |     fn async_fn<'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
-   |                 -- this lifetime was captured ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: hidden type must only reference lifetimes captured by this impl trait
-  --> $DIR/signature-mismatch.rs:15:40
-   |
-LL |     fn async_fn(&self, buff: &[u8]) -> impl Future<Output = Vec<u8>>;
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: hidden type inferred to be `impl Future<Output = Vec<u8>> + 'a`
-
-error: return type captures more lifetimes than trait definition
-  --> $DIR/signature-mismatch.rs:39:57
-   |
-LL |     fn async_fn_early<'a: 'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
-   |                       -- this lifetime was captured     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: hidden type must only reference lifetimes captured by this impl trait
-  --> $DIR/signature-mismatch.rs:16:57
-   |
-LL |     fn async_fn_early<'a: 'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>>;
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: hidden type inferred to be `impl Future<Output = Vec<u8>> + 'a`
-
-error: return type captures more lifetimes than trait definition
-  --> $DIR/signature-mismatch.rs:47:10
-   |
-LL |     fn async_fn_multiple<'a, 'b>(
-   |                              -- this lifetime was captured
-...
-LL |     ) -> impl Future<Output = Vec<u8>> + Captures2<'a, 'b> {
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: hidden type must only reference lifetimes captured by this impl trait
-  --> $DIR/signature-mismatch.rs:18:12
-   |
-LL |         -> impl Future<Output = Vec<u8>> + Captures<'a>;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: hidden type inferred to be `impl Future<Output = Vec<u8>> + Captures2<'a, 'b>`
-
-error[E0309]: the parameter type `T` may not live long enough
+error[E0623]: lifetime mismatch
   --> $DIR/signature-mismatch.rs:56:10
    |
+LL |         &'a self,
+   |         -------- this parameter and the return type are declared with different lifetimes...
+...
 LL |     ) -> impl Future<Output = Vec<u8>> {
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `impl Future<Output = Vec<u8>>` will meet its required lifetime bounds...
-   |
-note: ...that is required by this bound
-  --> $DIR/signature-mismatch.rs:23:42
-   |
-LL |     ) -> impl Future<Output = Vec<u8>> + 'a;
-   |                                          ^^
-help: consider adding an explicit lifetime bound...
-   |
-LL |     fn async_fn_reduce_outlive<'a, 'b, T: 'a>(
-   |                                         ++++
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          ...but data from `buff` is returned here
 
-error: aborting due to 4 previous errors
+error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0309`.
+For more information about this error, try `rustc --explain E0623`.

--- a/tests/ui/impl-trait/in-trait/variance.rs
+++ b/tests/ui/impl-trait/in-trait/variance.rs
@@ -1,0 +1,20 @@
+#![feature(rustc_attrs, return_position_impl_trait_in_trait)]
+#![allow(internal_features)]
+#![rustc_variance_of_opaques]
+
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+trait Foo<'i> {
+    fn implicit_capture_early<'a: 'a>() -> impl Sized {}
+    //~^ [o, *, *, o, o]
+    // Self, 'i, 'a, 'i_duplicated, 'a_duplicated
+
+    fn explicit_capture_early<'a: 'a>() -> impl Sized + Captures<'a> {} //~ [o, *, *, o, o]
+
+    fn implicit_capture_late<'a>(_: &'a ()) -> impl Sized {} //~ [o, *, o, o]
+
+    fn explicit_capture_late<'a>(_: &'a ()) -> impl Sized + Captures<'a> {} //~ [o, *, o, o]
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/variance.stderr
+++ b/tests/ui/impl-trait/in-trait/variance.stderr
@@ -1,0 +1,26 @@
+error: [o, *, *, o, o]
+  --> $DIR/variance.rs:9:44
+   |
+LL |     fn implicit_capture_early<'a: 'a>() -> impl Sized {}
+   |                                            ^^^^^^^^^^
+
+error: [o, *, *, o, o]
+  --> $DIR/variance.rs:13:44
+   |
+LL |     fn explicit_capture_early<'a: 'a>() -> impl Sized + Captures<'a> {}
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [o, *, o, o]
+  --> $DIR/variance.rs:15:48
+   |
+LL |     fn implicit_capture_late<'a>(_: &'a ()) -> impl Sized {}
+   |                                                ^^^^^^^^^^
+
+error: [o, *, o, o]
+  --> $DIR/variance.rs:17:48
+   |
+LL |     fn explicit_capture_late<'a>(_: &'a ()) -> impl Sized + Captures<'a> {}
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/impl-trait/variance.rs
+++ b/tests/ui/impl-trait/variance.rs
@@ -1,0 +1,16 @@
+#![feature(rustc_attrs)]
+#![allow(internal_features)]
+#![rustc_variance_of_opaques]
+
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+fn not_captured_early<'a: 'a>() -> impl Sized {} //~ [*]
+
+fn captured_early<'a: 'a>() -> impl Sized + Captures<'a> {} //~ [*, o]
+
+fn not_captured_late<'a>(_: &'a ()) -> impl Sized {} //~ []
+
+fn captured_late<'a>(_: &'a ()) -> impl Sized + Captures<'a> {} //~ [o]
+
+fn main() {}

--- a/tests/ui/impl-trait/variance.stderr
+++ b/tests/ui/impl-trait/variance.stderr
@@ -1,0 +1,26 @@
+error: [*]
+  --> $DIR/variance.rs:8:36
+   |
+LL | fn not_captured_early<'a: 'a>() -> impl Sized {}
+   |                                    ^^^^^^^^^^
+
+error: [*, o]
+  --> $DIR/variance.rs:10:32
+   |
+LL | fn captured_early<'a: 'a>() -> impl Sized + Captures<'a> {}
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: []
+  --> $DIR/variance.rs:12:40
+   |
+LL | fn not_captured_late<'a>(_: &'a ()) -> impl Sized {}
+   |                                        ^^^^^^^^^^
+
+error: [o]
+  --> $DIR/variance.rs:14:36
+   |
+LL | fn captured_late<'a>(_: &'a ()) -> impl Sized + Captures<'a> {}
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Much like #114616, this implements the lang team decision from this T-lang meeting on [opaque captures strategy moving forward](https://hackmd.io/sFaSIMJOQcuwCdnUvCxtuQ?view). This will be RFC'd soon, but given that RPITITs are a nightly feature, this shouldn't necessarily be blocked on that.

We unconditionally capture all lifetimes in RPITITs -- impl is not as simple as #114616, since we still need to duplicate RPIT lifetimes to make sure we reify any late-bound lifetimes in scope.

Closes #112194