### PR TITLE
Fix a typo in the error reporting for sealed traits.

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2789,7 +2789,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             // implement this trait and list them.
                             err.note(format!(
                                 "`{short_item_name}` is a \"sealed trait\", because to implement \
-                                 it you also need to implelement `{}`, which is not accessible; \
+                                 it you also need to implement `{}`, which is not accessible; \
                                  this is usually done to force you to use one of the provided \
                                  types that already implement it",
                                 with_no_trimmed_paths!(tcx.def_path_str(def_id)),

--- a/tests/ui/privacy/sealed-traits/sealed-trait-local.stderr
+++ b/tests/ui/privacy/sealed-traits/sealed-trait-local.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Sealed`
    |
 LL |     pub trait Sealed: self::b::Hidden {
    |                       ^^^^^^^^^^^^^^^ required by this bound in `Sealed`
-   = note: `Sealed` is a "sealed trait", because to implement it you also need to implelement `a::b::Hidden`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = note: `Sealed` is a "sealed trait", because to implement it you also need to implement `a::b::Hidden`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes a typo in error reporting: "implelement" -> "implement"