### PR TITLE
Set max_atomic_width for AVR to 16

### DIFF
--- a/compiler/rustc_target/src/spec/avr_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/avr_gnu_base.rs
@@ -23,7 +23,7 @@ pub fn target(target_cpu: &'static str, mmcu: &'static str) -> Target {
                 LinkerFlavor::Gnu(Cc::Yes, Lld::No),
                 &["-lgcc"],
             ),
-            max_atomic_width: Some(0),
+            max_atomic_width: Some(16),
             atomic_cas: false,
             relocation_model: RelocModel::Static,
             ..TargetOptions::default()


### PR DESCRIPTION
This is currently set to 0

https://github.com/rust-lang/rust/blob/90f0b24ad3e7fc0dc0e419c9da30d74629cd5736/compiler/rustc_target/src/spec/avr_gnu_base.rs#L26-L27

However, LLVM supports {8,16}-bit atomic load/store on AVR (support for RMW is still quite incomplete and only partially supported).

https://github.com/llvm/llvm-project/blob/llvmorg-15.0.0/llvm/test/CodeGen/AVR/atomics/load8.ll#L5-L13
https://github.com/llvm/llvm-project/blob/llvmorg-15.0.0/llvm/test/CodeGen/AVR/atomics/load16.ll#L3-L12
https://github.com/llvm/llvm-project/blob/llvmorg-15.0.0/llvm/test/CodeGen/AVR/atomics/store.ll#L3-L22

cc #99668

r? @Amanieu 