### PR TITLE
Set max_atomic_width for sparc-unknown-linux-gnu to 32

### DIFF
--- a/compiler/rustc_target/src/spec/sparc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/sparc_unknown_linux_gnu.rs
@@ -5,7 +5,7 @@ pub fn target() -> Target {
     let mut base = super::linux_gnu_base::opts();
     base.endian = Endian::Big;
     base.cpu = "v9".into();
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(32);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-mv8plus"]);
 
     Target {


### PR DESCRIPTION
This is currently set to 64

https://github.com/rust-lang/rust/blob/90f0b24ad3e7fc0dc0e419c9da30d74629cd5736/compiler/rustc_target/src/spec/sparc_unknown_linux_gnu.rs#L8

However, AFAIK, this architecture doesn't support 64-bit atomics, and LLVM generates libcalls: https://godbolt.org/z/chzThWGG1

(Currently, attempts to run `cargo test` for this target result in "undefined reference to `__sync_val_compare_and_swap_8'" error. https://github.com/taiki-e/rust-cross-toolchain/commit/02efe1e74f2280f06662eaf275690883b2f9c7ae)

r? @Amanieu