### PR TITLE
Remove arm crypto target feature

### DIFF
--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -29,7 +29,6 @@ const ARM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("aclass", Some(sym::arm_target_feature)),
     ("aes", Some(sym::arm_target_feature)),
     ("crc", Some(sym::arm_target_feature)),
-    ("crypto", Some(sym::arm_target_feature)),
     ("d32", Some(sym::arm_target_feature)),
     ("dotprod", Some(sym::arm_target_feature)),
     ("dsp", Some(sym::arm_target_feature)),


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/stdarch/pull/1407.

LLVM has moved away from a combined `crypto` feature on both aarch64 and arm, and we did the same on aarch64, but were deferred from doing the same on arm due to compatibility with older LLVM.

As the minimum LLVM version has increased, we can now remove this (unstable) target feature on arm.

r? @Amanieu 