### PR TITLE
Migrate GUI colors test to original CSS color format

### DIFF
--- a/tests/rustdoc-gui/scrape-examples-toggle.goml
+++ b/tests/rustdoc-gui/scrape-examples-toggle.goml
@@ -28,18 +28,18 @@ define-function: (
 
 call-function: ("check-color", {
     "theme": "ayu",
-    "toggle_line_color": "rgb(153, 153, 153)",
-    "toggle_line_hover_color": "rgb(197, 197, 197)",
+    "toggle_line_color": "#999",
+    "toggle_line_hover_color": "#c5c5c5",
 })
 call-function: ("check-color", {
     "theme": "dark",
-    "toggle_line_color": "rgb(153, 153, 153)",
-    "toggle_line_hover_color": "rgb(197, 197, 197)",
+    "toggle_line_color": "#999",
+    "toggle_line_hover_color": "#c5c5c5",
 })
 call-function: ("check-color", {
     "theme": "light",
-    "toggle_line_color": "rgb(204, 204, 204)",
-    "toggle_line_hover_color": "rgb(153, 153, 153)",
+    "toggle_line_color": "#ccc",
+    "toggle_line_hover_color": "#999",
 })
 
 // Toggling all docs will close additional examples


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/111459.

r? @notriddle