### PR TITLE
additional iterator traits for `Take` + `Repeat/RepeatWith`

### DIFF
--- a/library/core/tests/iter/adapters/take.rs
+++ b/library/core/tests/iter/adapters/take.rs
@@ -167,3 +167,22 @@ fn test_byref_take_consumed_items() {
     assert_eq!(count, 70);
     assert_eq!(inner, 90..90);
 }
+
+#[test]
+fn test_take_repeat_double_ended() {
+    let mut iter = repeat(0).take(100);
+    assert_eq!(iter.len(), 100);
+    assert_eq!(iter.next(), Some(0));
+    assert_eq!(iter.next_back(), Some(0));
+    assert_eq!(iter.advance_by(1), Ok(()));
+    assert_eq!(iter.advance_back_by(1), Ok(()));
+    assert_eq!(iter.len(), 96);
+}
+
+#[test]
+fn test_take_repeat_with_exact_size() {
+    let mut iter = repeat_with(|| 0).take(100);
+    assert_eq!(iter.len(), 100);
+    assert_eq!(iter.advance_by(100), Ok(()));
+    assert_eq!(iter.len(), 0);
+}


### PR DESCRIPTION
The `iter::repeat()` and `iter::repeat_with()` docs [recommend combining them](https://doc.rust-lang.org/nightly/std/iter/fn.repeat.html) with `take()` to get finite iterators. Currently those combinations don't implement ExactSizeIterator or DoubleEndedIterator. This adds them where appropriate

```diff
+ impl<T: Clone> DoubleEndedIterator for Take<Repeat<T>>

+ impl<T, F> ExactSizeIterator for Take<RepeatWith<F>> where F: FnMut() -> T {}
+ impl<T: Clone> ExactSizeIterator for Take<Repeat<T>> {}
```

`DoubleEndedIterator` is not implemented for `Take<RepeatWith>` because the generating closure may be stateful and can only dispense items in the forward direction.

These changes are insta-stable.