### PR TITLE
gcc: build with --disable-multilib, as it used only to bootstrap llvm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: mingw-check
-            os: ubuntu-20.04-4core-16gb
-            env: {}
-          - name: mingw-check-tidy
-            os: ubuntu-20.04-4core-16gb
-            env: {}
-          - name: x86_64-gnu-llvm-15
-            os: ubuntu-20.04-16core-64gb
-            env: {}
-          - name: x86_64-gnu-tools
+          - name: dist-x86_64-linux
             os: ubuntu-20.04-16core-64gb
             env: {}
     timeout-minutes: 600

--- a/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir /home/user
 COPY host-x86_64/dist-x86_64-linux/shared.sh /tmp/
 
 # Need at least GCC 5.1 to compile LLVM nowadays
-COPY host-x86_64/dist-x86_64-linux/build-gcc.sh /tmp/
+COPY host-x86_64/dist-i686-linux/build-gcc.sh /tmp/
 RUN ./build-gcc.sh && yum remove -y gcc gcc-c++
 
 COPY scripts/cmake.sh /tmp/

--- a/src/ci/docker/host-x86_64/dist-i686-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-i686-linux/build-gcc.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -ex
+
+source shared.sh
+
+GCC=8.5.0
+
+curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.xz | xzcat | tar xf -
+cd gcc-$GCC
+
+# FIXME(#49246): Remove the `sed` below.
+#
+# On 2018 March 21st, two Travis builders' cache for Docker are suddenly invalidated. Normally this
+# is fine, because we just need to rebuild the Docker image. However, it reveals a network issue:
+# downloading from `ftp://gcc.gnu.org/` from Travis (using passive mode) often leads to "Connection
+# timed out" error, and even when the download completed, the file is usually corrupted. This causes
+# nothing to be landed that day.
+#
+# We observed that the `gcc-4.8.5.tar.bz2` above can be downloaded successfully, so as a stability
+# improvement we try to download from the HTTPS mirror instead. Turns out this uncovered the third
+# bug: the host `gcc.gnu.org` and `cygwin.com` share the same IP, and the TLS certificate of the
+# latter host is presented to `wget`! Therefore, we choose to download from the insecure HTTP server
+# instead here.
+#
+sed -i'' 's|ftp://gcc\.gnu\.org/|https://gcc.gnu.org/|g' ./contrib/download_prerequisites
+
+./contrib/download_prerequisites
+mkdir ../gcc-build
+cd ../gcc-build
+hide_output ../gcc-$GCC/configure \
+    --prefix=/rustroot \
+    --enable-languages=c,c++ \
+    --disable-gnu-unique-object
+hide_output make -j$(nproc)
+hide_output make install
+ln -s gcc /rustroot/bin/cc
+
+cd ..
+rm -rf gcc-build
+rm -rf gcc-$GCC
+
+# FIXME: clang doesn't find 32-bit libraries in /rustroot/lib,
+# but it does look all the way under /rustroot/lib/[...]/32,
+# so we can link stuff there to help it out.
+ln /rustroot/lib/*.{a,so} -rst /rustroot/lib/gcc/x86_64-pc-linux-gnu/$GCC/32/

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -15,10 +15,8 @@ RUN yum upgrade -y && \
       gcc \
       gcc-c++ \
       git \
-      glibc-devel.i686 \
       glibc-devel.x86_64 \
       libedit-devel \
-      libstdc++-devel.i686 \
       libstdc++-devel.x86_64 \
       make \
       ncurses-devel \
@@ -30,7 +28,6 @@ RUN yum upgrade -y && \
       unzip \
       wget \
       xz \
-      zlib-devel.i686 \
       zlib-devel.x86_64 \
       && yum clean all
 

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -30,7 +30,8 @@ cd ../gcc-build
 hide_output ../gcc-$GCC/configure \
     --prefix=/rustroot \
     --enable-languages=c,c++ \
-    --disable-gnu-unique-object
+    --disable-gnu-unique-object \
+    --disable-multilib
 hide_output make -j$(nproc)
 hide_output make install
 ln -s gcc /rustroot/bin/cc
@@ -38,8 +39,3 @@ ln -s gcc /rustroot/bin/cc
 cd ..
 rm -rf gcc-build
 rm -rf gcc-$GCC
-
-# FIXME: clang doesn't find 32-bit libraries in /rustroot/lib,
-# but it does look all the way under /rustroot/lib/[...]/32,
-# so we can link stuff there to help it out.
-ln /rustroot/lib/*.{a,so} -rst /rustroot/lib/gcc/x86_64-pc-linux-gnu/$GCC/32/

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -315,16 +315,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: mingw-check
-            <<: *job-linux-4c
-
-          - name: mingw-check-tidy
-            <<: *job-linux-4c
-
-          - name: x86_64-gnu-llvm-15
-            <<: *job-linux-16c
-
-          - name: x86_64-gnu-tools
+          - &dist-x86_64-linux
+            name: dist-x86_64-linux
             <<: *job-linux-16c
 
   auto:


### PR DESCRIPTION
Should probably reduce CI time a little