### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1467,7 +1467,7 @@ pub enum InvalidNanComparisons {
     #[diag(lint_invalid_nan_comparisons_eq_ne)]
     EqNe {
         #[subdiagnostic]
-        suggestion: InvalidNanComparisonsSuggestion,
+        suggestion: Option<InvalidNanComparisonsSuggestion>,
     },
     #[diag(lint_invalid_nan_comparisons_lt_le_gt_ge)]
     LtLeGtGe,

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -572,32 +572,35 @@ fn lint_nan<'tcx>(
     }
 
     fn eq_ne(
+        cx: &LateContext<'_>,
         e: &hir::Expr<'_>,
         l: &hir::Expr<'_>,
         r: &hir::Expr<'_>,
         f: impl FnOnce(Span, Span) -> InvalidNanComparisonsSuggestion,
     ) -> InvalidNanComparisons {
-        let suggestion =
+        let suggestion = (!cx.tcx.hir().is_inside_const_context(e.hir_id)).then(|| {
             if let Some(l_span) = l.span.find_ancestor_inside(e.span) &&
-                let Some(r_span) = r.span.find_ancestor_inside(e.span) {
+                let Some(r_span) = r.span.find_ancestor_inside(e.span)
+            {
                 f(l_span, r_span)
             } else {
                 InvalidNanComparisonsSuggestion::Spanless
-            };
+            }
+        });
 
         InvalidNanComparisons::EqNe { suggestion }
     }
 
     let lint = match binop.node {
         hir::BinOpKind::Eq | hir::BinOpKind::Ne if is_nan(cx, l) => {
-            eq_ne(e, l, r, |l_span, r_span| InvalidNanComparisonsSuggestion::Spanful {
+            eq_ne(cx, e, l, r, |l_span, r_span| InvalidNanComparisonsSuggestion::Spanful {
                 nan_plus_binop: l_span.until(r_span),
                 float: r_span.shrink_to_hi(),
                 neg: (binop.node == hir::BinOpKind::Ne).then(|| r_span.shrink_to_lo()),
             })
         }
         hir::BinOpKind::Eq | hir::BinOpKind::Ne if is_nan(cx, r) => {
-            eq_ne(e, l, r, |l_span, r_span| InvalidNanComparisonsSuggestion::Spanful {
+            eq_ne(cx, e, l, r, |l_span, r_span| InvalidNanComparisonsSuggestion::Spanful {
                 nan_plus_binop: l_span.shrink_to_hi().to(r_span),
                 float: l_span.shrink_to_hi(),
                 neg: (binop.node == hir::BinOpKind::Ne).then(|| l_span.shrink_to_lo()),

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -578,6 +578,7 @@ fn lint_nan<'tcx>(
         r: &hir::Expr<'_>,
         f: impl FnOnce(Span, Span) -> InvalidNanComparisonsSuggestion,
     ) -> InvalidNanComparisons {
+        // FIXME(#72505): This suggestion can be restored if `f{32,64}::is_nan` is made const.
         let suggestion = (!cx.tcx.hir().is_inside_const_context(e.hir_id)).then(|| {
             if let Some(l_span) = l.span.find_ancestor_inside(e.span) &&
                 let Some(r_span) = r.span.find_ancestor_inside(e.span)

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3944,11 +3944,12 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
 
         if path.len() > 1
             && let Some(res) = result.full_res()
+            && let Some((&last_segment, prev_segs)) = path.split_last()
+            && prev_segs.iter().all(|seg| !seg.has_generic_args)
             && res != Res::Err
             && path[0].ident.name != kw::PathRoot
             && path[0].ident.name != kw::DollarCrate
         {
-            let last_segment = *path.last().unwrap();
             let unqualified_result = {
                 match self.resolve_path(&[last_segment], Some(ns), None) {
                     PathResult::NonModule(path_res) => path_res.expect_full_res(),

--- a/tests/rustdoc-gui/scrape-examples-toggle.goml
+++ b/tests/rustdoc-gui/scrape-examples-toggle.goml
@@ -28,18 +28,18 @@ define-function: (
 
 call-function: ("check-color", {
     "theme": "ayu",
-    "toggle_line_color": "rgb(153, 153, 153)",
-    "toggle_line_hover_color": "rgb(197, 197, 197)",
+    "toggle_line_color": "#999",
+    "toggle_line_hover_color": "#c5c5c5",
 })
 call-function: ("check-color", {
     "theme": "dark",
-    "toggle_line_color": "rgb(153, 153, 153)",
-    "toggle_line_hover_color": "rgb(197, 197, 197)",
+    "toggle_line_color": "#999",
+    "toggle_line_hover_color": "#c5c5c5",
 })
 call-function: ("check-color", {
     "theme": "light",
-    "toggle_line_color": "rgb(204, 204, 204)",
-    "toggle_line_hover_color": "rgb(153, 153, 153)",
+    "toggle_line_color": "#ccc",
+    "toggle_line_hover_color": "#999",
 })
 
 // Toggling all docs will close additional examples

--- a/tests/ui/lint/invalid-nan-comparison.stderr
+++ b/tests/ui/lint/invalid-nan-comparison.stderr
@@ -5,11 +5,6 @@ LL | const TEST: bool = 5f32 == f32::NAN;
    |                    ^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(invalid_nan_comparisons)]` on by default
-help: use `f32::is_nan()` or `f64::is_nan()` instead
-   |
-LL - const TEST: bool = 5f32 == f32::NAN;
-LL + const TEST: bool = 5f32.is_nan();
-   |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
   --> $DIR/invalid-nan-comparison.rs:14:5

--- a/tests/ui/resolve/issue-114433-invalid-unused-qualifications-suggestion.rs
+++ b/tests/ui/resolve/issue-114433-invalid-unused-qualifications-suggestion.rs
@@ -1,0 +1,10 @@
+#![deny(unused_qualifications)]
+// check-pass
+fn bar() {
+    match Option::<Option<()>>::None {
+        Some(v) => {}
+        None => {}
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #114486 (Avoid invalid NaN lint machine-applicable suggestion in const context)
 - #114503 (Remove invalid lint when there is a generic argument in prefix path)
 - #114509 (Migrate GUI colors test to original CSS color format)
 - #114524 (Also ICE when goals go from Ok to Err in new solver)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114486,114503,114509,114524)
<!-- homu-ignore:end -->