### PR TITLE
Implement `From<&'a &'static str>` for `Arguments<'a>`

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -10,6 +10,7 @@ use crate::mem;
 use crate::num::fmt as numfmt;
 use crate::ops::Deref;
 use crate::result;
+use crate::slice;
 use crate::str;
 
 mod builders;
@@ -419,6 +420,14 @@ impl Debug for Arguments<'_> {
 impl Display for Arguments<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         write(fmt.buf, *self)
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a> From<&'a &'static str> for Arguments<'a> {
+    #[inline]
+    fn from(value: &'a &'static str) -> Self {
+        Self::new_const(slice::from_ref(value))
     }
 }
 

--- a/library/core/tests/fmt/mod.rs
+++ b/library/core/tests/fmt/mod.rs
@@ -12,6 +12,13 @@ fn test_format_flags() {
 }
 
 #[test]
+fn test_arguments_from_str() {
+    assert_eq!(core::fmt::Arguments::from(&"a string literal").to_string(), "a string literal");
+
+    assert_eq!(core::fmt::Arguments::from(&"a string literal").as_str(), Some("a string literal"));
+}
+
+#[test]
 fn test_pointer_formats_data_pointer() {
     let b: &[u8] = b"";
     let s: &str = "";


### PR DESCRIPTION
Provides a way to construct an `Arguments` object from an `&'static str` object, and calling `as_str` on the result object will return `Some(&'static str)`.

ACP: [rust-lang/lib-team#257](https://github.com/rust-lang/libs-team/issues/257).