### PR TITLE
Strict provenance unwind

### DIFF
--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -63,7 +63,7 @@ pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
         _uwe: uw::_Unwind_Exception {
             exception_class: rust_exception_class(),
             exception_cleanup,
-            private: [0; uw::unwinder_private_data_size],
+            private: [core::ptr::null(); uw::unwinder_private_data_size],
         },
         canary: &CANARY,
         cause: data,

--- a/library/std/src/sys/personality/gcc.rs
+++ b/library/std/src/sys/personality/gcc.rs
@@ -38,7 +38,6 @@
 
 use super::dwarf::eh::{self, EHAction, EHContext};
 use crate::ffi::c_int;
-use libc::uintptr_t;
 use unwind as uw;
 
 // Register ids were lifted from LLVM's TargetLowering::getExceptionPointerRegister()
@@ -160,9 +159,9 @@ cfg_if::cfg_if! {
                         uw::_Unwind_SetGR(
                             context,
                             UNWIND_DATA_REG.0,
-                            exception_object as uintptr_t,
+                            exception_object as uw::_Unwind_Ptr,
                         );
-                        uw::_Unwind_SetGR(context, UNWIND_DATA_REG.1, 0);
+                        uw::_Unwind_SetGR(context, UNWIND_DATA_REG.1, core::ptr::null());
                         uw::_Unwind_SetIP(context, lpad);
                         return uw::_URC_INSTALL_CONTEXT;
                     }
@@ -222,9 +221,9 @@ cfg_if::cfg_if! {
                         uw::_Unwind_SetGR(
                             context,
                             UNWIND_DATA_REG.0,
-                            exception_object as uintptr_t,
+                            exception_object.cast(),
                         );
-                        uw::_Unwind_SetGR(context, UNWIND_DATA_REG.1, 0);
+                        uw::_Unwind_SetGR(context, UNWIND_DATA_REG.1, core::ptr::null());
                         uw::_Unwind_SetIP(context, lpad);
                         uw::_URC_INSTALL_CONTEXT
                     }

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(staged_api)]
 #![feature(c_unwind)]
 #![feature(cfg_target_abi)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(target_env = "msvc"), feature(libc))]
 #![allow(internal_features)]
 


### PR DESCRIPTION
1. Turned many `usize`s in the personality/unwind code that are actually pointers into `*const u8`.
2. Rewrote `read_encoded_pointer` to conform to strict-provenance, along the lines as described by @eddyb [in zulip some time ago](https://rust-lang.zulipchat.com/#narrow/stream/136281-t-opsem/topic/strict.20provenance.20in.20dwarf.3A.3Aeh/near/276197290).

This should make supporting CHERI in the future easier (but they use a [slightly modified format in the callsite table](https://cheri-compiler-explorer.cl.cam.ac.uk/z/n6GhhW), which requires a CHERI specific modification to `find_eh_action`).