### PR TITLE
linkchecker: Remove unneeded FIXME about intra-doc links

### DIFF
--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -368,7 +368,6 @@ impl Checker {
             return;
         }
         // Search for intra-doc links that rustdoc didn't warn about
-        // FIXME(#77199, 77200) Rustdoc should just warn about these directly.
         // NOTE: only looks at one line at a time; in practice this should find most links
         for (i, line) in source.lines().enumerate() {
             for broken_link in BROKEN_INTRA_DOC_LINK.captures_iter(line) {


### PR DESCRIPTION
It was added by https://github.com/rust-lang/rust/pull/77971 but the adder [proposed](https://github.com/rust-lang/rust/pull/77971#issuecomment-710026798) that the added code is a good fallback to have in case rustdoc gets buggy, and I agree. So remove the FIXME.

This PR is part of #44366 which is E-help-wanted.

r? @jyn514 since you added the FIXME

@rustbot label T-dev-tools