### PR TITLE
Add the `riscv_ext_intrinsics` feature for #114544

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -541,6 +541,8 @@ declare_features! (
     (active, return_position_impl_trait_in_trait, "1.65.0", Some(91611), None),
     /// Allows bounding the return type of AFIT/RPITIT.
     (incomplete, return_type_notation, "1.70.0", Some(109417), None),
+    /// Adds the intrinsics for all RISC-V Ratified Extensions.
+    (incomplete, riscv_ext_intrinsics, "1.71.0", Some(114544), None),
     /// Allows `extern "rust-cold"`.
     (active, rust_cold_cc, "1.63.0", Some(97544), None),
     /// Allows the use of SIMD types in functions declared in `extern` blocks.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1236,6 +1236,7 @@ symbols! {
         rhs,
         rintf32,
         rintf64,
+        riscv_ext_intrinsics,
         riscv_target_feature,
         rlib,
         rotate_left,

--- a/tests/ui/feature-gates/feature-gate-riscv-ext-intrinsics.rs
+++ b/tests/ui/feature-gates/feature-gate-riscv-ext-intrinsics.rs
@@ -1,0 +1,1 @@
+pub fn main() {}


### PR DESCRIPTION
This PR starts the implementation of #114544.

This feature is needed to remove the feature gate on `stdsimd` for the RISC-V intrinsics.