### PR TITLE
Generate better function argument names in global_allocator expansion

### DIFF
--- a/compiler/rustc_ast/src/expand/allocator.rs
+++ b/compiler/rustc_ast/src/expand/allocator.rs
@@ -33,29 +33,41 @@ pub enum AllocatorTy {
 
 pub struct AllocatorMethod {
     pub name: Symbol,
-    pub inputs: &'static [AllocatorTy],
+    pub inputs: &'static [AllocatorMethodInput],
     pub output: AllocatorTy,
+}
+
+pub struct AllocatorMethodInput {
+    pub name: &'static str,
+    pub ty: AllocatorTy,
 }
 
 pub static ALLOCATOR_METHODS: &[AllocatorMethod] = &[
     AllocatorMethod {
         name: sym::alloc,
-        inputs: &[AllocatorTy::Layout],
+        inputs: &[AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout }],
         output: AllocatorTy::ResultPtr,
     },
     AllocatorMethod {
         name: sym::dealloc,
-        inputs: &[AllocatorTy::Ptr, AllocatorTy::Layout],
+        inputs: &[
+            AllocatorMethodInput { name: "ptr", ty: AllocatorTy::Ptr },
+            AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout },
+        ],
         output: AllocatorTy::Unit,
     },
     AllocatorMethod {
         name: sym::realloc,
-        inputs: &[AllocatorTy::Ptr, AllocatorTy::Layout, AllocatorTy::Usize],
+        inputs: &[
+            AllocatorMethodInput { name: "ptr", ty: AllocatorTy::Ptr },
+            AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout },
+            AllocatorMethodInput { name: "new_size", ty: AllocatorTy::Usize },
+        ],
         output: AllocatorTy::ResultPtr,
     },
     AllocatorMethod {
         name: sym::alloc_zeroed,
-        inputs: &[AllocatorTy::Layout],
+        inputs: &[AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout }],
         output: AllocatorTy::ResultPtr,
     },
 ];

--- a/compiler/rustc_codegen_cranelift/src/allocator.rs
+++ b/compiler/rustc_codegen_cranelift/src/allocator.rs
@@ -39,8 +39,8 @@ fn codegen_inner(
     if kind == AllocatorKind::Default {
         for method in ALLOCATOR_METHODS {
             let mut arg_tys = Vec::with_capacity(method.inputs.len());
-            for ty in method.inputs.iter() {
-                match *ty {
+            for input in method.inputs.iter() {
+                match input.ty {
                     AllocatorTy::Layout => {
                         arg_tys.push(usize_ty); // size
                         arg_tys.push(usize_ty); // align

--- a/compiler/rustc_codegen_gcc/src/allocator.rs
+++ b/compiler/rustc_codegen_gcc/src/allocator.rs
@@ -27,8 +27,8 @@ pub(crate) unsafe fn codegen(tcx: TyCtxt<'_>, mods: &mut GccContext, _module_nam
     if kind == AllocatorKind::Default {
         for method in ALLOCATOR_METHODS {
             let mut types = Vec::with_capacity(method.inputs.len());
-            for ty in method.inputs.iter() {
-                match *ty {
+            for input in method.inputs.iter() {
+                match input.ty {
                     AllocatorTy::Layout => {
                         types.push(usize);
                         types.push(usize);

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -34,8 +34,8 @@ pub(crate) unsafe fn codegen(
     if kind == AllocatorKind::Default {
         for method in ALLOCATOR_METHODS {
             let mut args = Vec::with_capacity(method.inputs.len());
-            for ty in method.inputs.iter() {
-                match *ty {
+            for input in method.inputs.iter() {
+                match input.ty {
                     AllocatorTy::Layout => {
                         args.push(usize); // size
                         args.push(usize); // align


### PR DESCRIPTION
Generated code for `#[global_allocator] static ALLOCATOR: Allocator = Allocator;`&mdash;

**Before:**

```rust
const _: () = {
    #[rustc_std_internal_symbol]
    unsafe fn __rust_alloc(arg0: usize, arg1: usize) -> *mut u8 {
        ::core::alloc::GlobalAlloc::alloc(
            &ALLOCATOR,
            ::core::alloc::Layout::from_size_align_unchecked(arg0, arg1),
        )
    }
    #[rustc_std_internal_symbol]
    unsafe fn __rust_dealloc(arg0: *mut u8, arg1: usize, arg2: usize) -> () {
        ::core::alloc::GlobalAlloc::dealloc(
            &ALLOCATOR,
            arg0,
            ::core::alloc::Layout::from_size_align_unchecked(arg1, arg2),
        )
    }
    #[rustc_std_internal_symbol]
    unsafe fn __rust_realloc(
        arg0: *mut u8,
        arg1: usize,
        arg2: usize,
        arg3: usize,
    ) -> *mut u8 {
        ::core::alloc::GlobalAlloc::realloc(
            &ALLOCATOR,
            arg0,
            ::core::alloc::Layout::from_size_align_unchecked(arg1, arg2),
            arg3,
        )
    }
    #[rustc_std_internal_symbol]
    unsafe fn __rust_alloc_zeroed(arg0: usize, arg1: usize) -> *mut u8 {
        ::core::alloc::GlobalAlloc::alloc_zeroed(
            &ALLOCATOR,
            ::core::alloc::Layout::from_size_align_unchecked(arg0, arg1),
        )
    }
};
```

**After:**

```rust
const _: () = {
    #[rustc_std_internal_symbol]
    unsafe fn __rust_alloc(size: usize, align: usize) -> *mut u8 {
        ::core::alloc::GlobalAlloc::alloc(
            &ALLOCATOR,
            ::core::alloc::Layout::from_size_align_unchecked(size, align),
        )
    }
    #[rustc_std_internal_symbol]
    unsafe fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize) -> () {
        ::core::alloc::GlobalAlloc::dealloc(
            &ALLOCATOR,
            ptr,
            ::core::alloc::Layout::from_size_align_unchecked(size, align),
        )
    }
    #[rustc_std_internal_symbol]
    unsafe fn __rust_realloc(
        ptr: *mut u8,
        size: usize,
        align: usize,
        new_size: usize,
    ) -> *mut u8 {
        ::core::alloc::GlobalAlloc::realloc(
            &ALLOCATOR,
            ptr,
            ::core::alloc::Layout::from_size_align_unchecked(size, align),
            new_size,
        )
    }
    #[rustc_std_internal_symbol]
    unsafe fn __rust_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
        ::core::alloc::GlobalAlloc::alloc_zeroed(
            &ALLOCATOR,
            ::core::alloc::Layout::from_size_align_unchecked(size, align),
        )
    }
};
```