### PR TITLE
Issue numbers are enforced on active features; remove FIXME

### DIFF
--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -108,8 +108,6 @@ impl UnstableFeatures {
 
 fn find_lang_feature_issue(feature: Symbol) -> Option<NonZeroU32> {
     if let Some(info) = ACTIVE_FEATURES.iter().find(|t| t.name == feature) {
-        // FIXME (#28244): enforce that active features have issue numbers
-        // assert!(info.issue.is_some())
         info.issue
     } else {
         // search in Accepted, Removed, or Stable Removed features


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/51090 tidy enforces that active features have an issue number, so remove the FIXME.

This PR is part of #44366 which is E-help-wanted.
