### PR TITLE
Remove FIXME about NLL diagnostic that is already improved

### DIFF
--- a/tests/ui/nll/guarantor-issue-46974.rs
+++ b/tests/ui/nll/guarantor-issue-46974.rs
@@ -9,7 +9,6 @@ fn foo(s: &mut (i32,)) -> i32 {
 }
 
 fn bar(s: &Box<(i32,)>) -> &'static i32 {
-    // FIXME(#46983): error message should be better
     &s.0 //~ ERROR lifetime may not live long enough
 }
 

--- a/tests/ui/nll/guarantor-issue-46974.stderr
+++ b/tests/ui/nll/guarantor-issue-46974.stderr
@@ -10,11 +10,10 @@ LL |     *x
    |     -- borrow later used here
 
 error: lifetime may not live long enough
-  --> $DIR/guarantor-issue-46974.rs:13:5
+  --> $DIR/guarantor-issue-46974.rs:12:5
    |
 LL | fn bar(s: &Box<(i32,)>) -> &'static i32 {
    |           - let's call the lifetime of this reference `'1`
-LL |     // FIXME(#46983): error message should be better
 LL |     &s.0
    |     ^^^^ returning this value requires that `'1` must outlive `'static`
 


### PR DESCRIPTION
The FIXME was added in #46984 when the diagnostic message looked like this:

    // FIXME(#46983): error message should be better
    &s.0 //~ ERROR free region `` does not outlive free region `'static`

The message was improved in #90667 and now looks like this:

    &s.0 //~ ERROR lifetime may not live long enough

but the FIXME was not removed. The issue #46983 about that diagnostics should be improved has been closed. We can remove the FIXME now.

(This PR was made for #44366.)