### PR TITLE
remove blanket-Freeze for PhantomData

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -95,7 +95,6 @@ unsafe impl Sync for [u8; 16] {}
 #[lang = "freeze"]
 unsafe auto trait Freeze {}
 
-unsafe impl<T: ?Sized> Freeze for PhantomData<T> {}
 unsafe impl<T: ?Sized> Freeze for *const T {}
 unsafe impl<T: ?Sized> Freeze for *mut T {}
 unsafe impl<T: ?Sized> Freeze for &T {}

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -91,7 +91,6 @@ unsafe impl Sync for [u8; 16] {}
 #[lang = "freeze"]
 unsafe auto trait Freeze {}
 
-unsafe impl<T: ?Sized> Freeze for PhantomData<T> {}
 unsafe impl<T: ?Sized> Freeze for *const T {}
 unsafe impl<T: ?Sized> Freeze for *mut T {}
 unsafe impl<T: ?Sized> Freeze for &T {}

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -318,7 +318,7 @@ pub struct Rc<
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
 > {
     ptr: NonNull<RcBox<T>>,
-    phantom: PhantomData<RcBox<T>>,
+    phantom: PhantomData<Box<RcBox<T>>>,
     alloc: A,
 }
 
@@ -3400,7 +3400,7 @@ fn data_offset_align(align: usize) -> usize {
 #[derive(Debug)]
 pub struct UniqueRc<T> {
     ptr: NonNull<RcBox<T>>,
-    phantom: PhantomData<RcBox<T>>,
+    phantom: PhantomData<Box<RcBox<T>>>,
 }
 
 impl<T> UniqueRc<T> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -251,7 +251,7 @@ pub struct Arc<
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
 > {
     ptr: NonNull<ArcInner<T>>,
-    phantom: PhantomData<ArcInner<T>>,
+    phantom: PhantomData<Box<ArcInner<T>>>,
     alloc: A,
 }
 

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -872,7 +872,6 @@ pub(crate) unsafe auto trait Freeze {}
 impl<T: ?Sized> !Freeze for UnsafeCell<T> {}
 marker_impls! {
     unsafe Freeze for
-        {T: ?Sized} PhantomData<T>,
         {T: ?Sized} *const T,
         {T: ?Sized} *mut T,
         {T: ?Sized} &T,

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -1,6 +1,6 @@
 use crate::convert::From;
 use crate::fmt;
-use crate::marker::{PhantomData, Unsize};
+use crate::marker::{Freeze, PhantomData, Unsize};
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
 use crate::ptr::NonNull;
 
@@ -57,6 +57,10 @@ unsafe impl<T: Send + ?Sized> Send for Unique<T> {}
 /// `Unique` must enforce it.
 #[unstable(feature = "ptr_internals", issue = "none")]
 unsafe impl<T: Sync + ?Sized> Sync for Unique<T> {}
+
+/// `Unique` pointers are always `Freeze` since any interior mutability that might exist in `T` is
+/// masked by the pointer indirection.
+unsafe impl<T: ?Sized> Freeze for Unique<T> {}
 
 #[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: Sized> Unique<T> {

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 const ISSUES_ENTRY_LIMIT: usize = 1891;
-const ROOT_ENTRY_LIMIT: usize = 866;
+const ROOT_ENTRY_LIMIT: usize = 867; // this includes files *and* folders!
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/ui/unsafe-cell/phantom-data-not-freeze.rs
+++ b/tests/ui/unsafe-cell/phantom-data-not-freeze.rs
@@ -1,0 +1,15 @@
+use std::cell::UnsafeCell;
+use std::marker::PhantomData;
+
+// This checks that `PhantomData` does not entirely mask interior mutability.
+
+trait Trait {
+    const C: (u32, PhantomData<UnsafeCell<u32>>);
+}
+
+fn bar<T: Trait>() {
+    let x: &'static (u32, PhantomData<UnsafeCell<u32>>) = &T::C;
+    //~^ ERROR: dropped while borrowed
+}
+
+fn main() {}

--- a/tests/ui/unsafe-cell/phantom-data-not-freeze.stderr
+++ b/tests/ui/unsafe-cell/phantom-data-not-freeze.stderr
@@ -1,0 +1,14 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/phantom-data-not-freeze.rs:11:60
+   |
+LL |     let x: &'static (u32, PhantomData<UnsafeCell<u32>>) = &T::C;
+   |            --------------------------------------------    ^^^^ creates a temporary value which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
+LL |
+LL | }
+   | - temporary value is freed at the end of this statement
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0716`.


### PR DESCRIPTION
The exact behavior of types that are only partially covered by `UnsafeCell` is still [up for debate](https://github.com/rust-lang/unsafe-code-guidelines/issues/236). So we shouldn't rush to the conclusion that `PhantomData<UnsafeCell<T>>` has no interior mutability. Let's take back that blanket impl. This will need a crater run because it is a breaking change -- but the locations where `Freeze` makes the difference are few and far between, so the impact is likely to be low. (`UnsafeCell` is also `!Sync` and that has the much bigger impact, and is *not* masked by `PhantomData`.)

I couldn't find an existing ui test folder that fits, so I created a new one. tidy doesn't seem to like that though, it complains about new files *and* new folders, which is kind of counterproductive? I had to silence it the hard way.