### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -164,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -797,7 +797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
 dependencies = [
  "nix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1191,7 +1191,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1910,7 +1910,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.2",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1927,7 +1927,7 @@ checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi 0.3.2",
  "rustix 0.38.2",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2320,16 +2320,16 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "miow"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
+checksum = "359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4561,7 +4561,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4574,7 +4574,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.3",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4611,11 +4611,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix 0.37.22",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5085,7 +5085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix 0.37.22",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5264,7 +5264,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5874,21 +5874,6 @@ checksum = "2f5bca94a32bf1e6a376522b6601275a3b611ee885ec0f1b6a05f17e8cfd3385"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5902,13 +5887,13 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5919,21 +5904,9 @@ checksum = "b34c9a3b28cb41db7385546f7f9a8179348dffc89923dde66857b1ba5312f6b4"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5943,21 +5916,9 @@ checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5967,33 +5928,15 @@ checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/compiler/rustc_ast/src/expand/allocator.rs
+++ b/compiler/rustc_ast/src/expand/allocator.rs
@@ -33,29 +33,41 @@ pub enum AllocatorTy {
 
 pub struct AllocatorMethod {
     pub name: Symbol,
-    pub inputs: &'static [AllocatorTy],
+    pub inputs: &'static [AllocatorMethodInput],
     pub output: AllocatorTy,
+}
+
+pub struct AllocatorMethodInput {
+    pub name: &'static str,
+    pub ty: AllocatorTy,
 }
 
 pub static ALLOCATOR_METHODS: &[AllocatorMethod] = &[
     AllocatorMethod {
         name: sym::alloc,
-        inputs: &[AllocatorTy::Layout],
+        inputs: &[AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout }],
         output: AllocatorTy::ResultPtr,
     },
     AllocatorMethod {
         name: sym::dealloc,
-        inputs: &[AllocatorTy::Ptr, AllocatorTy::Layout],
+        inputs: &[
+            AllocatorMethodInput { name: "ptr", ty: AllocatorTy::Ptr },
+            AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout },
+        ],
         output: AllocatorTy::Unit,
     },
     AllocatorMethod {
         name: sym::realloc,
-        inputs: &[AllocatorTy::Ptr, AllocatorTy::Layout, AllocatorTy::Usize],
+        inputs: &[
+            AllocatorMethodInput { name: "ptr", ty: AllocatorTy::Ptr },
+            AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout },
+            AllocatorMethodInput { name: "new_size", ty: AllocatorTy::Usize },
+        ],
         output: AllocatorTy::ResultPtr,
     },
     AllocatorMethod {
         name: sym::alloc_zeroed,
-        inputs: &[AllocatorTy::Layout],
+        inputs: &[AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout }],
         output: AllocatorTy::ResultPtr,
     },
 ];

--- a/compiler/rustc_codegen_cranelift/src/allocator.rs
+++ b/compiler/rustc_codegen_cranelift/src/allocator.rs
@@ -39,8 +39,8 @@ fn codegen_inner(
     if kind == AllocatorKind::Default {
         for method in ALLOCATOR_METHODS {
             let mut arg_tys = Vec::with_capacity(method.inputs.len());
-            for ty in method.inputs.iter() {
-                match *ty {
+            for input in method.inputs.iter() {
+                match input.ty {
                     AllocatorTy::Layout => {
                         arg_tys.push(usize_ty); // size
                         arg_tys.push(usize_ty); // align

--- a/compiler/rustc_codegen_gcc/src/allocator.rs
+++ b/compiler/rustc_codegen_gcc/src/allocator.rs
@@ -27,8 +27,8 @@ pub(crate) unsafe fn codegen(tcx: TyCtxt<'_>, mods: &mut GccContext, _module_nam
     if kind == AllocatorKind::Default {
         for method in ALLOCATOR_METHODS {
             let mut types = Vec::with_capacity(method.inputs.len());
-            for ty in method.inputs.iter() {
-                match *ty {
+            for input in method.inputs.iter() {
+                match input.ty {
                     AllocatorTy::Layout => {
                         types.push(usize);
                         types.push(usize);

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -34,8 +34,8 @@ pub(crate) unsafe fn codegen(
     if kind == AllocatorKind::Default {
         for method in ALLOCATOR_METHODS {
             let mut args = Vec::with_capacity(method.inputs.len());
-            for ty in method.inputs.iter() {
-                match *ty {
+            for input in method.inputs.iter() {
+                match input.ty {
                     AllocatorTy::Layout => {
                         args.push(usize); // size
                         args.push(usize); // align

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -826,10 +826,10 @@ where
                 // predicate like `where Self: Sized` with `Self = dyn Trait`.
                 // See #102553 for an example of such a predicate.
                 if src.layout().is_unsized() {
-                    throw_inval!(SizeOfUnsizedType(src.layout().ty));
+                    throw_inval!(ConstPropNonsense);
                 }
                 if dest.layout().is_unsized() {
-                    throw_inval!(SizeOfUnsizedType(dest.layout().ty));
+                    throw_inval!(ConstPropNonsense);
                 }
                 assert_eq!(src.layout().size, dest.layout().size);
                 // Yay, we got a value that we can write directly.

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -101,7 +101,7 @@ where
         let (meta, offset) = if field_layout.is_unsized() {
             if base.layout().is_sized() {
                 // An unsized field of a sized type? Sure...
-                // But const-prop actually feeds us such nonsense MIR!
+                // But const-prop actually feeds us such nonsense MIR! (see test `const_prop/issue-86351.rs`)
                 throw_inval!(ConstPropNonsense);
             }
             let base_meta = base.meta(self)?;

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -269,7 +269,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let ty = self.subst_from_current_frame_and_normalize_erasing_regions(ty)?;
                 let layout = self.layout_of(ty)?;
                 if let mir::NullOp::SizeOf | mir::NullOp::AlignOf = null_op && layout.is_unsized() {
-                    // FIXME: This should be a span_bug (#80742)
+                    // FIXME: This should be a span_bug, but const generics can run MIR
+                    // that is not properly type-checked yet (#97477).
                     self.tcx.sess.delay_span_bug(
                         self.frame().current_span(),
                         format!("{null_op:?} MIR operator called for unsized type {ty}"),

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -108,8 +108,6 @@ impl UnstableFeatures {
 
 fn find_lang_feature_issue(feature: Symbol) -> Option<NonZeroU32> {
     if let Some(info) = ACTIVE_FEATURES.iter().find(|t| t.name == feature) {
-        // FIXME (#28244): enforce that active features have issue numbers
-        // assert!(info.issue.is_some())
         info.issue
     } else {
         // search in Accepted, Removed, or Stable Removed features

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -29,7 +29,7 @@ anyhow = "1"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-miow = "0.5"
+miow = "0.6"
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.48.0"

--- a/tests/ui/const_prop/ice-issue-111353.rs
+++ b/tests/ui/const_prop/ice-issue-111353.rs
@@ -1,0 +1,7 @@
+// build-pass
+#![crate_type = "lib"]
+#![feature(unsized_fn_params)]
+
+pub fn f(mut x: [i32]) {
+    x[0] = 1;
+}

--- a/tests/ui/const_prop/ice-issue-96944.rs
+++ b/tests/ui/const_prop/ice-issue-96944.rs
@@ -1,0 +1,26 @@
+// build-pass
+#![crate_type = "lib"]
+#![allow(arithmetic_overflow)]
+
+pub trait BitSplit {
+    type Half;
+    fn merge(halves: [Self::Half; 2]) -> Self;
+}
+
+macro_rules! impl_ints {
+    ($int:ty => $half:ty; $mask:expr) => {
+        impl BitSplit for $int {
+            type Half = $half;
+            #[inline]
+            fn merge(halves: [Self::Half; 2]) -> Self {
+                const HALF_SIZE: usize = std::mem::size_of::<$half>() * 8;
+                (halves[0] << HALF_SIZE) as $int | halves[1] as $int
+            }
+        }
+    };
+}
+
+impl_ints!(u128 => u64; 0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF);
+impl_ints!( u64 => u32;                     0x0000_0000_FFFF_FFFF);
+impl_ints!( u32 => u16;                               0x0000_FFFF);
+impl_ints!( u16 =>  u8;                                    0x00FF);

--- a/tests/ui/nll/guarantor-issue-46974.rs
+++ b/tests/ui/nll/guarantor-issue-46974.rs
@@ -9,7 +9,6 @@ fn foo(s: &mut (i32,)) -> i32 {
 }
 
 fn bar(s: &Box<(i32,)>) -> &'static i32 {
-    // FIXME(#46983): error message should be better
     &s.0 //~ ERROR lifetime may not live long enough
 }
 

--- a/tests/ui/nll/guarantor-issue-46974.stderr
+++ b/tests/ui/nll/guarantor-issue-46974.stderr
@@ -10,11 +10,10 @@ LL |     *x
    |     -- borrow later used here
 
 error: lifetime may not live long enough
-  --> $DIR/guarantor-issue-46974.rs:13:5
+  --> $DIR/guarantor-issue-46974.rs:12:5
    |
 LL | fn bar(s: &Box<(i32,)>) -> &'static i32 {
    |           - let's call the lifetime of this reference `'1`
-LL |     // FIXME(#46983): error message should be better
 LL |     &s.0
    |     ^^^^ returning this value requires that `'1` must outlive `'static`
 


### PR DESCRIPTION
Successful merges:

 - #114535 (bump schannel, miow to drop windows-sys 0.42)
 - #114542 (interpret: use ConstPropNonsense for more const-prop induced issues)
 - #114543 (add tests for some fixed ConstProp ICEs)
 - #114550 (Generate better function argument names in global_allocator expansion)
 - #114556 (Issue numbers are enforced on active features; remove FIXME)
 - #114558 (Remove FIXME about NLL diagnostic that is already improved)

Failed merges:

 - #114485 (Add trait decls to SMIR)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114535,114542,114543,114550,114556,114558)
<!-- homu-ignore:end -->