### PR TITLE
Stop using identity args for RPIT wf checks

### DIFF
--- a/tests/ui/type-alias-impl-trait/wf-check-rpit-lifetimes.rs
+++ b/tests/ui/type-alias-impl-trait/wf-check-rpit-lifetimes.rs
@@ -1,0 +1,19 @@
+//check-pass
+
+pub struct Key;
+#[derive(Clone)]
+pub struct Value;
+
+use std::collections::HashMap;
+
+pub struct DiagnosticBuilder<'db> {
+    inner: HashMap<&'db Key, Vec<&'db Value>>,
+}
+
+impl<'db> DiagnosticBuilder<'db> {
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'db Key, impl Iterator<Item = &'a Value>)> {
+        self.inner.iter().map(|(key, values)| (*key, values.iter().map(|v| *v)))
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
and instead load the args from the single use of a RPIT in its parent function's return type

follow up to https://github.com/rust-lang/rust/pull/113661

fixes https://github.com/rust-lang/rust/issues/114285

Before this PR, we used the RPIT identity substs for checking its hidden type's bounds. This means various late bound lifetimes from the function now became early bound lifetimes on the RPIT. That worked just fine, until you had nested RPITs that capture lifetimes, too. By accident it mostly worked, unless closures were involved.

While investigating this mess, I realized that we were going about all of this the wrong way around. Instead of trying to patch up the nested opaque types' hidden types, we could also just find the correct generic args of the opaque type that we're checking and not have to patch up anything after the fact.

So now, we walk the return type of the function, find the hidden type within that return type, and take its generic arguments. These generic arguments are in terms of the function signature, so they will have all late bound lifetimes still be in a binder. So we dismiss the binder by replacing all late bound vars in it with new inference vars, and then run the previous checks (minus the patching up, which was now dead code).

