### PR TITLE
impl Default for ExitCode

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1594,7 +1594,7 @@ impl From<io::Stderr> for Stdio {
 pub struct ExitStatus(imp::ExitStatus);
 
 /// The default value is one which indicates successful completion.
-#[stable(feature = "process-exitcode-default", since = "1.73.0")]
+#[stable(feature = "process_exitstatus_default", since = "1.73.0")]
 impl Default for ExitStatus {
     fn default() -> Self {
         // Ideally this would be done by ExitCode::default().into() but that is complicated.
@@ -1961,7 +1961,7 @@ impl ExitCode {
 }
 
 /// The default value is [`ExitCode::SUCCESS`]
-#[stable(feature = "process-exitcode-default", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "process_exitcode_default", since = "CURRENT_RUSTC_VERSION")]
 impl Default for ExitCode {
     fn default() -> Self {
         ExitCode::SUCCESS

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1960,6 +1960,14 @@ impl ExitCode {
     }
 }
 
+/// The default value is [`ExitCode::SUCCESS`]
+#[stable(feature = "process-exitcode-default", since = "CURRENT_RUSTC_VERSION")]
+impl Default for ExitCode {
+    fn default() -> Self {
+        ExitCode::SUCCESS
+    }
+}
+
 #[stable(feature = "process_exitcode", since = "1.61.0")]
 impl From<u8> for ExitCode {
     /// Construct an `ExitCode` from an arbitrary u8 value.


### PR DESCRIPTION
As suggested here
  https://github.com/rust-lang/rust/pull/106425#issuecomment-1382952598

Needs FCP since this is an insta-stable impl.

Ideally we would have `impl From<ExitCode> for ExitStatus` and implement the default `ExitStatus` using that.   That is sadly not so easy because of the various strange confusions about `ExitCode` (unix: exit status) vs `ExitStatus` (unix: wait status) in the not-really-unix platforms in `library//src/sys/unix/process`.  I'll try to follow that up.