### PR TITLE
Rename method in `opt-dist`

### DIFF
--- a/src/tools/opt-dist/src/environment/linux.rs
+++ b/src/tools/opt-dist/src/environment/linux.rs
@@ -14,7 +14,7 @@ impl Environment for LinuxEnvironment {
         Utf8PathBuf::from("/checkout")
     }
 
-    fn downloaded_llvm_dir(&self) -> Utf8PathBuf {
+    fn host_llvm_dir(&self) -> Utf8PathBuf {
         Utf8PathBuf::from("/rustroot")
     }
 

--- a/src/tools/opt-dist/src/environment/mod.rs
+++ b/src/tools/opt-dist/src/environment/mod.rs
@@ -15,8 +15,8 @@ pub trait Environment {
     /// The rustc checkout, where the compiler source is located.
     fn checkout_path(&self) -> Utf8PathBuf;
 
-    /// Path to the downloaded host LLVM.
-    fn downloaded_llvm_dir(&self) -> Utf8PathBuf;
+    /// Path to the host LLVM used to compile LLVM in `src/llvm-project`.
+    fn host_llvm_dir(&self) -> Utf8PathBuf;
 
     /// Directory where the optimization artifacts (PGO/BOLT profiles, etc.)
     /// will be stored.

--- a/src/tools/opt-dist/src/environment/windows.rs
+++ b/src/tools/opt-dist/src/environment/windows.rs
@@ -24,7 +24,7 @@ impl Environment for WindowsEnvironment {
         self.checkout_dir.clone()
     }
 
-    fn downloaded_llvm_dir(&self) -> Utf8PathBuf {
+    fn host_llvm_dir(&self) -> Utf8PathBuf {
         self.checkout_path().join("citools").join("clang-rust")
     }
 

--- a/src/tools/opt-dist/src/training.rs
+++ b/src/tools/opt-dist/src/training.rs
@@ -81,7 +81,7 @@ fn merge_llvm_profiles(
     profdata: LlvmProfdata,
 ) -> anyhow::Result<()> {
     let llvm_profdata = match profdata {
-        LlvmProfdata::Host => env.downloaded_llvm_dir().join("bin/llvm-profdata"),
+        LlvmProfdata::Host => env.host_llvm_dir().join("bin/llvm-profdata"),
         LlvmProfdata::Target => env
             .build_artifacts()
             .join("llvm")


### PR DESCRIPTION
This makes it clearer that the LLVM is the host one (it doesn't necessarily have to be downloaded). On Linux, it comes from the Dockerfile, on Windows it's downloaded.

Suggested here: https://github.com/rust-lang/rust/pull/114344#discussion_r1285596217

r? @lqd