### PR TITLE
fix: not insert missing lifetime for `ConstParamTy`

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2404,7 +2404,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                         should_continue = suggest(err, false, span, message, sugg);
                     }
                 }
-                LifetimeRibKind::Item => break,
+                LifetimeRibKind::Item | LifetimeRibKind::ConstParamTy => break,
                 _ => {}
             }
             if !should_continue {
@@ -2510,7 +2510,9 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
             .lifetime_ribs
             .iter()
             .rev()
-            .take_while(|rib| !matches!(rib.kind, LifetimeRibKind::Item))
+            .take_while(|rib| {
+                !matches!(rib.kind, LifetimeRibKind::Item | LifetimeRibKind::ConstParamTy)
+            })
             .flat_map(|rib| rib.bindings.iter())
             .map(|(&ident, &res)| (ident, res))
             .filter(|(ident, _)| ident.name != kw::UnderscoreLifetime)

--- a/tests/ui/const-generics/lifetime-in-const-param.rs
+++ b/tests/ui/const-generics/lifetime-in-const-param.rs
@@ -1,0 +1,9 @@
+// https://github.com/rust-lang/rust/issues/113462
+
+struct S2<'b>(&'b ());
+
+struct S<'a, const N: S2>(&'a ());
+//~^ ERROR missing lifetime specifier [E0106]
+//~| ERROR `S2<'_>` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/tests/ui/const-generics/lifetime-in-const-param.stderr
+++ b/tests/ui/const-generics/lifetime-in-const-param.stderr
@@ -1,0 +1,18 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/lifetime-in-const-param.rs:5:23
+   |
+LL | struct S<'a, const N: S2>(&'a ());
+   |                       ^^ expected named lifetime parameter
+
+error: `S2<'_>` is forbidden as the type of a const generic parameter
+  --> $DIR/lifetime-in-const-param.rs:5:23
+   |
+LL | struct S<'a, const N: S2>(&'a ());
+   |                       ^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: more complex types are supported with `#![feature(adt_const_params)]`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -3,11 +3,6 @@ error[E0106]: missing lifetime specifier
    |
 LL | fn d<const C: S>() {}
    |               ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL | fn d<'a, const C: S<'a>>() {}
-   |      +++           ++++
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/unusual-rib-combinations.rs:29:22


### PR DESCRIPTION
Fixes #113462

We should ignore the missing lifetime, as it's illegal to include a lifetime in a const param.

r? @compiler-errors 