### PR TITLE
interpret: remove incomplete protection against invalid where clauses

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -303,8 +303,6 @@ const_eval_remainder_overflow =
     overflow in signed remainder (dividing MIN by -1)
 const_eval_scalar_size_mismatch =
     scalar size mismatch: expected {$target_size} bytes but got {$data_size} bytes instead
-const_eval_size_of_unsized =
-    size_of called on unsized type `{$ty}`
 const_eval_size_overflow =
     overflow computing total size of `{$name}`
 

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -862,7 +862,6 @@ impl<'tcx> ReportErrorExt for InvalidProgramInfo<'tcx> {
             InvalidProgramInfo::FnAbiAdjustForForeignAbi(_) => {
                 rustc_middle::error::middle_adjust_for_foreign_abi_error
             }
-            InvalidProgramInfo::SizeOfUnsizedType(_) => const_eval_size_of_unsized,
             InvalidProgramInfo::ConstPropNonsense => {
                 panic!("We had const-prop nonsense, this should never be printed")
             }
@@ -889,9 +888,6 @@ impl<'tcx> ReportErrorExt for InvalidProgramInfo<'tcx> {
             ) => {
                 builder.set_arg("arch", arch);
                 builder.set_arg("abi", abi.name());
-            }
-            InvalidProgramInfo::SizeOfUnsizedType(ty) => {
-                builder.set_arg("ty", ty);
             }
         }
     }

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -269,13 +269,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let ty = self.subst_from_current_frame_and_normalize_erasing_regions(ty)?;
                 let layout = self.layout_of(ty)?;
                 if let mir::NullOp::SizeOf | mir::NullOp::AlignOf = null_op && layout.is_unsized() {
-                    // FIXME: This should be a span_bug, but const generics can run MIR
-                    // that is not properly type-checked yet (#97477).
-                    self.tcx.sess.delay_span_bug(
+                    span_bug!(
                         self.frame().current_span(),
-                        format!("{null_op:?} MIR operator called for unsized type {ty}"),
+                        "{null_op:?} MIR operator called for unsized type {ty}",
                     );
-                    throw_inval!(SizeOfUnsizedType(ty));
                 }
                 let val = match null_op {
                     mir::NullOp::SizeOf => layout.size.bytes(),

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -184,8 +184,6 @@ pub enum InvalidProgramInfo<'tcx> {
     /// (which unfortunately typeck does not reject).
     /// Not using `FnAbiError` as that contains a nested `LayoutError`.
     FnAbiAdjustForForeignAbi(call::AdjustForForeignAbiError),
-    /// SizeOf of unsized type was requested.
-    SizeOfUnsizedType(Ty<'tcx>),
     /// We are runnning into a nonsense situation due to ConstProp violating our invariants.
     ConstPropNonsense,
 }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1645,7 +1645,7 @@ impl<'test> TestCx<'test> {
         if self.props.known_bug {
             if !expected_errors.is_empty() {
                 self.fatal_proc_rec(
-                    "`known_bug` tests should not have an expected errors",
+                    "`known_bug` tests should not have an expected error",
                     proc_res,
                 );
             }

--- a/tests/ui/const-generics/generic_const_exprs/issue-80742.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-80742.rs
@@ -1,4 +1,9 @@
 // check-fail
+// known-bug: #97477
+// failure-status: 101
+// normalize-stderr-test "note: .*\n\n" -> ""
+// normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+// rustc-env:RUST_BACKTRACE=0
 
 // This test used to cause an ICE in rustc_mir::interpret::step::eval_rvalue_into_place
 
@@ -27,6 +32,5 @@ where
 }
 
 fn main() {
-    let dst = Inline::<dyn Debug>::new(0); //~ ERROR
-    //~^ ERROR
+    let dst = Inline::<dyn Debug>::new(0);
 }

--- a/tests/ui/const-generics/generic_const_exprs/issue-80742.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-80742.stderr
@@ -1,71 +1,10 @@
-error[E0080]: evaluation of `Inline::<dyn Debug>::{constant#0}` failed
+error: internal compiler error: compiler/rustc_const_eval/src/interpret/step.rs:272:21: SizeOf MIR operator called for unsized type dyn Debug
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: size_of called on unsized type `dyn Debug`
-   |
-note: inside `std::mem::size_of::<dyn Debug>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `Inline::<dyn Debug>::{constant#0}`
-  --> $DIR/issue-80742.rs:22:10
-   |
-LL |     [u8; size_of::<T>() + 1]: ,
-   |          ^^^^^^^^^^^^^^
 
-error[E0599]: the function or associated item `new` exists for struct `Inline<dyn Debug>`, but its trait bounds were not satisfied
-  --> $DIR/issue-80742.rs:30:36
-   |
-LL | struct Inline<T>
-   | ---------------- function or associated item `new` not found for this struct
-...
-LL |     let dst = Inline::<dyn Debug>::new(0);
-   |                                    ^^^ function or associated item cannot be called on `Inline<dyn Debug>` due to unsatisfied trait bounds
-  --> $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-   |
-   = note: doesn't satisfy `dyn Debug: Sized`
-   |
-note: trait bound `dyn Debug: Sized` was not satisfied
-  --> $DIR/issue-80742.rs:20:6
-   |
-LL | impl<T> Inline<T>
-   |      ^  ---------
-   |      |
-   |      unsatisfied trait bound introduced here
-help: consider relaxing the type parameter's implicit `Sized` bound
-   |
-LL | impl<T: ?Sized> Inline<T>
-   |       ++++++++
+Box<dyn Any>
+query stack during panic:
+#0 [eval_to_allocation_raw] const-evaluating + checking `<impl at $DIR/issue-80742.rs:25:1: 25:18>::{constant#0}`
+#1 [eval_to_valtree] evaluating type-level constant
+end of query stack
+error: aborting due to previous error
 
-error[E0080]: evaluation of `Inline::<dyn Debug>::{constant#0}` failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: size_of called on unsized type `dyn Debug`
-   |
-note: inside `std::mem::size_of::<dyn Debug>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `Inline::<dyn Debug>::{constant#0}`
-  --> $DIR/issue-80742.rs:14:10
-   |
-LL |     [u8; size_of::<T>() + 1]: ,
-   |          ^^^^^^^^^^^^^^
-
-error[E0277]: the size for values of type `dyn Debug` cannot be known at compilation time
-  --> $DIR/issue-80742.rs:30:15
-   |
-LL |     let dst = Inline::<dyn Debug>::new(0);
-   |               ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `dyn Debug`
-note: required by a bound in `Inline`
-  --> $DIR/issue-80742.rs:12:15
-   |
-LL | struct Inline<T>
-   |               ^ required by this bound in `Inline`
-help: consider relaxing the implicit `Sized` restriction
-   |
-LL | struct Inline<T: ?Sized>
-   |                ++++++++
-
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0080, E0277, E0599.
-For more information about an error, try `rustc --explain E0080`.


### PR DESCRIPTION
Cc https://github.com/rust-lang/rust/issues/97477, https://github.com/rust-lang/project-const-generics/issues/37

r? @lcnr 