### PR TITLE
Try disabling BOLT to test libLLVM17.so size with PGO/LTO only

### DIFF
--- a/src/tools/opt-dist/src/environment/linux.rs
+++ b/src/tools/opt-dist/src/environment/linux.rs
@@ -38,7 +38,7 @@ impl Environment for LinuxEnvironment {
     }
 
     fn supports_bolt(&self) -> bool {
-        true
+        false
     }
 
     fn supports_shared_llvm(&self) -> bool {


### PR DESCRIPTION
Test temporarily disabling BOLT, to see the size difference on libLLVM17.so when only using PGO and LTO.

r? @ghost