### PR TITLE
CI: switch to old docker builder to temporary solve caching issue

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -61,7 +61,7 @@ ENV CC=clang CXX=clang++
 # Should also be changed in the opt-dist tool for other environments.
 ENV PERF_COMMIT 8b2ac3042e1ff2c0074455a0a3618adef97156b1
 RUN curl -LS -o perf.zip https://github.com/rust-lang/rustc-perf/archive/$PERF_COMMIT.zip && \
-    unzip perf.zip && \
+    unzip -q perf.zip && \
     mv rustc-perf-$PERF_COMMIT rustc-perf && \
     rm perf.zip
 

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -90,6 +90,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
         context="$script_dir"
     fi
     echo "::group::Building docker image for $image"
+    docker images
     retry docker \
       build \
       --rm \
@@ -97,6 +98,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       -f "$dockerfile" \
       "$context"
     echo "::endgroup::"
+    docker images
 
     if [ "$CI" != "" ]; then
       s3url="s3://$SCCACHE_BUCKET/docker/$cksum"

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -108,6 +108,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       if ! grep -q "$digest" <(echo "$loaded_images"); then
         echo "Uploading finished image to $url"
         set +e
+        docker history rust-ci
         docker history -q rust-ci | \
           grep -v missing | \
           xargs docker save | \

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -76,8 +76,8 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       echo "Loading images into docker"
       # docker load sometimes hangs in the CI, so time out after 10 minutes with TERM,
       # KILL after 12 minutes
-      loaded_images=$(/usr/bin/timeout -k 720 600 docker load -i /tmp/rustci_docker_cache \
-        | sed 's/.* sha/sha/')
+      # FIXME: why can't parse output here?
+      loaded_images=$(docker load -i /tmp/rustci_docker_cache)
       set -e
       printf "Downloaded containers:\n$loaded_images\n"
     fi

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -93,7 +93,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
     docker images
     retry docker \
       build \
-      --rm \
+      --rm=false \
       -t rust-ci \
       -f "$dockerfile" \
       "$context"


### PR DESCRIPTION
Switch to old docker builder to temporary solve caching issues.
Also silence unzip, it too noisy