### PR TITLE
CI: use smaller machines in PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
       matrix:
         include:
           - name: mingw-check
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-4core-16gb
             env: {}
           - name: mingw-check-tidy
-            os: ubuntu-20.04-16core-64gb
+            os: ubuntu-20.04-4core-16gb
             env: {}
           - name: x86_64-gnu-llvm-15
             os: ubuntu-20.04-16core-64gb

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -318,10 +318,10 @@ jobs:
       matrix:
         include:
           - name: mingw-check
-            <<: *job-linux-16c
+            <<: *job-linux-4c
 
           - name: mingw-check-tidy
-            <<: *job-linux-16c
+            <<: *job-linux-4c
 
           - name: x86_64-gnu-llvm-15
             <<: *job-linux-16c


### PR DESCRIPTION
mingw-check job-linux-16c -> job-linux-4c
~job-linux-4c 20 min in auto job
~job-linux-16c 13 min in pr job
with current pr regressed to almost 21 min, it's ok.

mingw-check-tidy job-linux-16c -> job-linux-4c small enough, so reduce to minimal
~ job-linux-16c 3 min
with current pr regressed to almost 5 min, it's ok.

x86_64-gnu-tools job-linux-16c this is top job by time in PR, so don't touch it
~ job-linux-8c 1.30 hour in auto job
~ job-linux-16c 1 hour in pr job (affected by #114613, actual time ~ 30 min)

x86_64-gnu-llvm-15 job-linux-16c don't change too
~ job-linux-8c 1.30 hour in auto job
~ job-linux-16c 30 min in pr job

Noticed while working on https://github.com/rust-lang/rust/pull/114621, so current time affected by always rebuilded docker images (but pr images always rebuilded before too, so nvm)