### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -15,7 +15,6 @@
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/JSON.h"
-#include "llvm/Support/Host.h"
 #include "llvm/Support/Memory.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -25,7 +25,6 @@
 #if LLVM_VERSION_GE(17, 0)
 #include "llvm/Support/VirtualFileSystem.h"
 #endif
-#include "llvm/Support/Host.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/IPO/FunctionImport.h"

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2870,11 +2870,7 @@ define_print_and_forward_display! {
     }
 
     ty::ClosureKind {
-        match *self {
-            ty::ClosureKind::Fn => p!("Fn"),
-            ty::ClosureKind::FnMut => p!("FnMut"),
-            ty::ClosureKind::FnOnce => p!("FnOnce"),
-        }
+        p!(write("{}", self.as_str()))
     }
 
     ty::Predicate<'tcx> {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2404,7 +2404,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                         should_continue = suggest(err, false, span, message, sugg);
                     }
                 }
-                LifetimeRibKind::Item => break,
+                LifetimeRibKind::Item | LifetimeRibKind::ConstParamTy => break,
                 _ => {}
             }
             if !should_continue {
@@ -2510,7 +2510,9 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
             .lifetime_ribs
             .iter()
             .rev()
-            .take_while(|rib| !matches!(rib.kind, LifetimeRibKind::Item))
+            .take_while(|rib| {
+                !matches!(rib.kind, LifetimeRibKind::Item | LifetimeRibKind::ConstParamTy)
+            })
             .flat_map(|rib| rib.bindings.iter())
             .map(|(&ident, &res)| (ident, res))
             .filter(|(ident, _)| ident.name != kw::UnderscoreLifetime)

--- a/compiler/rustc_target/src/spec/aarch64_unknown_teeos.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_teeos.rs
@@ -1,0 +1,16 @@
+use crate::spec::Target;
+
+pub fn target() -> Target {
+    let mut base = super::teeos_base::opts();
+    base.features = "+strict-align,+neon,+fp-armv8".into();
+    base.max_atomic_width = Some(128);
+    base.linker = Some("aarch64-linux-gnu-ld".into());
+
+    Target {
+        llvm_target: "aarch64-unknown-none".into(),
+        pointer_width: 64,
+        data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
+        arch: "aarch64".into(),
+        options: base,
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -83,6 +83,7 @@ mod openbsd_base;
 mod redox_base;
 mod solaris_base;
 mod solid_base;
+mod teeos_base;
 mod thumb_base;
 mod uefi_msvc_base;
 mod unikraft_linux_musl_base;
@@ -1491,6 +1492,8 @@ supported_targets! {
     ("armv7-unknown-linux-uclibceabihf", armv7_unknown_linux_uclibceabihf),
 
     ("x86_64-unknown-none", x86_64_unknown_none),
+
+    ("aarch64-unknown-teeos", aarch64_unknown_teeos),
 
     ("mips64-openwrt-linux-musl", mips64_openwrt_linux_musl),
 

--- a/compiler/rustc_target/src/spec/teeos_base.rs
+++ b/compiler/rustc_target/src/spec/teeos_base.rs
@@ -1,0 +1,29 @@
+use super::{Cc, LinkerFlavor, Lld, PanicStrategy};
+use crate::spec::{RelroLevel, TargetOptions};
+
+pub fn opts() -> TargetOptions {
+    let lld_args = &["-zmax-page-size=4096", "-znow", "-ztext", "--execute-only"];
+    let cc_args = &["-Wl,-zmax-page-size=4096", "-Wl,-znow", "-Wl,-ztext", "-mexecute-only"];
+
+    let mut pre_link_args = TargetOptions::link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), lld_args);
+    super::add_link_args(&mut pre_link_args, LinkerFlavor::Gnu(Cc::Yes, Lld::No), cc_args);
+
+    TargetOptions {
+        os: "teeos".into(),
+        vendor: "unknown".into(),
+        dynamic_linking: true,
+        linker_flavor: LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+        // rpath hardcodes -Wl, so it can't be used together with ld.lld.
+        // C TAs also don't support rpath, so this is fine.
+        has_rpath: false,
+        // Note: Setting has_thread_local to true causes an error when
+        // loading / dyn-linking the TA
+        has_thread_local: false,
+        position_independent_executables: true,
+        relro_level: RelroLevel::Full,
+        crt_static_respected: true,
+        pre_link_args,
+        panic_strategy: PanicStrategy::Abort,
+        ..Default::default()
+    }
+}

--- a/compiler/rustc_trait_selection/messages.ftl
+++ b/compiler/rustc_trait_selection/messages.ftl
@@ -8,6 +8,15 @@ trait_selection_adjust_signature_remove_borrow = consider adjusting the signatur
         *[other] arguments
     }
 
+trait_selection_closure_fn_mut_label = closure is `FnMut` because it mutates the variable `{$place}` here
+
+trait_selection_closure_fn_once_label = closure is `FnOnce` because it moves the variable `{$place}` out of its environment
+
+trait_selection_closure_kind_mismatch = expected a closure that implements the `{$expected}` trait, but this closure only implements `{$found}`
+    .label = this closure implements `{$found}`, not `{$expected}`
+
+trait_selection_closure_kind_requirement = the requirement to implement `{$expected}` derives from here
+
 trait_selection_dump_vtable_entries = vtable entries for `{$trait_ref}`: {$entries}
 
 trait_selection_empty_on_clause_in_rustc_on_unimplemented = empty `on`-clause in `#[rustc_on_unimplemented]`

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -4,7 +4,7 @@ use rustc_errors::{
     SubdiagnosticMessage,
 };
 use rustc_macros::Diagnostic;
-use rustc_middle::ty::{self, PolyTraitRef, Ty};
+use rustc_middle::ty::{self, ClosureKind, PolyTraitRef, Ty};
 use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
@@ -130,4 +130,38 @@ impl AddToDiagnostic for AdjustSignatureBorrow {
             }
         }
     }
+}
+
+#[derive(Diagnostic)]
+#[diag(trait_selection_closure_kind_mismatch, code = "E0525")]
+pub struct ClosureKindMismatch {
+    #[primary_span]
+    #[label]
+    pub closure_span: Span,
+    pub expected: ClosureKind,
+    pub found: ClosureKind,
+    #[label(trait_selection_closure_kind_requirement)]
+    pub cause_span: Span,
+
+    #[subdiagnostic]
+    pub fn_once_label: Option<ClosureFnOnceLabel>,
+
+    #[subdiagnostic]
+    pub fn_mut_label: Option<ClosureFnMutLabel>,
+}
+
+#[derive(Subdiagnostic)]
+#[label(trait_selection_closure_fn_once_label)]
+pub struct ClosureFnOnceLabel {
+    #[primary_span]
+    pub span: Span,
+    pub place: String,
+}
+
+#[derive(Subdiagnostic)]
+#[label(trait_selection_closure_fn_mut_label)]
+pub struct ClosureFnMutLabel {
+    #[primary_span]
+    pub span: Span,
+    pub place: String,
 }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -7,6 +7,7 @@ use super::{
     ObligationCauseCode, ObligationCtxt, OutputTypeParameterMismatch, Overflow,
     PredicateObligation, SelectionError, TraitNotObjectSafe,
 };
+use crate::errors::{ClosureFnMutLabel, ClosureFnOnceLabel, ClosureKindMismatch};
 use crate::infer::error_reporting::{TyCategory, TypeAnnotationNeeded as ErrorCode};
 use crate::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use crate::infer::{self, InferCtxt};
@@ -3142,24 +3143,15 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         kind: ty::ClosureKind,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
         let closure_span = self.tcx.def_span(closure_def_id);
-        let mut err = struct_span_err!(
-            self.tcx.sess,
-            closure_span,
-            E0525,
-            "expected a closure that implements the `{}` trait, \
-                but this closure only implements `{}`",
-            kind,
-            found_kind
-        );
 
-        err.span_label(
+        let mut err = ClosureKindMismatch {
             closure_span,
-            format!("this closure implements `{found_kind}`, not `{kind}`"),
-        );
-        err.span_label(
-            obligation.cause.span,
-            format!("the requirement to implement `{kind}` derives from here"),
-        );
+            expected: kind,
+            found: found_kind,
+            cause_span: obligation.cause.span,
+            fn_once_label: None,
+            fn_mut_label: None,
+        };
 
         // Additional context information explaining why the closure only implements
         // a particular trait.
@@ -3167,30 +3159,22 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             let hir_id = self.tcx.hir().local_def_id_to_hir_id(closure_def_id.expect_local());
             match (found_kind, typeck_results.closure_kind_origins().get(hir_id)) {
                 (ty::ClosureKind::FnOnce, Some((span, place))) => {
-                    err.span_label(
-                        *span,
-                        format!(
-                            "closure is `FnOnce` because it moves the \
-                            variable `{}` out of its environment",
-                            ty::place_to_string_for_capture(self.tcx, place)
-                        ),
-                    );
+                    err.fn_once_label = Some(ClosureFnOnceLabel {
+                        span: *span,
+                        place: ty::place_to_string_for_capture(self.tcx, &place),
+                    })
                 }
                 (ty::ClosureKind::FnMut, Some((span, place))) => {
-                    err.span_label(
-                        *span,
-                        format!(
-                            "closure is `FnMut` because it mutates the \
-                            variable `{}` here",
-                            ty::place_to_string_for_capture(self.tcx, place)
-                        ),
-                    );
+                    err.fn_mut_label = Some(ClosureFnMutLabel {
+                        span: *span,
+                        place: ty::place_to_string_for_capture(self.tcx, &place),
+                    })
                 }
                 _ => {}
             }
         }
 
-        err
+        self.tcx.sess.create_err(err)
     }
 
     fn report_type_parameter_mismatch_cyclic_type_error(

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -134,7 +134,7 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &'static str, Option<&[&'static str]>)]
     // #[cfg(bootstrap)]
     (Some(Mode::Std), "target_vendor", Some(&["unikraft"])),
     (Some(Mode::Std), "target_env", Some(&["libnx"])),
-    // (Some(Mode::Std), "target_os", Some(&[])),
+    (Some(Mode::Std), "target_os", Some(&["teeos"])),
     // #[cfg(bootstrap)] mips32r6, mips64r6
     (
         Some(Mode::Std),

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -512,27 +512,21 @@ impl Step for Llvm {
         // When building LLVM as a shared library on linux, it can contain unexpected debuginfo:
         // some can come from the C++ standard library. Unless we're explicitly requesting LLVM to
         // be built with debuginfo, strip it away after the fact, to make dist artifacts smaller.
-        // FIXME: to make things simpler for now, limit this to the host and target where we know
-        // `strip -g` is both available and will fix the issue, i.e. on a x64 linux host that is not
-        // cross-compiling. Expand this to other appropriate targets in the future.
         if builder.llvm_link_shared()
             && builder.config.llvm_optimize
             && !builder.config.llvm_release_debuginfo
-            && target == "x86_64-unknown-linux-gnu"
-            && target == builder.config.build
         {
             // Find the name of the LLVM shared library that we just built.
             let lib_name = find_llvm_lib_name("so");
 
             // If the shared library exists in LLVM's `/build/lib/` or `/lib/` folders, strip its
-            // debuginfo. Note: `output` will propagate any errors here.
-            let strip_if_possible = |path: PathBuf| {
-                if path.exists() {
-                    output(Command::new("strip").arg("--strip-debug").arg(path));
-                }
-            };
-            strip_if_possible(out_dir.join("lib").join(&lib_name));
-            strip_if_possible(out_dir.join("build").join("lib").join(&lib_name));
+            // debuginfo.
+            crate::compile::strip_debug(builder, target, &out_dir.join("lib").join(&lib_name));
+            crate::compile::strip_debug(
+                builder,
+                target,
+                &out_dir.join("build").join("lib").join(&lib_name),
+            );
         }
 
         t!(stamp.write());

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -28,6 +28,7 @@
     - [armv7-unknown-linux-uclibceabihf](platform-support/armv7-unknown-linux-uclibceabihf.md)
     - [\*-android and \*-androideabi](platform-support/android.md)
     - [\*-linux-ohos](platform-support/openharmony.md)
+    - [aarch64-unknown-teeos](platform-support/aarch64-unknown-teeos.md)
     - [\*-esp-espidf](platform-support/esp-idf.md)
     - [\*-unknown-fuchsia](platform-support/fuchsia.md)
     - [\*-kmc-solid_\*](platform-support/kmc-solid.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -221,6 +221,7 @@ target | std | host | notes
 [`aarch64-nintendo-switch-freestanding`](platform-support/aarch64-nintendo-switch-freestanding.md) | * |  | ARM64 Nintendo Switch, Horizon
 [`aarch64-pc-windows-gnullvm`](platform-support/pc-windows-gnullvm.md) | ✓ | ✓ |
 [`aarch64-unknown-linux-ohos`](platform-support/openharmony.md) | ✓ |  | ARM64 OpenHarmony |
+[`aarch64-unknown-teeos`](platform-support/aarch64-unknown-teeos.md) | ? |  | ARM64 TEEOS |
 [`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS |
 `aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
 [`aarch64-unknown-hermit`](platform-support/hermit.md) | ✓ |  | ARM64 Hermit

--- a/src/doc/rustc/src/platform-support/aarch64-unknown-teeos.md
+++ b/src/doc/rustc/src/platform-support/aarch64-unknown-teeos.md
@@ -1,0 +1,100 @@
+# `aarch64-unknown-teeos`
+
+**Tier: 3**
+
+Target for the TEEOS operating system.
+
+TEEOS is a mini os run in TrustZone, for trusted/security apps. The kernel of TEEOS is HongMeng/ChCore micro kernel. The libc for TEEOS is a part of musl.
+It's very small that there is no RwLock, no network, no stdin, and no file system for apps in TEEOS.
+
+Some abbreviation:
+| Abbreviation | The full text | Description |
+|  ----  | ----  | ---- |
+| TEE | Trusted Execution Environment | ARM TrustZone devide the system into two worlds/modes -- the secure world/mode and the normal world/mode. TEE is in the secure world/mode. |
+| REE | Rich Execution Environment | The normal world. for example, Linux for Android phone is in REE side. |
+| TA | Trusted Application | The app run in TEE side system. |
+| CA | Client Application | The progress run in REE side system. |
+
+TEEOS is open source in progress. [MORE about](https://gitee.com/opentrustee-group)
+
+## Target maintainers
+
+- Petrochenkov Vadim
+- Sword-Destiny
+
+## Setup
+We use OpenHarmony SDK for TEEOS.
+
+The OpenHarmony SDK doesn't currently support Rust compilation directly, so
+some setup is required.
+
+First, you must obtain the OpenHarmony SDK from [this page](https://gitee.com/openharmony/docs/tree/master/en/release-notes).
+Select the version of OpenHarmony you are developing for and download the "Public SDK package for the standard system".
+
+Create the following shell scripts that wrap Clang from the OpenHarmony SDK:
+
+`aarch64-unknown-teeos-clang.sh`
+
+```sh
+#!/bin/sh
+exec /path/to/ohos-sdk/linux/native/llvm/bin/clang \
+  --target aarch64-linux-gnu \
+  "$@"
+```
+
+`aarch64-unknown-teeos-clang++.sh`
+
+```sh
+#!/bin/sh
+exec /path/to/ohos-sdk/linux/native/llvm/bin/clang++ \
+  --target aarch64-linux-gnu \
+  "$@"
+```
+
+## Building the target
+
+To build a rust toolchain, create a `config.toml` with the following contents:
+
+```toml
+profile = "compiler"
+changelog-seen = 2
+
+[build]
+sanitizers = true
+profiler = true
+target = ["x86_64-unknown-linux-gnu", "aarch64-unknown-teeos"]
+submodules = false
+compiler-docs = false
+extended = true
+
+[install]
+bindir = "bin"
+libdir = "lib"
+
+[target.aarch64-unknown-teeos]
+cc = "/path/to/scripts/aarch64-unknown-teeos-clang.sh"
+cxx = "/path/to/scripts/aarch64-unknown-teeos-clang.sh"
+linker = "/path/to/scripts/aarch64-unknown-teeos-clang.sh"
+ar = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ar"
+ranlib = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ranlib"
+llvm-config = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-config"
+```
+
+## Building Rust programs
+
+Rust does not yet ship pre-compiled artifacts for this target. To compile for
+this target, you will either need to build Rust with the target enabled (see
+"Building the target" above), or build your own copy of `core` by using
+`build-std` or similar.
+
+You will need to configure the linker to use in `~/.cargo/config`:
+```toml
+[target.aarch64-unknown-teeos]
+linker = "/path/to/aarch64-unknown-teeos-clang.sh"
+```
+
+## Testing
+
+Running the Rust testsuite is not possible now.
+
+More information about how to test CA/TA. [See here](https://gitee.com/openharmony-sig/tee_tee_dev_kit/tree/master/docs)

--- a/tests/rustdoc-json/enums/field_order.rs
+++ b/tests/rustdoc-json/enums/field_order.rs
@@ -1,0 +1,40 @@
+// Check that the order of fields is preserved.
+
+pub enum Whatever {
+    Foo {
+        // Important: random prefixes are used here to ensure that
+        // sorting fields by name would cause this test to fail.
+        ews_0: i32,
+        dik_1: i32,
+        hsk_2: i32,
+        djt_3: i32,
+        jnr_4: i32,
+        dfs_5: i32,
+        bja_6: i32,
+        lyc_7: i32,
+        yqd_8: i32,
+        vll_9: i32,
+    },
+}
+
+// @set 0 = '$.index[*][?(@.name == "ews_0")].id'
+// @set 1 = '$.index[*][?(@.name == "dik_1")].id'
+// @set 2 = '$.index[*][?(@.name == "hsk_2")].id'
+// @set 3 = '$.index[*][?(@.name == "djt_3")].id'
+// @set 4 = '$.index[*][?(@.name == "jnr_4")].id'
+// @set 5 = '$.index[*][?(@.name == "dfs_5")].id'
+// @set 6 = '$.index[*][?(@.name == "bja_6")].id'
+// @set 7 = '$.index[*][?(@.name == "lyc_7")].id'
+// @set 8 = '$.index[*][?(@.name == "yqd_8")].id'
+// @set 9 = '$.index[*][?(@.name == "vll_9")].id'
+
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[0]' $0
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[1]' $1
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[2]' $2
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[3]' $3
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[4]' $4
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[5]' $5
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[6]' $6
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[7]' $7
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[8]' $8
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.struct.fields[9]' $9

--- a/tests/rustdoc-json/enums/variant_order.rs
+++ b/tests/rustdoc-json/enums/variant_order.rs
@@ -1,0 +1,38 @@
+// Check that the order of variants is preserved.
+
+pub enum Foo {
+    // Important: random prefixes are used here to ensure that
+    // sorting fields by name would cause this test to fail.
+    Ews0,
+    Dik1,
+    Hsk2,
+    Djt3,
+    Jnr4,
+    Dfs5,
+    Bja6,
+    Lyc7,
+    Yqd8,
+    Vll9,
+}
+
+// @set 0 = '$.index[*][?(@.name == "Ews0")].id'
+// @set 1 = '$.index[*][?(@.name == "Dik1")].id'
+// @set 2 = '$.index[*][?(@.name == "Hsk2")].id'
+// @set 3 = '$.index[*][?(@.name == "Djt3")].id'
+// @set 4 = '$.index[*][?(@.name == "Jnr4")].id'
+// @set 5 = '$.index[*][?(@.name == "Dfs5")].id'
+// @set 6 = '$.index[*][?(@.name == "Bja6")].id'
+// @set 7 = '$.index[*][?(@.name == "Lyc7")].id'
+// @set 8 = '$.index[*][?(@.name == "Yqd8")].id'
+// @set 9 = '$.index[*][?(@.name == "Vll9")].id'
+
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[0]' $0
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[1]' $1
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[2]' $2
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[3]' $3
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[4]' $4
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[5]' $5
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[6]' $6
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[7]' $7
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[8]' $8
+// @is '$.index[*][?(@.name == "Foo")].inner.variants[9]' $9

--- a/tests/rustdoc-json/structs/field_order.rs
+++ b/tests/rustdoc-json/structs/field_order.rs
@@ -1,0 +1,38 @@
+// Check that the order of fields is preserved.
+
+pub struct Foo {
+    // Important: random prefixes are used here to ensure that
+    // sorting fields by name would cause this test to fail.
+    pub ews_0: i32,
+    pub dik_1: i32,
+    pub hsk_2: i32,
+    pub djt_3: i32,
+    pub jnr_4: i32,
+    pub dfs_5: i32,
+    pub bja_6: i32,
+    pub lyc_7: i32,
+    pub yqd_8: i32,
+    pub vll_9: i32,
+}
+
+// @set 0 = '$.index[*][?(@.name == "ews_0")].id'
+// @set 1 = '$.index[*][?(@.name == "dik_1")].id'
+// @set 2 = '$.index[*][?(@.name == "hsk_2")].id'
+// @set 3 = '$.index[*][?(@.name == "djt_3")].id'
+// @set 4 = '$.index[*][?(@.name == "jnr_4")].id'
+// @set 5 = '$.index[*][?(@.name == "dfs_5")].id'
+// @set 6 = '$.index[*][?(@.name == "bja_6")].id'
+// @set 7 = '$.index[*][?(@.name == "lyc_7")].id'
+// @set 8 = '$.index[*][?(@.name == "yqd_8")].id'
+// @set 9 = '$.index[*][?(@.name == "vll_9")].id'
+
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[0]' $0
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[1]' $1
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[2]' $2
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[3]' $3
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[4]' $4
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[5]' $5
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[6]' $6
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[7]' $7
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[8]' $8
+// @is '$.index[*][?(@.name == "Foo")].inner.kind.plain.fields[9]' $9

--- a/tests/rustdoc-json/unions/field_order.rs
+++ b/tests/rustdoc-json/unions/field_order.rs
@@ -1,0 +1,38 @@
+// Check that the order of fields is preserved.
+
+pub union Foo {
+    // Important: random prefixes are used here to ensure that
+    // sorting fields by name would cause this test to fail.
+    pub ews_0: i32,
+    pub dik_1: i32,
+    pub hsk_2: i32,
+    pub djt_3: i32,
+    pub jnr_4: i32,
+    pub dfs_5: i32,
+    pub bja_6: i32,
+    pub lyc_7: i32,
+    pub yqd_8: i32,
+    pub vll_9: i32,
+}
+
+// @set 0 = '$.index[*][?(@.name == "ews_0")].id'
+// @set 1 = '$.index[*][?(@.name == "dik_1")].id'
+// @set 2 = '$.index[*][?(@.name == "hsk_2")].id'
+// @set 3 = '$.index[*][?(@.name == "djt_3")].id'
+// @set 4 = '$.index[*][?(@.name == "jnr_4")].id'
+// @set 5 = '$.index[*][?(@.name == "dfs_5")].id'
+// @set 6 = '$.index[*][?(@.name == "bja_6")].id'
+// @set 7 = '$.index[*][?(@.name == "lyc_7")].id'
+// @set 8 = '$.index[*][?(@.name == "yqd_8")].id'
+// @set 9 = '$.index[*][?(@.name == "vll_9")].id'
+
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[0]' $0
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[1]' $1
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[2]' $2
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[3]' $3
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[4]' $4
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[5]' $5
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[6]' $6
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[7]' $7
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[8]' $8
+// @is '$.index[*][?(@.name == "Foo")].inner.fields[9]' $9

--- a/tests/ui/check-cfg/values-target-json.stderr
+++ b/tests/ui/check-cfg/values-target-json.stderr
@@ -6,7 +6,7 @@ LL | #[cfg(target_os = "linuz")]
    |                   |
    |                   help: there is a expected value with a similar name: `"linux"`
    |
-   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `ericos`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `tvos`, `uefi`, `unknown`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`
+   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `ericos`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `teeos`, `tvos`, `uefi`, `unknown`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -6,7 +6,7 @@ LL | #[cfg(target_os = "linuz")]
    |                   |
    |                   help: there is a expected value with a similar name: `"linux"`
    |
-   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `tvos`, `uefi`, `unknown`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`
+   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `teeos`, `tvos`, `uefi`, `unknown`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value

--- a/tests/ui/const-generics/lifetime-in-const-param.rs
+++ b/tests/ui/const-generics/lifetime-in-const-param.rs
@@ -1,0 +1,9 @@
+// https://github.com/rust-lang/rust/issues/113462
+
+struct S2<'b>(&'b ());
+
+struct S<'a, const N: S2>(&'a ());
+//~^ ERROR missing lifetime specifier [E0106]
+//~| ERROR `S2<'_>` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/tests/ui/const-generics/lifetime-in-const-param.stderr
+++ b/tests/ui/const-generics/lifetime-in-const-param.stderr
@@ -1,0 +1,18 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/lifetime-in-const-param.rs:5:23
+   |
+LL | struct S<'a, const N: S2>(&'a ());
+   |                       ^^ expected named lifetime parameter
+
+error: `S2<'_>` is forbidden as the type of a const generic parameter
+  --> $DIR/lifetime-in-const-param.rs:5:23
+   |
+LL | struct S<'a, const N: S2>(&'a ());
+   |                       ^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: more complex types are supported with `#![feature(adt_const_params)]`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -3,11 +3,6 @@ error[E0106]: missing lifetime specifier
    |
 LL | fn d<const C: S>() {}
    |               ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL | fn d<'a, const C: S<'a>>() {}
-   |      +++           ++++
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/unusual-rib-combinations.rs:29:22


### PR DESCRIPTION
Successful merges:

 - #110435 (rustdoc-json: Add test for field ordering.)
 - #113480 (add aarch64-unknown-teeos target)
 - #114548 (Migrate a trait selection error to use diagnostic translation)
 - #114606 (fix: not insert missing lifetime for `ConstParamTy`)
 - #114612 (update llvm-wrapper include to silence deprecation warning)
 - #114613 (Prevent constant rebuilds of `rustc-main` (and thus everything else))

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=110435,113480,114548,114606,114612,114613)
<!-- homu-ignore:end -->