### PR TITLE
tests: Uncomment now valid GAT code behind FIXME

### DIFF
--- a/tests/ui/generic-associated-types/streaming_iterator.rs
+++ b/tests/ui/generic-associated-types/streaming_iterator.rs
@@ -15,8 +15,7 @@ struct Foo<T: StreamingIterator + 'static> {
 
 // Users can bound parameters by the type constructed by that trait's associated type constructor
 // of a trait using HRTB. Both type equality bounds and trait bounds of this kind are valid:
-//FIXME(#44265): This next line should parse and be valid
-//fn foo<T: for<'a> StreamingIterator<Item<'a>=&'a [i32]>>(_iter: T) { /* ... */ }
+fn _bar<T: for<'a> StreamingIterator<Item<'a>=&'a [i32]>>(_iter: T) { /* ... */ }
 fn _foo<T>(_iter: T) where T: StreamingIterator, for<'a> T::Item<'a>: Display { /* ... */ }
 
 // Full example of enumerate iterator


### PR DESCRIPTION
The code fails to parse with `nightly-2021-02-05`:

    $ cargo +nightly-2021-02-05 build
    error: generic associated types in trait paths are currently not implemented
     --> src/main.rs:9:42
      |
    9 | fn _bar<T: for<'a> StreamingIterator<Item<'a> = &'a [i32]>>(_iter: T) { /* ... */
      |                                          ^^^^

but parses with `nightly-2021-02-06`:

    $ cargo +nightly-2021-02-06 build
    warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
    warning: 1 warning emitted

because it was (with high probability) fixed by #79554 which was merged within that nightly range.

This PR is part of #44366 which is E-help-wanted.