### PR TITLE
add provisional cache test for new solver

### DIFF
--- a/tests/ui/traits/new-solver/cycles/inductive-not-on-stack.rs
+++ b/tests/ui/traits/new-solver/cycles/inductive-not-on-stack.rs
@@ -1,0 +1,46 @@
+// compile-flags: -Ztrait-solver=next
+#![feature(rustc_attrs, trivial_bounds)]
+
+// We have to be careful here:
+//
+// We either have the provisional result of `A -> B -> A` on the
+// stack, which is a fully coinductive cycle. Accessing the
+// provisional result for `B` as part of the `A -> C -> B -> A` cycle
+// has to make sure we don't just use the result of `A -> B -> A` as the
+// new cycle is inductive.
+//
+// Alternatively, if we have `A -> C -> A` first, then `A -> B -> A` has
+// a purely inductive stack, so something could also go wrong here.
+
+#[rustc_coinductive]
+trait A {}
+#[rustc_coinductive]
+trait B {}
+trait C {}
+
+impl<T: B + C> A for T {}
+impl<T: A> B for T {}
+impl<T: B> C for T {}
+
+fn impls_a<T: A>() {}
+
+// The same test with reordered where clauses to make sure we're actually testing anything.
+#[rustc_coinductive]
+trait AR {}
+#[rustc_coinductive]
+trait BR {}
+trait CR {}
+
+impl<T: CR + BR> AR for T {}
+impl<T: AR> BR for T {}
+impl<T: BR> CR for T {}
+
+fn impls_ar<T: AR>() {}
+
+fn main() {
+    impls_a::<()>();
+    //~^ ERROR overflow evaluating the requirement `(): A`
+
+    impls_ar::<()>();
+    //~^ ERROR overflow evaluating the requirement `(): AR`
+}

--- a/tests/ui/traits/new-solver/cycles/inductive-not-on-stack.stderr
+++ b/tests/ui/traits/new-solver/cycles/inductive-not-on-stack.stderr
@@ -1,0 +1,29 @@
+error[E0275]: overflow evaluating the requirement `(): A`
+  --> $DIR/inductive-not-on-stack.rs:41:5
+   |
+LL |     impls_a::<()>();
+   |     ^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inductive_not_on_stack`)
+note: required by a bound in `impls_a`
+  --> $DIR/inductive-not-on-stack.rs:25:15
+   |
+LL | fn impls_a<T: A>() {}
+   |               ^ required by this bound in `impls_a`
+
+error[E0275]: overflow evaluating the requirement `(): AR`
+  --> $DIR/inductive-not-on-stack.rs:44:5
+   |
+LL |     impls_ar::<()>();
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inductive_not_on_stack`)
+note: required by a bound in `impls_ar`
+  --> $DIR/inductive-not-on-stack.rs:38:16
+   |
+LL | fn impls_ar<T: AR>() {}
+   |                ^^ required by this bound in `impls_ar`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
wrote it for chalk in https://github.com/rust-lang/chalk/pull/788 and never added it to the new solver.

r? @compiler-errors 