### PR TITLE
Mention riscv64-linux-android support in Android documentation

### DIFF
--- a/src/doc/rustc/src/platform-support/android.md
+++ b/src/doc/rustc/src/platform-support/android.md
@@ -39,6 +39,8 @@ edition of the [Android NDK].  Supported Android targets are:
 * thumbv7neon-linux-androideabi
 * x86_64-linux-android
 
+The riscv64-linux-android target is supported as a Tier 3 target.
+
 [Android NDK]: https://developer.android.com/ndk/downloads
 
 A list of all supported targets can be found


### PR DESCRIPTION
This CL brings the android.md file in-line with the list of supported targets from platform-support.md.

Followup to https://github.com/rust-lang/rust/pull/112858

r? @Mark-Simulacrum
