### PR TITLE
Rename copying `ascii::Char` methods from `as_` to `to_`

### DIFF
--- a/library/core/src/ascii/ascii_char.rs
+++ b/library/core/src/ascii/ascii_char.rs
@@ -518,14 +518,14 @@ impl AsciiChar {
     /// Gets this ASCII character as a byte.
     #[unstable(feature = "ascii_char", issue = "110998")]
     #[inline]
-    pub const fn as_u8(self) -> u8 {
+    pub const fn to_u8(self) -> u8 {
         self as u8
     }
 
     /// Gets this ASCII character as a `char` Unicode Scalar Value.
     #[unstable(feature = "ascii_char", issue = "110998")]
     #[inline]
-    pub const fn as_char(self) -> char {
+    pub const fn to_char(self) -> char {
         self as u8 as char
     }
 

--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -95,11 +95,11 @@ impl<const N: usize> EscapeIterInner<N> {
     }
 
     pub fn next(&mut self) -> Option<u8> {
-        self.alive.next().map(|i| self.data[usize::from(i)].as_u8())
+        self.alive.next().map(|i| self.data[usize::from(i)].to_u8())
     }
 
     pub fn next_back(&mut self) -> Option<u8> {
-        self.alive.next_back().map(|i| self.data[usize::from(i)].as_u8())
+        self.alive.next_back().map(|i| self.data[usize::from(i)].to_u8())
     }
 
     pub fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {


### PR DESCRIPTION
Tracking issue: #110998.

The [API guidelines][naming] describe `as_` as used for borrowed -> borrowed operations, and `to_` for
owned -> owned operations on `Copy` types.

[naming]: https://rust-lang.github.io/api-guidelines/naming.html