### PR TITLE
Remove usage of `--use-old-text` for BOLT

### DIFF
--- a/src/tools/opt-dist/src/bolt.rs
+++ b/src/tools/opt-dist/src/bolt.rs
@@ -65,8 +65,13 @@ pub fn bolt_optimize(path: &Utf8Path, profile: &LlvmBoltProfile) -> anyhow::Resu
         .arg("-jump-tables=move")
         // Fold functions with identical code
         .arg("-icf=1")
+        // The following flag saves about 50 MiB of libLLVM.so size.
+        // However, it succeeds very non-deterministically. To avoid frequent artifact size swings,
+        // it is kept disabled for now.
+        // FIXME(kobzol): try to re-enable this once BOLT in-place rewriting is merged or after
+        // we bump LLVM.
         // Try to reuse old text segments to reduce binary size
-        .arg("--use-old-text")
+        // .arg("--use-old-text")
         // Update DWARF debug info in the final binary
         .arg("-update-debug-sections")
         // Print optimization statistics


### PR DESCRIPTION
This flag has [reduced](https://github.com/rust-lang/rust/pull/114141) the size of `libLLVM.so` by ~50 MiB, but sadly it is quite non-deterministic and the size savings frequently fail, thus causing large artifact size [swings](https://github.com/rust-lang/rust/pull/114297#issuecomment-1670292387). To avoid the swings, it would be better to just disable the flag for now. 

r? @nikic