### PR TITLE
Keep printing extra comments in MIR dumps

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -706,7 +706,7 @@ fn test_unstable_options_tracking_hash() {
     untracked!(ls, true);
     untracked!(macro_backtrace, true);
     untracked!(meta_stats, true);
-    untracked!(mir_include_spans, true);
+    untracked!(mir_include_extra_comments, false);
     untracked!(nll_facts, true);
     untracked!(no_analysis, true);
     untracked!(no_leak_check, true);

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -352,7 +352,7 @@ where
     for statement in &data.statements {
         extra_data(PassWhere::BeforeLocation(current_location), w)?;
         let indented_body = format!("{INDENT}{INDENT}{statement:?};");
-        if tcx.sess.opts.unstable_opts.mir_include_spans {
+        if tcx.sess.opts.unstable_opts.mir_include_extra_comments {
             writeln!(
                 w,
                 "{:A$} // {}{}",
@@ -377,7 +377,7 @@ where
     // Terminator at the bottom.
     extra_data(PassWhere::BeforeLocation(current_location), w)?;
     let indented_terminator = format!("{0}{0}{1:?};", INDENT, data.terminator().kind);
-    if tcx.sess.opts.unstable_opts.mir_include_spans {
+    if tcx.sess.opts.unstable_opts.mir_include_extra_comments {
         writeln!(
             w,
             "{:A$} // {}{}",
@@ -407,7 +407,7 @@ fn write_extra<'tcx, F>(tcx: TyCtxt<'tcx>, write: &mut dyn Write, mut visit_op: 
 where
     F: FnMut(&mut ExtraComments<'tcx>),
 {
-    if tcx.sess.opts.unstable_opts.mir_include_spans {
+    if tcx.sess.opts.unstable_opts.mir_include_extra_comments {
         let mut extra_comments = ExtraComments { tcx, comments: vec![] };
         visit_op(&mut extra_comments);
         for comment in extra_comments.comments {
@@ -564,7 +564,7 @@ fn write_scope_tree(
             var_debug_info.value,
         );
 
-        if tcx.sess.opts.unstable_opts.mir_include_spans {
+        if tcx.sess.opts.unstable_opts.mir_include_extra_comments {
             writeln!(
                 w,
                 "{0:1$} // in {2}",
@@ -602,7 +602,7 @@ fn write_scope_tree(
 
         let local_name = if local == RETURN_PLACE { " return place" } else { "" };
 
-        if tcx.sess.opts.unstable_opts.mir_include_spans {
+        if tcx.sess.opts.unstable_opts.mir_include_extra_comments {
             writeln!(
                 w,
                 "{0:1$} //{2} in {3}",
@@ -639,7 +639,7 @@ fn write_scope_tree(
 
         let indented_header = format!("{0:1$}scope {2}{3} {{", "", indent, child.index(), special);
 
-        if tcx.sess.opts.unstable_opts.mir_include_spans {
+        if tcx.sess.opts.unstable_opts.mir_include_extra_comments {
             if let Some(span) = span {
                 writeln!(
                     w,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1599,9 +1599,9 @@ options! {
         "use like `-Zmir-enable-passes=+DestinationPropagation,-InstSimplify`. Forces the specified passes to be \
         enabled, overriding all other checks. Passes that are not specified are enabled or \
         disabled by other flags as usual."),
-    mir_include_spans: bool = (false, parse_bool, [UNTRACKED],
+    mir_include_spans: bool = (true, parse_bool, [UNTRACKED],
         "include extra comments in mir pretty printing, like line numbers and statement indices, \
-         details about types, etc. (default: no)"),
+         details about types, etc. (default: yes)"),
     mir_keep_place_mention: bool = (false, parse_bool, [TRACKED],
         "keep place mention MIR statements, interpreted e.g., by miri; implies -Zmir-opt-level=0 \
         (default: no)"),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1599,7 +1599,7 @@ options! {
         "use like `-Zmir-enable-passes=+DestinationPropagation,-InstSimplify`. Forces the specified passes to be \
         enabled, overriding all other checks. Passes that are not specified are enabled or \
         disabled by other flags as usual."),
-    mir_include_spans: bool = (true, parse_bool, [UNTRACKED],
+    mir_include_extra_comments: bool = (true, parse_bool, [UNTRACKED],
         "include extra comments in mir pretty printing, like line numbers and statement indices, \
          details about types, etc. (default: yes)"),
     mir_keep_place_mention: bool = (false, parse_bool, [TRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1600,7 +1600,8 @@ options! {
         enabled, overriding all other checks. Passes that are not specified are enabled or \
         disabled by other flags as usual."),
     mir_include_spans: bool = (false, parse_bool, [UNTRACKED],
-        "use line numbers relative to the function in mir pretty printing"),
+        "include extra comments in mir pretty printing, like line numbers and statement indices, \
+         details about types, etc. (default: no)"),
     mir_keep_place_mention: bool = (false, parse_bool, [TRACKED],
         "keep place mention MIR statements, interpreted e.g., by miri; implies -Zmir-opt-level=0 \
         (default: no)"),

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2363,6 +2363,7 @@ impl<'test> TestCx<'test> {
                     &zdump_arg,
                     "-Zvalidate-mir",
                     "-Zdump-mir-exclude-pass-number",
+                    "-Zmir-include-spans=false",
                 ]);
                 if let Some(pass) = &self.props.mir_unit_test {
                     rustc.args(&["-Zmir-opt-level=0", &format!("-Zmir-enable-passes=+{}", pass)]);

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2363,7 +2363,7 @@ impl<'test> TestCx<'test> {
                     &zdump_arg,
                     "-Zvalidate-mir",
                     "-Zdump-mir-exclude-pass-number",
-                    "-Zmir-include-spans=false",
+                    "-Zmir-include-extra-comments=false",
                 ]);
                 if let Some(pass) = &self.props.mir_unit_test {
                     rustc.args(&["-Zmir-opt-level=0", &format!("-Zmir-enable-passes=+{}", pass)]);

--- a/tests/mir-opt/pre-codegen/spans.rs
+++ b/tests/mir-opt/pre-codegen/spans.rs
@@ -1,7 +1,7 @@
 // Test that the comments we emit in MIR opts are accurate.
 //
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-// compile-flags: -Zmir-include-spans
+// compile-flags: -Zmir-include-extra-comments
 // ignore-wasm32
 
 #![crate_type = "lib"]

--- a/tests/run-make/const_fn_mir/dump.mir
+++ b/tests/run-make/const_fn_mir/dump.mir
@@ -1,45 +1,48 @@
 // WARNING: This output format is intended for human consumers only
 // and is subject to change without notice. Knock yourself out.
 fn foo() -> i32 {
-    let mut _0: i32;
-    let mut _1: (i32, bool);
+    let mut _0: i32;                     // return place in scope 0 at main.rs:4:19: 4:22
+    let mut _1: (i32, bool);             // in scope 0 at main.rs:5:5: 5:10
 
     bb0: {
-        _1 = CheckedAdd(const 5_i32, const 6_i32);
-        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 5_i32, const 6_i32) -> [success: bb1, unwind continue];
+        _1 = CheckedAdd(const 5_i32, const 6_i32); // scope 0 at main.rs:5:5: 5:10
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 5_i32, const 6_i32) -> [success: bb1, unwind continue]; // scope 0 at main.rs:5:5: 5:10
     }
 
     bb1: {
-        _0 = move (_1.0: i32);
-        return;
+        _0 = move (_1.0: i32);           // scope 0 at main.rs:5:5: 5:10
+        return;                          // scope 0 at main.rs:6:2: 6:2
     }
 }
 
 // MIR FOR CTFE
 fn foo() -> i32 {
-    let mut _0: i32;
-    let mut _1: (i32, bool);
+    let mut _0: i32;                     // return place in scope 0 at main.rs:4:19: 4:22
+    let mut _1: (i32, bool);             // in scope 0 at main.rs:5:5: 5:10
 
     bb0: {
-        _1 = CheckedAdd(const 5_i32, const 6_i32);
-        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 5_i32, const 6_i32) -> [success: bb1, unwind continue];
+        _1 = CheckedAdd(const 5_i32, const 6_i32); // scope 0 at main.rs:5:5: 5:10
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 5_i32, const 6_i32) -> [success: bb1, unwind continue]; // scope 0 at main.rs:5:5: 5:10
     }
 
     bb1: {
-        _0 = move (_1.0: i32);
-        return;
+        _0 = move (_1.0: i32);           // scope 0 at main.rs:5:5: 5:10
+        return;                          // scope 0 at main.rs:6:2: 6:2
     }
 }
 
 fn main() -> () {
-    let mut _0: ();
-    let _1: i32;
+    let mut _0: ();                      // return place in scope 0 at main.rs:8:11: 8:11
+    let _1: i32;                         // in scope 0 at main.rs:9:5: 9:10
 
     bb0: {
-        _1 = foo() -> [return: bb1, unwind continue];
+        _1 = foo() -> [return: bb1, unwind continue]; // scope 0 at main.rs:9:5: 9:10
+                                         // mir::Constant
+                                         // + span: main.rs:9:5: 9:8
+                                         // + literal: Const { ty: fn() -> i32 {foo}, val: Value(<ZST>) }
     }
 
     bb1: {
-        return;
+        return;                          // scope 0 at main.rs:10:2: 10:2
     }
 }


### PR DESCRIPTION
#112346 seems to have removed comments from MIR dumps altogether, not just from mir-opt dumps or in the mir-opt tests. It's unclear to me if it was intentional or not.

In any case, that in turn made the NLL mir dumps (`-Zdump-mir=nll`) lose all the important information without `-Zmir-include-spans`. For context, in case anyone reading this doesn't know: people working with borrowck data deal with CFG points/MIR locations in both region and liveness values, and the extra type info also contains lifetimes, and is used to reason about outlives constraints. 

For example:

```rust
| Inferred Region Values
...
| '?2 | U0 | {bb0[0..=1], bb1[0..=4], bb2[0..=4], bb3[0], bb4[0..=6], bb5[0..=3], bb6[0], bb7[0..=8], bb8[0], bb9[0..=6], bb10[0..=8], bb11[0..=1], bb12[0], bb13[0], '?2}
| '?3 | U0 | {bb0[1], bb1[0..=4], bb2[0..=4], bb3[0], bb4[0..=6], bb5[0..=3], bb6[0], bb7[0..=8], bb10[0..=8]}
| '?4 | U0 | {bb0[0..=1], bb1[0..=4], bb2[0..=4], bb3[0], bb4[0..=6], bb5[0..=3], bb6[0], bb7[0..=8], bb8[0], bb9[0..=6], bb10[0..=8], bb11[0..=1], bb12[0], bb13[0], '?1}
| '?5 | U0 | {bb4[4..=6]}
...
| Inference Constraints
...
| '?12 live at {bb7[8]}
| '?14 live at {bb1[0..=4], bb2[0..=4], bb3[0], bb4[0..=6], bb5[0..=3], bb6[0], bb7[0..=8], bb10[0..=8]}

```

```rust
_15 = [closure@closures-in-loops.rs:22:16: 22:18] { x: move _16 }; // bb7[6]: scope 2 at closures-in-loops.rs:22:16: 22:37
                                         // closure
                                         // + def_id: DefId(0:4 ~ closures_in_loops[58cd]::repreated_unique_borrow::{closure#0})
                                         // + args: [
                                         //     i16,
                                         //     extern "rust-call" fn(()),
                                         //     (&'?9 mut &'?10 mut std::string::String,),
                                         // ]
```

Removing the comments is unfortunate here, so this PR keeps printing this information by default, for now.

Since `-Zmir-include-spans` is also used to display/ignore the extra comments passed to pretty printing, I've renamed it to `-Zmir-include-extra-comments` to describe it more generally, and flipped back the default to true to not regress NLL dumps. 

Hopefully the new name and help text will also make it easier to find (arguably in these NLL dumps the statement location is the root of the info and not the spans, and I had to search GH PRs to find how to have it printed again).

To be clear, it's fine if we want to stop printing these comments by default if e.g. more people are annoyed by them than being helped. In that case, being able to force printing in specific passes could be good to preserve the NLL dumps' quality, or we can just as well also let the contributors and community know that they should adopt dumping with `-Zmir-include-extra-comments`.

r? @saethlin 