### PR TITLE
Suggest `pin!()` instead of `Pin::new()` when appropriate

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2495,10 +2495,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Try alternative arbitrary self types that could fulfill this call.
             // FIXME: probe for all types that *could* be arbitrary self-types, not
             // just this list.
-            for (rcvr_ty, post) in &[
-                (rcvr_ty, ""),
-                (Ty::new_mut_ref(self.tcx, self.tcx.lifetimes.re_erased, rcvr_ty), "&mut "),
-                (Ty::new_imm_ref(self.tcx, self.tcx.lifetimes.re_erased, rcvr_ty), "&"),
+            for (rcvr_ty, post, pin_call) in &[
+                (rcvr_ty, "", ""),
+                (
+                    Ty::new_mut_ref(self.tcx, self.tcx.lifetimes.re_erased, rcvr_ty),
+                    "&mut ",
+                    "as_mut",
+                ),
+                (Ty::new_imm_ref(self.tcx, self.tcx.lifetimes.re_erased, rcvr_ty), "&", "as_ref"),
             ] {
                 match self.lookup_probe_for_diagnostic(
                     item_name,
@@ -2532,6 +2536,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     Err(_) => (),
                 }
 
+                let pred = ty::TraitRef::new(
+                    self.tcx,
+                    self.tcx.lang_items().unpin_trait().unwrap(),
+                    [*rcvr_ty],
+                );
+                let unpin = self.predicate_must_hold_considering_regions(&Obligation::new(
+                    self.tcx,
+                    ObligationCause::misc(rcvr.span, self.body_id),
+                    self.param_env,
+                    pred,
+                ));
                 for (rcvr_ty, pre) in &[
                     (Ty::new_lang_item(self.tcx, *rcvr_ty, LangItem::OwnedBox), "Box::new"),
                     (Ty::new_lang_item(self.tcx, *rcvr_ty, LangItem::Pin), "Pin::new"),
@@ -2555,7 +2570,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         // Explicitly ignore the `Pin::as_ref()` method as `Pin` does not
                         // implement the `AsRef` trait.
                         let skip = skippable.contains(&did)
-                            || (("Pin::new" == *pre) && (sym::as_ref == item_name.name))
+                            || (("Pin::new" == *pre) && ((sym::as_ref == item_name.name) || !unpin))
                             || inputs_len.is_some_and(|inputs_len| pick.item.kind == ty::AssocKind::Fn && self.tcx.fn_sig(pick.item.def_id).skip_binder().skip_binder().inputs().len() != inputs_len);
                         // Make sure the method is defined for the *actual* receiver: we don't
                         // want to treat `Box<Self>` as a receiver if it only works because of
@@ -2567,7 +2582,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             );
                             err.multipart_suggestion(
                                 "consider wrapping the receiver expression with the \
-                                    appropriate type",
+                                 appropriate type",
                                 vec![
                                     (rcvr.span.shrink_to_lo(), format!("{pre}({post}")),
                                     (rcvr.span.shrink_to_hi(), ")".to_string()),
@@ -2578,6 +2593,39 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             alt_rcvr_sugg = true;
                         }
                     }
+                }
+                // We special case the situation where `Pin::new` wouldn't work, and isntead
+                // suggest using the `pin!()` macro instead.
+                if let Some(new_rcvr_t) = Ty::new_lang_item(self.tcx, *rcvr_ty, LangItem::Pin)
+                    && !alt_rcvr_sugg
+                    && !unpin
+                    && sym::as_ref != item_name.name
+                    && *pin_call != ""
+                    && let Ok(pick) = self.lookup_probe_for_diagnostic(
+                        item_name,
+                        new_rcvr_t,
+                        rcvr,
+                        ProbeScope::AllTraits,
+                        return_type,
+                    )
+                    && !skippable.contains(&Some(pick.item.container_id(self.tcx)))
+                    && pick.autoderefs == 0
+                    && inputs_len.is_some_and(|inputs_len| pick.item.kind == ty::AssocKind::Fn && self.tcx.fn_sig(pick.item.def_id).skip_binder().skip_binder().inputs().len() == inputs_len)
+                {
+                    let indent = self.tcx.sess
+                        .source_map()
+                        .indentation_before(rcvr.span)
+                        .unwrap_or_else(|| " ".to_string());
+                    err.multipart_suggestion(
+                        "consider pinning the expression",
+                        vec![
+                            (rcvr.span.shrink_to_lo(), format!("let mut pinned = std::pin::pin!(")),
+                            (rcvr.span.shrink_to_hi(), format!(");\n{indent}pinned.{pin_call}()")),
+                        ],
+                        Applicability::MaybeIncorrect,
+                    );
+                    // We don't care about the other suggestions.
+                    alt_rcvr_sugg = true;
                 }
             }
         }

--- a/tests/ui/async-await/issue-108572.fixed
+++ b/tests/ui/async-await/issue-108572.fixed
@@ -9,7 +9,8 @@ fn foo() -> impl Future<Output=()> {
 
 fn bar(cx: &mut std::task::Context<'_>) {
     let fut = foo();
-    fut.poll(cx);
+    let mut pinned = std::pin::pin!(fut);
+    pinned.as_mut().poll(cx);
     //~^ ERROR no method named `poll` found for opaque type `impl Future<Output = ()>` in the current scope [E0599]
 }
 fn main() {}

--- a/tests/ui/async-await/issue-108572.stderr
+++ b/tests/ui/async-await/issue-108572.stderr
@@ -1,11 +1,16 @@
 error[E0599]: no method named `poll` found for opaque type `impl Future<Output = ()>` in the current scope
-  --> $DIR/issue-108572.rs:10:9
+  --> $DIR/issue-108572.rs:12:9
    |
-LL |     fut.poll();
+LL |     fut.poll(cx);
    |         ^^^^ method not found in `impl Future<Output = ()>`
    |
    = help: method `poll` found on `Pin<&mut impl Future<Output = ()>>`, see documentation for `std::pin::Pin`
    = help: self type must be pinned to call `Future::poll`, see https://rust-lang.github.io/async-book/04_pinning/01_chapter.html#pinning-in-practice
+help: consider pinning the expression
+   |
+LL ~     let mut pinned = std::pin::pin!(fut);
+LL ~     pinned.as_mut().poll(cx);
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/async-await/pin-needed-to-poll.stderr
+++ b/tests/ui/async-await/pin-needed-to-poll.stderr
@@ -6,14 +6,12 @@ LL | struct Sleep;
 ...
 LL |         self.sleep.poll(cx)
    |                    ^^^^ method not found in `Sleep`
-  --> $SRC_DIR/core/src/future/future.rs:LL:COL
    |
-   = note: the method is available for `Pin<&mut Sleep>` here
+help: consider pinning the expression
    |
-help: consider wrapping the receiver expression with the appropriate type
+LL ~         let mut pinned = std::pin::pin!(self.sleep);
+LL ~         pinned.as_mut().poll(cx)
    |
-LL |         Pin::new(&mut self.sleep).poll(cx)
-   |         +++++++++++++           +
 
 error: aborting due to previous error
 

--- a/tests/ui/self/arbitrary_self_types_needing_mut_pin.fixed
+++ b/tests/ui/self/arbitrary_self_types_needing_mut_pin.fixed
@@ -8,5 +8,6 @@ impl S {
 }
 
 fn main() {
-    Pin::new(&mut S).x(); //~ ERROR no method named `x` found
+    let mut pinned = std::pin::pin!(S);
+    pinned.as_mut().x(); //~ ERROR no method named `x` found
 }

--- a/tests/ui/self/arbitrary_self_types_needing_mut_pin.stderr
+++ b/tests/ui/self/arbitrary_self_types_needing_mut_pin.stderr
@@ -4,16 +4,14 @@ error[E0599]: no method named `x` found for struct `S` in the current scope
 LL | struct S;
    | -------- method `x` not found for this struct
 ...
-LL |     fn x(self: Pin<&mut Self>) {
-   |        - the method is available for `Pin<&mut S>` here
-...
 LL |     S.x();
    |       ^ method not found in `S`
    |
-help: consider wrapping the receiver expression with the appropriate type
+help: consider pinning the expression
    |
-LL |     Pin::new(&mut S).x();
-   |     +++++++++++++  +
+LL ~     let mut pinned = std::pin::pin!(S);
+LL ~     pinned.as_mut().x();
+   |
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When encountering a type that needs to be pinned but that is `!Unpin`, suggest using the `pin!()` macro.

Fix #57994.