### PR TITLE
Unlock trailing where-clauses for lazy type aliases

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -239,5 +239,10 @@ ast_passes_visibility_not_permitted =
     .individual_impl_items = place qualifiers on individual impl items instead
     .individual_foreign_items = place qualifiers on individual foreign items instead
 
-ast_passes_where_after_type_alias = where clauses are not allowed after the type for type aliases
+ast_passes_where_clause_after_type_alias = where clauses are not allowed after the type for type aliases
+    .note = see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
+    .help = add `#![feature(lazy_type_alias)]` to the crate attributes to enable
+
+ast_passes_where_clause_before_type_alias = where clauses are not allowed before the type for type aliases
     .note = see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
+    .suggestion = move it to the end of the type declaration

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -496,11 +496,37 @@ pub struct FieldlessUnion {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes_where_after_type_alias)]
+#[diag(ast_passes_where_clause_after_type_alias)]
 #[note]
-pub struct WhereAfterTypeAlias {
+pub struct WhereClauseAfterTypeAlias {
     #[primary_span]
     pub span: Span,
+    #[help]
+    pub help: Option<()>,
+}
+
+#[derive(Diagnostic)]
+#[diag(ast_passes_where_clause_before_type_alias)]
+#[note]
+pub struct WhereClauseBeforeTypeAlias {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: WhereClauseBeforeTypeAliasSugg,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(
+    ast_passes_suggestion,
+    applicability = "machine-applicable",
+    style = "verbose"
+)]
+pub struct WhereClauseBeforeTypeAliasSugg {
+    #[suggestion_part(code = "")]
+    pub left: Span,
+    pub snippet: String,
+    #[suggestion_part(code = "{snippet}")]
+    pub right: Span,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/lazy-type-alias/leading-where-clause.fixed
+++ b/tests/ui/lazy-type-alias/leading-where-clause.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+// Check that we *reject* leading where-clauses on lazy type aliases.
+
+type Alias<T>
+
+= T where String: From<T>;
+//~^^^ ERROR where clauses are not allowed before the type for type aliases
+
+fn main() {
+    let _: Alias<&str>;
+}

--- a/tests/ui/lazy-type-alias/leading-where-clause.rs
+++ b/tests/ui/lazy-type-alias/leading-where-clause.rs
@@ -1,0 +1,16 @@
+// run-rustfix
+
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+// Check that we *reject* leading where-clauses on lazy type aliases.
+
+type Alias<T>
+where
+    String: From<T>,
+= T;
+//~^^^ ERROR where clauses are not allowed before the type for type aliases
+
+fn main() {
+    let _: Alias<&str>;
+}

--- a/tests/ui/lazy-type-alias/leading-where-clause.stderr
+++ b/tests/ui/lazy-type-alias/leading-where-clause.stderr
@@ -1,0 +1,16 @@
+error: where clauses are not allowed before the type for type aliases
+  --> $DIR/leading-where-clause.rs:9:1
+   |
+LL | / where
+LL | |     String: From<T>,
+   | |____________________^
+   |
+   = note: see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
+help: move it to the end of the type declaration
+   |
+LL + 
+LL ~ = T where String: From<T>;
+   |
+
+error: aborting due to previous error
+

--- a/tests/ui/lazy-type-alias/trailing-where-clause.rs
+++ b/tests/ui/lazy-type-alias/trailing-where-clause.rs
@@ -1,0 +1,13 @@
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+// Check that we allow & respect trailing where-clauses on lazy type aliases.
+
+type Alias<T> = T
+where
+    String: From<T>;
+
+fn main() {
+    let _: Alias<&str>;
+    let _: Alias<()>; //~ ERROR the trait bound `String: From<()>` is not satisfied
+}

--- a/tests/ui/lazy-type-alias/trailing-where-clause.stderr
+++ b/tests/ui/lazy-type-alias/trailing-where-clause.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `String: From<()>` is not satisfied
+  --> $DIR/trailing-where-clause.rs:12:12
+   |
+LL |     let _: Alias<()>;
+   |            ^^^^^^^^^ the trait `From<()>` is not implemented for `String`
+   |
+   = help: the following other types implement trait `From<T>`:
+             <String as From<char>>
+             <String as From<Box<str>>>
+             <String as From<Cow<'a, str>>>
+             <String as From<&str>>
+             <String as From<&mut str>>
+             <String as From<&String>>
+note: required by a bound on the type alias `Alias`
+  --> $DIR/trailing-where-clause.rs:8:13
+   |
+LL |     String: From<T>;
+   |             ^^^^^^^ required by this bound
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/where-clauses/where-clause-placement-type-alias.stderr
+++ b/tests/ui/where-clauses/where-clause-placement-type-alias.stderr
@@ -4,7 +4,8 @@ error: where clauses are not allowed after the type for type aliases
 LL | type Bar = () where u32: Copy;
    |               ^^^^^^^^^^^^^^^
    |
-   = note: see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
+   = note: see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
+   = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable
 
 error: where clauses are not allowed after the type for type aliases
   --> $DIR/where-clause-placement-type-alias.rs:8:15
@@ -12,7 +13,8 @@ error: where clauses are not allowed after the type for type aliases
 LL | type Baz = () where;
    |               ^^^^^
    |
-   = note: see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
+   = note: see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
+   = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Allows trailing where-clauses on lazy type aliases and forbids[^1] leading ones.
Completes #89122 (see section *Top-level type aliases*).

@rustbot label F-lazy_type_alias
r? @oli-obk

[^1]: This is absolutely fine since lazy type aliases are only meant to be stabilized as part of a new edition.