### PR TITLE
Record binder for bare trait object in LifetimeCollectVisitor

### DIFF
--- a/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.rs
+++ b/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.rs
@@ -1,0 +1,22 @@
+// edition:2015
+// check-pass
+// issue: 114664
+
+fn ice() -> impl AsRef<Fn(&())> {
+    //~^ WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+    //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+    //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+    Foo
+}
+
+struct Foo;
+impl AsRef<dyn Fn(&())> for Foo {
+    fn as_ref(&self) -> &(dyn for<'a> Fn(&'a ()) + 'static) {
+        todo!()
+    }
+}
+
+pub fn main() {}

--- a/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
+++ b/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
@@ -1,0 +1,42 @@
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/fresh-lifetime-from-bare-trait-obj-114664.rs:5:24
+   |
+LL | fn ice() -> impl AsRef<Fn(&())> {
+   |                        ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: `#[warn(bare_trait_objects)]` on by default
+help: use `dyn`
+   |
+LL | fn ice() -> impl AsRef<dyn Fn(&())> {
+   |                        +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/fresh-lifetime-from-bare-trait-obj-114664.rs:5:24
+   |
+LL | fn ice() -> impl AsRef<Fn(&())> {
+   |                        ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL | fn ice() -> impl AsRef<dyn Fn(&())> {
+   |                        +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/fresh-lifetime-from-bare-trait-obj-114664.rs:5:24
+   |
+LL | fn ice() -> impl AsRef<Fn(&())> {
+   |                        ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL | fn ice() -> impl AsRef<dyn Fn(&())> {
+   |                        +++
+
+warning: 3 warnings emitted
+


### PR DESCRIPTION
The `LifetimeCollectVisitor` had a bug where it was not recording the binder of bate trait objects. This was uncovered in #114487, when I changed opaque type lowering to ICE if it encountered a captured fresh lifetime with no def-id to map back to: https://github.com/rust-lang/rust/pull/114487/files#diff-ad0c15bbde97a607d4758ec7eaf88248be5d6b8ae084dfc84127f81e3f7a9bb4R1585

Fixes #114664 