### PR TITLE
Deny `FnDef` in patterns

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -325,6 +325,11 @@ impl<'tcx> ConstToPat<'tcx> {
                 // `PartialEq::eq` on it.
                 return Err(FallbackToConstRef);
             }
+            ty::FnDef(..) => {
+                self.saw_const_match_error.set(true);
+                tcx.sess.emit_err(InvalidPattern { span, non_sm_ty: ty });
+                PatKind::Wild
+            }
             ty::Adt(adt_def, _) if !self.type_marked_structural(ty) => {
                 debug!("adt_def {:?} has !type_marked_structural for cv.ty: {:?}", adt_def, ty,);
                 self.saw_const_match_error.set(true);
@@ -440,7 +445,7 @@ impl<'tcx> ConstToPat<'tcx> {
                     }
                 }
             },
-            ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::FnDef(..) => PatKind::Constant {
+            ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) => PatKind::Constant {
                 value: mir::ConstantKind::Ty(ty::Const::new_value(tcx, cv, ty)),
             },
             ty::FnPtr(..) | ty::RawPtr(..) => unreachable!(),

--- a/tests/ui/inline-const/pat-match-fndef.rs
+++ b/tests/ui/inline-const/pat-match-fndef.rs
@@ -1,0 +1,13 @@
+#![feature(inline_const_pat)]
+//~^ WARN the feature `inline_const_pat` is incomplete
+
+fn uwu() {}
+
+fn main() {
+    let x = [];
+    match x[123] {
+        const { uwu } => {}
+        //~^ ERROR `fn() {uwu}` cannot be used in patterns
+        _ => {}
+    }
+}

--- a/tests/ui/inline-const/pat-match-fndef.stderr
+++ b/tests/ui/inline-const/pat-match-fndef.stderr
@@ -1,0 +1,17 @@
+warning: the feature `inline_const_pat` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/pat-match-fndef.rs:1:12
+   |
+LL | #![feature(inline_const_pat)]
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: `fn() {uwu}` cannot be used in patterns
+  --> $DIR/pat-match-fndef.rs:9:9
+   |
+LL |         const { uwu } => {}
+   |         ^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+


### PR DESCRIPTION
We can only see these via `const { .. }` patterns, which are unstable.

cc #76001 (tracking issue for inline const pats)

Fixes #114658
Fixes #114659