### PR TITLE
Don't use `type_of` to determine if item has intrinsic shim

### DIFF
--- a/tests/ui/inline-const/instance-doesnt-depend-on-type.rs
+++ b/tests/ui/inline-const/instance-doesnt-depend-on-type.rs
@@ -1,0 +1,10 @@
+// check-pass
+// issue: 114660
+
+#![feature(inline_const)]
+
+fn main() {
+    const { core::mem::transmute::<u8, u8> };
+    // Don't resolve the instance of this inline constant to be an intrinsic,
+    // even if the type of the constant is `extern "intrinsic" fn(u8) -> u8`.
+}


### PR DESCRIPTION
When we're calling `resolve_instance` on an inline const, we were previously looking at the `type_of` for that const, seeing that it was an `extern "intrinsic"` fn def, and treating it as if we were computing the instance of that intrinsic itself. This is incorrect. 

Instead, we should be using the def-id of the item we're computing to determine if it's an intrinsic.

Fixes #114660 