### PR TITLE
make `typeid::typeid_itanium_cxx_abi::transform_ty` evaluate length in array types

### DIFF
--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -824,11 +824,8 @@ fn transform_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, options: TransformTyOptio
         }
 
         ty::Array(ty0, len) => {
-            let len = len
-                .try_to_scalar()
-                .unwrap()
-                .to_u64()
-                .unwrap_or_else(|_| panic!("failed to convert length to u64"));
+            let len = len.eval_target_usize(tcx, ty::ParamEnv::reveal_all());
+
             ty = Ty::new_array(tcx, transform_ty(tcx, *ty0, options), len);
         }
 

--- a/tests/ui/sanitize/issue-114275-cfi-const-expr-in-arry-len.rs
+++ b/tests/ui/sanitize/issue-114275-cfi-const-expr-in-arry-len.rs
@@ -1,0 +1,15 @@
+// Regression test for issue 114275 `typeid::typeid_itanium_cxx_abi::transform_ty`
+// was expecting array type lengths to be evaluated, this was causing an ICE.
+//
+// build-pass
+// compile-flags: -Ccodegen-units=1 -Clto -Zsanitizer=cfi -Ctarget-feature=-crt-static
+// needs-sanitizer-cfi
+
+#![crate_type = "lib"]
+
+#[repr(transparent)]
+pub struct Array([u8; 1 * 1]);
+
+pub extern "C" fn array() -> Array {
+    loop {}
+}


### PR DESCRIPTION
the ICE in https://github.com/rust-lang/rust/issues/114275 was caused by `transform_ty`
in compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs encountering an unevaluated const, while expecting it to already be evaluated.