### PR TITLE
Add `<[[T; N]; M]>::flatten` conversion to `[T; N * M]`

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -164,6 +164,7 @@
 #![feature(const_waker)]
 #![feature(core_panic)]
 #![feature(duration_consts_float)]
+#![feature(generic_const_exprs)]
 #![feature(internal_impls_macro)]
 #![feature(ip)]
 #![feature(ip_bits)]


### PR DESCRIPTION
This adds a method to convert 2-dimensional array to 1-dimension.