### PR TITLE
`Expr::can_have_side_effects()` is incorrect for struct/enum/array/tuple literals

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1843,7 +1843,7 @@ impl Expr<'_> {
                 .iter()
                 .map(|field| field.expr)
                 .chain(init.into_iter())
-                .all(|e| e.can_have_side_effects()),
+                .any(|e| e.can_have_side_effects()),
 
             ExprKind::Array(args)
             | ExprKind::Tup(args)
@@ -1857,7 +1857,7 @@ impl Expr<'_> {
                     ..
                 },
                 args,
-            ) => args.iter().all(|arg| arg.can_have_side_effects()),
+            ) => args.iter().any(|arg| arg.can_have_side_effects()),
             ExprKind::If(..)
             | ExprKind::Match(..)
             | ExprKind::MethodCall(..)

--- a/tests/ui/async-await/in-trait/return-type-suggestion.rs
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.rs
@@ -6,7 +6,6 @@ trait A {
     async fn e() {
         Ok(())
         //~^ ERROR mismatched types
-        //~| HELP consider using a semicolon here
     }
 }
 

--- a/tests/ui/async-await/in-trait/return-type-suggestion.stderr
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.stderr
@@ -2,9 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/return-type-suggestion.rs:7:9
    |
 LL |         Ok(())
-   |         ^^^^^^- help: consider using a semicolon here: `;`
-   |         |
-   |         expected `()`, found `Result<(), _>`
+   |         ^^^^^^ expected `()`, found `Result<(), _>`
    |
    = note: expected unit type `()`
                    found enum `Result<(), _>`

--- a/tests/ui/return/return-struct.rs
+++ b/tests/ui/return/return-struct.rs
@@ -1,0 +1,24 @@
+struct S;
+
+enum Age {
+    Years(i64, i64)
+}
+
+fn foo() {
+    let mut age = 29;
+    Age::Years({age += 1; age}, 55)
+    //~^ ERROR mismatched types
+}
+
+fn bar() {
+    let mut age = 29;
+    Age::Years(age, 55)
+    //~^ ERROR mismatched types
+}
+
+fn baz() {
+    S
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/return/return-struct.stderr
+++ b/tests/ui/return/return-struct.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> $DIR/return-struct.rs:9:5
+   |
+LL |     Age::Years({age += 1; age}, 55)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Age`
+   |
+help: consider using a semicolon here
+   |
+LL |     Age::Years({age += 1; age}, 55);
+   |                                    +
+help: try adding a return type
+   |
+LL | fn foo() -> Age {
+   |          ++++++
+
+error[E0308]: mismatched types
+  --> $DIR/return-struct.rs:15:5
+   |
+LL | fn bar() {
+   |          - help: try adding a return type: `-> Age`
+LL |     let mut age = 29;
+LL |     Age::Years(age, 55)
+   |     ^^^^^^^^^^^^^^^^^^^ expected `()`, found `Age`
+
+error[E0308]: mismatched types
+  --> $DIR/return-struct.rs:20:5
+   |
+LL | fn baz() {
+   |          - help: try adding a return type: `-> S`
+LL |     S
+   |     ^ expected `()`, found `S`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
It would return 'false' unless *all* sub-expressions had side effects. This would easily allow side effects to slip through, and also wrongly label empty literals as having side effects. Add some tests for the last point

The function is only used for simple lints and error messages, so not a serious bug.