### PR TITLE
Allow dropping `dyn` trait object's principal

### DIFF
--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -154,7 +154,9 @@ pub fn unsized_info<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         ) if src_dyn_kind == target_dyn_kind => {
             let old_info =
                 old_info.expect("unsized_info: missing old info for trait upcasting coercion");
-            if data_a.principal_def_id() == data_b.principal_def_id() {
+            if data_a.principal_def_id() == data_b.principal_def_id()
+                || data_b.principal().is_none()
+            {
                 // A NOP cast that doesn't actually change anything, should be allowed even with invalid vtables.
                 return old_info;
             }

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -537,7 +537,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         let mut responses = vec![];
         // If the principal def ids match (or are both none), then we're not doing
         // trait upcasting. We're just removing auto traits (or shortening the lifetime).
-        if a_data.principal_def_id() == b_data.principal_def_id() {
+        if a_data.principal_def_id() == b_data.principal_def_id() || b_data.principal().is_none() {
             if let Ok(resp) = self.consider_builtin_upcast_to_principal(
                 goal,
                 a_data,

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -767,7 +767,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 if auto_traits_compatible {
                     let principal_def_id_a = a_data.principal_def_id();
                     let principal_def_id_b = b_data.principal_def_id();
-                    if principal_def_id_a == principal_def_id_b {
+                    if principal_def_id_a == principal_def_id_b || principal_def_id_b.is_none() {
                         // no cyclic
                         candidates.vec.push(BuiltinUnsizeCandidate);
                     } else if principal_def_id_a.is_some() && principal_def_id_b.is_some() {

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -954,6 +954,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // We already checked the compatibility of auto traits within `assemble_candidates_for_unsizing`.
                 let iter = data_a
                     .principal()
+                    .filter(|_| {
+                        // optionally drop the principal, if we're unsizing to no principal
+                        data_b.principal().is_some()
+                    })
                     .map(|b| b.map_bound(ty::ExistentialPredicate::Trait))
                     .into_iter()
                     .chain(

--- a/tests/ui/traits/dyn-drop-principal.rs
+++ b/tests/ui/traits/dyn-drop-principal.rs
@@ -1,0 +1,33 @@
+// run-pass
+// check-run-results
+
+#![feature(trait_upcasting)]
+
+use std::any::Any;
+
+fn yeet_principal(x: Box<dyn Any + Send>) -> Box<dyn Send> { x }
+
+struct CallMe<F: FnOnce()>(Option<F>);
+
+impl<F: FnOnce()> CallMe<F> {
+    fn new(f: F) -> Self {
+        CallMe(Some(f))
+    }
+}
+
+impl<F: FnOnce()> Drop for CallMe<F> {
+    fn drop(&mut self) {
+        (self.0.take().unwrap())();
+    }
+}
+
+fn goodbye() {
+    println!("goodbye");
+}
+
+fn main() {
+    let x = Box::new(CallMe::new(goodbye)) as Box<dyn Any + Send>;
+    let y = yeet_principal(x);
+    println!("before");
+    drop(y);
+}

--- a/tests/ui/traits/dyn-drop-principal.run.stdout
+++ b/tests/ui/traits/dyn-drop-principal.run.stdout
@@ -1,0 +1,2 @@
+before
+goodbye


### PR DESCRIPTION
Allows us to cast from `dyn Trait + Send` to `dyn Send`, dropping the trait object's principal trait. This is **distinct** from trait upcasting, since it's trivial even if we were to totally rip out upcasting support -- it uses the same codepath as dropping auto traits, like `dyn Trait + Send` to `dyn Trait`, which is currently allowed without feature gates on stable.

This seems like something that would be nice to have, if anything, just for consistency. Nominating for T-lang discussion and FCP for that reason. I don't personally think this needs a feature gate, but that is also I guess up for debate!

This was originally noticed by lcnr in https://github.com/rust-lang/rust/pull/113393#discussion_r1269150526.

r? types on the impl