### PR TITLE
doc (unstable-book): fix a typo

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/profile_sample_use.md
+++ b/src/doc/unstable-book/src/compiler-flags/profile_sample_use.md
@@ -1,4 +1,4 @@
-# `profile-sample-use
+# `profile-sample-use`
 
 ---
 


### PR DESCRIPTION
Just fix a small typo.