### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1843,7 +1843,7 @@ impl Expr<'_> {
                 .iter()
                 .map(|field| field.expr)
                 .chain(init.into_iter())
-                .all(|e| e.can_have_side_effects()),
+                .any(|e| e.can_have_side_effects()),
 
             ExprKind::Array(args)
             | ExprKind::Tup(args)
@@ -1857,7 +1857,7 @@ impl Expr<'_> {
                     ..
                 },
                 args,
-            ) => args.iter().all(|arg| arg.can_have_side_effects()),
+            ) => args.iter().any(|arg| arg.can_have_side_effects()),
             ExprKind::If(..)
             | ExprKind::Match(..)
             | ExprKind::MethodCall(..)

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -824,11 +824,8 @@ fn transform_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, options: TransformTyOptio
         }
 
         ty::Array(ty0, len) => {
-            let len = len
-                .try_to_scalar()
-                .unwrap()
-                .to_u64()
-                .unwrap_or_else(|_| panic!("failed to convert length to u64"));
+            let len = len.eval_target_usize(tcx, ty::ParamEnv::reveal_all());
+
             ty = Ty::new_array(tcx, transform_ty(tcx, *ty0, options), len);
         }
 

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -39,7 +39,7 @@ impl<'a, Ty> Deref for TyAndLayout<'a, Ty> {
 
 /// Trait that needs to be implemented by the higher-level type representation
 /// (e.g. `rustc_middle::ty::Ty`), to provide `rustc_target::abi` functionality.
-pub trait TyAbiInterface<'a, C>: Sized {
+pub trait TyAbiInterface<'a, C>: Sized + std::fmt::Debug {
     fn ty_and_layout_for_variant(
         this: TyAndLayout<'a, Self>,
         cx: &C,
@@ -135,6 +135,11 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         for index in indices {
             offset += layout.fields.offset(index);
             layout = layout.field(cx, index);
+            assert!(
+                layout.is_sized(),
+                "offset of unsized field (type {:?}) cannot be computed statically",
+                layout.ty
+            );
         }
 
         offset

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1109,7 +1109,7 @@ fn needs_codegen_config(run: &RunConfig<'_>) -> bool {
     needs_codegen_cfg
 }
 
-const CODEGEN_BACKEND_PREFIX: &str = "rustc_codegen_";
+pub(crate) const CODEGEN_BACKEND_PREFIX: &str = "rustc_codegen_";
 
 fn is_codegen_cfg_needed(path: &TaskPath, run: &RunConfig<'_>) -> bool {
     if path.path.to_str().unwrap().contains(&CODEGEN_BACKEND_PREFIX) {

--- a/src/doc/unstable-book/src/compiler-flags/profile_sample_use.md
+++ b/src/doc/unstable-book/src/compiler-flags/profile_sample_use.md
@@ -1,4 +1,4 @@
-# `profile-sample-use
+# `profile-sample-use`
 
 ---
 

--- a/tests/ui/async-await/in-trait/return-type-suggestion.rs
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.rs
@@ -6,7 +6,6 @@ trait A {
     async fn e() {
         Ok(())
         //~^ ERROR mismatched types
-        //~| HELP consider using a semicolon here
     }
 }
 

--- a/tests/ui/async-await/in-trait/return-type-suggestion.stderr
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.stderr
@@ -2,9 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/return-type-suggestion.rs:7:9
    |
 LL |         Ok(())
-   |         ^^^^^^- help: consider using a semicolon here: `;`
-   |         |
-   |         expected `()`, found `Result<(), _>`
+   |         ^^^^^^ expected `()`, found `Result<(), _>`
    |
    = note: expected unit type `()`
                    found enum `Result<(), _>`

--- a/tests/ui/return/return-struct.rs
+++ b/tests/ui/return/return-struct.rs
@@ -1,0 +1,24 @@
+struct S;
+
+enum Age {
+    Years(i64, i64)
+}
+
+fn foo() {
+    let mut age = 29;
+    Age::Years({age += 1; age}, 55)
+    //~^ ERROR mismatched types
+}
+
+fn bar() {
+    let mut age = 29;
+    Age::Years(age, 55)
+    //~^ ERROR mismatched types
+}
+
+fn baz() {
+    S
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/return/return-struct.stderr
+++ b/tests/ui/return/return-struct.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> $DIR/return-struct.rs:9:5
+   |
+LL |     Age::Years({age += 1; age}, 55)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Age`
+   |
+help: consider using a semicolon here
+   |
+LL |     Age::Years({age += 1; age}, 55);
+   |                                    +
+help: try adding a return type
+   |
+LL | fn foo() -> Age {
+   |          ++++++
+
+error[E0308]: mismatched types
+  --> $DIR/return-struct.rs:15:5
+   |
+LL | fn bar() {
+   |          - help: try adding a return type: `-> Age`
+LL |     let mut age = 29;
+LL |     Age::Years(age, 55)
+   |     ^^^^^^^^^^^^^^^^^^^ expected `()`, found `Age`
+
+error[E0308]: mismatched types
+  --> $DIR/return-struct.rs:20:5
+   |
+LL | fn baz() {
+   |          - help: try adding a return type: `-> S`
+LL |     S
+   |     ^ expected `()`, found `S`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/sanitize/issue-114275-cfi-const-expr-in-arry-len.rs
+++ b/tests/ui/sanitize/issue-114275-cfi-const-expr-in-arry-len.rs
@@ -1,0 +1,15 @@
+// Regression test for issue 114275 `typeid::typeid_itanium_cxx_abi::transform_ty`
+// was expecting array type lengths to be evaluated, this was causing an ICE.
+//
+// build-pass
+// compile-flags: -Ccodegen-units=1 -Clto -Zsanitizer=cfi
+// needs-sanitizer-cfi
+
+#![crate_type = "lib"]
+
+#[repr(transparent)]
+pub struct Array([u8; 1 * 1]);
+
+pub extern "C" fn array() -> Array {
+    loop {}
+}

--- a/tests/ui/suggestions/issue-51055-missing-semicolon-between-call-and-tuple.stderr
+++ b/tests/ui/suggestions/issue-51055-missing-semicolon-between-call-and-tuple.stderr
@@ -5,7 +5,7 @@ LL |   fn vindictive() -> bool { true }
    |   ----------------------- `vindictive` defined here returns `bool`
 ...
 LL |       vindictive()
-   |       -^^^^^^^^^^^- help: consider using a semicolon here: `;`
+   |       -^^^^^^^^^^^- help: consider using a semicolon here to finish the statement: `;`
    |  _____|
    | |
 LL | |     (1, 2)

--- a/tests/ui/suggestions/missing-semicolon.fixed
+++ b/tests/ui/suggestions/missing-semicolon.fixed
@@ -1,0 +1,38 @@
+// run-rustfix
+#![allow(dead_code, unused_variables, path_statements)]
+fn a() {
+    let x = 5;
+    let y = x; //~ ERROR expected function
+    (); //~ ERROR expected `;`, found `}`
+}
+
+fn b() {
+    let x = 5;
+    let y = x; //~ ERROR expected function
+    ();
+}
+fn c() {
+    let x = 5;
+    x; //~ ERROR expected function
+    ()
+}
+fn d() { // ok
+    let x = || ();
+    x
+    ()
+}
+fn e() { // ok
+    let x = || ();
+    x
+    ();
+}
+fn f()
+ {
+    let y = 5; //~ ERROR expected function
+    (); //~ ERROR expected `;`, found `}`
+}
+fn g() {
+    5; //~ ERROR expected function
+    ();
+}
+fn main() {}

--- a/tests/ui/suggestions/missing-semicolon.rs
+++ b/tests/ui/suggestions/missing-semicolon.rs
@@ -1,0 +1,38 @@
+// run-rustfix
+#![allow(dead_code, unused_variables, path_statements)]
+fn a() {
+    let x = 5;
+    let y = x //~ ERROR expected function
+    () //~ ERROR expected `;`, found `}`
+}
+
+fn b() {
+    let x = 5;
+    let y = x //~ ERROR expected function
+    ();
+}
+fn c() {
+    let x = 5;
+    x //~ ERROR expected function
+    ()
+}
+fn d() { // ok
+    let x = || ();
+    x
+    ()
+}
+fn e() { // ok
+    let x = || ();
+    x
+    ();
+}
+fn f()
+ {
+    let y = 5 //~ ERROR expected function
+    () //~ ERROR expected `;`, found `}`
+}
+fn g() {
+    5 //~ ERROR expected function
+    ();
+}
+fn main() {}

--- a/tests/ui/suggestions/missing-semicolon.stderr
+++ b/tests/ui/suggestions/missing-semicolon.stderr
@@ -1,0 +1,75 @@
+error: expected `;`, found `}`
+  --> $DIR/missing-semicolon.rs:6:7
+   |
+LL |     ()
+   |       ^ help: add `;` here
+LL | }
+   | - unexpected token
+
+error: expected `;`, found `}`
+  --> $DIR/missing-semicolon.rs:32:7
+   |
+LL |     ()
+   |       ^ help: add `;` here
+LL | }
+   | - unexpected token
+
+error[E0618]: expected function, found `{integer}`
+  --> $DIR/missing-semicolon.rs:5:13
+   |
+LL |       let x = 5;
+   |           - `x` has type `{integer}`
+LL |       let y = x
+   |               ^- help: consider using a semicolon here to finish the statement: `;`
+   |  _____________|
+   | |
+LL | |     ()
+   | |______- call expression requires function
+
+error[E0618]: expected function, found `{integer}`
+  --> $DIR/missing-semicolon.rs:11:13
+   |
+LL |       let x = 5;
+   |           - `x` has type `{integer}`
+LL |       let y = x
+   |               ^- help: consider using a semicolon here to finish the statement: `;`
+   |  _____________|
+   | |
+LL | |     ();
+   | |______- call expression requires function
+
+error[E0618]: expected function, found `{integer}`
+  --> $DIR/missing-semicolon.rs:16:5
+   |
+LL |       let x = 5;
+   |           - `x` has type `{integer}`
+LL |       x
+   |       ^- help: consider using a semicolon here to finish the statement: `;`
+   |  _____|
+   | |
+LL | |     ()
+   | |______- call expression requires function
+
+error[E0618]: expected function, found `{integer}`
+  --> $DIR/missing-semicolon.rs:31:13
+   |
+LL |       let y = 5
+   |               ^- help: consider using a semicolon here to finish the statement: `;`
+   |  _____________|
+   | |
+LL | |     ()
+   | |______- call expression requires function
+
+error[E0618]: expected function, found `{integer}`
+  --> $DIR/missing-semicolon.rs:35:5
+   |
+LL |       5
+   |       ^- help: consider using a semicolon here to finish the statement: `;`
+   |  _____|
+   | |
+LL | |     ();
+   | |______- call expression requires function
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0618`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -490,7 +490,7 @@ cc = ["@nnethercote"]
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
-users_on_vacation = ["jyn514", "WaffleLapkin"]
+users_on_vacation = ["jyn514", "WaffleLapkin", "clubby789"]
 
 [assign.adhoc_groups]
 compiler-team = [


### PR DESCRIPTION
Successful merges:

 - #114278 (better error handling for `rust.codegen-backends` on deserialization)
 - #114474 (Detect missing `;` that parses as function call)
 - #114614 (offset_of: guard against invalid use (with unsized fields))
 - #114672 (make `typeid::typeid_itanium_cxx_abi::transform_ty` evaluate length in array types)
 - #114674 (Add clubby789 to `users_on_vacation`)
 - #114678 (`Expr::can_have_side_effects()` is incorrect for struct/enum/array/tuple literals)
 - #114681 (doc (unstable-book): fix a typo)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114278,114474,114614,114672,114674,114678,114681)
<!-- homu-ignore:end -->