### PR TITLE
downgrade `internal_features` to warn

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2215,7 +2215,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust,compile_fail
+    /// ```rust
     /// #![feature(rustc_attrs)]
     /// ```
     ///
@@ -2226,7 +2226,7 @@ declare_lint! {
     /// These features are an implementation detail of the compiler and standard
     /// library and are not supposed to be used in user code.
     pub INTERNAL_FEATURES,
-    Deny,
+    Warn,
     "internal features are not supposed to be used"
 }
 


### PR DESCRIPTION
Not sure if this requires an FCP or whatever. By having the lint as deny I need to modify test cases when testing them outside of the test suite as the test suite implicitly allows the lint. This takes maybe 10 to 20 seconds per test, but given just how frequently I end up copying tests to different repos it's a significant annoyance.

r? @Nilstrieb 