### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1843,7 +1843,7 @@ impl Expr<'_> {
                 .iter()
                 .map(|field| field.expr)
                 .chain(init.into_iter())
-                .all(|e| e.can_have_side_effects()),
+                .any(|e| e.can_have_side_effects()),
 
             ExprKind::Array(args)
             | ExprKind::Tup(args)
@@ -1857,7 +1857,7 @@ impl Expr<'_> {
                     ..
                 },
                 args,
-            ) => args.iter().all(|arg| arg.can_have_side_effects()),
+            ) => args.iter().any(|arg| arg.can_have_side_effects()),
             ExprKind::If(..)
             | ExprKind::Match(..)
             | ExprKind::MethodCall(..)

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1037,6 +1037,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// Returns false if the coercion creates any obligations that result in
     /// errors.
     pub fn can_coerce(&self, expr_ty: Ty<'tcx>, target: Ty<'tcx>) -> bool {
+        // FIXME(-Ztrait-solver=next): We need to structurally resolve both types here.
         let source = self.resolve_vars_with_obligations(expr_ty);
         debug!("coercion::can_with_predicates({:?} -> {:?})", source, target);
 

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -260,7 +260,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         ));
         let expr = expr.peel_drop_temps();
         let cause = self.misc(expr.span);
-        let expr_ty = self.resolve_vars_with_obligations(checked_ty);
+        let expr_ty = self.resolve_vars_if_possible(checked_ty);
         let mut err = self.err_ctxt().report_mismatched_types(&cause, expected, expr_ty, e);
 
         let is_insufficiently_polymorphic =

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -85,16 +85,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// to get more type information.
     // FIXME(-Ztrait-solver=next): A lot of the calls to this method should
     // probably be `try_structurally_resolve_type` or `structurally_resolve_type` instead.
-    pub(in super::super) fn resolve_vars_with_obligations(&self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        self.resolve_vars_with_obligations_and_mutate_fulfillment(ty, |_| {})
-    }
-
-    #[instrument(skip(self, mutate_fulfillment_errors), level = "debug", ret)]
-    pub(in super::super) fn resolve_vars_with_obligations_and_mutate_fulfillment(
-        &self,
-        mut ty: Ty<'tcx>,
-        mutate_fulfillment_errors: impl Fn(&mut Vec<traits::FulfillmentError<'tcx>>),
-    ) -> Ty<'tcx> {
+    #[instrument(skip(self), level = "debug", ret)]
+    pub(in super::super) fn resolve_vars_with_obligations(&self, mut ty: Ty<'tcx>) -> Ty<'tcx> {
         // No Infer()? Nothing needs doing.
         if !ty.has_non_region_infer() {
             debug!("no inference var, nothing needs doing");
@@ -112,7 +104,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // possible. This can help substantially when there are
         // indirect dependencies that don't seem worth tracking
         // precisely.
-        self.select_obligations_where_possible(mutate_fulfillment_errors);
+        self.select_obligations_where_possible(|_| {});
         self.resolve_vars_if_possible(ty)
     }
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -950,7 +950,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if !expected.is_unit() {
             return;
         }
-        let found = self.resolve_vars_with_obligations(found);
+        let found = self.resolve_vars_if_possible(found);
 
         let in_loop = self.is_loop(id)
             || self

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2994,7 +2994,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // This occurs for UFCS desugaring of `T::method`, where there is no
         // receiver expression for the method call, and thus no autoderef.
         if let SelfSource::QPath(_) = source {
-            return is_local(self.resolve_vars_with_obligations(rcvr_ty));
+            return is_local(rcvr_ty);
         }
 
         self.autoderef(span, rcvr_ty).any(|(ty, _)| is_local(ty))

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1109,7 +1109,7 @@ fn needs_codegen_config(run: &RunConfig<'_>) -> bool {
     needs_codegen_cfg
 }
 
-const CODEGEN_BACKEND_PREFIX: &str = "rustc_codegen_";
+pub(crate) const CODEGEN_BACKEND_PREFIX: &str = "rustc_codegen_";
 
 fn is_codegen_cfg_needed(path: &TaskPath, run: &RunConfig<'_>) -> bool {
     if path.path.to_str().unwrap().contains(&CODEGEN_BACKEND_PREFIX) {

--- a/src/doc/unstable-book/src/compiler-flags/profile_sample_use.md
+++ b/src/doc/unstable-book/src/compiler-flags/profile_sample_use.md
@@ -1,4 +1,4 @@
-# `profile-sample-use
+# `profile-sample-use`
 
 ---
 

--- a/tests/ui/async-await/in-trait/return-type-suggestion.rs
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.rs
@@ -6,7 +6,6 @@ trait A {
     async fn e() {
         Ok(())
         //~^ ERROR mismatched types
-        //~| HELP consider using a semicolon here
     }
 }
 

--- a/tests/ui/async-await/in-trait/return-type-suggestion.stderr
+++ b/tests/ui/async-await/in-trait/return-type-suggestion.stderr
@@ -2,9 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/return-type-suggestion.rs:7:9
    |
 LL |         Ok(())
-   |         ^^^^^^- help: consider using a semicolon here: `;`
-   |         |
-   |         expected `()`, found `Result<(), _>`
+   |         ^^^^^^ expected `()`, found `Result<(), _>`
    |
    = note: expected unit type `()`
                    found enum `Result<(), _>`

--- a/tests/ui/return/return-struct.rs
+++ b/tests/ui/return/return-struct.rs
@@ -1,0 +1,24 @@
+struct S;
+
+enum Age {
+    Years(i64, i64)
+}
+
+fn foo() {
+    let mut age = 29;
+    Age::Years({age += 1; age}, 55)
+    //~^ ERROR mismatched types
+}
+
+fn bar() {
+    let mut age = 29;
+    Age::Years(age, 55)
+    //~^ ERROR mismatched types
+}
+
+fn baz() {
+    S
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/return/return-struct.stderr
+++ b/tests/ui/return/return-struct.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> $DIR/return-struct.rs:9:5
+   |
+LL |     Age::Years({age += 1; age}, 55)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Age`
+   |
+help: consider using a semicolon here
+   |
+LL |     Age::Years({age += 1; age}, 55);
+   |                                    +
+help: try adding a return type
+   |
+LL | fn foo() -> Age {
+   |          ++++++
+
+error[E0308]: mismatched types
+  --> $DIR/return-struct.rs:15:5
+   |
+LL | fn bar() {
+   |          - help: try adding a return type: `-> Age`
+LL |     let mut age = 29;
+LL |     Age::Years(age, 55)
+   |     ^^^^^^^^^^^^^^^^^^^ expected `()`, found `Age`
+
+error[E0308]: mismatched types
+  --> $DIR/return-struct.rs:20:5
+   |
+LL | fn baz() {
+   |          - help: try adding a return type: `-> S`
+LL |     S
+   |     ^ expected `()`, found `S`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -490,7 +490,7 @@ cc = ["@nnethercote"]
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
-users_on_vacation = ["jyn514", "WaffleLapkin"]
+users_on_vacation = ["jyn514", "WaffleLapkin", "clubby789"]
 
 [assign.adhoc_groups]
 compiler-team = [


### PR DESCRIPTION
Successful merges:

 - #114278 (better error handling for `rust.codegen-backends` on deserialization)
 - #114674 (Add clubby789 to `users_on_vacation`)
 - #114678 (`Expr::can_have_side_effects()` is incorrect for struct/enum/array/tuple literals)
 - #114681 (doc (unstable-book): fix a typo)
 - #114684 (Remove redundant calls to `resolve_vars_with_obligations`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114278,114674,114678,114681,114684)
<!-- homu-ignore:end -->