### PR TITLE
Add missing normalization when checking const generics

### DIFF
--- a/tests/ui/lazy-type-alias/issue-114217-const-generic.rs
+++ b/tests/ui/lazy-type-alias/issue-114217-const-generic.rs
@@ -1,0 +1,17 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/114217>.
+// It ensures that enabling the lazy_type_alias` feature doesn't prevent
+// const generics to work with type aliases.
+
+// compile-flags: --crate-type lib
+// check-pass
+
+#![feature(lazy_type_alias)]
+//~^ WARN the feature `lazy_type_alias` is incomplete and may not be safe to use
+
+pub type Word = usize;
+
+pub struct IBig(usize);
+
+pub const fn base_as_ibig<const B: Word>() -> IBig {
+    IBig(B)
+}

--- a/tests/ui/lazy-type-alias/issue-114217-const-generic.stderr
+++ b/tests/ui/lazy-type-alias/issue-114217-const-generic.stderr
@@ -1,0 +1,11 @@
+warning: the feature `lazy_type_alias` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-114217-const-generic.rs:8:12
+   |
+LL | #![feature(lazy_type_alias)]
+   |            ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/114217.
Part of https://github.com/rust-lang/rust/issues/112792.

r? @compiler-errors 