### PR TITLE
parser: not insert dummy field in struct

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1851,21 +1851,11 @@ impl<'a> Parser<'a> {
         attrs: AttrVec,
     ) -> PResult<'a, FieldDef> {
         let name = self.parse_field_ident(adt_ty, lo)?;
-        // Parse the macro invocation and recover
         if self.token.kind == token::Not {
             if let Err(mut err) = self.unexpected::<FieldDef>() {
-                err.subdiagnostic(MacroExpandsToAdtField { adt_ty }).emit();
-                self.bump();
-                self.parse_delim_args()?;
-                return Ok(FieldDef {
-                    span: DUMMY_SP,
-                    ident: None,
-                    vis,
-                    id: DUMMY_NODE_ID,
-                    ty: self.mk_ty(DUMMY_SP, TyKind::Err),
-                    attrs,
-                    is_placeholder: false,
-                });
+                // Encounter the macro invocation
+                err.subdiagnostic(MacroExpandsToAdtField { adt_ty });
+                return Err(err);
             }
         }
         self.expect_field_ty_separator()?;

--- a/tests/ui/parser/macro/macro-expand-to-field.rs
+++ b/tests/ui/parser/macro/macro-expand-to-field.rs
@@ -1,5 +1,7 @@
 // compile-flags: --crate-type=lib
 
+// https://github.com/rust-lang/rust/issues/113766
+
 macro_rules! field {
     ($name:ident:$type:ty) => {
         $name:$type
@@ -13,15 +15,14 @@ macro_rules! variant {
 }
 
 struct Struct {
+    //~^ NOTE while parsing this struct
     field!(bar:u128),
     //~^ NOTE macros cannot expand to struct fields
     //~| ERROR unexpected token: `!`
     //~| NOTE unexpected token after this
     a: u32,
     b: u32,
-    field!(recovers:()), //~ NOTE macros cannot expand to struct fields
-    //~^ ERROR unexpected token: `!`
-    //~^^ NOTE unexpected token after this
+    field!(recovers:()),
 }
 
 enum EnumVariant {
@@ -35,7 +36,7 @@ enum EnumVariant {
     //~^ NOTE macros cannot expand to enum variants
     //~| ERROR unexpected token: `!`
     //~| NOTE unexpected token after this
-    Data {
+    Data { //~ NOTE while parsing this struct
         field!(x:u32),
         //~^ NOTE macros cannot expand to struct fields
         //~| ERROR unexpected token: `!`
@@ -44,27 +45,35 @@ enum EnumVariant {
 }
 
 enum EnumVariantField {
-    Named {
+    Named { //~ NOTE while parsing this struct
         field!(oopsies:()),
         //~^ NOTE macros cannot expand to struct fields
         //~| ERROR unexpected token: `!`
         //~| unexpected token after this
         field!(oopsies2:()),
-        //~^ NOTE macros cannot expand to struct fields
-        //~| ERROR unexpected token: `!`
-        //~| unexpected token after this
     },
 }
 
 union Union {
+    //~^ NOTE while parsing this union
     A: u32,
     field!(oopsies:()),
     //~^ NOTE macros cannot expand to union fields
     //~| ERROR unexpected token: `!`
-    //~| unexpected token after this
+    //~| NOTE unexpected token after this
     B: u32,
     field!(recovers:()),
-    //~^ NOTE macros cannot expand to union fields
-    //~| ERROR unexpected token: `!`
-    //~| unexpected token after this
 }
+
+// https://github.com/rust-lang/rust/issues/114636
+
+#[derive(Debug)]
+pub struct Lazy {
+    //~^ NOTE while parsing this struct
+    unreachable!()
+    //~^ NOTE macros cannot expand to struct fields
+    //~| ERROR unexpected token: `!`
+    //~| NOTE unexpected token after this
+}
+
+fn main() {}

--- a/tests/ui/parser/macro/macro-expand-to-field.stderr
+++ b/tests/ui/parser/macro/macro-expand-to-field.stderr
@@ -1,21 +1,16 @@
 error: unexpected token: `!`
-  --> $DIR/macro-expand-to-field.rs:16:10
+  --> $DIR/macro-expand-to-field.rs:19:10
    |
+LL | struct Struct {
+   |        ------ while parsing this struct
+LL |
 LL |     field!(bar:u128),
    |          ^ unexpected token after this
    |
    = note: macros cannot expand to struct fields
 
 error: unexpected token: `!`
-  --> $DIR/macro-expand-to-field.rs:22:10
-   |
-LL |     field!(recovers:()),
-   |          ^ unexpected token after this
-   |
-   = note: macros cannot expand to struct fields
-
-error: unexpected token: `!`
-  --> $DIR/macro-expand-to-field.rs:28:12
+  --> $DIR/macro-expand-to-field.rs:29:12
    |
 LL |     variant!(whoops),
    |            ^ unexpected token after this
@@ -23,7 +18,7 @@ LL |     variant!(whoops),
    = note: macros cannot expand to enum variants
 
 error: unexpected token: `!`
-  --> $DIR/macro-expand-to-field.rs:34:12
+  --> $DIR/macro-expand-to-field.rs:35:12
    |
 LL |     variant!(recovers),
    |            ^ unexpected token after this
@@ -31,44 +26,46 @@ LL |     variant!(recovers),
    = note: macros cannot expand to enum variants
 
 error: unexpected token: `!`
-  --> $DIR/macro-expand-to-field.rs:39:14
+  --> $DIR/macro-expand-to-field.rs:40:14
    |
+LL |     Data {
+   |     ---- while parsing this struct
 LL |         field!(x:u32),
    |              ^ unexpected token after this
    |
    = note: macros cannot expand to struct fields
 
 error: unexpected token: `!`
-  --> $DIR/macro-expand-to-field.rs:48:14
+  --> $DIR/macro-expand-to-field.rs:49:14
    |
+LL |     Named {
+   |     ----- while parsing this struct
 LL |         field!(oopsies:()),
    |              ^ unexpected token after this
    |
    = note: macros cannot expand to struct fields
 
 error: unexpected token: `!`
-  --> $DIR/macro-expand-to-field.rs:52:14
+  --> $DIR/macro-expand-to-field.rs:60:10
    |
-LL |         field!(oopsies2:()),
-   |              ^ unexpected token after this
-   |
-   = note: macros cannot expand to struct fields
-
-error: unexpected token: `!`
-  --> $DIR/macro-expand-to-field.rs:61:10
-   |
+LL | union Union {
+   |       ----- while parsing this union
+...
 LL |     field!(oopsies:()),
    |          ^ unexpected token after this
    |
    = note: macros cannot expand to union fields
 
 error: unexpected token: `!`
-  --> $DIR/macro-expand-to-field.rs:66:10
+  --> $DIR/macro-expand-to-field.rs:73:16
    |
-LL |     field!(recovers:()),
-   |          ^ unexpected token after this
+LL | pub struct Lazy {
+   |            ---- while parsing this struct
+LL |
+LL |     unreachable!()
+   |                ^ unexpected token after this
    |
-   = note: macros cannot expand to union fields
+   = note: macros cannot expand to struct fields
 
-error: aborting due to 9 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fixes #114636 

This PR eliminates the dummy field, initially introduced in #113999, thereby enabling unrestricted use of ﻿`ident.unwrap()`. A side effect of this action is that we can only report the error of the first macro invocation field within the struct node.

An alternative solution might be giving a virtual name to the macro, but it appears more complex.(https://github.com/rust-lang/rust/issues/114636#issuecomment-1670228715). Furthermore, if you think https://github.com/rust-lang/rust/issues/114636#issuecomment-1670228715 is a better solution, feel free to close this PR.