### PR TITLE
Infer `Lld::No` linker hint when the linker stem is a generic compiler driver

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2991,25 +2991,10 @@ fn add_lld_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor) {
         return;
     }
 
-    let self_contained_linker = sess.opts.cg.link_self_contained.linker();
-
-    // FIXME: some targets default to using `lld`, but users can only override the linker on the CLI
-    // and cannot yet select the precise linker flavor to opt out of that. See for example issue
-    // #113597 for the `thumbv6m-none-eabi` target: a driver is used, and its default linker
-    // conflicts with the target's flavor, causing unexpected arguments being passed.
-    //
-    // Until the new `LinkerFlavor`-like CLI options are stabilized, we only adopt MCP510's behavior
-    // if its dedicated unstable CLI flags are used, to keep the current sub-optimal stable
-    // behavior.
-    let using_mcp510 =
-        self_contained_linker || sess.opts.cg.linker_flavor.is_some_and(|f| f.is_unstable());
-    if !using_mcp510 && !unstable_use_lld {
-        return;
-    }
-
     // 1. Implement the "self-contained" part of this feature by adding rustc distribution
     //    directories to the tool's search path.
-    if self_contained_linker || unstable_use_lld {
+    let self_contained_linker = sess.opts.cg.link_self_contained.linker() || unstable_use_lld;
+    if self_contained_linker {
         for path in sess.get_tools_search_paths(false) {
             cmd.arg({
                 let mut arg = OsString::from("-B");

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -338,7 +338,7 @@ impl LinkerFlavor {
             || stem == "clang++"
             || stem.ends_with("-clang++")
         {
-            (Some(Cc::Yes), None)
+            (Some(Cc::Yes), Some(Lld::No))
         } else if stem == "wasm-ld"
             || stem.ends_with("-wasm-ld")
             || stem == "ld.lld"


### PR DESCRIPTION
This PR basically reverts the temporary solution in https://github.com/rust-lang/rust/pull/113631 to a more long-term solution.

r? @petrochenkov 

In [this comment](https://github.com/rust-lang/rust/pull/113631#issuecomment-1634598238), you had ideas about a long-term solution:

> I wonder what a good non-temporary solution for the inference would look like.
> 
>     * If the default is `(Cc::No, Lld::Yes)` (e.g. `rust-lld`)
>       
>       * and we switch to some specific platform compiler (e.g. `-C linker=arm-none-eabi-gcc`), should we change to `Lld::No`? Maybe yes?
>       * and we switch to some non-default but generic compiler `-C linker=clang`? Then maybe not?
> 
>     * If the default is `(Cc::Yes, Lld::Yes)` (e.g. future x86_64 linux with default LLD)
>       
>       * and we switch to some specific platform compiler (e.g. `-C linker=arm-none-eabi-gcc`), should we change to `Lld::No`? Maybe yes?
>       * and we switch to some non-default but generic compiler `-C linker=clang`? Then maybe not?
> 

I believe that we should infer the `Lld::No` linker hint for any `-Clinker` override, and all the cases above:
- the linker drivers have their own defaults, so in my mind `-Clinker` is a signal to use its default linker / flavor, rather than ours or the target's. In the case of generic compilers, it's more likely than not going to be `Lld::No`. I would expect this to be the case in general, even when including platform-specific compilers. 
- the guess will be wrong if the linker driver uses lld by default (and we also don't want to search for `-fuse-ld` link args), but will work in the more common cases. And the minority of other cases can fix the wrong guess by opting into the precise linker flavor.
- this also ensures backwards-compatibility: today, even on targets with an lld default and overriding the linker, rustc will not use lld. That includes `thumbv6m-none-eabi` where issue #113597 happened. 

It looks like the simplest option, and the one with least churn: we maintain the current behavior in ambiguous cases.

I've tested that this works on #113597, as expected from the failure. 

(I also have a no-std `run-make` test using a custom target json spec: basically simulating a future `x86_64-unknown-linux-gnu` using an lld flavor by default, to check that  e.g. `-Clinker=clang` doesn't use lld. I could add that test to this PR, but IIUC such a custom target requires `cargo -Z build-std` and we have no tests depending on this cargo feature yet. Let me know if you want to add this test of the linker inference for such targets.)

What do you think ?