### PR TITLE
Explicitly deny elided lifetimes in associated consts

### DIFF
--- a/tests/ui/associated-consts/infer-placeholder-in-non-suggestable-pos.rs
+++ b/tests/ui/associated-consts/infer-placeholder-in-non-suggestable-pos.rs
@@ -5,6 +5,7 @@ trait Trait {
 impl Trait for () {
     const ASSOC: &dyn Fn(_) = 1i32;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
+    //~| ERROR `&` without an explicit lifetime name cannot be used here
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/infer-placeholder-in-non-suggestable-pos.stderr
+++ b/tests/ui/associated-consts/infer-placeholder-in-non-suggestable-pos.stderr
@@ -1,9 +1,16 @@
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/infer-placeholder-in-non-suggestable-pos.rs:6:18
+   |
+LL |     const ASSOC: &dyn Fn(_) = 1i32;
+   |                  ^ explicit lifetime name needed here
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/infer-placeholder-in-non-suggestable-pos.rs:6:26
    |
 LL |     const ASSOC: &dyn Fn(_) = 1i32;
    |                          ^ not allowed in type signatures
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0121`.
+Some errors have detailed explanations: E0121, E0637.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/consts/assoc-const-elided-lifetime.rs
+++ b/tests/ui/consts/assoc-const-elided-lifetime.rs
@@ -1,0 +1,12 @@
+use std::marker::PhantomData;
+
+struct Foo<'a> {
+    x: PhantomData<&'a ()>,
+}
+
+impl<'a> Foo<'a> {
+    const FOO: Foo<'_> = Foo { x: PhantomData::<&'a ()> };
+    //~^ ERROR `'_` cannot be used here
+}
+
+fn main() {}

--- a/tests/ui/consts/assoc-const-elided-lifetime.stderr
+++ b/tests/ui/consts/assoc-const-elided-lifetime.stderr
@@ -1,0 +1,9 @@
+error[E0637]: `'_` cannot be used here
+  --> $DIR/assoc-const-elided-lifetime.rs:8:20
+   |
+LL |     const FOO: Foo<'_> = Foo { x: PhantomData::<&'a ()> };
+   |                    ^^ `'_` is a reserved lifetime name
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0637`.

--- a/tests/ui/suggestions/missing-lifetime-in-assoc-const-type.default.stderr
+++ b/tests/ui/suggestions/missing-lifetime-in-assoc-const-type.default.stderr
@@ -1,14 +1,8 @@
-error[E0106]: missing lifetime specifier
+error[E0637]: `&` without an explicit lifetime name cannot be used here
   --> $DIR/missing-lifetime-in-assoc-const-type.rs:6:14
    |
 LL |     const A: &str = "";
-   |              ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL ~ trait ZstAssert<'a>: Sized {
-LL ~     const A: &'a str = "";
-   |
+   |              ^ explicit lifetime name needed here
 
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-in-assoc-const-type.rs:7:14
@@ -23,19 +17,11 @@ LL |     const A: &str = "";
 LL ~     const B: S<'a> = S { s: &() };
    |
 
-error[E0106]: missing lifetime specifier
+error[E0637]: `'_` cannot be used here
   --> $DIR/missing-lifetime-in-assoc-const-type.rs:8:15
    |
 LL |     const C: &'_ str = "";
-   |               ^^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL ~ trait ZstAssert<'a>: Sized {
-LL |     const A: &str = "";
-LL |     const B: S = S { s: &() };
-LL ~     const C: &'a str = "";
-   |
+   |               ^^ `'_` is a reserved lifetime name
 
 error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lifetime-in-assoc-const-type.rs:9:14
@@ -54,4 +40,5 @@ LL ~     const D: T<'a, 'a> = T { a: &(), b: &() };
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0106`.
+Some errors have detailed explanations: E0106, E0637.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lifetime-in-assoc-const-type.generic_const_items.stderr
+++ b/tests/ui/suggestions/missing-lifetime-in-assoc-const-type.generic_const_items.stderr
@@ -1,13 +1,8 @@
-error[E0106]: missing lifetime specifier
+error[E0637]: `&` without an explicit lifetime name cannot be used here
   --> $DIR/missing-lifetime-in-assoc-const-type.rs:6:14
    |
 LL |     const A: &str = "";
-   |              ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |     const A<'a>: &'a str = "";
-   |            ++++   ++
+   |              ^ explicit lifetime name needed here
 
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-in-assoc-const-type.rs:7:14
@@ -20,16 +15,11 @@ help: consider introducing a named lifetime parameter
 LL |     const B<'a>: S<'a> = S { s: &() };
    |            ++++   ++++
 
-error[E0106]: missing lifetime specifier
+error[E0637]: `'_` cannot be used here
   --> $DIR/missing-lifetime-in-assoc-const-type.rs:8:15
    |
 LL |     const C: &'_ str = "";
-   |               ^^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |     const C<'a>: &'a str = "";
-   |            ++++   ~~
+   |               ^^ `'_` is a reserved lifetime name
 
 error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lifetime-in-assoc-const-type.rs:9:14
@@ -44,4 +34,5 @@ LL |     const D<'a>: T<'a, 'a> = T { a: &(), b: &() };
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0106`.
+Some errors have detailed explanations: E0106, E0637.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lifetime-in-assoc-const-type.rs
+++ b/tests/ui/suggestions/missing-lifetime-in-assoc-const-type.rs
@@ -3,9 +3,9 @@
 #![cfg_attr(generic_const_items, feature(generic_const_items), allow(incomplete_features))]
 
 trait ZstAssert: Sized {
-    const A: &str = ""; //~ ERROR missing lifetime specifier
+    const A: &str = ""; //~ ERROR `&` without an explicit lifetime name cannot be used here
     const B: S = S { s: &() }; //~ ERROR missing lifetime specifier
-    const C: &'_ str = ""; //~ ERROR missing lifetime specifier
+    const C: &'_ str = ""; //~ ERROR `'_` cannot be used here
     const D: T = T { a: &(), b: &() }; //~ ERROR missing lifetime specifier
 }
 


### PR DESCRIPTION
This seems to have regressed in #97313, after which we have begun resolving elided lifetimes in impls to anonymous early-bound lifetimes.

This PR applies an `AnonymousReportError` lifetime binder to both impl and trait const items to avoid this behavior. Only the former needs it, but also doing the latter for diagnostic consistency.

r? @cjgillot or @petrochenkov
Please review with whitespace changes disabled, the real diff is like 4 lines.

This probably requires a crater run anyways, but this is clearly a bug. I personally think we should use an `Elided(LifetimeRes::Static)` rib here, but that would require a T-lang FCP (or an RFC? idk).

cc #114706