### PR TITLE
TAITs do not constrain generic params

### DIFF
--- a/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
+++ b/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
@@ -59,7 +59,7 @@ struct ParameterCollector {
 impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ParameterCollector {
     fn visit_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
         match *t.kind() {
-            ty::Alias(ty::Projection | ty::Inherent, ..) if !self.include_nonconstraining => {
+            ty::Alias(..) if !self.include_nonconstraining => {
                 // projections are not injective
                 return ControlFlow::Continue(());
             }

--- a/tests/ui/type-alias-impl-trait/coherence.rs
+++ b/tests/ui/type-alias-impl-trait/coherence.rs
@@ -12,6 +12,6 @@ fn use_alias<T>(val: T) -> AliasOfForeignType<T> {
 }
 
 impl<T> foreign_crate::ForeignTrait for AliasOfForeignType<T> {}
-//~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
+//~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/coherence.rs
+++ b/tests/ui/type-alias-impl-trait/coherence.rs
@@ -11,7 +11,7 @@ fn use_alias<T>(val: T) -> AliasOfForeignType<T> {
     foreign_crate::ForeignType(val)
 }
 
-impl<T> foreign_crate::ForeignTrait for AliasOfForeignType<T> {}
-//~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
+impl foreign_crate::ForeignTrait for AliasOfForeignType<()> {}
+//~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/coherence.stderr
+++ b/tests/ui/type-alias-impl-trait/coherence.stderr
@@ -1,9 +1,14 @@
-error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/coherence.rs:14:6
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence.rs:14:1
    |
-LL | impl<T> foreign_crate::ForeignTrait for AliasOfForeignType<T> {}
-   |      ^ unconstrained type parameter
+LL | impl foreign_crate::ForeignTrait for AliasOfForeignType<()> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------
+   | |                                    |
+   | |                                    `AliasOfForeignType<()>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0207`.
+For more information about this error, try `rustc --explain E0117`.

--- a/tests/ui/type-alias-impl-trait/coherence.stderr
+++ b/tests/ui/type-alias-impl-trait/coherence.stderr
@@ -1,14 +1,9 @@
-error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
-  --> $DIR/coherence.rs:14:1
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/coherence.rs:14:6
    |
 LL | impl<T> foreign_crate::ForeignTrait for AliasOfForeignType<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------
-   | |                                       |
-   | |                                       `AliasOfForeignType<T>` is not defined in the current crate
-   | impl doesn't use only types from inside the current crate
-   |
-   = note: define and implement a trait or new type instead
+   |      ^ unconstrained type parameter
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0117`.
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/coherence_generalization.rs
+++ b/tests/ui/type-alias-impl-trait/coherence_generalization.rs
@@ -1,7 +1,6 @@
-// check-pass
-
 // FIXME(type_alias_impl_trait): What does this test? This needs a comment
 // explaining what we're worried about here.
+
 #![feature(type_alias_impl_trait)]
 trait Trait {}
 type Opaque<T> = impl Sized;
@@ -11,5 +10,6 @@ fn foo<T>() -> Opaque<T> {
 
 impl<T, V> Trait for (T, V, V, u32) {}
 impl<U, V> Trait for (Opaque<U>, V, i32, V) {}
+//~^ ERROR the type parameter `U` is not constrained by the impl trait, self type, or predicates
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/coherence_generalization.rs
+++ b/tests/ui/type-alias-impl-trait/coherence_generalization.rs
@@ -1,3 +1,5 @@
+// check-pass
+
 // FIXME(type_alias_impl_trait): What does this test? This needs a comment
 // explaining what we're worried about here.
 
@@ -8,8 +10,7 @@ fn foo<T>() -> Opaque<T> {
     ()
 }
 
-impl<T, V> Trait for (T, V, V, u32) {}
-impl<U, V> Trait for (Opaque<U>, V, i32, V) {}
-//~^ ERROR the type parameter `U` is not constrained by the impl trait, self type, or predicates
+impl<T, U, V> Trait for (T, U, V, V, u32) {}
+impl<U, V> Trait for (Opaque<U>, U, V, i32, V) {}
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/coherence_generalization.stderr
+++ b/tests/ui/type-alias-impl-trait/coherence_generalization.stderr
@@ -1,9 +1,0 @@
-error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/coherence_generalization.rs:12:6
-   |
-LL | impl<U, V> Trait for (Opaque<U>, V, i32, V) {}
-   |      ^ unconstrained type parameter
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/coherence_generalization.stderr
+++ b/tests/ui/type-alias-impl-trait/coherence_generalization.stderr
@@ -1,0 +1,9 @@
+error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/coherence_generalization.rs:12:6
+   |
+LL | impl<U, V> Trait for (Opaque<U>, V, i32, V) {}
+   |      ^ unconstrained type parameter
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/unconstrained-impl-param.rs
+++ b/tests/ui/type-alias-impl-trait/unconstrained-impl-param.rs
@@ -1,0 +1,25 @@
+#![feature(type_alias_impl_trait)]
+
+use std::fmt::Display;
+
+type Opaque<'a> = impl Sized + 'static;
+fn define<'a>() -> Opaque<'a> {}
+
+trait Trait {
+    type Assoc: Display;
+}
+impl<'a> Trait for Opaque<'a> {
+    //~^ ERROR the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
+    type Assoc = &'a str;
+}
+
+// ======= Exploit =======
+
+fn extend<T: Trait + 'static>(s: T::Assoc) -> Box<dyn Display> {
+    Box::new(s)
+}
+
+fn main() {
+    let val = extend::<Opaque<'_>>(&String::from("blah blah blah"));
+    println!("{}", val);
+}

--- a/tests/ui/type-alias-impl-trait/unconstrained-impl-param.rs
+++ b/tests/ui/type-alias-impl-trait/unconstrained-impl-param.rs
@@ -2,13 +2,13 @@
 
 use std::fmt::Display;
 
-type Opaque<'a> = impl Sized + 'static;
-fn define<'a>() -> Opaque<'a> {}
+type Opaque<X> = impl Sized + 'static;
+fn define<X>() -> Opaque<X> {}
 
 trait Trait {
     type Assoc: Display;
 }
-impl<'a> Trait for Opaque<'a> {
+impl<'a> Trait for Opaque<&'a str> {
     //~^ ERROR the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
     type Assoc = &'a str;
 }
@@ -20,6 +20,6 @@ fn extend<T: Trait + 'static>(s: T::Assoc) -> Box<dyn Display> {
 }
 
 fn main() {
-    let val = extend::<Opaque<'_>>(&String::from("blah blah blah"));
+    let val = extend::<Opaque<&'_ str>>(&String::from("blah blah blah"));
     println!("{}", val);
 }

--- a/tests/ui/type-alias-impl-trait/unconstrained-impl-param.stderr
+++ b/tests/ui/type-alias-impl-trait/unconstrained-impl-param.stderr
@@ -1,0 +1,9 @@
+error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-impl-param.rs:11:6
+   |
+LL | impl<'a> Trait for Opaque<'a> {
+   |      ^^ unconstrained lifetime parameter
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/unconstrained-impl-param.stderr
+++ b/tests/ui/type-alias-impl-trait/unconstrained-impl-param.stderr
@@ -1,7 +1,7 @@
 error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
   --> $DIR/unconstrained-impl-param.rs:11:6
    |
-LL | impl<'a> Trait for Opaque<'a> {
+LL | impl<'a> Trait for Opaque<&'a str> {
    |      ^^ unconstrained lifetime parameter
 
 error: aborting due to previous error


### PR DESCRIPTION
Fixes #108425

Not sure if I should rework those two failing tests. I guess `tests/ui/type-alias-impl-trait/coherence.rs` could just have the type parameter removed from it? IDK what `tests/ui/type-alias-impl-trait/coherence_generalization.rs` is even testing, though.

r? @aliemjay
cc @lcnr @oli-obk (when he's back from :palm_tree:)