### PR TITLE
Make Const more useful in smir

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -10,7 +10,7 @@
 use crate::rustc_internal::{self, opaque};
 use crate::stable_mir::mir::{CopyNonOverlapping, UserTypeProjection, VariantIdx};
 use crate::stable_mir::ty::{
-    allocation_filter, new_allocation, FloatTy, IntTy, Movability, RigidTy, TyKind, UintTy,
+    allocation_filter, new_allocation, Const, FloatTy, IntTy, Movability, RigidTy, TyKind, UintTy,
 };
 use crate::stable_mir::{self, Context};
 use rustc_hir as hir;
@@ -173,7 +173,11 @@ impl<'tcx> Stable<'tcx> for mir::Rvalue<'tcx> {
         use mir::Rvalue::*;
         match self {
             Use(op) => stable_mir::mir::Rvalue::Use(op.stable(tables)),
-            Repeat(op, len) => stable_mir::mir::Rvalue::Repeat(op.stable(tables), opaque(len)),
+            Repeat(op, len) => {
+                let cnst = ConstantKind::from_const(*len, tables.tcx);
+                let len = Const { literal: cnst.stable(tables) };
+                stable_mir::mir::Rvalue::Repeat(op.stable(tables), len)
+            }
             Ref(region, kind, place) => stable_mir::mir::Rvalue::Ref(
                 opaque(region),
                 kind.stable(tables),
@@ -358,7 +362,11 @@ impl<'tcx> Stable<'tcx> for ty::TermKind<'tcx> {
         use stable_mir::ty::TermKind;
         match self {
             ty::TermKind::Ty(ty) => TermKind::Type(tables.intern_ty(*ty)),
-            ty::TermKind::Const(const_) => TermKind::Const(opaque(const_)),
+            ty::TermKind::Const(cnst) => {
+                let cnst = ConstantKind::from_const(*cnst, tables.tcx);
+                let cnst = Const { literal: cnst.stable(tables) };
+                TermKind::Const(cnst)
+            }
         }
     }
 }
@@ -815,7 +823,10 @@ impl<'tcx> Stable<'tcx> for ty::GenericArgKind<'tcx> {
         match self {
             ty::GenericArgKind::Lifetime(region) => GenericArgKind::Lifetime(opaque(region)),
             ty::GenericArgKind::Type(ty) => GenericArgKind::Type(tables.intern_ty(*ty)),
-            ty::GenericArgKind::Const(const_) => GenericArgKind::Const(opaque(&const_)),
+            ty::GenericArgKind::Const(cnst) => {
+                let cnst = ConstantKind::from_const(*cnst, tables.tcx);
+                GenericArgKind::Const(stable_mir::ty::Const { literal: cnst.stable(tables) })
+            }
         }
     }
 }
@@ -1008,7 +1019,9 @@ impl<'tcx> Stable<'tcx> for Ty<'tcx> {
             }
             ty::Str => TyKind::RigidTy(RigidTy::Str),
             ty::Array(ty, constant) => {
-                TyKind::RigidTy(RigidTy::Array(tables.intern_ty(*ty), opaque(constant)))
+                let cnst = ConstantKind::from_const(*constant, tables.tcx);
+                let cnst = stable_mir::ty::Const { literal: cnst.stable(tables) };
+                TyKind::RigidTy(RigidTy::Array(tables.intern_ty(*ty), cnst))
             }
             ty::Slice(ty) => TyKind::RigidTy(RigidTy::Slice(tables.intern_ty(*ty))),
             ty::RawPtr(ty::TypeAndMut { ty, mutbl }) => {

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -15,7 +15,11 @@ impl Ty {
     }
 }
 
-pub(crate) type Const = Opaque;
+#[derive(Debug, Clone)]
+pub struct Const {
+    pub literal: ConstantKind,
+}
+
 type Ident = Opaque;
 pub(crate) type Region = Opaque;
 type Span = Opaque;


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/114587 is merged, we can make use of what we built and make Const more useful by making it not `Opaque`

r? @spastorino 