### PR TITLE
Don't add associated type bound for non-types

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -1,6 +1,9 @@
 hir_analysis_ambiguous_lifetime_bound =
     ambiguous lifetime bound, explicit lifetime bound required
 
+hir_analysis_assoc_bound_on_const = expected associated type, found {$descr}
+    .note = trait bounds not allowed on {$descr}
+
 hir_analysis_assoc_type_binding_not_allowed =
     associated type bindings are not allowed here
     .label = associated type not allowed here

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -918,3 +918,12 @@ pub struct UnusedAssociatedTypeBounds {
     #[suggestion(code = "")]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_assoc_bound_on_const)]
+#[note]
+pub struct AssocBoundOnConst {
+    #[primary_span]
+    pub span: Span,
+    pub descr: &'static str,
+}

--- a/tests/ui/associated-type-bounds/consts.rs
+++ b/tests/ui/associated-type-bounds/consts.rs
@@ -1,0 +1,10 @@
+#![feature(associated_type_bounds)]
+
+pub fn accept(_: impl Trait<K: Copy>) {}
+//~^ ERROR expected associated type, found associated constant
+
+pub trait Trait {
+    const K: i32;
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/consts.stderr
+++ b/tests/ui/associated-type-bounds/consts.stderr
@@ -1,0 +1,10 @@
+error: expected associated type, found associated constant
+  --> $DIR/consts.rs:3:29
+   |
+LL | pub fn accept(_: impl Trait<K: Copy>) {}
+   |                             ^
+   |
+   = note: trait bounds not allowed on associated constant
+
+error: aborting due to previous error
+


### PR DESCRIPTION
We had this fix for equality constraints (#99890), but for some reason not trait constraints :sweat_smile: 

Fixes #114744