### PR TITLE
fixed *const [type error] does not implement the Copy trait

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
@@ -68,7 +68,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
         let asm_ty = match *ty.kind() {
             // `!` is allowed for input but not for output (issue #87802)
             ty::Never if is_input => return None,
-            ty::Error(_) => return None,
+            _ if ty.references_error() => return None,
             ty::Int(IntTy::I8) | ty::Uint(UintTy::U8) => Some(InlineAsmType::I8),
             ty::Int(IntTy::I16) | ty::Uint(UintTy::U16) => Some(InlineAsmType::I16),
             ty::Int(IntTy::I32) | ty::Uint(UintTy::U32) => Some(InlineAsmType::I32),

--- a/tests/ui/asm/issue-113788.rs
+++ b/tests/ui/asm/issue-113788.rs
@@ -1,0 +1,7 @@
+// test that "error: arguments for inline assembly must be copyable" doesn't show up in this code
+// needs-asm-support
+// only-x86_64
+fn main() {
+    let peb: *const PEB; //~ ERROR cannot find type `PEB` in this scope [E0412]
+    unsafe { std::arch::asm!("mov {0}, fs:[0x30]", out(reg) peb); }
+}

--- a/tests/ui/asm/issue-113788.stderr
+++ b/tests/ui/asm/issue-113788.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `PEB` in this scope
+  --> $DIR/issue-113788.rs:5:21
+   |
+LL |     let peb: *const PEB;
+   |                     ^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Removes "error: arguments for inline assembly must be copyable" when moving an unknown type

Fixes: #113788