### PR TITLE
DebugInfo: Updates test cases that add method declarations.

### DIFF
--- a/tests/codegen/method-declaration.rs
+++ b/tests/codegen/method-declaration.rs
@@ -1,0 +1,26 @@
+// compile-flags: -g -Cno-prepopulate-passes
+
+// Verify that we added a declaration for a method.
+
+// CHECK: define{{.*}}@method{{.*}} !dbg ![[METHOD_DEF_DBG:[0-9]+]]
+// CHECK: define{{.*}}@function{{.*}} !dbg ![[FUNC_DEF_DBG:[0-9]+]]
+
+#![crate_type = "lib"]
+
+// CHECK-DAG: ![[FOO_DBG:[0-9]+]] = !DICompositeType(tag: {{.*}} name: "Foo", {{.*}} identifier:
+pub struct Foo;
+
+impl Foo {
+    // CHECK-DAG: ![[METHOD_DEF_DBG]] = distinct !DISubprogram(name: "method"{{.*}}, scope: ![[FOO_DBG]]{{.*}}DISPFlagDefinition{{.*}}, declaration: ![[METHOD_DECL_DBG:[0-9]+]]
+    // CHECK-DAG: ![[METHOD_DECL_DBG]] = !DISubprogram(name: "method"{{.*}}, scope: ![[FOO_DBG]]
+    #[no_mangle]
+    pub fn method() {}
+}
+
+// CHECK: ![[FUNC_DEF_DBG]] = distinct !DISubprogram(name: "function"
+// CHECK-NOT: declaration
+// CHECK-SAME: DISPFlagDefinition
+// CHECK-NOT: declaration
+// CHECK-SAME: )
+#[no_mangle]
+pub fn function() {}


### PR DESCRIPTION
We've investigated one reason why debugging information often goes wrong at https://reviews.llvm.org/D152095.
> LLVM can't handle IR where subprogram definitions are nested within DICompositeType when doing LTO builds, because there's no good way to cross the CU boundary to insert a nested DISubprogram definition in one CU into a type defined in another CU.

In #111167, we added a declaration for the DISubprogram for the method. This PR completes this test case.

stream history: https://rust-lang.zulipchat.com/#narrow/stream/187780-t-compiler.2Fwg-llvm/topic/Dwarf.20CUs/near/384269475.