### PR TITLE
Make early effective visibilities a separate query.

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1138,7 +1138,6 @@ rustc_queries! {
         desc { "checking effective visibilities" }
     }
     query check_private_in_public(_: ()) -> () {
-        eval_always
         desc { "checking for private elements in public interfaces" }
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1127,9 +1127,14 @@ rustc_queries! {
         cache_on_disk_if { true }
     }
 
+    /// Effective visibilities as computed by the resolver.
+    query early_effective_visibilities(_: ()) -> &'tcx Steal<EffectiveVisibilities> {
+        arena_cache
+        desc { "checking effective visibilities" }
+        feedable
+    }
     /// Performs part of the privacy check and computes effective visibilities.
     query effective_visibilities(_: ()) -> &'tcx EffectiveVisibilities {
-        eval_always
         desc { "checking effective visibilities" }
     }
     query check_private_in_public(_: ()) -> () {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -19,7 +19,6 @@ pub use self::IntVarValue::*;
 pub use self::Variance::*;
 use crate::error::{OpaqueHiddenTypeMismatch, TypeMismatchReason};
 use crate::metadata::ModChild;
-use crate::middle::privacy::EffectiveVisibilities;
 use crate::mir::{Body, GeneratorLayout};
 use crate::query::Providers;
 use crate::traits::{self, Reveal};
@@ -164,7 +163,6 @@ pub struct ResolverGlobalCtxt {
     pub visibilities: FxHashMap<LocalDefId, Visibility>,
     /// Item with a given `LocalDefId` was defined during macro expansion with ID `ExpnId`.
     pub expn_that_defined: FxHashMap<LocalDefId, ExpnId>,
-    pub effective_visibilities: EffectiveVisibilities,
     pub extern_crate_map: FxHashMap<LocalDefId, CrateNum>,
     pub maybe_unused_trait_imports: FxIndexSet<LocalDefId>,
     pub module_children: LocalDefIdMap<Vec<ModChild>>,

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1896,7 +1896,7 @@ fn effective_visibilities(tcx: TyCtxt<'_>, (): ()) -> &EffectiveVisibilities {
     // items which are reachable from external crates based on visibility.
     let mut visitor = EmbargoVisitor {
         tcx,
-        effective_visibilities: tcx.resolutions(()).effective_visibilities.clone(),
+        effective_visibilities: tcx.early_effective_visibilities(()).steal(),
         macro_reachable: Default::default(),
         // HACK(jynelson): trying to infer the type of `impl Trait` breaks `async-std` (and
         // `pub async fn` in general). Since rustdoc never needs to do codegen and doesn't

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1497,11 +1497,11 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 Some(StrippedCfgItem { parent_module, name: item.name, cfg: item.cfg })
             }),
         ));
+        self.tcx.feed_unit_query().early_effective_visibilities(Steal::new(effective_visibilities));
 
         let global_ctxt = ResolverGlobalCtxt {
             expn_that_defined,
             visibilities,
-            effective_visibilities,
             extern_crate_map,
             module_children: self.module_children,
             glob_map,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2774,7 +2774,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         let def_id = trait_pred.def_id();
                         let visible_item = if let Some(local) = def_id.as_local() {
                             // Check for local traits being reachable.
-                            let vis = &self.tcx.resolutions(()).effective_visibilities;
+                            let vis = &self.tcx.effective_visibilities(());
                             // Account for non-`pub` traits in the root of the local crate.
                             let is_locally_reachable = self.tcx.parent(def_id).is_crate_root();
                             vis.is_reachable(local) || is_locally_reachable


### PR DESCRIPTION
r? @ghost 