### PR TITLE
[style edition 2024] Combine all delimited exprs as last argument

### DIFF
--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -36,6 +36,10 @@ For a full history of changes in the Rust 2024 style edition, see the git
 history of the style guide. Notable changes in the Rust 2024 style edition
 include:
 
+- [#114764](https://github.com/rust-lang/rust/pull/114764) As the last member
+  of a delimited expression, delimited expressions are generally combinable,
+  regardless of the number of members. Previously only applied with exactly
+  one member (except for closures with explicit blocks).
 - Miscellaneous `rustfmt` bugfixes.
 
 ## Rust 2015/2018/2021 style edition

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -801,11 +801,11 @@ E.g., `&&Some(foo)` matches, `Foo(4, Bar)` does not.
 
 ## Combinable expressions
 
-Where a function call has a single argument, and that argument is formatted
-across multiple-lines, format the outer call as if it were a single-line call,
+When the last argument in a function call is formatted across
+multiple-lines, format the outer call as if it were a single-line call,
 if the result fits. Apply the same combining behaviour to any similar
 expressions which have multi-line, block-indented lists of sub-expressions
-delimited by parentheses (e.g., macros or tuple struct literals). E.g.,
+delimited by parentheses, brackets, or braces. E.g.,
 
 ```rust
 foo(bar(
@@ -831,20 +831,61 @@ let arr = [combinable(
     an_expr,
     another_expr,
 )];
+
+let x = Thing(an_expr, another_expr, match cond {
+    A => 1,
+    B => 2,
+});
+
+let x = format!("Stuff: {}", [
+    an_expr,
+    another_expr,
+]);
+
+let x = func(an_expr, another_expr, SomeStruct {
+    field: this_is_long,
+    another_field: 123,
+});
 ```
 
 Apply this behavior recursively.
 
-For a function with multiple arguments, if the last argument is a multi-line
-closure with an explicit block, there are no other closure arguments, and all
-the arguments and the first line of the closure fit on the first line, use the
-same combining behavior:
+If the last argument is a multi-line closure with an explicit block,
+only apply the combining behavior if there are no other closure arguments.
 
 ```rust
+// Combinable
 foo(first_arg, x, |param| {
     action();
     foo(param)
 })
+// Not combinable, because the closure is not the last argument
+foo(
+    first_arg,
+    |param| {
+        action();
+        foo(param)
+    },
+    whatever,
+)
+// Not combinable, because the first line of the closure does not fit
+foo(
+    first_arg,
+    x,
+    move |very_long_param_causing_line_to_overflow| -> Bar {
+        action();
+        foo(param)
+    },
+)
+// Not combinable, because there is more than one closure argument
+foo(
+    first_arg,
+    |x| x.bar(),
+    |param| {
+        action();
+        foo(param)
+    },
+)
 ```
 
 ## Ranges


### PR DESCRIPTION
Closes rust-lang/style-team#149

If this is merged, the rustfmt option `overflow_delimited_expr` should be enabled by default in style edition 2024.

[Rendered](https://github.com/pitaj/rust/blob/style-delimited-expressions/src/doc/style-guide/src/expressions.md#combinable-expressions)

r? joshtriplett