### PR TITLE
`box` macro similar to `vec` macro

### DIFF
--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -131,3 +131,19 @@ macro_rules! __rust_force_expr {
         $e
     };
 }
+
+/// Creates a [`Box`] given the expression
+///
+/// ```
+/// let boxed = box!(10);
+/// assert_eq!(boxed, Box::new(10));
+/// ```
+///
+/// [`Box`]: crate::boxed::Box
+#[macro_export]
+#[rustc_diagnostic_item = "box_macro"]
+macro_rules! box {
+    ($boxed:expr) => { 
+        $crate::boxed::Box::new($boxed) 
+    };
+}

--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -142,7 +142,6 @@ macro_rules! __rust_force_expr {
 /// [`Box`]: crate::boxed::Box
 #[macro_export]
 #[unstable(feature = "box_macro", issue = "114778", reason = "Might change")]
-#[rustc_diagnostic_item = "box_macro"]
 macro_rules! r#box {
     ($boxed:expr) => {
         $crate::boxed::Box::new($boxed)

--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -142,8 +142,8 @@ macro_rules! __rust_force_expr {
 /// [`Box`]: crate::boxed::Box
 #[macro_export]
 #[rustc_diagnostic_item = "box_macro"]
-macro_rules! box {
-    ($boxed:expr) => { 
-        $crate::boxed::Box::new($boxed) 
+macro_rules! r#box {
+    ($boxed:expr) => {
+        $crate::boxed::Box::new($boxed)
     };
 }

--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -141,6 +141,7 @@ macro_rules! __rust_force_expr {
 ///
 /// [`Box`]: crate::boxed::Box
 #[macro_export]
+#[unstable(feature = "box_macro", issue = "114778", reason = "Might change")]
 #[rustc_diagnostic_item = "box_macro"]
 macro_rules! r#box {
     ($boxed:expr) => {


### PR DESCRIPTION
Adds a `box` macro which can be used similarly to the `vec` macro.

```rs
let boxed = box!(10);
assert_eq!(boxed, Box::new(10));
```