### PR TITLE
Select obligations before processing wf obligation in `compare_method_predicate_entailment`

### DIFF
--- a/tests/ui/implied-bounds/implied-bounds-entailment-wf-vars-issue-114783-1.rs
+++ b/tests/ui/implied-bounds/implied-bounds-entailment-wf-vars-issue-114783-1.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+pub trait Foo {
+    type Error: Error;
+
+    fn foo(&self, stream: &<Self::Error as Error>::Span);
+}
+
+pub struct Wrapper<Inner>(Inner);
+
+impl<E: Error, Inner> Foo for Wrapper<Inner>
+where
+    Inner: Foo<Error = E>,
+{
+    type Error = E;
+
+    fn foo(&self, stream: &<Self::Error as Error>::Span) {
+        todo!()
+    }
+}
+
+pub trait Error {
+    type Span;
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/implied-bounds-entailment-wf-vars-issue-114783-2.rs
+++ b/tests/ui/implied-bounds/implied-bounds-entailment-wf-vars-issue-114783-2.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+trait AsBufferView {
+    type Device;
+}
+
+trait Error {
+    type Span;
+}
+
+trait Foo {
+    type Error: Error;
+    fn foo(&self) -> &<Self::Error as Error>::Span;
+}
+
+impl<D: Error, VBuf0> Foo for VBuf0
+where
+    VBuf0: AsBufferView<Device = D>,
+{
+    type Error = D;
+    fn foo(&self) -> &<Self::Error as Error>::Span {
+        todo!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
We need to select obligations before processing the WF obligation for the `IMPLIED_BOUNDS_ENTAILMENT` lint, since it skips over type variables.

Fixes #114783

r? @jackh726 