### PR TITLE
[library] Replace take with zip.

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -139,11 +139,9 @@ pub(crate) mod hack {
             let mut vec = Vec::with_capacity_in(s.len(), alloc);
             let mut guard = DropGuard { vec: &mut vec, num_init: 0 };
             let slots = guard.vec.spare_capacity_mut();
-            // .take(slots.len()) is necessary for LLVM to remove bounds checks
-            // and has better codegen than zip.
-            for (i, b) in s.iter().enumerate().take(slots.len()) {
+            for (i, (b, slot)) in s.iter().zip(slots.iter_mut()).enumerate() {
                 guard.num_init = i;
-                slots[i].write(b.clone());
+                slot.write(b.clone());
             }
             core::mem::forget(guard);
             // SAFETY:


### PR DESCRIPTION
Removed comment claimed that codegen for using `zip` is worse, but https://godbolt.org/z/b8399768d suggests otherwise. Most likely rustc got much better since that comment and invalidated its justification.

Just in case I also compared both implementations using benchmark https://gist.github.com/ttsugriy/e7e6a507ade27b6b7eec905962688ce2

and for M1 MacBook Air results are:
```
     Running benches/to_vec_benchmark.rs (target/release/deps/to_vec_benchmark-672dcbfe2c06ef8b)
to_vec/original         time:   [943.94 ns 953.24 ns 962.02 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
to_vec/proposed         time:   [929.50 ns 940.41 ns 950.74 ns]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  5 (5.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
```