### PR TITLE
std: add some missing repr(transparent)

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -88,6 +88,9 @@ use crate::str;
 // When attribute privacy is implemented, `CStr` should be annotated as `#[repr(transparent)]`.
 // Anyway, `CStr` representation and layout are considered implementation detail, are
 // not documented and must not be relied upon.
+// For now we just hide this from rustdoc, technically making our doc test builds rely on
+// unspecified layout assumptions. We are std, so we can get away with that.
+#[cfg_attr(not(doc), repr(transparent))]
 pub struct CStr {
     // FIXME: this should not be represented with a DST slice but rather with
     //        just a raw `c_char` along with some form of marker to make

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -82,14 +82,11 @@ use crate::str;
 #[stable(feature = "core_c_str", since = "1.64.0")]
 #[rustc_has_incoherent_inherent_impls]
 #[lang = "CStr"]
-// FIXME:
 // `fn from` in `impl From<&CStr> for Box<CStr>` current implementation relies
 // on `CStr` being layout-compatible with `[u8]`.
-// When attribute privacy is implemented, `CStr` should be annotated as `#[repr(transparent)]`.
-// Anyway, `CStr` representation and layout are considered implementation detail, are
-// not documented and must not be relied upon.
-// For now we just hide this from rustdoc, technically making our doc test builds rely on
-// unspecified layout assumptions. We are std, so we can get away with that.
+// However, `CStr` layout is considered an implementation detail and must not be relied upon. We
+// want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
+// `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
 #[cfg_attr(not(doc), repr(transparent))]
 pub struct CStr {
     // FIXME: this should not be represented with a DST slice but rather with

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -110,14 +110,11 @@ impl crate::sealed::Sealed for OsString {}
 /// [conversions]: super#conversions
 #[cfg_attr(not(test), rustc_diagnostic_item = "OsStr")]
 #[stable(feature = "rust1", since = "1.0.0")]
-// FIXME:
 // `OsStr::from_inner` current implementation relies
 // on `OsStr` being layout-compatible with `Slice`.
-// When attribute privacy is implemented, `OsStr` should be annotated as `#[repr(transparent)]`.
-// Anyway, `OsStr` representation and layout are considered implementation details, are
-// not documented and must not be relied upon.
-// For now we just hide this from rustdoc, technically making our doc test builds rely on
-// unspecified layout assumptions. We are std, so we can get away with that.
+// However, `OsStr` layout is considered an implementation detail and must not be relied upon. We
+// want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
+// `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
 #[cfg_attr(not(doc), repr(transparent))]
 pub struct OsStr {
     inner: Slice,

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -116,6 +116,9 @@ impl crate::sealed::Sealed for OsString {}
 // When attribute privacy is implemented, `OsStr` should be annotated as `#[repr(transparent)]`.
 // Anyway, `OsStr` representation and layout are considered implementation details, are
 // not documented and must not be relied upon.
+// For now we just hide this from rustdoc, technically making our doc test builds rely on
+// unspecified layout assumptions. We are std, so we can get away with that.
+#[cfg_attr(not(doc), repr(transparent))]
 pub struct OsStr {
     inner: Slice,
 }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1158,14 +1158,11 @@ impl FusedIterator for Ancestors<'_> {}
 /// Which method works best depends on what kind of situation you're in.
 #[cfg_attr(not(test), rustc_diagnostic_item = "PathBuf")]
 #[stable(feature = "rust1", since = "1.0.0")]
-// FIXME:
 // `PathBuf::as_mut_vec` current implementation relies
 // on `PathBuf` being layout-compatible with `Vec<u8>`.
-// When attribute privacy is implemented, `PathBuf` should be annotated as `#[repr(transparent)]`.
-// Anyway, `PathBuf` representation and layout are considered implementation detail, are
-// not documented and must not be relied upon.
-// For now we just hide this from rustdoc, technically making our doc test builds rely on
-// unspecified layout assumptions. We are std, so we can get away with that.
+// However, `PathBuf` layout is considered an implementation detail and must not be relied upon. We
+// want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
+// `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
 #[cfg_attr(not(doc), repr(transparent))]
 pub struct PathBuf {
     inner: OsString,
@@ -1986,14 +1983,11 @@ impl AsRef<OsStr> for PathBuf {
 /// ```
 #[cfg_attr(not(test), rustc_diagnostic_item = "Path")]
 #[stable(feature = "rust1", since = "1.0.0")]
-// FIXME:
 // `Path::new` current implementation relies
 // on `Path` being layout-compatible with `OsStr`.
-// When attribute privacy is implemented, `Path` should be annotated as `#[repr(transparent)]`.
-// Anyway, `Path` representation and layout are considered implementation detail, are
-// not documented and must not be relied upon.
-// For now we just hide this from rustdoc, technically making our doc test builds rely on
-// unspecified layout assumptions. We are std, so we can get away with that.
+// However, `Path` layout is considered an implementation detail and must not be relied upon. We
+// want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
+// `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
 #[cfg_attr(not(doc), repr(transparent))]
 pub struct Path {
     inner: OsStr,

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1164,6 +1164,9 @@ impl FusedIterator for Ancestors<'_> {}
 // When attribute privacy is implemented, `PathBuf` should be annotated as `#[repr(transparent)]`.
 // Anyway, `PathBuf` representation and layout are considered implementation detail, are
 // not documented and must not be relied upon.
+// For now we just hide this from rustdoc, technically making our doc test builds rely on
+// unspecified layout assumptions. We are std, so we can get away with that.
+#[cfg_attr(not(doc), repr(transparent))]
 pub struct PathBuf {
     inner: OsString,
 }
@@ -1989,6 +1992,9 @@ impl AsRef<OsStr> for PathBuf {
 // When attribute privacy is implemented, `Path` should be annotated as `#[repr(transparent)]`.
 // Anyway, `Path` representation and layout are considered implementation detail, are
 // not documented and must not be relied upon.
+// For now we just hide this from rustdoc, technically making our doc test builds rely on
+// unspecified layout assumptions. We are std, so we can get away with that.
+#[cfg_attr(not(doc), repr(transparent))]
 pub struct Path {
     inner: OsStr,
 }

--- a/library/std/src/sys/wasi/fd.rs
+++ b/library/std/src/sys/wasi/fd.rs
@@ -16,14 +16,20 @@ pub struct WasiFd {
 fn iovec<'a>(a: &'a mut [IoSliceMut<'_>]) -> &'a [wasi::Iovec] {
     assert_eq!(mem::size_of::<IoSliceMut<'_>>(), mem::size_of::<wasi::Iovec>());
     assert_eq!(mem::align_of::<IoSliceMut<'_>>(), mem::align_of::<wasi::Iovec>());
-    // SAFETY: `IoSliceMut` and `IoVec` have exactly the same memory layout
+    // SAFETY: `IoSliceMut` and `IoVec` have exactly the same memory layout.
+    // We decorate our `IoSliceMut` with `repr(transparent)` (see `io.rs`), and
+    // `crate::io::IoSliceMut` is a `repr(transparent)` wrapper around our type, so this is
+    // guaranteed.
     unsafe { mem::transmute(a) }
 }
 
 fn ciovec<'a>(a: &'a [IoSlice<'_>]) -> &'a [wasi::Ciovec] {
     assert_eq!(mem::size_of::<IoSlice<'_>>(), mem::size_of::<wasi::Ciovec>());
     assert_eq!(mem::align_of::<IoSlice<'_>>(), mem::align_of::<wasi::Ciovec>());
-    // SAFETY: `IoSlice` and `CIoVec` have exactly the same memory layout
+    // SAFETY: `IoSlice` and `CIoVec` have exactly the same memory layout.
+    // We decorate our `IoSlice` with `repr(transparent)` (see `io.rs`), and
+    // `crate::io::IoSlice` is a `repr(transparent)` wrapper around our type, so this is
+    // guaranteed.
     unsafe { mem::transmute(a) }
 }
 

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -459,6 +459,7 @@ impl Wtf8Buf {
     /// Converts this `Wtf8Buf` into a boxed `Wtf8`.
     #[inline]
     pub fn into_box(self) -> Box<Wtf8> {
+        // SAFETY: relies on `Wtf8` being `repr(transparent)`.
         unsafe { mem::transmute(self.bytes.into_boxed_slice()) }
     }
 
@@ -511,6 +512,7 @@ impl Extend<CodePoint> for Wtf8Buf {
 /// Similar to `&str`, but can additionally contain surrogate code points
 /// if they’re not in a surrogate pair.
 #[derive(Eq, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
 pub struct Wtf8 {
     bytes: [u8],
 }


### PR DESCRIPTION
For some types we don't want to stably guarantee this, so hide the `repr` from rustdoc. This nice approach was suggested by @thomcc.