### PR TITLE
Remove unnecessary FIXME

### DIFF
--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -445,7 +445,6 @@ impl<'tcx> Cx<'tcx> {
                     let rhs = self.mirror_expr(rhs);
                     self.overloaded_operator(expr, Box::new([lhs, rhs]))
                 } else {
-                    // FIXME overflow
                     match op.node {
                         hir::BinOpKind::And => ExprKind::LogicalOp {
                             op: LogicalOp::And,


### PR DESCRIPTION
Found this while browsing rustc, I traced it back to https://github.com/rust-lang/rust/pull/27893 when MIR first introduced, some time passed since then and I think this FIXME is no longer necessary.