### PR TITLE
Add test for unknown_lints from another file.

### DIFF
--- a/tests/ui/lint/unknown-lints/allow-in-other-module.rs
+++ b/tests/ui/lint/unknown-lints/allow-in-other-module.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+// Tests that the unknown_lints lint doesn't fire for an unknown lint loaded from a separate file.
+// The key part is that the stderr output should be empty.
+// Reported in https://github.com/rust-lang/rust/issues/84936
+// Fixed incidentally by https://github.com/rust-lang/rust/pull/97266
+
+// This `allow` should apply to submodules, whether they are inline or loaded from a file.
+#![allow(unknown_lints)]
+#![allow(dead_code)]
+// no warning
+#![allow(not_a_real_lint)]
+
+mod other;
+
+// no warning
+#[allow(not_a_real_lint)]
+fn m() {}
+
+mod mm {
+    // no warning
+    #[allow(not_a_real_lint)]
+    fn m() {}
+}
+
+fn main() {}

--- a/tests/ui/lint/unknown-lints/other.rs
+++ b/tests/ui/lint/unknown-lints/other.rs
@@ -1,0 +1,10 @@
+// ignore-test
+
+// Companion to allow-in-other-module.rs
+
+// This should not warn.
+#![allow(not_a_real_lint)]
+
+// This should not warn, either.
+#[allow(not_a_real_lint)]
+fn m() {}


### PR DESCRIPTION
This adds a test for #84936 which was incidentally fixed via #97266. It is a strange issue where `#![allow(unknown_lints)]` at the crate root was not applying to unknown lints that fired in a non-inline-module. I did not dig further into how #97266 fixed it, but I did verify it. I couldn't find any existing tests which did anything similar.

Closes #84936
