### PR TITLE
Upgrade std to gimli 0.28.0

### DIFF
--- a/tests/ui/std/slice-from-array-issue-113238.rs
+++ b/tests/ui/std/slice-from-array-issue-113238.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+// This intends to use the unsizing coercion from array to slice, but it only
+// works if we resolve `<&[u8]>::from` as the reflexive `From<T> for T`. In
+// #113238, we found that gimli had added its own `From<EndianSlice> for &[u8]`
+// that affected all `std/backtrace` users.
+fn main() {
+    let _ = <&[u8]>::from(&[]);
+}


### PR DESCRIPTION
Gimli 0.28 removed its `From<EndianSlice> for &[u8]` that was the root cause of #113238.

This dependency update mirrors rust-lang/backtrace-rs#557, but since that doesn't require any code changes in `backtrace`, we can also apply that right away for our nested `std/backtrace` feature.