### PR TITLE
Only consider object candidates for object-safe dyn types in new solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
@@ -826,6 +826,11 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             ty::Dynamic(bounds, ..) => bounds,
         };
 
+        // Do not consider built-in object impls for non-object-safe types.
+        if bounds.principal_def_id().is_some_and(|def_id| !tcx.check_is_object_safe(def_id)) {
+            return;
+        }
+
         // Consider all of the auto-trait and projection bounds, which don't
         // need to be recorded as a `BuiltinImplSource::Object` since they don't
         // really have a vtable base...

--- a/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.rs
+++ b/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.rs
@@ -1,5 +1,7 @@
 // Check that we can manually implement an object-unsafe trait for its trait object.
 
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 // run-pass
 
 #![feature(object_safe_for_dispatch)]


### PR DESCRIPTION
We apparently allow this per RFC2027 :skull:

r? lcnr