### PR TITLE
Assemble `ConstEvaluatable` from param-env in new solver

### DIFF
--- a/tests/ui/const-generics/issues/issue-105037.rs
+++ b/tests/ui/const-generics/issues/issue-105037.rs
@@ -1,4 +1,7 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 // run-pass
+
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 #![allow(dead_code)]


### PR DESCRIPTION
Not sure how useful this is on its own, but it does cause a handful of GCE tests to go from fail -> pass. Since it's not doing the deep const walking like the old solver, and also since we don't expand abstract consts or anything like that, lots of GCE tests remain failing, but this seems like a harmless improvement over the status quo.

r? @lcnr or @BoxyUwU 