### PR TITLE
add missing feature(error_in_core)

### DIFF
--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -130,6 +130,7 @@ pub trait Error: Debug + Display {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     /// use core::fmt;
     /// use core::error::{request_ref, Request};
     ///
@@ -360,6 +361,7 @@ impl dyn Error {
 ///
 /// ```rust
 /// # #![feature(error_generic_member_access)]
+/// # #![feature(error_in_core)]
 /// use std::error::Error;
 /// use core::error::request_value;
 ///
@@ -383,6 +385,7 @@ where
 ///
 /// ```rust
 /// # #![feature(error_generic_member_access)]
+/// # #![feature(error_in_core)]
 /// use core::error::Error;
 /// use core::error::request_ref;
 ///
@@ -454,6 +457,7 @@ where
 ///
 /// ```
 /// #![feature(error_generic_member_access)]
+/// #![feature(error_in_core)]
 /// use core::fmt;
 /// use core::error::Request;
 /// use core::error::request_ref;
@@ -524,6 +528,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -558,6 +563,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -593,6 +599,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -625,6 +632,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -691,6 +699,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     /// use core::error::request_value;
@@ -778,6 +787,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     /// use core::error::request_ref;


### PR DESCRIPTION
Needed to fix feature gate errors in https://github.com/rust-lang/miri-test-libstd/actions/runs/5862810459/job/15895203359. I don't know how doctests are passing in-tree without this feature gate...