### PR TITLE
add track_caller for arith ops

### DIFF
--- a/library/core/src/internal_macros.rs
+++ b/library/core/src/internal_macros.rs
@@ -31,6 +31,7 @@ macro_rules! forward_ref_binop {
             type Output = <$t as $imp<$u>>::Output;
 
             #[inline]
+            #[track_caller]
             fn $method(self, other: $u) -> <$t as $imp<$u>>::Output {
                 $imp::$method(*self, other)
             }
@@ -41,6 +42,7 @@ macro_rules! forward_ref_binop {
             type Output = <$t as $imp<$u>>::Output;
 
             #[inline]
+            #[track_caller]
             fn $method(self, other: &$u) -> <$t as $imp<$u>>::Output {
                 $imp::$method(self, *other)
             }
@@ -51,6 +53,7 @@ macro_rules! forward_ref_binop {
             type Output = <$t as $imp<$u>>::Output;
 
             #[inline]
+            #[track_caller]
             fn $method(self, other: &$u) -> <$t as $imp<$u>>::Output {
                 $imp::$method(*self, *other)
             }
@@ -69,6 +72,7 @@ macro_rules! forward_ref_op_assign {
         #[$attr]
         impl $imp<&$u> for $t {
             #[inline]
+            #[track_caller]
             fn $method(&mut self, other: &$u) {
                 $imp::$method(self, *other);
             }

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -98,6 +98,7 @@ macro_rules! add_impl {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn add(self, other: $t) -> $t { self + other }
         }
@@ -206,6 +207,7 @@ macro_rules! sub_impl {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn sub(self, other: $t) -> $t { self - other }
         }
@@ -335,6 +337,7 @@ macro_rules! mul_impl {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn mul(self, other: $t) -> $t { self * other }
         }
@@ -474,6 +477,7 @@ macro_rules! div_impl_integer {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             fn div(self, other: $t) -> $t { self / other }
         }
 
@@ -575,6 +579,7 @@ macro_rules! rem_impl_integer {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             fn rem(self, other: $t) -> $t { self % other }
         }
 
@@ -749,6 +754,7 @@ macro_rules! add_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl AddAssign for $t {
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn add_assign(&mut self, other: $t) { *self += other }
         }
@@ -815,6 +821,7 @@ macro_rules! sub_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl SubAssign for $t {
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn sub_assign(&mut self, other: $t) { *self -= other }
         }
@@ -872,6 +879,7 @@ macro_rules! mul_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl MulAssign for $t {
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn mul_assign(&mut self, other: $t) { *self *= other }
         }
@@ -929,6 +937,7 @@ macro_rules! div_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl DivAssign for $t {
             #[inline]
+            #[track_caller]
             fn div_assign(&mut self, other: $t) { *self /= other }
         }
 
@@ -989,6 +998,7 @@ macro_rules! rem_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl RemAssign for $t {
             #[inline]
+            #[track_caller]
             fn rem_assign(&mut self, other: $t) { *self %= other }
         }
 

--- a/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-abort.diff
@@ -8,7 +8,7 @@
       let mut _3: u8;
       scope 1 {
       }
-      scope 2 (inlined <u8 as Add>::add) {
+      scope 2 (inlined #[track_caller] <u8 as Add>::add) {
           debug self => _2;
           debug other => _3;
           let mut _4: (u8, bool);

--- a/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-unwind.diff
@@ -8,7 +8,7 @@
       let mut _3: u8;
       scope 1 {
       }
-      scope 2 (inlined <u8 as Add>::add) {
+      scope 2 (inlined #[track_caller] <u8 as Add>::add) {
           debug self => _2;
           debug other => _3;
           let mut _4: (u8, bool);

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-abort.diff
@@ -8,7 +8,7 @@
       let mut _3: u8;
       scope 1 {
       }
-      scope 2 (inlined <u8 as Add>::add) {
+      scope 2 (inlined #[track_caller] <u8 as Add>::add) {
           debug self => _2;
           debug other => _3;
           let mut _4: (u8, bool);

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
@@ -8,7 +8,7 @@
       let mut _3: u8;
       scope 1 {
       }
-      scope 2 (inlined <u8 as Add>::add) {
+      scope 2 (inlined #[track_caller] <u8 as Add>::add) {
           debug self => _2;
           debug other => _3;
           let mut _4: (u8, bool);

--- a/tests/ui/numbers-arithmetic/location-add-assign-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-add-assign-overflow.rs
@@ -1,0 +1,8 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-add-assign-overflow.rs
+
+fn main() {
+    let mut a: u8 = 255;
+    a += &1;
+}

--- a/tests/ui/numbers-arithmetic/location-add-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-add-overflow.rs
@@ -1,0 +1,7 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-add-overflow.rs
+
+fn main() {
+    let _: u8 = 255 + &1;
+}

--- a/tests/ui/numbers-arithmetic/location-divide-assign-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-divide-assign-by-zero.rs
@@ -1,0 +1,8 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-divide-assign-by-zero.rs
+
+fn main() {
+    let mut a = 1;
+    a /= &0;
+}

--- a/tests/ui/numbers-arithmetic/location-divide-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-divide-by-zero.rs
@@ -1,0 +1,9 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-divide-by-zero.rs
+
+// https://github.com/rust-lang/rust/issues/114814
+
+fn main() {
+    let _ = 1 / &0;
+}

--- a/tests/ui/numbers-arithmetic/location-mod-assign-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-mod-assign-by-zero.rs
@@ -1,0 +1,8 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-mod-assign-by-zero.rs
+
+fn main() {
+    let mut a = 1;
+    a %= &0;
+}

--- a/tests/ui/numbers-arithmetic/location-mod-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-mod-by-zero.rs
@@ -1,0 +1,7 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-mod-by-zero.rs
+
+fn main() {
+    let _ = 1 % &0;
+}

--- a/tests/ui/numbers-arithmetic/location-mul-assign-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-mul-assign-overflow.rs
@@ -1,0 +1,8 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-mul-assign-overflow.rs
+
+fn main() {
+    let mut a: u8 = 255;
+    a *= &2;
+}

--- a/tests/ui/numbers-arithmetic/location-mul-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-mul-overflow.rs
@@ -1,0 +1,7 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-mul-overflow.rs
+
+fn main() {
+    let _: u8 = 255 * &2;
+}

--- a/tests/ui/numbers-arithmetic/location-sub-assign-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-sub-assign-overflow.rs
@@ -1,0 +1,8 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-sub-assign-overflow.rs
+
+fn main() {
+    let mut a: u8 = 0;
+    a -= &1;
+}

--- a/tests/ui/numbers-arithmetic/location-sub-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-sub-overflow.rs
@@ -1,0 +1,7 @@
+// run-fail
+// ignore-wasm32
+// error-pattern:location-sub-overflow.rs
+
+fn main() {
+    let _: u8 = 0 - &1;
+}


### PR DESCRIPTION
Fixes #114814

`#[track_caller]` is works, r? @scottmcm 