### PR TITLE
Refine error message for thread-safe usage of std::sync::Arc<{Self}>

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -79,7 +79,7 @@ macro marker_impls {
     on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
     message = "`{Self}` cannot be sent between threads safely",
     label = "`{Self}` cannot be sent between threads safely",
-    note = "consider using `std::sync::Arc<{Self}>`; for more information visit \
+    note = "consider whether `std::sync::Arc<{Self}>` could be incorporated to share this value between threads; for more information visit \
             <https://doc.rust-lang.org/book/ch16-03-shared-state.html>"
 )]
 pub unsafe auto trait Send {

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -634,7 +634,7 @@ impl<T: ?Sized> Copy for &T {}
     on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
     message = "`{Self}` cannot be shared between threads safely",
     label = "`{Self}` cannot be shared between threads safely",
-    note = "consider using `std::sync::Arc<{Self}>`; for more information visit \
+    note = "consider whether `std::sync::Arc<{Self}>` could be incorporated to share this value between threads; for more information visit \
             <https://doc.rust-lang.org/book/ch16-03-shared-state.html>"
 )]
 pub unsafe auto trait Sync {

--- a/tests/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/tests/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -5,7 +5,7 @@ LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8
    |                                    ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
-   = note: consider using `std::sync::Arc<<<Self as Case1>::C as Iterator>::Item>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<<<Self as Case1>::C as Iterator>::Item>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Send {
@@ -30,7 +30,7 @@ LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8
    |                                                                                             ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
-   = note: consider using `std::sync::Arc<<<Self as Case1>::C as Iterator>::Item>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<<<Self as Case1>::C as Iterator>::Item>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Sync {

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
@@ -14,7 +14,7 @@ LL |     is_send(foo::<T>());
    |             ^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>>`
-   = note: consider using `std::sync::Arc<impl Future<Output = Result<(), ()>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<impl Future<Output = Result<(), ()>>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/basic.rs:13:5
    |

--- a/tests/ui/async-await/async-fn-nonsend.drop_tracking.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.drop_tracking.stderr
@@ -29,7 +29,7 @@ LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dyn std::fmt::Write>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:49:15
    |

--- a/tests/ui/async-await/async-fn-nonsend.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.drop_tracking_mir.stderr
@@ -26,7 +26,7 @@ LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dyn std::fmt::Write>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:49:15
    |

--- a/tests/ui/async-await/async-fn-nonsend.no_drop_tracking.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.no_drop_tracking.stderr
@@ -53,7 +53,7 @@ LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dyn std::fmt::Write>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:49:15
    |
@@ -78,7 +78,7 @@ LL |     assert_send(non_sync_with_method_call_panic());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call_panic` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dyn std::fmt::Write>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:56:15
    |
@@ -103,7 +103,7 @@ LL |     assert_send(non_sync_with_method_call_infinite_loop());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call_infinite_loop` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dyn std::fmt::Write>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:63:15
    |

--- a/tests/ui/async-await/in-trait/missing-send-bound.stderr
+++ b/tests/ui/async-await/in-trait/missing-send-bound.stderr
@@ -5,7 +5,7 @@ LL |     assert_is_send(test::<T>());
    |                    ^^^^^^^^^^^ future returned by `test` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `impl Future<Output = ()>`
-   = note: consider using `std::sync::Arc<impl Future<Output = ()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<impl Future<Output = ()>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/missing-send-bound.rs:10:5
    |

--- a/tests/ui/async-await/issue-64130-1-sync.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.drop_tracking.stderr
@@ -5,7 +5,7 @@ LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
    = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:18:11
    |

--- a/tests/ui/async-await/issue-64130-1-sync.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.drop_tracking_mir.stderr
@@ -5,7 +5,7 @@ LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
    = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:18:11
    |

--- a/tests/ui/async-await/issue-64130-1-sync.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.no_drop_tracking.stderr
@@ -5,7 +5,7 @@ LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
    = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:18:11
    |

--- a/tests/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
@@ -5,7 +5,7 @@ LL | pub fn foo() -> impl Future + Send {
    |                 ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `(dyn Any + Send + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Any + Send + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<(dyn Any + Send + 'static)>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-4-async-move.rs:27:23
    |

--- a/tests/ui/async-await/issue-64130-non-send-future-diags.stderr
+++ b/tests/ui/async-await/issue-64130-non-send-future-diags.stderr
@@ -5,7 +5,7 @@ LL |     is_send(foo());
    |             ^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, u32>`
-   = note: consider using `std::sync::Arc<MutexGuard<'_, u32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<MutexGuard<'_, u32>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-non-send-future-diags.rs:17:11
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking.stderr
@@ -10,7 +10,7 @@ LL | |     });
    | |_____^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-67252-unnamed-future.rs:21:11: 25:6]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut ()>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:23:17
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking_mir.stderr
@@ -5,7 +5,7 @@ LL |     spawn(async {
    |     ^^^^^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-67252-unnamed-future.rs:21:11: 25:6]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut ()>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:23:17
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.no_drop_tracking.stderr
@@ -10,7 +10,7 @@ LL | |     });
    | |_____^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-67252-unnamed-future.rs:21:11: 25:6]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut ()>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:23:17
    |

--- a/tests/ui/async-await/issue-70818.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70818.drop_tracking.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<U>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<U>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send`
   --> $DIR/issue-70818.rs:9:18
    |

--- a/tests/ui/async-await/issue-70818.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-70818.drop_tracking_mir.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<U>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<U>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send`
   --> $DIR/issue-70818.rs:9:18
    |

--- a/tests/ui/async-await/issue-70818.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70818.no_drop_tracking.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<U>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<U>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send`
   --> $DIR/issue-70818.rs:9:18
    |

--- a/tests/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
@@ -5,7 +5,7 @@ LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut ()>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`

--- a/tests/ui/async-await/issue-70935-complex-spans.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.drop_tracking_mir.stderr
@@ -5,7 +5,7 @@ LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut ()>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`

--- a/tests/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
@@ -5,7 +5,7 @@ LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut ()>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-70935-complex-spans.rs:24:12
    |

--- a/tests/ui/async-await/issue-71137.stderr
+++ b/tests/ui/async-await/issue-71137.stderr
@@ -5,7 +5,7 @@ LL |   fake_spawn(wrong_mutex());
    |              ^^^^^^^^^^^^^ future returned by `wrong_mutex` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, i32>`
-   = note: consider using `std::sync::Arc<MutexGuard<'_, i32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<MutexGuard<'_, i32>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-71137.rs:14:26
    |

--- a/tests/ui/async-await/issue-86507.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-86507.drop_tracking.stderr
@@ -8,7 +8,7 @@ LL | |                 }
 LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/issue-86507.rs:22:29
    |

--- a/tests/ui/async-await/issue-86507.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-86507.drop_tracking_mir.stderr
@@ -8,7 +8,7 @@ LL | |                 }
 LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/issue-86507.rs:22:29
    |

--- a/tests/ui/async-await/issue-86507.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-86507.no_drop_tracking.stderr
@@ -8,7 +8,7 @@ LL | |                 }
 LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/issue-86507.rs:22:29
    |

--- a/tests/ui/async-await/issues/issue-65436-raw-ptr-not-send.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issues/issue-65436-raw-ptr-not-send.no_drop_tracking.stderr
@@ -9,7 +9,7 @@ LL | |     })
    | |_____^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-65436-raw-ptr-not-send.rs:17:17: 20:6]`, the trait `Send` is not implemented for `*const u8`
-   = note: consider using `std::sync::Arc<*const u8>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*const u8>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-65436-raw-ptr-not-send.rs:19:36
    |

--- a/tests/ui/async-await/issues/issue-67893.stderr
+++ b/tests/ui/async-await/issues/issue-67893.stderr
@@ -5,7 +5,7 @@ LL |     g(issue_67893::run())
    |       ^^^^^^^^^^^^^^^^^^ future is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, ()>`
-   = note: consider using `std::sync::Arc<MutexGuard<'_, ()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<MutexGuard<'_, ()>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/auxiliary/issue_67893.rs:12:27
    |

--- a/tests/ui/async-await/partial-drop-partial-reinit.drop_tracking.stderr
+++ b/tests/ui/async-await/partial-drop-partial-reinit.drop_tracking.stderr
@@ -10,7 +10,7 @@ LL | async fn foo() {
    |                - within this `impl Future<Output = ()>`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSend>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(NotSend,)`
    = note: required because it captures the following types: `ResumeTy`, `(NotSend,)`, `()`, `impl Future<Output = ()>`
 note: required because it's used within this `async fn` body

--- a/tests/ui/async-await/partial-drop-partial-reinit.no_drop_tracking.stderr
+++ b/tests/ui/async-await/partial-drop-partial-reinit.no_drop_tracking.stderr
@@ -10,7 +10,7 @@ LL | async fn foo() {
    |                - within this `impl Future<Output = ()>`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSend>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(NotSend,)`
    = note: required because it captures the following types: `ResumeTy`, `(NotSend,)`, `impl Future<Output = ()>`, `()`
 note: required because it's used within this `async fn` body

--- a/tests/ui/async-await/partial-drop-partial-reinit.rs
+++ b/tests/ui/async-await/partial-drop-partial-reinit.rs
@@ -12,7 +12,7 @@ fn main() {
     //~| NOTE bound introduced by
     //~| NOTE appears within the type
     //~| NOTE captures the following types
-    //~| NOTE consider using `std::sync::Arc<NotSend>`
+    //~| NOTE consider whether `std::sync::Arc<NotSend>`
 }
 
 fn gimme_send<T: Send>(t: T) {

--- a/tests/ui/auto-traits/issue-83857-ub.stderr
+++ b/tests/ui/auto-traits/issue-83857-ub.stderr
@@ -5,7 +5,7 @@ LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo<T, U>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Foo<T, U>`
-   = note: consider using `std::sync::Arc<Foo<T, U>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo<T, U>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `Foo<T, U>` to implement `WithAssoc`
   --> $DIR/issue-83857-ub.rs:15:15
    |

--- a/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -4,7 +4,7 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T: Sync+'static> Foo for (T,) { }
    |                                ^^^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(T,)`
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-double-superkind.rs:4:13
@@ -22,7 +22,7 @@ error[E0277]: `T` cannot be shared between threads safely
 LL | impl <T: Send> Foo for (T,T) { }
    |                        ^^^^^ `T` cannot be shared between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(T, T)`
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-double-superkind.rs:4:18

--- a/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -4,7 +4,7 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
    |                                                        ^^^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `X<T>`
   --> $DIR/builtin-superkinds-in-metadata.rs:9:8
    |

--- a/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -4,7 +4,7 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T: Sync+'static> Foo for T { }
    |                                ^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-typaram-not-send.rs:3:13
    |

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -4,7 +4,7 @@ error[E0277]: `F` cannot be sent between threads safely
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
    |                      ^^^^ `F` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<F>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<F>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `X`
   --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:1:43
    |

--- a/tests/ui/closures/closure-bounds-subtype.stderr
+++ b/tests/ui/closures/closure-bounds-subtype.stderr
@@ -6,7 +6,7 @@ LL |     take_const_owned(f);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<F>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<F>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `take_const_owned`
   --> $DIR/closure-bounds-subtype.rs:4:50
    |

--- a/tests/ui/closures/closure-move-sync.stderr
+++ b/tests/ui/closures/closure-move-sync.stderr
@@ -11,7 +11,7 @@ LL | |     });
    | |_____^ `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
-   = note: consider using `std::sync::Arc<std::sync::mpsc::Receiver<()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<std::sync::mpsc::Receiver<()>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&std::sync::mpsc::Receiver<()>` to implement `Send`
 note: required because it's used within this closure
   --> $DIR/closure-move-sync.rs:6:27

--- a/tests/ui/error-codes/E0277-2.stderr
+++ b/tests/ui/error-codes/E0277-2.stderr
@@ -5,7 +5,7 @@ LL |     is_send::<Foo>();
    |               ^^^ `*const u8` cannot be sent between threads safely
    |
    = help: within `Foo`, the trait `Send` is not implemented for `*const u8`
-   = note: consider using `std::sync::Arc<*const u8>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*const u8>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Baz`
   --> $DIR/E0277-2.rs:9:8
    |

--- a/tests/ui/extern/extern-type-diag-not-similar.stderr
+++ b/tests/ui/extern/extern-type-diag-not-similar.stderr
@@ -5,7 +5,7 @@ LL |     assert_send::<Foo>()
    |                   ^^^ `Foo` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/extern-type-diag-not-similar.rs:17:19
    |

--- a/tests/ui/extern/extern-types-not-sync-send.stderr
+++ b/tests/ui/extern/extern-types-not-sync-send.stderr
@@ -5,7 +5,7 @@ LL |     assert_sync::<A>();
    |                   ^ `A` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `A`
-   = note: consider using `std::sync::Arc<A>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<A>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_sync`
   --> $DIR/extern-types-not-sync-send.rs:9:28
    |
@@ -19,7 +19,7 @@ LL |     assert_send::<A>();
    |                   ^ `A` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `A`
-   = note: consider using `std::sync::Arc<A>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<A>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/extern-types-not-sync-send.rs:10:28
    |

--- a/tests/ui/fmt/send-sync.stderr
+++ b/tests/ui/fmt/send-sync.stderr
@@ -7,7 +7,7 @@ LL |     send(format_args!("{:?}", c));
    |     required by a bound introduced by this call
    |
    = help: within `[core::fmt::rt::Argument<'_>]`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
-   = note: consider using `std::sync::Arc<core::fmt::rt::Opaque>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<core::fmt::rt::Opaque>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
 note: required because it appears within the type `Argument<'_>`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
@@ -30,7 +30,7 @@ LL |     sync(format_args!("{:?}", c));
    |     required by a bound introduced by this call
    |
    = help: within `Arguments<'_>`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
-   = note: consider using `std::sync::Arc<core::fmt::rt::Opaque>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<core::fmt::rt::Opaque>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
 note: required because it appears within the type `Argument<'_>`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL

--- a/tests/ui/generator/drop-tracking-parent-expression.drop_tracking.stderr
+++ b/tests/ui/generator/drop-tracking-parent-expression.drop_tracking.stderr
@@ -14,7 +14,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -57,7 +57,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -100,7 +100,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<insignificant_dtor::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |

--- a/tests/ui/generator/drop-tracking-parent-expression.drop_tracking_mir.stderr
+++ b/tests/ui/generator/drop-tracking-parent-expression.drop_tracking_mir.stderr
@@ -14,7 +14,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -55,7 +55,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -96,7 +96,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<insignificant_dtor::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |

--- a/tests/ui/generator/drop-tracking-parent-expression.no_drop_tracking.stderr
+++ b/tests/ui/generator/drop-tracking-parent-expression.no_drop_tracking.stderr
@@ -14,7 +14,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<copy::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -57,7 +57,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<copy::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |
@@ -99,7 +99,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -142,7 +142,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |
@@ -184,7 +184,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -227,7 +227,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |
@@ -269,7 +269,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<insignificant_dtor::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -312,7 +312,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<insignificant_dtor::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |

--- a/tests/ui/generator/drop-yield-twice.stderr
+++ b/tests/ui/generator/drop-yield-twice.stderr
@@ -11,7 +11,7 @@ LL | |     })
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/drop-yield-twice.rs:7:17: 7:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-yield-twice.rs:9:9
    |

--- a/tests/ui/generator/issue-57017.no_drop_tracking.stderr
+++ b/tests/ui/generator/issue-57017.no_drop_tracking.stderr
@@ -14,7 +14,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `copy::unsync::Client`
-   = note: consider using `std::sync::Arc<copy::unsync::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<copy::unsync::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:30:28
    |
@@ -56,7 +56,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/issue-57017.rs:41:21: 41:28]`, the trait `Send` is not implemented for `copy::unsend::Client`
-   = note: consider using `std::sync::Arc<copy::unsend::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<copy::unsend::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:42:28
    |
@@ -98,7 +98,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `derived_drop::unsync::Client`
-   = note: consider using `std::sync::Arc<derived_drop::unsync::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::unsync::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:30:28
    |
@@ -140,7 +140,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/issue-57017.rs:41:21: 41:28]`, the trait `Send` is not implemented for `derived_drop::unsend::Client`
-   = note: consider using `std::sync::Arc<derived_drop::unsend::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::unsend::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:42:28
    |
@@ -182,7 +182,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `significant_drop::unsync::Client`
-   = note: consider using `std::sync::Arc<significant_drop::unsync::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::unsync::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:30:28
    |
@@ -224,7 +224,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/issue-57017.rs:41:21: 41:28]`, the trait `Send` is not implemented for `significant_drop::unsend::Client`
-   = note: consider using `std::sync::Arc<significant_drop::unsend::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::unsend::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:42:28
    |

--- a/tests/ui/generator/issue-57478.no_drop_tracking.stderr
+++ b/tests/ui/generator/issue-57478.no_drop_tracking.stderr
@@ -11,7 +11,7 @@ LL | |     })
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/issue-57478.rs:13:17: 13:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57478.rs:17:9
    |

--- a/tests/ui/generator/not-send-sync.drop_tracking.stderr
+++ b/tests/ui/generator/not-send-sync.drop_tracking.stderr
@@ -11,7 +11,7 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:17:17: 17:19]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:20:9
    |
@@ -41,7 +41,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:24:17: 24:19]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSend>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:27:9
    |

--- a/tests/ui/generator/not-send-sync.drop_tracking_mir.stderr
+++ b/tests/ui/generator/not-send-sync.drop_tracking_mir.stderr
@@ -5,7 +5,7 @@ LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ generator is not `Sync`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:17:17: 17:19]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:20:9
    |
@@ -26,7 +26,7 @@ LL |     assert_send(|| {
    |     ^^^^^^^^^^^ generator is not `Send`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:24:17: 24:19]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSend>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:27:9
    |

--- a/tests/ui/generator/not-send-sync.no_drop_tracking.stderr
+++ b/tests/ui/generator/not-send-sync.no_drop_tracking.stderr
@@ -11,7 +11,7 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:17:17: 17:19]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:20:9
    |
@@ -41,7 +41,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:24:17: 24:19]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSend>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:27:9
    |

--- a/tests/ui/generator/parent-expression.drop_tracking.stderr
+++ b/tests/ui/generator/parent-expression.drop_tracking.stderr
@@ -14,7 +14,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -57,7 +57,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -100,7 +100,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<insignificant_dtor::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |

--- a/tests/ui/generator/parent-expression.drop_tracking_mir.stderr
+++ b/tests/ui/generator/parent-expression.drop_tracking_mir.stderr
@@ -14,7 +14,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -55,7 +55,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -96,7 +96,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<insignificant_dtor::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |

--- a/tests/ui/generator/parent-expression.no_drop_tracking.stderr
+++ b/tests/ui/generator/parent-expression.no_drop_tracking.stderr
@@ -14,7 +14,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<copy::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -57,7 +57,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<copy::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |
@@ -99,7 +99,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -142,7 +142,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<derived_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |
@@ -184,7 +184,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -227,7 +227,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<significant_drop::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |
@@ -269,7 +269,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<insignificant_dtor::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -312,7 +312,7 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<insignificant_dtor::Client>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |

--- a/tests/ui/generator/partial-drop.drop_tracking.stderr
+++ b/tests/ui/generator/partial-drop.drop_tracking.stderr
@@ -11,7 +11,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:17:17: 17:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:21:9
    |
@@ -42,7 +42,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:24:17: 24:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:29:9
    |

--- a/tests/ui/generator/partial-drop.no_drop_tracking.stderr
+++ b/tests/ui/generator/partial-drop.no_drop_tracking.stderr
@@ -11,7 +11,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:17:17: 17:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:21:9
    |
@@ -42,7 +42,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:24:17: 24:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:29:9
    |

--- a/tests/ui/generator/print/generator-print-verbose-2.drop_tracking.stderr
+++ b/tests/ui/generator/print/generator-print-verbose-2.drop_tracking.stderr
@@ -11,7 +11,7 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[main::{closure#0} upvar_tys=() {NotSync, ()}]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:23:9
    |
@@ -41,7 +41,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[main::{closure#1} upvar_tys=() {NotSend, ()}]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSend>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:30:9
    |

--- a/tests/ui/generator/print/generator-print-verbose-2.drop_tracking_mir.stderr
+++ b/tests/ui/generator/print/generator-print-verbose-2.drop_tracking_mir.stderr
@@ -5,7 +5,7 @@ LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ generator is not `Sync`
    |
    = help: within `[main::{closure#0} upvar_tys=() [main::{closure#0}]]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:23:9
    |
@@ -26,7 +26,7 @@ LL |     assert_send(|| {
    |     ^^^^^^^^^^^ generator is not `Send`
    |
    = help: within `[main::{closure#1} upvar_tys=() [main::{closure#1}]]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSend>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:30:9
    |

--- a/tests/ui/generator/print/generator-print-verbose-2.no_drop_tracking.stderr
+++ b/tests/ui/generator/print/generator-print-verbose-2.no_drop_tracking.stderr
@@ -11,7 +11,7 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[main::{closure#0} upvar_tys=() {NotSync, ()}]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:23:9
    |
@@ -41,7 +41,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[main::{closure#1} upvar_tys=() {NotSend, ()}]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NotSend>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:30:9
    |

--- a/tests/ui/generator/ref-upvar-not-send.rs
+++ b/tests/ui/generator/ref-upvar-not-send.rs
@@ -15,7 +15,7 @@ fn main() {
     assert_send(move || {
         //~^ ERROR generator cannot be sent between threads safely
         //~| NOTE generator is not `Send`
-        //~| NOTE consider using `std::sync::Arc
+        //~| NOTE consider whether `std::sync::Arc
         yield;
         let _x = x;
     });
@@ -24,7 +24,7 @@ fn main() {
     assert_send(move || {
         //~^ ERROR generator cannot be sent between threads safely
         //~| NOTE generator is not `Send`
-        //~| NOTE consider using `std::sync::Arc
+        //~| NOTE consider whether `std::sync::Arc
         yield;
         let _y = y;
     });

--- a/tests/ui/generator/ref-upvar-not-send.stderr
+++ b/tests/ui/generator/ref-upvar-not-send.stderr
@@ -12,7 +12,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut ()>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/ref-upvar-not-send.rs:20:18
    |
@@ -38,7 +38,7 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/ref-upvar-not-send.rs:24:17: 24:24]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut ()>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
   --> $DIR/ref-upvar-not-send.rs:29:18
    |

--- a/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.stderr
@@ -5,7 +5,7 @@ LL |     fn bar() -> Wrapper<impl Sized>;
    |                 ^^^^^^^^^^^^^^^^^^^ `impl Sized` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `impl Sized`
-   = note: consider using `std::sync::Arc<impl Sized>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<impl Sized>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Wrapper`
   --> $DIR/check-wf-on-non-defaulted-rpitit.rs:3:19
    |

--- a/tests/ui/issues/issue-24446.stderr
+++ b/tests/ui/issues/issue-24446.stderr
@@ -13,7 +13,7 @@ LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    |                 ^^^^^^^^^^^^^^^ `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Fn() -> u32 + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Fn() -> u32 + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<(dyn Fn() -> u32 + 'static)>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: shared static variables must have a type that implements `Sync`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -4,7 +4,7 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `S<T>` to implement `Gettable<T>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |
@@ -43,7 +43,7 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `S<T>` to implement `Gettable<T>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |

--- a/tests/ui/kindck/kindck-send-object.stderr
+++ b/tests/ui/kindck/kindck-send-object.stderr
@@ -5,7 +5,7 @@ LL |     assert_send::<&'static (dyn Dummy + 'static)>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<(dyn Dummy + 'static)>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object.rs:5:18
@@ -20,7 +20,7 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
-   = note: consider using `std::sync::Arc<dyn Dummy>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dyn Dummy>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -5,7 +5,7 @@ LL |     assert_send::<&'a dyn Dummy>();
    |                   ^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'a)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'a)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<(dyn Dummy + 'a)>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&'a (dyn Dummy + 'a)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object1.rs:5:18
@@ -20,7 +20,7 @@ LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |                   ^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'a)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<(dyn Dummy + 'a)>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<(dyn Dummy + 'a)>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-object2.stderr
+++ b/tests/ui/kindck/kindck-send-object2.stderr
@@ -5,7 +5,7 @@ LL |     assert_send::<&'static dyn Dummy>();
    |                   ^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<(dyn Dummy + 'static)>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object2.rs:3:18
@@ -20,7 +20,7 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
-   = note: consider using `std::sync::Arc<dyn Dummy>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dyn Dummy>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-owned.stderr
+++ b/tests/ui/kindck/kindck-send-owned.stderr
@@ -5,7 +5,7 @@ LL |     assert_send::<Box<*mut u8>>();
    |                   ^^^^^^^^^^^^ `*mut u8` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut u8`
-   = note: consider using `std::sync::Arc<*mut u8>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut u8>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<*mut u8>` to implement `Send`
 note: required because it appears within the type `Box<*mut u8>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-unsafe.stderr
+++ b/tests/ui/kindck/kindck-send-unsafe.stderr
@@ -5,7 +5,7 @@ LL |     assert_send::<*mut isize>();
    |                   ^^^^^^^^^^ `*mut isize` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut isize`
-   = note: consider using `std::sync::Arc<*mut isize>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut isize>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-unsafe.rs:3:19
    |
@@ -19,7 +19,7 @@ LL |     assert_send::<*mut &'a isize>();
    |                   ^^^^^^^^^^^^^^ `*mut &'a isize` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut &'a isize`
-   = note: consider using `std::sync::Arc<*mut &'a isize>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*mut &'a isize>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-unsafe.rs:3:19
    |

--- a/tests/ui/mut/mutable-enum-indirect.stderr
+++ b/tests/ui/mut/mutable-enum-indirect.stderr
@@ -7,7 +7,7 @@ LL |     bar(&x);
    |     required by a bound introduced by this call
    |
    = help: within `&Foo`, the trait `Sync` is not implemented for `NoSync`
-   = note: consider using `std::sync::Arc<NoSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NoSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/mutable-enum-indirect.rs:11:6
    |

--- a/tests/ui/no_send-enum.stderr
+++ b/tests/ui/no_send-enum.stderr
@@ -7,7 +7,7 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: within `Foo`, the trait `Send` is not implemented for `NoSend`
-   = note: consider using `std::sync::Arc<NoSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NoSend>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/no_send-enum.rs:8:6
    |

--- a/tests/ui/no_share-enum.stderr
+++ b/tests/ui/no_share-enum.stderr
@@ -7,7 +7,7 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: within `Foo`, the trait `Sync` is not implemented for `NoSync`
-   = note: consider using `std::sync::Arc<NoSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NoSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/no_share-enum.rs:8:6
    |

--- a/tests/ui/no_share-struct.stderr
+++ b/tests/ui/no_share-struct.stderr
@@ -7,7 +7,7 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `bar`
   --> $DIR/no_share-struct.rs:8:11
    |

--- a/tests/ui/phantom-auto-trait.stderr
+++ b/tests/ui/phantom-auto-trait.stderr
@@ -6,7 +6,7 @@ LL |     is_zen(x)
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `&T` to implement `Zen`
   --> $DIR/phantom-auto-trait.rs:10:24
    |
@@ -37,7 +37,7 @@ LL |     is_zen(x)
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `&T` to implement `Zen`
   --> $DIR/phantom-auto-trait.rs:10:24
    |

--- a/tests/ui/recursion/recursive-requirements.stderr
+++ b/tests/ui/recursion/recursive-requirements.stderr
@@ -5,7 +5,7 @@ LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Bar` cannot be shared between threads safely
    |
    = help: within `Foo`, the trait `Sync` is not implemented for `*const Bar`
-   = note: consider using `std::sync::Arc<*const Bar>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*const Bar>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/recursive-requirements.rs:5:12
    |
@@ -24,7 +24,7 @@ LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Foo` cannot be shared between threads safely
    |
    = help: within `Foo`, the trait `Sync` is not implemented for `*const Foo`
-   = note: consider using `std::sync::Arc<*const Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*const Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Bar`
   --> $DIR/recursive-requirements.rs:10:12
    |

--- a/tests/ui/statics/issue-17718-static-sync.stderr
+++ b/tests/ui/statics/issue-17718-static-sync.stderr
@@ -5,7 +5,7 @@ LL | static BAR: Foo = Foo;
    |             ^^^ `Foo` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: shared static variables must have a type that implements `Sync`
 
 error: aborting due to previous error

--- a/tests/ui/stdlib-unit-tests/not-sync.stderr
+++ b/tests/ui/stdlib-unit-tests/not-sync.stderr
@@ -47,7 +47,7 @@ LL |     test::<Weak<i32>>();
    |            ^^^^^^^^^ `std::rc::Weak<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::rc::Weak<i32>`
-   = note: consider using `std::sync::Arc<std::rc::Weak<i32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<std::rc::Weak<i32>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/not-sync.rs:5:12
    |
@@ -61,7 +61,7 @@ LL |     test::<Receiver<i32>>();
    |            ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<i32>`
-   = note: consider using `std::sync::Arc<std::sync::mpsc::Receiver<i32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<std::sync::mpsc::Receiver<i32>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/not-sync.rs:5:12
    |

--- a/tests/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
+++ b/tests/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
@@ -7,7 +7,7 @@ LL |     assert_is_send(&bar);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
-   = note: consider using `std::sync::Arc<<impl Foo as Foo>::Bar>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<<impl Foo as Foo>::Bar>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_is_send`
   --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:30:22
    |
@@ -27,7 +27,7 @@ LL |     assert_is_send(&bar);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
-   = note: consider using `std::sync::Arc<<impl Foo as Foo>::Bar>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<<impl Foo as Foo>::Bar>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_is_send`
   --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:30:22
    |

--- a/tests/ui/suggestions/restrict-type-argument.stderr
+++ b/tests/ui/suggestions/restrict-type-argument.stderr
@@ -6,7 +6,7 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<impl Sync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<impl Sync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -25,7 +25,7 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<S>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -44,7 +44,7 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<S>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -63,7 +63,7 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<S>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -82,7 +82,7 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<S>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -101,7 +101,7 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<S>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |

--- a/tests/ui/traits/bad-method-typaram-kind.stderr
+++ b/tests/ui/traits/bad-method-typaram-kind.stderr
@@ -4,7 +4,7 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     1.bar::<T>();
    |             ^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Bar::bar`
   --> $DIR/bad-method-typaram-kind.rs:6:14
    |

--- a/tests/ui/traits/inductive-overflow/two-traits.stderr
+++ b/tests/ui/traits/inductive-overflow/two-traits.stderr
@@ -4,7 +4,7 @@ error[E0277]: `T` cannot be shared between threads safely
 LL |     type X = Self;
    |              ^^^^ `T` cannot be shared between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Magic::X`
   --> $DIR/two-traits.rs:8:13
    |

--- a/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -7,7 +7,7 @@ LL |     Outer(TestType);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy::TestType`
-   = note: consider using `std::sync::Arc<dummy::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dummy::TestType>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Outer`
   --> $DIR/negated-auto-traits-error.rs:10:17
    |
@@ -21,7 +21,7 @@ LL |     Outer(TestType);
    |     ^^^^^^^^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dummy::TestType`
-   = note: consider using `std::sync::Arc<dummy::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dummy::TestType>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Outer`
   --> $DIR/negated-auto-traits-error.rs:10:17
    |
@@ -37,7 +37,7 @@ LL |     is_send(TestType);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy1b::TestType`
-   = note: consider using `std::sync::Arc<dummy1b::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dummy1b::TestType>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
    |
@@ -53,7 +53,7 @@ LL |     is_send((8, TestType));
    |     required by a bound introduced by this call
    |
    = help: within `({integer}, dummy1c::TestType)`, the trait `Send` is not implemented for `dummy1c::TestType`
-   = note: consider using `std::sync::Arc<dummy1c::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dummy1c::TestType>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `({integer}, TestType)`
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
@@ -92,7 +92,7 @@ LL |     is_send(Box::new(Outer2(TestType)));
    |     required by a bound introduced by this call
    |
    = help: within `Outer2<dummy3::TestType>`, the trait `Send` is not implemented for `dummy3::TestType`
-   = note: consider using `std::sync::Arc<dummy3::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<dummy3::TestType>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Outer2<TestType>`
   --> $DIR/negated-auto-traits-error.rs:12:8
    |
@@ -116,7 +116,7 @@ LL |     is_sync(Outer2(TestType));
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `main::TestType`
-   = note: consider using `std::sync::Arc<main::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<main::TestType>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `Outer2<main::TestType>` to implement `Sync`
   --> $DIR/negated-auto-traits-error.rs:14:22
    |

--- a/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
+++ b/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
@@ -7,7 +7,7 @@ LL |     is_send(foo());
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `impl Future<Output = ()>`
-   = note: consider using `std::sync::Arc<impl Future<Output = ()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<impl Future<Output = ()>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/auto-with-drop_tracking_mir.rs:24:24
    |

--- a/tests/ui/traits/no_send-struct.stderr
+++ b/tests/ui/traits/no_send-struct.stderr
@@ -7,7 +7,7 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Foo>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `bar`
   --> $DIR/no_send-struct.rs:11:11
    |

--- a/tests/ui/traits/non_lifetime_binders/fail.stderr
+++ b/tests/ui/traits/non_lifetime_binders/fail.stderr
@@ -29,7 +29,7 @@ LL |     auto_trait();
    |     ^^^^^^^^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `T`
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `auto_trait`
   --> $DIR/fail.rs:15:15
    |

--- a/tests/ui/traits/unsend-future.stderr
+++ b/tests/ui/traits/unsend-future.stderr
@@ -5,7 +5,7 @@ LL |     require_handler(handler)
    |                     ^^^^^^^ future returned by `handler` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `*const i32`
-   = note: consider using `std::sync::Arc<*const i32>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<*const i32>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/unsend-future.rs:15:14
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
@@ -5,7 +5,7 @@ LL |     is_send::<T::AssocType>();
    |               ^^^^^^^^^^^^ `<T as Trait>::AssocType` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `<T as Trait>::AssocType`
-   = note: consider using `std::sync::Arc<<T as Trait>::AssocType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<<T as Trait>::AssocType>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-assoc-type.rs:14:14
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-negation-send.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-negation-send.stderr
@@ -5,7 +5,7 @@ LL |     is_send::<MyNotSendable>();
    |               ^^^^^^^^^^^^^ `MyNotSendable` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `MyNotSendable`
-   = note: consider using `std::sync::Arc<MyNotSendable>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<MyNotSendable>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-negation-send.rs:15:15
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
@@ -5,7 +5,7 @@ LL |     is_sync::<MyNotSync>();
    |               ^^^^^^^^^ `MyNotSync` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `MyNotSync`
-   = note: consider using `std::sync::Arc<MyNotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<MyNotSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_sync`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:15
    |
@@ -19,7 +19,7 @@ LL |     is_sync::<MyTypeWUnsafe>();
    |               ^^^^^^^^^^^^^ `UnsafeCell<u8>` cannot be shared between threads safely
    |
    = help: within `MyTypeWUnsafe`, the trait `Sync` is not implemented for `UnsafeCell<u8>`
-   = note: consider using `std::sync::Arc<UnsafeCell<u8>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<UnsafeCell<u8>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `MyTypeWUnsafe`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:21:8
    |
@@ -38,7 +38,7 @@ LL |     is_sync::<MyTypeManaged>();
    |               ^^^^^^^^^^^^^ `Managed` cannot be shared between threads safely
    |
    = help: within `MyTypeManaged`, the trait `Sync` is not implemented for `Managed`
-   = note: consider using `std::sync::Arc<Managed>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<Managed>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `MyTypeManaged`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:25:8
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -4,7 +4,7 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     is_send::<T>()
    |               ^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<T>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-send-param.rs:8:14
    |

--- a/tests/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/tests/ui/typeck/typeck-unsafe-always-share.stderr
@@ -7,7 +7,7 @@ LL |     test(us);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<MySync<{integer}>>`
-   = note: consider using `std::sync::Arc<UnsafeCell<MySync<{integer}>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<UnsafeCell<MySync<{integer}>>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |
@@ -23,7 +23,7 @@ LL |     test(uns);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<NoSync>`
-   = note: consider using `std::sync::Arc<UnsafeCell<NoSync>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<UnsafeCell<NoSync>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |
@@ -39,7 +39,7 @@ LL |     test(ms);
    |     required by a bound introduced by this call
    |
    = help: within `MySync<NoSync>`, the trait `Sync` is not implemented for `UnsafeCell<NoSync>`
-   = note: consider using `std::sync::Arc<UnsafeCell<NoSync>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<UnsafeCell<NoSync>>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `MySync<NoSync>`
   --> $DIR/typeck-unsafe-always-share.rs:8:8
    |
@@ -60,7 +60,7 @@ LL |     test(NoSync);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `NoSync`
-   = note: consider using `std::sync::Arc<NoSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = note: consider whether `std::sync::Arc<NoSync>` could be incorporated to share this value between threads; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/114687