### PR TITLE
Update LLVM submodule

### DIFF
--- a/tests/codegen/issues/issue-114312.rs
+++ b/tests/codegen/issues/issue-114312.rs
@@ -1,0 +1,27 @@
+// compile-flags: -O
+// min-llvm-version: 17
+// only-x86_64-unknown-linux-gnu
+
+// We want to check that this function does not mis-optimize to loop jumping.
+
+#![crate_type = "lib"]
+
+#[repr(C)]
+pub enum Expr {
+    Sum,
+    // must have more than usize data
+    Sub(usize, u8),
+}
+
+#[no_mangle]
+pub extern "C" fn issue_114312(expr: Expr) {
+    // CHECK-LABEL: @issue_114312(
+    // CHECK-NOT: readonly
+    // CHECK-SAME: byval
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: ret void
+    match expr {
+        Expr::Sum => {}
+        Expr::Sub(_, _) => issue_114312(Expr::Sum),
+    }
+}

--- a/tests/ui/match/issue-114691.rs
+++ b/tests/ui/match/issue-114691.rs
@@ -1,0 +1,39 @@
+// run-pass
+
+// This test used to be miscompiled by LLVM 17.
+#![allow(dead_code)]
+
+enum Pass {
+    Opaque {
+        clear_color: [f32; 4],
+        with_depth_pre_pass: bool,
+    },
+    Transparent,
+}
+
+enum LoadOp {
+    Clear,
+    Load,
+}
+
+#[inline(never)]
+fn check(x: Option<LoadOp>) {
+    assert!(x.is_none());
+}
+
+#[inline(never)]
+fn test(mode: Pass) {
+    check(match mode {
+        Pass::Opaque {
+            with_depth_pre_pass: true,
+            ..
+        }
+        | Pass::Transparent => None,
+        _ => Some(LoadOp::Clear),
+    });
+}
+
+fn main() {
+    println!("Hello, world!");
+    test(Pass::Transparent);
+}


### PR DESCRIPTION
Merge the current release/17.x branch.

Fixes #114691.
Fixes #114312.

The test for the latter is taken from #114726.