### PR TITLE
add codegen test for `trailing_zeros` comparison

### DIFF
--- a/tests/codegen/trailing_zeros.rs
+++ b/tests/codegen/trailing_zeros.rs
@@ -1,0 +1,22 @@
+// compile-flags: -O
+// min-llvm-version: 17
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @trailing_zeros_ge
+#[no_mangle]
+pub fn trailing_zeros_ge(val: u32) -> bool {
+    // CHECK: %[[AND:.*]] = and i32 %val, 7
+    // CHECK: %[[ICMP:.*]] = icmp eq i32 %[[AND]], 0
+    // CHECK: ret i1 %[[ICMP]]
+    val.trailing_zeros() >= 3
+}
+
+// CHECK-LABEL: @trailing_zeros_gt
+#[no_mangle]
+pub fn trailing_zeros_gt(val: u64) -> bool {
+    // CHECK: %[[AND:.*]] = and i64 %val, 15
+    // CHECK: %[[ICMP:.*]] = icmp eq i64 %[[AND]], 0
+    // CHECK: ret i1 %[[ICMP]]
+    val.trailing_zeros() > 3
+}


### PR DESCRIPTION
This PR add codegen test for 
https://github.com/rust-lang/rust/issues/107554#issuecomment-1677369236

Fixes #107554.