### PR TITLE
rustdoc: show inner enum and struct in type definition for concrete type

### DIFF
--- a/src/doc/rustdoc/src/how-to-read-rustdoc.md
+++ b/src/doc/rustdoc/src/how-to-read-rustdoc.md
@@ -38,6 +38,22 @@ followed by a list of fields or variants for Rust types.
 Finally, the page lists associated functions and trait implementations,
 including automatic and blanket implementations that `rustdoc` knows about.
 
+### Sections
+
+<!-- FIXME: Implementations -->
+<!-- FIXME: Trait Implementations -->
+<!-- FIXME: Implementors -->
+<!-- FIXME: Auto Trait Implementations -->
+
+#### Aliased Type
+
+A type alias is expanded at compile time to its
+[aliased type](https://doc.rust-lang.org/reference/items/type-aliases.html).
+That may involve substituting some or all of the type parameters in the target
+type with types provided by the type alias definition. The Aliased Type section
+shows the result of this expansion, including the types of public fields or
+variants, which may depend on those substitutions.
+
 ### Navigation
 
 Subheadings, variants, fields, and many other things in this documentation

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -20,7 +20,8 @@ use rustc_span::symbol::{kw, sym, Symbol};
 use crate::clean::{
     self, clean_fn_decl_from_did_and_sig, clean_generics, clean_impl_item, clean_middle_assoc_item,
     clean_middle_field, clean_middle_ty, clean_trait_ref_with_bindings, clean_ty,
-    clean_ty_generics, clean_variant_def, utils, Attributes, AttributesExt, ImplKind, ItemId, Type,
+    clean_ty_alias_inner_type, clean_ty_generics, clean_variant_def, utils, Attributes,
+    AttributesExt, ImplKind, ItemId, Type,
 };
 use crate::core::DocContext;
 use crate::formats::item_type::ItemType;
@@ -289,19 +290,14 @@ fn build_union(cx: &mut DocContext<'_>, did: DefId) -> clean::Union {
 
 fn build_type_alias(cx: &mut DocContext<'_>, did: DefId) -> Box<clean::TypeAlias> {
     let predicates = cx.tcx.explicit_predicates_of(did);
-    let type_ = clean_middle_ty(
-        ty::Binder::dummy(cx.tcx.type_of(did).instantiate_identity()),
-        cx,
-        Some(did),
-        None,
-    );
+    let ty = cx.tcx.type_of(did).instantiate_identity();
+    let type_ = clean_middle_ty(ty::Binder::dummy(ty), cx, Some(did), None);
+    let inner_type = clean_ty_alias_inner_type(ty, cx);
 
     Box::new(clean::TypeAlias {
         type_,
         generics: clean_ty_generics(cx, cx.tcx.generics_of(did), predicates),
-        // FIXME: Figure-out how to handle inner_type with
-        // clean_ty_typedef_inner_type
-        inner_type: None,
+        inner_type,
         item_type: None,
     })
 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -299,6 +299,9 @@ fn build_type_alias(cx: &mut DocContext<'_>, did: DefId) -> Box<clean::TypeAlias
     Box::new(clean::TypeAlias {
         type_,
         generics: clean_ty_generics(cx, cx.tcx.generics_of(did), predicates),
+        // FIXME: Figure-out how to handle inner_type with
+        // clean_ty_typedef_inner_type
+        inner_type: None,
         item_type: None,
     })
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -971,10 +971,8 @@ fn clean_ty_alias_inner_type<'tcx>(
             .map(|variant| clean_variant_def_with_args(variant, args, cx))
             .collect();
 
-        let has_stripped_variants = adt_def.variants().len() != variants.len();
         TypeAliasInnerType::Enum {
             variants,
-            has_stripped_variants,
             is_non_exhaustive: adt_def.is_variant_list_non_exhaustive(),
         }
     } else {
@@ -987,11 +985,10 @@ fn clean_ty_alias_inner_type<'tcx>(
         let fields: Vec<_> =
             clean_variant_def_with_args(variant, args, cx).kind.inner_items().cloned().collect();
 
-        let has_stripped_fields = variant.fields.len() != fields.len();
         if adt_def.is_struct() {
-            TypeAliasInnerType::Struct { ctor_kind: variant.ctor_kind(), fields, has_stripped_fields }
+            TypeAliasInnerType::Struct { ctor_kind: variant.ctor_kind(), fields }
         } else {
-            TypeAliasInnerType::Union { fields, has_stripped_fields }
+            TypeAliasInnerType::Union { fields }
         }
     })
 }
@@ -2415,7 +2412,6 @@ pub(crate) fn clean_variant_def_with_args<'tcx>(
             variant
                 .fields
                 .iter()
-                .filter(|field| field.vis.is_public())
                 .map(|field| {
                     let ty = cx.tcx.type_of(field.did).instantiate(cx.tcx, args);
                     clean_field_with_def_id(
@@ -2431,7 +2427,6 @@ pub(crate) fn clean_variant_def_with_args<'tcx>(
             fields: variant
                 .fields
                 .iter()
-                .filter(|field| field.vis.is_public())
                 .map(|field| {
                     let ty = cx.tcx.type_of(field.did).instantiate(cx.tcx, args);
                     clean_field_with_def_id(

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2230,9 +2230,30 @@ pub(crate) struct PathSegment {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) enum TypeAliasInnerType {
+    Enum {
+        variants: IndexVec<VariantIdx, Item>,
+        has_stripped_variants: bool,
+        is_non_exhaustive: bool,
+    },
+    Union {
+        fields: Vec<Item>,
+        has_stripped_fields: bool,
+    },
+    Struct {
+        ctor_kind: Option<CtorKind>,
+        fields: Vec<Item>,
+        has_stripped_fields: bool,
+    },
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct TypeAlias {
     pub(crate) type_: Type,
     pub(crate) generics: Generics,
+    /// Inner `AdtDef` type, ie `type TyKind = IrTyKind<Adt, Ty>`,
+    /// to be shown directly on the typedef page.
+    pub(crate) inner_type: Option<TypeAliasInnerType>,
     /// `type_` can come from either the HIR or from metadata. If it comes from HIR, it may be a type
     /// alias instead of the final type. This will always have the final type, regardless of whether
     /// `type_` came from HIR or from metadata.

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2252,6 +2252,23 @@ pub(crate) struct TypeAlias {
     pub(crate) item_type: Option<Type>,
 }
 
+impl TypeAlias {
+    pub(crate) fn should_display_inner_type(&self) -> bool {
+        // Only show inner variants if:
+        //  - the typealias does NOT have any generics (modulo lifetimes)
+        //  - AND the aliased type has some generics
+        //
+        // Otherwise, showing a non-generic type is rendurant with its own page, or
+        // if it still has some generics, it's not as useful.
+        self.generics
+            .params
+            .iter()
+            .all(|param| matches!(param.kind, GenericParamDefKind::Lifetime { .. }))
+            && self.generics.where_predicates.is_empty()
+            && self.type_.generics().is_some_and(|generics| !generics.is_empty())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct OpaqueTy {
     pub(crate) bounds: Vec<GenericBound>,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2252,23 +2252,6 @@ pub(crate) struct TypeAlias {
     pub(crate) item_type: Option<Type>,
 }
 
-impl TypeAlias {
-    pub(crate) fn should_display_inner_type(&self) -> bool {
-        // Only show inner variants if:
-        //  - the typealias does NOT have any generics (modulo lifetimes)
-        //  - AND the aliased type has some generics
-        //
-        // Otherwise, showing a non-generic type is rendurant with its own page, or
-        // if it still has some generics, it's not as useful.
-        self.generics
-            .params
-            .iter()
-            .all(|param| matches!(param.kind, GenericParamDefKind::Lifetime { .. }))
-            && self.generics.where_predicates.is_empty()
-            && self.type_.generics().is_some_and(|generics| !generics.is_empty())
-    }
-}
-
 #[derive(Clone, Debug)]
 pub(crate) struct OpaqueTy {
     pub(crate) bounds: Vec<GenericBound>,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2231,20 +2231,9 @@ pub(crate) struct PathSegment {
 
 #[derive(Clone, Debug)]
 pub(crate) enum TypeAliasInnerType {
-    Enum {
-        variants: IndexVec<VariantIdx, Item>,
-        has_stripped_variants: bool,
-        is_non_exhaustive: bool,
-    },
-    Union {
-        fields: Vec<Item>,
-        has_stripped_fields: bool,
-    },
-    Struct {
-        ctor_kind: Option<CtorKind>,
-        fields: Vec<Item>,
-        has_stripped_fields: bool,
-    },
+    Enum { variants: IndexVec<VariantIdx, Item>, is_non_exhaustive: bool },
+    Union { fields: Vec<Item> },
+    Struct { ctor_kind: Option<CtorKind>, fields: Vec<Item> },
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -457,6 +457,7 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
             | clean::StructItem(..)
             | clean::UnionItem(..)
             | clean::VariantItem(..)
+            | clean::TypeAliasItem(..)
             | clean::ImplItem(..) => {
                 self.cache.parent_stack.push(ParentStackItem::new(&item));
                 (self.fold_item_recur(item), true)

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1270,30 +1270,34 @@ fn item_type_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &c
         }
 
         match &t.inner_type {
-            Some(clean::TypeAliasInnerType::Enum {
-                variants,
-                has_stripped_variants: has_stripped_entries,
-                is_non_exhaustive,
-            }) => {
+            Some(clean::TypeAliasInnerType::Enum { variants, is_non_exhaustive }) => {
                 toggle(w, |w| {
+                    let variants_iter = || variants.iter().filter(|i| !i.is_stripped());
                     wrap_item(w, |w| {
+                        let variants_len = variants.len();
+                        let variants_count = variants_iter().count();
+                        let has_stripped_entries = variants_len != variants_count;
+
                         write!(w, "enum {}{}", it.name.unwrap(), t.generics.print(cx));
                         render_enum_fields(
                             w,
                             cx,
                             None,
-                            variants.iter(),
-                            variants.len(),
-                            *has_stripped_entries,
+                            variants_iter(),
+                            variants_count,
+                            has_stripped_entries,
                             *is_non_exhaustive,
                         )
                     });
-                    item_variants(w, cx, it, variants.iter());
+                    item_variants(w, cx, it, variants_iter());
                 });
             }
-            Some(clean::TypeAliasInnerType::Union { fields, has_stripped_fields }) => {
+            Some(clean::TypeAliasInnerType::Union { fields }) => {
                 toggle(w, |w| {
                     wrap_item(w, |w| {
+                        let fields_count = fields.iter().filter(|i| !i.is_stripped()).count();
+                        let has_stripped_fields = fields.len() != fields_count;
+
                         write!(w, "union {}{}", it.name.unwrap(), t.generics.print(cx));
                         render_struct_fields(
                             w,
@@ -1302,16 +1306,19 @@ fn item_type_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &c
                             fields,
                             "",
                             true,
-                            *has_stripped_fields,
+                            has_stripped_fields,
                             cx,
                         );
                     });
                     item_fields(w, cx, it, fields, None);
                 });
             }
-            Some(clean::TypeAliasInnerType::Struct { ctor_kind, fields, has_stripped_fields }) => {
+            Some(clean::TypeAliasInnerType::Struct { ctor_kind, fields }) => {
                 toggle(w, |w| {
                     wrap_item(w, |w| {
+                        let fields_count = fields.iter().filter(|i| !i.is_stripped()).count();
+                        let has_stripped_fields = fields.len() != fields_count;
+
                         write!(w, "struct {}{}", it.name.unwrap(), t.generics.print(cx));
                         render_struct_fields(
                             w,
@@ -1320,7 +1327,7 @@ fn item_type_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &c
                             fields,
                             "",
                             true,
-                            *has_stripped_fields,
+                            has_stripped_fields,
                             cx,
                         );
                     });

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1237,7 +1237,7 @@ fn item_type_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &c
 
     write!(w, "{}", document(cx, it, None, HeadingOffset::H2));
 
-    if let Some(inner_type) = &t.inner_type && t.should_display_inner_type() {
+    if let Some(inner_type) = &t.inner_type {
         write!(
             w,
             "<h2 id=\"aliased-type\" class=\"small-section-header\">\
@@ -1256,7 +1256,7 @@ fn item_type_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &c
                     render_enum_fields(
                         w,
                         cx,
-                        None,
+                        Some(&t.generics),
                         variants_iter(),
                         variants_count,
                         has_stripped_entries,
@@ -1271,7 +1271,16 @@ fn item_type_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &c
                     let has_stripped_fields = fields.len() != fields_count;
 
                     write!(w, "union {}{}", it.name.unwrap(), t.generics.print(cx));
-                    render_struct_fields(w, None, None, fields, "", true, has_stripped_fields, cx);
+                    render_struct_fields(
+                        w,
+                        Some(&t.generics),
+                        None,
+                        fields,
+                        "",
+                        true,
+                        has_stripped_fields,
+                        cx,
+                    );
                 });
                 item_fields(w, cx, it, fields, None);
             }
@@ -1283,7 +1292,7 @@ fn item_type_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &c
                     write!(w, "struct {}{}", it.name.unwrap(), t.generics.print(cx));
                     render_struct_fields(
                         w,
-                        None,
+                        Some(&t.generics),
                         *ctor_kind,
                         fields,
                         "",

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -236,7 +236,7 @@ fn sidebar_type_alias<'a>(
     t: &'a clean::TypeAlias,
 ) -> Vec<LinkBlock<'a>> {
     let mut items = vec![];
-    if let Some(inner_type) = &t.inner_type && t.should_display_inner_type() {
+    if let Some(inner_type) = &t.inner_type {
         match inner_type {
             clean::TypeAliasInnerType::Enum { variants, is_non_exhaustive: _ } => {
                 let mut variants = variants

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -82,7 +82,7 @@ pub(super) fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buf
         clean::PrimitiveItem(_) => sidebar_primitive(cx, it),
         clean::UnionItem(ref u) => sidebar_union(cx, it, u),
         clean::EnumItem(ref e) => sidebar_enum(cx, it, e),
-        clean::TypeAliasItem(_) => sidebar_type_alias(cx, it),
+        clean::TypeAliasItem(ref t) => sidebar_type_alias(cx, it, t),
         clean::ModuleItem(ref m) => vec![sidebar_module(&m.items)],
         clean::ForeignTypeItem => sidebar_foreign_type(cx, it),
         _ => vec![],
@@ -230,8 +230,32 @@ fn sidebar_primitive<'a>(cx: &'a Context<'_>, it: &'a clean::Item) -> Vec<LinkBl
     }
 }
 
-fn sidebar_type_alias<'a>(cx: &'a Context<'_>, it: &'a clean::Item) -> Vec<LinkBlock<'a>> {
+fn sidebar_type_alias<'a>(
+    cx: &'a Context<'_>,
+    it: &'a clean::Item,
+    t: &'a clean::TypeAlias,
+) -> Vec<LinkBlock<'a>> {
     let mut items = vec![];
+    if let Some(inner_type) = &t.inner_type && t.should_display_inner_type() {
+        match inner_type {
+            clean::TypeAliasInnerType::Enum { variants, is_non_exhaustive: _ } => {
+                let mut variants = variants
+                    .iter()
+                    .filter(|i| !i.is_stripped())
+                    .filter_map(|v| v.name)
+                    .map(|name| Link::new(format!("variant.{name}"), name.to_string()))
+                    .collect::<Vec<_>>();
+                variants.sort_unstable();
+
+                items.push(LinkBlock::new(Link::new("variants", "Variants"), variants));
+            }
+            clean::TypeAliasInnerType::Union { fields }
+            | clean::TypeAliasInnerType::Struct { ctor_kind: _, fields } => {
+                let fields = get_struct_fields_name(fields);
+                items.push(LinkBlock::new(Link::new("fields", "Fields"), fields));
+            }
+        }
+    }
     sidebar_assoc_items(cx, it, &mut items);
     items
 }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -789,7 +789,7 @@ pub(crate) fn from_macro_kind(kind: rustc_span::hygiene::MacroKind) -> MacroKind
 
 impl FromWithTcx<Box<clean::TypeAlias>> for TypeAlias {
     fn from_tcx(type_alias: Box<clean::TypeAlias>, tcx: TyCtxt<'_>) -> Self {
-        let clean::TypeAlias { type_, generics, item_type: _ } = *type_alias;
+        let clean::TypeAlias { type_, generics, item_type: _, inner_type: _ } = *type_alias;
         TypeAlias { type_: type_.into_tcx(tcx), generics: generics.into_tcx(tcx) }
     }
 }

--- a/tests/rustdoc/auxiliary/cross_crate_generic_typedef.rs
+++ b/tests/rustdoc/auxiliary/cross_crate_generic_typedef.rs
@@ -1,0 +1,5 @@
+pub struct InlineOne<A> {
+   pub inline: A
+}
+
+pub type InlineU64 = InlineOne<u64>;

--- a/tests/rustdoc/typedef-inner-variants-lazy_type_alias.rs
+++ b/tests/rustdoc/typedef-inner-variants-lazy_type_alias.rs
@@ -1,0 +1,34 @@
+#![crate_name = "inner_types_lazy"]
+
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+// @has 'inner_types_lazy/struct.Pair.html'
+pub struct Pair<A, B> {
+    pub first: A,
+    pub second: B,
+}
+
+// @has 'inner_types_lazy/type.ReversedTypesPair.html'
+// @count - '//*[@id="aliased-type"]' 1
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 1
+// @count - '//span[@class="where fmt-newline"]' 0
+pub type ReversedTypesPair<Q, R> = Pair<R, Q>;
+
+// @has 'inner_types_lazy/type.ReadWrite.html'
+// @count - '//*[@id="aliased-type"]' 1
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 1
+// @count - '//span[@class="where fmt-newline"]' 2
+pub type ReadWrite<R, W> = Pair<R, W>
+where
+    R: std::io::Read,
+    W: std::io::Write;
+
+// @has 'inner_types_lazy/type.VecPair.html'
+// @count - '//*[@id="aliased-type"]' 1
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 1
+// @count - '//span[@class="where fmt-newline"]' 0
+pub type VecPair<U, V> = Pair<Vec<U>, Vec<V>>;

--- a/tests/rustdoc/typedef-inner-variants.rs
+++ b/tests/rustdoc/typedef-inner-variants.rs
@@ -43,14 +43,15 @@ pub enum IrTyKind<A, I: Interner> {
 pub type NearlyTyKind<A> = IrTyKind<A, TyCtxt>;
 
 // @has 'inner_variants/type.TyKind.html'
+// @count - '//*[@id="aliased-type"]' 1
 // @count - '//*[@id="variants"]' 1
 // @count - '//*[@id="fields"]' 0
 // @count - '//*[@class="variant"]' 3
-// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "enum TyKind"
-// @has - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code/a[1]' "Adt"
-// @has - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code/a[2]' "Adt"
-// @has - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code/a[3]' "Ty"
-// @has - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code/a[4]' "i64"
+// @matches - '//pre[@class="rust item-decl"]//code' "enum TyKind"
+// @has - '//pre[@class="rust item-decl"]//code/a[1]' "Adt"
+// @has - '//pre[@class="rust item-decl"]//code/a[2]' "Adt"
+// @has - '//pre[@class="rust item-decl"]//code/a[3]' "Ty"
+// @has - '//pre[@class="rust item-decl"]//code/a[4]' "i64"
 pub type TyKind = IrTyKind<i64, TyCtxt>;
 
 // @has 'inner_variants/union.OneOr.html'
@@ -60,10 +61,11 @@ pub union OneOr<A: Copy> {
 }
 
 // @has 'inner_variants/type.OneOrF64.html'
+// @count - '//*[@id="aliased-type"]' 1
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 1
 // @count - '//*[@class="structfield small-section-header"]' 2
-// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "union OneOrF64"
+// @matches - '//pre[@class="rust item-decl"]//code' "union OneOrF64"
 pub type OneOrF64 = OneOr<f64>;
 
 // @has 'inner_variants/struct.One.html'
@@ -75,10 +77,12 @@ pub struct One<T> {
 }
 
 // @has 'inner_variants/type.OneU64.html'
+// @count - '//*[@id="aliased-type"]' 1
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 1
 // @count - '//*[@class="structfield small-section-header"]' 1
-// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "struct OneU64"
+// @matches - '//pre[@class="rust item-decl"]//code' "struct OneU64"
+// @matches - '//pre[@class="rust item-decl"]//code' "pub val"
 pub type OneU64 = One<u64>;
 
 // @has 'inner_variants/struct.OnceA.html'
@@ -87,10 +91,11 @@ pub struct OnceA<'a, A> {
 }
 
 // @has 'inner_variants/type.Once.html'
+// @count - '//*[@id="aliased-type"]' 1
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 1
-// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "struct Once<'a>"
-// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "&'a"
+// @matches - '//pre[@class="rust item-decl"]//code' "struct Once<'a>"
+// @matches - '//pre[@class="rust item-decl"]//code' "&'a"
 pub type Once<'a> = OnceA<'a, i64>;
 
 // @has 'inner_variants/struct.HighlyGenericStruct.html'
@@ -100,12 +105,13 @@ pub struct HighlyGenericStruct<A, B, C, D> {
 
 // VERIFY that we NOT show the Aliased Type
 // @has 'inner_variants/type.HighlyGenericAABB.html'
-// @count - '//details[@class="toggle"]' 0
+// @count - '//*[@id="aliased-type"]' 1
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 0
 pub type HighlyGenericAABB<A, B> = HighlyGenericStruct<A, A, B, B>;
 
 // @has 'inner_variants/type.InlineU64.html'
+// @count - '//*[@id="aliased-type"]' 1
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 1
 pub use cross_crate_generic_typedef::InlineU64;

--- a/tests/rustdoc/typedef-inner-variants.rs
+++ b/tests/rustdoc/typedef-inner-variants.rs
@@ -1,0 +1,80 @@
+#![crate_name = "inner_variants"]
+
+pub struct Adt;
+pub struct Ty;
+
+// @has 'inner_variants/type.AliasTy.html'
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 0
+pub type AliasTy = Ty;
+
+// @has 'inner_variants/enum.IrTyKind.html'
+pub enum IrTyKind<A, B> {
+    /// Doc comment for AdtKind
+    AdtKind(A),
+    /// and another one for TyKind
+    TyKind(A, B),
+    // no comment
+    StructKind { a: A, },
+}
+
+// @has 'inner_variants/type.NearlyTyKind.html'
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 0
+pub type NearlyTyKind<B> = IrTyKind<Adt, B>;
+
+// @has 'inner_variants/type.TyKind.html'
+// @count - '//*[@id="variants"]' 1
+// @count - '//*[@id="fields"]' 0
+// @count - '//*[@class="variant"]' 3
+// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "enum TyKind"
+pub type TyKind = IrTyKind<Adt, Ty>;
+
+// @has 'inner_variants/union.OneOr.html'
+pub union OneOr<A: Copy> {
+    pub one: i64,
+    pub or: A,
+}
+
+// @has 'inner_variants/type.OneOrF64.html'
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 1
+// @count - '//*[@class="structfield small-section-header"]' 2
+// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "union OneOrF64"
+pub type OneOrF64 = OneOr<f64>;
+
+// @has 'inner_variants/struct.One.html'
+pub struct One<T> {
+    pub val: T,
+    __hidden: T,
+}
+
+// @has 'inner_variants/type.OneU64.html'
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 1
+// @count - '//*[@class="structfield small-section-header"]' 1
+// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "struct OneU64"
+pub type OneU64 = One<u64>;
+
+// @has 'inner_variants/struct.OnceA.html'
+pub struct OnceA<'a, A> {
+    a: &'a A, // private
+}
+
+// @has 'inner_variants/type.Once.html'
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 0
+// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "struct Once<'a>"
+pub type Once<'a> = OnceA<'a, i64>;
+
+// @has 'inner_variants/struct.HighlyGenericStruct.html'
+pub struct HighlyGenericStruct<A, B, C, D> {
+    pub z: (A, B, C, D)
+}
+
+// VERIFY that we NOT show the Aliased Type
+// @has 'inner_variants/type.HighlyGenericAABB.html'
+// @count - '//details[@class="toggle"]' 0
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 0
+pub type HighlyGenericAABB<A, B> = HighlyGenericStruct<A, A, B, B>;

--- a/tests/rustdoc/typedef-inner-variants.rs
+++ b/tests/rustdoc/typedef-inner-variants.rs
@@ -38,7 +38,8 @@ pub enum IrTyKind<A, I: Interner> {
 }
 
 // @has 'inner_variants/type.NearlyTyKind.html'
-// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="aliased-type"]' 1
+// @count - '//*[@id="variants"]' 1
 // @count - '//*[@id="fields"]' 0
 pub type NearlyTyKind<A> = IrTyKind<A, TyCtxt>;
 
@@ -103,11 +104,12 @@ pub struct HighlyGenericStruct<A, B, C, D> {
     pub z: (A, B, C, D)
 }
 
-// VERIFY that we NOT show the Aliased Type
 // @has 'inner_variants/type.HighlyGenericAABB.html'
 // @count - '//*[@id="aliased-type"]' 1
 // @count - '//*[@id="variants"]' 0
-// @count - '//*[@id="fields"]' 0
+// @count - '//*[@id="fields"]' 1
+// @matches - '//pre[@class="rust item-decl"]//code' "struct HighlyGenericAABB<A, B>"
+// @matches - '//pre[@class="rust item-decl"]//code' "pub z"
 pub type HighlyGenericAABB<A, B> = HighlyGenericStruct<A, A, B, B>;
 
 // @has 'inner_variants/type.InlineU64.html'

--- a/tests/rustdoc/typedef-inner-variants.rs
+++ b/tests/rustdoc/typedef-inner-variants.rs
@@ -8,6 +8,17 @@ extern crate cross_crate_generic_typedef;
 
 pub struct Adt;
 pub struct Ty;
+pub struct TyCtxt;
+
+pub trait Interner {
+    type Adt;
+    type Ty;
+}
+
+impl Interner for TyCtxt {
+    type Adt = Adt;
+    type Ty = Ty;
+}
 
 // @has 'inner_variants/type.AliasTy.html'
 // @count - '//*[@id="variants"]' 0
@@ -15,11 +26,11 @@ pub struct Ty;
 pub type AliasTy = Ty;
 
 // @has 'inner_variants/enum.IrTyKind.html'
-pub enum IrTyKind<A, B> {
+pub enum IrTyKind<A, I: Interner> {
     /// Doc comment for AdtKind
-    AdtKind(A),
+    AdtKind(I::Adt),
     /// and another one for TyKind
-    TyKind(A, B),
+    TyKind(I::Adt, <I as Interner>::Ty),
     // no comment
     StructKind { a: A, },
     #[doc(hidden)]
@@ -29,14 +40,18 @@ pub enum IrTyKind<A, B> {
 // @has 'inner_variants/type.NearlyTyKind.html'
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 0
-pub type NearlyTyKind<B> = IrTyKind<Adt, B>;
+pub type NearlyTyKind<A> = IrTyKind<A, TyCtxt>;
 
 // @has 'inner_variants/type.TyKind.html'
 // @count - '//*[@id="variants"]' 1
 // @count - '//*[@id="fields"]' 0
 // @count - '//*[@class="variant"]' 3
 // @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "enum TyKind"
-pub type TyKind = IrTyKind<Adt, Ty>;
+// @has - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code/a[1]' "Adt"
+// @has - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code/a[2]' "Adt"
+// @has - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code/a[3]' "Ty"
+// @has - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code/a[4]' "i64"
+pub type TyKind = IrTyKind<i64, TyCtxt>;
 
 // @has 'inner_variants/union.OneOr.html'
 pub union OneOr<A: Copy> {
@@ -68,13 +83,14 @@ pub type OneU64 = One<u64>;
 
 // @has 'inner_variants/struct.OnceA.html'
 pub struct OnceA<'a, A> {
-    a: &'a A, // private
+    pub a: &'a A,
 }
 
 // @has 'inner_variants/type.Once.html'
 // @count - '//*[@id="variants"]' 0
-// @count - '//*[@id="fields"]' 0
+// @count - '//*[@id="fields"]' 1
 // @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "struct Once<'a>"
+// @matches - '//details[@class="toggle"]//pre[@class="rust item-decl"]//code' "&'a"
 pub type Once<'a> = OnceA<'a, i64>;
 
 // @has 'inner_variants/struct.HighlyGenericStruct.html'

--- a/tests/rustdoc/typedef-inner-variants.rs
+++ b/tests/rustdoc/typedef-inner-variants.rs
@@ -1,4 +1,10 @@
+// This test checks different combinations of structs, enums, and unions
+// for the "Show Aliased Type" feature on type definition.
+
 #![crate_name = "inner_variants"]
+
+// aux-build:cross_crate_generic_typedef.rs
+extern crate cross_crate_generic_typedef;
 
 pub struct Adt;
 pub struct Ty;
@@ -78,3 +84,8 @@ pub struct HighlyGenericStruct<A, B, C, D> {
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 0
 pub type HighlyGenericAABB<A, B> = HighlyGenericStruct<A, A, B, B>;
+
+// @has 'inner_variants/type.InlineU64.html'
+// @count - '//*[@id="variants"]' 0
+// @count - '//*[@id="fields"]' 1
+pub use cross_crate_generic_typedef::InlineU64;

--- a/tests/rustdoc/typedef-inner-variants.rs
+++ b/tests/rustdoc/typedef-inner-variants.rs
@@ -22,6 +22,8 @@ pub enum IrTyKind<A, B> {
     TyKind(A, B),
     // no comment
     StructKind { a: A, },
+    #[doc(hidden)]
+    Unspecified,
 }
 
 // @has 'inner_variants/type.NearlyTyKind.html'
@@ -52,7 +54,9 @@ pub type OneOrF64 = OneOr<f64>;
 // @has 'inner_variants/struct.One.html'
 pub struct One<T> {
     pub val: T,
-    __hidden: T,
+    #[doc(hidden)]
+    pub __hidden: T,
+    __private: T,
 }
 
 // @has 'inner_variants/type.OneU64.html'


### PR DESCRIPTION
This PR implements the [Display enum variants for generic enum in type def page](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Display.20enum.20variants.20for.20generic.20enum.20in.20type.20def.20page) #rustdoc/zulip proposal.

This proposal comes from looking at [`TyKind`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/sty/type.TyKind.html) typedef from the compiler. On that page, the documentation is able to show the layout for each variant, but not the variants themselves. This proposal suggests showing the fields and variants for those "concrete type". This would mean that instead of having many unresolved generics, like in `IrTyKind`:
```rust
    Array(I::Ty, I::Const),
    Slice(I::Ty),
    RawPtr(I::TypeAndMut),
    Ref(I::Region, I::Ty, I::Mutability),
    FnDef(I::DefId, I::GenericArgsRef),
```
those would be resolved with direct links to the proper types in the `TyKind` typedef page:
```rust
    Array(Ty<'tcx>, Const<'tcx>),
    Slice(Ty<'tcx>),
    RawPtr(TypeAndMut<'tcx>),
    Ref(Region<'tcx>, Ty<'tcx>, Mutability<'tcx>),
    FnDef(DefId<'tcx>, GenericArgsRef<'tcx>),
```
Saving both time and confusion.

-----

<details>

<summary>Old description</summary>

I've chosen to add the enums and structs under the "Show Aliased Type" details, as well as showing the variants and fields under the usual "Variants" and "Fields" sections. ~~*under new the `Inner Variants` and `Inner Fields` sections (except for their names, they are identical to the one found in the enum, struct and union pages). Those sections are complementary and do not replace anything else.*~~

This PR proposes the following condition for showing the aliased type (basically, has the aliased type some generics that are all of them resolved):
 - the typedef does NOT have any generics (modulo lifetimes)
 - AND the aliased type has some generics

</details>

### Examples

```rust
pub enum IrTyKind<'a, I: Interner> {
    /// Doc comment for AdtKind
    AdtKind(&'a I::Adt),
    /// and another one for TyKind
    TyKind(I::Adt, I::Ty),
    // no comment
    StructKind { a: I::Adt, },
}

pub type TyKind<'a> = IrTyKind<'a, TyCtxt>;
```
![TyKind](https://github.com/rust-lang/rust/assets/3616612/13307679-6d48-40d6-ad50-6db0b7f36ac7)

<details>
<summary>Old</summary>

![image](https://github.com/rust-lang/rust/assets/3616612/4147c049-d056-42d4-8a01-d43ebe747308)

![TyKind](https://user-images.githubusercontent.com/3616612/260988247-34831aa9-470d-4286-ad9f-3e8002153a92.png)

![TyKind](https://github.com/rust-lang/rust/assets/3616612/62381bb3-fa0f-4b05-926d-77759cf9115a)

</details>

```rust
pub struct One<T> {
    pub val: T,
    #[doc(hidden)]
    pub inner_tag: u64,
    __hidden: T,
}

/// `One` with `u64` as payload
pub type OneU64 = One<u64>;
```
![OneU64](https://github.com/rust-lang/rust/assets/3616612/d551b474-ce88-4f8c-bc94-5c88aba51424)

<details>
<summary>Old</summary>

![image](https://github.com/rust-lang/rust/assets/3616612/1a3f53c0-17bf-4aa7-894d-3fedc15b33da)

![OneU64](https://github.com/rust-lang/rust/assets/3616612/7b124a5b-e287-4efb-b9ca-fdcd1cdeeba8)

![OneU64](https://github.com/rust-lang/rust/assets/3616612/ddd962be-4f76-4ecd-81bd-531f3dd23832)

</details>

r? @GuillaumeGomez