### PR TITLE
windows: provide more accurate result for available_parallelism if cores > 64

### DIFF
--- a/library/std/src/sys/windows/c/windows_sys.lst
+++ b/library/std/src/sys/windows/c/windows_sys.lst
@@ -2477,11 +2477,11 @@ Windows.Win32.System.Pipes.PIPE_TYPE_BYTE
 Windows.Win32.System.Pipes.PIPE_TYPE_MESSAGE
 Windows.Win32.System.Pipes.PIPE_WAIT
 Windows.Win32.System.SystemInformation.GetSystemDirectoryW
-Windows.Win32.System.SystemInformation.GetSystemInfo
 Windows.Win32.System.SystemInformation.GetSystemTimeAsFileTime
 Windows.Win32.System.SystemInformation.GetWindowsDirectoryW
 Windows.Win32.System.SystemInformation.PROCESSOR_ARCHITECTURE
 Windows.Win32.System.SystemInformation.SYSTEM_INFO
+Windows.Win32.System.SystemServices.ALL_PROCESSOR_GROUPS
 Windows.Win32.System.SystemServices.DLL_PROCESS_DETACH
 Windows.Win32.System.SystemServices.DLL_THREAD_DETACH
 Windows.Win32.System.SystemServices.EXCEPTION_MAXIMUM_PARAMETERS
@@ -2513,6 +2513,7 @@ Windows.Win32.System.Threading.DEBUG_PROCESS
 Windows.Win32.System.Threading.DETACHED_PROCESS
 Windows.Win32.System.Threading.ExitProcess
 Windows.Win32.System.Threading.EXTENDED_STARTUPINFO_PRESENT
+Windows.Win32.System.Threading.GetActiveProcessorCount
 Windows.Win32.System.Threading.GetCurrentProcess
 Windows.Win32.System.Threading.GetCurrentProcessId
 Windows.Win32.System.Threading.GetCurrentThread

--- a/library/std/src/sys/windows/c/windows_sys.rs
+++ b/library/std/src/sys/windows/c/windows_sys.rs
@@ -220,6 +220,10 @@ extern "system" {
 }
 #[link(name = "kernel32")]
 extern "system" {
+    pub fn GetActiveProcessorCount(groupnumber: u16) -> u32;
+}
+#[link(name = "kernel32")]
+extern "system" {
     pub fn GetCommandLineW() -> PCWSTR;
 }
 #[link(name = "kernel32")]
@@ -336,10 +340,6 @@ extern "system" {
 #[link(name = "kernel32")]
 extern "system" {
     pub fn GetSystemDirectoryW(lpbuffer: PWSTR, usize: u32) -> u32;
-}
-#[link(name = "kernel32")]
-extern "system" {
-    pub fn GetSystemInfo(lpsysteminfo: *mut SYSTEM_INFO) -> ();
 }
 #[link(name = "kernel32")]
 extern "system" {
@@ -822,6 +822,7 @@ impl ::core::clone::Clone for ADDRINFOA {
 pub const AF_INET: ADDRESS_FAMILY = 2u16;
 pub const AF_INET6: ADDRESS_FAMILY = 23u16;
 pub const AF_UNSPEC: ADDRESS_FAMILY = 0u16;
+pub const ALL_PROCESSOR_GROUPS: u32 = 65535u32;
 #[repr(C)]
 pub union ARM64_NT_NEON128 {
     pub Anonymous: ARM64_NT_NEON128_0,


### PR DESCRIPTION
This should give more accurate result if number of cores > 64

see:
https://devblogs.microsoft.com/oldnewthing/20200824-00/?p=104116
https://github.com/ninja-build/ninja/pull/1604

Could probably implement using GetLogicalProcessorInformationEx
see: https://github.com/ninja-build/ninja/pull/1674

https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getactiveprocessorcount >= Win 7

crates that probably want to fix it too:
`sysinfo`: but maybe `GetLogicalProcessorInformationEx` instead?
`num_cpus`: obviously