### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1648,7 +1648,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         hir::ExprKind::Match(
             scrutinee,
             arena_vec![self; break_arm, continue_arm],
-            hir::MatchSource::TryDesugar,
+            hir::MatchSource::TryDesugar(scrutinee.hir_id),
         )
     }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2148,7 +2148,7 @@ pub enum MatchSource {
     /// A desugared `for _ in _ { .. }` loop.
     ForLoopDesugar,
     /// A desugared `?` operator.
-    TryDesugar,
+    TryDesugar(HirId),
     /// A desugared `<expr>.await`.
     AwaitDesugar,
     /// A desugared `format_args!()`.
@@ -2162,7 +2162,7 @@ impl MatchSource {
         match self {
             Normal => "match",
             ForLoopDesugar => "for",
-            TryDesugar => "?",
+            TryDesugar(_) => "?",
             AwaitDesugar => ".await",
             FormatArgs => "format_args!()",
         }

--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -147,6 +147,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
 
             if !arm_ty.is_never() {
+                // When a match arm has type `!`, then it doesn't influence the expected type for
+                // the following arm. If all of the prior arms are `!`, then the influence comes
+                // from elsewhere and we shouldn't point to any previous arm.
                 prior_arm = Some((arm_block_id, arm_ty, arm_span));
             }
         }

--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -107,14 +107,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let (span, code) = match prior_arm {
                 // The reason for the first arm to fail is not that the match arms diverge,
                 // but rather that there's a prior obligation that doesn't hold.
-                None => (
-                    arm_span,
-                    ObligationCauseCode::BlockTailExpression(
-                        arm.body.hir_id,
-                        scrut.hir_id,
-                        match_src,
-                    ),
-                ),
+                None => {
+                    (arm_span, ObligationCauseCode::BlockTailExpression(arm.body.hir_id, match_src))
+                }
                 Some((prior_arm_block_id, prior_arm_ty, prior_arm_span)) => (
                     expr.span,
                     ObligationCauseCode::MatchExpressionArm(Box::new(MatchExpressionArmCause {
@@ -127,7 +122,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         scrut_span: scrut.span,
                         source: match_src,
                         prior_arms: other_arms.clone(),
-                        scrut_hir_id: scrut.hir_id,
                         opt_suggest_box_span,
                     })),
                 ),

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1603,7 +1603,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                         );
                         err.span_label(cause.span, "return type is not `()`");
                     }
-                    ObligationCauseCode::BlockTailExpression(blk_id) => {
+                    ObligationCauseCode::BlockTailExpression(blk_id, ..) => {
                         let parent_id = fcx.tcx.hir().parent_id(blk_id);
                         err = self.report_return_mismatched_types(
                             cause,

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1645,10 +1645,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
 
                 augment_error(&mut err);
 
-                let is_insufficiently_polymorphic =
-                    matches!(coercion_error, TypeError::RegionsInsufficientlyPolymorphic(..));
-
-                if !is_insufficiently_polymorphic && let Some(expr) = expression {
+                if let Some(expr) = expression {
                     fcx.emit_coerce_suggestions(
                         &mut err,
                         expr,

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1751,7 +1751,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 ) && !in_external_macro(fcx.tcx.sess, cond_expr.span)
                     && !matches!(
                         cond_expr.kind,
-                        hir::ExprKind::Match(.., hir::MatchSource::TryDesugar)
+                        hir::ExprKind::Match(.., hir::MatchSource::TryDesugar(_))
                     )
             {
                 err.span_label(cond_expr.span, "expected this to be `()`");

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -84,6 +84,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         self.annotate_expected_due_to_let_ty(err, expr, error);
 
+        // FIXME(#73154): For now, we do leak check when coercing function
+        // pointers in typeck, instead of only during borrowck. This can lead
+        // to these `RegionsInsufficientlyPolymorphic` errors that aren't helpful.
+        if matches!(error, Some(TypeError::RegionsInsufficientlyPolymorphic(..))) {
+            return;
+        }
+
         if self.is_destruct_assignment_desugaring(expr) {
             return;
         }
@@ -263,22 +270,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let expr_ty = self.resolve_vars_with_obligations(checked_ty);
         let mut err = self.err_ctxt().report_mismatched_types(&cause, expected, expr_ty, e);
 
-        let is_insufficiently_polymorphic =
-            matches!(e, TypeError::RegionsInsufficientlyPolymorphic(..));
-
-        // FIXME(#73154): For now, we do leak check when coercing function
-        // pointers in typeck, instead of only during borrowck. This can lead
-        // to these `RegionsInsufficientlyPolymorphic` errors that aren't helpful.
-        if !is_insufficiently_polymorphic {
-            self.emit_coerce_suggestions(
-                &mut err,
-                expr,
-                expr_ty,
-                expected,
-                expected_ty_expr,
-                Some(e),
-            );
-        }
+        self.emit_coerce_suggestions(&mut err, expr, expr_ty, expected, expected_ty_expr, Some(e));
 
         (expected, Some(err))
     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1582,11 +1582,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let span = self.get_expr_coercion_span(tail_expr);
                 let cause = self.cause(
                     span,
-                    ObligationCauseCode::BlockTailExpression(
-                        blk.hir_id,
-                        blk.hir_id,
-                        hir::MatchSource::Normal,
-                    ),
+                    ObligationCauseCode::BlockTailExpression(blk.hir_id, hir::MatchSource::Normal),
                 );
                 let ty_for_diagnostic = coerce.merged_ty();
                 // We use coerce_inner here because we want to augment the error

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1580,7 +1580,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let coerce = ctxt.coerce.as_mut().unwrap();
             if let Some((tail_expr, tail_expr_ty)) = tail_expr_ty {
                 let span = self.get_expr_coercion_span(tail_expr);
-                let cause = self.cause(span, ObligationCauseCode::BlockTailExpression(blk.hir_id));
+                let cause = self.cause(
+                    span,
+                    ObligationCauseCode::BlockTailExpression(
+                        blk.hir_id,
+                        blk.hir_id,
+                        hir::MatchSource::Normal,
+                    ),
+                );
                 let ty_for_diagnostic = coerce.merged_ty();
                 // We use coerce_inner here because we want to augment the error
                 // suggesting to wrap the block in square brackets if it might've

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1927,7 +1927,12 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     true
                 };
 
-            if should_suggest_fixes {
+            // FIXME(#73154): For now, we do leak check when coercing function
+            // pointers in typeck, instead of only during borrowck. This can lead
+            // to these `RegionsInsufficientlyPolymorphic` errors that aren't helpful.
+            if should_suggest_fixes
+                && !matches!(terr, TypeError::RegionsInsufficientlyPolymorphic(..))
+            {
                 self.suggest_tuple_pattern(cause, &exp_found, diag);
                 self.suggest_accessing_field_where_appropriate(cause, &exp_found, diag);
                 self.suggest_await_on_expect_found(cause, span, &exp_found, diag);

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -745,8 +745,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             }
             ObligationCauseCode::BlockTailExpression(
                 _,
-                scrut_hir_id,
-                hir::MatchSource::TryDesugar,
+                hir::MatchSource::TryDesugar(scrut_hir_id),
             ) => {
                 if let Some(ty::error::ExpectedFound { expected, .. }) = exp_found {
                     let scrut_expr = self.tcx.hir().expect_expr(scrut_hir_id);
@@ -782,12 +781,11 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 prior_arm_ty,
                 source,
                 ref prior_arms,
-                scrut_hir_id,
                 opt_suggest_box_span,
                 scrut_span,
                 ..
             }) => match source {
-                hir::MatchSource::TryDesugar => {
+                hir::MatchSource::TryDesugar(scrut_hir_id) => {
                     if let Some(ty::error::ExpectedFound { expected, .. }) = exp_found {
                         let scrut_expr = self.tcx.hir().expect_expr(scrut_hir_id);
                         let scrut_ty = if let hir::ExprKind::Call(_, args) = &scrut_expr.kind {
@@ -2077,7 +2075,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         if let &(MatchExpressionArm(box MatchExpressionArmCause { source, .. })
             | BlockTailExpression(.., source)
         ) = code
-            && let hir::MatchSource::TryDesugar = source
+            && let hir::MatchSource::TryDesugar(_) = source
             && let Some((expected_ty, found_ty, _, _)) = self.values_str(trace.values)
         {
             suggestions.push(TypeErrorAdditionalDiags::TryCannotConvert {
@@ -2954,11 +2952,11 @@ impl<'tcx> ObligationCauseExt<'tcx> for ObligationCause<'tcx> {
             CompareImplItemObligation { kind: ty::AssocKind::Const, .. } => {
                 ObligationCauseFailureCode::ConstCompat { span, subdiags }
             }
-            BlockTailExpression(.., hir::MatchSource::TryDesugar) => {
+            BlockTailExpression(.., hir::MatchSource::TryDesugar(_)) => {
                 ObligationCauseFailureCode::TryCompat { span, subdiags }
             }
             MatchExpressionArm(box MatchExpressionArmCause { source, .. }) => match source {
-                hir::MatchSource::TryDesugar => {
+                hir::MatchSource::TryDesugar(_) => {
                     ObligationCauseFailureCode::TryCompat { span, subdiags }
                 }
                 _ => ObligationCauseFailureCode::MatchCompat { span, subdiags },

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -146,7 +146,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
 
         if let SubregionOrigin::Subtype(box TypeTrace { cause, .. }) = sub_origin {
             if let ObligationCauseCode::ReturnValue(hir_id)
-            | ObligationCauseCode::BlockTailExpression(hir_id) = cause.code()
+            | ObligationCauseCode::BlockTailExpression(hir_id, ..) = cause.code()
             {
                 let parent_id = tcx.hir().get_parent_item(*hir_id);
                 if let Some(fn_decl) = tcx.hir().fn_decl_by_hir_id(parent_id.into()) {

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -346,6 +346,7 @@ pub enum ExprKind<'tcx> {
     /// A `match` expression.
     Match {
         scrutinee: ExprId,
+        scrutinee_hir_id: hir::HirId,
         arms: Box<[ArmId]>,
     },
     /// A block.

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -70,7 +70,7 @@ pub fn walk_expr<'a, 'tcx: 'a, V: Visitor<'a, 'tcx>>(visitor: &mut V, expr: &Exp
             visitor.visit_expr(&visitor.thir()[expr]);
         }
         Loop { body } => visitor.visit_expr(&visitor.thir()[body]),
-        Match { scrutinee, ref arms } => {
+        Match { scrutinee, ref arms, .. } => {
             visitor.visit_expr(&visitor.thir()[scrutinee]);
             for &arm in &**arms {
                 visitor.visit_arm(&visitor.thir()[arm]);

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -402,7 +402,7 @@ pub enum ObligationCauseCode<'tcx> {
     OpaqueReturnType(Option<(Ty<'tcx>, Span)>),
 
     /// Block implicit return
-    BlockTailExpression(hir::HirId),
+    BlockTailExpression(hir::HirId, hir::HirId, hir::MatchSource),
 
     /// #[feature(trivial_bounds)] is not enabled
     TrivialBound,

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -402,7 +402,7 @@ pub enum ObligationCauseCode<'tcx> {
     OpaqueReturnType(Option<(Ty<'tcx>, Span)>),
 
     /// Block implicit return
-    BlockTailExpression(hir::HirId, hir::HirId, hir::MatchSource),
+    BlockTailExpression(hir::HirId, hir::MatchSource),
 
     /// #[feature(trivial_bounds)] is not enabled
     TrivialBound,
@@ -543,7 +543,6 @@ pub struct MatchExpressionArmCause<'tcx> {
     pub scrut_span: Span,
     pub source: hir::MatchSource,
     pub prior_arms: Vec<Span>,
-    pub scrut_hir_id: hir::HirId,
     pub opt_suggest_box_span: Option<Span>,
 }
 

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -65,7 +65,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
                 let target = self.parse_block(args[1])?;
                 self.parse_call(args[2], destination, target)
             },
-            ExprKind::Match { scrutinee, arms } => {
+            ExprKind::Match { scrutinee, arms, .. } => {
                 let discr = self.parse_operand(*scrutinee)?;
                 self.parse_match(arms, expr.span).map(|t| TerminatorKind::SwitchInt { discr, targets: t })
             },

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -47,7 +47,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Block { block: ast_block } => {
                 this.ast_block(destination, block, ast_block, source_info)
             }
-            ExprKind::Match { scrutinee, ref arms } => {
+            ExprKind::Match { scrutinee, ref arms, .. } => {
                 this.match_expr(destination, expr_span, block, &this.thir[scrutinee], arms)
             }
             ExprKind::If { cond, then, else_opt, if_then_scope } => {

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -733,6 +733,7 @@ impl<'tcx> Cx<'tcx> {
             },
             hir::ExprKind::Match(ref discr, ref arms, _) => ExprKind::Match {
                 scrutinee: self.mirror_expr(discr),
+                scrutinee_hir_id: discr.hir_id,
                 arms: arms.iter().map(|a| self.convert_arm(a)).collect(),
             },
             hir::ExprKind::Loop(ref body, ..) => {

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -325,6 +325,11 @@ impl<'tcx> ConstToPat<'tcx> {
                 // `PartialEq::eq` on it.
                 return Err(FallbackToConstRef);
             }
+            ty::FnDef(..) => {
+                self.saw_const_match_error.set(true);
+                tcx.sess.emit_err(InvalidPattern { span, non_sm_ty: ty });
+                PatKind::Wild
+            }
             ty::Adt(adt_def, _) if !self.type_marked_structural(ty) => {
                 debug!("adt_def {:?} has !type_marked_structural for cv.ty: {:?}", adt_def, ty,);
                 self.saw_const_match_error.set(true);
@@ -440,7 +445,7 @@ impl<'tcx> ConstToPat<'tcx> {
                     }
                 }
             },
-            ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::FnDef(..) => PatKind::Constant {
+            ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) => PatKind::Constant {
                 value: mir::ConstantKind::Ty(ty::Const::new_value(tcx, cv, ty)),
             },
             ty::FnPtr(..) | ty::RawPtr(..) => unreachable!(),

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -321,7 +321,7 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 print_indented!(self, format!("pat: {:?}", pat), depth_lvl + 1);
                 print_indented!(self, "}", depth_lvl);
             }
-            Match { scrutinee, arms } => {
+            Match { scrutinee, arms, .. } => {
                 print_indented!(self, "Match {", depth_lvl);
                 print_indented!(self, "scrutinee:", depth_lvl + 1);
                 self.print_expr(*scrutinee, depth_lvl + 2);

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -45,7 +45,7 @@ impl NonConstExpr {
 
             Self::Loop(ForLoop) | Self::Match(ForLoopDesugar) => &[sym::const_for],
 
-            Self::Match(TryDesugar) => &[sym::const_try],
+            Self::Match(TryDesugar(_)) => &[sym::const_try],
 
             // All other expressions are allowed.
             Self::Loop(Loop | While) | Self::Match(Normal | FormatArgs) => &[],

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2700,7 +2700,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             | ObligationCauseCode::MatchImpl(..)
             | ObligationCauseCode::ReturnType
             | ObligationCauseCode::ReturnValue(_)
-            | ObligationCauseCode::BlockTailExpression(_)
+            | ObligationCauseCode::BlockTailExpression(..)
             | ObligationCauseCode::AwaitableExpr(_)
             | ObligationCauseCode::ForLoopIterator
             | ObligationCauseCode::QuestionMark

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -130,6 +130,7 @@ pub trait Error: Debug + Display {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     /// use core::fmt;
     /// use core::error::{request_ref, Request};
     ///
@@ -360,6 +361,7 @@ impl dyn Error {
 ///
 /// ```rust
 /// # #![feature(error_generic_member_access)]
+/// # #![feature(error_in_core)]
 /// use std::error::Error;
 /// use core::error::request_value;
 ///
@@ -383,6 +385,7 @@ where
 ///
 /// ```rust
 /// # #![feature(error_generic_member_access)]
+/// # #![feature(error_in_core)]
 /// use core::error::Error;
 /// use core::error::request_ref;
 ///
@@ -454,6 +457,7 @@ where
 ///
 /// ```
 /// #![feature(error_generic_member_access)]
+/// #![feature(error_in_core)]
 /// use core::fmt;
 /// use core::error::Request;
 /// use core::error::request_ref;
@@ -524,6 +528,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -558,6 +563,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -593,6 +599,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -625,6 +632,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -691,6 +699,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     /// use core::error::request_value;
@@ -778,6 +787,7 @@ impl<'a> Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
+    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     /// use core::error::request_ref;

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1530,9 +1530,18 @@ impl From<fs::File> for Stdio {
 // vs `_exit`.  Naming of Unix system calls is not standardised across Unices, so terminology is a
 // matter of convention and tradition.  For clarity we usually speak of `exit`, even when we might
 // mean an underlying system call such as `_exit`.
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[stable(feature = "process", since = "1.0.0")]
 pub struct ExitStatus(imp::ExitStatus);
+
+/// The default value is one which indicates successful completion.
+#[stable(feature = "process-exitcode-default", since = "CURRENT_RUSTC_VERSION")]
+impl Default for ExitStatus {
+    fn default() -> Self {
+        // Ideally this would be done by ExitCode::default().into() but that is complicated.
+        ExitStatus::from_inner(imp::ExitStatus::default())
+    }
+}
 
 /// Allows extension traits within `std`.
 #[unstable(feature = "sealed", issue = "none")]

--- a/library/std/src/sys/wasi/thread.rs
+++ b/library/std/src/sys/wasi/thread.rs
@@ -20,9 +20,9 @@ cfg_if::cfg_if! {
             // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-top-half/musl/include/alltypes.h.in#L108
             #[repr(C)]
             union pthread_attr_union {
-                __i: [ffi::c_int; if mem::size_of::<ffi::c_int>() == 8 { 14 } else { 9 }],
-                __vi: [ffi::c_int; if mem::size_of::<ffi::c_int>() == 8 { 14 } else { 9 }],
-                __s: [ffi::c_ulong; if mem::size_of::<ffi::c_int>() == 8 { 7 } else { 9 }],
+                __i: [ffi::c_int; if mem::size_of::<ffi::c_long>() == 8 { 14 } else { 9 }],
+                __vi: [ffi::c_int; if mem::size_of::<ffi::c_long>() == 8 { 14 } else { 9 }],
+                __s: [ffi::c_ulong; if mem::size_of::<ffi::c_long>() == 8 { 7 } else { 9 }],
             }
 
             #[repr(C)]

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -584,7 +584,7 @@ See the [Symbol Mangling] chapter for details on symbol mangling and the manglin
 This instructs `rustc` to generate code specifically for a particular processor.
 
 You can run `rustc --print target-cpus` to see the valid options to pass
-and the default target CPU for the current buid target.
+and the default target CPU for the current build target.
 Each target has a default base CPU. Special values include:
 
 * `native` can be passed to use the processor of the host machine.

--- a/src/doc/rustc/src/platform-support/aarch64-unknown-teeos.md
+++ b/src/doc/rustc/src/platform-support/aarch64-unknown-teeos.md
@@ -10,7 +10,7 @@ It's very small that there is no RwLock, no network, no stdin, and no file syste
 Some abbreviation:
 | Abbreviation | The full text | Description |
 |  ----  | ----  | ---- |
-| TEE | Trusted Execution Environment | ARM TrustZone devide the system into two worlds/modes -- the secure world/mode and the normal world/mode. TEE is in the secure world/mode. |
+| TEE | Trusted Execution Environment | ARM TrustZone divides the system into two worlds/modes -- the secure world/mode and the normal world/mode. TEE is in the secure world/mode. |
 | REE | Rich Execution Environment | The normal world. for example, Linux for Android phone is in REE side. |
 | TA | Trusted Application | The app run in TEE side system. |
 | CA | Client Application | The progress run in REE side system. |

--- a/src/doc/rustc/src/platform-support/loongarch-linux.md
+++ b/src/doc/rustc/src/platform-support/loongarch-linux.md
@@ -71,7 +71,7 @@ CXX_loongarch64_unknown_linux_gnu=/TOOLCHAIN_PATH/bin/loongarch64-unknown-linux-
 AR_loongarch64_unknown_linux_gnu=/TOOLCHAIN_PATH/bin/loongarch64-unknown-linux-gnu-gcc-ar \
 CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNUN_LINKER=/TOOLCHAIN_PATH/bin/loongarch64-unknown-linux-gnu-gcc \
 # SET TARGET SYSTEM LIBRARY PATH
-CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNUN_RUNNER="qemu-loongarch64 -L /TOOLCHAIN_PATH/TARGET_LIBRAY_PATH" \
+CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNUN_RUNNER="qemu-loongarch64 -L /TOOLCHAIN_PATH/TARGET_LIBRARY_PATH" \
 cargo run --target loongarch64-unknown-linux-gnu --release
 ```
 Tested on x86 architecture, other architectures not tested.

--- a/src/doc/rustc/src/platform-support/netbsd.md
+++ b/src/doc/rustc/src/platform-support/netbsd.md
@@ -86,7 +86,7 @@ The Rust testsuite could presumably be run natively.
 
 For the systems where the maintainer can build natively, the rust
 compiler itself is re-built natively.  This involves the rust compiler
-being re-built with the newly self-built rust compiler, so excercises
+being re-built with the newly self-built rust compiler, so exercises
 the result quite extensively.
 
 Additionally, for some systems we build `librsvg`, and for the more

--- a/src/doc/rustc/src/platform-support/x86_64h-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/x86_64h-apple-darwin.md
@@ -20,7 +20,7 @@ will fail to load on machines that do not support this.
 
 It should support the full standard library (`std` and `alloc` either with
 default or user-defined allocators). This target is probably most useful when
-targetted via cross-compilation (including from `x86_64-apple-darwin`), but if
+targeted via cross-compilation (including from `x86_64-apple-darwin`), but if
 built manually, the host tools work.
 
 It is similar to `x86_64-apple-darwin` in nearly all respects, although the
@@ -49,7 +49,7 @@ suite seems to work.
 
 Cross-compilation to this target from Apple hosts should generally work without
 much configuration, so long as XCode and the CommandLineTools are installed.
-Targetting it from non-Apple hosts is difficult, but no moreso than targetting
+Targeting it from non-Apple hosts is difficult, but no more so than targeting
 `x86_64-apple-darwin`.
 
 When compiling C code for this target, either the "`x86_64h-apple-macosx*`" LLVM

--- a/src/doc/unstable-book/src/compiler-flags/path-options.md
+++ b/src/doc/unstable-book/src/compiler-flags/path-options.md
@@ -1,6 +1,6 @@
 # `--print` Options
 
-The behavior of the `--print` flag can be modified by optionally be specifiying a filepath
+The behavior of the `--print` flag can be modified by optionally be specifying a filepath
 for each requested information kind, in the format `--print KIND=PATH`, just like for
 `--emit`. When a path is specified, information will be written there instead of to stdout.
 

--- a/src/tools/clippy/clippy_lints/src/dereference.rs
+++ b/src/tools/clippy/clippy_lints/src/dereference.rs
@@ -802,7 +802,8 @@ fn in_postfix_position<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>) -> boo
         match parent.kind {
             ExprKind::Call(child, _) | ExprKind::MethodCall(_, child, _, _) | ExprKind::Index(child, _, _)
                 if child.hir_id == e.hir_id => true,
-            ExprKind::Field(_, _) | ExprKind::Match(_, _, MatchSource::TryDesugar | MatchSource::AwaitDesugar) => true,
+            ExprKind::Match(.., MatchSource::TryDesugar(_) | MatchSource::AwaitDesugar)
+                | ExprKind::Field(_, _) => true,
             _ => false,
         }
     } else {

--- a/src/tools/clippy/clippy_lints/src/matches/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/mod.rs
@@ -1038,7 +1038,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                 wild_in_or_pats::check(cx, arms);
             }
 
-            if source == MatchSource::TryDesugar {
+            if let MatchSource::TryDesugar(_) = source {
                 try_err::check(cx, expr, ex);
             }
 

--- a/src/tools/clippy/clippy_lints/src/matches/try_err.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/try_err.rs
@@ -80,7 +80,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, scrutine
 
 /// Finds function return type by examining return expressions in match arms.
 fn find_return_type<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx ExprKind<'_>) -> Option<Ty<'tcx>> {
-    if let ExprKind::Match(_, arms, MatchSource::TryDesugar) = expr {
+    if let ExprKind::Match(_, arms, MatchSource::TryDesugar(_)) = expr {
         for arm in *arms {
             if let ExprKind::Ret(Some(ret)) = arm.body.kind {
                 return Some(cx.typeck_results().expr_ty(ret));

--- a/src/tools/clippy/clippy_lints/src/methods/clone_on_copy.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/clone_on_copy.rs
@@ -64,7 +64,7 @@ pub(super) fn check(
                     ExprKind::Path(QPath::LangItem(rustc_hir::LangItem::TryTraitBranch, _, _))
                 ),
                 ExprKind::MethodCall(_, self_arg, ..) if expr.hir_id == self_arg.hir_id => true,
-                ExprKind::Match(_, _, MatchSource::TryDesugar | MatchSource::AwaitDesugar)
+                ExprKind::Match(_, _, MatchSource::TryDesugar(_) | MatchSource::AwaitDesugar)
                 | ExprKind::Field(..)
                 | ExprKind::Index(..) => true,
                 _ => false,

--- a/src/tools/clippy/clippy_lints/src/methods/str_splitn.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/str_splitn.rs
@@ -236,7 +236,7 @@ fn indirect_usage<'tcx>(
             !matches!(
                 node,
                 Node::Expr(Expr {
-                    kind: ExprKind::Match(.., MatchSource::TryDesugar),
+                    kind: ExprKind::Match(.., MatchSource::TryDesugar(_)),
                     ..
                 })
             )

--- a/src/tools/clippy/clippy_lints/src/needless_question_mark.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_question_mark.rs
@@ -122,7 +122,7 @@ fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
         } else {
             return;
         };
-        if let ExprKind::Match(inner_expr_with_q, _, MatchSource::TryDesugar) = &arg.kind;
+        if let ExprKind::Match(inner_expr_with_q, _, MatchSource::TryDesugar(_)) = &arg.kind;
         if let ExprKind::Call(called, [inner_expr]) = &inner_expr_with_q.kind;
         if let ExprKind::Path(QPath::LangItem(LangItem::TryTraitBranch, ..)) = &called.kind;
         if expr.span.ctxt() == inner_expr.span.ctxt();

--- a/src/tools/clippy/clippy_lints/src/question_mark_used.rs
+++ b/src/tools/clippy/clippy_lints/src/question_mark_used.rs
@@ -34,7 +34,7 @@ declare_lint_pass!(QuestionMarkUsed => [QUESTION_MARK_USED]);
 
 impl<'tcx> LateLintPass<'tcx> for QuestionMarkUsed {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if let ExprKind::Match(_, _, MatchSource::TryDesugar) = expr.kind {
+        if let ExprKind::Match(_, _, MatchSource::TryDesugar(_)) = expr.kind {
             if !span_is_local(expr.span) {
                 return;
             }

--- a/src/tools/clippy/clippy_lints/src/redundant_closure_call.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_closure_call.rs
@@ -52,7 +52,7 @@ impl ReturnVisitor {
 
 impl<'tcx> Visitor<'tcx> for ReturnVisitor {
     fn visit_expr(&mut self, ex: &'tcx hir::Expr<'tcx>) {
-        if let hir::ExprKind::Ret(_) | hir::ExprKind::Match(.., hir::MatchSource::TryDesugar) = ex.kind {
+        if let hir::ExprKind::Ret(_) | hir::ExprKind::Match(.., hir::MatchSource::TryDesugar(_)) = ex.kind {
             self.found_return = true;
         } else {
             hir_visit::walk_expr(self, ex);

--- a/src/tools/clippy/clippy_lints/src/returns.rs
+++ b/src/tools/clippy/clippy_lints/src/returns.rs
@@ -164,7 +164,7 @@ impl<'tcx> LateLintPass<'tcx> for Return {
         if !in_external_macro(cx.sess(), stmt.span)
             && let StmtKind::Semi(expr) = stmt.kind
             && let ExprKind::Ret(Some(ret)) = expr.kind
-            && let ExprKind::Match(.., MatchSource::TryDesugar) = ret.kind
+            && let ExprKind::Match(.., MatchSource::TryDesugar(_)) = ret.kind
             // Ensure this is not the final stmt, otherwise removing it would cause a compile error
             && let OwnerNode::Item(item) = cx.tcx.hir().owner(cx.tcx.hir().get_parent_item(expr.hir_id))
             && let ItemKind::Fn(_, _, body) = item.kind

--- a/src/tools/clippy/clippy_lints/src/unit_types/unit_arg.rs
+++ b/src/tools/clippy/clippy_lints/src/unit_types/unit_arg.rs
@@ -42,7 +42,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
             if cx.typeck_results().expr_ty(arg).is_unit() && !utils::is_unit_literal(arg) {
                 !matches!(
                     &arg.kind,
-                    ExprKind::Match(.., MatchSource::TryDesugar) | ExprKind::Path(..)
+                    ExprKind::Match(.., MatchSource::TryDesugar(_)) | ExprKind::Path(..)
                 )
             } else {
                 false

--- a/src/tools/clippy/clippy_lints/src/useless_conversion.rs
+++ b/src/tools/clippy/clippy_lints/src/useless_conversion.rs
@@ -113,7 +113,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
         }
 
         match e.kind {
-            ExprKind::Match(_, arms, MatchSource::TryDesugar) => {
+            ExprKind::Match(_, arms, MatchSource::TryDesugar(_)) => {
                 let (ExprKind::Ret(Some(e)) | ExprKind::Break(_, Some(e))) = arms[0].body.kind else {
                     return;
                 };

--- a/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
+++ b/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
@@ -149,7 +149,7 @@ fn expr_search_pat(tcx: TyCtxt<'_>, e: &Expr<'_>) -> (Pat, Pat) {
             (Pat::Str("for"), Pat::Str("}"))
         },
         ExprKind::Match(_, _, MatchSource::Normal) => (Pat::Str("match"), Pat::Str("}")),
-        ExprKind::Match(e, _, MatchSource::TryDesugar) => (expr_search_pat(tcx, e).0, Pat::Str("?")),
+        ExprKind::Match(e, _, MatchSource::TryDesugar(_)) => (expr_search_pat(tcx, e).0, Pat::Str("?")),
         ExprKind::Match(e, _, MatchSource::AwaitDesugar) | ExprKind::Yield(e, YieldSource::Await { .. }) => {
             (expr_search_pat(tcx, e).0, Pat::Str("await"))
         },

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -1765,7 +1765,7 @@ pub fn is_try<'tcx>(cx: &LateContext<'_>, expr: &'tcx Expr<'tcx>) -> Option<&'tc
 
     if let ExprKind::Match(_, arms, ref source) = expr.kind {
         // desugared from a `?` operator
-        if *source == MatchSource::TryDesugar {
+        if let MatchSource::TryDesugar(_) = *source {
             return Some(expr);
         }
 

--- a/src/tools/clippy/clippy_utils/src/visitors.rs
+++ b/src/tools/clippy/clippy_utils/src/visitors.rs
@@ -161,7 +161,7 @@ pub fn for_each_expr_with_closures<'tcx, B, C: Continue>(
 /// returns `true` if expr contains match expr desugared from try
 fn contains_try(expr: &hir::Expr<'_>) -> bool {
     for_each_expr(expr, |e| {
-        if matches!(e.kind, hir::ExprKind::Match(_, _, hir::MatchSource::TryDesugar)) {
+        if matches!(e.kind, hir::ExprKind::Match(_, _, hir::MatchSource::TryDesugar(_))) {
             ControlFlow::Break(())
         } else {
             ControlFlow::Continue(())

--- a/src/tools/clippy/tests/ui/if_same_then_else2.rs
+++ b/src/tools/clippy/tests/ui/if_same_then_else2.rs
@@ -98,7 +98,7 @@ fn if_same_then_else2() -> Result<&'static str, ()> {
     };
 
     if true {
-        //~^ ERROR: this `if` has identical blocks
+        // FIXME: should emit "this `if` has identical blocks"
         Ok("foo")?;
     } else {
         Ok("foo")?;

--- a/src/tools/clippy/tests/ui/if_same_then_else2.stderr
+++ b/src/tools/clippy/tests/ui/if_same_then_else2.stderr
@@ -83,25 +83,6 @@ LL | |     };
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else2.rs:100:13
-   |
-LL |       if true {
-   |  _____________^
-LL | |
-LL | |         Ok("foo")?;
-LL | |     } else {
-   | |_____^
-   |
-note: same as this
-  --> $DIR/if_same_then_else2.rs:103:12
-   |
-LL |       } else {
-   |  ____________^
-LL | |         Ok("foo")?;
-LL | |     }
-   | |_____^
-
-error: this `if` has identical blocks
   --> $DIR/if_same_then_else2.rs:124:20
    |
 LL |       } else if true {
@@ -122,5 +103,5 @@ LL | |         return Ok(&foo[0..]);
 LL | |     }
    | |_____^
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/codegen/trailing_zeros.rs
+++ b/tests/codegen/trailing_zeros.rs
@@ -1,0 +1,22 @@
+// compile-flags: -O
+// min-llvm-version: 17
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @trailing_zeros_ge
+#[no_mangle]
+pub fn trailing_zeros_ge(val: u32) -> bool {
+    // CHECK: %[[AND:.*]] = and i32 %val, 7
+    // CHECK: %[[ICMP:.*]] = icmp eq i32 [[AND]], 0
+    // CHECK: ret i1 [[ICMP]]
+    val.trailing_zeros() >= 3
+}
+
+// CHECK-LABEL: @trailing_zeros_gt
+#[no_mangle]
+pub fn trailing_zeros_gt(val: u64) -> bool {
+    // CHECK: %[[AND:.*]] = and i64 %val, 15
+    // CHECK: %[[ICMP:.*]] = icmp eq i64 [[AND]], 0
+    // CHECK: ret i1 [[ICMP]]
+    val.trailing_zeros() > 3
+}

--- a/tests/rustdoc-gui/unsafe-fn.goml
+++ b/tests/rustdoc-gui/unsafe-fn.goml
@@ -23,6 +23,6 @@ define-function: (
     },
 )
 
-call-function: ("sup-check", ("dark", "rgb(221, 221, 221)"))
-call-function: ("sup-check", ("ayu", "rgb(197, 197, 197)"))
-call-function: ("sup-check", ("light", "rgb(0, 0, 0)"))
+call-function: ("sup-check", ("ayu", "#c5c5c5"))
+call-function: ("sup-check", ("dark", "#ddd"))
+call-function: ("sup-check", ("light", "black"))

--- a/tests/ui/did_you_mean/compatible-variants.stderr
+++ b/tests/ui/did_you_mean/compatible-variants.stderr
@@ -61,6 +61,8 @@ LL +     Some(())
 error[E0308]: `?` operator has incompatible types
   --> $DIR/compatible-variants.rs:35:5
    |
+LL | fn d() -> Option<()> {
+   |           ---------- expected `Option<()>` because of return type
 LL |     c()?
    |     ^^^^ expected `Option<()>`, found `()`
    |

--- a/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.stderr
+++ b/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/placeholder-pattern-fail.rs:9:47
    |
 LL |     let _: for<'a, 'b> fn(Inv<'a>, Inv<'b>) = sub;
-   |                                               ^^^ one type is more general than the other
+   |            --------------------------------   ^^^ one type is more general than the other
+   |            |
+   |            expected due to this
    |
    = note: expected fn pointer `for<'a, 'b> fn(Inv<'a>, Inv<'b>)`
               found fn pointer `for<'a> fn(Inv<'a>, Inv<'a>)`

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-exists-forall-fn.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-exists-forall-fn.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/hrtb-exists-forall-fn.rs:17:34
    |
 LL |     let _: for<'b> fn(&'b u32) = foo();
-   |                                  ^^^^^ one type is more general than the other
+   |            -------------------   ^^^^^ one type is more general than the other
+   |            |
+   |            expected due to this
    |
    = note: expected fn pointer `for<'b> fn(&'b u32)`
               found fn pointer `fn(&u32)`

--- a/tests/ui/inline-const/pat-match-fndef.rs
+++ b/tests/ui/inline-const/pat-match-fndef.rs
@@ -1,0 +1,13 @@
+#![feature(inline_const_pat)]
+//~^ WARN the feature `inline_const_pat` is incomplete
+
+fn uwu() {}
+
+fn main() {
+    let x = [];
+    match x[123] {
+        const { uwu } => {}
+        //~^ ERROR `fn() {uwu}` cannot be used in patterns
+        _ => {}
+    }
+}

--- a/tests/ui/inline-const/pat-match-fndef.stderr
+++ b/tests/ui/inline-const/pat-match-fndef.stderr
@@ -1,0 +1,17 @@
+warning: the feature `inline_const_pat` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/pat-match-fndef.rs:1:12
+   |
+LL | #![feature(inline_const_pat)]
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: `fn() {uwu}` cannot be used in patterns
+  --> $DIR/pat-match-fndef.rs:9:9
+   |
+LL |         const { uwu } => {}
+   |         ^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/tests/ui/issues/issue-51632-try-desugar-incompatible-types.stderr
+++ b/tests/ui/issues/issue-51632-try-desugar-incompatible-types.stderr
@@ -1,6 +1,8 @@
 error[E0308]: `?` operator has incompatible types
   --> $DIR/issue-51632-try-desugar-incompatible-types.rs:8:5
    |
+LL | fn forbidden_narratives() -> Result<isize, ()> {
+   |                              ----------------- expected `Result<isize, ()>` because of return type
 LL |     missing_discourses()?
    |     ^^^^^^^^^^^^^^^^^^^^^ expected `Result<isize, ()>`, found `isize`
    |

--- a/tests/ui/match/non-first-arm-doesnt-match-expected-return-type.rs
+++ b/tests/ui/match/non-first-arm-doesnt-match-expected-return-type.rs
@@ -1,0 +1,21 @@
+#![allow(unused)]
+
+fn test(shouldwe: Option<u32>, shouldwe2: Option<u32>) -> u32 {
+    //~^ NOTE expected `u32` because of return type
+    match shouldwe {
+        Some(val) => {
+            match shouldwe2 {
+                Some(val) => {
+                    return val;
+                }
+                None => (), //~ ERROR mismatched types
+                //~^ NOTE expected `u32`, found `()`
+            }
+        }
+        None => return 12,
+    }
+}
+
+fn main() {
+    println!("returned {}", test(None, Some(5)));
+}

--- a/tests/ui/match/non-first-arm-doesnt-match-expected-return-type.stderr
+++ b/tests/ui/match/non-first-arm-doesnt-match-expected-return-type.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/non-first-arm-doesnt-match-expected-return-type.rs:11:25
+   |
+LL | fn test(shouldwe: Option<u32>, shouldwe2: Option<u32>) -> u32 {
+   |                                                           --- expected `u32` because of return type
+...
+LL |                 None => (),
+   |                         ^^ expected `u32`, found `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/regions/higher-ranked-implied.stderr
+++ b/tests/ui/regions/higher-ranked-implied.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/higher-ranked-implied.rs:12:16
    |
 LL |     let y: B = x;
-   |                ^ one type is more general than the other
+   |            -   ^ one type is more general than the other
+   |            |
+   |            expected due to this
    |
    = note: expected fn pointer `for<'a, 'b> fn(Inv<&'a &'b ()>, Inv<&'b &'a ()>, Inv<&'b ()>)`
               found fn pointer `for<'a, 'b> fn(Inv<&'a &'b ()>, Inv<&'b &'a ()>, Inv<&'a ()>)`
@@ -11,7 +13,9 @@ error[E0308]: mismatched types
   --> $DIR/higher-ranked-implied.rs:13:16
    |
 LL |     let _: A = y;
-   |                ^ one type is more general than the other
+   |            -   ^ one type is more general than the other
+   |            |
+   |            expected due to this
    |
    = note: expected fn pointer `for<'a, 'b> fn(Inv<&'a &'b ()>, Inv<&'b &'a ()>, Inv<&'a ()>)`
               found fn pointer `for<'a, 'b> fn(Inv<&'a &'b ()>, Inv<&'b &'a ()>, Inv<&'b ()>)`

--- a/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:20:43
    |
 LL |     let _: fn(&mut &isize, &mut &isize) = a;
-   |                                           ^ one type is more general than the other
+   |            ----------------------------   ^ one type is more general than the other
+   |            |
+   |            expected due to this
    |
    = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b isize, &'c mut &'d isize)`
                  found fn item `for<'a, 'b> fn(&'a mut &isize, &'b mut &isize) {a::<'_, '_>}`

--- a/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:22:56
    |
 LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
-   |                                                        ^ one type is more general than the other
+   |            -----------------------------------------   ^ one type is more general than the other
+   |            |
+   |            expected due to this
    |
    = note: expected fn pointer `for<'a, 'b, 'c, 'd, 'e, 'f> fn(&'a mut &'b isize, &'c mut &'d isize, &'e mut &'f isize)`
                  found fn item `for<'a, 'b, 'c> fn(&'a mut &isize, &'b mut &isize, &'c mut &isize) {a::<'_, '_, '_>}`

--- a/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
+++ b/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/regions-lifetime-bounds-on-fns.rs:20:43
    |
 LL |     let _: fn(&mut &isize, &mut &isize) = a;
-   |                                           ^ one type is more general than the other
+   |            ----------------------------   ^ one type is more general than the other
+   |            |
+   |            expected due to this
    |
    = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b isize, &'c mut &'d isize)`
                  found fn item `for<'a, 'b> fn(&'a mut &isize, &'b mut &isize) {a::<'_, '_>}`

--- a/tests/ui/suggestions/remove-question-symbol-with-paren.stderr
+++ b/tests/ui/suggestions/remove-question-symbol-with-paren.stderr
@@ -1,6 +1,9 @@
 error[E0308]: `?` operator has incompatible types
   --> $DIR/remove-question-symbol-with-paren.rs:5:6
    |
+LL | fn foo() -> Option<()> {
+   |             ---------- expected `Option<()>` because of return type
+LL |     let x = Some(());
 LL |     (x?)
    |      ^^ expected `Option<()>`, found `()`
    |


### PR DESCRIPTION
Successful merges:

 - #114588 (Improve docs for impl Default for ExitStatus)
 - #114619 (Fix pthread_attr_union layout on Wasi)
 - #114644 (Point out expectation even if we have `TypeError::RegionsInsufficientlyPolymorphic`)
 - #114668 (Deny `FnDef` in patterns)
 - #114819 (Point at return type when it influences non-first `match` arm)
 - #114826 (Fix typos)
 - #114828 (Probe when assembling upcast candidates so they don't step on eachother's toes in new solver)
 - #114837 (add missing feature(error_in_core))
 - #114850 (add codegen test for `trailing_zeros` comparison)
 - #114853 (Migrate GUI colors test to original CSS color format)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114588,114619,114644,114668,114819,114826,114828,114837,114850,114853)
<!-- homu-ignore:end -->