### PR TITLE
Don't ICE in `is_trivially_sized` when encountering late-bound self ty

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2827,11 +2827,11 @@ impl<'tcx> Ty<'tcx> {
 
             ty::Adt(def, _args) => def.sized_constraint(tcx).skip_binder().is_empty(),
 
-            ty::Alias(..) | ty::Param(_) | ty::Placeholder(..) => false,
+            ty::Alias(..) | ty::Param(_) | ty::Placeholder(..) | ty::Bound(..) => false,
 
             ty::Infer(ty::TyVar(_)) => false,
 
-            ty::Bound(..) | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
                 bug!("`is_trivially_sized` applied to unexpected type: {:?}", self)
             }
         }

--- a/tests/ui/traits/non_lifetime_binders/sized-late-bound-issue-114872.rs
+++ b/tests/ui/traits/non_lifetime_binders/sized-late-bound-issue-114872.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![feature(non_lifetime_binders)]
+//~^ WARN is incomplete and may not be safe
+
+pub fn foo()
+where
+    for<V> V: Sized,
+{
+    bar();
+}
+
+pub fn bar()
+where
+    for<V> V: Sized,
+{
+}
+
+pub fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/sized-late-bound-issue-114872.stderr
+++ b/tests/ui/traits/non_lifetime_binders/sized-late-bound-issue-114872.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/sized-late-bound-issue-114872.rs:3:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
We can see a bound ty var here:
https://github.com/rust-lang/rust/blob/b531630f4255216fce1400c45976e04f1ab35a84/compiler/rustc_trait_selection/src/traits/query/type_op/prove_predicate.rs#L13-L34

Fixes #114872 