### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -1,6 +1,9 @@
 hir_analysis_ambiguous_lifetime_bound =
     ambiguous lifetime bound, explicit lifetime bound required
 
+hir_analysis_assoc_bound_on_const = expected associated type, found {$descr}
+    .note = trait bounds not allowed on {$descr}
+
 hir_analysis_assoc_type_binding_not_allowed =
     associated type bindings are not allowed here
     .label = associated type not allowed here

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -918,3 +918,12 @@ pub struct UnusedAssociatedTypeBounds {
     #[suggestion(code = "")]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_assoc_bound_on_const)]
+#[note]
+pub struct AssocBoundOnConst {
+    #[primary_span]
+    pub span: Span,
+    pub descr: &'static str,
+}

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -599,6 +599,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 = self.typeck_results.borrow().qpath_res(qpath, callee_expr.hir_id)
             // Only suggest removing parens if there are no arguments
             && arg_exprs.is_empty()
+            && call_expr.span.contains(callee_expr.span)
         {
             let descr = match kind {
                 def::CtorOf::Struct => "struct",

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -85,6 +85,22 @@ pub fn all_local_items() -> CrateItems {
     with(|cx| cx.all_local_items())
 }
 
+pub fn all_trait_decls() -> TraitDecls {
+    with(|cx| cx.all_trait_decls())
+}
+
+pub fn trait_decl(trait_def: &TraitDef) -> TraitDecl {
+    with(|cx| cx.trait_decl(trait_def))
+}
+
+pub fn all_trait_impls() -> ImplTraitDecls {
+    with(|cx| cx.all_trait_impls())
+}
+
+pub fn trait_impl(trait_impl: &ImplDef) -> ImplTrait {
+    with(|cx| cx.trait_impl(trait_impl))
+}
+
 pub trait Context {
     fn entry_fn(&mut self) -> Option<CrateItem>;
     /// Retrieve all items of the local crate that have a MIR associated with them.

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -58,7 +58,7 @@
 
 // To run alloc tests without x.py without ending up with two copies of alloc, Miri needs to be
 // able to "empty" this crate. See <https://github.com/rust-lang/miri-test-libstd/issues/4>.
-// rustc itself never sets the feature, so this line has no affect there.
+// rustc itself never sets the feature, so this line has no effect there.
 #![cfg(any(not(feature = "miri-test-libstd"), test, doctest))]
 //
 #![allow(unused_attributes)]

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -612,7 +612,7 @@ pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
 }
 
 /// Converts the bytes while the bytes are still ascii.
-/// For better average performance, this is happens in chunks of `2*size_of::<usize>()`.
+/// For better average performance, this happens in chunks of `2*size_of::<usize>()`.
 /// Returns a vec with the converted bytes.
 #[inline]
 #[cfg(not(test))]

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1406,6 +1406,22 @@ mod impls {
                 _ => unsafe { unreachable_unchecked() },
             }
         }
+
+        #[inline]
+        fn min(self, other: bool) -> bool {
+            self & other
+        }
+
+        #[inline]
+        fn max(self, other: bool) -> bool {
+            self | other
+        }
+
+        #[inline]
+        fn clamp(self, min: bool, max: bool) -> bool {
+            assert!(min <= max);
+            self.max(min).min(max)
+        }
     }
 
     ord_impl! { char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -9,7 +9,7 @@
 //! This includes changes in the stability of the constness.
 //!
 //! In order to make an intrinsic usable at compile-time, one needs to copy the implementation
-//! from <https://github.com/rust-lang/miri/blob/master/src/shims/intrinsics.rs> to
+//! from <https://github.com/rust-lang/miri/blob/master/src/shims/intrinsics> to
 //! <https://github.com/rust-lang/rust/blob/master/compiler/rustc_const_eval/src/interpret/intrinsics.rs> and add a
 //! `#[rustc_const_unstable(feature = "const_such_and_such", issue = "01234")]` to the intrinsic declaration.
 //!

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -51,7 +51,7 @@
 #![cfg(not(test))]
 // To run core tests without x.py without ending up with two copies of core, Miri needs to be
 // able to "empty" this crate. See <https://github.com/rust-lang/miri-test-libstd/issues/4>.
-// rustc itself never sets the feature, so this line has no affect there.
+// rustc itself never sets the feature, so this line has no effect there.
 #![cfg(any(not(feature = "miri-test-libstd"), test, doctest))]
 #![stable(feature = "core", since = "1.6.0")]
 #![doc(

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -190,7 +190,7 @@
 
 // To run std tests without x.py without ending up with two copies of std, Miri needs to be
 // able to "empty" this crate. See <https://github.com/rust-lang/miri-test-libstd/issues/4>.
-// rustc itself never sets the feature, so this line has no affect there.
+// rustc itself never sets the feature, so this line has no effect there.
 #![cfg(any(not(feature = "miri-test-libstd"), test, doctest))]
 // miri-test-libstd also prefers to make std use the sysroot versions of the dependencies.
 #![cfg_attr(feature = "miri-test-libstd", feature(rustc_private))]

--- a/tests/ui/associated-type-bounds/consts.rs
+++ b/tests/ui/associated-type-bounds/consts.rs
@@ -1,0 +1,10 @@
+#![feature(associated_type_bounds)]
+
+pub fn accept(_: impl Trait<K: Copy>) {}
+//~^ ERROR expected associated type, found associated constant
+
+pub trait Trait {
+    const K: i32;
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/consts.stderr
+++ b/tests/ui/associated-type-bounds/consts.stderr
@@ -1,0 +1,10 @@
+error: expected associated type, found associated constant
+  --> $DIR/consts.rs:3:29
+   |
+LL | pub fn accept(_: impl Trait<K: Copy>) {}
+   |                             ^
+   |
+   = note: trait bounds not allowed on associated constant
+
+error: aborting due to previous error
+

--- a/tests/ui/suggestions/issue-114701.rs
+++ b/tests/ui/suggestions/issue-114701.rs
@@ -1,0 +1,15 @@
+enum Enum<T> { , SVariant { v: T }, UVariant } //~ ERROR expected identifier, found `,`
+
+macro_rules! is_variant {
+    (TSVariant, ) => (!);
+    (SVariant, ) => (!);
+    (UVariant, $expr:expr) => (is_variant!(@check UVariant, {}, $expr));
+    (@check $variant:ident, $matcher:tt, $expr:expr) => (
+        assert!(if let Enum::$variant::<()> $matcher = $expr () else { false }, //~ ERROR this `if` expression
+                );
+    );
+}
+
+fn main() {
+    is_variant!(UVariant, Enum::<()>::UVariant); //~ ERROR expected function
+}

--- a/tests/ui/suggestions/issue-114701.rs
+++ b/tests/ui/suggestions/issue-114701.rs
@@ -1,11 +1,11 @@
-enum Enum<T> { , SVariant { v: T }, UVariant } //~ ERROR expected identifier, found `,`
+enum Enum<T> { SVariant { v: T }, UVariant }
 
 macro_rules! is_variant {
     (TSVariant, ) => (!);
     (SVariant, ) => (!);
     (UVariant, $expr:expr) => (is_variant!(@check UVariant, {}, $expr));
     (@check $variant:ident, $matcher:tt, $expr:expr) => (
-        assert!(if let Enum::$variant::<()> $matcher = $expr () else { false }, //~ ERROR this `if` expression
+        assert!(if let Enum::$variant::<()> $matcher = $expr () { true } else { false },
                 );
     );
 }

--- a/tests/ui/suggestions/issue-114701.stderr
+++ b/tests/ui/suggestions/issue-114701.stderr
@@ -1,48 +1,15 @@
-error: expected identifier, found `,`
-  --> $DIR/issue-114701.rs:1:16
-   |
-LL | enum Enum<T> { , SVariant { v: T }, UVariant }
-   |                ^
-   |                |
-   |                expected identifier
-   |                help: remove this comma
-
-error: this `if` expression is missing a block after the condition
-  --> $DIR/issue-114701.rs:8:17
-   |
-LL |         assert!(if let Enum::$variant::<()> $matcher = $expr () else { false },
-   |                 ^^
-...
-LL |     is_variant!(UVariant, Enum::<()>::UVariant);
-   |     ------------------------------------------- in this macro invocation
-   |
-help: add a block here
-  --> $DIR/issue-114701.rs:8:64
-   |
-LL |         assert!(if let Enum::$variant::<()> $matcher = $expr () else { false },
-   |                                                                ^
-...
-LL |     is_variant!(UVariant, Enum::<()>::UVariant);
-   |     ------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `is_variant` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: remove the `if` if you meant to write a `let...else` statement
-   |
-LL -         assert!(if let Enum::$variant::<()> $matcher = $expr () else { false },
-LL +         assert!(let Enum::$variant::<()> $matcher = $expr () else { false },
-   |
-
 error[E0618]: expected function, found `Enum<()>`
   --> $DIR/issue-114701.rs:14:27
    |
-LL | enum Enum<T> { , SVariant { v: T }, UVariant }
-   |                                     -------- `Enum::UVariant` defined here
+LL | enum Enum<T> { SVariant { v: T }, UVariant }
+   |                                   -------- `Enum::UVariant` defined here
 ...
-LL |         assert!(if let Enum::$variant::<()> $matcher = $expr () else { false },
+LL |         assert!(if let Enum::$variant::<()> $matcher = $expr () { true } else { false },
    |                                                        -------- call expression requires function
 ...
 LL |     is_variant!(UVariant, Enum::<()>::UVariant);
    |                           ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0618`.

--- a/tests/ui/suggestions/issue-114701.stderr
+++ b/tests/ui/suggestions/issue-114701.stderr
@@ -1,0 +1,48 @@
+error: expected identifier, found `,`
+  --> $DIR/issue-114701.rs:1:16
+   |
+LL | enum Enum<T> { , SVariant { v: T }, UVariant }
+   |                ^
+   |                |
+   |                expected identifier
+   |                help: remove this comma
+
+error: this `if` expression is missing a block after the condition
+  --> $DIR/issue-114701.rs:8:17
+   |
+LL |         assert!(if let Enum::$variant::<()> $matcher = $expr () else { false },
+   |                 ^^
+...
+LL |     is_variant!(UVariant, Enum::<()>::UVariant);
+   |     ------------------------------------------- in this macro invocation
+   |
+help: add a block here
+  --> $DIR/issue-114701.rs:8:64
+   |
+LL |         assert!(if let Enum::$variant::<()> $matcher = $expr () else { false },
+   |                                                                ^
+...
+LL |     is_variant!(UVariant, Enum::<()>::UVariant);
+   |     ------------------------------------------- in this macro invocation
+   = note: this error originates in the macro `is_variant` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `if` if you meant to write a `let...else` statement
+   |
+LL -         assert!(if let Enum::$variant::<()> $matcher = $expr () else { false },
+LL +         assert!(let Enum::$variant::<()> $matcher = $expr () else { false },
+   |
+
+error[E0618]: expected function, found `Enum<()>`
+  --> $DIR/issue-114701.rs:14:27
+   |
+LL | enum Enum<T> { , SVariant { v: T }, UVariant }
+   |                                     -------- `Enum::UVariant` defined here
+...
+LL |         assert!(if let Enum::$variant::<()> $matcher = $expr () else { false },
+   |                                                        -------- call expression requires function
+...
+LL |     is_variant!(UVariant, Enum::<()>::UVariant);
+   |                           ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0618`.


### PR DESCRIPTION
Successful merges:

 - #114721 (Optimizing the rest of bool's Ord implementation)
 - #114746 (Don't add associated type bound for non-types)
 - #114779 (Add check before suggest removing parens)
 - #114859 (Add trait related queries to SMIR's rustc_internal)
 - #114861 (fix typo: affect -> effect)
 - #114867 ([nit] Fix a comment typo.)
 - #114871 (Update the link in the docs of `std::intrinsics`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114721,114746,114779,114859,114861,114867,114871)
<!-- homu-ignore:end -->