### PR TITLE
Allow a MIR analysis to perform the state `join` directly

### DIFF
--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -392,7 +392,7 @@ where
         &mut self,
         _block: BasicBlock,
         _discr: &Operand<'tcx>,
-        _apply_edge_effects: &mut impl SwitchIntEdgeEffects<Self::Domain>,
+        _apply_edge_effects: &mut impl SwitchIntEdgeEffects<'tcx, Self>,
     ) {
     }
 }


### PR DESCRIPTION
`AnalysisJoin` is a separate trait in order for the domain type to provide the join via `JoinSemiLattice`. This also prevents a custom join implementation when using a `JoinSemiLattice` type as the domain, but that's probably not useful to do in the first place.

---

This is needed to make `clippy::redundant_clone` an analysis pass. Given the following:
```rust
let x = String::new();
let y = &x;
let z = if true {
    y.clone();
} else {
    String::from("foo")
};
println!("{y} {z}");
```
To avoid linting on the clone, the join between the two branches needs to be able to see that `x` is borrowed at that point and cannot be moved. Since borrowing is a different analysis pass this needs to be passed into the join somehow.