### PR TITLE
Remove references in VarDebugInfo

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -42,9 +42,6 @@ pub struct PerLocalVarDebugInfo<'tcx, D> {
 
     /// `.place.projection` from `mir::VarDebugInfo`.
     pub projection: &'tcx ty::List<mir::PlaceElem<'tcx>>,
-
-    /// `references` from `mir::VarDebugInfo`.
-    pub references: u8,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -323,7 +320,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     dbg_var,
                     fragment: None,
                     projection: ty::List::empty(),
-                    references: 0,
                 })
             }
         } else {
@@ -399,15 +395,14 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         &self,
         bx: &mut Bx,
         local: mir::Local,
-        mut base: PlaceRef<'tcx, Bx::Value>,
+        base: PlaceRef<'tcx, Bx::Value>,
         var: PerLocalVarDebugInfo<'tcx, Bx::DIVariable>,
     ) {
         let Some(dbg_var) = var.dbg_var else { return };
         let Some(dbg_loc) = self.dbg_loc(var.source_info) else { return };
 
-        let DebugInfoOffset { mut direct_offset, indirect_offsets, result: _ } =
+        let DebugInfoOffset { direct_offset, indirect_offsets, result: _ } =
             calculate_debuginfo_offset(bx, local, &var, base.layout);
-        let mut indirect_offsets = &indirect_offsets[..];
 
         // When targeting MSVC, create extra allocas for arguments instead of pointing multiple
         // dbg_var_addr() calls into the same alloca with offsets. MSVC uses CodeView records
@@ -421,9 +416,12 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             // LLVM can handle simple things but anything more complex than just a direct
             // offset or one indirect offset of 0 is too complex for it to generate CV records
             // correctly.
-            && (direct_offset != Size::ZERO || !matches!(indirect_offsets, [Size::ZERO] | []));
+            && (direct_offset != Size::ZERO || !matches!(&indirect_offsets[..], [Size::ZERO] | []));
 
-        let create_alloca = |bx: &mut Bx, place: PlaceRef<'tcx, Bx::Value>, refcount| {
+        if should_create_individual_allocas {
+            let DebugInfoOffset { direct_offset: _, indirect_offsets: _, result: place } =
+                calculate_debuginfo_offset(bx, local, &var, base);
+
             // Create a variable which will be a pointer to the actual value
             let ptr_ty = Ty::new_ptr(
                 bx.tcx(),
@@ -431,35 +429,16 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             );
             let ptr_layout = bx.layout_of(ptr_ty);
             let alloca = PlaceRef::alloca(bx, ptr_layout);
-            bx.set_var_name(alloca.llval, &format!("{}.ref{}.dbg.spill", var.name, refcount));
+            bx.set_var_name(alloca.llval, &(var.name.to_string() + ".dbg.spill"));
 
             // Write the pointer to the variable
             bx.store(place.llval, alloca.llval, alloca.align);
 
             // Point the debug info to `*alloca` for the current variable
-            alloca
-        };
-
-        if var.references > 0 {
-            base = calculate_debuginfo_offset(bx, local, &var, base).result;
-
-            // Point the debug info to `&...&base == alloca` for the current variable
-            for refcount in 0..var.references {
-                base = create_alloca(bx, base, refcount);
-            }
-
-            direct_offset = Size::ZERO;
-            indirect_offsets = &[];
-        } else if should_create_individual_allocas {
-            let place = calculate_debuginfo_offset(bx, local, &var, base).result;
-
-            // Point the debug info to `*alloca` for the current variable
-            base = create_alloca(bx, place, 0);
-            direct_offset = Size::ZERO;
-            indirect_offsets = &[Size::ZERO];
+            bx.dbg_var_addr(dbg_var, dbg_loc, alloca.llval, Size::ZERO, &[Size::ZERO], None);
+        } else {
+            bx.dbg_var_addr(dbg_var, dbg_loc, base.llval, direct_offset, &indirect_offsets, None);
         }
-
-        bx.dbg_var_addr(dbg_var, dbg_loc, base.llval, direct_offset, indirect_offsets, None);
     }
 
     pub fn debug_introduce_locals(&self, bx: &mut Bx) {
@@ -492,7 +471,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             };
 
             let dbg_var = dbg_scope_and_span.map(|(dbg_scope, _, span)| {
-                let (mut var_ty, var_kind) = match var.value {
+                let (var_ty, var_kind) = match var.value {
                     mir::VarDebugInfoContents::Place(place) => {
                         let var_ty = self.monomorphized_place_ty(place.as_ref());
                         let var_kind = if let Some(arg_index) = var.argument_index
@@ -529,13 +508,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     }
                 };
 
-                for _ in 0..var.references {
-                    var_ty = Ty::new_ptr(
-                        bx.tcx(),
-                        ty::TypeAndMut { mutbl: mir::Mutability::Mut, ty: var_ty },
-                    );
-                }
-
                 self.cx.create_dbg_var(var.name, var_ty, dbg_scope, var_kind, span)
             });
 
@@ -547,7 +519,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         dbg_var,
                         fragment: None,
                         projection: place.projection,
-                        references: var.references,
                     });
                 }
                 mir::VarDebugInfoContents::Const(c) => {
@@ -601,7 +572,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 Some(fragment_start..fragment_start + fragment_layout.size)
                             },
                             projection: place.projection,
-                            references: var.references,
                         });
                     }
                 }

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -701,12 +701,6 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
             VarDebugInfoContents::Const(_) => {}
             VarDebugInfoContents::Place(place) => {
                 check_place(self, place);
-                if debuginfo.references != 0 && place.projection.last() == Some(&PlaceElem::Deref) {
-                    self.fail(
-                        START_BLOCK.start_location(),
-                        format!("debuginfo {debuginfo:?}, has both ref and deref"),
-                    );
-                }
             }
             VarDebugInfoContents::Composite { ty, ref fragments } => {
                 for f in fragments {

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1109,10 +1109,6 @@ pub struct VarDebugInfo<'tcx> {
     /// originated from (starting from 1). Note, if MIR inlining is enabled, then this is the
     /// argument number in the original function before it was inlined.
     pub argument_index: Option<u16>,
-
-    /// The data represents `name` dereferenced `references` times,
-    /// and not the direct value.
-    pub references: u8,
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -555,13 +555,8 @@ fn write_scope_tree(
         }
 
         let indented_debug_info = format!(
-            "{0:1$}debug {2} => {3:&<4$}{5:?};",
-            INDENT,
-            indent,
-            var_debug_info.name,
-            "",
-            var_debug_info.references as usize,
-            var_debug_info.value,
+            "{0:1$}debug {2} => {3:?};",
+            INDENT, indent, var_debug_info.name, var_debug_info.value,
         );
 
         if tcx.sess.opts.unstable_opts.mir_include_spans {

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -840,7 +840,6 @@ macro_rules! make_mir_visitor {
                     source_info,
                     value,
                     argument_index: _,
-                    references: _,
                 } = var_debug_info;
 
                 self.visit_source_info(source_info);

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -438,7 +438,6 @@ CloneLiftImpls! {
     (),
     bool,
     usize,
-    u8,
     u16,
     u32,
     u64,

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -2242,7 +2242,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.var_debug_info.push(VarDebugInfo {
             name,
             source_info: debug_source_info,
-            references: 0,
             value: VarDebugInfoContents::Place(for_arm_body.into()),
             argument_index: None,
         });
@@ -2262,7 +2261,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.var_debug_info.push(VarDebugInfo {
                 name,
                 source_info: debug_source_info,
-                references: 0,
                 value: VarDebugInfoContents::Place(ref_for_guard.into()),
                 argument_index: None,
             });

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -820,7 +820,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 };
                 self.var_debug_info.push(VarDebugInfo {
                     name,
-                    references: 0,
                     source_info: SourceInfo::outermost(captured_place.var_ident.span),
                     value: VarDebugInfoContents::Place(use_place),
                     argument_index: None,
@@ -851,7 +850,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.var_debug_info.push(VarDebugInfo {
                     name,
                     source_info,
-                    references: 0,
                     value: VarDebugInfoContents::Place(arg_local.into()),
                     argument_index: Some(argument_index as u16 + 1),
                 });

--- a/compiler/rustc_mir_transform/src/ref_prop.rs
+++ b/compiler/rustc_mir_transform/src/ref_prop.rs
@@ -265,7 +265,6 @@ fn compute_replacement<'tcx>(
         targets,
         storage_to_remove,
         allowed_replacements,
-        fully_replacable_locals,
         any_replacement: false,
     };
 
@@ -346,7 +345,6 @@ struct Replacer<'tcx> {
     storage_to_remove: BitSet<Local>,
     allowed_replacements: FxHashSet<(Local, Location)>,
     any_replacement: bool,
-    fully_replacable_locals: BitSet<Local>,
 }
 
 impl<'tcx> MutVisitor<'tcx> for Replacer<'tcx> {
@@ -365,12 +363,6 @@ impl<'tcx> MutVisitor<'tcx> for Replacer<'tcx> {
         {
             if let Some((&PlaceElem::Deref, rest)) = target.projection.split_last() {
                 *place = Place::from(target.local).project_deeper(rest, self.tcx);
-                self.any_replacement = true;
-            } else if self.fully_replacable_locals.contains(place.local)
-                && let Some(references) = debuginfo.references.checked_add(1)
-            {
-                debuginfo.references = references;
-                *place = target;
                 self.any_replacement = true;
             } else {
                 break

--- a/compiler/rustc_type_ir/src/structural_impls.rs
+++ b/compiler/rustc_type_ir/src/structural_impls.rs
@@ -23,7 +23,6 @@ TrivialTypeTraversalImpls! {
     (),
     bool,
     usize,
-    u8,
     u16,
     u32,
     u64,

--- a/tests/codegen/slice-ref-equality.rs
+++ b/tests/codegen/slice-ref-equality.rs
@@ -44,48 +44,48 @@ pub fn is_zero_array(data: &[u8; 4]) -> bool {
 // equality for non-byte types also just emit a `bcmp`, not a loop.
 
 // CHECK-LABEL: @eq_slice_of_nested_u8(
-// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %x.1
-// CHECK-SAME: [[USIZE]] noundef %y.1
+// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %1
+// CHECK-SAME: [[USIZE]] noundef %3
 #[no_mangle]
 fn eq_slice_of_nested_u8(x: &[[u8; 3]], y: &[[u8; 3]]) -> bool {
-    // CHECK: icmp eq [[USIZE]] %x.1, %y.1
-    // CHECK: %[[BYTES:.+]] = mul nsw [[USIZE]] %x.1, 3
+    // CHECK: icmp eq [[USIZE]] %1, %3
+    // CHECK: %[[BYTES:.+]] = mul nsw [[USIZE]] %1, 3
     // CHECK: tail call{{( noundef)?}} i32 @{{bcmp|memcmp}}(ptr
     // CHECK-SAME: , [[USIZE]]{{( noundef)?}} %[[BYTES]])
     x == y
 }
 
 // CHECK-LABEL: @eq_slice_of_i32(
-// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %x.1
-// CHECK-SAME: [[USIZE]] noundef %y.1
+// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %1
+// CHECK-SAME: [[USIZE]] noundef %3
 #[no_mangle]
 fn eq_slice_of_i32(x: &[i32], y: &[i32]) -> bool {
-    // CHECK: icmp eq [[USIZE]] %x.1, %y.1
-    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %x.1, 2
+    // CHECK: icmp eq [[USIZE]] %1, %3
+    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %1, 2
     // CHECK: tail call{{( noundef)?}} i32 @{{bcmp|memcmp}}(ptr
     // CHECK-SAME: , [[USIZE]]{{( noundef)?}} %[[BYTES]])
     x == y
 }
 
 // CHECK-LABEL: @eq_slice_of_nonzero(
-// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %x.1
-// CHECK-SAME: [[USIZE]] noundef %y.1
+// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %1
+// CHECK-SAME: [[USIZE]] noundef %3
 #[no_mangle]
 fn eq_slice_of_nonzero(x: &[NonZeroU32], y: &[NonZeroU32]) -> bool {
-    // CHECK: icmp eq [[USIZE]] %x.1, %y.1
-    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %x.1, 2
+    // CHECK: icmp eq [[USIZE]] %1, %3
+    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %1, 2
     // CHECK: tail call{{( noundef)?}} i32 @{{bcmp|memcmp}}(ptr
     // CHECK-SAME: , [[USIZE]]{{( noundef)?}} %[[BYTES]])
     x == y
 }
 
 // CHECK-LABEL: @eq_slice_of_option_of_nonzero(
-// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %x.1
-// CHECK-SAME: [[USIZE]] noundef %y.1
+// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %1
+// CHECK-SAME: [[USIZE]] noundef %3
 #[no_mangle]
 fn eq_slice_of_option_of_nonzero(x: &[Option<NonZeroI16>], y: &[Option<NonZeroI16>]) -> bool {
-    // CHECK: icmp eq [[USIZE]] %x.1, %y.1
-    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %x.1, 1
+    // CHECK: icmp eq [[USIZE]] %1, %3
+    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %1, 1
     // CHECK: tail call{{( noundef)?}} i32 @{{bcmp|memcmp}}(ptr
     // CHECK-SAME: , [[USIZE]]{{( noundef)?}} %[[BYTES]])
     x == y

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
@@ -7,7 +7,8 @@
       let mut _2: std::option::Option<T>;
 +     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
 +         debug self => _2;
-+         let mut _3: isize;
++         let mut _3: &std::option::Option<T>;
++         let mut _4: isize;
 +         scope 2 {
 +             debug val => _0;
 +         }
@@ -20,7 +21,7 @@
 +             }
 +         }
 +         scope 4 (inlined Option::<T>::is_some) {
-+             debug self => &_2;
++             debug self => _3;
 +         }
 +     }
   
@@ -28,8 +29,9 @@
           StorageLive(_2);
           _2 = move _1;
 -         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind unreachable];
-+         _3 = discriminant(_2);
-+         switchInt(move _3) -> [1: bb2, otherwise: bb1];
++         StorageLive(_3);
++         _4 = discriminant(_2);
++         switchInt(move _4) -> [1: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -38,6 +40,7 @@
 + 
 +     bb2: {
 +         _0 = move ((_2 as Some).0: T);
++         StorageDead(_3);
           StorageDead(_2);
           return;
       }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -7,7 +7,8 @@
       let mut _2: std::option::Option<T>;
 +     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
 +         debug self => _2;
-+         let mut _3: isize;
++         let mut _3: &std::option::Option<T>;
++         let mut _4: isize;
 +         scope 2 {
 +             debug val => _0;
 +         }
@@ -20,7 +21,7 @@
 +             }
 +         }
 +         scope 4 (inlined Option::<T>::is_some) {
-+             debug self => &_2;
++             debug self => _3;
 +         }
 +     }
   
@@ -28,8 +29,9 @@
           StorageLive(_2);
           _2 = move _1;
 -         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind: bb2];
-+         _3 = discriminant(_2);
-+         switchInt(move _3) -> [1: bb2, otherwise: bb1];
++         StorageLive(_3);
++         _4 = discriminant(_2);
++         switchInt(move _4) -> [1: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -42,6 +44,7 @@
 -         resume;
 +     bb2: {
 +         _0 = move ((_2 as Some).0: T);
++         StorageDead(_3);
 +         StorageDead(_2);
 +         return;
       }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
@@ -6,6 +6,7 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
         debug self => _1;
         let mut _2: isize;
+        let mut _3: &std::option::Option<T>;
         scope 2 {
             debug val => _0;
         }
@@ -18,17 +19,19 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
             }
         }
         scope 4 (inlined Option::<T>::is_some) {
-            debug self => &_1;
+            debug self => _3;
         }
     }
 
     bb0: {
+        StorageLive(_3);
         _2 = discriminant(_1);
         switchInt(move _2) -> [1: bb1, otherwise: bb2];
     }
 
     bb1: {
         _0 = move ((_1 as Some).0: T);
+        StorageDead(_3);
         return;
     }
 

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
@@ -6,6 +6,7 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
         debug self => _1;
         let mut _2: isize;
+        let mut _3: &std::option::Option<T>;
         scope 2 {
             debug val => _0;
         }
@@ -18,17 +19,19 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
             }
         }
         scope 4 (inlined Option::<T>::is_some) {
-            debug self => &_1;
+            debug self => _3;
         }
     }
 
     bb0: {
+        StorageLive(_3);
         _2 = discriminant(_1);
         switchInt(move _2) -> [1: bb1, otherwise: bb2];
     }
 
     bb1: {
         _0 = move ((_1 as Some).0: T);
+        StorageDead(_3);
         return;
     }
 

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
@@ -13,13 +13,16 @@
       let mut _8: usize;
       let mut _9: usize;
       let mut _10: bool;
-      let mut _11: !;
+      let mut _14: !;
       scope 1 {
           debug v => _2;
+          let _11: &T;
+          let _12: &T;
+          let _13: &T;
           scope 2 {
-              debug v1 => &(*_2)[0 of 3];
-              debug v2 => &(*_2)[1 of 3];
-              debug v3 => &(*_2)[2 of 3];
+              debug v1 => _11;
+              debug v2 => _12;
+              debug v3 => _13;
           }
       }
   
@@ -39,10 +42,19 @@
       }
   
       bb1: {
-          _11 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind unreachable;
+          _14 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind unreachable;
       }
   
       bb2: {
+          StorageLive(_11);
+          _11 = &(*_2)[0 of 3];
+          StorageLive(_12);
+          _12 = &(*_2)[1 of 3];
+          StorageLive(_13);
+          _13 = &(*_2)[2 of 3];
+          StorageDead(_13);
+          StorageDead(_12);
+          StorageDead(_11);
           StorageDead(_4);
           return;
       }

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
@@ -13,13 +13,16 @@
       let mut _8: usize;
       let mut _9: usize;
       let mut _10: bool;
-      let mut _11: !;
+      let mut _14: !;
       scope 1 {
           debug v => _2;
+          let _11: &T;
+          let _12: &T;
+          let _13: &T;
           scope 2 {
-              debug v1 => &(*_2)[0 of 3];
-              debug v2 => &(*_2)[1 of 3];
-              debug v3 => &(*_2)[2 of 3];
+              debug v1 => _11;
+              debug v2 => _12;
+              debug v3 => _13;
           }
       }
   
@@ -39,10 +42,19 @@
       }
   
       bb1: {
-          _11 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind continue;
+          _14 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind continue;
       }
   
       bb2: {
+          StorageLive(_11);
+          _11 = &(*_2)[0 of 3];
+          StorageLive(_12);
+          _12 = &(*_2)[1 of 3];
+          StorageLive(_13);
+          _13 = &(*_2)[2 of 3];
+          StorageDead(_13);
+          StorageDead(_12);
+          StorageDead(_11);
           StorageDead(_4);
           return;
       }

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
@@ -8,8 +8,9 @@ fn num_to_digit(_1: char) -> u32 {
         debug self => _1;
         debug radix => const 8_u32;
         let _2: std::option::Option<u32>;
+        let mut _7: &std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
-            debug self => &_2;
+            debug self => _7;
             let mut _3: isize;
         }
     }
@@ -23,12 +24,14 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb0: {
+        StorageLive(_7);
         StorageLive(_2);
         _2 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
         _3 = discriminant(_2);
+        StorageDead(_7);
         StorageDead(_2);
         switchInt(move _3) -> [1: bb2, otherwise: bb7];
     }

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
@@ -8,8 +8,9 @@ fn num_to_digit(_1: char) -> u32 {
         debug self => _1;
         debug radix => const 8_u32;
         let _2: std::option::Option<u32>;
+        let mut _7: &std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
-            debug self => &_2;
+            debug self => _7;
             let mut _3: isize;
         }
     }
@@ -23,12 +24,14 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb0: {
+        StorageLive(_7);
         StorageLive(_2);
         _2 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> [return: bb1, unwind continue];
     }
 
     bb1: {
         _3 = discriminant(_2);
+        StorageDead(_7);
         StorageDead(_2);
         switchInt(move _3) -> [1: bb2, otherwise: bb7];
     }

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.mir
@@ -10,13 +10,14 @@ fn step_forward(_1: u32, _2: usize) -> u32 {
         let _3: std::option::Option<u32>;
         let mut _6: bool;
         let mut _7: u32;
+        let mut _8: &std::option::Option<u32>;
         scope 2 {
         }
         scope 3 (inlined Option::<u32>::is_none) {
-            debug self => &_3;
+            debug self => _8;
             let mut _5: bool;
             scope 4 (inlined Option::<u32>::is_some) {
-                debug self => &_3;
+                debug self => _8;
                 let mut _4: isize;
             }
         }
@@ -28,6 +29,7 @@ fn step_forward(_1: u32, _2: usize) -> u32 {
 
     bb0: {
         StorageLive(_6);
+        StorageLive(_8);
         StorageLive(_3);
         _3 = <u32 as Step>::forward_checked(_1, _2) -> [return: bb1, unwind continue];
     }
@@ -39,6 +41,7 @@ fn step_forward(_1: u32, _2: usize) -> u32 {
         _6 = Not(move _5);
         StorageDead(_5);
         StorageDead(_3);
+        StorageDead(_8);
         switchInt(move _6) -> [0: bb3, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
@@ -10,6 +10,7 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
     let mut _8: std::option::Option<U>;
     let mut _9: isize;
     let _11: ();
+    let mut _12: &mut std::iter::FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>>;
     scope 1 {
         debug iter => _5;
         let _10: U;
@@ -17,7 +18,7 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
             debug x => _10;
         }
         scope 4 (inlined <FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>> as Iterator>::next) {
-            debug self => &_5;
+            debug self => _12;
             let mut _6: &mut impl Iterator<Item = T>;
             let mut _7: &mut impl Fn(T) -> Option<U>;
         }

--- a/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
@@ -4,95 +4,108 @@ fn int_range(_1: usize, _2: usize) -> () {
     debug start => _1;
     debug end => _2;
     let mut _0: ();
-    let mut _3: usize;
-    let mut _6: std::option::Option<usize>;
-    let mut _9: isize;
-    let _11: ();
+    let mut _3: std::ops::Range<usize>;
+    let mut _4: std::ops::Range<usize>;
+    let mut _8: std::option::Option<usize>;
+    let mut _11: isize;
+    let _13: ();
+    let mut _14: &mut std::ops::Range<usize>;
     scope 1 {
-        debug iter => std::ops::Range<usize>{ .0 => _3, .1 => _2, };
-        let _10: usize;
+        debug iter => _4;
+        let _12: usize;
         scope 2 {
-            debug i => _10;
+            debug i => _12;
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
-            debug self => &std::ops::Range<usize>{ .0 => _3, .1 => _2, };
+            debug self => _14;
             scope 5 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => &std::ops::Range<usize>{ .0 => _3, .1 => _2, };
-                let mut _5: bool;
-                let _7: usize;
-                let mut _8: usize;
+                debug self => _14;
+                let mut _7: bool;
+                let _9: usize;
+                let mut _10: usize;
+                let mut _15: &usize;
+                let mut _16: &usize;
                 scope 6 {
-                    debug old => _7;
+                    debug old => _9;
                     scope 7 {
                     }
                 }
                 scope 8 (inlined cmp::impls::<impl PartialOrd for usize>::lt) {
-                    debug self => &_3;
-                    debug other => &_2;
-                    let mut _4: usize;
+                    debug self => _15;
+                    debug other => _16;
+                    let mut _5: usize;
+                    let mut _6: usize;
                 }
             }
         }
     }
     scope 3 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
-        debug self => std::ops::Range<usize>{ .0 => _1, .1 => _2, };
+        debug self => _3;
     }
 
     bb0: {
-        StorageLive(_3);
-        _3 = _1;
+        _3 = std::ops::Range::<usize> { start: _1, end: _2 };
+        StorageLive(_4);
+        _4 = move _3;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_6);
+        StorageLive(_8);
+        StorageLive(_9);
         StorageLive(_7);
+        StorageLive(_15);
+        StorageLive(_16);
         StorageLive(_5);
-        StorageLive(_4);
-        _4 = _3;
-        _5 = Lt(move _4, _2);
-        StorageDead(_4);
-        switchInt(move _5) -> [0: bb2, otherwise: bb3];
+        _5 = (_4.0: usize);
+        StorageLive(_6);
+        _6 = (_4.1: usize);
+        _7 = Lt(move _5, move _6);
+        StorageDead(_6);
+        StorageDead(_5);
+        StorageDead(_16);
+        StorageDead(_15);
+        switchInt(move _7) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _6 = Option::<usize>::None;
+        _8 = Option::<usize>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _7 = _3;
-        StorageLive(_8);
-        _8 = <usize as Step>::forward_unchecked(_7, const 1_usize) -> [return: bb4, unwind continue];
+        _9 = (_4.0: usize);
+        StorageLive(_10);
+        _10 = <usize as Step>::forward_unchecked(_9, const 1_usize) -> [return: bb4, unwind continue];
     }
 
     bb4: {
-        _3 = move _8;
-        StorageDead(_8);
-        _6 = Option::<usize>::Some(_7);
+        (_4.0: usize) = move _10;
+        StorageDead(_10);
+        _8 = Option::<usize>::Some(_9);
         goto -> bb5;
     }
 
     bb5: {
-        StorageDead(_5);
         StorageDead(_7);
-        _9 = discriminant(_6);
-        switchInt(move _9) -> [0: bb6, 1: bb7, otherwise: bb9];
+        StorageDead(_9);
+        _11 = discriminant(_8);
+        switchInt(move _11) -> [0: bb6, 1: bb7, otherwise: bb9];
     }
 
     bb6: {
-        StorageDead(_6);
-        StorageDead(_3);
+        StorageDead(_8);
+        StorageDead(_4);
         return;
     }
 
     bb7: {
-        _10 = ((_6 as Some).0: usize);
-        _11 = opaque::<usize>(move _10) -> [return: bb8, unwind continue];
+        _12 = ((_8 as Some).0: usize);
+        _13 = opaque::<usize>(move _12) -> [return: bb8, unwind continue];
     }
 
     bb8: {
-        StorageDead(_6);
+        StorageDead(_8);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -5,87 +5,100 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     debug end => _2;
     debug f => _3;
     let mut _0: ();
-    let mut _4: u32;
-    let mut _7: std::option::Option<u32>;
-    let mut _10: isize;
-    let mut _12: &impl Fn(u32);
-    let mut _13: (u32,);
-    let _14: ();
+    let mut _4: std::ops::Range<u32>;
+    let mut _5: std::ops::Range<u32>;
+    let mut _9: std::option::Option<u32>;
+    let mut _12: isize;
+    let mut _14: &impl Fn(u32);
+    let mut _15: (u32,);
+    let _16: ();
+    let mut _17: &mut std::ops::Range<u32>;
     scope 1 {
-        debug iter => std::ops::Range<u32>{ .0 => _4, .1 => _2, };
-        let _11: u32;
+        debug iter => _5;
+        let _13: u32;
         scope 2 {
-            debug x => _11;
+            debug x => _13;
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) {
-            debug self => &std::ops::Range<u32>{ .0 => _4, .1 => _2, };
+            debug self => _17;
             scope 5 (inlined <std::ops::Range<u32> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => &std::ops::Range<u32>{ .0 => _4, .1 => _2, };
-                let mut _6: bool;
-                let _8: u32;
-                let mut _9: u32;
+                debug self => _17;
+                let mut _8: bool;
+                let _10: u32;
+                let mut _11: u32;
+                let mut _18: &u32;
+                let mut _19: &u32;
                 scope 6 {
-                    debug old => _8;
+                    debug old => _10;
                     scope 7 {
                     }
                 }
                 scope 8 (inlined cmp::impls::<impl PartialOrd for u32>::lt) {
-                    debug self => &_4;
-                    debug other => &_2;
-                    let mut _5: u32;
+                    debug self => _18;
+                    debug other => _19;
+                    let mut _6: u32;
+                    let mut _7: u32;
                 }
             }
         }
     }
     scope 3 (inlined <std::ops::Range<u32> as IntoIterator>::into_iter) {
-        debug self => std::ops::Range<u32>{ .0 => _1, .1 => _2, };
+        debug self => _4;
     }
 
     bb0: {
-        StorageLive(_4);
-        _4 = _1;
+        _4 = std::ops::Range::<u32> { start: _1, end: _2 };
+        StorageLive(_5);
+        _5 = move _4;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_7);
+        StorageLive(_9);
+        StorageLive(_10);
         StorageLive(_8);
+        StorageLive(_18);
+        StorageLive(_19);
         StorageLive(_6);
-        StorageLive(_5);
-        _5 = _4;
-        _6 = Lt(move _5, _2);
-        StorageDead(_5);
-        switchInt(move _6) -> [0: bb2, otherwise: bb3];
+        _6 = (_5.0: u32);
+        StorageLive(_7);
+        _7 = (_5.1: u32);
+        _8 = Lt(move _6, move _7);
+        StorageDead(_7);
+        StorageDead(_6);
+        StorageDead(_19);
+        StorageDead(_18);
+        switchInt(move _8) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _7 = Option::<u32>::None;
+        _9 = Option::<u32>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _8 = _4;
-        StorageLive(_9);
-        _9 = <u32 as Step>::forward_unchecked(_8, const 1_usize) -> [return: bb4, unwind unreachable];
+        _10 = (_5.0: u32);
+        StorageLive(_11);
+        _11 = <u32 as Step>::forward_unchecked(_10, const 1_usize) -> [return: bb4, unwind unreachable];
     }
 
     bb4: {
-        _4 = move _9;
-        StorageDead(_9);
-        _7 = Option::<u32>::Some(_8);
+        (_5.0: u32) = move _11;
+        StorageDead(_11);
+        _9 = Option::<u32>::Some(_10);
         goto -> bb5;
     }
 
     bb5: {
-        StorageDead(_6);
         StorageDead(_8);
-        _10 = discriminant(_7);
-        switchInt(move _10) -> [0: bb6, 1: bb8, otherwise: bb10];
+        StorageDead(_10);
+        _12 = discriminant(_9);
+        switchInt(move _12) -> [0: bb6, 1: bb8, otherwise: bb10];
     }
 
     bb6: {
-        StorageDead(_7);
-        StorageDead(_4);
+        StorageDead(_9);
+        StorageDead(_5);
         drop(_3) -> [return: bb7, unwind unreachable];
     }
 
@@ -94,18 +107,18 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb8: {
-        _11 = ((_7 as Some).0: u32);
-        StorageLive(_12);
-        _12 = &_3;
-        StorageLive(_13);
-        _13 = (_11,);
-        _14 = <impl Fn(u32) as Fn<(u32,)>>::call(move _12, move _13) -> [return: bb9, unwind unreachable];
+        _13 = ((_9 as Some).0: u32);
+        StorageLive(_14);
+        _14 = &_3;
+        StorageLive(_15);
+        _15 = (_13,);
+        _16 = <impl Fn(u32) as Fn<(u32,)>>::call(move _14, move _15) -> [return: bb9, unwind unreachable];
     }
 
     bb9: {
-        StorageDead(_13);
-        StorageDead(_12);
-        StorageDead(_7);
+        StorageDead(_15);
+        StorageDead(_14);
+        StorageDead(_9);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -5,87 +5,100 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     debug end => _2;
     debug f => _3;
     let mut _0: ();
-    let mut _4: u32;
-    let mut _7: std::option::Option<u32>;
-    let mut _10: isize;
-    let mut _12: &impl Fn(u32);
-    let mut _13: (u32,);
-    let _14: ();
+    let mut _4: std::ops::Range<u32>;
+    let mut _5: std::ops::Range<u32>;
+    let mut _9: std::option::Option<u32>;
+    let mut _12: isize;
+    let mut _14: &impl Fn(u32);
+    let mut _15: (u32,);
+    let _16: ();
+    let mut _17: &mut std::ops::Range<u32>;
     scope 1 {
-        debug iter => std::ops::Range<u32>{ .0 => _4, .1 => _2, };
-        let _11: u32;
+        debug iter => _5;
+        let _13: u32;
         scope 2 {
-            debug x => _11;
+            debug x => _13;
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) {
-            debug self => &std::ops::Range<u32>{ .0 => _4, .1 => _2, };
+            debug self => _17;
             scope 5 (inlined <std::ops::Range<u32> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => &std::ops::Range<u32>{ .0 => _4, .1 => _2, };
-                let mut _6: bool;
-                let _8: u32;
-                let mut _9: u32;
+                debug self => _17;
+                let mut _8: bool;
+                let _10: u32;
+                let mut _11: u32;
+                let mut _18: &u32;
+                let mut _19: &u32;
                 scope 6 {
-                    debug old => _8;
+                    debug old => _10;
                     scope 7 {
                     }
                 }
                 scope 8 (inlined cmp::impls::<impl PartialOrd for u32>::lt) {
-                    debug self => &_4;
-                    debug other => &_2;
-                    let mut _5: u32;
+                    debug self => _18;
+                    debug other => _19;
+                    let mut _6: u32;
+                    let mut _7: u32;
                 }
             }
         }
     }
     scope 3 (inlined <std::ops::Range<u32> as IntoIterator>::into_iter) {
-        debug self => std::ops::Range<u32>{ .0 => _1, .1 => _2, };
+        debug self => _4;
     }
 
     bb0: {
-        StorageLive(_4);
-        _4 = _1;
+        _4 = std::ops::Range::<u32> { start: _1, end: _2 };
+        StorageLive(_5);
+        _5 = move _4;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_7);
+        StorageLive(_9);
+        StorageLive(_10);
         StorageLive(_8);
+        StorageLive(_18);
+        StorageLive(_19);
         StorageLive(_6);
-        StorageLive(_5);
-        _5 = _4;
-        _6 = Lt(move _5, _2);
-        StorageDead(_5);
-        switchInt(move _6) -> [0: bb2, otherwise: bb3];
+        _6 = (_5.0: u32);
+        StorageLive(_7);
+        _7 = (_5.1: u32);
+        _8 = Lt(move _6, move _7);
+        StorageDead(_7);
+        StorageDead(_6);
+        StorageDead(_19);
+        StorageDead(_18);
+        switchInt(move _8) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _7 = Option::<u32>::None;
+        _9 = Option::<u32>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _8 = _4;
-        StorageLive(_9);
-        _9 = <u32 as Step>::forward_unchecked(_8, const 1_usize) -> [return: bb4, unwind: bb11];
+        _10 = (_5.0: u32);
+        StorageLive(_11);
+        _11 = <u32 as Step>::forward_unchecked(_10, const 1_usize) -> [return: bb4, unwind: bb11];
     }
 
     bb4: {
-        _4 = move _9;
-        StorageDead(_9);
-        _7 = Option::<u32>::Some(_8);
+        (_5.0: u32) = move _11;
+        StorageDead(_11);
+        _9 = Option::<u32>::Some(_10);
         goto -> bb5;
     }
 
     bb5: {
-        StorageDead(_6);
         StorageDead(_8);
-        _10 = discriminant(_7);
-        switchInt(move _10) -> [0: bb6, 1: bb8, otherwise: bb10];
+        StorageDead(_10);
+        _12 = discriminant(_9);
+        switchInt(move _12) -> [0: bb6, 1: bb8, otherwise: bb10];
     }
 
     bb6: {
-        StorageDead(_7);
-        StorageDead(_4);
+        StorageDead(_9);
+        StorageDead(_5);
         drop(_3) -> [return: bb7, unwind continue];
     }
 
@@ -94,18 +107,18 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb8: {
-        _11 = ((_7 as Some).0: u32);
-        StorageLive(_12);
-        _12 = &_3;
-        StorageLive(_13);
-        _13 = (_11,);
-        _14 = <impl Fn(u32) as Fn<(u32,)>>::call(move _12, move _13) -> [return: bb9, unwind: bb11];
+        _13 = ((_9 as Some).0: u32);
+        StorageLive(_14);
+        _14 = &_3;
+        StorageLive(_15);
+        _15 = (_13,);
+        _16 = <impl Fn(u32) as Fn<(u32,)>>::call(move _14, move _15) -> [return: bb9, unwind: bb11];
     }
 
     bb9: {
-        StorageDead(_13);
-        StorageDead(_12);
-        StorageDead(_7);
+        StorageDead(_15);
+        StorageDead(_14);
+        StorageDead(_9);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-abort.mir
@@ -10,14 +10,16 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
             let mut _4: bool;
             let _5: u32;
             let mut _6: u32;
+            let mut _7: &u32;
+            let mut _8: &u32;
             scope 3 {
                 debug old => _5;
                 scope 4 {
                 }
             }
             scope 5 (inlined cmp::impls::<impl PartialOrd for u32>::lt) {
-                debug self => &((*_1).0: u32);
-                debug other => &((*_1).1: u32);
+                debug self => _7;
+                debug other => _8;
                 let mut _2: u32;
                 let mut _3: u32;
             }
@@ -27,6 +29,8 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
     bb0: {
         StorageLive(_5);
         StorageLive(_4);
+        StorageLive(_7);
+        StorageLive(_8);
         StorageLive(_2);
         _2 = ((*_1).0: u32);
         StorageLive(_3);
@@ -34,6 +38,8 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
         _4 = Lt(move _2, move _3);
         StorageDead(_3);
         StorageDead(_2);
+        StorageDead(_8);
+        StorageDead(_7);
         switchInt(move _4) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
@@ -10,14 +10,16 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
             let mut _4: bool;
             let _5: u32;
             let mut _6: u32;
+            let mut _7: &u32;
+            let mut _8: &u32;
             scope 3 {
                 debug old => _5;
                 scope 4 {
                 }
             }
             scope 5 (inlined cmp::impls::<impl PartialOrd for u32>::lt) {
-                debug self => &((*_1).0: u32);
-                debug other => &((*_1).1: u32);
+                debug self => _7;
+                debug other => _8;
                 let mut _2: u32;
                 let mut _3: u32;
             }
@@ -27,6 +29,8 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
     bb0: {
         StorageLive(_5);
         StorageLive(_4);
+        StorageLive(_7);
+        StorageLive(_8);
         StorageLive(_2);
         _2 = ((*_1).0: u32);
         StorageLive(_3);
@@ -34,6 +38,8 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
         _4 = Lt(move _2, move _3);
         StorageDead(_3);
         StorageDead(_2);
+        StorageDead(_8);
+        StorageDead(_7);
         switchInt(move _4) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
@@ -3,138 +3,206 @@
 fn variant_a::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:7:25: 7:39], _2: &&(usize, usize, usize, usize)) -> bool {
     let mut _0: bool;
     let mut _3: &(usize, usize, usize, usize);
-    let mut _4: &(usize, usize, usize, usize);
+    let _4: &usize;
     let mut _5: &(usize, usize, usize, usize);
-    let mut _6: &(usize, usize, usize, usize);
-    let mut _9: bool;
-    let mut _10: bool;
-    let mut _13: bool;
+    let _6: &usize;
+    let mut _7: &(usize, usize, usize, usize);
+    let _8: &usize;
+    let mut _9: &(usize, usize, usize, usize);
+    let _10: &usize;
+    let _11: &usize;
     let mut _16: bool;
     let mut _17: bool;
-    let mut _20: bool;
+    let _18: &usize;
+    let mut _23: bool;
+    let _24: &usize;
+    let mut _29: bool;
+    let mut _30: bool;
+    let _31: &usize;
+    let mut _36: bool;
+    let mut _37: &&usize;
+    let mut _38: &&usize;
+    let mut _39: &&usize;
+    let mut _40: &&usize;
+    let mut _41: &&usize;
+    let mut _42: &&usize;
+    let mut _43: &&usize;
+    let mut _44: &&usize;
     scope 1 {
-        debug a => &((*_3).0: usize);
-        debug b => &((*_4).1: usize);
-        debug c => &((*_5).2: usize);
-        debug d => &((*_6).3: usize);
+        debug a => _4;
+        debug b => _6;
+        debug c => _8;
+        debug d => _10;
         scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
-            debug self => &&((*_3).0: usize);
-            debug other => &&((*_5).2: usize);
+            debug self => _37;
+            debug other => _38;
+            let mut _12: &usize;
+            let mut _13: &usize;
             scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
-                debug self => &((*_3).0: usize);
-                debug other => &((*_5).2: usize);
-                let mut _7: usize;
-                let mut _8: usize;
-            }
-        }
-        scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
-            debug self => &&((*_5).2: usize);
-            debug other => &&((*_3).0: usize);
-            scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
-                debug self => &((*_5).2: usize);
-                debug other => &((*_3).0: usize);
+                debug self => _12;
+                debug other => _13;
                 let mut _14: usize;
                 let mut _15: usize;
             }
         }
+        scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
+            debug self => _41;
+            debug other => _42;
+            let mut _25: &usize;
+            let mut _26: &usize;
+            scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
+                debug self => _25;
+                debug other => _26;
+                let mut _27: usize;
+                let mut _28: usize;
+            }
+        }
         scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
-            debug self => &&((*_6).3: usize);
-            debug other => &&((*_4).1: usize);
+            debug self => _39;
+            debug other => _40;
+            let mut _19: &usize;
+            let mut _20: &usize;
             scope 7 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
-                debug self => &((*_6).3: usize);
-                debug other => &((*_4).1: usize);
-                let mut _11: usize;
-                let mut _12: usize;
+                debug self => _19;
+                debug other => _20;
+                let mut _21: usize;
+                let mut _22: usize;
             }
         }
         scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
-            debug self => &&((*_4).1: usize);
-            debug other => &&((*_6).3: usize);
+            debug self => _43;
+            debug other => _44;
+            let mut _32: &usize;
+            let mut _33: &usize;
             scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
-                debug self => &((*_4).1: usize);
-                debug other => &((*_6).3: usize);
-                let mut _18: usize;
-                let mut _19: usize;
+                debug self => _32;
+                debug other => _33;
+                let mut _34: usize;
+                let mut _35: usize;
             }
         }
     }
 
     bb0: {
+        StorageLive(_4);
         _3 = deref_copy (*_2);
-        _4 = deref_copy (*_2);
+        _4 = &((*_3).0: usize);
+        StorageLive(_6);
         _5 = deref_copy (*_2);
-        _6 = deref_copy (*_2);
-        StorageLive(_10);
-        StorageLive(_9);
-        StorageLive(_7);
-        _7 = ((*_3).0: usize);
+        _6 = &((*_5).1: usize);
         StorageLive(_8);
-        _8 = ((*_5).2: usize);
-        _9 = Le(move _7, move _8);
-        StorageDead(_8);
-        StorageDead(_7);
-        switchInt(move _9) -> [0: bb1, otherwise: bb2];
+        _7 = deref_copy (*_2);
+        _8 = &((*_7).2: usize);
+        StorageLive(_10);
+        _9 = deref_copy (*_2);
+        _10 = &((*_9).3: usize);
+        StorageLive(_17);
+        StorageLive(_16);
+        StorageLive(_37);
+        StorageLive(_38);
+        StorageLive(_11);
+        _11 = _8;
+        _12 = deref_copy _4;
+        _13 = deref_copy _11;
+        StorageLive(_14);
+        _14 = (*_12);
+        StorageLive(_15);
+        _15 = (*_13);
+        _16 = Le(move _14, move _15);
+        StorageDead(_15);
+        StorageDead(_14);
+        StorageDead(_11);
+        StorageDead(_38);
+        StorageDead(_37);
+        switchInt(move _16) -> [0: bb1, otherwise: bb2];
     }
 
     bb1: {
-        _10 = const false;
+        _17 = const false;
         goto -> bb3;
     }
 
     bb2: {
-        StorageLive(_13);
-        StorageLive(_11);
-        _11 = ((*_6).3: usize);
-        StorageLive(_12);
-        _12 = ((*_4).1: usize);
-        _13 = Le(move _11, move _12);
-        StorageDead(_12);
-        StorageDead(_11);
-        _10 = move _13;
+        StorageLive(_23);
+        StorageLive(_39);
+        StorageLive(_40);
+        StorageLive(_18);
+        _18 = _6;
+        _19 = deref_copy _10;
+        _20 = deref_copy _18;
+        StorageLive(_21);
+        _21 = (*_19);
+        StorageLive(_22);
+        _22 = (*_20);
+        _23 = Le(move _21, move _22);
+        StorageDead(_22);
+        StorageDead(_21);
+        StorageDead(_18);
+        StorageDead(_40);
+        StorageDead(_39);
+        _17 = move _23;
         goto -> bb3;
     }
 
     bb3: {
-        StorageDead(_13);
-        StorageDead(_9);
-        switchInt(move _10) -> [0: bb4, otherwise: bb8];
+        StorageDead(_23);
+        StorageDead(_16);
+        switchInt(move _17) -> [0: bb4, otherwise: bb8];
     }
 
     bb4: {
-        StorageLive(_17);
-        StorageLive(_16);
-        StorageLive(_14);
-        _14 = ((*_5).2: usize);
-        StorageLive(_15);
-        _15 = ((*_3).0: usize);
-        _16 = Le(move _14, move _15);
-        StorageDead(_15);
-        StorageDead(_14);
-        switchInt(move _16) -> [0: bb5, otherwise: bb6];
+        StorageLive(_30);
+        StorageLive(_29);
+        StorageLive(_41);
+        StorageLive(_42);
+        StorageLive(_24);
+        _24 = _4;
+        _25 = deref_copy _8;
+        _26 = deref_copy _24;
+        StorageLive(_27);
+        _27 = (*_25);
+        StorageLive(_28);
+        _28 = (*_26);
+        _29 = Le(move _27, move _28);
+        StorageDead(_28);
+        StorageDead(_27);
+        StorageDead(_24);
+        StorageDead(_42);
+        StorageDead(_41);
+        switchInt(move _29) -> [0: bb5, otherwise: bb6];
     }
 
     bb5: {
-        _17 = const false;
+        _30 = const false;
         goto -> bb7;
     }
 
     bb6: {
-        StorageLive(_20);
-        StorageLive(_18);
-        _18 = ((*_4).1: usize);
-        StorageLive(_19);
-        _19 = ((*_6).3: usize);
-        _20 = Le(move _18, move _19);
-        StorageDead(_19);
-        StorageDead(_18);
-        _17 = move _20;
+        StorageLive(_36);
+        StorageLive(_43);
+        StorageLive(_44);
+        StorageLive(_31);
+        _31 = _10;
+        _32 = deref_copy _6;
+        _33 = deref_copy _31;
+        StorageLive(_34);
+        _34 = (*_32);
+        StorageLive(_35);
+        _35 = (*_33);
+        _36 = Le(move _34, move _35);
+        StorageDead(_35);
+        StorageDead(_34);
+        StorageDead(_31);
+        StorageDead(_44);
+        StorageDead(_43);
+        _30 = move _36;
         goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_20);
-        StorageDead(_16);
-        _0 = move _17;
+        StorageDead(_36);
+        StorageDead(_29);
+        _0 = move _30;
         goto -> bb9;
     }
 
@@ -144,8 +212,12 @@ fn variant_a::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:7:25: 7:39], _2
     }
 
     bb9: {
+        StorageDead(_30);
         StorageDead(_17);
         StorageDead(_10);
+        StorageDead(_8);
+        StorageDead(_6);
+        StorageDead(_4);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-abort.mir
@@ -5,95 +5,109 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     debug f => _2;
     let mut _0: ();
     let mut _3: usize;
-    let mut _4: usize;
-    let mut _7: std::option::Option<usize>;
-    let mut _10: isize;
-    let mut _12: usize;
-    let mut _13: bool;
-    let mut _15: &impl Fn(usize, &T);
-    let mut _16: (usize, &T);
-    let _17: ();
-    let mut _18: usize;
+    let mut _4: std::ops::Range<usize>;
+    let mut _5: std::ops::Range<usize>;
+    let mut _9: std::option::Option<usize>;
+    let mut _12: isize;
+    let mut _14: usize;
+    let mut _15: bool;
+    let mut _17: &impl Fn(usize, &T);
+    let mut _18: (usize, &T);
+    let _19: ();
+    let mut _20: &mut std::ops::Range<usize>;
     scope 1 {
-        debug iter => std::ops::Range<usize>{ .0 => _4, .1 => _3, };
-        let _11: usize;
+        debug iter => _5;
+        let _13: usize;
         scope 2 {
-            debug i => _11;
-            let _14: &T;
+            debug i => _13;
+            let _16: &T;
             scope 3 {
-                debug x => _14;
+                debug x => _16;
             }
         }
         scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
-            debug self => &std::ops::Range<usize>{ .0 => _4, .1 => _3, };
+            debug self => _20;
             scope 6 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => &std::ops::Range<usize>{ .0 => _4, .1 => _3, };
-                let mut _6: bool;
-                let _8: usize;
-                let mut _9: usize;
+                debug self => _20;
+                let mut _8: bool;
+                let _10: usize;
+                let mut _11: usize;
+                let mut _21: &usize;
+                let mut _22: &usize;
                 scope 7 {
-                    debug old => _8;
+                    debug old => _10;
                     scope 8 {
                     }
                 }
                 scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::lt) {
-                    debug self => &_4;
-                    debug other => &_3;
-                    let mut _5: usize;
+                    debug self => _21;
+                    debug other => _22;
+                    let mut _6: usize;
+                    let mut _7: usize;
                 }
             }
         }
     }
     scope 4 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
-        debug self => std::ops::Range<usize>{ .0 => _18, .1 => _3, };
+        debug self => _4;
     }
 
     bb0: {
+        StorageLive(_3);
         _3 = Len((*_1));
-        StorageLive(_4);
-        _4 = const 0_usize;
+        _4 = std::ops::Range::<usize> { start: const 0_usize, end: move _3 };
+        StorageDead(_3);
+        StorageLive(_5);
+        _5 = move _4;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_7);
+        StorageLive(_9);
+        StorageLive(_10);
         StorageLive(_8);
+        StorageLive(_21);
+        StorageLive(_22);
         StorageLive(_6);
-        StorageLive(_5);
-        _5 = _4;
-        _6 = Lt(move _5, _3);
-        StorageDead(_5);
-        switchInt(move _6) -> [0: bb2, otherwise: bb3];
+        _6 = (_5.0: usize);
+        StorageLive(_7);
+        _7 = (_5.1: usize);
+        _8 = Lt(move _6, move _7);
+        StorageDead(_7);
+        StorageDead(_6);
+        StorageDead(_22);
+        StorageDead(_21);
+        switchInt(move _8) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _7 = Option::<usize>::None;
+        _9 = Option::<usize>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _8 = _4;
-        StorageLive(_9);
-        _9 = <usize as Step>::forward_unchecked(_8, const 1_usize) -> [return: bb4, unwind unreachable];
+        _10 = (_5.0: usize);
+        StorageLive(_11);
+        _11 = <usize as Step>::forward_unchecked(_10, const 1_usize) -> [return: bb4, unwind unreachable];
     }
 
     bb4: {
-        _4 = move _9;
-        StorageDead(_9);
-        _7 = Option::<usize>::Some(_8);
+        (_5.0: usize) = move _11;
+        StorageDead(_11);
+        _9 = Option::<usize>::Some(_10);
         goto -> bb5;
     }
 
     bb5: {
-        StorageDead(_6);
         StorageDead(_8);
-        _10 = discriminant(_7);
-        switchInt(move _10) -> [0: bb6, 1: bb8, otherwise: bb11];
+        StorageDead(_10);
+        _12 = discriminant(_9);
+        switchInt(move _12) -> [0: bb6, 1: bb8, otherwise: bb11];
     }
 
     bb6: {
-        StorageDead(_7);
-        StorageDead(_4);
+        StorageDead(_9);
+        StorageDead(_5);
         drop(_2) -> [return: bb7, unwind unreachable];
     }
 
@@ -102,25 +116,25 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb8: {
-        _11 = ((_7 as Some).0: usize);
-        _12 = Len((*_1));
-        _13 = Lt(_11, _12);
-        assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> [success: bb9, unwind unreachable];
+        _13 = ((_9 as Some).0: usize);
+        _14 = Len((*_1));
+        _15 = Lt(_13, _14);
+        assert(move _15, "index out of bounds: the length is {} but the index is {}", move _14, _13) -> [success: bb9, unwind unreachable];
     }
 
     bb9: {
-        _14 = &(*_1)[_11];
-        StorageLive(_15);
-        _15 = &_2;
-        StorageLive(_16);
-        _16 = (_11, _14);
-        _17 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _15, move _16) -> [return: bb10, unwind unreachable];
+        _16 = &(*_1)[_13];
+        StorageLive(_17);
+        _17 = &_2;
+        StorageLive(_18);
+        _18 = (_13, _16);
+        _19 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _17, move _18) -> [return: bb10, unwind unreachable];
     }
 
     bb10: {
-        StorageDead(_16);
-        StorageDead(_15);
-        StorageDead(_7);
+        StorageDead(_18);
+        StorageDead(_17);
+        StorageDead(_9);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
@@ -5,95 +5,109 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     debug f => _2;
     let mut _0: ();
     let mut _3: usize;
-    let mut _4: usize;
-    let mut _7: std::option::Option<usize>;
-    let mut _10: isize;
-    let mut _12: usize;
-    let mut _13: bool;
-    let mut _15: &impl Fn(usize, &T);
-    let mut _16: (usize, &T);
-    let _17: ();
-    let mut _18: usize;
+    let mut _4: std::ops::Range<usize>;
+    let mut _5: std::ops::Range<usize>;
+    let mut _9: std::option::Option<usize>;
+    let mut _12: isize;
+    let mut _14: usize;
+    let mut _15: bool;
+    let mut _17: &impl Fn(usize, &T);
+    let mut _18: (usize, &T);
+    let _19: ();
+    let mut _20: &mut std::ops::Range<usize>;
     scope 1 {
-        debug iter => std::ops::Range<usize>{ .0 => _4, .1 => _3, };
-        let _11: usize;
+        debug iter => _5;
+        let _13: usize;
         scope 2 {
-            debug i => _11;
-            let _14: &T;
+            debug i => _13;
+            let _16: &T;
             scope 3 {
-                debug x => _14;
+                debug x => _16;
             }
         }
         scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
-            debug self => &std::ops::Range<usize>{ .0 => _4, .1 => _3, };
+            debug self => _20;
             scope 6 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => &std::ops::Range<usize>{ .0 => _4, .1 => _3, };
-                let mut _6: bool;
-                let _8: usize;
-                let mut _9: usize;
+                debug self => _20;
+                let mut _8: bool;
+                let _10: usize;
+                let mut _11: usize;
+                let mut _21: &usize;
+                let mut _22: &usize;
                 scope 7 {
-                    debug old => _8;
+                    debug old => _10;
                     scope 8 {
                     }
                 }
                 scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::lt) {
-                    debug self => &_4;
-                    debug other => &_3;
-                    let mut _5: usize;
+                    debug self => _21;
+                    debug other => _22;
+                    let mut _6: usize;
+                    let mut _7: usize;
                 }
             }
         }
     }
     scope 4 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
-        debug self => std::ops::Range<usize>{ .0 => _18, .1 => _3, };
+        debug self => _4;
     }
 
     bb0: {
+        StorageLive(_3);
         _3 = Len((*_1));
-        StorageLive(_4);
-        _4 = const 0_usize;
+        _4 = std::ops::Range::<usize> { start: const 0_usize, end: move _3 };
+        StorageDead(_3);
+        StorageLive(_5);
+        _5 = move _4;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_7);
+        StorageLive(_9);
+        StorageLive(_10);
         StorageLive(_8);
+        StorageLive(_21);
+        StorageLive(_22);
         StorageLive(_6);
-        StorageLive(_5);
-        _5 = _4;
-        _6 = Lt(move _5, _3);
-        StorageDead(_5);
-        switchInt(move _6) -> [0: bb2, otherwise: bb3];
+        _6 = (_5.0: usize);
+        StorageLive(_7);
+        _7 = (_5.1: usize);
+        _8 = Lt(move _6, move _7);
+        StorageDead(_7);
+        StorageDead(_6);
+        StorageDead(_22);
+        StorageDead(_21);
+        switchInt(move _8) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _7 = Option::<usize>::None;
+        _9 = Option::<usize>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _8 = _4;
-        StorageLive(_9);
-        _9 = <usize as Step>::forward_unchecked(_8, const 1_usize) -> [return: bb4, unwind: bb12];
+        _10 = (_5.0: usize);
+        StorageLive(_11);
+        _11 = <usize as Step>::forward_unchecked(_10, const 1_usize) -> [return: bb4, unwind: bb12];
     }
 
     bb4: {
-        _4 = move _9;
-        StorageDead(_9);
-        _7 = Option::<usize>::Some(_8);
+        (_5.0: usize) = move _11;
+        StorageDead(_11);
+        _9 = Option::<usize>::Some(_10);
         goto -> bb5;
     }
 
     bb5: {
-        StorageDead(_6);
         StorageDead(_8);
-        _10 = discriminant(_7);
-        switchInt(move _10) -> [0: bb6, 1: bb8, otherwise: bb11];
+        StorageDead(_10);
+        _12 = discriminant(_9);
+        switchInt(move _12) -> [0: bb6, 1: bb8, otherwise: bb11];
     }
 
     bb6: {
-        StorageDead(_7);
-        StorageDead(_4);
+        StorageDead(_9);
+        StorageDead(_5);
         drop(_2) -> [return: bb7, unwind continue];
     }
 
@@ -102,25 +116,25 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb8: {
-        _11 = ((_7 as Some).0: usize);
-        _12 = Len((*_1));
-        _13 = Lt(_11, _12);
-        assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> [success: bb9, unwind: bb12];
+        _13 = ((_9 as Some).0: usize);
+        _14 = Len((*_1));
+        _15 = Lt(_13, _14);
+        assert(move _15, "index out of bounds: the length is {} but the index is {}", move _14, _13) -> [success: bb9, unwind: bb12];
     }
 
     bb9: {
-        _14 = &(*_1)[_11];
-        StorageLive(_15);
-        _15 = &_2;
-        StorageLive(_16);
-        _16 = (_11, _14);
-        _17 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _15, move _16) -> [return: bb10, unwind: bb12];
+        _16 = &(*_1)[_13];
+        StorageLive(_17);
+        _17 = &_2;
+        StorageLive(_18);
+        _18 = (_13, _16);
+        _19 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _17, move _18) -> [return: bb10, unwind: bb12];
     }
 
     bb10: {
-        StorageDead(_16);
-        StorageDead(_15);
-        StorageDead(_7);
+        StorageDead(_18);
+        StorageDead(_17);
+        StorageDead(_9);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -12,6 +12,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     let mut _20: &impl Fn(&T);
     let mut _21: (&T,);
     let _22: ();
+    let mut _23: &mut std::iter::Rev<std::slice::Iter<'_, T>>;
     scope 1 {
         debug iter => _15;
         let _19: &T;
@@ -19,7 +20,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             debug x => _19;
         }
         scope 25 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
-            debug self => &_15;
+            debug self => _23;
             let mut _16: &mut std::slice::Iter<'_, T>;
         }
     }
@@ -48,15 +49,15 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                                     debug ptr => _9;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
                                         debug self => _9;
-                                        let mut _23: *mut u8;
+                                        let mut _24: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _23;
+                                                debug ptr => _24;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _23;
+                                                    debug self => _24;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _23;
+                                                            debug self => _24;
                                                         }
                                                     }
                                                 }
@@ -131,10 +132,10 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageLive(_9);
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
-        StorageLive(_23);
+        StorageLive(_24);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
-        StorageDead(_23);
+        StorageDead(_24);
         StorageDead(_10);
         StorageDead(_9);
         StorageLive(_12);

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -12,6 +12,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     let mut _20: &impl Fn(&T);
     let mut _21: (&T,);
     let _22: ();
+    let mut _23: &mut std::iter::Rev<std::slice::Iter<'_, T>>;
     scope 1 {
         debug iter => _15;
         let _19: &T;
@@ -19,7 +20,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             debug x => _19;
         }
         scope 25 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
-            debug self => &_15;
+            debug self => _23;
             let mut _16: &mut std::slice::Iter<'_, T>;
         }
     }
@@ -48,15 +49,15 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                                     debug ptr => _9;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
                                         debug self => _9;
-                                        let mut _23: *mut u8;
+                                        let mut _24: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _23;
+                                                debug ptr => _24;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _23;
+                                                    debug self => _24;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _23;
+                                                            debug self => _24;
                                                         }
                                                     }
                                                 }
@@ -131,10 +132,10 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageLive(_9);
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
-        StorageLive(_23);
+        StorageLive(_24);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
-        StorageDead(_23);
+        StorageDead(_24);
         StorageDead(_10);
         StorageDead(_9);
         StorageLive(_12);

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -22,27 +22,23 @@
       let _24: &mut u8;
       let mut _25: debuginfo::T;
       scope 1 {
--         debug ref_mut_u8 => _1;
-+         debug ref_mut_u8 => &_2;
+          debug ref_mut_u8 => _1;
           let _3: &u8;
           let mut _28: &debuginfo::T;
           scope 2 {
--             debug field => _3;
-+             debug field => &((*_28).0: u8);
+              debug field => _3;
               let _5: &u8;
               scope 3 {
 -                 debug reborrow => _5;
-+                 debug reborrow => &_2;
++                 debug reborrow => _1;
                   let _9: &i32;
                   let _22: &&&mut u8;
                   let mut _27: &std::option::Option<i32>;
                   scope 4 {
--                     debug variant_field => _9;
-+                     debug variant_field => &(((*_27) as Some).0: i32);
+                      debug variant_field => _9;
                   }
                   scope 5 {
--                     debug constant_index => _19;
-+                     debug constant_index => &(*_11)[1 of 3];
+                      debug constant_index => _19;
                       debug subslice => _20;
                       debug constant_index_from_end => _21;
                       let _19: &i32;
@@ -51,21 +47,20 @@
                       let mut _26: &[i32; 10];
                   }
                   scope 6 {
--                     debug multiple_borrow => _22;
-+                     debug multiple_borrow => &&&(_25.0: u8);
+                      debug multiple_borrow => _22;
                   }
               }
           }
       }
   
       bb0: {
--         StorageLive(_1);
+          StorageLive(_1);
           StorageLive(_2);
           _2 = const 5_u8;
--         _1 = &mut _2;
--         StorageLive(_3);
+          _1 = &mut _2;
+          StorageLive(_3);
           _28 = const _;
--         _3 = &((*_28).0: u8);
+          _3 = &((*_28).0: u8);
 -         StorageLive(_5);
 -         _5 = &(*_1);
 -         StorageLive(_6);
@@ -76,11 +71,11 @@
       }
   
       bb1: {
--         StorageLive(_9);
+          StorageLive(_9);
           _27 = const _;
--         _9 = &(((*_27) as Some).0: i32);
+          _9 = &(((*_27) as Some).0: i32);
 -         _6 = const ();
--         StorageDead(_9);
+          StorageDead(_9);
           goto -> bb4;
       }
   
@@ -118,8 +113,8 @@
       }
   
       bb6: {
--         StorageLive(_19);
--         _19 = &(*_11)[1 of 3];
+          StorageLive(_19);
+          _19 = &(*_11)[1 of 3];
           StorageLive(_20);
           _20 = &(*_11)[2:-1];
           StorageLive(_21);
@@ -127,7 +122,7 @@
 -         _10 = const ();
           StorageDead(_21);
           StorageDead(_20);
--         StorageDead(_19);
+          StorageDead(_19);
           goto -> bb8;
       }
   
@@ -140,23 +135,23 @@
           StorageDead(_12);
           StorageDead(_11);
 -         StorageDead(_10);
--         StorageLive(_22);
--         StorageLive(_23);
--         StorageLive(_24);
+          StorageLive(_22);
+          StorageLive(_23);
+          StorageLive(_24);
           StorageLive(_25);
           _25 = T(const 6_u8);
--         _24 = &mut (_25.0: u8);
--         _23 = &_24;
--         _22 = &_23;
+          _24 = &mut (_25.0: u8);
+          _23 = &_24;
+          _22 = &_23;
           _0 = const ();
           StorageDead(_25);
--         StorageDead(_24);
--         StorageDead(_23);
--         StorageDead(_22);
+          StorageDead(_24);
+          StorageDead(_23);
+          StorageDead(_22);
 -         StorageDead(_5);
--         StorageDead(_3);
+          StorageDead(_3);
           StorageDead(_2);
--         StorageDead(_1);
+          StorageDead(_1);
           return;
       }
   }

--- a/tests/mir-opt/reference_prop.mut_raw_then_mut_shr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.mut_raw_then_mut_shr.ReferencePropagation.diff
@@ -13,16 +13,15 @@
           debug x => _1;
           let _2: &mut i32;
           scope 2 {
--             debug xref => _2;
-+             debug xref => &_1;
+              debug xref => _2;
               let _3: *mut i32;
               scope 3 {
 -                 debug xraw => _3;
-+                 debug xraw => &_1;
++                 debug xraw => _2;
                   let _6: &i32;
                   scope 4 {
 -                     debug xshr => _6;
-+                     debug xshr => &_1;
++                     debug xshr => _2;
                       let _7: i32;
                       scope 5 {
                           debug a => _7;
@@ -38,7 +37,7 @@
           StorageLive(_1);
           _1 = const 2_i32;
 -         StorageLive(_2);
--         _2 = &mut _1;
+          _2 = &mut _1;
 -         StorageLive(_3);
 -         StorageLive(_4);
 -         StorageLive(_5);

--- a/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
@@ -52,8 +52,7 @@
           debug a => _4;
           let _5: &usize;
           scope 2 {
--             debug b => _5;
-+             debug b => &_4;
+              debug b => _5;
               let _6: usize;
               scope 3 {
                   debug c => _6;
@@ -158,12 +157,10 @@
           debug a => _60;
           let _61: &usize;
           scope 30 {
--             debug b => _61;
-+             debug b => &_60;
+              debug b => _61;
               let _62: &&usize;
               scope 31 {
--                 debug d => _62;
-+                 debug d => &&_60;
+                  debug d => _62;
                   let _63: usize;
                   scope 32 {
                       debug c => _63;
@@ -175,12 +172,10 @@
           debug a => _66;
           let mut _67: &usize;
           scope 34 {
--             debug b => _67;
-+             debug b => &_66;
+              debug b => _67;
               let _68: &mut &usize;
               scope 35 {
--                 debug d => _68;
-+                 debug d => &&_66;
+                  debug d => _68;
                   let _69: usize;
                   scope 36 {
                       debug c => _69;
@@ -193,8 +188,8 @@
 -         StorageLive(_3);
           StorageLive(_4);
           _4 = const 5_usize;
--         StorageLive(_5);
--         _5 = &_4;
+          StorageLive(_5);
+          _5 = &_4;
           StorageLive(_6);
 -         _6 = (*_5);
 +         _6 = _4;
@@ -209,7 +204,7 @@
           StorageDead(_7);
 -         _3 = const ();
           StorageDead(_6);
--         StorageDead(_5);
+          StorageDead(_5);
           StorageDead(_4);
 -         StorageDead(_3);
 -         StorageLive(_9);
@@ -394,13 +389,12 @@
 -         StorageLive(_59);
           StorageLive(_60);
           _60 = const 5_usize;
--         StorageLive(_61);
--         _61 = &_60;
--         StorageLive(_62);
--         _62 = &_61;
+          StorageLive(_61);
+          _61 = &_60;
+          StorageLive(_62);
+          _62 = &_61;
           StorageLive(_63);
--         _63 = (*_61);
-+         _63 = _60;
+          _63 = (*_61);
           StorageLive(_64);
           StorageLive(_65);
           _65 = ();
@@ -412,19 +406,18 @@
           StorageDead(_64);
 -         _59 = const ();
           StorageDead(_63);
--         StorageDead(_62);
--         StorageDead(_61);
+          StorageDead(_62);
+          StorageDead(_61);
           StorageDead(_60);
 -         StorageDead(_59);
           StorageLive(_66);
           _66 = const 5_usize;
--         StorageLive(_67);
--         _67 = &_66;
--         StorageLive(_68);
--         _68 = &mut _67;
+          StorageLive(_67);
+          _67 = &_66;
+          StorageLive(_68);
+          _68 = &mut _67;
           StorageLive(_69);
--         _69 = (*_67);
-+         _69 = _66;
+          _69 = (*_67);
           StorageLive(_70);
           StorageLive(_71);
           _71 = ();
@@ -436,8 +429,8 @@
           StorageDead(_70);
           _0 = const ();
           StorageDead(_69);
--         StorageDead(_68);
--         StorageDead(_67);
+          StorageDead(_68);
+          StorageDead(_67);
           StorageDead(_66);
           return;
       }

--- a/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
@@ -45,8 +45,7 @@
               debug a => _4;
               let _5: *const usize;
               scope 3 {
--                 debug b => _5;
-+                 debug b => &_4;
+                  debug b => _5;
                   let _6: usize;
                   scope 4 {
                       debug c => _6;
@@ -175,12 +174,10 @@
               debug a => _58;
               let _59: *const usize;
               scope 39 {
--                 debug b => _59;
-+                 debug b => &_58;
+                  debug b => _59;
                   let _60: *const usize;
                   scope 40 {
--                     debug c => _60;
-+                     debug c => &_58;
+                      debug c => _60;
                       let _61: usize;
                       scope 41 {
                           debug e => _61;
@@ -195,12 +192,10 @@
               debug a => _65;
               let _66: *const usize;
               scope 44 {
--                 debug b => _66;
-+                 debug b => &_65;
+                  debug b => _66;
                   let _67: &*const usize;
                   scope 45 {
--                     debug d => _67;
-+                     debug d => &&_65;
+                      debug d => _67;
                       let _68: usize;
                       scope 46 {
                           debug c => _68;
@@ -215,12 +210,10 @@
               debug a => _71;
               let mut _72: *const usize;
               scope 49 {
--                 debug b => _72;
-+                 debug b => &_71;
+                  debug b => _72;
                   let _73: &mut *const usize;
                   scope 50 {
--                     debug d => _73;
-+                     debug d => &&_71;
+                      debug d => _73;
                       let _74: usize;
                       scope 51 {
                           debug c => _74;
@@ -234,8 +227,8 @@
 -         StorageLive(_3);
           StorageLive(_4);
           _4 = const 5_usize;
--         StorageLive(_5);
--         _5 = &raw const _4;
+          StorageLive(_5);
+          _5 = &raw const _4;
           StorageLive(_6);
 -         _6 = (*_5);
 +         _6 = _4;
@@ -250,7 +243,7 @@
           StorageDead(_7);
 -         _3 = const ();
           StorageDead(_6);
--         StorageDead(_5);
+          StorageDead(_5);
           StorageDead(_4);
 -         StorageDead(_3);
 -         StorageLive(_9);
@@ -427,10 +420,11 @@
 -         StorageLive(_57);
           StorageLive(_58);
           _58 = const 13_usize;
--         StorageLive(_59);
--         _59 = &raw const _58;
--         StorageLive(_60);
+          StorageLive(_59);
+          _59 = &raw const _58;
+          StorageLive(_60);
 -         _60 = &raw const (*_59);
++         _60 = &raw const _58;
           StorageLive(_61);
 -         _61 = (*_60);
 +         _61 = _58;
@@ -445,20 +439,19 @@
           StorageDead(_62);
 -         _57 = const ();
           StorageDead(_61);
--         StorageDead(_60);
--         StorageDead(_59);
+          StorageDead(_60);
+          StorageDead(_59);
           StorageDead(_58);
 -         StorageDead(_57);
 -         StorageLive(_64);
           StorageLive(_65);
           _65 = const 5_usize;
--         StorageLive(_66);
--         _66 = &raw const _65;
--         StorageLive(_67);
--         _67 = &_66;
+          StorageLive(_66);
+          _66 = &raw const _65;
+          StorageLive(_67);
+          _67 = &_66;
           StorageLive(_68);
--         _68 = (*_66);
-+         _68 = _65;
+          _68 = (*_66);
           StorageLive(_69);
           StorageLive(_70);
           _70 = ();
@@ -470,19 +463,18 @@
           StorageDead(_69);
 -         _64 = const ();
           StorageDead(_68);
--         StorageDead(_67);
--         StorageDead(_66);
+          StorageDead(_67);
+          StorageDead(_66);
           StorageDead(_65);
 -         StorageDead(_64);
           StorageLive(_71);
           _71 = const 5_usize;
--         StorageLive(_72);
--         _72 = &raw const _71;
--         StorageLive(_73);
--         _73 = &mut _72;
+          StorageLive(_72);
+          _72 = &raw const _71;
+          StorageLive(_73);
+          _73 = &mut _72;
           StorageLive(_74);
--         _74 = (*_72);
-+         _74 = _71;
+          _74 = (*_72);
           StorageLive(_75);
           StorageLive(_76);
           _76 = ();
@@ -494,8 +486,8 @@
           StorageDead(_75);
           _0 = const ();
           StorageDead(_74);
--         StorageDead(_73);
--         StorageDead(_72);
+          StorageDead(_73);
+          StorageDead(_72);
           StorageDead(_71);
           return;
       }

--- a/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
@@ -52,8 +52,7 @@
           debug a => _4;
           let _5: &mut usize;
           scope 2 {
--             debug b => _5;
-+             debug b => &_4;
+              debug b => _5;
               let _6: usize;
               scope 3 {
                   debug c => _6;
@@ -158,12 +157,10 @@
           debug a => _60;
           let _61: &mut usize;
           scope 30 {
--             debug b => _61;
-+             debug b => &_60;
+              debug b => _61;
               let _62: &&mut usize;
               scope 31 {
--                 debug d => _62;
-+                 debug d => &&_60;
+                  debug d => _62;
                   let _63: usize;
                   scope 32 {
                       debug c => _63;
@@ -175,12 +172,10 @@
           debug a => _66;
           let mut _67: &mut usize;
           scope 34 {
--             debug b => _67;
-+             debug b => &_66;
+              debug b => _67;
               let _68: &mut &mut usize;
               scope 35 {
--                 debug d => _68;
-+                 debug d => &&_66;
+                  debug d => _68;
                   let _69: usize;
                   scope 36 {
                       debug c => _69;
@@ -193,8 +188,8 @@
 -         StorageLive(_3);
           StorageLive(_4);
           _4 = const 5_usize;
--         StorageLive(_5);
--         _5 = &mut _4;
+          StorageLive(_5);
+          _5 = &mut _4;
           StorageLive(_6);
 -         _6 = (*_5);
 +         _6 = _4;
@@ -209,7 +204,7 @@
           StorageDead(_7);
 -         _3 = const ();
           StorageDead(_6);
--         StorageDead(_5);
+          StorageDead(_5);
           StorageDead(_4);
 -         StorageDead(_3);
 -         StorageLive(_9);
@@ -391,13 +386,12 @@
 -         StorageLive(_59);
           StorageLive(_60);
           _60 = const 5_usize;
--         StorageLive(_61);
--         _61 = &mut _60;
--         StorageLive(_62);
--         _62 = &_61;
+          StorageLive(_61);
+          _61 = &mut _60;
+          StorageLive(_62);
+          _62 = &_61;
           StorageLive(_63);
--         _63 = (*_61);
-+         _63 = _60;
+          _63 = (*_61);
           StorageLive(_64);
           StorageLive(_65);
           _65 = ();
@@ -409,19 +403,18 @@
           StorageDead(_64);
 -         _59 = const ();
           StorageDead(_63);
--         StorageDead(_62);
--         StorageDead(_61);
+          StorageDead(_62);
+          StorageDead(_61);
           StorageDead(_60);
 -         StorageDead(_59);
           StorageLive(_66);
           _66 = const 5_usize;
--         StorageLive(_67);
--         _67 = &mut _66;
--         StorageLive(_68);
--         _68 = &mut _67;
+          StorageLive(_67);
+          _67 = &mut _66;
+          StorageLive(_68);
+          _68 = &mut _67;
           StorageLive(_69);
--         _69 = (*_67);
-+         _69 = _66;
+          _69 = (*_67);
           StorageLive(_70);
           StorageLive(_71);
           _71 = ();
@@ -433,8 +426,8 @@
           StorageDead(_70);
           _0 = const ();
           StorageDead(_69);
--         StorageDead(_68);
--         StorageDead(_67);
+          StorageDead(_68);
+          StorageDead(_67);
           StorageDead(_66);
           return;
       }

--- a/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
@@ -42,8 +42,7 @@
               debug a => _4;
               let _5: *mut usize;
               scope 3 {
--                 debug b => _5;
-+                 debug b => &_4;
+                  debug b => _5;
                   let _6: usize;
                   scope 4 {
                       debug c => _6;
@@ -172,12 +171,10 @@
               debug a => _58;
               let _59: *mut usize;
               scope 39 {
--                 debug b => _59;
-+                 debug b => &_58;
+                  debug b => _59;
                   let _60: &*mut usize;
                   scope 40 {
--                     debug d => _60;
-+                     debug d => &&_58;
+                      debug d => _60;
                       let _61: usize;
                       scope 41 {
                           debug c => _61;
@@ -192,12 +189,10 @@
               debug a => _64;
               let mut _65: *mut usize;
               scope 44 {
--                 debug b => _65;
-+                 debug b => &_64;
+                  debug b => _65;
                   let _66: &mut *mut usize;
                   scope 45 {
--                     debug d => _66;
-+                     debug d => &&_64;
+                      debug d => _66;
                       let _67: usize;
                       scope 46 {
                           debug c => _67;
@@ -211,8 +206,8 @@
 -         StorageLive(_3);
           StorageLive(_4);
           _4 = const 5_usize;
--         StorageLive(_5);
--         _5 = &raw mut _4;
+          StorageLive(_5);
+          _5 = &raw mut _4;
           StorageLive(_6);
 -         _6 = (*_5);
 +         _6 = _4;
@@ -227,7 +222,7 @@
           StorageDead(_7);
 -         _3 = const ();
           StorageDead(_6);
--         StorageDead(_5);
+          StorageDead(_5);
           StorageDead(_4);
 -         StorageDead(_3);
 -         StorageLive(_9);
@@ -401,13 +396,12 @@
 -         StorageLive(_57);
           StorageLive(_58);
           _58 = const 5_usize;
--         StorageLive(_59);
--         _59 = &raw mut _58;
--         StorageLive(_60);
--         _60 = &_59;
+          StorageLive(_59);
+          _59 = &raw mut _58;
+          StorageLive(_60);
+          _60 = &_59;
           StorageLive(_61);
--         _61 = (*_59);
-+         _61 = _58;
+          _61 = (*_59);
           StorageLive(_62);
           StorageLive(_63);
           _63 = ();
@@ -419,19 +413,18 @@
           StorageDead(_62);
 -         _57 = const ();
           StorageDead(_61);
--         StorageDead(_60);
--         StorageDead(_59);
+          StorageDead(_60);
+          StorageDead(_59);
           StorageDead(_58);
 -         StorageDead(_57);
           StorageLive(_64);
           _64 = const 5_usize;
--         StorageLive(_65);
--         _65 = &raw mut _64;
--         StorageLive(_66);
--         _66 = &mut _65;
+          StorageLive(_65);
+          _65 = &raw mut _64;
+          StorageLive(_66);
+          _66 = &mut _65;
           StorageLive(_67);
--         _67 = (*_65);
-+         _67 = _64;
+          _67 = (*_65);
           StorageLive(_68);
           StorageLive(_69);
           _69 = ();
@@ -443,8 +436,8 @@
           StorageDead(_68);
           _0 = const ();
           StorageDead(_67);
--         StorageDead(_66);
--         StorageDead(_65);
+          StorageDead(_66);
+          StorageDead(_65);
           StorageDead(_64);
           return;
       }

--- a/tests/ui/mir/debug-ref-undef.rs
+++ b/tests/ui/mir/debug-ref-undef.rs
@@ -1,0 +1,57 @@
+// run-pass
+// compile-flags: -g -O -Zmir-opt-level=0 -Zinline-mir=y -Zmir-enable-passes=+ReferencePropagation
+
+#![allow(dead_code)]
+
+use std::marker::PhantomData;
+
+struct RawTable<T> {
+    marker: PhantomData<T>,
+}
+
+impl<T> RawTable<T> {
+    fn iter(&self) -> RawIter<T> {
+        RawIter { marker: PhantomData }
+    }
+}
+
+struct RawIter<T> {
+    marker: PhantomData<T>,
+}
+
+impl<T> Iterator for RawIter<T> {
+    type Item = ();
+    fn next(&mut self) -> Option<()> {
+        None
+    }
+}
+
+struct HashMap<T> {
+    table: RawTable<T>,
+}
+
+struct Iter<T> {
+    inner: RawIter<T>, // Removing this breaks the reproducer
+}
+
+impl<T> IntoIterator for &HashMap<T> {
+    type Item = T;
+    type IntoIter = Iter<T>;
+    fn into_iter(self) -> Iter<T> {
+        Iter { inner: self.table.iter() }
+    }
+}
+
+impl<T> Iterator for Iter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        None
+    }
+}
+
+pub fn main() {
+    let maybe_hash_set: Option<HashMap<()>> = None;
+    for _ in maybe_hash_set.as_ref().unwrap_or(&HashMap { table: RawTable { marker: PhantomData } })
+    {
+    }
+}


### PR DESCRIPTION
The codegen implementation is broken, and attempted to read uninitialized memory.

Fixes https://github.com/rust-lang/rust/issues/114488