### PR TITLE
Fix suggestion for attempting to define a string with single quotes

### DIFF
--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -80,20 +80,14 @@ pub(crate) fn emit_unescape_error(
             let sugg = sugg.unwrap_or_else(|| {
                 let prefix = mode.prefix_noraw();
                 let mut escaped = String::with_capacity(lit.len());
-                let mut chrs = lit.chars().peekable();
-                while let Some(first) = chrs.next() {
-                    match (first, chrs.peek()) {
-                        ('\\', Some('"')) => {
-                            escaped.push('\\');
-                            escaped.push('"');
-                            chrs.next();
-                        }
-                        ('"', _) => {
-                            escaped.push('\\');
-                            escaped.push('"')
-                        }
-                        (c, _) => escaped.push(c),
-                    };
+                let mut in_escape = false;
+                for c in lit.chars() {
+                    match c {
+                        '\\' => in_escape = !in_escape,
+                        '"' if !in_escape => escaped.push('\\'),
+                        _ => in_escape = false,
+                    }
+                    escaped.push(c);
                 }
                 let sugg = format!("{prefix}\"{escaped}\"");
                 MoreThanOneCharSugg::Quotes {

--- a/tests/ui/inference/str-as-char.fixed
+++ b/tests/ui/inference/str-as-char.fixed
@@ -7,4 +7,5 @@ fn main() {
     let _: &str = "a";   //~ ERROR mismatched types
     let _: &str = "\"\"\""; //~ ERROR character literal may only contain one codepoint
     let _: &str = "\"\"\""; //~ ERROR character literal may only contain one codepoint
+    let _: &str = "\"\"\\\"\\\"\\\\\""; //~ ERROR character literal may only contain one codepoint
 }

--- a/tests/ui/inference/str-as-char.rs
+++ b/tests/ui/inference/str-as-char.rs
@@ -7,4 +7,5 @@ fn main() {
     let _: &str = 'a';   //~ ERROR mismatched types
     let _: &str = '"""'; //~ ERROR character literal may only contain one codepoint
     let _: &str = '\"\"\"'; //~ ERROR character literal may only contain one codepoint
+    let _: &str = '"\"\\"\\\"\\\\"'; //~ ERROR character literal may only contain one codepoint
 }

--- a/tests/ui/inference/str-as-char.stderr
+++ b/tests/ui/inference/str-as-char.stderr
@@ -20,6 +20,17 @@ help: if you meant to write a `str` literal, use double quotes
 LL |     let _: &str = "\"\"\"";
    |                   ~~~~~~~~
 
+error: character literal may only contain one codepoint
+  --> $DIR/str-as-char.rs:10:19
+   |
+LL |     let _: &str = '"\"\"\\"\\"';
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     let _: &str = "\"\"\\"\\"\\\"";
+   |                   ~~~~~~~~~~~~~~~~~~~~
+
 error[E0308]: mismatched types
   --> $DIR/str-as-char.rs:7:19
    |
@@ -33,6 +44,6 @@ help: if you meant to write a `str` literal, use double quotes
 LL |     let _: &str = "a";
    |                   ~~~
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Currently attempting to compile `fn main() { let _ = '\\"'; }` will result in the following error message:
```
error: character literal may only contain one codepoint
 --> src/main.rs:1:21
  |
1 | fn main() { let _ = '\\"'; }
  |                     ^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
1 | fn main() { let _ = "\\""; }
  |                     ~~~~~
```
The suggestion is invalid as it fails to escape the `"`. This PR fixes the suggestion so that it now reads:
```
help: if you meant to write a `str` literal, use double quotes
  |
1 | fn main() { let _ = "\\\""; }
  |                     ~~~~~~
```
The relevant test is also updated to ensure that this does not regress in future.