### PR TITLE
Normalize return type of `deduce_future_output_from_obligations`

### DIFF
--- a/tests/ui/async-await/normalize-output-in-signature-deduction.rs
+++ b/tests/ui/async-await/normalize-output-in-signature-deduction.rs
@@ -1,0 +1,19 @@
+// edition:2021
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+struct Foo;
+
+impl Trait for Foo {}
+pub trait Trait {}
+
+pub type TAIT<T> = impl Trait;
+
+async fn foo<T>() -> TAIT<T> {
+    Foo
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #114909
Also confirmed to fix #114727 manually

Now that we have weak/lazy type aliases, we need to normalize those in future signatures to ensure that `replace_opaque_types_with_inference_vars` actually sees TAITs behind them. This isn't needed in the new solver, but added a test to make sure it doesn't regress there either.

r? types cc @oli-obk (who's gone, worst case can delay this PR until he's back)