### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2827,11 +2827,11 @@ impl<'tcx> Ty<'tcx> {
 
             ty::Adt(def, _args) => def.sized_constraint(tcx).skip_binder().is_empty(),
 
-            ty::Alias(..) | ty::Param(_) | ty::Placeholder(..) => false,
+            ty::Alias(..) | ty::Param(_) | ty::Placeholder(..) | ty::Bound(..) => false,
 
             ty::Infer(ty::TyVar(_)) => false,
 
-            ty::Bound(..) | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
                 bug!("`is_trivially_sized` applied to unexpected type: {:?}", self)
             }
         }

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -20,10 +20,10 @@ use crate::str;
 /// in each pair are borrowed references; the latter are owned
 /// strings.
 ///
-/// Note that this structure is **not** `repr(C)` and is not recommended to be
-/// placed in the signatures of FFI functions. Instead, safe wrappers of FFI
-/// functions may leverage the unsafe [`CStr::from_ptr`] constructor to provide
-/// a safe interface to other consumers.
+/// Note that this structure does **not** have a guaranteed layout (the `repr(transparent)`
+/// notwithstanding) and is not recommended to be placed in the signatures of FFI functions.
+/// Instead, safe wrappers of FFI functions may leverage the unsafe [`CStr::from_ptr`] constructor
+/// to provide a safe interface to other consumers.
 ///
 /// [`CString`]: ../../std/ffi/struct.CString.html
 /// [`String`]: ../../std/string/struct.String.html

--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -303,12 +303,11 @@ pub struct IntoIter<T> {
     rx: Receiver<T>,
 }
 
-/// The sending-half of Rust's asynchronous [`channel`] type. This half can only be
-/// owned by one thread, but it can be cloned to send to other threads.
+/// The sending-half of Rust's asynchronous [`channel`] type.
 ///
 /// Messages can be sent through this channel with [`send`].
 ///
-/// Note: all senders (the original and the clones) need to be dropped for the receiver
+/// Note: all senders (the original and its clones) need to be dropped for the receiver
 /// to stop blocking to receive messages with [`Receiver::recv`].
 ///
 /// [`send`]: Sender::send

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -463,7 +463,9 @@ fn run_test(
     // Run the code!
     let mut cmd;
 
+    let output_file = make_maybe_absolute_path(output_file);
     if let Some(tool) = runtool {
+        let tool = make_maybe_absolute_path(tool.into());
         cmd = Command::new(tool);
         cmd.args(runtool_args);
         cmd.arg(output_file);
@@ -495,6 +497,20 @@ fn run_test(
     }
 
     Ok(())
+}
+
+/// Converts a path intended to use as a command to absolute if it is
+/// relative, and not a single component.
+///
+/// This is needed to deal with relative paths interacting with
+/// `Command::current_dir` in a platform-specific way.
+fn make_maybe_absolute_path(path: PathBuf) -> PathBuf {
+    if path.components().count() == 1 {
+        // Look up process via PATH.
+        path
+    } else {
+        std::env::current_dir().map(|c| c.join(&path)).unwrap_or_else(|_| path)
+    }
 }
 
 /// Transforms a test into code that can be compiled into a Rust binary, and returns the number of

--- a/tests/run-make/doctests-keep-binaries/Makefile
+++ b/tests/run-make/doctests-keep-binaries/Makefile
@@ -3,7 +3,9 @@ include ../tools.mk
 
 # Check that valid binaries are persisted by running them, regardless of whether the --run or --no-run option is used.
 
-all: run no_run
+MY_SRC_DIR := ${CURDIR}
+
+all: run no_run test_run_directory
 
 run:
 	mkdir -p $(TMPDIR)/doctests
@@ -20,3 +22,12 @@ no_run:
 	$(TMPDIR)/doctests/t_rs_2_0/rust_out
 	$(TMPDIR)/doctests/t_rs_8_0/rust_out
 	rm -rf $(TMPDIR)/doctests
+
+# Behavior with --test-run-directory with relative paths.
+test_run_directory:
+	mkdir -p $(TMPDIR)/doctests
+	mkdir -p $(TMPDIR)/rundir
+	$(RUSTC) --crate-type rlib t.rs
+	( cd $(TMPDIR); \
+		$(RUSTDOC) -Zunstable-options --test --persist-doctests doctests --test-run-directory rundir --extern t=libt.rlib $(MY_SRC_DIR)/t.rs )
+	rm -rf $(TMPDIR)/doctests $(TMPDIR)/rundir

--- a/tests/run-make/doctests-runtool/Makefile
+++ b/tests/run-make/doctests-runtool/Makefile
@@ -1,0 +1,20 @@
+# ignore-cross-compile
+include ../tools.mk
+
+# Tests behavior of rustdoc --runtool
+
+MY_SRC_DIR := ${CURDIR}
+
+all: with_test_run_directory
+
+# Behavior with --runtool with relative paths and --test-run-directory.
+with_test_run_directory:
+	mkdir -p $(TMPDIR)/rundir
+	mkdir -p $(TMPDIR)/runtool
+	$(RUSTC) --crate-type rlib t.rs
+	$(RUSTC) runtool.rs -o $(TMPDIR)/runtool/runtool
+	( cd $(TMPDIR); \
+		$(RUSTDOC) -Zunstable-options --test --test-run-directory rundir \
+			--runtool runtool/runtool --extern t=libt.rlib $(MY_SRC_DIR)/t.rs \
+	)
+	rm -rf $(TMPDIR)/rundir $(TMPDIR)/runtool

--- a/tests/run-make/doctests-runtool/runtool.rs
+++ b/tests/run-make/doctests-runtool/runtool.rs
@@ -1,0 +1,3 @@
+fn main() {
+    eprintln!("{:?}", std::env::args().collect::<Vec<_>>());
+}

--- a/tests/run-make/doctests-runtool/t.rs
+++ b/tests/run-make/doctests-runtool/t.rs
@@ -1,0 +1,11 @@
+/// Fungle the foople.
+/// ```
+/// t::foople();
+/// ```
+pub fn foople() {}
+
+/// Flomble the florp
+/// ```
+/// t::florp();
+/// ```
+pub fn florp() {}

--- a/tests/ui/traits/non_lifetime_binders/sized-late-bound-issue-114872.rs
+++ b/tests/ui/traits/non_lifetime_binders/sized-late-bound-issue-114872.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![feature(non_lifetime_binders)]
+//~^ WARN is incomplete and may not be safe
+
+pub fn foo()
+where
+    for<V> V: Sized,
+{
+    bar();
+}
+
+pub fn bar()
+where
+    for<V> V: Sized,
+{
+}
+
+pub fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/sized-late-bound-issue-114872.stderr
+++ b/tests/ui/traits/non_lifetime_binders/sized-late-bound-issue-114872.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/sized-late-bound-issue-114872.rs:3:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -386,7 +386,6 @@ cc = ["@camelid"]
 message = "Some changes occurred in HTML/CSS/JS."
 cc = [
     "@GuillaumeGomez",
-    "@Folyd",
     "@jsha",
 ]
 


### PR DESCRIPTION
Successful merges:

 - #112751 (rustdoc: Fixes with --test-run-directory and relative paths.)
 - #114749 (Update `mpsc::Sender` doc to reflect that it implements `Sync`)
 - #114876 (Don't ICE in `is_trivially_sized` when encountering late-bound self ty)
 - #114881 (clarify CStr lack of layout guarnatees)
 - #114921 (Remove Folyd from librustdoc static files)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112751,114749,114876,114881,114921)
<!-- homu-ignore:end -->