### PR TITLE
coverage: Tidy up `run-coverage` tests in several small ways

### DIFF
--- a/tests/run-coverage-rustdoc/doctest.coverage
+++ b/tests/run-coverage-rustdoc/doctest.coverage
@@ -10,6 +10,8 @@ $DIR/auxiliary/doctest_crate.rs:
    LL|      3|}
 
 $DIR/doctest.rs:
+   LL|       |// aux-build:doctest_crate.rs
+   LL|       |
    LL|       |//! This test ensures that code from doctests is properly re-mapped.
    LL|       |//! See <https://github.com/rust-lang/rust/issues/79417> for more info.
    LL|       |//!
@@ -78,7 +80,7 @@ $DIR/doctest.rs:
    LL|       |//!     doctest_main()
    LL|       |//! }
    LL|       |//! ```
-   LL|       |// aux-build:doctest_crate.rs
+   LL|       |
    LL|       |/// doctest attached to fn testing external code:
    LL|       |/// ```
    LL|      1|/// extern crate doctest_crate;

--- a/tests/run-coverage-rustdoc/doctest.rs
+++ b/tests/run-coverage-rustdoc/doctest.rs
@@ -1,3 +1,5 @@
+// aux-build:doctest_crate.rs
+
 //! This test ensures that code from doctests is properly re-mapped.
 //! See <https://github.com/rust-lang/rust/issues/79417> for more info.
 //!
@@ -63,7 +65,7 @@
 //!     doctest_main()
 //! }
 //! ```
-// aux-build:doctest_crate.rs
+
 /// doctest attached to fn testing external code:
 /// ```
 /// extern crate doctest_crate;

--- a/tests/run-coverage/assert.coverage
+++ b/tests/run-coverage/assert.coverage
@@ -7,7 +7,7 @@
                                                   ^1
    LL|      3|}
    LL|       |
-   LL|      1|fn main() -> Result<(),u8> {
+   LL|      1|fn main() -> Result<(), u8> {
    LL|      1|    let mut countdown = 10;
    LL|     11|    while countdown > 0 {
    LL|     11|        if countdown == 1 {

--- a/tests/run-coverage/assert.rs
+++ b/tests/run-coverage/assert.rs
@@ -6,7 +6,7 @@ fn might_fail_assert(one_plus_one: u32) {
     assert_eq!(1 + 1, one_plus_one, "the argument was wrong");
 }
 
-fn main() -> Result<(),u8> {
+fn main() -> Result<(), u8> {
     let mut countdown = 10;
     while countdown > 0 {
         if countdown == 1 {

--- a/tests/run-coverage/async2.coverage
+++ b/tests/run-coverage/async2.coverage
@@ -1,11 +1,5 @@
    LL|       |// compile-flags: --edition=2018
    LL|       |
-   LL|       |use core::{
-   LL|       |    future::Future,
-   LL|       |    marker::Send,
-   LL|       |    pin::Pin,
-   LL|       |};
-   LL|       |
    LL|      1|fn non_async_func() {
    LL|      1|    println!("non_async_func was covered");
    LL|      1|    let b = true;

--- a/tests/run-coverage/async2.coverage
+++ b/tests/run-coverage/async2.coverage
@@ -9,9 +9,6 @@
                    ^0
    LL|      1|}
    LL|       |
-   LL|       |
-   LL|       |
-   LL|       |
    LL|      1|async fn async_func() {
    LL|      1|    println!("async_func was covered");
    LL|      1|    let b = true;
@@ -20,9 +17,6 @@
    LL|      1|    }
                    ^0
    LL|      1|}
-   LL|       |
-   LL|       |
-   LL|       |
    LL|       |
    LL|      1|async fn async_func_just_println() {
    LL|      1|    println!("async_func_just_println was covered");

--- a/tests/run-coverage/async2.rs
+++ b/tests/run-coverage/async2.rs
@@ -8,9 +8,6 @@ fn non_async_func() {
     }
 }
 
-
-
-
 async fn async_func() {
     println!("async_func was covered");
     let b = true;
@@ -18,9 +15,6 @@ async fn async_func() {
         println!("async_func println in block");
     }
 }
-
-
-
 
 async fn async_func_just_println() {
     println!("async_func_just_println was covered");

--- a/tests/run-coverage/async2.rs
+++ b/tests/run-coverage/async2.rs
@@ -1,11 +1,5 @@
 // compile-flags: --edition=2018
 
-use core::{
-    future::Future,
-    marker::Send,
-    pin::Pin,
-};
-
 fn non_async_func() {
     println!("non_async_func was covered");
     let b = true;

--- a/tests/run-coverage/auxiliary/inline_always_with_dead_code.rs
+++ b/tests/run-coverage/auxiliary/inline_always_with_dead_code.rs
@@ -4,9 +4,9 @@
 
 mod foo {
     #[inline(always)]
-    pub fn called() { }
+    pub fn called() {}
 
-    fn uncalled() { }
+    fn uncalled() {}
 }
 
 pub mod bar {

--- a/tests/run-coverage/auxiliary/unused_mod_helper.rs
+++ b/tests/run-coverage/auxiliary/unused_mod_helper.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub fn never_called_function() {
     println!("I am never called");
 }

--- a/tests/run-coverage/auxiliary/used_crate.rs
+++ b/tests/run-coverage/auxiliary/used_crate.rs
@@ -1,6 +1,8 @@
 #![allow(unused_assignments, unused_variables)]
+// Verify that coverage works with optimizations:
 // compile-flags: -C opt-level=3
-use std::fmt::Debug; // ^^ validates coverage now works with optimizations
+
+use std::fmt::Debug;
 
 pub fn used_function() {
     // Initialize test constants in a way that cannot be determined at compile time, to ensure

--- a/tests/run-coverage/auxiliary/used_crate.rs
+++ b/tests/run-coverage/auxiliary/used_crate.rs
@@ -42,6 +42,7 @@ pub fn unused_function() {
     }
 }
 
+#[allow(dead_code)]
 fn unused_private_function() {
     let is_true = std::env::args().len() == 1;
     let mut countdown = 2;

--- a/tests/run-coverage/auxiliary/used_inline_crate.rs
+++ b/tests/run-coverage/auxiliary/used_inline_crate.rs
@@ -1,7 +1,7 @@
 #![allow(unused_assignments, unused_variables)]
-
+// Verify that coverage works with optimizations:
 // compile-flags: -C opt-level=3
-// ^^ validates coverage now works with optimizations
+
 use std::fmt::Debug;
 
 pub fn used_function() {

--- a/tests/run-coverage/auxiliary/used_inline_crate.rs
+++ b/tests/run-coverage/auxiliary/used_inline_crate.rs
@@ -29,12 +29,6 @@ pub fn used_inline_function() {
     use_this_lib_crate();
 }
 
-
-
-
-
-
-
 #[inline(always)]
 pub fn used_only_from_bin_crate_generic_function<T: Debug>(arg: T) {
     println!("used_only_from_bin_crate_generic_function with {:?}", arg);

--- a/tests/run-coverage/auxiliary/used_inline_crate.rs
+++ b/tests/run-coverage/auxiliary/used_inline_crate.rs
@@ -71,6 +71,7 @@ pub fn unused_function() {
 }
 
 #[inline(always)]
+#[allow(dead_code)]
 fn unused_private_function() {
     let is_true = std::env::args().len() == 1;
     let mut countdown = 2;

--- a/tests/run-coverage/closure.coverage
+++ b/tests/run-coverage/closure.coverage
@@ -1,6 +1,11 @@
    LL|       |#![allow(unused_assignments, unused_variables)]
    LL|       |// compile-flags: -C opt-level=2
-   LL|      1|fn main() { // ^^ fix described in rustc_middle/mir/mono.rs
+   LL|       |
+   LL|       |// This test used to be sensitive to certain coverage-specific hacks in
+   LL|       |// `rustc_middle/mir/mono.rs`, but those hacks were later cleaned up by
+   LL|       |// <https://github.com/rust-lang/rust/pull/83666>.
+   LL|       |
+   LL|      1|fn main() {
    LL|      1|    // Initialize test constants in a way that cannot be determined at compile time, to ensure
    LL|      1|    // rustc and LLVM cannot optimize out statements (or coverage counters) downstream from
    LL|      1|    // dependent conditions.

--- a/tests/run-coverage/closure.coverage
+++ b/tests/run-coverage/closure.coverage
@@ -10,7 +10,7 @@
    LL|      1|    // rustc and LLVM cannot optimize out statements (or coverage counters) downstream from
    LL|      1|    // dependent conditions.
    LL|      1|    let is_true = std::env::args().len() == 1;
-   LL|      1|    let is_false = ! is_true;
+   LL|      1|    let is_false = !is_true;
    LL|      1|
    LL|      1|    let mut some_string = Some(String::from("the string content"));
    LL|      1|    println!(

--- a/tests/run-coverage/closure.rs
+++ b/tests/run-coverage/closure.rs
@@ -1,6 +1,11 @@
 #![allow(unused_assignments, unused_variables)]
 // compile-flags: -C opt-level=2
-fn main() { // ^^ fix described in rustc_middle/mir/mono.rs
+
+// This test used to be sensitive to certain coverage-specific hacks in
+// `rustc_middle/mir/mono.rs`, but those hacks were later cleaned up by
+// <https://github.com/rust-lang/rust/pull/83666>.
+
+fn main() {
     // Initialize test constants in a way that cannot be determined at compile time, to ensure
     // rustc and LLVM cannot optimize out statements (or coverage counters) downstream from
     // dependent conditions.

--- a/tests/run-coverage/closure.rs
+++ b/tests/run-coverage/closure.rs
@@ -10,7 +10,7 @@ fn main() {
     // rustc and LLVM cannot optimize out statements (or coverage counters) downstream from
     // dependent conditions.
     let is_true = std::env::args().len() == 1;
-    let is_false = ! is_true;
+    let is_false = !is_true;
 
     let mut some_string = Some(String::from("the string content"));
     println!(

--- a/tests/run-coverage/closure_macro_async.coverage
+++ b/tests/run-coverage/closure_macro_async.coverage
@@ -42,7 +42,7 @@
    LL|       |
    LL|       |#[no_coverage]
    LL|       |fn main() {
-   LL|       |    executor::block_on(test());
+   LL|       |    executor::block_on(test()).unwrap();
    LL|       |}
    LL|       |
    LL|       |mod executor {

--- a/tests/run-coverage/closure_macro_async.coverage
+++ b/tests/run-coverage/closure_macro_async.coverage
@@ -57,16 +57,12 @@
    LL|       |        let mut future = unsafe { Pin::new_unchecked(&mut future) };
    LL|       |        use std::hint::unreachable_unchecked;
    LL|       |        static VTABLE: RawWakerVTable = RawWakerVTable::new(
-   LL|       |
    LL|       |            #[no_coverage]
    LL|       |            |_| unsafe { unreachable_unchecked() }, // clone
-   LL|       |
    LL|       |            #[no_coverage]
    LL|       |            |_| unsafe { unreachable_unchecked() }, // wake
-   LL|       |
    LL|       |            #[no_coverage]
    LL|       |            |_| unsafe { unreachable_unchecked() }, // wake_by_ref
-   LL|       |
    LL|       |            #[no_coverage]
    LL|       |            |_| (),
    LL|       |        );

--- a/tests/run-coverage/closure_macro_async.rs
+++ b/tests/run-coverage/closure_macro_async.rs
@@ -56,16 +56,12 @@ mod executor {
         let mut future = unsafe { Pin::new_unchecked(&mut future) };
         use std::hint::unreachable_unchecked;
         static VTABLE: RawWakerVTable = RawWakerVTable::new(
-
             #[no_coverage]
             |_| unsafe { unreachable_unchecked() }, // clone
-
             #[no_coverage]
             |_| unsafe { unreachable_unchecked() }, // wake
-
             #[no_coverage]
             |_| unsafe { unreachable_unchecked() }, // wake_by_ref
-
             #[no_coverage]
             |_| (),
         );

--- a/tests/run-coverage/closure_macro_async.rs
+++ b/tests/run-coverage/closure_macro_async.rs
@@ -41,7 +41,7 @@ pub async fn test() -> Result<(), String> {
 
 #[no_coverage]
 fn main() {
-    executor::block_on(test());
+    executor::block_on(test()).unwrap();
 }
 
 mod executor {

--- a/tests/run-coverage/conditions.coverage
+++ b/tests/run-coverage/conditions.coverage
@@ -59,7 +59,6 @@
    LL|       |        }
    LL|      0|    }
    LL|       |
-   LL|       |
    LL|      1|    let mut countdown = 0;
    LL|      1|    if true {
    LL|      1|        countdown = 1;

--- a/tests/run-coverage/conditions.rs
+++ b/tests/run-coverage/conditions.rs
@@ -55,7 +55,6 @@ fn main() {
         }
     }
 
-
     let mut countdown = 0;
     if true {
         countdown = 1;

--- a/tests/run-coverage/dead_code.coverage
+++ b/tests/run-coverage/dead_code.coverage
@@ -1,4 +1,4 @@
-   LL|       |#![allow(unused_assignments, unused_variables)]
+   LL|       |#![allow(dead_code, unused_assignments, unused_variables)]
    LL|       |
    LL|      0|pub fn unused_pub_fn_not_in_library() {
    LL|      0|    // Initialize test constants in a way that cannot be determined at compile time, to ensure

--- a/tests/run-coverage/dead_code.rs
+++ b/tests/run-coverage/dead_code.rs
@@ -1,4 +1,4 @@
-#![allow(unused_assignments, unused_variables)]
+#![allow(dead_code, unused_assignments, unused_variables)]
 
 pub fn unused_pub_fn_not_in_library() {
     // Initialize test constants in a way that cannot be determined at compile time, to ensure

--- a/tests/run-coverage/drop_trait.coverage
+++ b/tests/run-coverage/drop_trait.coverage
@@ -11,7 +11,7 @@
    LL|      2|    }
    LL|       |}
    LL|       |
-   LL|      1|fn main() -> Result<(),u8> {
+   LL|      1|fn main() -> Result<(), u8> {
    LL|      1|    let _firecracker = Firework { strength: 1 };
    LL|      1|
    LL|      1|    let _tnt = Firework { strength: 100 };

--- a/tests/run-coverage/drop_trait.rs
+++ b/tests/run-coverage/drop_trait.rs
@@ -11,7 +11,7 @@ impl Drop for Firework {
     }
 }
 
-fn main() -> Result<(),u8> {
+fn main() -> Result<(), u8> {
     let _firecracker = Firework { strength: 1 };
 
     let _tnt = Firework { strength: 100 };

--- a/tests/run-coverage/generics.coverage
+++ b/tests/run-coverage/generics.coverage
@@ -41,7 +41,7 @@
   ------------------
    LL|       |}
    LL|       |
-   LL|      1|fn main() -> Result<(),u8> {
+   LL|      1|fn main() -> Result<(), u8> {
    LL|      1|    let mut firecracker = Firework { strength: 1 };
    LL|      1|    firecracker.set_strength(2);
    LL|      1|
@@ -53,10 +53,6 @@
    LL|      1|        println!("Exiting with error...");
    LL|      1|        return Err(1);
    LL|      0|    }
-   LL|      0|
-   LL|      0|
-   LL|      0|
-   LL|      0|
    LL|      0|
    LL|      0|    let _ = Firework { strength: 1000 };
    LL|      0|

--- a/tests/run-coverage/generics.rs
+++ b/tests/run-coverage/generics.rs
@@ -19,7 +19,7 @@ impl<T> Drop for Firework<T> where T: Copy + std::fmt::Display {
     }
 }
 
-fn main() -> Result<(),u8> {
+fn main() -> Result<(), u8> {
     let mut firecracker = Firework { strength: 1 };
     firecracker.set_strength(2);
 
@@ -31,10 +31,6 @@ fn main() -> Result<(),u8> {
         println!("Exiting with error...");
         return Err(1);
     }
-
-
-
-
 
     let _ = Firework { strength: 1000 };
 

--- a/tests/run-coverage/issue-85461.coverage
+++ b/tests/run-coverage/issue-85461.coverage
@@ -24,6 +24,7 @@ $DIR/auxiliary/inline_always_with_dead_code.rs:
 
 $DIR/issue-85461.rs:
    LL|       |// Regression test for #85461: MSVC sometimes fail to link with dead code and #[inline(always)]
+   LL|       |
    LL|       |// aux-build:inline_always_with_dead_code.rs
    LL|       |extern crate inline_always_with_dead_code;
    LL|       |

--- a/tests/run-coverage/issue-85461.coverage
+++ b/tests/run-coverage/issue-85461.coverage
@@ -5,9 +5,9 @@ $DIR/auxiliary/inline_always_with_dead_code.rs:
    LL|       |
    LL|       |mod foo {
    LL|       |    #[inline(always)]
-   LL|      2|    pub fn called() { }
+   LL|      2|    pub fn called() {}
    LL|       |
-   LL|      0|    fn uncalled() { }
+   LL|      0|    fn uncalled() {}
    LL|       |}
    LL|       |
    LL|       |pub mod bar {

--- a/tests/run-coverage/issue-85461.rs
+++ b/tests/run-coverage/issue-85461.rs
@@ -1,4 +1,5 @@
 // Regression test for #85461: MSVC sometimes fail to link with dead code and #[inline(always)]
+
 // aux-build:inline_always_with_dead_code.rs
 extern crate inline_always_with_dead_code;
 

--- a/tests/run-coverage/issue-93054.coverage
+++ b/tests/run-coverage/issue-93054.coverage
@@ -1,3 +1,5 @@
+   LL|       |#![allow(dead_code, unreachable_code)]
+   LL|       |
    LL|       |// Regression test for #93054: Functions using uninhabited types often only have a single,
    LL|       |// unreachable basic block which doesn't get instrumented. This should not cause llvm-cov to fail.
    LL|       |// Since these kinds functions can't be invoked anyway, it's ok to not have coverage data for them.

--- a/tests/run-coverage/issue-93054.coverage
+++ b/tests/run-coverage/issue-93054.coverage
@@ -6,26 +6,26 @@
    LL|       |
    LL|       |// compile-flags: --edition=2021
    LL|       |
-   LL|       |enum Never { }
+   LL|       |enum Never {}
    LL|       |
    LL|       |impl Never {
    LL|       |    fn foo(self) {
-   LL|       |        match self { }
-   LL|       |        make().map(|never| match never { });
+   LL|       |        match self {}
+   LL|       |        make().map(|never| match never {});
    LL|       |    }
    LL|       |
    LL|       |    fn bar(&self) {
-   LL|       |        match *self { }
+   LL|       |        match *self {}
    LL|       |    }
    LL|       |}
    LL|       |
    LL|      0|async fn foo2(never: Never) {
-   LL|       |    match never { }
+   LL|       |    match never {}
    LL|       |}
    LL|       |
    LL|      0|fn make() -> Option<Never> {
    LL|      0|    None
    LL|      0|}
    LL|       |
-   LL|      1|fn main() { }
+   LL|      1|fn main() {}
 

--- a/tests/run-coverage/issue-93054.rs
+++ b/tests/run-coverage/issue-93054.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unreachable_code)]
+
 // Regression test for #93054: Functions using uninhabited types often only have a single,
 // unreachable basic block which doesn't get instrumented. This should not cause llvm-cov to fail.
 // Since these kinds functions can't be invoked anyway, it's ok to not have coverage data for them.

--- a/tests/run-coverage/issue-93054.rs
+++ b/tests/run-coverage/issue-93054.rs
@@ -6,25 +6,25 @@
 
 // compile-flags: --edition=2021
 
-enum Never { }
+enum Never {}
 
 impl Never {
     fn foo(self) {
-        match self { }
-        make().map(|never| match never { });
+        match self {}
+        make().map(|never| match never {});
     }
 
     fn bar(&self) {
-        match *self { }
+        match *self {}
     }
 }
 
 async fn foo2(never: Never) {
-    match never { }
+    match never {}
 }
 
 fn make() -> Option<Never> {
     None
 }
 
-fn main() { }
+fn main() {}

--- a/tests/run-coverage/loops_branches.coverage
+++ b/tests/run-coverage/loops_branches.coverage
@@ -9,8 +9,7 @@
    LL|      1|    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
    LL|      1|        if true {
    LL|      1|            if false {
-   LL|      0|                while true {
-   LL|      0|                }
+   LL|      0|                while true {}
    LL|      1|            }
    LL|      1|            write!(f, "cool")?;
                                            ^0

--- a/tests/run-coverage/loops_branches.rs
+++ b/tests/run-coverage/loops_branches.rs
@@ -9,8 +9,7 @@ impl std::fmt::Debug for DebugTest {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if true {
             if false {
-                while true {
-                }
+                while true {}
             }
             write!(f, "cool")?;
         } else {

--- a/tests/run-coverage/match_or_pattern.coverage
+++ b/tests/run-coverage/match_or_pattern.coverage
@@ -1,5 +1,3 @@
-   LL|       |#![feature(or_patterns)]
-   LL|       |
    LL|      1|fn main() {
    LL|      1|    // Initialize test constants in a way that cannot be determined at compile time, to ensure
    LL|      1|    // rustc and LLVM cannot optimize out statements (or coverage counters) downstream from

--- a/tests/run-coverage/match_or_pattern.rs
+++ b/tests/run-coverage/match_or_pattern.rs
@@ -1,5 +1,3 @@
-#![feature(or_patterns)]
-
 fn main() {
     // Initialize test constants in a way that cannot be determined at compile time, to ensure
     // rustc and LLVM cannot optimize out statements (or coverage counters) downstream from

--- a/tests/run-coverage/no_cov_crate.coverage
+++ b/tests/run-coverage/no_cov_crate.coverage
@@ -12,6 +12,7 @@
    LL|       |}
    LL|       |
    LL|       |#[no_coverage]
+   LL|       |#[allow(dead_code)]
    LL|       |fn do_not_add_coverage_not_called() {
    LL|       |    println!("not called and not covered");
    LL|       |}
@@ -24,6 +25,7 @@
    LL|      1|    println!("called and covered");
    LL|      1|}
    LL|       |
+   LL|       |#[allow(dead_code)]
    LL|      0|fn add_coverage_not_called() {
    LL|      0|    println!("not called but covered");
    LL|      0|}

--- a/tests/run-coverage/no_cov_crate.rs
+++ b/tests/run-coverage/no_cov_crate.rs
@@ -12,6 +12,7 @@ fn do_not_add_coverage_2() {
 }
 
 #[no_coverage]
+#[allow(dead_code)]
 fn do_not_add_coverage_not_called() {
     println!("not called and not covered");
 }
@@ -24,6 +25,7 @@ fn add_coverage_2() {
     println!("called and covered");
 }
 
+#[allow(dead_code)]
 fn add_coverage_not_called() {
     println!("not called but covered");
 }

--- a/tests/run-coverage/overflow.coverage
+++ b/tests/run-coverage/overflow.coverage
@@ -12,7 +12,7 @@
    LL|      4|    result
    LL|      4|}
    LL|       |
-   LL|      1|fn main() -> Result<(),u8> {
+   LL|      1|fn main() -> Result<(), u8> {
    LL|      1|    let mut countdown = 10;
    LL|     11|    while countdown > 0 {
    LL|     11|        if countdown == 1 {

--- a/tests/run-coverage/overflow.rs
+++ b/tests/run-coverage/overflow.rs
@@ -12,7 +12,7 @@ fn might_overflow(to_add: u32) -> u32 {
     result
 }
 
-fn main() -> Result<(),u8> {
+fn main() -> Result<(), u8> {
     let mut countdown = 10;
     while countdown > 0 {
         if countdown == 1 {

--- a/tests/run-coverage/try_error_result.coverage
+++ b/tests/run-coverage/try_error_result.coverage
@@ -1,7 +1,7 @@
    LL|       |#![allow(unused_assignments)]
    LL|       |// failure-status: 1
    LL|       |
-   LL|      6|fn call(return_error: bool) -> Result<(),()> {
+   LL|      6|fn call(return_error: bool) -> Result<(), ()> {
    LL|      6|    if return_error {
    LL|      1|        Err(())
    LL|       |    } else {
@@ -9,7 +9,7 @@
    LL|       |    }
    LL|      6|}
    LL|       |
-   LL|      1|fn test1() -> Result<(),()> {
+   LL|      1|fn test1() -> Result<(), ()> {
    LL|      1|    let mut
    LL|      1|        countdown = 10
    LL|       |    ;
@@ -38,18 +38,18 @@
    LL|       |
    LL|       |struct Thing1;
    LL|       |impl Thing1 {
-   LL|     18|    fn get_thing_2(&self, return_error: bool) -> Result<Thing2,()> {
+   LL|     18|    fn get_thing_2(&self, return_error: bool) -> Result<Thing2, ()> {
    LL|     18|        if return_error {
    LL|      1|            Err(())
    LL|       |        } else {
-   LL|     17|            Ok(Thing2{})
+   LL|     17|            Ok(Thing2 {})
    LL|       |        }
    LL|     18|    }
    LL|       |}
    LL|       |
    LL|       |struct Thing2;
    LL|       |impl Thing2 {
-   LL|     17|    fn call(&self, return_error: bool) -> Result<u32,()> {
+   LL|     17|    fn call(&self, return_error: bool) -> Result<u32, ()> {
    LL|     17|        if return_error {
    LL|      2|            Err(())
    LL|       |        } else {
@@ -58,7 +58,7 @@
    LL|     17|    }
    LL|       |}
    LL|       |
-   LL|      1|fn test2() -> Result<(),()> {
+   LL|      1|fn test2() -> Result<(), ()> {
    LL|      1|    let thing1 = Thing1{};
    LL|      1|    let mut
    LL|      1|        countdown = 10
@@ -115,7 +115,7 @@
    LL|      0|    Ok(())
    LL|      1|}
    LL|       |
-   LL|      1|fn main() -> Result<(),()> {
+   LL|      1|fn main() -> Result<(), ()> {
    LL|      1|    test1().expect_err("test1 should fail");
    LL|      1|    test2()
    LL|      1|    ?

--- a/tests/run-coverage/try_error_result.rs
+++ b/tests/run-coverage/try_error_result.rs
@@ -1,7 +1,7 @@
 #![allow(unused_assignments)]
 // failure-status: 1
 
-fn call(return_error: bool) -> Result<(),()> {
+fn call(return_error: bool) -> Result<(), ()> {
     if return_error {
         Err(())
     } else {
@@ -9,7 +9,7 @@ fn call(return_error: bool) -> Result<(),()> {
     }
 }
 
-fn test1() -> Result<(),()> {
+fn test1() -> Result<(), ()> {
     let mut
         countdown = 10
     ;
@@ -37,18 +37,18 @@ fn test1() -> Result<(),()> {
 
 struct Thing1;
 impl Thing1 {
-    fn get_thing_2(&self, return_error: bool) -> Result<Thing2,()> {
+    fn get_thing_2(&self, return_error: bool) -> Result<Thing2, ()> {
         if return_error {
             Err(())
         } else {
-            Ok(Thing2{})
+            Ok(Thing2 {})
         }
     }
 }
 
 struct Thing2;
 impl Thing2 {
-    fn call(&self, return_error: bool) -> Result<u32,()> {
+    fn call(&self, return_error: bool) -> Result<u32, ()> {
         if return_error {
             Err(())
         } else {
@@ -57,7 +57,7 @@ impl Thing2 {
     }
 }
 
-fn test2() -> Result<(),()> {
+fn test2() -> Result<(), ()> {
     let thing1 = Thing1{};
     let mut
         countdown = 10
@@ -109,7 +109,7 @@ fn test2() -> Result<(),()> {
     Ok(())
 }
 
-fn main() -> Result<(),()> {
+fn main() -> Result<(), ()> {
     test1().expect_err("test1 should fail");
     test2()
     ?

--- a/tests/run-coverage/unused.coverage
+++ b/tests/run-coverage/unused.coverage
@@ -1,3 +1,5 @@
+   LL|       |#![allow(dead_code, unused_assignments, unused_must_use, unused_variables)]
+   LL|       |
    LL|      2|fn foo<T>(x: T) {
    LL|      2|    let mut i = 0;
    LL|     22|    while i < 10 {

--- a/tests/run-coverage/unused.rs
+++ b/tests/run-coverage/unused.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_assignments, unused_must_use, unused_variables)]
+
 fn foo<T>(x: T) {
     let mut i = 0;
     while i < 10 {

--- a/tests/run-coverage/unused_mod.coverage
+++ b/tests/run-coverage/unused_mod.coverage
@@ -1,4 +1,5 @@
 $DIR/auxiliary/unused_mod_helper.rs:
+   LL|       |#[allow(dead_code)]
    LL|      0|pub fn never_called_function() {
    LL|      0|    println!("I am never called");
    LL|      0|}

--- a/tests/run-coverage/uses_crate.coverage
+++ b/tests/run-coverage/uses_crate.coverage
@@ -90,6 +90,7 @@ $DIR/auxiliary/used_crate.rs:
    LL|      0|    }
    LL|      0|}
    LL|       |
+   LL|       |#[allow(dead_code)]
    LL|      0|fn unused_private_function() {
    LL|      0|    let is_true = std::env::args().len() == 1;
    LL|      0|    let mut countdown = 2;

--- a/tests/run-coverage/uses_crate.coverage
+++ b/tests/run-coverage/uses_crate.coverage
@@ -1,7 +1,9 @@
 $DIR/auxiliary/used_crate.rs:
    LL|       |#![allow(unused_assignments, unused_variables)]
+   LL|       |// Verify that coverage works with optimizations:
    LL|       |// compile-flags: -C opt-level=3
-   LL|       |use std::fmt::Debug; // ^^ validates coverage now works with optimizations
+   LL|       |
+   LL|       |use std::fmt::Debug;
    LL|       |
    LL|      1|pub fn used_function() {
    LL|      1|    // Initialize test constants in a way that cannot be determined at compile time, to ensure

--- a/tests/run-coverage/uses_inline_crate.coverage
+++ b/tests/run-coverage/uses_inline_crate.coverage
@@ -32,12 +32,6 @@ $DIR/auxiliary/used_inline_crate.rs:
    LL|      1|    use_this_lib_crate();
    LL|      1|}
    LL|       |
-   LL|       |
-   LL|       |
-   LL|       |
-   LL|       |
-   LL|       |
-   LL|       |
    LL|       |#[inline(always)]
    LL|      2|pub fn used_only_from_bin_crate_generic_function<T: Debug>(arg: T) {
    LL|      2|    println!("used_only_from_bin_crate_generic_function with {:?}", arg);

--- a/tests/run-coverage/uses_inline_crate.coverage
+++ b/tests/run-coverage/uses_inline_crate.coverage
@@ -1,8 +1,8 @@
 $DIR/auxiliary/used_inline_crate.rs:
    LL|       |#![allow(unused_assignments, unused_variables)]
-   LL|       |
+   LL|       |// Verify that coverage works with optimizations:
    LL|       |// compile-flags: -C opt-level=3
-   LL|       |// ^^ validates coverage now works with optimizations
+   LL|       |
    LL|       |use std::fmt::Debug;
    LL|       |
    LL|      1|pub fn used_function() {

--- a/tests/run-coverage/uses_inline_crate.coverage
+++ b/tests/run-coverage/uses_inline_crate.coverage
@@ -120,6 +120,7 @@ $DIR/auxiliary/used_inline_crate.rs:
    LL|      0|}
    LL|       |
    LL|       |#[inline(always)]
+   LL|       |#[allow(dead_code)]
    LL|      0|fn unused_private_function() {
    LL|      0|    let is_true = std::env::args().len() == 1;
    LL|      0|    let mut countdown = 2;

--- a/tests/run-coverage/while_early_ret.coverage
+++ b/tests/run-coverage/while_early_ret.coverage
@@ -1,7 +1,7 @@
    LL|       |#![allow(unused_assignments)]
    LL|       |// failure-status: 1
    LL|       |
-   LL|      1|fn main() -> Result<(),u8> {
+   LL|      1|fn main() -> Result<(), u8> {
    LL|      1|    let mut countdown = 10;
    LL|       |    while
    LL|      7|        countdown

--- a/tests/run-coverage/while_early_ret.rs
+++ b/tests/run-coverage/while_early_ret.rs
@@ -1,7 +1,7 @@
 #![allow(unused_assignments)]
 // failure-status: 1
 
-fn main() -> Result<(),u8> {
+fn main() -> Result<(), u8> {
     let mut countdown = 10;
     while
         countdown

--- a/tests/run-coverage/yield.coverage
+++ b/tests/run-coverage/yield.coverage
@@ -7,7 +7,7 @@
    LL|      1|fn main() {
    LL|      1|    let mut generator = || {
    LL|      1|        yield 1;
-   LL|      1|        return "foo"
+   LL|      1|        return "foo";
    LL|      1|    };
    LL|       |
    LL|      1|    match Pin::new(&mut generator).resume(()) {
@@ -23,7 +23,7 @@
    LL|      1|        yield 1;
    LL|      1|        yield 2;
    LL|      0|        yield 3;
-   LL|      0|        return "foo"
+   LL|      0|        return "foo";
    LL|      0|    };
    LL|       |
    LL|      1|    match Pin::new(&mut generator).resume(()) {

--- a/tests/run-coverage/yield.rs
+++ b/tests/run-coverage/yield.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 fn main() {
     let mut generator = || {
         yield 1;
-        return "foo"
+        return "foo";
     };
 
     match Pin::new(&mut generator).resume(()) {
@@ -23,7 +23,7 @@ fn main() {
         yield 1;
         yield 2;
         yield 3;
-        return "foo"
+        return "foo";
     };
 
     match Pin::new(&mut generator).resume(()) {


### PR DESCRIPTION
Prior to #114875 (anonymized line numbers), these tests were very sensitive to lines being added/removed, since doing so would change the line numbers in every subsequent line of output. Therefore they ended up with a few small style issues that weren't worth the hassle of fixing.

Now that we can freely rearrange lines without needing to re-bless the entire output, we can tidy up the tests in various trivial ways.