### PR TITLE
Add musl toolchain to dist-armv7-linux

### DIFF
--- a/src/ci/docker/host-x86_64/dist-armv7-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-armv7-linux/Dockerfile
@@ -6,6 +6,14 @@ RUN sh /scripts/cross-apt-packages.sh
 COPY scripts/crosstool-ng.sh /scripts/
 RUN sh /scripts/crosstool-ng.sh
 
+WORKDIR /build
+
+COPY scripts/musl-toolchain.sh /build/
+# We need to mitigate rust-lang/rust#34978 when compiling musl itself as well
+RUN CFLAGS="-Wa,--compress-debug-sections=none -Wl,--compress-debug-sections=none" \
+    CXXFLAGS="-Wa,--compress-debug-sections=none -Wl,--compress-debug-sections=none" \
+    bash musl-toolchain.sh armv7 eabihf && rm -rf build
+
 COPY scripts/rustbuild-setup.sh /scripts/
 RUN sh /scripts/rustbuild-setup.sh
 WORKDIR /tmp
@@ -21,9 +29,18 @@ ENV PATH=$PATH:/x-tools/armv7-unknown-linux-gnueabihf/bin
 
 ENV CC_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-gcc \
     AR_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-ar \
-    CXX_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-g++
+    CXX_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-g++ \
+    CC_armv7_unknown_linux_musleabihf=armv7-unknown-linux-gnueabihf-gcc \
+    AR_armv7_unknown_linux_musleabihf=armv7-unknown-linux-gnueabihf-ar \
+    CXX_armv7_unknown_linux_musleabihf=armv7-unknown-linux-gnueabihf-g++
 
-ENV HOSTS=armv7-unknown-linux-gnueabihf
+ENV HOSTS=armv7-unknown-linux-gnueabihf,armv7-unknown-linux-musleabihf
 
-ENV RUST_CONFIGURE_ARGS --enable-full-tools --disable-docs
+ENV RUST_CONFIGURE_ARGS \
+      --enable-full-tools \
+      --disable-docs \
+      --musl-root-armv7hf=/usr/local/armv7-linux-musleabihf \
+      --enable-sanitizers \
+      --enable-profiler \
+      --set target.armv7-unknown-linux-musleabihf.crt-static=false
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -28,7 +28,8 @@ exit 1
 }
 
 ARCH=$1
-TARGET=$ARCH-linux-musl
+ABI=$2
+TARGET=$ARCH-linux-musl$ABI
 
 # Don't depend on the mirrors of sabotage linux that musl-cross-make uses.
 LINUX_HEADERS_SITE=https://ci-mirrors.rust-lang.org/rustc/sabotage-linux-tarballs


### PR DESCRIPTION
This adds the armv7-unknown-linux-musleabihf toolchain to the dist-armv7-linux docker image. The pr prepares for making rustup available on armv7-unknown-linux-musleabihf targets.

This pr is in **draft** because i am not able to build and test the image locally. But i get the same error on the current master branch rev 4a0402cd805aa1f4dd8e2d96b038be664db293c3:

```
$ ./src/ci/docker/run.sh dist-armv7-linux
...
Building LLVM for armv7-unknown-linux-gnueabihf
CMAKE_TOOLCHAIN_FILE_armv7-unknown-linux-gnueabihf = None
CMAKE_TOOLCHAIN_FILE_armv7_unknown_linux_gnueabihf = None
TARGET_CMAKE_TOOLCHAIN_FILE = None
CMAKE_TOOLCHAIN_FILE = None
CMAKE_PREFIX_PATH_armv7-unknown-linux-gnueabihf = None
CMAKE_PREFIX_PATH_armv7_unknown_linux_gnueabihf = None
TARGET_CMAKE_PREFIX_PATH = None
CMAKE_PREFIX_PATH = None
CMAKE_armv7-unknown-linux-gnueabihf = None
CMAKE_armv7_unknown_linux_gnueabihf = None
TARGET_CMAKE = None
CMAKE = None
running: cd "/checkout/obj/build/armv7-unknown-linux-gnueabihf/llvm/build" && CMAKE_PREFIX_PATH="" DESTDIR="" "cmake" "/checkout/src/llvm-project/llvm" "-G" "Ninja" "-DLLVM_ENABLE_ASSERTIONS=ON" "-DLLVM_UNREACHABLE_OPTIMIZE=OFF" "-DLLVM_ENABLE_PLUGINS=OFF" "-DLLVM_TARGETS_TO_BUILD=AArch64;ARM;BPF;Hexagon;LoongArch;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;WebAssembly;X86" "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=AVR;M68k;CSKY" "-DLLVM_INCLUDE_EXAMPLES=OFF" "-DLLVM_INCLUDE_DOCS=OFF" "-DLLVM_INCLUDE_BENCHMARKS=OFF" "-DLLVM_INCLUDE_TESTS=OFF" "-DLLVM_ENABLE_TERMINFO=OFF" "-DLLVM_ENABLE_LIBEDIT=OFF" "-DLLVM_ENABLE_BINDINGS=OFF" "-DLLVM_ENABLE_Z3_SOLVER=OFF" "-DLLVM_PARALLEL_COMPILE_JOBS=24" "-DLLVM_TARGET_ARCH=armv7" "-DLLVM_DEFAULT_TARGET_TRIPLE=armv7-unknown-linux-gnueabihf" "-DLLVM_ENABLE_WARNINGS=OFF" "-DLLVM_INSTALL_UTILS=ON" "-DLLVM_ENABLE_ZSTD=OFF" "-DLLVM_ENABLE_ZLIB=ON" "-DLLVM_LINK_LLVM_DYLIB=ON" "-DLLVM_ENABLE_LIBXML2=OFF" "-DLLVM_TABLEGEN=/checkout/obj/build/x86_64-unknown-linux-gnu/ci-llvm/bin/llvm-tblgen" "-DLLVM_NM=/checkout/obj/build/x86_64-unknown-linux-gnu/ci-llvm/bin/llvm-nm" "-DLLVM_CONFIG_PATH=/checkout/obj/build/x86_64-unknown-linux-gnu/ci-llvm/bin/llvm-config" "-DLLVM_VERSION_SUFFIX=-rust-1.73.0-nightly" "-DCMAKE_INSTALL_MESSAGE=LAZY" "-DCMAKE_CROSSCOMPILING=True" "-DCMAKE_SYSTEM_NAME=Linux" "-DCMAKE_C_COMPILER_LAUNCHER=sccache" "-DCMAKE_CXX_COMPILER_LAUNCHER=sccache" "-DCMAKE_C_COMPILER=armv7-unknown-linux-gnueabihf-gcc" "-DCMAKE_CXX_COMPILER=armv7-unknown-linux-gnueabihf-g++" "-DCMAKE_ASM_COMPILER=armv7-unknown-linux-gnueabihf-gcc" "-DCMAKE_C_FLAGS=-ffunction-sections -fdata-sections -fPIC -march=armv7-a -mfpu=vfpv3-d16" "-DCMAKE_CXX_FLAGS=-ffunction-sections -fdata-sections -fPIC -march=armv7-a -mfpu=vfpv3-d16" "-DCMAKE_SHARED_LINKER_FLAGS=" "-DCMAKE_MODULE_LINKER_FLAGS=" "-DCMAKE_EXE_LINKER_FLAGS=" "-DCMAKE_INSTALL_PREFIX=/checkout/obj/build/armv7-unknown-linux-gnueabihf/llvm" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -march=armv7-a -mfpu=vfpv3-d16" "-DCMAKE_BUILD_TYPE=Release"
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR) 
-- Native target architecture is ARM
-- Threads enabled.
-- Doxygen disabled.
-- Ninja version: 1.10.1
-- Could NOT find OCaml (missing: OCAMLFIND OCAML_VERSION OCAML_STDLIB_PATH) 
-- OCaml bindings disabled.
-- LLVM host triple: x86_64-unknown-linux-gnu
-- LLVM default target triple: armv7-unknown-linux-gnueabihf
-- Building with -fPIC
-- Setting native build dir to /checkout/obj/build/armv7-unknown-linux-gnueabihf/llvm/build/NATIVE
-- LLVMHello ignored -- Loadable modules not supported on this platform.
-- Targeting AArch64
-- Targeting ARM
-- Targeting BPF
-- Targeting Hexagon
-- Targeting LoongArch
-- Targeting MSP430
-- Targeting Mips
-- Targeting NVPTX
-- Targeting PowerPC
-- Targeting RISCV
-- Targeting Sparc
-- Targeting SystemZ
-- Targeting WebAssembly
-- Targeting X86
-- Targeting AVR
-- Targeting M68k
-- Targeting CSKY
-- BugpointPasses ignored -- Loadable modules not supported on this platform.
-- Configuring done
-- Generating done
-- Build files have been written to: /checkout/obj/build/armv7-unknown-linux-gnueabihf/llvm/build
running: cd "/checkout/obj/build/armv7-unknown-linux-gnueabihf/llvm/build" && DESTDIR="" "cmake" "--build" "." "--target" "install" "--config" "Release" "--" "-j" "24"
[1/3] Building CXX object tools/llvm-config/CMakeFiles/llvm-config.dir/llvm-config.cpp.o
[2/3] Linking CXX executable bin/llvm-config
[2/3] Install the project...
-- Install configuration: "Release"
-- Creating llvm-ranlib
-- Creating llvm-lib
-- Creating llvm-dlltool
-- Installing: /checkout/obj/build/armv7-unknown-linux-gnueabihf/llvm/bin/llvm-config
-- Set runtime path of "/checkout/obj/build/armv7-unknown-linux-gnueabihf/llvm/bin/llvm-config" to "$ORIGIN/../lib"
-- Creating llvm-install-name-tool
-- Creating llvm-bitcode-strip
-- Creating llvm-strip
-- Creating llvm-otool
-- Creating llvm-windres
-- Creating llvm-readelf
-- Creating libLLVM-17.0.0-rust-1.73.0-nightly.so
-- Creating libLLVM.so
-- Creating llvm-addr2line
-- Installing: /checkout/obj/build/armv7-unknown-linux-gnueabihf/llvm/lib/cmake/llvm/LLVMConfigExtensions.cmake
cargo:root=/checkout/obj/build/armv7-unknown-linux-gnueabihf/llvm


failed to execute command: "/checkout/obj/build/x86_64-unknown-linux-gnu/llvm/build/bin/llvm-config" "--version"
error: No such file or directory (os error 2)


Build completed unsuccessfully in 0:03:17
```