### PR TITLE
[beta] backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,17 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
- "compiler_builtins",
  "gimli 0.27.3",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "compiler_builtins",
+ "gimli 0.28.0",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
 ]
@@ -179,7 +188,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74cfb39880a59e122232cb5fb06b20b4382d58c12fa9747d16f846d38a7b094c"
 dependencies = [
- "object",
+ "object 0.31.1",
 ]
 
 [[package]]
@@ -249,12 +258,12 @@ version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
- "addr2line",
+ "addr2line 0.20.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.31.1",
  "rustc-demangle",
 ]
 
@@ -1362,6 +1371,12 @@ name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
@@ -2204,15 +2219,24 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
- "compiler_builtins",
  "crc32fast",
  "flate2",
  "hashbrown 0.13.2",
  "indexmap 1.9.3",
  "memchr",
+ "ruzstd",
+]
+
+[[package]]
+name = "object"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+dependencies = [
+ "compiler_builtins",
+ "memchr",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
- "ruzstd",
 ]
 
 [[package]]
@@ -3029,7 +3053,7 @@ dependencies = [
  "cstr",
  "libc",
  "measureme",
- "object",
+ "object 0.31.1",
  "rustc-demangle",
  "rustc_ast",
  "rustc_attr",
@@ -3065,7 +3089,7 @@ dependencies = [
  "itertools",
  "jobserver",
  "libc",
- "object",
+ "object 0.31.1",
  "pathdiff",
  "regex",
  "rustc_arena",
@@ -3996,7 +4020,7 @@ name = "rustc_target"
 version = "0.0.0"
 dependencies = [
  "bitflags 1.3.2",
- "object",
+ "object 0.31.1",
  "rustc_abi",
  "rustc_data_structures",
  "rustc_feature",
@@ -4490,7 +4514,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "std"
 version = "0.0.0"
 dependencies = [
- "addr2line",
+ "addr2line 0.21.0",
  "alloc",
  "cfg-if",
  "compiler_builtins",
@@ -4501,7 +4525,7 @@ dependencies = [
  "hermit-abi 0.3.1",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.32.0",
  "panic_abort",
  "panic_unwind",
  "profiler_builtins",
@@ -4773,7 +4797,7 @@ checksum = "98c040e1340b889d4180c64e1d787efa9c32cb1617757e101480b61238b0d927"
 dependencies = [
  "gimli 0.26.2",
  "hashbrown 0.12.3",
- "object",
+ "object 0.31.1",
  "tracing",
 ]
 

--- a/compiler/rustc_codegen_ssa/src/mir/constant.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/constant.rs
@@ -67,6 +67,20 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) -> Result<Option<ty::ValTree<'tcx>>, ErrorHandled> {
         let uv = match constant.literal {
             mir::ConstantKind::Unevaluated(uv, _) => uv.shrink(),
+            mir::ConstantKind::Ty(c) => match c.kind() {
+                // A constant that came from a const generic but was then used as an argument to old-style
+                // simd_shuffle (passing as argument instead of as a generic param).
+                rustc_type_ir::ConstKind::Value(valtree) => return Ok(Some(valtree)),
+                other => span_bug!(constant.span, "{other:#?}"),
+            },
+            // We should never encounter `ConstantKind::Val` unless MIR opts (like const prop) evaluate
+            // a constant and write that value back into `Operand`s. This could happen, but is unlikely.
+            // Also: all users of `simd_shuffle` are on unstable and already need to take a lot of care
+            // around intrinsics. For an issue to happen here, it would require a macro expanding to a
+            // `simd_shuffle` call without wrapping the constant argument in a `const {}` block, but
+            // the user pass through arbitrary expressions.
+            // FIXME(oli-obk): replace the magic const generic argument of `simd_shuffle` with a real
+            // const generic.
             other => span_bug!(constant.span, "{other:#?}"),
         };
         let uv = self.monomorphize(uv);

--- a/compiler/rustc_codegen_ssa/src/mir/constant.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/constant.rs
@@ -65,7 +65,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         &self,
         constant: &mir::Constant<'tcx>,
     ) -> Result<Option<ty::ValTree<'tcx>>, ErrorHandled> {
-        let uv = match constant.literal {
+        let uv = match self.monomorphize(constant.literal) {
             mir::ConstantKind::Unevaluated(uv, _) => uv.shrink(),
             mir::ConstantKind::Ty(c) => match c.kind() {
                 // A constant that came from a const generic but was then used as an argument to old-style

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -25,11 +25,11 @@ hashbrown = { version = "0.14", default-features = false, features = ['rustc-dep
 std_detect = { path = "../stdarch/crates/std_detect", default-features = false, features = ['rustc-dep-of-std'] }
 
 # Dependencies of the `backtrace` crate
-addr2line = { version = "0.20.0", optional = true, default-features = false }
+addr2line = { version = "0.21.0", optional = true, default-features = false }
 rustc-demangle = { version = "0.1.21", features = ['rustc-dep-of-std'] }
 miniz_oxide = { version = "0.7.0", optional = true, default-features = false, public = false }
 [dependencies.object]
-version = "0.31.1"
+version = "0.32.0"
 optional = true
 default-features = false
 features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive']

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1425,9 +1425,9 @@ pub trait Write {
     ///
     /// If this method consumed `n > 0` bytes of `buf` it must return [`Ok(n)`].
     /// If the return value is `Ok(n)` then `n` must satisfy `n <= buf.len()`.
-    /// Unless `buf` is empty, this function shouldn’t return `Ok(0)` since the
-    /// caller may interpret that as an error.  To indicate lack of space,
-    /// implementors should return [`ErrorKind::StorageFull`] error instead.
+    /// A return value of `Ok(0)` typically means that the underlying object is
+    /// no longer able to accept bytes and will likely not be able to in the
+    /// future as well, or that the buffer provided is empty.
     ///
     /// # Errors
     ///

--- a/tests/ui/simd/shuffle.rs
+++ b/tests/ui/simd/shuffle.rs
@@ -1,4 +1,7 @@
-//run-pass
+// run-pass
+// revisions: opt noopt
+//[noopt] compile-flags: -Copt-level=0
+//[opt] compile-flags: -O
 #![feature(repr_simd, platform_intrinsics)]
 #![allow(incomplete_features)]
 #![feature(adt_const_params)]

--- a/tests/ui/simd/shuffle.rs
+++ b/tests/ui/simd/shuffle.rs
@@ -1,13 +1,20 @@
 //run-pass
 #![feature(repr_simd, platform_intrinsics)]
+#![allow(incomplete_features)]
+#![feature(adt_const_params)]
 
 extern "platform-intrinsic" {
     fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;
+    fn simd_shuffle16<T, U>(x: T, y: T, idx: [u32; 16]) -> U;
 }
 
 #[derive(Copy, Clone)]
 #[repr(simd)]
 struct Simd<T, const N: usize>([T; N]);
+
+pub unsafe fn __shuffle_vector16<const IDX: [u32; 16], T, U>(x: T, y: T) -> U {
+    simd_shuffle16(x, y, IDX)
+}
 
 fn main() {
     const I1: [u32; 4] = [0, 2, 4, 6];
@@ -20,5 +27,17 @@ fn main() {
 
         let y: Simd<u8, 2> = simd_shuffle(a, b, I2);
         assert_eq!(y.0, [1, 5]);
+    }
+    // Test that an indirection (via an unnamed constant)
+    // through a const generic parameter also works.
+    // See https://github.com/rust-lang/rust/issues/113500 for details.
+    let a = Simd::<u8, 16>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    let b = Simd::<u8, 16>([16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
+    unsafe {
+        __shuffle_vector16::<
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] },
+            Simd<u8, 16>,
+            Simd<u8, 16>,
+        >(a, b);
     }
 }

--- a/tests/ui/std/slice-from-array-issue-113238.rs
+++ b/tests/ui/std/slice-from-array-issue-113238.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+// This intends to use the unsizing coercion from array to slice, but it only
+// works if we resolve `<&[u8]>::from` as the reflexive `From<T> for T`. In
+// #113238, we found that gimli had added its own `From<EndianSlice> for &[u8]`
+// that affected all `std/backtrace` users.
+fn main() {
+    let _ = <&[u8]>::from(&[]);
+}

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -13,7 +13,7 @@ LL |     let _: &[i8] = data.into();
              <[T; 4] as From<(T, T, T, T)>>
              <[T; 5] as From<(T, T, T, T, T)>>
              <[T; 6] as From<(T, T, T, T, T, T)>>
-           and 7 others
+           and 6 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 
 error: aborting due to previous error


### PR DESCRIPTION
* Upgrade std to gimli 0.28.0 #114825 
* Partially revert #107200 #114897 
* Permit pre-evaluated constants in simd_shuffle #113529 

r? cuviper