### PR TITLE
`ignore-cross-compile` on `optimization-remarks-dir-pgo` test

### DIFF
--- a/tests/run-make/optimization-remarks-dir-pgo/Makefile
+++ b/tests/run-make/optimization-remarks-dir-pgo/Makefile
@@ -1,5 +1,6 @@
 # needs-profiler-support
 # ignore-windows-gnu
+# ignore-cross-compile
 
 # FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
 # properly. Since we only have GCC on the CI ignore the test for now.


### PR DESCRIPTION
We noticed this on our upstream pull on ferrocene a week ago as it was failing our CI. The test attempts to run the produced binary which won't work when cross compiling.