### PR TITLE
fix library doctest: not failing on some feature gates as expected

### DIFF
--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -830,6 +830,9 @@ impl<'tcx> Visitor<'tcx> for Checker<'tcx> {
                             None,
                             path.span,
                             None,
+                            #[cfg(bootstrap)]
+                            AllowUnstable::No,
+                            #[cfg(not(bootstrap))]
                             if is_unstable_reexport(self.tcx, id) {
                                 AllowUnstable::Yes
                             } else {


### PR DESCRIPTION
Updating the behavior of `fn is_unstable_reexport` to return false for bootstrap environment would result in a breakage of https://github.com/rust-lang/rust/issues/94972. This was the quickest and simplest solution to fix this elusive bug, which was only identified through miri tests.

Related https://github.com/rust-lang/rust/issues/114838