### PR TITLE
adds a column number to `dbg!()`

### DIFF
--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -355,15 +355,15 @@ macro_rules! dbg {
     // `$val` expression could be a block (`{ .. }`), in which case the `eprintln!`
     // will be malformed.
     () => {
-        $crate::eprintln!("[{}:{}]", $crate::file!(), $crate::line!())
+        $crate::eprintln!("[{}:{}:{}]", $crate::file!(), $crate::line!(), $crate::column!())
     };
     ($val:expr $(,)?) => {
         // Use of `match` here is intentional because it affects the lifetimes
         // of temporaries - https://stackoverflow.com/a/48732525/1063961
         match $val {
             tmp => {
-                $crate::eprintln!("[{}:{}] {} = {:#?}",
-                    $crate::file!(), $crate::line!(), $crate::stringify!($val), &tmp);
+                $crate::eprintln!("[{}:{}:{}] {} = {:#?}",
+                    $crate::file!(), $crate::line!(), $crate::column!(), $crate::stringify!($val), &tmp);
                 tmp
             }
         }

--- a/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-expected-behavior.run.stderr
+++ b/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-expected-behavior.run.stderr
@@ -1,28 +1,28 @@
-[$DIR/dbg-macro-expected-behavior.rs:22] Unit = Unit
-[$DIR/dbg-macro-expected-behavior.rs:23] a = Unit
-[$DIR/dbg-macro-expected-behavior.rs:29] Point { x: 42, y: 24 } = Point {
+[$DIR/dbg-macro-expected-behavior.rs:22:19] Unit = Unit
+[$DIR/dbg-macro-expected-behavior.rs:23:19] a = Unit
+[$DIR/dbg-macro-expected-behavior.rs:29:24] Point { x: 42, y: 24 } = Point {
     x: 42,
     y: 24,
 }
-[$DIR/dbg-macro-expected-behavior.rs:30] b = Point {
+[$DIR/dbg-macro-expected-behavior.rs:30:24] b = Point {
     x: 42,
     y: 24,
 }
-[$DIR/dbg-macro-expected-behavior.rs:38]
-[$DIR/dbg-macro-expected-behavior.rs:42] &a = NoCopy(
+[$DIR/dbg-macro-expected-behavior.rs:38:17]
+[$DIR/dbg-macro-expected-behavior.rs:42:27] &a = NoCopy(
     1337,
 )
-[$DIR/dbg-macro-expected-behavior.rs:42] dbg!(&a) = NoCopy(
+[$DIR/dbg-macro-expected-behavior.rs:42:22] dbg!(&a) = NoCopy(
     1337,
 )
-[$DIR/dbg-macro-expected-behavior.rs:47] f(&42) = 42
+[$DIR/dbg-macro-expected-behavior.rs:47:18] f(&42) = 42
 before
-[$DIR/dbg-macro-expected-behavior.rs:52] { foo += 1; eprintln!("before"); 7331 } = 7331
-[$DIR/dbg-macro-expected-behavior.rs:60] ("Yeah",) = (
+[$DIR/dbg-macro-expected-behavior.rs:52:22] { foo += 1; eprintln!("before"); 7331 } = 7331
+[$DIR/dbg-macro-expected-behavior.rs:60:27] ("Yeah",) = (
     "Yeah",
 )
-[$DIR/dbg-macro-expected-behavior.rs:63] 1 = 1
-[$DIR/dbg-macro-expected-behavior.rs:63] 2 = 2
-[$DIR/dbg-macro-expected-behavior.rs:67] 1u8 = 1
-[$DIR/dbg-macro-expected-behavior.rs:67] 2u32 = 2
-[$DIR/dbg-macro-expected-behavior.rs:67] "Yeah" = "Yeah"
+[$DIR/dbg-macro-expected-behavior.rs:63:29] 1 = 1
+[$DIR/dbg-macro-expected-behavior.rs:63:29] 2 = 2
+[$DIR/dbg-macro-expected-behavior.rs:67:37] 1u8 = 1
+[$DIR/dbg-macro-expected-behavior.rs:67:37] 2u32 = 2
+[$DIR/dbg-macro-expected-behavior.rs:67:37] "Yeah" = "Yeah"


### PR DESCRIPTION
this would be very nice to have for a few reasons:
1. the rfc, when deciding not to add column numbers to macro, failed to acknowledge any potential ambiguous cases -- such as the one provided in #114910 -- which do exist
2. would be able to consistently and easily jump directly to the `dbg!()` regardless of the sutation
3. takes up, at a maximum, 3 characters of _horizontal_ screen space

fixes #114910