### PR TITLE
Expose core::error::request_value in std

### DIFF
--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -10,7 +10,7 @@ use crate::fmt::{self, Write};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::error::Error;
 #[unstable(feature = "error_generic_member_access", issue = "99301")]
-pub use core::error::{request_ref, Request};
+pub use core::error::{request_ref, request_value, Request};
 
 mod private {
     // This is a hack to prevent `type_id` from being overridden by `Error`


### PR DESCRIPTION
I think this was simply forgotten in #113464.

/cc @waynr 

r? @Amanieu 