### PR TITLE
Ignore unexpected incr-comp session dirs

### DIFF
--- a/compiler/rustc_incremental/src/persist/fs.rs
+++ b/compiler/rustc_incremental/src/persist/fs.rs
@@ -538,9 +538,13 @@ where
             continue;
         }
 
-        let timestamp = extract_timestamp_from_session_dir(&directory_name).unwrap_or_else(|e| {
-            bug!("unexpected incr-comp session dir: {}: {}", session_dir.display(), e)
-        });
+        let timestamp = match extract_timestamp_from_session_dir(&directory_name) {
+            Ok(timestamp) => timestamp,
+            Err(e) => {
+                debug!("unexpected incr-comp session dir: {}: {}", session_dir.display(), e);
+                continue;
+            }
+        };
 
         if timestamp > best_candidate.0 {
             best_candidate = (timestamp, Some(session_dir.clone()));

--- a/compiler/rustc_incremental/src/persist/fs.rs
+++ b/compiler/rustc_incremental/src/persist/fs.rs
@@ -538,8 +538,8 @@ where
             continue;
         }
 
-        let timestamp = extract_timestamp_from_session_dir(&directory_name).unwrap_or_else(|_| {
-            bug!("unexpected incr-comp session dir: {}", session_dir.display())
+        let timestamp = extract_timestamp_from_session_dir(&directory_name).unwrap_or_else(|e| {
+            bug!("unexpected incr-comp session dir: {}: {}", session_dir.display(), e)
         });
 
         if timestamp > best_candidate.0 {
@@ -562,14 +562,14 @@ fn is_session_directory_lock_file(file_name: &str) -> bool {
     file_name.starts_with("s-") && file_name.ends_with(LOCK_FILE_EXT)
 }
 
-fn extract_timestamp_from_session_dir(directory_name: &str) -> Result<SystemTime, ()> {
+fn extract_timestamp_from_session_dir(directory_name: &str) -> Result<SystemTime, &'static str> {
     if !is_session_directory(directory_name) {
-        return Err(());
+        return Err("not a directory");
     }
 
     let dash_indices: Vec<_> = directory_name.match_indices('-').map(|(idx, _)| idx).collect();
     if dash_indices.len() != 3 {
-        return Err(());
+        return Err("not three dashes in name");
     }
 
     string_to_timestamp(&directory_name[dash_indices[0] + 1..dash_indices[1]])
@@ -581,11 +581,11 @@ fn timestamp_to_string(timestamp: SystemTime) -> String {
     base_n::encode(micros as u128, INT_ENCODE_BASE)
 }
 
-fn string_to_timestamp(s: &str) -> Result<SystemTime, ()> {
+fn string_to_timestamp(s: &str) -> Result<SystemTime, &'static str> {
     let micros_since_unix_epoch = u64::from_str_radix(s, INT_ENCODE_BASE as u32);
 
     if micros_since_unix_epoch.is_err() {
-        return Err(());
+        return Err("timestamp not an int");
     }
 
     let micros_since_unix_epoch = micros_since_unix_epoch.unwrap();


### PR DESCRIPTION
Clearly the code path can be hit without the presence of a compiler bug.
All it takes is mischief. See #71698.

Ignore problematic directories instead of ICE:ing. `continue`ing is
 already done for problematic dirs in the code block above us.

Closes #71698.

With this fix, the output is this instead of ICE:

```
$ cargo +stage1 new gz-ice && cd gz-ice
$ cargo +stage1 build
$ find target -type f -exec gzip {} \;
$ cargo +stage1 run

     Created binary (application) `gz-ice` package
   Compiling gz-ice v0.1.0 (/tmp/gz-ice)
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
gzip: target/debug/gz-ice has 1 other link  -- unchanged
gzip: target/debug/deps/gz_ice-de919414dd9926b9 has 1 other link  -- unchanged
   Compiling gz-ice v0.1.0 (/tmp/gz-ice)
warning: failed to garbage collect invalid incremental compilation session directory `/tmp/gz-ice/target/debug/incremental/gz_ice-23qx9z9j9vghe/s-gnwd8daity-kp10sj.lock.gz`: Not a directory (os error 20)

warning: `gz-ice` (bin "gz-ice") generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/gz-ice`
Hello, world!
```