### PR TITLE
Allow lexer to include emoji components for diagnostics.

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -429,7 +429,9 @@ impl Cursor<'_> {
                 Literal { kind, suffix_start }
             }
             // Identifier starting with an emoji. Only lexed for graceful error recovery.
-            c if !c.is_ascii() && c.is_emoji_char() => self.fake_ident_or_unknown_prefix(),
+            c if !c.is_ascii() && c.is_emoji_char_or_emoji_component() => {
+                self.fake_ident_or_unknown_prefix()
+            }
             _ => Unknown,
         };
         let res = Token::new(token_kind, self.pos_within_token());
@@ -513,7 +515,9 @@ impl Cursor<'_> {
         // we see a prefix here, it is definitely an unknown prefix.
         match self.first() {
             '#' | '"' | '\'' => UnknownPrefix,
-            c if !c.is_ascii() && c.is_emoji_char() => self.fake_ident_or_unknown_prefix(),
+            c if !c.is_ascii() && c.is_emoji_char_or_emoji_component() => {
+                self.fake_ident_or_unknown_prefix()
+            }
             _ => Ident,
         }
     }
@@ -522,8 +526,7 @@ impl Cursor<'_> {
         // Start is already eaten, eat the rest of identifier.
         self.eat_while(|c| {
             unicode_xid::UnicodeXID::is_xid_continue(c)
-                || (!c.is_ascii() && c.is_emoji_char())
-                || c == '\u{200d}'
+                || (!c.is_ascii() && c.is_emoji_char_or_emoji_component())
         });
         // Known prefixes must have been handled earlier. So if
         // we see a prefix here, it is definitely an unknown prefix.

--- a/tests/ui/lexer/lex-emoji-identifiers.rs
+++ b/tests/ui/lexer/lex-emoji-identifiers.rs
@@ -2,9 +2,7 @@ fn invalid_emoji_usages() {
     let arrow↔️ = "basic emoji"; //~ ERROR: identifiers cannot contain emoji
     let planet🪐 = "basic emoji"; //~ ERROR: identifiers cannot contain emoji
     let wireless🛜 = "basic emoji"; //~ ERROR: identifiers cannot contain emoji
-    // FIXME
-    let key1️⃣ = "keycap sequence"; //~ ERROR: unknown start of token
-                                    //~^ WARN: identifier contains uncommon Unicode codepoints
+    let key1️⃣ = "keycap sequence"; //~ ERROR: identifiers cannot contain emoji
     let flag🇺🇳 = "flag sequence"; //~ ERROR: identifiers cannot contain emoji
     let wales🏴 = "tag sequence"; //~ ERROR: identifiers cannot contain emoji
     let folded🙏🏿 = "modifier sequence"; //~ ERROR: identifiers cannot contain emoji

--- a/tests/ui/lexer/lex-emoji-identifiers.stderr
+++ b/tests/ui/lexer/lex-emoji-identifiers.stderr
@@ -1,9 +1,3 @@
-error: unknown start of token: \u{20e3}
-  --> $DIR/lex-emoji-identifiers.rs:6:14
-   |
-LL |     let key1️⃣ = "keycap sequence";
-   |             ^
-
 error: identifiers cannot contain emoji: `arrow↔️`
   --> $DIR/lex-emoji-identifiers.rs:2:9
    |
@@ -22,31 +16,29 @@ error: identifiers cannot contain emoji: `wireless🛜`
 LL |     let wireless🛜 = "basic emoji";
    |         ^^^^^^^^^^
 
+error: identifiers cannot contain emoji: `key1️⃣`
+  --> $DIR/lex-emoji-identifiers.rs:5:9
+   |
+LL |     let key1️⃣ = "keycap sequence";
+   |         ^^^^
+
 error: identifiers cannot contain emoji: `flag🇺🇳`
-  --> $DIR/lex-emoji-identifiers.rs:8:9
+  --> $DIR/lex-emoji-identifiers.rs:6:9
    |
 LL |     let flag🇺🇳 = "flag sequence";
    |         ^^^^^^
 
 error: identifiers cannot contain emoji: `wales🏴`
-  --> $DIR/lex-emoji-identifiers.rs:9:9
+  --> $DIR/lex-emoji-identifiers.rs:7:9
    |
 LL |     let wales🏴 = "tag sequence";
    |         ^^^^^^^
 
 error: identifiers cannot contain emoji: `folded🙏🏿`
-  --> $DIR/lex-emoji-identifiers.rs:10:9
+  --> $DIR/lex-emoji-identifiers.rs:8:9
    |
 LL |     let folded🙏🏿 = "modifier sequence";
    |         ^^^^^^^^^^
 
-warning: identifier contains uncommon Unicode codepoints
-  --> $DIR/lex-emoji-identifiers.rs:6:9
-   |
-LL |     let key1️⃣ = "keycap sequence";
-   |         ^^^^
-   |
-   = note: `#[warn(uncommon_codepoints)]` on by default
-
-error: aborting due to 7 previous errors; 1 warning emitted
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This modifies the lexer to include emoji components as the continue characters of "fake identifier"s used for diagnostics.

Previously, the code is including the characters recommended for emoji usages for this "fake identifier" approach. This change expands the list to include those characters that are used within emoji sequences, including (Unicode 15):
* `U+200D` (ZWJ)
* `U+20E3` (Keycap) (see unit test in this PR for its usage)
* `U+FE0F` (Emoji variation selector)
* `U+1F1E6..=U+1F1FF` (Regional indicator)
* `U+1F3FB..=U+1F3FF` (Skin tone modifier)
* `U+1F9B0..=U+1F9B3` (Hair modifier)
* `U+E0020..=U+E007F` (Tag characters)

cc @Manishearth 
