### PR TITLE
Increase parallelism in various locations

### DIFF
--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -9,7 +9,7 @@ pub mod place;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_data_structures::sync::{DynSend, DynSync, try_par_for_each_in};
+use rustc_data_structures::sync::{DynSend, DynSync, par_for_each_in, try_par_for_each_in};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId};
 use rustc_hir::lints::DelayedLint;
@@ -99,46 +99,62 @@ impl ModuleItems {
     }
 
     /// Closures and inline consts
-    pub fn par_nested_bodies(
+    pub fn try_par_nested_bodies(
         &self,
         f: impl Fn(LocalDefId) -> Result<(), ErrorGuaranteed> + DynSend + DynSync,
     ) -> Result<(), ErrorGuaranteed> {
         try_par_for_each_in(&self.nested_bodies[..], |&&id| f(id))
     }
 
-    pub fn par_items(
+    pub fn try_par_items(
         &self,
         f: impl Fn(ItemId) -> Result<(), ErrorGuaranteed> + DynSend + DynSync,
     ) -> Result<(), ErrorGuaranteed> {
         try_par_for_each_in(&self.free_items[..], |&&id| f(id))
     }
 
-    pub fn par_trait_items(
+    pub fn try_par_trait_items(
         &self,
         f: impl Fn(TraitItemId) -> Result<(), ErrorGuaranteed> + DynSend + DynSync,
     ) -> Result<(), ErrorGuaranteed> {
         try_par_for_each_in(&self.trait_items[..], |&&id| f(id))
     }
 
-    pub fn par_impl_items(
+    pub fn try_par_impl_items(
         &self,
         f: impl Fn(ImplItemId) -> Result<(), ErrorGuaranteed> + DynSend + DynSync,
     ) -> Result<(), ErrorGuaranteed> {
         try_par_for_each_in(&self.impl_items[..], |&&id| f(id))
     }
 
-    pub fn par_foreign_items(
+    pub fn try_par_foreign_items(
         &self,
         f: impl Fn(ForeignItemId) -> Result<(), ErrorGuaranteed> + DynSend + DynSync,
     ) -> Result<(), ErrorGuaranteed> {
         try_par_for_each_in(&self.foreign_items[..], |&&id| f(id))
     }
 
-    pub fn par_opaques(
+    pub fn try_par_opaques(
         &self,
         f: impl Fn(LocalDefId) -> Result<(), ErrorGuaranteed> + DynSend + DynSync,
     ) -> Result<(), ErrorGuaranteed> {
         try_par_for_each_in(&self.opaques[..], |&&id| f(id))
+    }
+
+    pub fn par_items(&self, f: impl Fn(ItemId) + DynSend + DynSync) {
+        par_for_each_in(&self.free_items[..], |&&id| f(id))
+    }
+
+    pub fn par_trait_items(&self, f: impl Fn(TraitItemId) + DynSend + DynSync) {
+        par_for_each_in(&self.trait_items[..], |&&id| f(id))
+    }
+
+    pub fn par_impl_items(&self, f: impl Fn(ImplItemId) + DynSend + DynSync) {
+        par_for_each_in(&self.impl_items[..], |&&id| f(id))
+    }
+
+    pub fn par_foreign_items(&self, f: impl Fn(ForeignItemId) + DynSend + DynSync) {
+        par_for_each_in(&self.foreign_items[..], |&&id| f(id))
     }
 }
 

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1882,6 +1882,6 @@ fn check_private_in_public(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
     let checker = PrivateItemsInPublicInterfacesChecker { tcx, effective_visibilities };
 
     let crate_items = tcx.hir_module_items(module_def_id);
-    let _ = crate_items.par_items(|id| Ok(checker.check_item(id)));
-    let _ = crate_items.par_foreign_items(|id| Ok(checker.check_foreign_item(id)));
+    crate_items.par_items(|id| checker.check_item(id));
+    crate_items.par_foreign_items(|id| checker.check_foreign_item(id));
 }

--- a/tests/ui/macros/macro-span-issue-116502.stderr
+++ b/tests/ui/macros/macro-span-issue-116502.stderr
@@ -5,6 +5,17 @@ LL |             _
    |             ^ not allowed in type signatures
 ...
 LL |     struct S<T = m!()>(m!(), T)
+   |                        ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/macro-span-issue-116502.rs:7:13
+   |
+LL |             _
+   |             ^ not allowed in type signatures
+...
+LL |     struct S<T = m!()>(m!(), T)
    |                  ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -17,17 +28,6 @@ LL |             _
 ...
 LL |         T: Trait<m!()>;
    |                  ---- in this macro invocation
-   |
-   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/macro-span-issue-116502.rs:7:13
-   |
-LL |             _
-   |             ^ not allowed in type signatures
-...
-LL |     struct S<T = m!()>(m!(), T)
-   |                        ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/span/issue-35987.rs
+++ b/tests/ui/span/issue-35987.rs
@@ -3,7 +3,7 @@ struct Foo<T: Clone>(T);
 use std::ops::Add;
 
 impl<T: Clone, Add> Add for Foo<T> {
-//~^ ERROR expected trait, found type parameter
+    //~^ ERROR expected trait, found type parameter
     type Output = usize;
 
     fn add(self, rhs: Self) -> Self::Output {

--- a/tests/ui/traits/object/suggestion-trait-object-issue-139174.stderr
+++ b/tests/ui/traits/object/suggestion-trait-object-issue-139174.stderr
@@ -17,6 +17,12 @@ LL |     x: usize + 'a,
    |        ^^^^^ not a trait
 
 error[E0782]: expected a type, found a trait
+  --> $DIR/suggestion-trait-object-issue-139174.rs:16:8
+   |
+LL |     x: usize + 'a,
+   |        ^^^^^^^^^^
+
+error[E0782]: expected a type, found a trait
   --> $DIR/suggestion-trait-object-issue-139174.rs:3:36
    |
 LL | fn f<'a>(x: Box<dyn Fn() -> Option<usize + 'a>>) -> usize {
@@ -27,12 +33,6 @@ error[E0782]: expected a type, found a trait
    |
 LL | fn create_adder<'a>(x: i32) -> usize + 'a {
    |                                ^^^^^^^^^^
-
-error[E0782]: expected a type, found a trait
-  --> $DIR/suggestion-trait-object-issue-139174.rs:16:8
-   |
-LL |     x: usize + 'a,
-   |        ^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -44,6 +44,60 @@ LL | struct BadStruct1<_, _>(_);
    |                   |
    |                   first use of `_`
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:66:8
+   |
+LL |     a: _,
+   |        ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:68:9
+   |
+LL |     b: (_, _),
+   |         ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:68:12
+   |
+LL |     b: (_, _),
+   |            ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:123:12
+   |
+LL |         a: _,
+   |            ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:125:13
+   |
+LL |         b: (_, _),
+   |             ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:125:16
+   |
+LL |         b: (_, _),
+   |                ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:158:21
+   |
+LL | struct BadStruct<_>(_);
+   |                     ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:173:25
+   |
+LL | struct BadStruct1<_, _>(_);
+   |                         ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:178:25
+   |
+LL | struct BadStruct2<_, T>(_, T);
+   |                         ^ not allowed in type signatures
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:7:14
    |
@@ -137,60 +191,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL | fn test8(_f: fn() -> _) { }
    |                      ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:66:8
-   |
-LL |     a: _,
-   |        ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:68:9
-   |
-LL |     b: (_, _),
-   |         ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:68:12
-   |
-LL |     b: (_, _),
-   |            ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:123:12
-   |
-LL |         a: _,
-   |            ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:125:13
-   |
-LL |         b: (_, _),
-   |             ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:125:16
-   |
-LL |         b: (_, _),
-   |                ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:158:21
-   |
-LL | struct BadStruct<_>(_);
-   |                     ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:173:25
-   |
-LL | struct BadStruct1<_, _>(_);
-   |                         ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:178:25
-   |
-LL | struct BadStruct2<_, T>(_, T);
-   |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:47:26


### PR DESCRIPTION
This is a rebase of https://github.com/rust-lang/rust/pull/67870 which consists of various additions of parallelism in the compiler. 

Performance improvement for the parallel compiler with 6 threads:
<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th></tr><tr><td>🟣 <b>clap</b>:check</td><td align="right">0.7382s</td><td align="right">0.6639s</td><td align="right">💚  -10.07%</td></tr><tr><td>🟣 <b>hyper</b>:check</td><td align="right">0.1873s</td><td align="right">0.1609s</td><td align="right">💚  -14.10%</td></tr><tr><td>🟣 <b>regex</b>:check</td><td align="right">0.4478s</td><td align="right">0.4173s</td><td align="right">💚  -6.81%</td></tr><tr><td>🟣 <b>syn</b>:check</td><td align="right">0.7475s</td><td align="right">0.6857s</td><td align="right">💚  -8.26%</td></tr><tr><td>🟣 <b>syntex_syntax</b>:check</td><td align="right">2.3616s</td><td align="right">2.1652s</td><td align="right">💚  -8.32%</td></tr><tr><td>Total</td><td align="right">4.4823s</td><td align="right">4.0929s</td><td align="right">💚  -8.69%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">0.9049s</td><td align="right">💚  -9.51%</td></tr></table>

cc @SparrowLii 