### PR TITLE
Simplify the Formatter::debug_map doc example

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2221,7 +2221,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-    ///         fmt.debug_map().entries(self.0.iter().map(|&(ref k, ref v)| (k, v))).finish()
+    ///         fmt.debug_map().entries(self.0.iter().copied()).finish()
     ///     }
     /// }
     ///


### PR DESCRIPTION
While browsing the documentation, I noticed that the doc example of [`Formatter::debug_map`] can be simplified a bit. This commit fixes this.

[`Formatter::debug_map`]:
  https://doc.rust-lang.org/nightly/std/fmt/struct.Formatter.html#method.debug_map