### PR TITLE
Don't do intra-pass validation on MIR shims

### DIFF
--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -90,7 +90,11 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> Body<'
     };
     debug!("make_shim({:?}) = untransformed {:?}", instance, result);
 
-    pm::run_passes(
+    // We don't validate MIR here because the shims may generate code that's
+    // only valid in a reveal-all param-env. However, since we do initial
+    // validation with the MirBuilt phase, which uses a user-facing param-env.
+    // This causes validation errors when TAITs are involved.
+    pm::run_passes_no_validate(
         tcx,
         &mut result,
         &[

--- a/tests/ui/type-alias-impl-trait/auxiliary/drop-shim-relates-opaque-aux.rs
+++ b/tests/ui/type-alias-impl-trait/auxiliary/drop-shim-relates-opaque-aux.rs
@@ -1,0 +1,21 @@
+// crate foo
+
+#![feature(type_alias_impl_trait)]
+
+type Tait = impl Sized;
+fn _constrain() -> Tait {}
+
+struct WrapperWithDrop<T>(T);
+impl<T> Drop for WrapperWithDrop<T> {
+    fn drop(&mut self) {}
+}
+
+pub struct Foo(WrapperWithDrop<Tait>);
+
+trait Id {
+    type Id: ?Sized;
+}
+impl<T: ?Sized> Id for T {
+    type Id = T;
+}
+pub struct Bar(WrapperWithDrop<<Tait as Id>::Id>);

--- a/tests/ui/type-alias-impl-trait/drop-shim-relates-opaque-issue-114375.rs
+++ b/tests/ui/type-alias-impl-trait/drop-shim-relates-opaque-issue-114375.rs
@@ -1,0 +1,10 @@
+// aux-build:drop-shim-relates-opaque-aux.rs
+// compile-flags: -Zvalidate-mir --crate-type=lib
+// build-pass
+
+extern crate drop_shim_relates_opaque_aux;
+
+pub fn drop_foo(_: drop_shim_relates_opaque_aux::Foo) {}
+pub fn drop_bar(_: drop_shim_relates_opaque_aux::Bar) {}
+
+fn main() {}


### PR DESCRIPTION
Fixes #114375

In the test that was committed, we end up generating the drop shim for `struct Foo` that looks like:

```
fn std::ptr::drop_in_place(_1: *mut Foo) -> () {
    let mut _0: ();

    bb0: {
        goto -> bb5;
    }

    bb1: {
        return;
    }

    bb2 (cleanup): {
        resume;
    }

    bb3: {
        goto -> bb1;
    }

    bb4 (cleanup): {
        drop(((*_1).0: foo::WrapperWithDrop<()>)) -> [return: bb2, unwind terminate];
    }

    bb5: {
        drop(((*_1).0: foo::WrapperWithDrop<()>)) -> [return: bb3, unwind: bb2];
    }
}
```

In `bb4` and `bb5`, we assert that `(*_1).0` has type `WrapperWithDrop<()>`. However, In a user-facing param env, the type is actually `WrapperWithDrop<Tait>`. These types are not equal in a user-facing param-env (and can't be made equal even if we use `DefiningAnchor::Bubble`, since it's a non-local TAIT).