### PR TITLE
Migrate GUI colors test to original CSS color format

### DIFF
--- a/tests/rustdoc-gui/docblock-table.goml
+++ b/tests/rustdoc-gui/docblock-table.goml
@@ -36,17 +36,17 @@ define-function: (
 )
 
 call-function: ("check-colors", {
-    "theme": "dark",
-    "border_color": "rgb(224, 224, 224)",
-    "zebra_stripe_color": "rgb(42, 42, 42)",
+    "theme": "ayu",
+    "border_color": "#5c6773",
+    "zebra_stripe_color": "#191f26",
 })
 call-function: ("check-colors", {
-    "theme": "ayu",
-    "border_color": "rgb(92, 103, 115)",
-    "zebra_stripe_color": "rgb(25, 31, 38)",
+    "theme": "dark",
+    "border_color": "#e0e0e0",
+    "zebra_stripe_color": "#2a2a2a",
 })
 call-function: ("check-colors", {
     "theme": "light",
-    "border_color": "rgb(224, 224, 224)",
-    "zebra_stripe_color": "rgb(245, 245, 245)",
+    "border_color": "#e0e0e0",
+    "zebra_stripe_color": "#f5f5f5",
 })


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/111459.

r? @notriddle