### PR TITLE
Fix doc for `Path.strip_prefix()`'s errors' return type

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2343,7 +2343,7 @@ impl Path {
     /// # Errors
     ///
     /// If `base` is not a prefix of `self` (i.e., [`starts_with`]
-    /// returns `false`), returns [`Err`].
+    /// returns `false`), returns [`StripPrefixError`].
     ///
     /// [`starts_with`]: Path::starts_with
     ///


### PR DESCRIPTION
The documentation for `Path.strip_prefix()` reports that the method returns an [`Err`] if `base` is not a prefix of `self`, when it actually returns a [`StripPrefixError`].