### PR TITLE
Reimplement references VarDebugInfo

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -508,7 +508,13 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     }
                 };
 
-                self.cx.create_dbg_var(var.name, var_ty, dbg_scope, var_kind, span)
+                let name = if var.references > 0 {
+                    Symbol::intern(&format!("{0:*<1$}{2}", "", var.references as usize, var.name))
+                } else {
+                    var.name
+                };
+
+                self.cx.create_dbg_var(name, var_ty, dbg_scope, var_kind, span)
             });
 
             match var.value {

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -701,6 +701,12 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
             VarDebugInfoContents::Const(_) => {}
             VarDebugInfoContents::Place(place) => {
                 check_place(self, place);
+                if debuginfo.references != 0 && place.projection.last() == Some(&PlaceElem::Deref) {
+                    self.fail(
+                        START_BLOCK.start_location(),
+                        format!("debuginfo {debuginfo:?}, has both ref and deref"),
+                    );
+                }
             }
             VarDebugInfoContents::Composite { ty, ref fragments } => {
                 for f in fragments {

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1109,6 +1109,10 @@ pub struct VarDebugInfo<'tcx> {
     /// originated from (starting from 1). Note, if MIR inlining is enabled, then this is the
     /// argument number in the original function before it was inlined.
     pub argument_index: Option<u16>,
+
+    /// The data represents `name` dereferenced `references` times,
+    /// and not the direct value.
+    pub references: u8,
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -555,8 +555,13 @@ fn write_scope_tree(
         }
 
         let indented_debug_info = format!(
-            "{0:1$}debug {2} => {3:?};",
-            INDENT, indent, var_debug_info.name, var_debug_info.value,
+            "{0:1$}debug {2} => {3:&<4$}{5:?};",
+            INDENT,
+            indent,
+            var_debug_info.name,
+            "",
+            var_debug_info.references as usize,
+            var_debug_info.value,
         );
 
         if tcx.sess.opts.unstable_opts.mir_include_spans {

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -840,6 +840,7 @@ macro_rules! make_mir_visitor {
                     source_info,
                     value,
                     argument_index: _,
+                    references: _,
                 } = var_debug_info;
 
                 self.visit_source_info(source_info);

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -438,6 +438,7 @@ CloneLiftImpls! {
     (),
     bool,
     usize,
+    u8,
     u16,
     u32,
     u64,

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -205,7 +205,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
         )
     }
 
-    fn parse_operand(&self, expr_id: ExprId) -> PResult<Operand<'tcx>> {
+    pub fn parse_operand(&self, expr_id: ExprId) -> PResult<Operand<'tcx>> {
         parse_by_kind!(self, expr_id, expr, "operand",
             @call("mir_move", args) => self.parse_place(args[0]).map(Operand::Move),
             @call("mir_static", args) => self.parse_static(args[0]),

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -2242,6 +2242,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.var_debug_info.push(VarDebugInfo {
             name,
             source_info: debug_source_info,
+            references: 0,
             value: VarDebugInfoContents::Place(for_arm_body.into()),
             argument_index: None,
         });
@@ -2261,6 +2262,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.var_debug_info.push(VarDebugInfo {
                 name,
                 source_info: debug_source_info,
+                references: 0,
                 value: VarDebugInfoContents::Place(ref_for_guard.into()),
                 argument_index: None,
             });

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -820,6 +820,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 };
                 self.var_debug_info.push(VarDebugInfo {
                     name,
+                    references: 0,
                     source_info: SourceInfo::outermost(captured_place.var_ident.span),
                     value: VarDebugInfoContents::Place(use_place),
                     argument_index: None,
@@ -850,6 +851,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.var_debug_info.push(VarDebugInfo {
                     name,
                     source_info,
+                    references: 0,
                     value: VarDebugInfoContents::Place(arg_local.into()),
                     argument_index: Some(argument_index as u16 + 1),
                 });

--- a/compiler/rustc_mir_transform/src/ref_prop.rs
+++ b/compiler/rustc_mir_transform/src/ref_prop.rs
@@ -265,6 +265,7 @@ fn compute_replacement<'tcx>(
         targets,
         storage_to_remove,
         allowed_replacements,
+        fully_replacable_locals,
         any_replacement: false,
     };
 
@@ -345,6 +346,7 @@ struct Replacer<'tcx> {
     storage_to_remove: BitSet<Local>,
     allowed_replacements: FxHashSet<(Local, Location)>,
     any_replacement: bool,
+    fully_replacable_locals: BitSet<Local>,
 }
 
 impl<'tcx> MutVisitor<'tcx> for Replacer<'tcx> {
@@ -363,6 +365,12 @@ impl<'tcx> MutVisitor<'tcx> for Replacer<'tcx> {
         {
             if let Some((&PlaceElem::Deref, rest)) = target.projection.split_last() {
                 *place = Place::from(target.local).project_deeper(rest, self.tcx);
+                self.any_replacement = true;
+            } else if self.fully_replacable_locals.contains(place.local)
+                && let Some(references) = debuginfo.references.checked_add(1)
+            {
+                debuginfo.references = references;
+                *place = target;
                 self.any_replacement = true;
             } else {
                 break

--- a/compiler/rustc_type_ir/src/structural_impls.rs
+++ b/compiler/rustc_type_ir/src/structural_impls.rs
@@ -23,6 +23,7 @@ TrivialTypeTraversalImpls! {
     (),
     bool,
     usize,
+    u8,
     u16,
     u32,
     u64,

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -360,6 +360,11 @@ define!(
     #[doc(hidden)]
     fn __internal_make_place<T>(place: T) -> *mut T
 );
+define!(
+    "mir_debuginfo",
+    #[doc(hidden)]
+    fn __debuginfo<T>(name: &'static str, s: T)
+);
 
 /// Macro for generating custom MIR.
 ///
@@ -370,6 +375,7 @@ pub macro mir {
     (
         $(type RET = $ret_ty:ty ;)?
         $(let $local_decl:ident $(: $local_decl_ty:ty)? ;)*
+        $(debug $dbg_name:ident => $dbg_data:expr ;)*
 
         {
             $($entry:tt)*
@@ -393,26 +399,32 @@ pub macro mir {
             $(
                 let $local_decl $(: $local_decl_ty)? ;
             )*
-
             ::core::intrinsics::mir::__internal_extract_let!($($entry)*);
             $(
                 ::core::intrinsics::mir::__internal_extract_let!($($block)*);
             )*
 
             {
-                // Finally, the contents of the basic blocks
-                ::core::intrinsics::mir::__internal_remove_let!({
-                    {}
-                    { $($entry)* }
-                });
+                // Now debuginfo
                 $(
-                    ::core::intrinsics::mir::__internal_remove_let!({
-                        {}
-                        { $($block)* }
-                    });
+                    __debuginfo(stringify!($dbg_name), $dbg_data);
                 )*
 
-                RET
+                {
+                    // Finally, the contents of the basic blocks
+                    ::core::intrinsics::mir::__internal_remove_let!({
+                        {}
+                        { $($entry)* }
+                    });
+                    $(
+                        ::core::intrinsics::mir::__internal_remove_let!({
+                            {}
+                            { $($block)* }
+                        });
+                    )*
+
+                    RET
+                }
             }
         }
     }}

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -12,7 +12,8 @@
 //!
 //! Typical usage will look like this:
 //!
-//! ```rust
+#![cfg_attr(bootstrap, doc = "```rust,ignore")]
+#![cfg_attr(not(bootstrap), doc = "```rust")]
 //! #![feature(core_intrinsics, custom_mir)]
 #![cfg_attr(not(bootstrap), doc = "#![allow(internal_features)]")]
 //!
@@ -62,7 +63,8 @@
 //!
 //! # Examples
 //!
-//! ```rust
+#![cfg_attr(bootstrap, doc = "```rust,ignore")]
+#![cfg_attr(not(bootstrap), doc = "```rust")]
 //! #![feature(core_intrinsics, custom_mir)]
 #![cfg_attr(not(bootstrap), doc = "#![allow(internal_features)]")]
 //!
@@ -316,9 +318,10 @@ define!(
     ///
     /// # Examples
     ///
-    /// ```rust
-    #[cfg_attr(not(bootstrap), doc = "#![allow(internal_features)]")]
+    #[cfg_attr(bootstrap, doc = "```rust,ignore")]
+    #[cfg_attr(not(bootstrap), doc = "```rust")]
     /// #![feature(custom_mir, core_intrinsics)]
+    #[cfg_attr(not(bootstrap), doc = "#![allow(internal_features)]")]
     ///
     /// use core::intrinsics::mir::*;
     ///

--- a/tests/codegen/slice-ref-equality.rs
+++ b/tests/codegen/slice-ref-equality.rs
@@ -44,48 +44,48 @@ pub fn is_zero_array(data: &[u8; 4]) -> bool {
 // equality for non-byte types also just emit a `bcmp`, not a loop.
 
 // CHECK-LABEL: @eq_slice_of_nested_u8(
-// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %1
-// CHECK-SAME: [[USIZE]] noundef %3
+// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %x.1
+// CHECK-SAME: [[USIZE]] noundef %y.1
 #[no_mangle]
 fn eq_slice_of_nested_u8(x: &[[u8; 3]], y: &[[u8; 3]]) -> bool {
-    // CHECK: icmp eq [[USIZE]] %1, %3
-    // CHECK: %[[BYTES:.+]] = mul nsw [[USIZE]] %1, 3
+    // CHECK: icmp eq [[USIZE]] %x.1, %y.1
+    // CHECK: %[[BYTES:.+]] = mul nsw [[USIZE]] %x.1, 3
     // CHECK: tail call{{( noundef)?}} i32 @{{bcmp|memcmp}}(ptr
     // CHECK-SAME: , [[USIZE]]{{( noundef)?}} %[[BYTES]])
     x == y
 }
 
 // CHECK-LABEL: @eq_slice_of_i32(
-// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %1
-// CHECK-SAME: [[USIZE]] noundef %3
+// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %x.1
+// CHECK-SAME: [[USIZE]] noundef %y.1
 #[no_mangle]
 fn eq_slice_of_i32(x: &[i32], y: &[i32]) -> bool {
-    // CHECK: icmp eq [[USIZE]] %1, %3
-    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %1, 2
+    // CHECK: icmp eq [[USIZE]] %x.1, %y.1
+    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %x.1, 2
     // CHECK: tail call{{( noundef)?}} i32 @{{bcmp|memcmp}}(ptr
     // CHECK-SAME: , [[USIZE]]{{( noundef)?}} %[[BYTES]])
     x == y
 }
 
 // CHECK-LABEL: @eq_slice_of_nonzero(
-// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %1
-// CHECK-SAME: [[USIZE]] noundef %3
+// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %x.1
+// CHECK-SAME: [[USIZE]] noundef %y.1
 #[no_mangle]
 fn eq_slice_of_nonzero(x: &[NonZeroU32], y: &[NonZeroU32]) -> bool {
-    // CHECK: icmp eq [[USIZE]] %1, %3
-    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %1, 2
+    // CHECK: icmp eq [[USIZE]] %x.1, %y.1
+    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %x.1, 2
     // CHECK: tail call{{( noundef)?}} i32 @{{bcmp|memcmp}}(ptr
     // CHECK-SAME: , [[USIZE]]{{( noundef)?}} %[[BYTES]])
     x == y
 }
 
 // CHECK-LABEL: @eq_slice_of_option_of_nonzero(
-// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %1
-// CHECK-SAME: [[USIZE]] noundef %3
+// CHECK-SAME: [[USIZE:i16|i32|i64]] noundef %x.1
+// CHECK-SAME: [[USIZE]] noundef %y.1
 #[no_mangle]
 fn eq_slice_of_option_of_nonzero(x: &[Option<NonZeroI16>], y: &[Option<NonZeroI16>]) -> bool {
-    // CHECK: icmp eq [[USIZE]] %1, %3
-    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %1, 1
+    // CHECK: icmp eq [[USIZE]] %x.1, %y.1
+    // CHECK: %[[BYTES:.+]] = shl nsw [[USIZE]] %x.1, 1
     // CHECK: tail call{{( noundef)?}} i32 @{{bcmp|memcmp}}(ptr
     // CHECK-SAME: , [[USIZE]]{{( noundef)?}} %[[BYTES]])
     x == y

--- a/tests/debuginfo/reference-debuginfo.rs
+++ b/tests/debuginfo/reference-debuginfo.rs
@@ -8,116 +8,71 @@
 // === GDB TESTS ===================================================================================
 
 // gdb-command:run
-// gdb-command:print *bool_ref
-// gdb-check:$1 = true
-
-// gdb-command:print *int_ref
-// gdb-check:$2 = -1
-
-// gdb-command:print/d *char_ref
-// gdb-check:$3 = 97
-
-// gdb-command:print *i8_ref
-// gdbg-check:$4 = 68 'D'
-// gdbr-check:$4 = 68
-
-// gdb-command:print *i16_ref
-// gdb-check:$5 = -16
-
-// gdb-command:print *i32_ref
-// gdb-check:$6 = -32
-
-// gdb-command:print *i64_ref
-// gdb-check:$7 = -64
-
-// gdb-command:print *uint_ref
-// gdb-check:$8 = 1
-
-// gdb-command:print *u8_ref
-// gdbg-check:$9 = 100 'd'
-// gdbr-check:$9 = 100
-
-// gdb-command:print *u16_ref
-// gdb-check:$10 = 16
-
-// gdb-command:print *u32_ref
-// gdb-check:$11 = 32
-
-// gdb-command:print *u64_ref
-// gdb-check:$12 = 64
-
-// gdb-command:print *f32_ref
-// gdb-check:$13 = 2.5
-
-// gdb-command:print *f64_ref
-// gdb-check:$14 = 3.5
-
-// gdb-command:print *f64_double_ref
-// gdb-check:$15 = 3.5
+// gdb-command:info locals
+// gdb-check:*f64_double_ref = 3.5
+// gdb-check:*f64_ref = 3.5
+// gdb-check:f64_val = 3.5
+// gdb-check:*f32_ref = 2.5
+// gdb-check:f32_val = 2.5
+// gdb-check:*u64_ref = 64
+// gdb-check:u64_val = 64
+// gdb-check:*u32_ref = 32
+// gdb-check:u32_val = 32
+// gdb-check:*u16_ref = 16
+// gdb-check:u16_val = 16
+// gdb-check:*u8_ref = 100
+// gdb-check:u8_val = 100
+// gdb-check:*uint_ref = 1
+// gdb-check:uint_val = 1
+// gdb-check:*i64_ref = -64
+// gdb-check:i64_val = -64
+// gdb-check:*i32_ref = -32
+// gdb-check:*i16_ref = -16
+// gdb-check:i16_val = -16
+// gdb-check:*i8_ref = 68
+// gdb-check:i8_val = 68
+// gdb-check:*char_ref = 97 'a'
+// gdb-check:char_val = 97 'a'
+// gdb-check:*int_ref = -1
+// gdb-check:int_val = -1
+// gdb-check:*bool_ref = true
+// gdb-check:bool_val = true
 
 
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run
-// lldb-command:print *bool_ref
-// lldbg-check:[...]$0 = true
+// lldb-command:frame variable
+// lldbr-check:(bool) bool_val = true
 // lldbr-check:(bool) *bool_ref = true
-
-// lldb-command:print *int_ref
-// lldbg-check:[...]$1 = -1
-// lldbr-check:(isize) *int_ref = -1
-
-// NOTE: only rust-enabled lldb supports 32bit chars
-// lldbr-command:print *char_ref
-// lldbr-check:(char) *char_ref = 'a'
-
-// lldb-command:print *i8_ref
-// lldbg-check:[...]$2 = 'D'
-// lldbr-check:(i8) *i8_ref = 68
-
-// lldb-command:print *i16_ref
-// lldbg-check:[...]$3 = -16
-// lldbr-check:(i16) *i16_ref = -16
-
-// lldb-command:print *i32_ref
-// lldbg-check:[...]$4 = -32
-// lldbr-check:(i32) *i32_ref = -32
-
-// lldb-command:print *i64_ref
-// lldbg-check:[...]$5 = -64
-// lldbr-check:(i64) *i64_ref = -64
-
-// lldb-command:print *uint_ref
-// lldbg-check:[...]$6 = 1
-// lldbr-check:(usize) *uint_ref = 1
-
-// lldb-command:print *u8_ref
-// lldbg-check:[...]$7 = 'd'
-// lldbr-check:(u8) *u8_ref = 100
-
-// lldb-command:print *u16_ref
-// lldbg-check:[...]$8 = 16
-// lldbr-check:(u16) *u16_ref = 16
-
-// lldb-command:print *u32_ref
-// lldbg-check:[...]$9 = 32
-// lldbr-check:(u32) *u32_ref = 32
-
-// lldb-command:print *u64_ref
-// lldbg-check:[...]$10 = 64
-// lldbr-check:(u64) *u64_ref = 64
-
-// lldb-command:print *f32_ref
-// lldbg-check:[...]$11 = 2.5
-// lldbr-check:(f32) *f32_ref = 2.5
-
-// lldb-command:print *f64_ref
-// lldbg-check:[...]$12 = 3.5
-// lldbr-check:(f64) *f64_ref = 3.5
-
-// lldb-command:print *f64_double_ref
-// lldbg-check:[...]$13 = 3.5
-// lldbr-check:(f64) **f64_double_ref = 3.5
+// lldbr-check:(long) int_val = -1
+// lldbr-check:(long) *int_ref = -1
+// lldbr-check:(char32_t) char_val = U+0x00000061 U'a'
+// lldbr-check:(char32_t) *char_ref = U+0x00000061 U'a'
+// lldbr-check:(char) i8_val = 'D'
+// lldbr-check:(char) *i8_ref = 'D'
+// lldbr-check:(short) i16_val = -16
+// lldbr-check:(short) *i16_ref = -16
+// lldbr-check:(int) i32_val = -32
+// lldbr-check:(int) *i32_ref = -32
+// lldbr-check:(long) i64_val = -64
+// lldbr-check:(long) *i64_ref = -64
+// lldbr-check:(unsigned long) uint_val = 1
+// lldbr-check:(unsigned long) *uint_ref = 1
+// lldbr-check:(unsigned char) u8_val = 'd'
+// lldbr-check:(unsigned char) *u8_ref = 'd'
+// lldbr-check:(unsigned short) u16_val = 16
+// lldbr-check:(unsigned short) *u16_ref = 16
+// lldbr-check:(unsigned int) u32_val = 32
+// lldbr-check:(unsigned int) *u32_ref = 32
+// lldbr-check:(unsigned long) u64_val = 64
+// lldbr-check:(unsigned long) *u64_ref = 64
+// lldbr-check:(float) f32_val = 2.5
+// lldbr-check:(float) *f32_ref = 2.5
+// lldbr-check:(double) f64_val = 3.5
+// lldbr-check:(double) *f64_ref = 3.5
+// lldbr-check:(double) *f64_double_ref = 3.5
+// lldbr-check:[...]$0 = true
 
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]

--- a/tests/mir-opt/building/custom/debuginfo.numbered.built.after.mir
+++ b/tests/mir-opt/building/custom/debuginfo.numbered.built.after.mir
@@ -1,0 +1,11 @@
+// MIR for `numbered` after built
+
+fn numbered(_1: (u32, i32)) -> () {
+    debug first => (_1.0: u32);
+    debug second => (_1.0: u32);
+    let mut _0: ();
+
+    bb0: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/custom/debuginfo.pointee.built.after.mir
+++ b/tests/mir-opt/building/custom/debuginfo.pointee.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `pointee` after built
+
+fn pointee(_1: &mut Option<i32>) -> () {
+    debug foo => (((*_1) as variant#1).0: i32);
+    let mut _0: ();
+
+    bb0: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/custom/debuginfo.pointee.built.after.mir
+++ b/tests/mir-opt/building/custom/debuginfo.pointee.built.after.mir
@@ -2,6 +2,8 @@
 
 fn pointee(_1: &mut Option<i32>) -> () {
     debug foo => (((*_1) as variant#1).0: i32);
+    debug addr => &(((*_1) as variant#1).0: i32);
+    debug biaddr => &&(((*_1) as variant#1).0: i32);
     let mut _0: ();
 
     bb0: {

--- a/tests/mir-opt/building/custom/debuginfo.rs
+++ b/tests/mir-opt/building/custom/debuginfo.rs
@@ -1,0 +1,71 @@
+#![feature(custom_mir, core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::mir::*;
+
+// EMIT_MIR debuginfo.pointee.built.after.mir
+#[custom_mir(dialect = "built")]
+fn pointee(opt: &mut Option<i32>) {
+    mir!(
+        debug foo => Field::<i32>(Variant(*opt, 1), 0);
+        {
+            Return()
+        }
+    )
+}
+
+// EMIT_MIR debuginfo.numbered.built.after.mir
+#[custom_mir(dialect = "analysis", phase = "post-cleanup")]
+fn numbered(i: (u32, i32)) {
+    mir!(
+        debug first => i.0;
+        debug second => i.0;
+        {
+            Return()
+        }
+    )
+}
+
+struct S { x: f32 }
+
+// EMIT_MIR debuginfo.structured.built.after.mir
+#[custom_mir(dialect = "analysis", phase = "post-cleanup")]
+fn structured(i: S) {
+    mir!(
+        debug x => i.x;
+        {
+            Return()
+        }
+    )
+}
+
+// EMIT_MIR debuginfo.variant.built.after.mir
+#[custom_mir(dialect = "built")]
+fn variant(opt: Option<i32>) {
+    mir!(
+        debug inner => Field::<i32>(Variant(opt, 1), 0);
+        {
+            Return()
+        }
+    )
+}
+
+// EMIT_MIR debuginfo.variant_deref.built.after.mir
+#[custom_mir(dialect = "built")]
+fn variant_deref(opt: Option<&i32>) {
+    mir!(
+        debug pointer => Field::<&i32>(Variant(opt, 1), 0);
+        debug deref => *Field::<&i32>(Variant(opt, 1), 0);
+        {
+            Return()
+        }
+    )
+}
+
+fn main() {
+    numbered((5, 6));
+    structured(S { x: 5. });
+    variant(Some(5));
+    variant_deref(Some(&5));
+    pointee(&mut Some(5));
+}

--- a/tests/mir-opt/building/custom/debuginfo.rs
+++ b/tests/mir-opt/building/custom/debuginfo.rs
@@ -8,6 +8,8 @@ use core::intrinsics::mir::*;
 fn pointee(opt: &mut Option<i32>) {
     mir!(
         debug foo => Field::<i32>(Variant(*opt, 1), 0);
+        debug addr => &Field::<i32>(Variant(*opt, 1), 0);
+        debug biaddr => &&Field::<i32>(Variant(*opt, 1), 0);
         {
             Return()
         }

--- a/tests/mir-opt/building/custom/debuginfo.structured.built.after.mir
+++ b/tests/mir-opt/building/custom/debuginfo.structured.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `structured` after built
+
+fn structured(_1: S) -> () {
+    debug x => (_1.0: f32);
+    let mut _0: ();
+
+    bb0: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/custom/debuginfo.variant.built.after.mir
+++ b/tests/mir-opt/building/custom/debuginfo.variant.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `variant` after built
+
+fn variant(_1: Option<i32>) -> () {
+    debug inner => ((_1 as variant#1).0: i32);
+    let mut _0: ();
+
+    bb0: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/custom/debuginfo.variant_deref.built.after.mir
+++ b/tests/mir-opt/building/custom/debuginfo.variant_deref.built.after.mir
@@ -1,0 +1,11 @@
+// MIR for `variant_deref` after built
+
+fn variant_deref(_1: Option<&i32>) -> () {
+    debug pointer => ((_1 as variant#1).0: &i32);
+    debug deref => (*((_1 as variant#1).0: &i32));
+    let mut _0: ();
+
+    bb0: {
+        return;
+    }
+}

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
@@ -7,8 +7,7 @@
       let mut _2: std::option::Option<T>;
 +     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
 +         debug self => _2;
-+         let mut _3: &std::option::Option<T>;
-+         let mut _4: isize;
++         let mut _3: isize;
 +         scope 2 {
 +             debug val => _0;
 +         }
@@ -21,7 +20,7 @@
 +             }
 +         }
 +         scope 4 (inlined Option::<T>::is_some) {
-+             debug self => _3;
++             debug self => &_2;
 +         }
 +     }
   
@@ -29,9 +28,8 @@
           StorageLive(_2);
           _2 = move _1;
 -         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind unreachable];
-+         StorageLive(_3);
-+         _4 = discriminant(_2);
-+         switchInt(move _4) -> [1: bb2, otherwise: bb1];
++         _3 = discriminant(_2);
++         switchInt(move _3) -> [1: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -40,7 +38,6 @@
 + 
 +     bb2: {
 +         _0 = move ((_2 as Some).0: T);
-+         StorageDead(_3);
           StorageDead(_2);
           return;
       }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -7,8 +7,7 @@
       let mut _2: std::option::Option<T>;
 +     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
 +         debug self => _2;
-+         let mut _3: &std::option::Option<T>;
-+         let mut _4: isize;
++         let mut _3: isize;
 +         scope 2 {
 +             debug val => _0;
 +         }
@@ -21,7 +20,7 @@
 +             }
 +         }
 +         scope 4 (inlined Option::<T>::is_some) {
-+             debug self => _3;
++             debug self => &_2;
 +         }
 +     }
   
@@ -29,9 +28,8 @@
           StorageLive(_2);
           _2 = move _1;
 -         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind: bb2];
-+         StorageLive(_3);
-+         _4 = discriminant(_2);
-+         switchInt(move _4) -> [1: bb2, otherwise: bb1];
++         _3 = discriminant(_2);
++         switchInt(move _3) -> [1: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -44,7 +42,6 @@
 -         resume;
 +     bb2: {
 +         _0 = move ((_2 as Some).0: T);
-+         StorageDead(_3);
 +         StorageDead(_2);
 +         return;
       }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
@@ -6,7 +6,6 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
         debug self => _1;
         let mut _2: isize;
-        let mut _3: &std::option::Option<T>;
         scope 2 {
             debug val => _0;
         }
@@ -19,19 +18,17 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
             }
         }
         scope 4 (inlined Option::<T>::is_some) {
-            debug self => _3;
+            debug self => &_1;
         }
     }
 
     bb0: {
-        StorageLive(_3);
         _2 = discriminant(_1);
         switchInt(move _2) -> [1: bb1, otherwise: bb2];
     }
 
     bb1: {
         _0 = move ((_1 as Some).0: T);
-        StorageDead(_3);
         return;
     }
 

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
@@ -6,7 +6,6 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
         debug self => _1;
         let mut _2: isize;
-        let mut _3: &std::option::Option<T>;
         scope 2 {
             debug val => _0;
         }
@@ -19,19 +18,17 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
             }
         }
         scope 4 (inlined Option::<T>::is_some) {
-            debug self => _3;
+            debug self => &_1;
         }
     }
 
     bb0: {
-        StorageLive(_3);
         _2 = discriminant(_1);
         switchInt(move _2) -> [1: bb1, otherwise: bb2];
     }
 
     bb1: {
         _0 = move ((_1 as Some).0: T);
-        StorageDead(_3);
         return;
     }
 

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
@@ -13,16 +13,13 @@
       let mut _8: usize;
       let mut _9: usize;
       let mut _10: bool;
-      let mut _14: !;
+      let mut _11: !;
       scope 1 {
           debug v => _2;
-          let _11: &T;
-          let _12: &T;
-          let _13: &T;
           scope 2 {
-              debug v1 => _11;
-              debug v2 => _12;
-              debug v3 => _13;
+              debug v1 => &(*_2)[0 of 3];
+              debug v2 => &(*_2)[1 of 3];
+              debug v3 => &(*_2)[2 of 3];
           }
       }
   
@@ -42,19 +39,10 @@
       }
   
       bb1: {
-          _14 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind unreachable;
+          _11 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind unreachable;
       }
   
       bb2: {
-          StorageLive(_11);
-          _11 = &(*_2)[0 of 3];
-          StorageLive(_12);
-          _12 = &(*_2)[1 of 3];
-          StorageLive(_13);
-          _13 = &(*_2)[2 of 3];
-          StorageDead(_13);
-          StorageDead(_12);
-          StorageDead(_11);
           StorageDead(_4);
           return;
       }

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
@@ -13,16 +13,13 @@
       let mut _8: usize;
       let mut _9: usize;
       let mut _10: bool;
-      let mut _14: !;
+      let mut _11: !;
       scope 1 {
           debug v => _2;
-          let _11: &T;
-          let _12: &T;
-          let _13: &T;
           scope 2 {
-              debug v1 => _11;
-              debug v2 => _12;
-              debug v3 => _13;
+              debug v1 => &(*_2)[0 of 3];
+              debug v2 => &(*_2)[1 of 3];
+              debug v3 => &(*_2)[2 of 3];
           }
       }
   
@@ -42,19 +39,10 @@
       }
   
       bb1: {
-          _14 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind continue;
+          _11 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind continue;
       }
   
       bb2: {
-          StorageLive(_11);
-          _11 = &(*_2)[0 of 3];
-          StorageLive(_12);
-          _12 = &(*_2)[1 of 3];
-          StorageLive(_13);
-          _13 = &(*_2)[2 of 3];
-          StorageDead(_13);
-          StorageDead(_12);
-          StorageDead(_11);
           StorageDead(_4);
           return;
       }

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
@@ -8,9 +8,8 @@ fn num_to_digit(_1: char) -> u32 {
         debug self => _1;
         debug radix => const 8_u32;
         let _2: std::option::Option<u32>;
-        let mut _7: &std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
-            debug self => _7;
+            debug self => &_2;
             let mut _3: isize;
         }
     }
@@ -24,14 +23,12 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb0: {
-        StorageLive(_7);
         StorageLive(_2);
         _2 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
         _3 = discriminant(_2);
-        StorageDead(_7);
         StorageDead(_2);
         switchInt(move _3) -> [1: bb2, otherwise: bb7];
     }

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
@@ -8,9 +8,8 @@ fn num_to_digit(_1: char) -> u32 {
         debug self => _1;
         debug radix => const 8_u32;
         let _2: std::option::Option<u32>;
-        let mut _7: &std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
-            debug self => _7;
+            debug self => &_2;
             let mut _3: isize;
         }
     }
@@ -24,14 +23,12 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb0: {
-        StorageLive(_7);
         StorageLive(_2);
         _2 = char::methods::<impl char>::to_digit(_1, const 8_u32) -> [return: bb1, unwind continue];
     }
 
     bb1: {
         _3 = discriminant(_2);
-        StorageDead(_7);
         StorageDead(_2);
         switchInt(move _3) -> [1: bb2, otherwise: bb7];
     }

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.mir
@@ -10,14 +10,13 @@ fn step_forward(_1: u32, _2: usize) -> u32 {
         let _3: std::option::Option<u32>;
         let mut _6: bool;
         let mut _7: u32;
-        let mut _8: &std::option::Option<u32>;
         scope 2 {
         }
         scope 3 (inlined Option::<u32>::is_none) {
-            debug self => _8;
+            debug self => &_3;
             let mut _5: bool;
             scope 4 (inlined Option::<u32>::is_some) {
-                debug self => _8;
+                debug self => &_3;
                 let mut _4: isize;
             }
         }
@@ -29,7 +28,6 @@ fn step_forward(_1: u32, _2: usize) -> u32 {
 
     bb0: {
         StorageLive(_6);
-        StorageLive(_8);
         StorageLive(_3);
         _3 = <u32 as Step>::forward_checked(_1, _2) -> [return: bb1, unwind continue];
     }
@@ -41,7 +39,6 @@ fn step_forward(_1: u32, _2: usize) -> u32 {
         _6 = Not(move _5);
         StorageDead(_5);
         StorageDead(_3);
-        StorageDead(_8);
         switchInt(move _6) -> [0: bb3, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
@@ -10,7 +10,6 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
     let mut _8: std::option::Option<U>;
     let mut _9: isize;
     let _11: ();
-    let mut _12: &mut std::iter::FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>>;
     scope 1 {
         debug iter => _5;
         let _10: U;
@@ -18,7 +17,7 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
             debug x => _10;
         }
         scope 4 (inlined <FilterMap<impl Iterator<Item = T>, impl Fn(T) -> Option<U>> as Iterator>::next) {
-            debug self => _12;
+            debug self => &_5;
             let mut _6: &mut impl Iterator<Item = T>;
             let mut _7: &mut impl Fn(T) -> Option<U>;
         }

--- a/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
@@ -4,108 +4,95 @@ fn int_range(_1: usize, _2: usize) -> () {
     debug start => _1;
     debug end => _2;
     let mut _0: ();
-    let mut _3: std::ops::Range<usize>;
-    let mut _4: std::ops::Range<usize>;
-    let mut _8: std::option::Option<usize>;
-    let mut _11: isize;
-    let _13: ();
-    let mut _14: &mut std::ops::Range<usize>;
+    let mut _3: usize;
+    let mut _6: std::option::Option<usize>;
+    let mut _9: isize;
+    let _11: ();
     scope 1 {
-        debug iter => _4;
-        let _12: usize;
+        debug iter => std::ops::Range<usize>{ .0 => _3, .1 => _2, };
+        let _10: usize;
         scope 2 {
-            debug i => _12;
+            debug i => _10;
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
-            debug self => _14;
+            debug self => &std::ops::Range<usize>{ .0 => _3, .1 => _2, };
             scope 5 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => _14;
-                let mut _7: bool;
-                let _9: usize;
-                let mut _10: usize;
-                let mut _15: &usize;
-                let mut _16: &usize;
+                debug self => &std::ops::Range<usize>{ .0 => _3, .1 => _2, };
+                let mut _5: bool;
+                let _7: usize;
+                let mut _8: usize;
                 scope 6 {
-                    debug old => _9;
+                    debug old => _7;
                     scope 7 {
                     }
                 }
                 scope 8 (inlined cmp::impls::<impl PartialOrd for usize>::lt) {
-                    debug self => _15;
-                    debug other => _16;
-                    let mut _5: usize;
-                    let mut _6: usize;
+                    debug self => &_3;
+                    debug other => &_2;
+                    let mut _4: usize;
                 }
             }
         }
     }
     scope 3 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
-        debug self => _3;
+        debug self => std::ops::Range<usize>{ .0 => _1, .1 => _2, };
     }
 
     bb0: {
-        _3 = std::ops::Range::<usize> { start: _1, end: _2 };
-        StorageLive(_4);
-        _4 = move _3;
+        StorageLive(_3);
+        _3 = _1;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_8);
-        StorageLive(_9);
-        StorageLive(_7);
-        StorageLive(_15);
-        StorageLive(_16);
-        StorageLive(_5);
-        _5 = (_4.0: usize);
         StorageLive(_6);
-        _6 = (_4.1: usize);
-        _7 = Lt(move _5, move _6);
-        StorageDead(_6);
-        StorageDead(_5);
-        StorageDead(_16);
-        StorageDead(_15);
-        switchInt(move _7) -> [0: bb2, otherwise: bb3];
+        StorageLive(_7);
+        StorageLive(_5);
+        StorageLive(_4);
+        _4 = _3;
+        _5 = Lt(move _4, _2);
+        StorageDead(_4);
+        switchInt(move _5) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _8 = Option::<usize>::None;
+        _6 = Option::<usize>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _9 = (_4.0: usize);
-        StorageLive(_10);
-        _10 = <usize as Step>::forward_unchecked(_9, const 1_usize) -> [return: bb4, unwind continue];
+        _7 = _3;
+        StorageLive(_8);
+        _8 = <usize as Step>::forward_unchecked(_7, const 1_usize) -> [return: bb4, unwind continue];
     }
 
     bb4: {
-        (_4.0: usize) = move _10;
-        StorageDead(_10);
-        _8 = Option::<usize>::Some(_9);
+        _3 = move _8;
+        StorageDead(_8);
+        _6 = Option::<usize>::Some(_7);
         goto -> bb5;
     }
 
     bb5: {
+        StorageDead(_5);
         StorageDead(_7);
-        StorageDead(_9);
-        _11 = discriminant(_8);
-        switchInt(move _11) -> [0: bb6, 1: bb7, otherwise: bb9];
+        _9 = discriminant(_6);
+        switchInt(move _9) -> [0: bb6, 1: bb7, otherwise: bb9];
     }
 
     bb6: {
-        StorageDead(_8);
-        StorageDead(_4);
+        StorageDead(_6);
+        StorageDead(_3);
         return;
     }
 
     bb7: {
-        _12 = ((_8 as Some).0: usize);
-        _13 = opaque::<usize>(move _12) -> [return: bb8, unwind continue];
+        _10 = ((_6 as Some).0: usize);
+        _11 = opaque::<usize>(move _10) -> [return: bb8, unwind continue];
     }
 
     bb8: {
-        StorageDead(_8);
+        StorageDead(_6);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -5,100 +5,87 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     debug end => _2;
     debug f => _3;
     let mut _0: ();
-    let mut _4: std::ops::Range<u32>;
-    let mut _5: std::ops::Range<u32>;
-    let mut _9: std::option::Option<u32>;
-    let mut _12: isize;
-    let mut _14: &impl Fn(u32);
-    let mut _15: (u32,);
-    let _16: ();
-    let mut _17: &mut std::ops::Range<u32>;
+    let mut _4: u32;
+    let mut _7: std::option::Option<u32>;
+    let mut _10: isize;
+    let mut _12: &impl Fn(u32);
+    let mut _13: (u32,);
+    let _14: ();
     scope 1 {
-        debug iter => _5;
-        let _13: u32;
+        debug iter => std::ops::Range<u32>{ .0 => _4, .1 => _2, };
+        let _11: u32;
         scope 2 {
-            debug x => _13;
+            debug x => _11;
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) {
-            debug self => _17;
+            debug self => &std::ops::Range<u32>{ .0 => _4, .1 => _2, };
             scope 5 (inlined <std::ops::Range<u32> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => _17;
-                let mut _8: bool;
-                let _10: u32;
-                let mut _11: u32;
-                let mut _18: &u32;
-                let mut _19: &u32;
+                debug self => &std::ops::Range<u32>{ .0 => _4, .1 => _2, };
+                let mut _6: bool;
+                let _8: u32;
+                let mut _9: u32;
                 scope 6 {
-                    debug old => _10;
+                    debug old => _8;
                     scope 7 {
                     }
                 }
                 scope 8 (inlined cmp::impls::<impl PartialOrd for u32>::lt) {
-                    debug self => _18;
-                    debug other => _19;
-                    let mut _6: u32;
-                    let mut _7: u32;
+                    debug self => &_4;
+                    debug other => &_2;
+                    let mut _5: u32;
                 }
             }
         }
     }
     scope 3 (inlined <std::ops::Range<u32> as IntoIterator>::into_iter) {
-        debug self => _4;
+        debug self => std::ops::Range<u32>{ .0 => _1, .1 => _2, };
     }
 
     bb0: {
-        _4 = std::ops::Range::<u32> { start: _1, end: _2 };
-        StorageLive(_5);
-        _5 = move _4;
+        StorageLive(_4);
+        _4 = _1;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_9);
-        StorageLive(_10);
-        StorageLive(_8);
-        StorageLive(_18);
-        StorageLive(_19);
-        StorageLive(_6);
-        _6 = (_5.0: u32);
         StorageLive(_7);
-        _7 = (_5.1: u32);
-        _8 = Lt(move _6, move _7);
-        StorageDead(_7);
-        StorageDead(_6);
-        StorageDead(_19);
-        StorageDead(_18);
-        switchInt(move _8) -> [0: bb2, otherwise: bb3];
+        StorageLive(_8);
+        StorageLive(_6);
+        StorageLive(_5);
+        _5 = _4;
+        _6 = Lt(move _5, _2);
+        StorageDead(_5);
+        switchInt(move _6) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _9 = Option::<u32>::None;
+        _7 = Option::<u32>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _10 = (_5.0: u32);
-        StorageLive(_11);
-        _11 = <u32 as Step>::forward_unchecked(_10, const 1_usize) -> [return: bb4, unwind unreachable];
+        _8 = _4;
+        StorageLive(_9);
+        _9 = <u32 as Step>::forward_unchecked(_8, const 1_usize) -> [return: bb4, unwind unreachable];
     }
 
     bb4: {
-        (_5.0: u32) = move _11;
-        StorageDead(_11);
-        _9 = Option::<u32>::Some(_10);
+        _4 = move _9;
+        StorageDead(_9);
+        _7 = Option::<u32>::Some(_8);
         goto -> bb5;
     }
 
     bb5: {
+        StorageDead(_6);
         StorageDead(_8);
-        StorageDead(_10);
-        _12 = discriminant(_9);
-        switchInt(move _12) -> [0: bb6, 1: bb8, otherwise: bb10];
+        _10 = discriminant(_7);
+        switchInt(move _10) -> [0: bb6, 1: bb8, otherwise: bb10];
     }
 
     bb6: {
-        StorageDead(_9);
-        StorageDead(_5);
+        StorageDead(_7);
+        StorageDead(_4);
         drop(_3) -> [return: bb7, unwind unreachable];
     }
 
@@ -107,18 +94,18 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb8: {
-        _13 = ((_9 as Some).0: u32);
-        StorageLive(_14);
-        _14 = &_3;
-        StorageLive(_15);
-        _15 = (_13,);
-        _16 = <impl Fn(u32) as Fn<(u32,)>>::call(move _14, move _15) -> [return: bb9, unwind unreachable];
+        _11 = ((_7 as Some).0: u32);
+        StorageLive(_12);
+        _12 = &_3;
+        StorageLive(_13);
+        _13 = (_11,);
+        _14 = <impl Fn(u32) as Fn<(u32,)>>::call(move _12, move _13) -> [return: bb9, unwind unreachable];
     }
 
     bb9: {
-        StorageDead(_15);
-        StorageDead(_14);
-        StorageDead(_9);
+        StorageDead(_13);
+        StorageDead(_12);
+        StorageDead(_7);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -5,100 +5,87 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     debug end => _2;
     debug f => _3;
     let mut _0: ();
-    let mut _4: std::ops::Range<u32>;
-    let mut _5: std::ops::Range<u32>;
-    let mut _9: std::option::Option<u32>;
-    let mut _12: isize;
-    let mut _14: &impl Fn(u32);
-    let mut _15: (u32,);
-    let _16: ();
-    let mut _17: &mut std::ops::Range<u32>;
+    let mut _4: u32;
+    let mut _7: std::option::Option<u32>;
+    let mut _10: isize;
+    let mut _12: &impl Fn(u32);
+    let mut _13: (u32,);
+    let _14: ();
     scope 1 {
-        debug iter => _5;
-        let _13: u32;
+        debug iter => std::ops::Range<u32>{ .0 => _4, .1 => _2, };
+        let _11: u32;
         scope 2 {
-            debug x => _13;
+            debug x => _11;
         }
         scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) {
-            debug self => _17;
+            debug self => &std::ops::Range<u32>{ .0 => _4, .1 => _2, };
             scope 5 (inlined <std::ops::Range<u32> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => _17;
-                let mut _8: bool;
-                let _10: u32;
-                let mut _11: u32;
-                let mut _18: &u32;
-                let mut _19: &u32;
+                debug self => &std::ops::Range<u32>{ .0 => _4, .1 => _2, };
+                let mut _6: bool;
+                let _8: u32;
+                let mut _9: u32;
                 scope 6 {
-                    debug old => _10;
+                    debug old => _8;
                     scope 7 {
                     }
                 }
                 scope 8 (inlined cmp::impls::<impl PartialOrd for u32>::lt) {
-                    debug self => _18;
-                    debug other => _19;
-                    let mut _6: u32;
-                    let mut _7: u32;
+                    debug self => &_4;
+                    debug other => &_2;
+                    let mut _5: u32;
                 }
             }
         }
     }
     scope 3 (inlined <std::ops::Range<u32> as IntoIterator>::into_iter) {
-        debug self => _4;
+        debug self => std::ops::Range<u32>{ .0 => _1, .1 => _2, };
     }
 
     bb0: {
-        _4 = std::ops::Range::<u32> { start: _1, end: _2 };
-        StorageLive(_5);
-        _5 = move _4;
+        StorageLive(_4);
+        _4 = _1;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_9);
-        StorageLive(_10);
-        StorageLive(_8);
-        StorageLive(_18);
-        StorageLive(_19);
-        StorageLive(_6);
-        _6 = (_5.0: u32);
         StorageLive(_7);
-        _7 = (_5.1: u32);
-        _8 = Lt(move _6, move _7);
-        StorageDead(_7);
-        StorageDead(_6);
-        StorageDead(_19);
-        StorageDead(_18);
-        switchInt(move _8) -> [0: bb2, otherwise: bb3];
+        StorageLive(_8);
+        StorageLive(_6);
+        StorageLive(_5);
+        _5 = _4;
+        _6 = Lt(move _5, _2);
+        StorageDead(_5);
+        switchInt(move _6) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _9 = Option::<u32>::None;
+        _7 = Option::<u32>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _10 = (_5.0: u32);
-        StorageLive(_11);
-        _11 = <u32 as Step>::forward_unchecked(_10, const 1_usize) -> [return: bb4, unwind: bb11];
+        _8 = _4;
+        StorageLive(_9);
+        _9 = <u32 as Step>::forward_unchecked(_8, const 1_usize) -> [return: bb4, unwind: bb11];
     }
 
     bb4: {
-        (_5.0: u32) = move _11;
-        StorageDead(_11);
-        _9 = Option::<u32>::Some(_10);
+        _4 = move _9;
+        StorageDead(_9);
+        _7 = Option::<u32>::Some(_8);
         goto -> bb5;
     }
 
     bb5: {
+        StorageDead(_6);
         StorageDead(_8);
-        StorageDead(_10);
-        _12 = discriminant(_9);
-        switchInt(move _12) -> [0: bb6, 1: bb8, otherwise: bb10];
+        _10 = discriminant(_7);
+        switchInt(move _10) -> [0: bb6, 1: bb8, otherwise: bb10];
     }
 
     bb6: {
-        StorageDead(_9);
-        StorageDead(_5);
+        StorageDead(_7);
+        StorageDead(_4);
         drop(_3) -> [return: bb7, unwind continue];
     }
 
@@ -107,18 +94,18 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb8: {
-        _13 = ((_9 as Some).0: u32);
-        StorageLive(_14);
-        _14 = &_3;
-        StorageLive(_15);
-        _15 = (_13,);
-        _16 = <impl Fn(u32) as Fn<(u32,)>>::call(move _14, move _15) -> [return: bb9, unwind: bb11];
+        _11 = ((_7 as Some).0: u32);
+        StorageLive(_12);
+        _12 = &_3;
+        StorageLive(_13);
+        _13 = (_11,);
+        _14 = <impl Fn(u32) as Fn<(u32,)>>::call(move _12, move _13) -> [return: bb9, unwind: bb11];
     }
 
     bb9: {
-        StorageDead(_15);
-        StorageDead(_14);
-        StorageDead(_9);
+        StorageDead(_13);
+        StorageDead(_12);
+        StorageDead(_7);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-abort.mir
@@ -10,16 +10,14 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
             let mut _4: bool;
             let _5: u32;
             let mut _6: u32;
-            let mut _7: &u32;
-            let mut _8: &u32;
             scope 3 {
                 debug old => _5;
                 scope 4 {
                 }
             }
             scope 5 (inlined cmp::impls::<impl PartialOrd for u32>::lt) {
-                debug self => _7;
-                debug other => _8;
+                debug self => &((*_1).0: u32);
+                debug other => &((*_1).1: u32);
                 let mut _2: u32;
                 let mut _3: u32;
             }
@@ -29,8 +27,6 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
     bb0: {
         StorageLive(_5);
         StorageLive(_4);
-        StorageLive(_7);
-        StorageLive(_8);
         StorageLive(_2);
         _2 = ((*_1).0: u32);
         StorageLive(_3);
@@ -38,8 +34,6 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
         _4 = Lt(move _2, move _3);
         StorageDead(_3);
         StorageDead(_2);
-        StorageDead(_8);
-        StorageDead(_7);
         switchInt(move _4) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
@@ -10,16 +10,14 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
             let mut _4: bool;
             let _5: u32;
             let mut _6: u32;
-            let mut _7: &u32;
-            let mut _8: &u32;
             scope 3 {
                 debug old => _5;
                 scope 4 {
                 }
             }
             scope 5 (inlined cmp::impls::<impl PartialOrd for u32>::lt) {
-                debug self => _7;
-                debug other => _8;
+                debug self => &((*_1).0: u32);
+                debug other => &((*_1).1: u32);
                 let mut _2: u32;
                 let mut _3: u32;
             }
@@ -29,8 +27,6 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
     bb0: {
         StorageLive(_5);
         StorageLive(_4);
-        StorageLive(_7);
-        StorageLive(_8);
         StorageLive(_2);
         _2 = ((*_1).0: u32);
         StorageLive(_3);
@@ -38,8 +34,6 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
         _4 = Lt(move _2, move _3);
         StorageDead(_3);
         StorageDead(_2);
-        StorageDead(_8);
-        StorageDead(_7);
         switchInt(move _4) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
@@ -3,206 +3,138 @@
 fn variant_a::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:7:25: 7:39], _2: &&(usize, usize, usize, usize)) -> bool {
     let mut _0: bool;
     let mut _3: &(usize, usize, usize, usize);
-    let _4: &usize;
+    let mut _4: &(usize, usize, usize, usize);
     let mut _5: &(usize, usize, usize, usize);
-    let _6: &usize;
-    let mut _7: &(usize, usize, usize, usize);
-    let _8: &usize;
-    let mut _9: &(usize, usize, usize, usize);
-    let _10: &usize;
-    let _11: &usize;
+    let mut _6: &(usize, usize, usize, usize);
+    let mut _9: bool;
+    let mut _10: bool;
+    let mut _13: bool;
     let mut _16: bool;
     let mut _17: bool;
-    let _18: &usize;
-    let mut _23: bool;
-    let _24: &usize;
-    let mut _29: bool;
-    let mut _30: bool;
-    let _31: &usize;
-    let mut _36: bool;
-    let mut _37: &&usize;
-    let mut _38: &&usize;
-    let mut _39: &&usize;
-    let mut _40: &&usize;
-    let mut _41: &&usize;
-    let mut _42: &&usize;
-    let mut _43: &&usize;
-    let mut _44: &&usize;
+    let mut _20: bool;
     scope 1 {
-        debug a => _4;
-        debug b => _6;
-        debug c => _8;
-        debug d => _10;
+        debug a => &((*_3).0: usize);
+        debug b => &((*_4).1: usize);
+        debug c => &((*_5).2: usize);
+        debug d => &((*_6).3: usize);
         scope 2 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
-            debug self => _37;
-            debug other => _38;
-            let mut _12: &usize;
-            let mut _13: &usize;
+            debug self => &&((*_3).0: usize);
+            debug other => &&((*_5).2: usize);
             scope 3 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
-                debug self => _12;
-                debug other => _13;
+                debug self => &((*_3).0: usize);
+                debug other => &((*_5).2: usize);
+                let mut _7: usize;
+                let mut _8: usize;
+            }
+        }
+        scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
+            debug self => &&((*_5).2: usize);
+            debug other => &&((*_3).0: usize);
+            scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
+                debug self => &((*_5).2: usize);
+                debug other => &((*_3).0: usize);
                 let mut _14: usize;
                 let mut _15: usize;
             }
         }
-        scope 4 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
-            debug self => _41;
-            debug other => _42;
-            let mut _25: &usize;
-            let mut _26: &usize;
-            scope 5 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
-                debug self => _25;
-                debug other => _26;
-                let mut _27: usize;
-                let mut _28: usize;
-            }
-        }
         scope 6 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
-            debug self => _39;
-            debug other => _40;
-            let mut _19: &usize;
-            let mut _20: &usize;
+            debug self => &&((*_6).3: usize);
+            debug other => &&((*_4).1: usize);
             scope 7 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
-                debug self => _19;
-                debug other => _20;
-                let mut _21: usize;
-                let mut _22: usize;
+                debug self => &((*_6).3: usize);
+                debug other => &((*_4).1: usize);
+                let mut _11: usize;
+                let mut _12: usize;
             }
         }
         scope 8 (inlined cmp::impls::<impl PartialOrd for &usize>::le) {
-            debug self => _43;
-            debug other => _44;
-            let mut _32: &usize;
-            let mut _33: &usize;
+            debug self => &&((*_4).1: usize);
+            debug other => &&((*_6).3: usize);
             scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::le) {
-                debug self => _32;
-                debug other => _33;
-                let mut _34: usize;
-                let mut _35: usize;
+                debug self => &((*_4).1: usize);
+                debug other => &((*_6).3: usize);
+                let mut _18: usize;
+                let mut _19: usize;
             }
         }
     }
 
     bb0: {
-        StorageLive(_4);
         _3 = deref_copy (*_2);
-        _4 = &((*_3).0: usize);
-        StorageLive(_6);
+        _4 = deref_copy (*_2);
         _5 = deref_copy (*_2);
-        _6 = &((*_5).1: usize);
-        StorageLive(_8);
-        _7 = deref_copy (*_2);
-        _8 = &((*_7).2: usize);
+        _6 = deref_copy (*_2);
         StorageLive(_10);
-        _9 = deref_copy (*_2);
-        _10 = &((*_9).3: usize);
-        StorageLive(_17);
-        StorageLive(_16);
-        StorageLive(_37);
-        StorageLive(_38);
-        StorageLive(_11);
-        _11 = _8;
-        _12 = deref_copy _4;
-        _13 = deref_copy _11;
-        StorageLive(_14);
-        _14 = (*_12);
-        StorageLive(_15);
-        _15 = (*_13);
-        _16 = Le(move _14, move _15);
-        StorageDead(_15);
-        StorageDead(_14);
-        StorageDead(_11);
-        StorageDead(_38);
-        StorageDead(_37);
-        switchInt(move _16) -> [0: bb1, otherwise: bb2];
+        StorageLive(_9);
+        StorageLive(_7);
+        _7 = ((*_3).0: usize);
+        StorageLive(_8);
+        _8 = ((*_5).2: usize);
+        _9 = Le(move _7, move _8);
+        StorageDead(_8);
+        StorageDead(_7);
+        switchInt(move _9) -> [0: bb1, otherwise: bb2];
     }
 
     bb1: {
-        _17 = const false;
+        _10 = const false;
         goto -> bb3;
     }
 
     bb2: {
-        StorageLive(_23);
-        StorageLive(_39);
-        StorageLive(_40);
-        StorageLive(_18);
-        _18 = _6;
-        _19 = deref_copy _10;
-        _20 = deref_copy _18;
-        StorageLive(_21);
-        _21 = (*_19);
-        StorageLive(_22);
-        _22 = (*_20);
-        _23 = Le(move _21, move _22);
-        StorageDead(_22);
-        StorageDead(_21);
-        StorageDead(_18);
-        StorageDead(_40);
-        StorageDead(_39);
-        _17 = move _23;
+        StorageLive(_13);
+        StorageLive(_11);
+        _11 = ((*_6).3: usize);
+        StorageLive(_12);
+        _12 = ((*_4).1: usize);
+        _13 = Le(move _11, move _12);
+        StorageDead(_12);
+        StorageDead(_11);
+        _10 = move _13;
         goto -> bb3;
     }
 
     bb3: {
-        StorageDead(_23);
-        StorageDead(_16);
-        switchInt(move _17) -> [0: bb4, otherwise: bb8];
+        StorageDead(_13);
+        StorageDead(_9);
+        switchInt(move _10) -> [0: bb4, otherwise: bb8];
     }
 
     bb4: {
-        StorageLive(_30);
-        StorageLive(_29);
-        StorageLive(_41);
-        StorageLive(_42);
-        StorageLive(_24);
-        _24 = _4;
-        _25 = deref_copy _8;
-        _26 = deref_copy _24;
-        StorageLive(_27);
-        _27 = (*_25);
-        StorageLive(_28);
-        _28 = (*_26);
-        _29 = Le(move _27, move _28);
-        StorageDead(_28);
-        StorageDead(_27);
-        StorageDead(_24);
-        StorageDead(_42);
-        StorageDead(_41);
-        switchInt(move _29) -> [0: bb5, otherwise: bb6];
+        StorageLive(_17);
+        StorageLive(_16);
+        StorageLive(_14);
+        _14 = ((*_5).2: usize);
+        StorageLive(_15);
+        _15 = ((*_3).0: usize);
+        _16 = Le(move _14, move _15);
+        StorageDead(_15);
+        StorageDead(_14);
+        switchInt(move _16) -> [0: bb5, otherwise: bb6];
     }
 
     bb5: {
-        _30 = const false;
+        _17 = const false;
         goto -> bb7;
     }
 
     bb6: {
-        StorageLive(_36);
-        StorageLive(_43);
-        StorageLive(_44);
-        StorageLive(_31);
-        _31 = _10;
-        _32 = deref_copy _6;
-        _33 = deref_copy _31;
-        StorageLive(_34);
-        _34 = (*_32);
-        StorageLive(_35);
-        _35 = (*_33);
-        _36 = Le(move _34, move _35);
-        StorageDead(_35);
-        StorageDead(_34);
-        StorageDead(_31);
-        StorageDead(_44);
-        StorageDead(_43);
-        _30 = move _36;
+        StorageLive(_20);
+        StorageLive(_18);
+        _18 = ((*_4).1: usize);
+        StorageLive(_19);
+        _19 = ((*_6).3: usize);
+        _20 = Le(move _18, move _19);
+        StorageDead(_19);
+        StorageDead(_18);
+        _17 = move _20;
         goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_36);
-        StorageDead(_29);
-        _0 = move _30;
+        StorageDead(_20);
+        StorageDead(_16);
+        _0 = move _17;
         goto -> bb9;
     }
 
@@ -212,12 +144,8 @@ fn variant_a::{closure#0}(_1: &mut [closure@$DIR/slice_filter.rs:7:25: 7:39], _2
     }
 
     bb9: {
-        StorageDead(_30);
         StorageDead(_17);
         StorageDead(_10);
-        StorageDead(_8);
-        StorageDead(_6);
-        StorageDead(_4);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-abort.mir
@@ -5,109 +5,95 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     debug f => _2;
     let mut _0: ();
     let mut _3: usize;
-    let mut _4: std::ops::Range<usize>;
-    let mut _5: std::ops::Range<usize>;
-    let mut _9: std::option::Option<usize>;
-    let mut _12: isize;
-    let mut _14: usize;
-    let mut _15: bool;
-    let mut _17: &impl Fn(usize, &T);
-    let mut _18: (usize, &T);
-    let _19: ();
-    let mut _20: &mut std::ops::Range<usize>;
+    let mut _4: usize;
+    let mut _7: std::option::Option<usize>;
+    let mut _10: isize;
+    let mut _12: usize;
+    let mut _13: bool;
+    let mut _15: &impl Fn(usize, &T);
+    let mut _16: (usize, &T);
+    let _17: ();
+    let mut _18: usize;
     scope 1 {
-        debug iter => _5;
-        let _13: usize;
+        debug iter => std::ops::Range<usize>{ .0 => _4, .1 => _3, };
+        let _11: usize;
         scope 2 {
-            debug i => _13;
-            let _16: &T;
+            debug i => _11;
+            let _14: &T;
             scope 3 {
-                debug x => _16;
+                debug x => _14;
             }
         }
         scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
-            debug self => _20;
+            debug self => &std::ops::Range<usize>{ .0 => _4, .1 => _3, };
             scope 6 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => _20;
-                let mut _8: bool;
-                let _10: usize;
-                let mut _11: usize;
-                let mut _21: &usize;
-                let mut _22: &usize;
+                debug self => &std::ops::Range<usize>{ .0 => _4, .1 => _3, };
+                let mut _6: bool;
+                let _8: usize;
+                let mut _9: usize;
                 scope 7 {
-                    debug old => _10;
+                    debug old => _8;
                     scope 8 {
                     }
                 }
                 scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::lt) {
-                    debug self => _21;
-                    debug other => _22;
-                    let mut _6: usize;
-                    let mut _7: usize;
+                    debug self => &_4;
+                    debug other => &_3;
+                    let mut _5: usize;
                 }
             }
         }
     }
     scope 4 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
-        debug self => _4;
+        debug self => std::ops::Range<usize>{ .0 => _18, .1 => _3, };
     }
 
     bb0: {
-        StorageLive(_3);
         _3 = Len((*_1));
-        _4 = std::ops::Range::<usize> { start: const 0_usize, end: move _3 };
-        StorageDead(_3);
-        StorageLive(_5);
-        _5 = move _4;
+        StorageLive(_4);
+        _4 = const 0_usize;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_9);
-        StorageLive(_10);
-        StorageLive(_8);
-        StorageLive(_21);
-        StorageLive(_22);
-        StorageLive(_6);
-        _6 = (_5.0: usize);
         StorageLive(_7);
-        _7 = (_5.1: usize);
-        _8 = Lt(move _6, move _7);
-        StorageDead(_7);
-        StorageDead(_6);
-        StorageDead(_22);
-        StorageDead(_21);
-        switchInt(move _8) -> [0: bb2, otherwise: bb3];
+        StorageLive(_8);
+        StorageLive(_6);
+        StorageLive(_5);
+        _5 = _4;
+        _6 = Lt(move _5, _3);
+        StorageDead(_5);
+        switchInt(move _6) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _9 = Option::<usize>::None;
+        _7 = Option::<usize>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _10 = (_5.0: usize);
-        StorageLive(_11);
-        _11 = <usize as Step>::forward_unchecked(_10, const 1_usize) -> [return: bb4, unwind unreachable];
+        _8 = _4;
+        StorageLive(_9);
+        _9 = <usize as Step>::forward_unchecked(_8, const 1_usize) -> [return: bb4, unwind unreachable];
     }
 
     bb4: {
-        (_5.0: usize) = move _11;
-        StorageDead(_11);
-        _9 = Option::<usize>::Some(_10);
+        _4 = move _9;
+        StorageDead(_9);
+        _7 = Option::<usize>::Some(_8);
         goto -> bb5;
     }
 
     bb5: {
+        StorageDead(_6);
         StorageDead(_8);
-        StorageDead(_10);
-        _12 = discriminant(_9);
-        switchInt(move _12) -> [0: bb6, 1: bb8, otherwise: bb11];
+        _10 = discriminant(_7);
+        switchInt(move _10) -> [0: bb6, 1: bb8, otherwise: bb11];
     }
 
     bb6: {
-        StorageDead(_9);
-        StorageDead(_5);
+        StorageDead(_7);
+        StorageDead(_4);
         drop(_2) -> [return: bb7, unwind unreachable];
     }
 
@@ -116,25 +102,25 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb8: {
-        _13 = ((_9 as Some).0: usize);
-        _14 = Len((*_1));
-        _15 = Lt(_13, _14);
-        assert(move _15, "index out of bounds: the length is {} but the index is {}", move _14, _13) -> [success: bb9, unwind unreachable];
+        _11 = ((_7 as Some).0: usize);
+        _12 = Len((*_1));
+        _13 = Lt(_11, _12);
+        assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> [success: bb9, unwind unreachable];
     }
 
     bb9: {
-        _16 = &(*_1)[_13];
-        StorageLive(_17);
-        _17 = &_2;
-        StorageLive(_18);
-        _18 = (_13, _16);
-        _19 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _17, move _18) -> [return: bb10, unwind unreachable];
+        _14 = &(*_1)[_11];
+        StorageLive(_15);
+        _15 = &_2;
+        StorageLive(_16);
+        _16 = (_11, _14);
+        _17 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _15, move _16) -> [return: bb10, unwind unreachable];
     }
 
     bb10: {
-        StorageDead(_18);
-        StorageDead(_17);
-        StorageDead(_9);
+        StorageDead(_16);
+        StorageDead(_15);
+        StorageDead(_7);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
@@ -5,109 +5,95 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     debug f => _2;
     let mut _0: ();
     let mut _3: usize;
-    let mut _4: std::ops::Range<usize>;
-    let mut _5: std::ops::Range<usize>;
-    let mut _9: std::option::Option<usize>;
-    let mut _12: isize;
-    let mut _14: usize;
-    let mut _15: bool;
-    let mut _17: &impl Fn(usize, &T);
-    let mut _18: (usize, &T);
-    let _19: ();
-    let mut _20: &mut std::ops::Range<usize>;
+    let mut _4: usize;
+    let mut _7: std::option::Option<usize>;
+    let mut _10: isize;
+    let mut _12: usize;
+    let mut _13: bool;
+    let mut _15: &impl Fn(usize, &T);
+    let mut _16: (usize, &T);
+    let _17: ();
+    let mut _18: usize;
     scope 1 {
-        debug iter => _5;
-        let _13: usize;
+        debug iter => std::ops::Range<usize>{ .0 => _4, .1 => _3, };
+        let _11: usize;
         scope 2 {
-            debug i => _13;
-            let _16: &T;
+            debug i => _11;
+            let _14: &T;
             scope 3 {
-                debug x => _16;
+                debug x => _14;
             }
         }
         scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
-            debug self => _20;
+            debug self => &std::ops::Range<usize>{ .0 => _4, .1 => _3, };
             scope 6 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
-                debug self => _20;
-                let mut _8: bool;
-                let _10: usize;
-                let mut _11: usize;
-                let mut _21: &usize;
-                let mut _22: &usize;
+                debug self => &std::ops::Range<usize>{ .0 => _4, .1 => _3, };
+                let mut _6: bool;
+                let _8: usize;
+                let mut _9: usize;
                 scope 7 {
-                    debug old => _10;
+                    debug old => _8;
                     scope 8 {
                     }
                 }
                 scope 9 (inlined cmp::impls::<impl PartialOrd for usize>::lt) {
-                    debug self => _21;
-                    debug other => _22;
-                    let mut _6: usize;
-                    let mut _7: usize;
+                    debug self => &_4;
+                    debug other => &_3;
+                    let mut _5: usize;
                 }
             }
         }
     }
     scope 4 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
-        debug self => _4;
+        debug self => std::ops::Range<usize>{ .0 => _18, .1 => _3, };
     }
 
     bb0: {
-        StorageLive(_3);
         _3 = Len((*_1));
-        _4 = std::ops::Range::<usize> { start: const 0_usize, end: move _3 };
-        StorageDead(_3);
-        StorageLive(_5);
-        _5 = move _4;
+        StorageLive(_4);
+        _4 = const 0_usize;
         goto -> bb1;
     }
 
     bb1: {
-        StorageLive(_9);
-        StorageLive(_10);
-        StorageLive(_8);
-        StorageLive(_21);
-        StorageLive(_22);
-        StorageLive(_6);
-        _6 = (_5.0: usize);
         StorageLive(_7);
-        _7 = (_5.1: usize);
-        _8 = Lt(move _6, move _7);
-        StorageDead(_7);
-        StorageDead(_6);
-        StorageDead(_22);
-        StorageDead(_21);
-        switchInt(move _8) -> [0: bb2, otherwise: bb3];
+        StorageLive(_8);
+        StorageLive(_6);
+        StorageLive(_5);
+        _5 = _4;
+        _6 = Lt(move _5, _3);
+        StorageDead(_5);
+        switchInt(move _6) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _9 = Option::<usize>::None;
+        _7 = Option::<usize>::None;
         goto -> bb5;
     }
 
     bb3: {
-        _10 = (_5.0: usize);
-        StorageLive(_11);
-        _11 = <usize as Step>::forward_unchecked(_10, const 1_usize) -> [return: bb4, unwind: bb12];
+        _8 = _4;
+        StorageLive(_9);
+        _9 = <usize as Step>::forward_unchecked(_8, const 1_usize) -> [return: bb4, unwind: bb12];
     }
 
     bb4: {
-        (_5.0: usize) = move _11;
-        StorageDead(_11);
-        _9 = Option::<usize>::Some(_10);
+        _4 = move _9;
+        StorageDead(_9);
+        _7 = Option::<usize>::Some(_8);
         goto -> bb5;
     }
 
     bb5: {
+        StorageDead(_6);
         StorageDead(_8);
-        StorageDead(_10);
-        _12 = discriminant(_9);
-        switchInt(move _12) -> [0: bb6, 1: bb8, otherwise: bb11];
+        _10 = discriminant(_7);
+        switchInt(move _10) -> [0: bb6, 1: bb8, otherwise: bb11];
     }
 
     bb6: {
-        StorageDead(_9);
-        StorageDead(_5);
+        StorageDead(_7);
+        StorageDead(_4);
         drop(_2) -> [return: bb7, unwind continue];
     }
 
@@ -116,25 +102,25 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb8: {
-        _13 = ((_9 as Some).0: usize);
-        _14 = Len((*_1));
-        _15 = Lt(_13, _14);
-        assert(move _15, "index out of bounds: the length is {} but the index is {}", move _14, _13) -> [success: bb9, unwind: bb12];
+        _11 = ((_7 as Some).0: usize);
+        _12 = Len((*_1));
+        _13 = Lt(_11, _12);
+        assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> [success: bb9, unwind: bb12];
     }
 
     bb9: {
-        _16 = &(*_1)[_13];
-        StorageLive(_17);
-        _17 = &_2;
-        StorageLive(_18);
-        _18 = (_13, _16);
-        _19 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _17, move _18) -> [return: bb10, unwind: bb12];
+        _14 = &(*_1)[_11];
+        StorageLive(_15);
+        _15 = &_2;
+        StorageLive(_16);
+        _16 = (_11, _14);
+        _17 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _15, move _16) -> [return: bb10, unwind: bb12];
     }
 
     bb10: {
-        StorageDead(_18);
-        StorageDead(_17);
-        StorageDead(_9);
+        StorageDead(_16);
+        StorageDead(_15);
+        StorageDead(_7);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -12,7 +12,6 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     let mut _20: &impl Fn(&T);
     let mut _21: (&T,);
     let _22: ();
-    let mut _23: &mut std::iter::Rev<std::slice::Iter<'_, T>>;
     scope 1 {
         debug iter => _15;
         let _19: &T;
@@ -20,7 +19,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             debug x => _19;
         }
         scope 25 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
-            debug self => _23;
+            debug self => &_15;
             let mut _16: &mut std::slice::Iter<'_, T>;
         }
     }
@@ -49,15 +48,15 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                                     debug ptr => _9;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
                                         debug self => _9;
-                                        let mut _24: *mut u8;
+                                        let mut _23: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _24;
+                                                debug ptr => _23;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _24;
+                                                    debug self => _23;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _24;
+                                                            debug self => _23;
                                                         }
                                                     }
                                                 }
@@ -132,10 +131,10 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageLive(_9);
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
-        StorageLive(_24);
+        StorageLive(_23);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
-        StorageDead(_24);
+        StorageDead(_23);
         StorageDead(_10);
         StorageDead(_9);
         StorageLive(_12);

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -12,7 +12,6 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     let mut _20: &impl Fn(&T);
     let mut _21: (&T,);
     let _22: ();
-    let mut _23: &mut std::iter::Rev<std::slice::Iter<'_, T>>;
     scope 1 {
         debug iter => _15;
         let _19: &T;
@@ -20,7 +19,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             debug x => _19;
         }
         scope 25 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
-            debug self => _23;
+            debug self => &_15;
             let mut _16: &mut std::slice::Iter<'_, T>;
         }
     }
@@ -49,15 +48,15 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                                     debug ptr => _9;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
                                         debug self => _9;
-                                        let mut _24: *mut u8;
+                                        let mut _23: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _24;
+                                                debug ptr => _23;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _24;
+                                                    debug self => _23;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _24;
+                                                            debug self => _23;
                                                         }
                                                     }
                                                 }
@@ -132,10 +131,10 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageLive(_9);
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
-        StorageLive(_24);
+        StorageLive(_23);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
-        StorageDead(_24);
+        StorageDead(_23);
         StorageDead(_10);
         StorageDead(_9);
         StorageLive(_12);

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -22,23 +22,27 @@
       let _24: &mut u8;
       let mut _25: debuginfo::T;
       scope 1 {
-          debug ref_mut_u8 => _1;
+-         debug ref_mut_u8 => _1;
++         debug ref_mut_u8 => &_2;
           let _3: &u8;
           let mut _28: &debuginfo::T;
           scope 2 {
-              debug field => _3;
+-             debug field => _3;
++             debug field => &((*_28).0: u8);
               let _5: &u8;
               scope 3 {
 -                 debug reborrow => _5;
-+                 debug reborrow => _1;
++                 debug reborrow => &_2;
                   let _9: &i32;
                   let _22: &&&mut u8;
                   let mut _27: &std::option::Option<i32>;
                   scope 4 {
-                      debug variant_field => _9;
+-                     debug variant_field => _9;
++                     debug variant_field => &(((*_27) as Some).0: i32);
                   }
                   scope 5 {
-                      debug constant_index => _19;
+-                     debug constant_index => _19;
++                     debug constant_index => &(*_11)[1 of 3];
                       debug subslice => _20;
                       debug constant_index_from_end => _21;
                       let _19: &i32;
@@ -47,20 +51,21 @@
                       let mut _26: &[i32; 10];
                   }
                   scope 6 {
-                      debug multiple_borrow => _22;
+-                     debug multiple_borrow => _22;
++                     debug multiple_borrow => &&&(_25.0: u8);
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);
+-         StorageLive(_1);
           StorageLive(_2);
           _2 = const 5_u8;
-          _1 = &mut _2;
-          StorageLive(_3);
+-         _1 = &mut _2;
+-         StorageLive(_3);
           _28 = const _;
-          _3 = &((*_28).0: u8);
+-         _3 = &((*_28).0: u8);
 -         StorageLive(_5);
 -         _5 = &(*_1);
 -         StorageLive(_6);
@@ -71,11 +76,11 @@
       }
   
       bb1: {
-          StorageLive(_9);
+-         StorageLive(_9);
           _27 = const _;
-          _9 = &(((*_27) as Some).0: i32);
+-         _9 = &(((*_27) as Some).0: i32);
 -         _6 = const ();
-          StorageDead(_9);
+-         StorageDead(_9);
           goto -> bb4;
       }
   
@@ -113,8 +118,8 @@
       }
   
       bb6: {
-          StorageLive(_19);
-          _19 = &(*_11)[1 of 3];
+-         StorageLive(_19);
+-         _19 = &(*_11)[1 of 3];
           StorageLive(_20);
           _20 = &(*_11)[2:-1];
           StorageLive(_21);
@@ -122,7 +127,7 @@
 -         _10 = const ();
           StorageDead(_21);
           StorageDead(_20);
-          StorageDead(_19);
+-         StorageDead(_19);
           goto -> bb8;
       }
   
@@ -135,23 +140,23 @@
           StorageDead(_12);
           StorageDead(_11);
 -         StorageDead(_10);
-          StorageLive(_22);
-          StorageLive(_23);
-          StorageLive(_24);
+-         StorageLive(_22);
+-         StorageLive(_23);
+-         StorageLive(_24);
           StorageLive(_25);
           _25 = T(const 6_u8);
-          _24 = &mut (_25.0: u8);
-          _23 = &_24;
-          _22 = &_23;
+-         _24 = &mut (_25.0: u8);
+-         _23 = &_24;
+-         _22 = &_23;
           _0 = const ();
           StorageDead(_25);
-          StorageDead(_24);
-          StorageDead(_23);
-          StorageDead(_22);
+-         StorageDead(_24);
+-         StorageDead(_23);
+-         StorageDead(_22);
 -         StorageDead(_5);
-          StorageDead(_3);
+-         StorageDead(_3);
           StorageDead(_2);
-          StorageDead(_1);
+-         StorageDead(_1);
           return;
       }
   }

--- a/tests/mir-opt/reference_prop.mut_raw_then_mut_shr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.mut_raw_then_mut_shr.ReferencePropagation.diff
@@ -13,15 +13,16 @@
           debug x => _1;
           let _2: &mut i32;
           scope 2 {
-              debug xref => _2;
+-             debug xref => _2;
++             debug xref => &_1;
               let _3: *mut i32;
               scope 3 {
 -                 debug xraw => _3;
-+                 debug xraw => _2;
++                 debug xraw => &_1;
                   let _6: &i32;
                   scope 4 {
 -                     debug xshr => _6;
-+                     debug xshr => _2;
++                     debug xshr => &_1;
                       let _7: i32;
                       scope 5 {
                           debug a => _7;
@@ -37,7 +38,7 @@
           StorageLive(_1);
           _1 = const 2_i32;
 -         StorageLive(_2);
-          _2 = &mut _1;
+-         _2 = &mut _1;
 -         StorageLive(_3);
 -         StorageLive(_4);
 -         StorageLive(_5);

--- a/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation.ReferencePropagation.diff
@@ -52,7 +52,8 @@
           debug a => _4;
           let _5: &usize;
           scope 2 {
-              debug b => _5;
+-             debug b => _5;
++             debug b => &_4;
               let _6: usize;
               scope 3 {
                   debug c => _6;
@@ -157,10 +158,12 @@
           debug a => _60;
           let _61: &usize;
           scope 30 {
-              debug b => _61;
+-             debug b => _61;
++             debug b => &_60;
               let _62: &&usize;
               scope 31 {
-                  debug d => _62;
+-                 debug d => _62;
++                 debug d => &&_60;
                   let _63: usize;
                   scope 32 {
                       debug c => _63;
@@ -172,10 +175,12 @@
           debug a => _66;
           let mut _67: &usize;
           scope 34 {
-              debug b => _67;
+-             debug b => _67;
++             debug b => &_66;
               let _68: &mut &usize;
               scope 35 {
-                  debug d => _68;
+-                 debug d => _68;
++                 debug d => &&_66;
                   let _69: usize;
                   scope 36 {
                       debug c => _69;
@@ -188,8 +193,8 @@
 -         StorageLive(_3);
           StorageLive(_4);
           _4 = const 5_usize;
-          StorageLive(_5);
-          _5 = &_4;
+-         StorageLive(_5);
+-         _5 = &_4;
           StorageLive(_6);
 -         _6 = (*_5);
 +         _6 = _4;
@@ -204,7 +209,7 @@
           StorageDead(_7);
 -         _3 = const ();
           StorageDead(_6);
-          StorageDead(_5);
+-         StorageDead(_5);
           StorageDead(_4);
 -         StorageDead(_3);
 -         StorageLive(_9);
@@ -389,12 +394,13 @@
 -         StorageLive(_59);
           StorageLive(_60);
           _60 = const 5_usize;
-          StorageLive(_61);
-          _61 = &_60;
-          StorageLive(_62);
-          _62 = &_61;
+-         StorageLive(_61);
+-         _61 = &_60;
+-         StorageLive(_62);
+-         _62 = &_61;
           StorageLive(_63);
-          _63 = (*_61);
+-         _63 = (*_61);
++         _63 = _60;
           StorageLive(_64);
           StorageLive(_65);
           _65 = ();
@@ -406,18 +412,19 @@
           StorageDead(_64);
 -         _59 = const ();
           StorageDead(_63);
-          StorageDead(_62);
-          StorageDead(_61);
+-         StorageDead(_62);
+-         StorageDead(_61);
           StorageDead(_60);
 -         StorageDead(_59);
           StorageLive(_66);
           _66 = const 5_usize;
-          StorageLive(_67);
-          _67 = &_66;
-          StorageLive(_68);
-          _68 = &mut _67;
+-         StorageLive(_67);
+-         _67 = &_66;
+-         StorageLive(_68);
+-         _68 = &mut _67;
           StorageLive(_69);
-          _69 = (*_67);
+-         _69 = (*_67);
++         _69 = _66;
           StorageLive(_70);
           StorageLive(_71);
           _71 = ();
@@ -429,8 +436,8 @@
           StorageDead(_70);
           _0 = const ();
           StorageDead(_69);
-          StorageDead(_68);
-          StorageDead(_67);
+-         StorageDead(_68);
+-         StorageDead(_67);
           StorageDead(_66);
           return;
       }

--- a/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_const_ptr.ReferencePropagation.diff
@@ -45,7 +45,8 @@
               debug a => _4;
               let _5: *const usize;
               scope 3 {
-                  debug b => _5;
+-                 debug b => _5;
++                 debug b => &_4;
                   let _6: usize;
                   scope 4 {
                       debug c => _6;
@@ -174,10 +175,12 @@
               debug a => _58;
               let _59: *const usize;
               scope 39 {
-                  debug b => _59;
+-                 debug b => _59;
++                 debug b => &_58;
                   let _60: *const usize;
                   scope 40 {
-                      debug c => _60;
+-                     debug c => _60;
++                     debug c => &_58;
                       let _61: usize;
                       scope 41 {
                           debug e => _61;
@@ -192,10 +195,12 @@
               debug a => _65;
               let _66: *const usize;
               scope 44 {
-                  debug b => _66;
+-                 debug b => _66;
++                 debug b => &_65;
                   let _67: &*const usize;
                   scope 45 {
-                      debug d => _67;
+-                     debug d => _67;
++                     debug d => &&_65;
                       let _68: usize;
                       scope 46 {
                           debug c => _68;
@@ -210,10 +215,12 @@
               debug a => _71;
               let mut _72: *const usize;
               scope 49 {
-                  debug b => _72;
+-                 debug b => _72;
++                 debug b => &_71;
                   let _73: &mut *const usize;
                   scope 50 {
-                      debug d => _73;
+-                     debug d => _73;
++                     debug d => &&_71;
                       let _74: usize;
                       scope 51 {
                           debug c => _74;
@@ -227,8 +234,8 @@
 -         StorageLive(_3);
           StorageLive(_4);
           _4 = const 5_usize;
-          StorageLive(_5);
-          _5 = &raw const _4;
+-         StorageLive(_5);
+-         _5 = &raw const _4;
           StorageLive(_6);
 -         _6 = (*_5);
 +         _6 = _4;
@@ -243,7 +250,7 @@
           StorageDead(_7);
 -         _3 = const ();
           StorageDead(_6);
-          StorageDead(_5);
+-         StorageDead(_5);
           StorageDead(_4);
 -         StorageDead(_3);
 -         StorageLive(_9);
@@ -420,11 +427,10 @@
 -         StorageLive(_57);
           StorageLive(_58);
           _58 = const 13_usize;
-          StorageLive(_59);
-          _59 = &raw const _58;
-          StorageLive(_60);
+-         StorageLive(_59);
+-         _59 = &raw const _58;
+-         StorageLive(_60);
 -         _60 = &raw const (*_59);
-+         _60 = &raw const _58;
           StorageLive(_61);
 -         _61 = (*_60);
 +         _61 = _58;
@@ -439,19 +445,20 @@
           StorageDead(_62);
 -         _57 = const ();
           StorageDead(_61);
-          StorageDead(_60);
-          StorageDead(_59);
+-         StorageDead(_60);
+-         StorageDead(_59);
           StorageDead(_58);
 -         StorageDead(_57);
 -         StorageLive(_64);
           StorageLive(_65);
           _65 = const 5_usize;
-          StorageLive(_66);
-          _66 = &raw const _65;
-          StorageLive(_67);
-          _67 = &_66;
+-         StorageLive(_66);
+-         _66 = &raw const _65;
+-         StorageLive(_67);
+-         _67 = &_66;
           StorageLive(_68);
-          _68 = (*_66);
+-         _68 = (*_66);
++         _68 = _65;
           StorageLive(_69);
           StorageLive(_70);
           _70 = ();
@@ -463,18 +470,19 @@
           StorageDead(_69);
 -         _64 = const ();
           StorageDead(_68);
-          StorageDead(_67);
-          StorageDead(_66);
+-         StorageDead(_67);
+-         StorageDead(_66);
           StorageDead(_65);
 -         StorageDead(_64);
           StorageLive(_71);
           _71 = const 5_usize;
-          StorageLive(_72);
-          _72 = &raw const _71;
-          StorageLive(_73);
-          _73 = &mut _72;
+-         StorageLive(_72);
+-         _72 = &raw const _71;
+-         StorageLive(_73);
+-         _73 = &mut _72;
           StorageLive(_74);
-          _74 = (*_72);
+-         _74 = (*_72);
++         _74 = _71;
           StorageLive(_75);
           StorageLive(_76);
           _76 = ();
@@ -486,8 +494,8 @@
           StorageDead(_75);
           _0 = const ();
           StorageDead(_74);
-          StorageDead(_73);
-          StorageDead(_72);
+-         StorageDead(_73);
+-         StorageDead(_72);
           StorageDead(_71);
           return;
       }

--- a/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut.ReferencePropagation.diff
@@ -52,7 +52,8 @@
           debug a => _4;
           let _5: &mut usize;
           scope 2 {
-              debug b => _5;
+-             debug b => _5;
++             debug b => &_4;
               let _6: usize;
               scope 3 {
                   debug c => _6;
@@ -157,10 +158,12 @@
           debug a => _60;
           let _61: &mut usize;
           scope 30 {
-              debug b => _61;
+-             debug b => _61;
++             debug b => &_60;
               let _62: &&mut usize;
               scope 31 {
-                  debug d => _62;
+-                 debug d => _62;
++                 debug d => &&_60;
                   let _63: usize;
                   scope 32 {
                       debug c => _63;
@@ -172,10 +175,12 @@
           debug a => _66;
           let mut _67: &mut usize;
           scope 34 {
-              debug b => _67;
+-             debug b => _67;
++             debug b => &_66;
               let _68: &mut &mut usize;
               scope 35 {
-                  debug d => _68;
+-                 debug d => _68;
++                 debug d => &&_66;
                   let _69: usize;
                   scope 36 {
                       debug c => _69;
@@ -188,8 +193,8 @@
 -         StorageLive(_3);
           StorageLive(_4);
           _4 = const 5_usize;
-          StorageLive(_5);
-          _5 = &mut _4;
+-         StorageLive(_5);
+-         _5 = &mut _4;
           StorageLive(_6);
 -         _6 = (*_5);
 +         _6 = _4;
@@ -204,7 +209,7 @@
           StorageDead(_7);
 -         _3 = const ();
           StorageDead(_6);
-          StorageDead(_5);
+-         StorageDead(_5);
           StorageDead(_4);
 -         StorageDead(_3);
 -         StorageLive(_9);
@@ -386,12 +391,13 @@
 -         StorageLive(_59);
           StorageLive(_60);
           _60 = const 5_usize;
-          StorageLive(_61);
-          _61 = &mut _60;
-          StorageLive(_62);
-          _62 = &_61;
+-         StorageLive(_61);
+-         _61 = &mut _60;
+-         StorageLive(_62);
+-         _62 = &_61;
           StorageLive(_63);
-          _63 = (*_61);
+-         _63 = (*_61);
++         _63 = _60;
           StorageLive(_64);
           StorageLive(_65);
           _65 = ();
@@ -403,18 +409,19 @@
           StorageDead(_64);
 -         _59 = const ();
           StorageDead(_63);
-          StorageDead(_62);
-          StorageDead(_61);
+-         StorageDead(_62);
+-         StorageDead(_61);
           StorageDead(_60);
 -         StorageDead(_59);
           StorageLive(_66);
           _66 = const 5_usize;
-          StorageLive(_67);
-          _67 = &mut _66;
-          StorageLive(_68);
-          _68 = &mut _67;
+-         StorageLive(_67);
+-         _67 = &mut _66;
+-         StorageLive(_68);
+-         _68 = &mut _67;
           StorageLive(_69);
-          _69 = (*_67);
+-         _69 = (*_67);
++         _69 = _66;
           StorageLive(_70);
           StorageLive(_71);
           _71 = ();
@@ -426,8 +433,8 @@
           StorageDead(_70);
           _0 = const ();
           StorageDead(_69);
-          StorageDead(_68);
-          StorageDead(_67);
+-         StorageDead(_68);
+-         StorageDead(_67);
           StorageDead(_66);
           return;
       }

--- a/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.reference_propagation_mut_ptr.ReferencePropagation.diff
@@ -42,7 +42,8 @@
               debug a => _4;
               let _5: *mut usize;
               scope 3 {
-                  debug b => _5;
+-                 debug b => _5;
++                 debug b => &_4;
                   let _6: usize;
                   scope 4 {
                       debug c => _6;
@@ -171,10 +172,12 @@
               debug a => _58;
               let _59: *mut usize;
               scope 39 {
-                  debug b => _59;
+-                 debug b => _59;
++                 debug b => &_58;
                   let _60: &*mut usize;
                   scope 40 {
-                      debug d => _60;
+-                     debug d => _60;
++                     debug d => &&_58;
                       let _61: usize;
                       scope 41 {
                           debug c => _61;
@@ -189,10 +192,12 @@
               debug a => _64;
               let mut _65: *mut usize;
               scope 44 {
-                  debug b => _65;
+-                 debug b => _65;
++                 debug b => &_64;
                   let _66: &mut *mut usize;
                   scope 45 {
-                      debug d => _66;
+-                     debug d => _66;
++                     debug d => &&_64;
                       let _67: usize;
                       scope 46 {
                           debug c => _67;
@@ -206,8 +211,8 @@
 -         StorageLive(_3);
           StorageLive(_4);
           _4 = const 5_usize;
-          StorageLive(_5);
-          _5 = &raw mut _4;
+-         StorageLive(_5);
+-         _5 = &raw mut _4;
           StorageLive(_6);
 -         _6 = (*_5);
 +         _6 = _4;
@@ -222,7 +227,7 @@
           StorageDead(_7);
 -         _3 = const ();
           StorageDead(_6);
-          StorageDead(_5);
+-         StorageDead(_5);
           StorageDead(_4);
 -         StorageDead(_3);
 -         StorageLive(_9);
@@ -396,12 +401,13 @@
 -         StorageLive(_57);
           StorageLive(_58);
           _58 = const 5_usize;
-          StorageLive(_59);
-          _59 = &raw mut _58;
-          StorageLive(_60);
-          _60 = &_59;
+-         StorageLive(_59);
+-         _59 = &raw mut _58;
+-         StorageLive(_60);
+-         _60 = &_59;
           StorageLive(_61);
-          _61 = (*_59);
+-         _61 = (*_59);
++         _61 = _58;
           StorageLive(_62);
           StorageLive(_63);
           _63 = ();
@@ -413,18 +419,19 @@
           StorageDead(_62);
 -         _57 = const ();
           StorageDead(_61);
-          StorageDead(_60);
-          StorageDead(_59);
+-         StorageDead(_60);
+-         StorageDead(_59);
           StorageDead(_58);
 -         StorageDead(_57);
           StorageLive(_64);
           _64 = const 5_usize;
-          StorageLive(_65);
-          _65 = &raw mut _64;
-          StorageLive(_66);
-          _66 = &mut _65;
+-         StorageLive(_65);
+-         _65 = &raw mut _64;
+-         StorageLive(_66);
+-         _66 = &mut _65;
           StorageLive(_67);
-          _67 = (*_65);
+-         _67 = (*_65);
++         _67 = _64;
           StorageLive(_68);
           StorageLive(_69);
           _69 = ();
@@ -436,8 +443,8 @@
           StorageDead(_68);
           _0 = const ();
           StorageDead(_67);
-          StorageDead(_66);
-          StorageDead(_65);
+-         StorageDead(_66);
+-         StorageDead(_65);
           StorageDead(_64);
           return;
       }


### PR DESCRIPTION
This feature was removed recently in https://github.com/rust-lang/rust/pull/114904 because implemented unsoundly. This PR proposes a simpler re-implementation.

We introduce an additional `references` field in `VarDebugInfo`. This additional field allows to optimize out references that are only used for debuginfo:
```rust
debug x => _1
_1 = &_2
```

If debuginfo is the only use of `_1`, this would become
```rust
debug x => &_2
```

For codegen, we associate the local `_2` with the name `*x`. This is suboptimal, as most debugger won't understand that `*x` is a name, and not the dereference of `x`.