### PR TITLE
Fix standard library not compiling with dependency cc v1.0.80+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,9 +430,12 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "1"
+resolver = "2"
 members = [
   "compiler/rustc",
   "library/std",


### PR DESCRIPTION
Noticed in #112865.

`cc` (which is needed as a dev-dependency for compiling std) introduced a dependency to `libc` in 1.0.80 and has default features enabled for it. The Rust workspace where the standard lib resides currently uses the resolver v1, which faces this issue: rust-lang/cargo#10719 (it combines the features enabled for dev-dependencies with those for dependencies), so updating the resolver version is necessary.

I also updated `cc` to make sure this fixes the problem.