### PR TITLE
Add projection obligations when comparing impl too

### DIFF
--- a/tests/ui/implied-bounds/implied_bounds_entailment_alias_var.rs
+++ b/tests/ui/implied-bounds/implied_bounds_entailment_alias_var.rs
@@ -1,0 +1,32 @@
+// check-pass
+
+trait Data {
+    type Elem;
+}
+
+impl<F, S: Data<Elem = F>> Data for ArrayBase<S> {
+    type Elem = F;
+}
+
+struct DatasetIter<'a, R: Data> {
+    data: &'a R::Elem,
+}
+
+pub struct ArrayBase<S> {
+    data: S,
+}
+
+trait Trait {
+    type Item;
+    fn next() -> Option<Self::Item>;
+}
+
+impl<'a, D: Data> Trait for DatasetIter<'a, ArrayBase<D>> {
+    type Item = ();
+
+    fn next() -> Option<Self::Item> {
+        None
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #115033

In the test, when we ask for WF obligations of `DatasetIter<'a, ArrayBase<D>>`, we get back two important obligations: `[<D as Data>::Elem -> ?1, ?1: 'a]`. If we don't add the projection obligation, `?1` remains unconstrained.

An alternative solution would be to use unnormalized obligations, where we only have one relevant obligation: `<D as Data>::Elem: 'a`. This would leave no inference vars unconstrained.