### PR TITLE
when terminating during unwinding, show the reason why

### DIFF
--- a/compiler/rustc_borrowck/src/invalidation.rs
+++ b/compiler/rustc_borrowck/src/invalidation.rs
@@ -202,7 +202,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
                 }
             }
             TerminatorKind::Goto { target: _ }
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Unreachable
             | TerminatorKind::FalseEdge { real_target: _, imaginary_target: _ }
             | TerminatorKind::FalseUnwind { real_target: _, unwind: _ } => {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -770,7 +770,7 @@ impl<'cx, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx, R> for MirBorro
             }
 
             TerminatorKind::Goto { target: _ }
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Unreachable
             | TerminatorKind::UnwindResume
             | TerminatorKind::Return
@@ -817,7 +817,7 @@ impl<'cx, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx, R> for MirBorro
                 }
             }
 
-            TerminatorKind::UnwindTerminate
+            TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Assert { .. }
             | TerminatorKind::Call { .. }
             | TerminatorKind::Drop { .. }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1334,7 +1334,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         match &term.kind {
             TerminatorKind::Goto { .. }
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::Unreachable
@@ -1613,7 +1613,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     span_mirbug!(self, block_data, "resume on non-cleanup block!")
                 }
             }
-            TerminatorKind::UnwindTerminate => {
+            TerminatorKind::UnwindTerminate(_) => {
                 if !is_cleanup {
                     span_mirbug!(self, block_data, "abort on non-cleanup block!")
                 }
@@ -1697,7 +1697,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     span_mirbug!(self, ctxt, "unwind on cleanup block")
                 }
             }
-            UnwindAction::Unreachable | UnwindAction::Terminate => (),
+            UnwindAction::Unreachable | UnwindAction::Terminate(_) => (),
         }
     }
 

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -474,8 +474,8 @@ fn codegen_fn_body(fx: &mut FunctionCx<'_, '_, '_>, start_block: Block) {
                     *destination,
                 );
             }
-            TerminatorKind::UnwindTerminate => {
-                codegen_panic_cannot_unwind(fx, source_info);
+            TerminatorKind::UnwindTerminate(reason) => {
+                codegen_unwind_terminate(fx, source_info, *reason);
             }
             TerminatorKind::UnwindResume => {
                 // FIXME implement unwinding
@@ -971,13 +971,14 @@ pub(crate) fn codegen_panic_nounwind<'tcx>(
     codegen_panic_inner(fx, rustc_hir::LangItem::PanicNounwind, &args, source_info.span);
 }
 
-pub(crate) fn codegen_panic_cannot_unwind<'tcx>(
+pub(crate) fn codegen_unwind_terminate<'tcx>(
     fx: &mut FunctionCx<'_, '_, 'tcx>,
     source_info: mir::SourceInfo,
+    reason: UnwindTerminateReason,
 ) {
     let args = [];
 
-    codegen_panic_inner(fx, rustc_hir::LangItem::PanicCannotUnwind, &args, source_info.span);
+    codegen_panic_inner(fx, reason.lang_item(), &args, source_info.span);
 }
 
 fn codegen_panic_inner<'tcx>(

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -551,7 +551,7 @@ pub(crate) fn mir_operand_get_const_val<'tcx>(
                     TerminatorKind::Goto { .. }
                     | TerminatorKind::SwitchInt { .. }
                     | TerminatorKind::UnwindResume
-                    | TerminatorKind::UnwindTerminate
+                    | TerminatorKind::UnwindTerminate(_)
                     | TerminatorKind::Return
                     | TerminatorKind::Unreachable
                     | TerminatorKind::Drop { .. }

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -285,7 +285,7 @@ pub fn cleanup_kinds(mir: &mir::Body<'_>) -> IndexVec<mir::BasicBlock, CleanupKi
             match data.terminator().kind {
                 TerminatorKind::Goto { .. }
                 | TerminatorKind::UnwindResume
-                | TerminatorKind::UnwindTerminate
+                | TerminatorKind::UnwindTerminate(_)
                 | TerminatorKind::Return
                 | TerminatorKind::GeneratorDrop
                 | TerminatorKind::Unreachable

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -12,7 +12,7 @@ use crate::MemFlags;
 use rustc_ast as ast;
 use rustc_ast::{InlineAsmOptions, InlineAsmTemplatePiece};
 use rustc_hir::lang_items::LangItem;
-use rustc_middle::mir::{self, AssertKind, SwitchTargets};
+use rustc_middle::mir::{self, AssertKind, SwitchTargets, UnwindTerminateReason};
 use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf, ValidityRequirement};
 use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
 use rustc_middle::ty::{self, Instance, Ty};
@@ -178,7 +178,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
             mir::UnwindAction::Cleanup(cleanup) => Some(self.llbb_with_cleanup(fx, cleanup)),
             mir::UnwindAction::Continue => None,
             mir::UnwindAction::Unreachable => None,
-            mir::UnwindAction::Terminate => {
+            mir::UnwindAction::Terminate(reason) => {
                 if fx.mir[self.bb].is_cleanup && base::wants_new_eh_instructions(fx.cx.tcx().sess) {
                     // MSVC SEH will abort automatically if an exception tries to
                     // propagate out from cleanup.
@@ -191,7 +191,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
 
                     None
                 } else {
-                    Some(fx.terminate_block())
+                    Some(fx.terminate_block(reason))
                 }
             }
         };
@@ -264,7 +264,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
     ) -> MergingSucc {
         let unwind_target = match unwind {
             mir::UnwindAction::Cleanup(cleanup) => Some(self.llbb_with_cleanup(fx, cleanup)),
-            mir::UnwindAction::Terminate => Some(fx.terminate_block()),
+            mir::UnwindAction::Terminate(reason) => Some(fx.terminate_block(reason)),
             mir::UnwindAction::Continue => None,
             mir::UnwindAction::Unreachable => None,
         };
@@ -649,12 +649,13 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         helper: TerminatorCodegenHelper<'tcx>,
         bx: &mut Bx,
         terminator: &mir::Terminator<'tcx>,
+        reason: UnwindTerminateReason,
     ) {
         let span = terminator.source_info.span;
         self.set_debug_loc(bx, terminator.source_info);
 
         // Obtain the panic entry point.
-        let (fn_abi, llfn) = common::build_langcall(bx, Some(span), LangItem::PanicCannotUnwind);
+        let (fn_abi, llfn) = common::build_langcall(bx, Some(span), reason.lang_item());
 
         // Codegen the actual panic invoke/call.
         let merging_succ = helper.do_call(
@@ -1229,8 +1230,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 MergingSucc::False
             }
 
-            mir::TerminatorKind::UnwindTerminate => {
-                self.codegen_terminate_terminator(helper, bx, terminator);
+            mir::TerminatorKind::UnwindTerminate(reason) => {
+                self.codegen_terminate_terminator(helper, bx, terminator, reason);
                 MergingSucc::False
             }
 
@@ -1579,79 +1580,83 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         })
     }
 
-    fn terminate_block(&mut self) -> Bx::BasicBlock {
-        self.terminate_block.unwrap_or_else(|| {
-            let funclet;
-            let llbb;
-            let mut bx;
-            if base::wants_msvc_seh(self.cx.sess()) {
-                // This is a basic block that we're aborting the program for,
-                // notably in an `extern` function. These basic blocks are inserted
-                // so that we assert that `extern` functions do indeed not panic,
-                // and if they do we abort the process.
-                //
-                // On MSVC these are tricky though (where we're doing funclets). If
-                // we were to do a cleanuppad (like below) the normal functions like
-                // `longjmp` would trigger the abort logic, terminating the
-                // program. Instead we insert the equivalent of `catch(...)` for C++
-                // which magically doesn't trigger when `longjmp` files over this
-                // frame.
-                //
-                // Lots more discussion can be found on #48251 but this codegen is
-                // modeled after clang's for:
-                //
-                //      try {
-                //          foo();
-                //      } catch (...) {
-                //          bar();
-                //      }
-                //
-                // which creates an IR snippet like
-                //
-                //      cs_terminate:
-                //         %cs = catchswitch within none [%cp_terminate] unwind to caller
-                //      cp_terminate:
-                //         %cp = catchpad within %cs [null, i32 64, null]
-                //         ...
+    fn terminate_block(&mut self, reason: UnwindTerminateReason) -> Bx::BasicBlock {
+        if let Some(bb) = self.terminate_in_cleanup_block && reason == UnwindTerminateReason::InCleanup {
+            return bb;
+        }
 
-                llbb = Bx::append_block(self.cx, self.llfn, "cs_terminate");
-                let cp_llbb = Bx::append_block(self.cx, self.llfn, "cp_terminate");
+        let funclet;
+        let llbb;
+        let mut bx;
+        if base::wants_msvc_seh(self.cx.sess()) {
+            // This is a basic block that we're aborting the program for,
+            // notably in an `extern` function. These basic blocks are inserted
+            // so that we assert that `extern` functions do indeed not panic,
+            // and if they do we abort the process.
+            //
+            // On MSVC these are tricky though (where we're doing funclets). If
+            // we were to do a cleanuppad (like below) the normal functions like
+            // `longjmp` would trigger the abort logic, terminating the
+            // program. Instead we insert the equivalent of `catch(...)` for C++
+            // which magically doesn't trigger when `longjmp` files over this
+            // frame.
+            //
+            // Lots more discussion can be found on #48251 but this codegen is
+            // modeled after clang's for:
+            //
+            //      try {
+            //          foo();
+            //      } catch (...) {
+            //          bar();
+            //      }
+            //
+            // which creates an IR snippet like
+            //
+            //      cs_terminate:
+            //         %cs = catchswitch within none [%cp_terminate] unwind to caller
+            //      cp_terminate:
+            //         %cp = catchpad within %cs [null, i32 64, null]
+            //         ...
 
-                let mut cs_bx = Bx::build(self.cx, llbb);
-                let cs = cs_bx.catch_switch(None, None, &[cp_llbb]);
+            llbb = Bx::append_block(self.cx, self.llfn, "cs_terminate");
+            let cp_llbb = Bx::append_block(self.cx, self.llfn, "cp_terminate");
 
-                // The "null" here is actually a RTTI type descriptor for the
-                // C++ personality function, but `catch (...)` has no type so
-                // it's null. The 64 here is actually a bitfield which
-                // represents that this is a catch-all block.
-                bx = Bx::build(self.cx, cp_llbb);
-                let null =
-                    bx.const_null(bx.type_ptr_ext(bx.cx().data_layout().instruction_address_space));
-                let sixty_four = bx.const_i32(64);
-                funclet = Some(bx.catch_pad(cs, &[null, sixty_four, null]));
-            } else {
-                llbb = Bx::append_block(self.cx, self.llfn, "terminate");
-                bx = Bx::build(self.cx, llbb);
+            let mut cs_bx = Bx::build(self.cx, llbb);
+            let cs = cs_bx.catch_switch(None, None, &[cp_llbb]);
 
-                let llpersonality = self.cx.eh_personality();
-                bx.filter_landing_pad(llpersonality);
+            // The "null" here is actually a RTTI type descriptor for the
+            // C++ personality function, but `catch (...)` has no type so
+            // it's null. The 64 here is actually a bitfield which
+            // represents that this is a catch-all block.
+            bx = Bx::build(self.cx, cp_llbb);
+            let null =
+                bx.const_null(bx.type_ptr_ext(bx.cx().data_layout().instruction_address_space));
+            let sixty_four = bx.const_i32(64);
+            funclet = Some(bx.catch_pad(cs, &[null, sixty_four, null]));
+        } else {
+            llbb = Bx::append_block(self.cx, self.llfn, "terminate");
+            bx = Bx::build(self.cx, llbb);
 
-                funclet = None;
-            }
+            let llpersonality = self.cx.eh_personality();
+            bx.filter_landing_pad(llpersonality);
 
-            self.set_debug_loc(&mut bx, mir::SourceInfo::outermost(self.mir.span));
+            funclet = None;
+        }
 
-            let (fn_abi, fn_ptr) = common::build_langcall(&bx, None, LangItem::PanicCannotUnwind);
-            let fn_ty = bx.fn_decl_backend_type(&fn_abi);
+        self.set_debug_loc(&mut bx, mir::SourceInfo::outermost(self.mir.span));
 
-            let llret = bx.call(fn_ty, None, Some(&fn_abi), fn_ptr, &[], funclet.as_ref());
-            bx.do_not_inline(llret);
+        let (fn_abi, fn_ptr) = common::build_langcall(&bx, None, reason.lang_item());
+        let fn_ty = bx.fn_decl_backend_type(&fn_abi);
 
-            bx.unreachable();
+        let llret = bx.call(fn_ty, None, Some(&fn_abi), fn_ptr, &[], funclet.as_ref());
+        bx.do_not_inline(llret);
 
-            self.terminate_block = Some(llbb);
-            llbb
-        })
+        bx.unreachable();
+
+        if reason == UnwindTerminateReason::InCleanup {
+            self.terminate_in_cleanup_block = Some(llbb);
+        }
+        llbb
     }
 
     /// Get the backend `BasicBlock` for a MIR `BasicBlock`, either already

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1581,8 +1581,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 
     fn terminate_block(&mut self, reason: UnwindTerminateReason) -> Bx::BasicBlock {
-        if let Some(bb) = self.terminate_in_cleanup_block && reason == UnwindTerminateReason::InCleanup {
-            return bb;
+        if let Some((cached_bb, cached_reason)) = self.terminate_block && reason == cached_reason {
+            return cached_bb;
         }
 
         let funclet;
@@ -1653,9 +1653,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
         bx.unreachable();
 
-        if reason == UnwindTerminateReason::InCleanup {
-            self.terminate_in_cleanup_block = Some(llbb);
-        }
+        self.terminate_block = Some((llbb, reason));
         llbb
     }
 

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -5,6 +5,7 @@ use rustc_index::IndexVec;
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::mir::traversal;
+use rustc_middle::mir::UnwindTerminateReason;
 use rustc_middle::ty::layout::{FnAbiOf, HasTyCtxt, TyAndLayout};
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt, TypeFoldable, TypeVisitableExt};
 use rustc_target::abi::call::{FnAbi, PassMode};
@@ -83,8 +84,8 @@ pub struct FunctionCx<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> {
     /// Cached unreachable block
     unreachable_block: Option<Bx::BasicBlock>,
 
-    /// Cached terminate upon unwinding (reason: InCleanup) block
-    terminate_in_cleanup_block: Option<Bx::BasicBlock>,
+    /// Cached terminate upon unwinding block and its reason
+    terminate_block: Option<(Bx::BasicBlock, UnwindTerminateReason)>,
 
     /// The location where each MIR arg/var/tmp/ret is stored. This is
     /// usually an `PlaceRef` representing an alloca, but not always:
@@ -199,7 +200,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         personality_slot: None,
         cached_llbbs,
         unreachable_block: None,
-        terminate_in_cleanup_block: None,
+        terminate_block: None,
         cleanup_kinds,
         landing_pads: IndexVec::from_elem(None, &mir.basic_blocks),
         funclets: IndexVec::from_fn_n(|_| None, mir.basic_blocks.len()),

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -222,7 +222,10 @@ pub trait Machine<'mir, 'tcx: 'mir>: Sized {
     fn panic_nounwind(_ecx: &mut InterpCx<'mir, 'tcx, Self>, msg: &str) -> InterpResult<'tcx>;
 
     /// Called when unwinding reached a state where execution should be terminated.
-    fn unwind_terminate(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx>;
+    fn unwind_terminate(
+        ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        reason: mir::UnwindTerminateReason,
+    ) -> InterpResult<'tcx>;
 
     /// Called for all binary operations where the LHS has pointer type.
     ///
@@ -462,6 +465,7 @@ pub trait Machine<'mir, 'tcx: 'mir>: Sized {
 
     /// Called immediately after a stack frame got popped, but before jumping back to the caller.
     /// The `locals` have already been destroyed!
+    #[inline(always)]
     fn after_stack_pop(
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,
         _frame: Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>,
@@ -501,7 +505,10 @@ pub macro compile_time_machine(<$mir: lifetime, $tcx: lifetime>) {
     }
 
     #[inline(always)]
-    fn unwind_terminate(_ecx: &mut InterpCx<$mir, $tcx, Self>) -> InterpResult<$tcx> {
+    fn unwind_terminate(
+        _ecx: &mut InterpCx<$mir, $tcx, Self>,
+        _reason: mir::UnwindTerminateReason,
+    ) -> InterpResult<$tcx> {
         unreachable!("unwinding cannot happen during compile-time evaluation")
     }
 

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -196,8 +196,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 }
             }
 
-            UnwindTerminate => {
-                M::unwind_terminate(self)?;
+            UnwindTerminate(reason) => {
+                M::unwind_terminate(self, reason)?;
             }
 
             // When we encounter Resume, we've finished unwinding

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -1037,7 +1037,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 self.check_op(ops::Generator(hir::GeneratorKind::Gen))
             }
 
-            TerminatorKind::UnwindTerminate => {
+            TerminatorKind::UnwindTerminate(_) => {
                 // Cleanup blocks are skipped for const checking (see `visit_basic_block_data`).
                 span_bug!(self.span, "`Terminate` terminator outside of cleanup block")
             }

--- a/compiler/rustc_const_eval/src/transform/check_consts/post_drop_elaboration.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/post_drop_elaboration.rs
@@ -106,7 +106,7 @@ impl<'tcx> Visitor<'tcx> for CheckLiveDrops<'_, 'tcx> {
                 }
             }
 
-            mir::TerminatorKind::UnwindTerminate
+            mir::TerminatorKind::UnwindTerminate(_)
             | mir::TerminatorKind::Call { .. }
             | mir::TerminatorKind::Assert { .. }
             | mir::TerminatorKind::FalseEdge { .. }

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -238,6 +238,7 @@ language_item_table! {
     PanicLocation,           sym::panic_location,      panic_location,             Target::Struct,         GenericRequirement::None;
     PanicImpl,               sym::panic_impl,          panic_impl,                 Target::Fn,             GenericRequirement::None;
     PanicCannotUnwind,       sym::panic_cannot_unwind, panic_cannot_unwind,        Target::Fn,             GenericRequirement::Exact(0);
+    PanicInCleanup,          sym::panic_in_cleanup,    panic_in_cleanup,           Target::Fn,             GenericRequirement::Exact(0);
     /// libstd panic entry point. Necessary for const eval to be able to catch it
     BeginPanic,              sym::begin_panic,         begin_panic_fn,             Target::Fn,             GenericRequirement::None;
 

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -1,3 +1,4 @@
+use rustc_hir::LangItem;
 use smallvec::SmallVec;
 
 use super::{BasicBlock, InlineAsmOperand, Operand, SourceInfo, TerminatorKind, UnwindAction};
@@ -100,6 +101,32 @@ impl<'a> Iterator for SwitchTargetsIter<'a> {
 
 impl<'a> ExactSizeIterator for SwitchTargetsIter<'a> {}
 
+impl UnwindAction {
+    fn cleanup_block(self) -> Option<BasicBlock> {
+        match self {
+            UnwindAction::Cleanup(bb) => Some(bb),
+            UnwindAction::Continue | UnwindAction::Unreachable | UnwindAction::Terminate(_) => None,
+        }
+    }
+}
+
+impl UnwindTerminateReason {
+    pub fn as_str(self) -> &'static str {
+        // Keep this in sync with the messages in `core/src/panicking.rs`.
+        match self {
+            UnwindTerminateReason::Abi => "panic in a function that cannot unwind",
+            UnwindTerminateReason::InCleanup => "panic in a destructor during cleanup",
+        }
+    }
+
+    pub fn lang_item(self) -> LangItem {
+        match self {
+            UnwindTerminateReason::Abi => LangItem::PanicCannotUnwind,
+            UnwindTerminateReason::InCleanup => LangItem::PanicInCleanup,
+        }
+    }
+}
+
 #[derive(Clone, Debug, TyEncodable, TyDecodable, HashStable, TypeFoldable, TypeVisitable)]
 pub struct Terminator<'tcx> {
     pub source_info: SourceInfo,
@@ -156,7 +183,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                 Some(t).into_iter().chain((&[]).into_iter().copied())
             }
             UnwindResume
-            | UnwindTerminate
+            | UnwindTerminate(_)
             | GeneratorDrop
             | Return
             | Unreachable
@@ -198,7 +225,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                 Some(t).into_iter().chain(&mut [])
             }
             UnwindResume
-            | UnwindTerminate
+            | UnwindTerminate(_)
             | GeneratorDrop
             | Return
             | Unreachable
@@ -215,7 +242,7 @@ impl<'tcx> TerminatorKind<'tcx> {
         match *self {
             TerminatorKind::Goto { .. }
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::GeneratorDrop
@@ -234,7 +261,7 @@ impl<'tcx> TerminatorKind<'tcx> {
         match *self {
             TerminatorKind::Goto { .. }
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::GeneratorDrop
@@ -271,18 +298,27 @@ impl<'tcx> Debug for TerminatorKind<'tcx> {
         let labels = self.fmt_successor_labels();
         assert_eq!(successor_count, labels.len());
 
-        let unwind = match self.unwind() {
-            // Not needed or included in successors
-            None | Some(UnwindAction::Cleanup(_)) => None,
-            Some(UnwindAction::Continue) => Some("unwind continue"),
-            Some(UnwindAction::Unreachable) => Some("unwind unreachable"),
-            Some(UnwindAction::Terminate) => Some("unwind terminate"),
+        // `Cleanup` is already included in successors
+        let show_unwind = !matches!(self.unwind(), None | Some(UnwindAction::Cleanup(_)));
+        let fmt_unwind = |fmt: &mut Formatter<'_>| -> fmt::Result {
+            match self.unwind() {
+                // Not needed or included in successors
+                None | Some(UnwindAction::Cleanup(_)) => unreachable!(),
+                Some(UnwindAction::Continue) => write!(fmt, "unwind continue"),
+                Some(UnwindAction::Unreachable) => write!(fmt, "unwind unreachable"),
+                Some(UnwindAction::Terminate(reason)) => {
+                    write!(fmt, "unwind terminate ({})", reason.as_str())
+                }
+            }
         };
 
-        match (successor_count, unwind) {
-            (0, None) => Ok(()),
-            (0, Some(unwind)) => write!(fmt, " -> {unwind}"),
-            (1, None) => write!(fmt, " -> {:?}", self.successors().next().unwrap()),
+        match (successor_count, show_unwind) {
+            (0, false) => Ok(()),
+            (0, true) => {
+                write!(fmt, " -> ")?;
+                fmt_unwind(fmt)
+            }
+            (1, false) => write!(fmt, " -> {:?}", self.successors().next().unwrap()),
             _ => {
                 write!(fmt, " -> [")?;
                 for (i, target) in self.successors().enumerate() {
@@ -291,8 +327,9 @@ impl<'tcx> Debug for TerminatorKind<'tcx> {
                     }
                     write!(fmt, "{}: {:?}", labels[i], target)?;
                 }
-                if let Some(unwind) = unwind {
-                    write!(fmt, ", {unwind}")?;
+                if show_unwind {
+                    write!(fmt, ", ")?;
+                    fmt_unwind(fmt)?;
                 }
                 write!(fmt, "]")
             }
@@ -312,7 +349,9 @@ impl<'tcx> TerminatorKind<'tcx> {
             Return => write!(fmt, "return"),
             GeneratorDrop => write!(fmt, "generator_drop"),
             UnwindResume => write!(fmt, "resume"),
-            UnwindTerminate => write!(fmt, "abort"),
+            UnwindTerminate(reason) => {
+                write!(fmt, "abort(\"{}\")", reason.as_str())
+            }
             Yield { value, resume_arg, .. } => write!(fmt, "{resume_arg:?} = yield({value:?})"),
             Unreachable => write!(fmt, "unreachable"),
             Drop { place, .. } => write!(fmt, "drop({place:?})"),
@@ -391,7 +430,7 @@ impl<'tcx> TerminatorKind<'tcx> {
     pub fn fmt_successor_labels(&self) -> Vec<Cow<'static, str>> {
         use self::TerminatorKind::*;
         match *self {
-            Return | UnwindResume | UnwindTerminate | Unreachable | GeneratorDrop => vec![],
+            Return | UnwindResume | UnwindTerminate(_) | Unreachable | GeneratorDrop => vec![],
             Goto { .. } => vec!["".into()],
             SwitchInt { ref targets, .. } => targets
                 .values
@@ -443,7 +482,8 @@ pub enum TerminatorEdges<'mir, 'tcx> {
     /// Special action for `Yield`, `Call` and `InlineAsm` terminators.
     AssignOnReturn {
         return_: Option<BasicBlock>,
-        unwind: UnwindAction,
+        /// The cleanup block, if it exists.
+        cleanup: Option<BasicBlock>,
         place: CallReturnPlaces<'mir, 'tcx>,
     },
     /// Special edge for `SwitchInt`.
@@ -486,7 +526,7 @@ impl<'tcx> TerminatorKind<'tcx> {
     pub fn edges(&self) -> TerminatorEdges<'_, 'tcx> {
         use TerminatorKind::*;
         match *self {
-            Return | UnwindResume | UnwindTerminate | GeneratorDrop | Unreachable => {
+            Return | UnwindResume | UnwindTerminate(_) | GeneratorDrop | Unreachable => {
                 TerminatorEdges::None
             }
 
@@ -496,7 +536,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             | Drop { target, unwind, place: _, replace: _ }
             | FalseUnwind { real_target: target, unwind } => match unwind {
                 UnwindAction::Cleanup(unwind) => TerminatorEdges::Double(target, unwind),
-                UnwindAction::Continue | UnwindAction::Terminate | UnwindAction::Unreachable => {
+                UnwindAction::Continue | UnwindAction::Terminate(_) | UnwindAction::Unreachable => {
                     TerminatorEdges::Single(target)
                 }
             },
@@ -508,7 +548,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             Yield { resume: target, drop, resume_arg, value: _ } => {
                 TerminatorEdges::AssignOnReturn {
                     return_: Some(target),
-                    unwind: drop.map_or(UnwindAction::Terminate, UnwindAction::Cleanup),
+                    cleanup: drop,
                     place: CallReturnPlaces::Yield(resume_arg),
                 }
             }
@@ -516,7 +556,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             Call { unwind, destination, target, func: _, args: _, fn_span: _, call_source: _ } => {
                 TerminatorEdges::AssignOnReturn {
                     return_: target,
-                    unwind,
+                    cleanup: unwind.cleanup_block(),
                     place: CallReturnPlaces::Call(destination),
                 }
             }
@@ -530,7 +570,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                 unwind,
             } => TerminatorEdges::AssignOnReturn {
                 return_: destination,
-                unwind,
+                cleanup: unwind.cleanup_block(),
                 place: CallReturnPlaces::InlineAsm(operands),
             },
 

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -119,6 +119,14 @@ impl UnwindTerminateReason {
         }
     }
 
+    /// A short representation of this used for MIR printing.
+    pub fn as_short_str(self) -> &'static str {
+        match self {
+            UnwindTerminateReason::Abi => "abi",
+            UnwindTerminateReason::InCleanup => "cleanup",
+        }
+    }
+
     pub fn lang_item(self) -> LangItem {
         match self {
             UnwindTerminateReason::Abi => LangItem::PanicCannotUnwind,
@@ -301,13 +309,14 @@ impl<'tcx> Debug for TerminatorKind<'tcx> {
         // `Cleanup` is already included in successors
         let show_unwind = !matches!(self.unwind(), None | Some(UnwindAction::Cleanup(_)));
         let fmt_unwind = |fmt: &mut Formatter<'_>| -> fmt::Result {
+            write!(fmt, "unwind ")?;
             match self.unwind() {
                 // Not needed or included in successors
                 None | Some(UnwindAction::Cleanup(_)) => unreachable!(),
-                Some(UnwindAction::Continue) => write!(fmt, "unwind continue"),
-                Some(UnwindAction::Unreachable) => write!(fmt, "unwind unreachable"),
+                Some(UnwindAction::Continue) => write!(fmt, "continue"),
+                Some(UnwindAction::Unreachable) => write!(fmt, "unreachable"),
                 Some(UnwindAction::Terminate(reason)) => {
-                    write!(fmt, "unwind terminate ({})", reason.as_str())
+                    write!(fmt, "terminate({})", reason.as_short_str())
                 }
             }
         };
@@ -350,7 +359,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             GeneratorDrop => write!(fmt, "generator_drop"),
             UnwindResume => write!(fmt, "resume"),
             UnwindTerminate(reason) => {
-                write!(fmt, "abort(\"{}\")", reason.as_str())
+                write!(fmt, "abort({})", reason.as_short_str())
             }
             Yield { value, resume_arg, .. } => write!(fmt, "{resume_arg:?} = yield({value:?})"),
             Unreachable => write!(fmt, "unreachable"),

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -470,7 +470,7 @@ macro_rules! make_mir_visitor {
                 match kind {
                     TerminatorKind::Goto { .. } |
                     TerminatorKind::UnwindResume |
-                    TerminatorKind::UnwindTerminate |
+                    TerminatorKind::UnwindTerminate(_) |
                     TerminatorKind::GeneratorDrop |
                     TerminatorKind::Unreachable |
                     TerminatorKind::FalseEdge { .. } |

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -370,7 +370,7 @@ impl DropTree {
                     let terminator = TerminatorKind::Drop {
                         target: blocks[drop_data.1].unwrap(),
                         // The caller will handle this if needed.
-                        unwind: UnwindAction::Terminate,
+                        unwind: UnwindAction::Terminate(UnwindTerminateReason::InCleanup),
                         place: drop_data.0.local.into(),
                         replace: false,
                     };
@@ -1507,7 +1507,7 @@ impl<'tcx> DropTreeBuilder<'tcx> for Unwind {
             TerminatorKind::Goto { .. }
             | TerminatorKind::SwitchInt { .. }
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::Yield { .. }

--- a/compiler/rustc_mir_build/src/lints.rs
+++ b/compiler/rustc_mir_build/src/lints.rs
@@ -186,7 +186,7 @@ impl<'mir, 'tcx, C: TerminatorClassifier<'tcx>> TriColorVisitor<BasicBlocks<'tcx
 
         match self.body[bb].terminator().kind {
             // These terminators return control flow to the caller.
-            TerminatorKind::UnwindTerminate
+            TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::UnwindResume
             | TerminatorKind::Return

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -80,7 +80,7 @@ impl Unwind {
     fn into_action(self) -> UnwindAction {
         match self {
             Unwind::To(bb) => UnwindAction::Cleanup(bb),
-            Unwind::InCleanup => UnwindAction::Terminate,
+            Unwind::InCleanup => UnwindAction::Terminate(UnwindTerminateReason::InCleanup),
         }
     }
 

--- a/compiler/rustc_mir_dataflow/src/framework/direction.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/direction.rs
@@ -1,5 +1,5 @@
 use rustc_middle::mir::{
-    self, BasicBlock, CallReturnPlaces, Location, SwitchTargets, TerminatorEdges, UnwindAction,
+    self, BasicBlock, CallReturnPlaces, Location, SwitchTargets, TerminatorEdges,
 };
 use std::ops::RangeInclusive;
 
@@ -486,10 +486,10 @@ impl Direction for Forward {
                 propagate(target, exit_state);
                 propagate(unwind, exit_state);
             }
-            TerminatorEdges::AssignOnReturn { return_, unwind, place } => {
+            TerminatorEdges::AssignOnReturn { return_, cleanup, place } => {
                 // This must be done *first*, otherwise the unwind path will see the assignments.
-                if let UnwindAction::Cleanup(unwind) = unwind {
-                    propagate(unwind, exit_state);
+                if let Some(cleanup) = cleanup {
+                    propagate(cleanup, exit_state);
                 }
                 if let Some(return_) = return_ {
                     analysis.apply_call_return_effect(exit_state, bb, place);

--- a/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
@@ -131,7 +131,7 @@ where
                 }
             }
 
-            TerminatorKind::UnwindTerminate
+            TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Assert { .. }
             | TerminatorKind::Call { .. }
             | TerminatorKind::FalseEdge { .. }

--- a/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
@@ -291,7 +291,7 @@ impl<'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'_, '_, 'tcx> {
 
             // Nothing to do for these. Match exhaustively so this fails to compile when new
             // variants are added.
-            TerminatorKind::UnwindTerminate
+            TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Assert { .. }
             | TerminatorKind::Drop { .. }
             | TerminatorKind::FalseEdge { .. }
@@ -328,7 +328,7 @@ impl<'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'_, '_, 'tcx> {
             // Nothing to do for these. Match exhaustively so this fails to compile when new
             // variants are added.
             TerminatorKind::Yield { .. }
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Assert { .. }
             | TerminatorKind::Drop { .. }
             | TerminatorKind::FalseEdge { .. }

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -371,7 +371,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             // need recording.
             | TerminatorKind::Return
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::Unreachable
             | TerminatorKind::Drop { .. } => {}

--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -270,7 +270,7 @@ pub trait ValueAnalysis<'tcx> {
             }
             TerminatorKind::Goto { .. }
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::Assert { .. }

--- a/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
+++ b/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
@@ -104,7 +104,7 @@ impl<'tcx> MirPass<'tcx> for AbortUnwindingCalls {
 
         for id in calls_to_terminate {
             let cleanup = body.basic_blocks_mut()[id].terminator_mut().unwind_mut().unwrap();
-            *cleanup = UnwindAction::Terminate;
+            *cleanup = UnwindAction::Terminate(UnwindTerminateReason::Abi);
         }
 
         for id in cleanups_to_remove {

--- a/compiler/rustc_mir_transform/src/add_call_guards.rs
+++ b/compiler/rustc_mir_transform/src/add_call_guards.rs
@@ -53,8 +53,10 @@ impl AddCallGuards {
                     kind: TerminatorKind::Call { target: Some(ref mut destination), unwind, .. },
                     source_info,
                 }) if pred_count[*destination] > 1
-                    && (matches!(unwind, UnwindAction::Cleanup(_) | UnwindAction::Terminate)
-                        || self == &AllCallEdges) =>
+                    && (matches!(
+                        unwind,
+                        UnwindAction::Cleanup(_) | UnwindAction::Terminate(_)
+                    ) || self == &AllCallEdges) =>
                 {
                     // It's a critical edge, break it
                     let call_guard = BasicBlockData {

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -58,7 +58,7 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
             | TerminatorKind::Assert { .. }
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::FalseEdge { .. }

--- a/compiler/rustc_mir_transform/src/const_prop_lint.rs
+++ b/compiler/rustc_mir_transform/src/const_prop_lint.rs
@@ -679,7 +679,7 @@ impl<'tcx> Visitor<'tcx> for ConstPropagator<'_, 'tcx> {
             // None of these have Operands to const-propagate.
             TerminatorKind::Goto { .. }
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::Drop { .. }

--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -116,7 +116,7 @@ impl CoverageGraph {
 
             match term.kind {
                 TerminatorKind::Return { .. }
-                | TerminatorKind::UnwindTerminate
+                | TerminatorKind::UnwindTerminate(_)
                 | TerminatorKind::Yield { .. }
                 | TerminatorKind::SwitchInt { .. } => {
                     // The `bb` has more than one _outgoing_ edge, or exits the function. Save the

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -868,7 +868,7 @@ pub(super) fn filtered_terminator_span(terminator: &Terminator<'_>) -> Option<Sp
 
         // Retain spans from all other terminators
         TerminatorKind::UnwindResume
-        | TerminatorKind::UnwindTerminate
+        | TerminatorKind::UnwindTerminate(_)
         | TerminatorKind::Return
         | TerminatorKind::Yield { .. }
         | TerminatorKind::GeneratorDrop

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -648,7 +648,7 @@ impl WriteInfo {
             }
             TerminatorKind::Goto { .. }
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable { .. } => (),
             TerminatorKind::Drop { .. } => {

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -362,8 +362,13 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                                     UnwindAction::Unreachable => {
                                         Unwind::To(self.patch.unreachable_cleanup_block())
                                     }
-                                    UnwindAction::Terminate => {
-                                        Unwind::To(self.patch.terminate_block())
+                                    UnwindAction::Terminate(reason) => {
+                                        debug_assert_ne!(
+                                            reason,
+                                            UnwindTerminateReason::InCleanup,
+                                            "we are not in a cleanup block, InCleanup reason should be impossible"
+                                        );
+                                        Unwind::To(self.patch.terminate_block(reason))
                                     }
                                 }
                             };
@@ -496,7 +501,8 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             if let TerminatorKind::Call {
                 destination,
                 target: Some(_),
-                unwind: UnwindAction::Continue | UnwindAction::Unreachable | UnwindAction::Terminate,
+                unwind:
+                    UnwindAction::Continue | UnwindAction::Unreachable | UnwindAction::Terminate(_),
                 ..
             } = data.terminator().kind
             {

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -1091,7 +1091,7 @@ fn elaborate_generator_drops<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
                 UnwindAction::Cleanup(tgt) => tgt,
                 UnwindAction::Continue => elaborator.patch.resume_block(),
                 UnwindAction::Unreachable => elaborator.patch.unreachable_cleanup_block(),
-                UnwindAction::Terminate => elaborator.patch.terminate_block(),
+                UnwindAction::Terminate(reason) => elaborator.patch.terminate_block(reason),
             })
         };
         elaborate_drop(
@@ -1239,7 +1239,7 @@ fn can_unwind<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) -> bool {
             // These never unwind.
             TerminatorKind::Goto { .. }
             | TerminatorKind::SwitchInt { .. }
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::GeneratorDrop
@@ -1759,7 +1759,7 @@ impl<'tcx> Visitor<'tcx> for EnsureGeneratorFieldAssignmentsNeverAlias<'_> {
             | TerminatorKind::Goto { .. }
             | TerminatorKind::SwitchInt { .. }
             | TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::Drop { .. }

--- a/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
@@ -72,7 +72,7 @@ impl RemoveNoopLandingPads {
             TerminatorKind::GeneratorDrop
             | TerminatorKind::Yield { .. }
             | TerminatorKind::Return
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Unreachable
             | TerminatorKind::Call { .. }
             | TerminatorKind::Assert { .. }

--- a/compiler/rustc_mir_transform/src/separate_const_switch.rs
+++ b/compiler/rustc_mir_transform/src/separate_const_switch.rs
@@ -114,7 +114,7 @@ pub fn separate_const_switch(body: &mut Body<'_>) -> usize {
                         | TerminatorKind::Assert { .. }
                         | TerminatorKind::FalseUnwind { .. }
                         | TerminatorKind::Yield { .. }
-                        | TerminatorKind::UnwindTerminate
+                        | TerminatorKind::UnwindTerminate(_)
                         | TerminatorKind::Return
                         | TerminatorKind::Unreachable
                         | TerminatorKind::InlineAsm { .. }
@@ -166,7 +166,7 @@ pub fn separate_const_switch(body: &mut Body<'_>) -> usize {
             }
 
             TerminatorKind::UnwindResume
-            | TerminatorKind::UnwindTerminate
+            | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::GeneratorDrop

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -570,10 +570,10 @@ impl<'tcx> CloneShimBuilder<'tcx> {
                 TerminatorKind::Drop {
                     place: dest_field,
                     target: unwind,
-                    unwind: UnwindAction::Terminate,
+                    unwind: UnwindAction::Terminate(UnwindTerminateReason::InCleanup),
                     replace: false,
                 },
-                true,
+                /* is_cleanup */ true,
             );
             unwind = next_unwind;
         }
@@ -851,10 +851,10 @@ fn build_call_shim<'tcx>(
             TerminatorKind::Drop {
                 place: rcvr_place(),
                 target: BasicBlock::new(4),
-                unwind: UnwindAction::Terminate,
+                unwind: UnwindAction::Terminate(UnwindTerminateReason::InCleanup),
                 replace: false,
             },
-            true,
+            /* is_cleanup */ true,
         );
 
         // BB #4 - resume

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -737,6 +737,13 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
         let source = self.body.source_info(location).span;
 
         let tcx = self.tcx;
+        let push_mono_lang_item = |this: &mut Self, lang_item: LangItem| {
+            let instance = Instance::mono(tcx, tcx.require_lang_item(lang_item, Some(source)));
+            if should_codegen_locally(tcx, &instance) {
+                this.output.push(create_fn_mono_item(tcx, instance, source));
+            }
+        };
+
         match terminator.kind {
             mir::TerminatorKind::Call { ref func, .. } => {
                 let callee_ty = func.ty(self.body, tcx);
@@ -771,19 +778,10 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
                     mir::AssertKind::BoundsCheck { .. } => LangItem::PanicBoundsCheck,
                     _ => LangItem::Panic,
                 };
-                let instance = Instance::mono(tcx, tcx.require_lang_item(lang_item, Some(source)));
-                if should_codegen_locally(tcx, &instance) {
-                    self.output.push(create_fn_mono_item(tcx, instance, source));
-                }
+                push_mono_lang_item(self, lang_item);
             }
-            mir::TerminatorKind::UnwindTerminate { .. } => {
-                let instance = Instance::mono(
-                    tcx,
-                    tcx.require_lang_item(LangItem::PanicCannotUnwind, Some(source)),
-                );
-                if should_codegen_locally(tcx, &instance) {
-                    self.output.push(create_fn_mono_item(tcx, instance, source));
-                }
+            mir::TerminatorKind::UnwindTerminate(reason) => {
+                push_mono_lang_item(self, reason.lang_item());
             }
             mir::TerminatorKind::Goto { .. }
             | mir::TerminatorKind::SwitchInt { .. }
@@ -796,14 +794,8 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
             | mir::TerminatorKind::FalseUnwind { .. } => bug!(),
         }
 
-        if let Some(mir::UnwindAction::Terminate) = terminator.unwind() {
-            let instance = Instance::mono(
-                tcx,
-                tcx.require_lang_item(LangItem::PanicCannotUnwind, Some(source)),
-            );
-            if should_codegen_locally(tcx, &instance) {
-                self.output.push(create_fn_mono_item(tcx, instance, source));
-            }
+        if let Some(mir::UnwindAction::Terminate(reason)) = terminator.unwind() {
+            push_mono_lang_item(self, reason.lang_item());
         }
 
         self.super_terminator(terminator, location);

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -590,7 +590,7 @@ impl<'tcx> Stable<'tcx> for mir::UnwindAction {
         match self {
             UnwindAction::Continue => stable_mir::mir::UnwindAction::Continue,
             UnwindAction::Unreachable => stable_mir::mir::UnwindAction::Unreachable,
-            UnwindAction::Terminate => stable_mir::mir::UnwindAction::Terminate,
+            UnwindAction::Terminate(_) => stable_mir::mir::UnwindAction::Terminate,
             UnwindAction::Cleanup(bb) => stable_mir::mir::UnwindAction::Cleanup(bb.as_usize()),
         }
     }
@@ -788,7 +788,7 @@ impl<'tcx> Stable<'tcx> for mir::Terminator<'tcx> {
                 otherwise: targets.otherwise().as_usize(),
             },
             UnwindResume => Terminator::Resume,
-            UnwindTerminate => Terminator::Abort,
+            UnwindTerminate(_) => Terminator::Abort,
             Return => Terminator::Return,
             Unreachable => Terminator::Unreachable,
             Drop { place, target, unwind, replace: _ } => Terminator::Drop {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1100,6 +1100,7 @@ symbols! {
         panic_handler,
         panic_impl,
         panic_implementation,
+        panic_in_cleanup,
         panic_info,
         panic_location,
         panic_misaligned_pointer_dereference,

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -179,6 +179,8 @@ fn panic_misaligned_pointer_dereference(required: usize, found: usize) -> ! {
 
 /// Panic because we cannot unwind out of a function.
 ///
+/// This is a separate function to avoid the codesize impact of each crate containing the string to
+/// pass to `panic_nounwind`.
 /// This function is called directly by the codegen backend, and must not have
 /// any extra arguments (including those synthesized by track_caller).
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never), cold)]
@@ -187,6 +189,21 @@ fn panic_misaligned_pointer_dereference(required: usize, found: usize) -> ! {
 #[rustc_nounwind]
 fn panic_cannot_unwind() -> ! {
     panic_nounwind("panic in a function that cannot unwind")
+}
+
+/// Panic because we are unwinding out of a destructor during cleanup.
+///
+/// This is a separate function to avoid the codesize impact of each crate containing the string to
+/// pass to `panic_nounwind`.
+/// This function is called directly by the codegen backend, and must not have
+/// any extra arguments (including those synthesized by track_caller).
+#[cfg(not(bootstrap))]
+#[cfg_attr(not(feature = "panic_immediate_abort"), inline(never), cold)]
+#[cfg_attr(feature = "panic_immediate_abort", inline)]
+#[lang = "panic_in_cleanup"] // needed by codegen for panic in nounwind function
+#[rustc_nounwind]
+fn panic_in_cleanup() -> ! {
+    panic_nounwind("panic in a destructor during cleanup")
 }
 
 /// This function is used instead of panic_fmt in const eval.

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -188,6 +188,7 @@ fn panic_misaligned_pointer_dereference(required: usize, found: usize) -> ! {
 #[lang = "panic_cannot_unwind"] // needed by codegen for panic in nounwind function
 #[rustc_nounwind]
 fn panic_cannot_unwind() -> ! {
+    // Keep the text in sync with `UnwindTerminateReason::as_str` in `rustc_middle`.
     panic_nounwind("panic in a function that cannot unwind")
 }
 
@@ -203,6 +204,7 @@ fn panic_cannot_unwind() -> ! {
 #[lang = "panic_in_cleanup"] // needed by codegen for panic in nounwind function
 #[rustc_nounwind]
 fn panic_in_cleanup() -> ! {
+    // Keep the text in sync with `UnwindTerminateReason::as_str` in `rustc_middle`.
     panic_nounwind("panic in a destructor during cleanup")
 }
 

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -292,7 +292,7 @@ fn check_terminator<'tcx>(
         | TerminatorKind::Goto { .. }
         | TerminatorKind::Return
         | TerminatorKind::UnwindResume
-        | TerminatorKind::UnwindTerminate
+        | TerminatorKind::UnwindTerminate(_)
         | TerminatorKind::Unreachable => Ok(()),
         TerminatorKind::Drop { place, .. } => {
             if !is_ty_const_destruct(tcx, place.ty(&body.local_decls, tcx).ty, body) {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3634,26 +3634,30 @@ impl<'test> TestCx<'test> {
         let expected_stderr = self.load_expected_output(stderr_kind);
         let expected_stdout = self.load_expected_output(stdout_kind);
 
-        let normalized_stdout = match output_kind {
+        let mut normalized_stdout =
+            self.normalize_output(&proc_res.stdout, &self.props.normalize_stdout);
+        match output_kind {
             TestOutput::Run if self.config.remote_test_client.is_some() => {
                 // When tests are run using the remote-test-client, the string
                 // 'uploaded "$TEST_BUILD_DIR/<test_executable>, waiting for result"'
                 // is printed to stdout by the client and then captured in the ProcRes,
-                // so it needs to be removed when comparing the run-pass test execution output
+                // so it needs to be removed when comparing the run-pass test execution output.
                 static REMOTE_TEST_RE: Lazy<Regex> = Lazy::new(|| {
                     Regex::new(
                         "^uploaded \"\\$TEST_BUILD_DIR(/[[:alnum:]_\\-.]+)+\", waiting for result\n"
                     )
                     .unwrap()
                 });
-                REMOTE_TEST_RE
-                    .replace(
-                        &self.normalize_output(&proc_res.stdout, &self.props.normalize_stdout),
-                        "",
-                    )
-                    .to_string()
+                normalized_stdout = REMOTE_TEST_RE.replace(&normalized_stdout, "").to_string();
+                // When there is a panic, the remote-test-client also prints "died due to signal";
+                // that needs to be removed as well.
+                static SIGNAL_DIED_RE: Lazy<Regex> =
+                    Lazy::new(|| Regex::new("^died due to signal [0-9]+\n").unwrap());
+                normalized_stdout = SIGNAL_DIED_RE.replace(&normalized_stdout, "").to_string();
+                // FIXME: it would be much nicer if we could just tell the remote-test-client to not
+                // print these things.
             }
-            _ => self.normalize_output(&proc_res.stdout, &self.props.normalize_stdout),
+            _ => {}
         };
 
         let stderr = if explicit_format {

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -975,9 +975,9 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for MiriMachine<'mir, 'tcx> {
         ecx.start_panic_nounwind(msg)
     }
 
-    fn unwind_terminate(ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx> {
+    fn unwind_terminate(ecx: &mut InterpCx<'mir, 'tcx, Self>, reason: mir::UnwindTerminateReason) -> InterpResult<'tcx> {
         // Call the lang item.
-        let panic = ecx.tcx.lang_items().panic_cannot_unwind().unwrap();
+        let panic = ecx.tcx.lang_items().get(reason.lang_item()).unwrap();
         let panic = ty::Instance::mono(ecx.tcx.tcx, panic);
         ecx.call_function(
             panic,

--- a/src/tools/miri/tests/fail/panic/double_panic.stderr
+++ b/src/tools/miri/tests/fail/panic/double_panic.stderr
@@ -5,7 +5,7 @@ thread 'main' panicked at $DIR/double_panic.rs:LL:CC:
 second
 stack backtrace:
 thread 'main' panicked at RUSTLIB/core/src/panicking.rs:LL:CC:
-panic in a function that cannot unwind
+panic in a destructor during cleanup
 stack backtrace:
 thread caused non-unwinding panic. aborting.
 error: abnormal termination: the program aborted execution
@@ -20,7 +20,7 @@ LL |     ABORT();
    = note: inside `std::sys_common::backtrace::__rust_end_short_backtrace::<[closure@std::panicking::begin_panic_handler::{closure#0}], !>` at RUSTLIB/std/src/sys_common/backtrace.rs:LL:CC
    = note: inside `std::panicking::begin_panic_handler` at RUSTLIB/std/src/panicking.rs:LL:CC
    = note: inside `core::panicking::panic_nounwind` at RUSTLIB/core/src/panicking.rs:LL:CC
-   = note: inside `core::panicking::panic_cannot_unwind` at RUSTLIB/core/src/panicking.rs:LL:CC
+   = note: inside `core::panicking::panic_in_cleanup` at RUSTLIB/core/src/panicking.rs:LL:CC
 note: inside `main`
   --> $DIR/double_panic.rs:LL:CC
    |

--- a/tests/mir-opt/asm_unwind_panic_abort.main.AbortUnwindingCalls.after.mir
+++ b/tests/mir-opt/asm_unwind_panic_abort.main.AbortUnwindingCalls.after.mir
@@ -9,7 +9,7 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);
         _1 = const ();
-        asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind terminate];
+        asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind terminate (panic in a function that cannot unwind)];
     }
 
     bb1: {

--- a/tests/mir-opt/asm_unwind_panic_abort.main.AbortUnwindingCalls.after.mir
+++ b/tests/mir-opt/asm_unwind_panic_abort.main.AbortUnwindingCalls.after.mir
@@ -9,7 +9,7 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);
         _1 = const ();
-        asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind terminate (panic in a function that cannot unwind)];
+        asm!("", options(MAY_UNWIND)) -> [return: bb1, unwind terminate(abi)];
     }
 
     bb1: {

--- a/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
+++ b/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
@@ -47,7 +47,7 @@
   
       bb2 (cleanup): {
           _5 = move _6;
--         drop(_6) -> [return: bb6, unwind terminate];
+-         drop(_6) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb6;
       }
   
@@ -71,12 +71,12 @@
       }
   
       bb6 (cleanup): {
--         drop(_5) -> [return: bb7, unwind terminate];
+-         drop(_5) -> [return: bb7, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb7;
       }
   
       bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate];
+-         drop(_4) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb8;
       }
   

--- a/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
+++ b/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
@@ -47,7 +47,7 @@
   
       bb2 (cleanup): {
           _5 = move _6;
--         drop(_6) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_6) -> [return: bb6, unwind terminate(cleanup)];
 +         goto -> bb6;
       }
   
@@ -71,12 +71,12 @@
       }
   
       bb6 (cleanup): {
--         drop(_5) -> [return: bb7, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_5) -> [return: bb7, unwind terminate(cleanup)];
 +         goto -> bb7;
       }
   
       bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
 +         goto -> bb8;
       }
   

--- a/tests/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
@@ -51,7 +51,7 @@ fn main() -> () {
 
     bb2 (cleanup): {
         _5 = move _6;
-        drop(_6) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
+        drop(_6) -> [return: bb6, unwind terminate(cleanup)];
     }
 
     bb3: {
@@ -73,11 +73,11 @@ fn main() -> () {
     }
 
     bb6 (cleanup): {
-        drop(_5) -> [return: bb7, unwind terminate (panic in a destructor during cleanup)];
+        drop(_5) -> [return: bb7, unwind terminate(cleanup)];
     }
 
     bb7 (cleanup): {
-        drop(_4) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
+        drop(_4) -> [return: bb8, unwind terminate(cleanup)];
     }
 
     bb8 (cleanup): {

--- a/tests/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
@@ -51,7 +51,7 @@ fn main() -> () {
 
     bb2 (cleanup): {
         _5 = move _6;
-        drop(_6) -> [return: bb6, unwind terminate];
+        drop(_6) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb3: {
@@ -73,11 +73,11 @@ fn main() -> () {
     }
 
     bb6 (cleanup): {
-        drop(_5) -> [return: bb7, unwind terminate];
+        drop(_5) -> [return: bb7, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb7 (cleanup): {
-        drop(_4) -> [return: bb8, unwind terminate];
+        drop(_4) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb8 (cleanup): {

--- a/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-abort.mir
@@ -54,15 +54,15 @@ fn main() -> () {
     }
 
     bb6 (cleanup): {
-        drop(_7) -> [return: bb7, unwind terminate];
+        drop(_7) -> [return: bb7, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate];
+        drop(_1) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb8 (cleanup): {
-        drop(_5) -> [return: bb9, unwind terminate];
+        drop(_5) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb9 (cleanup): {

--- a/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-abort.mir
@@ -54,15 +54,15 @@ fn main() -> () {
     }
 
     bb6 (cleanup): {
-        drop(_7) -> [return: bb7, unwind terminate (panic in a destructor during cleanup)];
+        drop(_7) -> [return: bb7, unwind terminate(cleanup)];
     }
 
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb8 (cleanup): {
-        drop(_5) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
+        drop(_5) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb9 (cleanup): {

--- a/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-unwind.mir
@@ -54,15 +54,15 @@ fn main() -> () {
     }
 
     bb6 (cleanup): {
-        drop(_7) -> [return: bb7, unwind terminate];
+        drop(_7) -> [return: bb7, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate];
+        drop(_1) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb8 (cleanup): {
-        drop(_5) -> [return: bb9, unwind terminate];
+        drop(_5) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb9 (cleanup): {

--- a/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/box_expr.main.ElaborateDrops.before.panic-unwind.mir
@@ -54,15 +54,15 @@ fn main() -> () {
     }
 
     bb6 (cleanup): {
-        drop(_7) -> [return: bb7, unwind terminate (panic in a destructor during cleanup)];
+        drop(_7) -> [return: bb7, unwind terminate(cleanup)];
     }
 
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb8 (cleanup): {
-        drop(_5) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
+        drop(_5) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb9 (cleanup): {

--- a/tests/mir-opt/building/enum_cast.droppy.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.droppy.built.after.mir
@@ -62,7 +62,7 @@ fn droppy() -> () {
     }
 
     bb4 (cleanup): {
-        drop(_2) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+        drop(_2) -> [return: bb5, unwind terminate(cleanup)];
     }
 
     bb5 (cleanup): {

--- a/tests/mir-opt/building/enum_cast.droppy.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.droppy.built.after.mir
@@ -62,7 +62,7 @@ fn droppy() -> () {
     }
 
     bb4 (cleanup): {
-        drop(_2) -> [return: bb5, unwind terminate];
+        drop(_2) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb5 (cleanup): {

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.built.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.built.after.mir
@@ -89,15 +89,15 @@ fn move_out_by_subslice() -> () {
     }
 
     bb9 (cleanup): {
-        drop(_1) -> [return: bb12, unwind terminate];
+        drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb10 (cleanup): {
-        drop(_7) -> [return: bb11, unwind terminate];
+        drop(_7) -> [return: bb11, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate];
+        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.built.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.built.after.mir
@@ -89,15 +89,15 @@ fn move_out_by_subslice() -> () {
     }
 
     bb9 (cleanup): {
-        drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb10 (cleanup): {
-        drop(_7) -> [return: bb11, unwind terminate (panic in a destructor during cleanup)];
+        drop(_7) -> [return: bb11, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.built.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.built.after.mir
@@ -89,15 +89,15 @@ fn move_out_from_end() -> () {
     }
 
     bb9 (cleanup): {
-        drop(_1) -> [return: bb12, unwind terminate];
+        drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb10 (cleanup): {
-        drop(_7) -> [return: bb11, unwind terminate];
+        drop(_7) -> [return: bb11, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate];
+        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.built.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.built.after.mir
@@ -89,15 +89,15 @@ fn move_out_from_end() -> () {
     }
 
     bb9 (cleanup): {
-        drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb10 (cleanup): {
-        drop(_7) -> [return: bb11, unwind terminate (panic in a destructor during cleanup)];
+        drop(_7) -> [return: bb11, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstSimplify.panic-unwind.diff
+++ b/tests/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstSimplify.panic-unwind.diff
@@ -63,7 +63,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstSimplify.panic-unwind.diff
+++ b/tests/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstSimplify.panic-unwind.diff
@@ -63,7 +63,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate];
+          drop(_2) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
@@ -28,7 +28,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate];
+          drop(_2) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
@@ -28,7 +28,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
@@ -28,7 +28,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate];
+          drop(_2) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
@@ -28,7 +28,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-unwind.mir
+++ b/tests/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-unwind.mir
@@ -104,7 +104,7 @@ yields ()
 
     bb13 (cleanup): {
         StorageDead(_3);
-        drop(_1) -> [return: bb14, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb14, unwind terminate(cleanup)];
     }
 
     bb14 (cleanup): {
@@ -113,6 +113,6 @@ yields ()
 
     bb15 (cleanup): {
         StorageDead(_3);
-        drop(_1) -> [return: bb14, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb14, unwind terminate(cleanup)];
     }
 }

--- a/tests/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-unwind.mir
+++ b/tests/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-unwind.mir
@@ -104,7 +104,7 @@ yields ()
 
     bb13 (cleanup): {
         StorageDead(_3);
-        drop(_1) -> [return: bb14, unwind terminate];
+        drop(_1) -> [return: bb14, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb14 (cleanup): {
@@ -113,6 +113,6 @@ yields ()
 
     bb15 (cleanup): {
         StorageDead(_3);
-        drop(_1) -> [return: bb14, unwind terminate];
+        drop(_1) -> [return: bb14, unwind terminate (panic in a destructor during cleanup)];
     }
 }

--- a/tests/mir-opt/inline/asm_unwind.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/asm_unwind.main.Inline.panic-abort.diff
@@ -17,7 +17,7 @@
           StorageLive(_1);
 -         _1 = foo() -> [return: bb1, unwind unreachable];
 +         StorageLive(_2);
-+         asm!("", options(MAY_UNWIND)) -> [return: bb2, unwind terminate];
++         asm!("", options(MAY_UNWIND)) -> [return: bb2, unwind terminate (panic in a function that cannot unwind)];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/asm_unwind.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/asm_unwind.main.Inline.panic-abort.diff
@@ -17,7 +17,7 @@
           StorageLive(_1);
 -         _1 = foo() -> [return: bb1, unwind unreachable];
 +         StorageLive(_2);
-+         asm!("", options(MAY_UNWIND)) -> [return: bb2, unwind terminate (panic in a function that cannot unwind)];
++         asm!("", options(MAY_UNWIND)) -> [return: bb2, unwind terminate(abi)];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/asm_unwind.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/asm_unwind.main.Inline.panic-unwind.diff
@@ -32,7 +32,7 @@
 +     }
 + 
 +     bb3 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
++         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
 +     }
 + 
 +     bb4 (cleanup): {

--- a/tests/mir-opt/inline/asm_unwind.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/asm_unwind.main.Inline.panic-unwind.diff
@@ -32,7 +32,7 @@
 +     }
 + 
 +     bb3 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate];
++         drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb4 (cleanup): {

--- a/tests/mir-opt/inline/cycle.f.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.f.Inline.panic-unwind.diff
@@ -30,7 +30,7 @@
       }
   
       bb3 (cleanup): {
-          drop(_1) -> [return: bb4, unwind terminate];
+          drop(_1) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
       }
   
       bb4 (cleanup): {

--- a/tests/mir-opt/inline/cycle.f.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.f.Inline.panic-unwind.diff
@@ -30,7 +30,7 @@
       }
   
       bb3 (cleanup): {
-          drop(_1) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
+          drop(_1) -> [return: bb4, unwind terminate(cleanup)];
       }
   
       bb4 (cleanup): {

--- a/tests/mir-opt/inline/cycle.g.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.g.Inline.panic-unwind.diff
@@ -36,7 +36,7 @@
 +     }
 + 
 +     bb3 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
++         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
 +     }
 + 
 +     bb4 (cleanup): {

--- a/tests/mir-opt/inline/cycle.g.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.g.Inline.panic-unwind.diff
@@ -36,7 +36,7 @@
 +     }
 + 
 +     bb3 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate];
++         drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb4 (cleanup): {

--- a/tests/mir-opt/inline/cycle.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.main.Inline.panic-unwind.diff
@@ -36,7 +36,7 @@
 +     }
 + 
 +     bb3 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
++         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
 +     }
 + 
 +     bb4 (cleanup): {

--- a/tests/mir-opt/inline/cycle.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.main.Inline.panic-unwind.diff
@@ -36,7 +36,7 @@
 +     }
 + 
 +     bb3 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate];
++         drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb4 (cleanup): {

--- a/tests/mir-opt/inline/dont_ice_on_generic_rust_call.call.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/dont_ice_on_generic_rust_call.call.Inline.panic-unwind.diff
@@ -27,7 +27,7 @@
       }
   
       bb3 (cleanup): {
-          drop(_1) -> [return: bb4, unwind terminate];
+          drop(_1) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
       }
   
       bb4 (cleanup): {

--- a/tests/mir-opt/inline/dont_ice_on_generic_rust_call.call.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/dont_ice_on_generic_rust_call.call.Inline.panic-unwind.diff
@@ -27,7 +27,7 @@
       }
   
       bb3 (cleanup): {
-          drop(_1) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
+          drop(_1) -> [return: bb4, unwind terminate(cleanup)];
       }
   
       bb4 (cleanup): {

--- a/tests/mir-opt/inline/inline_box_fn.call.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_box_fn.call.Inline.panic-unwind.diff
@@ -30,7 +30,7 @@
       }
   
       bb3 (cleanup): {
-          drop(_1) -> [return: bb4, unwind terminate];
+          drop(_1) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
       }
   
       bb4 (cleanup): {

--- a/tests/mir-opt/inline/inline_box_fn.call.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_box_fn.call.Inline.panic-unwind.diff
@@ -30,7 +30,7 @@
       }
   
       bb3 (cleanup): {
-          drop(_1) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
+          drop(_1) -> [return: bb4, unwind terminate(cleanup)];
       }
   
       bb4 (cleanup): {

--- a/tests/mir-opt/inline/inline_diverging.h.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_diverging.h.Inline.panic-unwind.diff
@@ -54,11 +54,11 @@
 +     }
 + 
 +     bb4 (cleanup): {
-+         drop(_4) -> [return: bb5, unwind terminate];
++         drop(_4) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb5 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate];
++         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb6 (cleanup): {

--- a/tests/mir-opt/inline/inline_diverging.h.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_diverging.h.Inline.panic-unwind.diff
@@ -54,11 +54,11 @@
 +     }
 + 
 +     bb4 (cleanup): {
-+         drop(_4) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
++         drop(_4) -> [return: bb5, unwind terminate(cleanup)];
 +     }
 + 
 +     bb5 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
++         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
 +     }
 + 
 +     bb6 (cleanup): {

--- a/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
@@ -155,7 +155,7 @@
 -         StorageDead(_1);
 -         return;
 +     bb3 (cleanup): {
-+         drop(_2) -> [return: bb2, unwind terminate];
++         drop(_2) -> [return: bb2, unwind terminate (panic in a destructor during cleanup)];
       }
   
 -     bb4 (cleanup): {

--- a/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
@@ -155,7 +155,7 @@
 -         StorageDead(_1);
 -         return;
 +     bb3 (cleanup): {
-+         drop(_2) -> [return: bb2, unwind terminate (panic in a destructor during cleanup)];
++         drop(_2) -> [return: bb2, unwind terminate(cleanup)];
       }
   
 -     bb4 (cleanup): {

--- a/tests/mir-opt/inline/issue_78442.bar.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_78442.bar.Inline.panic-unwind.diff
@@ -37,7 +37,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_1) -> [return: bb5, unwind terminate];
+          drop(_1) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/inline/issue_78442.bar.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_78442.bar.Inline.panic-unwind.diff
@@ -37,7 +37,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_1) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+          drop(_1) -> [return: bb5, unwind terminate(cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/inline/issue_78442.bar.RevealAll.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_78442.bar.RevealAll.panic-unwind.diff
@@ -40,7 +40,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_1) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+          drop(_1) -> [return: bb5, unwind terminate(cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/inline/issue_78442.bar.RevealAll.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_78442.bar.RevealAll.panic-unwind.diff
@@ -40,7 +40,7 @@
       }
   
       bb4 (cleanup): {
-          drop(_1) -> [return: bb5, unwind terminate];
+          drop(_1) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
       }
   
       bb5 (cleanup): {

--- a/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
+++ b/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
@@ -40,7 +40,7 @@
   
       bb4 (cleanup): {
           _8 = &mut _3;
-          _9 = <Box<[i32]> as Drop>::drop(move _8) -> [return: bb1, unwind terminate (panic in a destructor during cleanup)];
+          _9 = <Box<[i32]> as Drop>::drop(move _8) -> [return: bb1, unwind terminate(cleanup)];
       }
   }
   

--- a/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
+++ b/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
@@ -40,7 +40,7 @@
   
       bb4 (cleanup): {
           _8 = &mut _3;
-          _9 = <Box<[i32]> as Drop>::drop(move _8) -> [return: bb1, unwind terminate];
+          _9 = <Box<[i32]> as Drop>::drop(move _8) -> [return: bb1, unwind terminate (panic in a destructor during cleanup)];
       }
   }
   

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
@@ -40,17 +40,17 @@
       }
   
       bb3 (cleanup): {
--         drop(_3) -> [return: bb5, unwind terminate];
+-         drop(_3) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb5;
       }
   
       bb4 (cleanup): {
--         drop(_4) -> [return: bb5, unwind terminate];
+-         drop(_4) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb5;
       }
   
       bb5 (cleanup): {
--         drop(_2) -> [return: bb6, unwind terminate];
+-         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb8;
       }
   
@@ -59,7 +59,7 @@
 +     }
 + 
 +     bb7 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate];
++         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb8 (cleanup): {

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
@@ -40,17 +40,17 @@
       }
   
       bb3 (cleanup): {
--         drop(_3) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_3) -> [return: bb5, unwind terminate(cleanup)];
 +         goto -> bb5;
       }
   
       bb4 (cleanup): {
--         drop(_4) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_4) -> [return: bb5, unwind terminate(cleanup)];
 +         goto -> bb5;
       }
   
       bb5 (cleanup): {
--         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
 +         goto -> bb8;
       }
   
@@ -59,7 +59,7 @@
 +     }
 + 
 +     bb7 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
++         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
 +     }
 + 
 +     bb8 (cleanup): {

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
@@ -40,17 +40,17 @@
       }
   
       bb3 (cleanup): {
--         drop(_3) -> [return: bb5, unwind terminate];
+-         drop(_3) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb5;
       }
   
       bb4 (cleanup): {
--         drop(_4) -> [return: bb5, unwind terminate];
+-         drop(_4) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb5;
       }
   
       bb5 (cleanup): {
--         drop(_2) -> [return: bb6, unwind terminate];
+-         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb8;
       }
   
@@ -59,7 +59,7 @@
 +     }
 + 
 +     bb7 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate];
++         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb8 (cleanup): {

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
@@ -40,17 +40,17 @@
       }
   
       bb3 (cleanup): {
--         drop(_3) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_3) -> [return: bb5, unwind terminate(cleanup)];
 +         goto -> bb5;
       }
   
       bb4 (cleanup): {
--         drop(_4) -> [return: bb5, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_4) -> [return: bb5, unwind terminate(cleanup)];
 +         goto -> bb5;
       }
   
       bb5 (cleanup): {
--         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
 +         goto -> bb8;
       }
   
@@ -59,7 +59,7 @@
 +     }
 + 
 +     bb7 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
++         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
 +     }
 + 
 +     bb8 (cleanup): {

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
@@ -47,7 +47,7 @@
   
       bb3 (cleanup): {
           _2 = move _5;
--         drop(_5) -> [return: bb8, unwind terminate];
+-         drop(_5) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb8;
       }
   
@@ -70,17 +70,17 @@
       }
   
       bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate];
+-         drop(_4) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb8;
       }
   
       bb8 (cleanup): {
--         drop(_2) -> [return: bb9, unwind terminate];
+-         drop(_2) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb9;
       }
   
       bb9 (cleanup): {
--         drop(_1) -> [return: bb10, unwind terminate];
+-         drop(_1) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb12;
       }
   
@@ -89,7 +89,7 @@
 +     }
 + 
 +     bb11 (cleanup): {
-+         drop(_1) -> [return: bb10, unwind terminate];
++         drop(_1) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb12 (cleanup): {

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
@@ -47,7 +47,7 @@
   
       bb3 (cleanup): {
           _2 = move _5;
--         drop(_5) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_5) -> [return: bb8, unwind terminate(cleanup)];
 +         goto -> bb8;
       }
   
@@ -70,17 +70,17 @@
       }
   
       bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
 +         goto -> bb8;
       }
   
       bb8 (cleanup): {
--         drop(_2) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_2) -> [return: bb9, unwind terminate(cleanup)];
 +         goto -> bb9;
       }
   
       bb9 (cleanup): {
--         drop(_1) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
 +         goto -> bb12;
       }
   
@@ -89,7 +89,7 @@
 +     }
 + 
 +     bb11 (cleanup): {
-+         drop(_1) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
++         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
 +     }
 + 
 +     bb12 (cleanup): {

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
@@ -47,7 +47,7 @@
   
       bb3 (cleanup): {
           _2 = move _5;
--         drop(_5) -> [return: bb8, unwind terminate];
+-         drop(_5) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb8;
       }
   
@@ -70,17 +70,17 @@
       }
   
       bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate];
+-         drop(_4) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb8;
       }
   
       bb8 (cleanup): {
--         drop(_2) -> [return: bb9, unwind terminate];
+-         drop(_2) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb9;
       }
   
       bb9 (cleanup): {
--         drop(_1) -> [return: bb10, unwind terminate];
+-         drop(_1) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb12;
       }
   
@@ -89,7 +89,7 @@
 +     }
 + 
 +     bb11 (cleanup): {
-+         drop(_1) -> [return: bb10, unwind terminate];
++         drop(_1) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb12 (cleanup): {

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
@@ -47,7 +47,7 @@
   
       bb3 (cleanup): {
           _2 = move _5;
--         drop(_5) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_5) -> [return: bb8, unwind terminate(cleanup)];
 +         goto -> bb8;
       }
   
@@ -70,17 +70,17 @@
       }
   
       bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
 +         goto -> bb8;
       }
   
       bb8 (cleanup): {
--         drop(_2) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_2) -> [return: bb9, unwind terminate(cleanup)];
 +         goto -> bb9;
       }
   
       bb9 (cleanup): {
--         drop(_1) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
 +         goto -> bb12;
       }
   
@@ -89,7 +89,7 @@
 +     }
 + 
 +     bb11 (cleanup): {
-+         drop(_1) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
++         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
 +     }
 + 
 +     bb12 (cleanup): {

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
@@ -58,7 +58,7 @@
 +         _8 = const true;
 +         _9 = const true;
           _1 = move _3;
--         drop(_3) -> [return: bb11, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_3) -> [return: bb11, unwind terminate(cleanup)];
 +         goto -> bb11;
       }
   
@@ -102,7 +102,7 @@
       }
   
       bb11 (cleanup): {
--         drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
 +         goto -> bb12;
       }
   
@@ -124,7 +124,7 @@
 +     }
 + 
 +     bb16 (cleanup): {
-+         drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
++         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
 +     bb17: {

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
@@ -58,7 +58,7 @@
 +         _8 = const true;
 +         _9 = const true;
           _1 = move _3;
--         drop(_3) -> [return: bb11, unwind terminate];
+-         drop(_3) -> [return: bb11, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb11;
       }
   
@@ -102,7 +102,7 @@
       }
   
       bb11 (cleanup): {
--         drop(_1) -> [return: bb12, unwind terminate];
+-         drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb12;
       }
   
@@ -124,7 +124,7 @@
 +     }
 + 
 +     bb16 (cleanup): {
-+         drop(_1) -> [return: bb12, unwind terminate];
++         drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb17: {

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
@@ -58,7 +58,7 @@
 +         _8 = const true;
 +         _9 = const true;
           _1 = move _3;
--         drop(_3) -> [return: bb11, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_3) -> [return: bb11, unwind terminate(cleanup)];
 +         goto -> bb11;
       }
   
@@ -102,7 +102,7 @@
       }
   
       bb11 (cleanup): {
--         drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
 +         goto -> bb12;
       }
   
@@ -124,7 +124,7 @@
 +     }
 + 
 +     bb16 (cleanup): {
-+         drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
++         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
 +     bb17: {

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
@@ -58,7 +58,7 @@
 +         _8 = const true;
 +         _9 = const true;
           _1 = move _3;
--         drop(_3) -> [return: bb11, unwind terminate];
+-         drop(_3) -> [return: bb11, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb11;
       }
   
@@ -102,7 +102,7 @@
       }
   
       bb11 (cleanup): {
--         drop(_1) -> [return: bb12, unwind terminate];
+-         drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
 +         goto -> bb12;
       }
   
@@ -124,7 +124,7 @@
 +     }
 + 
 +     bb16 (cleanup): {
-+         drop(_1) -> [return: bb12, unwind terminate];
++         drop(_1) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
 +     }
 + 
 +     bb17: {

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-abort.mir
@@ -100,11 +100,11 @@ fn test() -> Option<Box<u32>> {
     }
 
     bb11 (cleanup): {
-        drop(_1) -> [return: bb13, unwind terminate];
+        drop(_1) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb12 (cleanup): {
-        drop(_5) -> [return: bb13, unwind terminate];
+        drop(_5) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb13 (cleanup): {

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-abort.mir
@@ -100,11 +100,11 @@ fn test() -> Option<Box<u32>> {
     }
 
     bb11 (cleanup): {
-        drop(_1) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb13, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {
-        drop(_5) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
+        drop(_5) -> [return: bb13, unwind terminate(cleanup)];
     }
 
     bb13 (cleanup): {

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
@@ -100,11 +100,11 @@ fn test() -> Option<Box<u32>> {
     }
 
     bb11 (cleanup): {
-        drop(_1) -> [return: bb13, unwind terminate];
+        drop(_1) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb12 (cleanup): {
-        drop(_5) -> [return: bb13, unwind terminate];
+        drop(_5) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb13 (cleanup): {

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
@@ -100,11 +100,11 @@ fn test() -> Option<Box<u32>> {
     }
 
     bb11 (cleanup): {
-        drop(_1) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb13, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {
-        drop(_5) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
+        drop(_5) -> [return: bb13, unwind terminate(cleanup)];
     }
 
     bb13 (cleanup): {

--- a/tests/mir-opt/issue_91633.bar.built.after.mir
+++ b/tests/mir-opt/issue_91633.bar.built.after.mir
@@ -28,7 +28,7 @@ fn bar(_1: Box<[T]>) -> () {
     }
 
     bb3 (cleanup): {
-        drop(_1) -> [return: bb4, unwind terminate];
+        drop(_1) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb4 (cleanup): {

--- a/tests/mir-opt/issue_91633.bar.built.after.mir
+++ b/tests/mir-opt/issue_91633.bar.built.after.mir
@@ -28,7 +28,7 @@ fn bar(_1: Box<[T]>) -> () {
     }
 
     bb3 (cleanup): {
-        drop(_1) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb4, unwind terminate(cleanup)];
     }
 
     bb4 (cleanup): {

--- a/tests/mir-opt/issue_91633.foo.built.after.mir
+++ b/tests/mir-opt/issue_91633.foo.built.after.mir
@@ -45,7 +45,7 @@ fn foo(_1: Box<[T]>) -> T {
     }
 
     bb5 (cleanup): {
-        drop(_1) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb6, unwind terminate(cleanup)];
     }
 
     bb6 (cleanup): {

--- a/tests/mir-opt/issue_91633.foo.built.after.mir
+++ b/tests/mir-opt/issue_91633.foo.built.after.mir
@@ -45,7 +45,7 @@ fn foo(_1: Box<[T]>) -> T {
     }
 
     bb5 (cleanup): {
-        drop(_1) -> [return: bb6, unwind terminate];
+        drop(_1) -> [return: bb6, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb6 (cleanup): {

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -243,7 +243,7 @@
       }
   
 -     bb25 (cleanup): {
--         drop(_2) -> [return: bb26, unwind terminate];
+-         drop(_2) -> [return: bb26, unwind terminate (panic in a destructor during cleanup)];
 +     bb22 (cleanup): {
 +         goto -> bb27;
       }

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -243,7 +243,7 @@
       }
   
 -     bb25 (cleanup): {
--         drop(_2) -> [return: bb26, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_2) -> [return: bb26, unwind terminate(cleanup)];
 +     bb22 (cleanup): {
 +         goto -> bb27;
       }

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -243,7 +243,7 @@
       }
   
 -     bb25 (cleanup): {
--         drop(_2) -> [return: bb26, unwind terminate];
+-         drop(_2) -> [return: bb26, unwind terminate (panic in a destructor during cleanup)];
 +     bb22 (cleanup): {
 +         goto -> bb27;
       }

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -243,7 +243,7 @@
       }
   
 -     bb25 (cleanup): {
--         drop(_2) -> [return: bb26, unwind terminate (panic in a destructor during cleanup)];
+-         drop(_2) -> [return: bb26, unwind terminate(cleanup)];
 +     bb22 (cleanup): {
 +         goto -> bb27;
       }

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
@@ -31,7 +31,7 @@ fn main() -> () {
     }
 
     bb3 (cleanup): {
-        drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
+        drop(_2) -> [return: bb4, unwind terminate(cleanup)];
     }
 
     bb4 (cleanup): {

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
@@ -31,7 +31,7 @@ fn main() -> () {
     }
 
     bb3 (cleanup): {
-        drop(_2) -> [return: bb4, unwind terminate];
+        drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb4 (cleanup): {

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
@@ -31,7 +31,7 @@ fn main() -> () {
     }
 
     bb3 (cleanup): {
-        drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
+        drop(_2) -> [return: bb4, unwind terminate(cleanup)];
     }
 
     bb4 (cleanup): {

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
@@ -31,7 +31,7 @@ fn main() -> () {
     }
 
     bb3 (cleanup): {
-        drop(_2) -> [return: bb4, unwind terminate];
+        drop(_2) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb4 (cleanup): {

--- a/tests/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -33,7 +33,7 @@ fn main() -> () {
 
     bb1 (cleanup): {
         (_1.0: Aligned) = move _4;
-        drop(_1) -> [return: bb3, unwind terminate (panic in a destructor during cleanup)];
+        drop(_1) -> [return: bb3, unwind terminate(cleanup)];
     }
 
     bb2: {

--- a/tests/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -33,7 +33,7 @@ fn main() -> () {
 
     bb1 (cleanup): {
         (_1.0: Aligned) = move _4;
-        drop(_1) -> [return: bb3, unwind terminate];
+        drop(_1) -> [return: bb3, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb2: {

--- a/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
@@ -83,7 +83,7 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
     }
 
     bb9 (cleanup): {
-        drop(_5) -> [return: bb10, unwind terminate];
+        drop(_5) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb10 (cleanup): {

--- a/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
@@ -83,7 +83,7 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
     }
 
     bb9 (cleanup): {
-        drop(_5) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
+        drop(_5) -> [return: bb10, unwind terminate(cleanup)];
     }
 
     bb10 (cleanup): {

--- a/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
@@ -75,7 +75,7 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
     }
 
     bb9 (cleanup): {
-        drop(_5) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
+        drop(_5) -> [return: bb10, unwind terminate(cleanup)];
     }
 
     bb10 (cleanup): {

--- a/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
@@ -75,7 +75,7 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
     }
 
     bb9 (cleanup): {
-        drop(_5) -> [return: bb10, unwind terminate];
+        drop(_5) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb10 (cleanup): {

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -67,7 +67,7 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
     }
 
     bb9 (cleanup): {
-        drop(_3) -> [return: bb10, unwind terminate];
+        drop(_3) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb10 (cleanup): {

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -67,7 +67,7 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
     }
 
     bb9 (cleanup): {
-        drop(_3) -> [return: bb10, unwind terminate (panic in a destructor during cleanup)];
+        drop(_3) -> [return: bb10, unwind terminate(cleanup)];
     }
 
     bb10 (cleanup): {

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -127,7 +127,7 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb11 (cleanup): {
-        drop(_3) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+        drop(_3) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -127,7 +127,7 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb11 (cleanup): {
-        drop(_3) -> [return: bb12, unwind terminate];
+        drop(_3) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
@@ -82,7 +82,7 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb8 (cleanup): {
-        drop(_3) -> [return: bb9, unwind terminate];
+        drop(_3) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb9 (cleanup): {

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
@@ -82,7 +82,7 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     }
 
     bb8 (cleanup): {
-        drop(_3) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
+        drop(_3) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb9 (cleanup): {

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -195,7 +195,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate];
+        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -195,7 +195,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -182,7 +182,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate];
+        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -182,7 +182,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
@@ -143,7 +143,7 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb12 (cleanup): {
-        drop(_2) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
+        drop(_2) -> [return: bb13, unwind terminate(cleanup)];
     }
 
     bb13 (cleanup): {

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
@@ -143,7 +143,7 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb12 (cleanup): {
-        drop(_2) -> [return: bb13, unwind terminate];
+        drop(_2) -> [return: bb13, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb13 (cleanup): {

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -196,7 +196,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate];
+        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -196,7 +196,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate (panic in a destructor during cleanup)];
+        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {

--- a/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -167,11 +167,11 @@ fn main() -> () {
     }
 
     bb7 (cleanup): {
-        drop(_21) -> [return: bb9, unwind terminate];
+        drop(_21) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb8 (cleanup): {
-        drop(_5) -> [return: bb9, unwind terminate];
+        drop(_5) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb9 (cleanup): {

--- a/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -167,11 +167,11 @@ fn main() -> () {
     }
 
     bb7 (cleanup): {
-        drop(_21) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
+        drop(_21) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb8 (cleanup): {
-        drop(_5) -> [return: bb9, unwind terminate (panic in a destructor during cleanup)];
+        drop(_5) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb9 (cleanup): {

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
@@ -24,7 +24,7 @@ fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
     bb3 (cleanup): {
         _4 = &raw mut (*_1)[_3];
         _3 = Add(move _3, const 1_usize);
-        drop((*_4)) -> [return: bb4, unwind terminate];
+        drop((*_4)) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb4 (cleanup): {

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
@@ -24,7 +24,7 @@ fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
     bb3 (cleanup): {
         _4 = &raw mut (*_1)[_3];
         _3 = Add(move _3, const 1_usize);
-        drop((*_4)) -> [return: bb4, unwind terminate (panic in a destructor during cleanup)];
+        drop((*_4)) -> [return: bb4, unwind terminate(cleanup)];
     }
 
     bb4 (cleanup): {

--- a/tests/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
@@ -22,7 +22,7 @@ fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
     }
 
     bb4 (cleanup): {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb2, unwind terminate];
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb2, unwind terminate (panic in a destructor during cleanup)];
     }
 
     bb5: {

--- a/tests/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
@@ -22,7 +22,7 @@ fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
     }
 
     bb4 (cleanup): {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb2, unwind terminate (panic in a destructor during cleanup)];
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb2, unwind terminate(cleanup)];
     }
 
     bb5: {

--- a/tests/ui/backtrace.rs
+++ b/tests/ui/backtrace.rs
@@ -100,14 +100,17 @@ fn runtest(me: &str) {
         let s = str::from_utf8(&out.stderr).unwrap();
         // loosened the following from double::h to double:: due to
         // spurious failures on mac, 32bit, optimized
-        assert!(s.contains("stack backtrace") && contains_verbose_expected(s, "double"),
-                "bad output3: {}", s);
+        assert!(
+            s.contains("stack backtrace") &&
+                s.contains("panic in a destructor during cleanup") &&
+                contains_verbose_expected(s, "double"),
+            "bad output3: {}", s
+        );
 
         // Make sure a stack trace isn't printed too many times
         //
-        // Currently it is printed 3 times ("once", "twice" and "panic in a
-        // function that cannot unwind") but in the future the last one may be
-        // removed.
+        // Currently it is printed 3 times ("once", "twice" and "panic in a destructor during
+        // cleanup") but in the future the last one may be removed.
         let p = template(me).arg("double-fail")
                                     .env("RUST_BACKTRACE", "1").spawn().unwrap();
         let out = p.wait_with_output().unwrap();

--- a/tests/ui/panics/panic-in-cleanup.rs
+++ b/tests/ui/panics/panic-in-cleanup.rs
@@ -1,0 +1,19 @@
+// run-fail
+// check-run-results
+// error-pattern: panic in a destructor during cleanup
+// normalize-stderr-test: "\n +[0-9]+:[^\n]+" -> ""
+// normalize-stderr-test: "\n +at [^\n]+" -> ""
+// ignore-emscripten no processes
+
+struct Bomb;
+
+impl Drop for Bomb {
+    fn drop(&mut self) {
+        panic!("BOOM");
+    }
+}
+
+fn main() {
+    let _b = Bomb;
+    panic!();
+}

--- a/tests/ui/panics/panic-in-cleanup.rs
+++ b/tests/ui/panics/panic-in-cleanup.rs
@@ -1,9 +1,12 @@
 // run-fail
+// exec-env:RUST_BACKTRACE=0
 // check-run-results
 // error-pattern: panic in a destructor during cleanup
 // normalize-stderr-test: "\n +[0-9]+:[^\n]+" -> ""
 // normalize-stderr-test: "\n +at [^\n]+" -> ""
-// ignore-emscripten no processes
+// needs-unwind
+// ignore-emscripten "RuntimeError" junk in output
+// ignore-msvc SEH doesn't do panic-during-cleanup the same way as everyone else
 
 struct Bomb;
 

--- a/tests/ui/panics/panic-in-cleanup.run.stderr
+++ b/tests/ui/panics/panic-in-cleanup.run.stderr
@@ -1,0 +1,10 @@
+thread 'main' panicked at $DIR/panic-in-cleanup.rs:18:5:
+explicit panic
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+thread 'main' panicked at $DIR/panic-in-cleanup.rs:12:9:
+BOOM
+stack backtrace:
+thread 'main' panicked at library/core/src/panicking.rs:126:5:
+panic in a destructor during cleanup
+stack backtrace:
+thread caused non-unwinding panic. aborting.

--- a/tests/ui/panics/panic-in-cleanup.run.stderr
+++ b/tests/ui/panics/panic-in-cleanup.run.stderr
@@ -1,7 +1,7 @@
-thread 'main' panicked at $DIR/panic-in-cleanup.rs:18:5:
+thread 'main' panicked at $DIR/panic-in-cleanup.rs:21:5:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-thread 'main' panicked at $DIR/panic-in-cleanup.rs:12:9:
+thread 'main' panicked at $DIR/panic-in-cleanup.rs:15:9:
 BOOM
 stack backtrace:
 thread 'main' panicked at library/core/src/panicking.rs:126:5:

--- a/tests/ui/panics/panic-in-ffi.rs
+++ b/tests/ui/panics/panic-in-ffi.rs
@@ -1,0 +1,15 @@
+// run-fail
+// check-run-results
+// error-pattern: panic in a function that cannot unwind
+// normalize-stderr-test: "\n +[0-9]+:[^\n]+" -> ""
+// normalize-stderr-test: "\n +at [^\n]+" -> ""
+// ignore-emscripten no processes
+#![feature(c_unwind)]
+
+extern "C" fn panic_in_ffi() {
+    panic!("Test");
+}
+
+fn main() {
+    panic_in_ffi();
+}

--- a/tests/ui/panics/panic-in-ffi.rs
+++ b/tests/ui/panics/panic-in-ffi.rs
@@ -1,9 +1,11 @@
 // run-fail
+// exec-env:RUST_BACKTRACE=0
 // check-run-results
 // error-pattern: panic in a function that cannot unwind
 // normalize-stderr-test: "\n +[0-9]+:[^\n]+" -> ""
 // normalize-stderr-test: "\n +at [^\n]+" -> ""
-// ignore-emscripten no processes
+// needs-unwind
+// ignore-emscripten "RuntimeError" junk in output
 #![feature(c_unwind)]
 
 extern "C" fn panic_in_ffi() {

--- a/tests/ui/panics/panic-in-ffi.run.stderr
+++ b/tests/ui/panics/panic-in-ffi.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/panic-in-ffi.rs:10:5:
+thread 'main' panicked at $DIR/panic-in-ffi.rs:12:5:
 Test
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'main' panicked at library/core/src/panicking.rs:126:5:

--- a/tests/ui/panics/panic-in-ffi.run.stderr
+++ b/tests/ui/panics/panic-in-ffi.run.stderr
@@ -1,0 +1,7 @@
+thread 'main' panicked at $DIR/panic-in-ffi.rs:10:5:
+Test
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+thread 'main' panicked at library/core/src/panicking.rs:126:5:
+panic in a function that cannot unwind
+stack backtrace:
+thread caused non-unwinding panic. aborting.


### PR DESCRIPTION
With this, the output on double-panic becomes something like that:
```
thread 'main' panicked at src/tools/miri/tests/fail/panic/double_panic.rs:15:5:
first
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at src/tools/miri/tests/fail/panic/double_panic.rs:10:9:
second
stack backtrace:
   0:           0xbe273a - std::backtrace_rs::backtrace::miri::trace_unsynchronized::<&mut [closure@std::sys_common::backtrace::_print_fmt::{closure#1}]>
                               at /home/r/src/rust/rustc.3/library/std/src/../../backtrace/src/backtrace/miri.rs:99:5
   1:           0xbe22e6 - std::backtrace_rs::backtrace::miri::trace::<&mut [closure@std::sys_common::backtrace::_print_fmt::{closure#1}]>
                               at /home/r/src/rust/rustc.3/library/std/src/../../backtrace/src/backtrace/miri.rs:62:14
   2:           0xbe1086 - std::backtrace_rs::backtrace::trace_unsynchronized::<[closure@std::sys_common::backtrace::_print_fmt::{closure#1}]>
                               at /home/r/src/rust/rustc.3/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   3:           0xba3afd - std::sys_common::backtrace::_print_fmt
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:67:5
   4:           0xba2471 - <std::sys_common::backtrace::_print::DisplayBacktrace as std::fmt::Display>::fmt
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:44:22
   5:           0xbcf754 - core::fmt::rt::Argument::<'_>::fmt
                               at /home/r/src/rust/rustc.3/library/core/src/fmt/rt.rs:138:9
   6:           0x9b8f81 - std::fmt::write
                               at /home/r/src/rust/rustc.3/library/core/src/fmt/mod.rs:1094:17
   7:           0x21391d - <std::sys::unix::stdio::Stderr as std::io::Write>::write_fmt
                               at /home/r/src/rust/rustc.3/library/std/src/io/mod.rs:1714:15
   8:           0xba37b1 - std::sys_common::backtrace::_print
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:47:5
   9:           0xba365b - std::sys_common::backtrace::print
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:34:9
  10:           0x143c67 - std::panic_hook_with_disk_dump::{closure#1}
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:278:22
  11:           0x144187 - std::panic_hook_with_disk_dump
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:312:9
  12:           0x143659 - std::panicking::default_hook
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:239:5
  13:           0x1482a7 - std::panicking::rust_panic_with_hook
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:729:13
  14:           0x1475d5 - std::rt::begin_panic::<&str>::{closure#0}
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:650:9
  15:           0xba496a - std::sys_common::backtrace::__rust_end_short_backtrace::<[closure@std::rt::begin_panic<&str>::{closure#0}], !>
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:170:18
  16:           0x147599 - std::rt::begin_panic::<&str>
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:649:12
  17:            0x31916 - <Foo as std::ops::Drop>::drop
                               at src/tools/miri/tests/fail/panic/double_panic.rs:10:9
  18:           0x1a2b5e - std::ptr::drop_in_place::<Foo> - shim(Some(Foo))
                               at /home/r/src/rust/rustc.3/library/core/src/ptr/mod.rs:497:1
  19:            0x202bf - main
                               at src/tools/miri/tests/fail/panic/double_panic.rs:16:1
  20:            0xcc6a8 - <fn() as std::ops::FnOnce<()>>::call_once - shim(fn())
                               at /home/r/src/rust/rustc.3/library/core/src/ops/function.rs:250:5
  21:           0xba47d9 - std::sys_common::backtrace::__rust_begin_short_backtrace::<fn(), ()>
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:154:18
  22:           0x141a6a - std::rt::lang_start::<()>::{closure#0}
                               at /home/r/src/rust/rustc.3/library/std/src/rt.rs:166:18
  23:            0xcca18 - std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once
                               at /home/r/src/rust/rustc.3/library/core/src/ops/function.rs:284:13
  24:           0x146469 - std::panicking::try::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:524:40
  25:           0x145e09 - std::panicking::try::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:488:19
  26:            0x7b0ac - std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
                               at /home/r/src/rust/rustc.3/library/std/src/panic.rs:142:14
  27:           0x14189b - std::rt::lang_start_internal::{closure#2}
                               at /home/r/src/rust/rustc.3/library/std/src/rt.rs:148:48
  28:           0x146481 - std::panicking::try::do_call::<[closure@std::rt::lang_start_internal::{closure#2}], isize>
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:524:40
  29:           0x145e2c - std::panicking::try::<isize, [closure@std::rt::lang_start_internal::{closure#2}]>
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:488:19
  30:            0x7b0d5 - std::panic::catch_unwind::<[closure@std::rt::lang_start_internal::{closure#2}], isize>
                               at /home/r/src/rust/rustc.3/library/std/src/panic.rs:142:14
  31:           0x1418b0 - std::rt::lang_start_internal
                               at /home/r/src/rust/rustc.3/library/std/src/rt.rs:148:20
  32:           0x141a97 - std::rt::lang_start::<()>
                               at /home/r/src/rust/rustc.3/library/std/src/rt.rs:165:17
thread 'main' panicked at /home/r/src/rust/rustc.3/library/core/src/panicking.rs:126:5:
panic in a destructor during cleanup
stack backtrace:
   0:           0xe9f6d7 - std::backtrace_rs::backtrace::miri::trace_unsynchronized::<&mut [closure@std::sys_common::backtrace::_print_fmt::{closure#1}]>
                               at /home/r/src/rust/rustc.3/library/std/src/../../backtrace/src/backtrace/miri.rs:99:5
   1:           0xe9f27d - std::backtrace_rs::backtrace::miri::trace::<&mut [closure@std::sys_common::backtrace::_print_fmt::{closure#1}]>
                               at /home/r/src/rust/rustc.3/library/std/src/../../backtrace/src/backtrace/miri.rs:62:14
   2:           0xe9e016 - std::backtrace_rs::backtrace::trace_unsynchronized::<[closure@std::sys_common::backtrace::_print_fmt::{closure#1}]>
                               at /home/r/src/rust/rustc.3/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   3:           0xba3afd - std::sys_common::backtrace::_print_fmt
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:67:5
   4:           0xba2471 - <std::sys_common::backtrace::_print::DisplayBacktrace as std::fmt::Display>::fmt
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:44:22
   5:           0xbcf754 - core::fmt::rt::Argument::<'_>::fmt
                               at /home/r/src/rust/rustc.3/library/core/src/fmt/rt.rs:138:9
   6:           0x9b8f81 - std::fmt::write
                               at /home/r/src/rust/rustc.3/library/core/src/fmt/mod.rs:1094:17
   7:           0x4d0895 - <std::sys::unix::stdio::Stderr as std::io::Write>::write_fmt
                               at /home/r/src/rust/rustc.3/library/std/src/io/mod.rs:1714:15
   8:           0xba37b1 - std::sys_common::backtrace::_print
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:47:5
   9:           0xba365b - std::sys_common::backtrace::print
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:34:9
  10:           0x400bd4 - std::panic_hook_with_disk_dump::{closure#1}
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:278:22
  11:           0x144187 - std::panic_hook_with_disk_dump
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:312:9
  12:           0x143659 - std::panicking::default_hook
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:239:5
  13:           0x1482a7 - std::panicking::rust_panic_with_hook
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:729:13
  14:           0x40403b - std::panicking::begin_panic_handler::{closure#0}
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:619:13
  15:           0xe618b3 - std::sys_common::backtrace::__rust_end_short_backtrace::<[closure@std::panicking::begin_panic_handler::{closure#0}], !>
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:170:18
  16:           0x403fc8 - std::panicking::begin_panic_handler
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:617:5
  17:           0xee23e9 - core::panicking::panic_nounwind_fmt
                               at /home/r/src/rust/rustc.3/library/core/src/panicking.rs:96:14
  18:           0xee29e6 - core::panicking::panic_nounwind
                               at /home/r/src/rust/rustc.3/library/core/src/panicking.rs:126:5
  19:           0xee365e - core::panicking::panic_in_cleanup
                               at /home/r/src/rust/rustc.3/library/core/src/panicking.rs:206:5
  20:            0x2028a - main
                               at src/tools/miri/tests/fail/panic/double_panic.rs:13:1
  21:           0x3895ee - <fn() as std::ops::FnOnce<()>>::call_once - shim(fn())
                               at /home/r/src/rust/rustc.3/library/core/src/ops/function.rs:250:5
  22:           0xe61725 - std::sys_common::backtrace::__rust_begin_short_backtrace::<fn(), ()>
                               at /home/r/src/rust/rustc.3/library/std/src/sys_common/backtrace.rs:154:18
  23:           0x3fe9aa - std::rt::lang_start::<()>::{closure#0}
                               at /home/r/src/rust/rustc.3/library/std/src/rt.rs:166:18
  24:           0x389962 - std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once
                               at /home/r/src/rust/rustc.3/library/core/src/ops/function.rs:284:13
  25:           0x4033b9 - std::panicking::try::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:524:40
  26:           0x402d58 - std::panicking::try::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:488:19
  27:           0x337ff7 - std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
                               at /home/r/src/rust/rustc.3/library/std/src/panic.rs:142:14
  28:           0x3fe7e7 - std::rt::lang_start_internal::{closure#2}
                               at /home/r/src/rust/rustc.3/library/std/src/rt.rs:148:48
  29:           0x4033d6 - std::panicking::try::do_call::<[closure@std::rt::lang_start_internal::{closure#2}], isize>
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:524:40
  30:           0x402d7f - std::panicking::try::<isize, [closure@std::rt::lang_start_internal::{closure#2}]>
                               at /home/r/src/rust/rustc.3/library/std/src/panicking.rs:488:19
  31:           0x338028 - std::panic::catch_unwind::<[closure@std::rt::lang_start_internal::{closure#2}], isize>
                               at /home/r/src/rust/rustc.3/library/std/src/panic.rs:142:14
  32:           0x1418b0 - std::rt::lang_start_internal
                               at /home/r/src/rust/rustc.3/library/std/src/rt.rs:148:20
  33:           0x3fe9dc - std::rt::lang_start::<()>
                               at /home/r/src/rust/rustc.3/library/std/src/rt.rs:165:17
thread caused non-unwinding panic. aborting.
```
If we also land https://github.com/rust-lang/rust/pull/115020, the 2nd backtrace disappears, hopefully making the "panic in a destructor during cleanup" easier to see.

Fixes https://github.com/rust-lang/rust/issues/114954.