### PR TITLE
add codegen test for the move before passing to nocapture, by shared-ref arg

### DIFF
--- a/tests/codegen/move-before-nocapture-ref-arg.rs
+++ b/tests/codegen/move-before-nocapture-ref-arg.rs
@@ -1,0 +1,22 @@
+// Verify that move before the call of the function with noalias, nocapture, readonly.
+// #107436
+// compile-flags: -O
+// min-llvm-version: 17
+
+#![crate_type = "lib"]
+
+#[repr(C)]
+pub struct ThreeSlices<'a>(&'a [u32], &'a [u32], &'a [u32]);
+
+#[no_mangle]
+pub fn sum_slices(val: ThreeSlices) -> u32 {
+    // CHECK-NOT: memcpy
+    let val = val;
+    sum(&val)
+}
+
+#[no_mangle]
+#[inline(never)]
+pub fn sum(val: &ThreeSlices) -> u32 {
+    val.0.iter().sum::<u32>() + val.1.iter().sum::<u32>() + val.2.iter().sum::<u32>()
+}


### PR DESCRIPTION
This PR adds codegen test for https://github.com/rust-lang/rust/issues/107436#issuecomment-1685792517 (It seems like this works from llvm-16?)

Fixes #107436
