### PR TITLE
Fix syntax in E0191 explanation.

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0191.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0191.md
@@ -7,8 +7,8 @@ trait Trait {
     type Bar;
 }
 
-type Foo = Trait; // error: the value of the associated type `Bar` (from
-                  //        the trait `Trait`) must be specified
+type Foo = dyn Trait; // error: the value of the associated type `Bar` (from
+                      //        the trait `Trait`) must be specified
 ```
 
 Trait objects need to have all associated types specified. Please verify that
@@ -20,5 +20,5 @@ trait Trait {
     type Bar;
 }
 
-type Foo = Trait<Bar=i32>; // ok!
+type Foo = dyn Trait<Bar=i32>; // ok!
 ```


### PR DESCRIPTION
This trait needs `dyn` in modern Rust.

Fixes #115042.