### PR TITLE
docs: add alias log1p to ln_1p

### DIFF
--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -822,6 +822,7 @@ impl f32 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[doc(alias = "log1p")]
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -822,6 +822,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-20);
     /// ```
+    #[doc(alias = "log1p")]
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This is what the function is called in several other languages:

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p
* https://numpy.org/doc/stable/reference/generated/numpy.log1p.html
* https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/log1p-log1pf-log1pl2?view=msvc-170

It also confused people at URLO: https://users.rust-lang.org/t/64-bit-trigonometry/98599/27

Similar to:

* https://github.com/rust-lang/rust/pull/114971
* https://github.com/rust-lang/rust/pull/114977