### PR TITLE
rustdoc: use unicode-aware checks for redundant explicit link fastpath

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1430,20 +1430,15 @@ impl LinkCollector<'_, '_> {
         // Otherwise, check if 2 links are same, if so, skip the resolve process.
         //
         // Notice that this algorithm is passive, might possibly miss actual redudant cases.
-        let explicit_link = &explicit_link.to_string();
+        let explicit_link = explicit_link.to_string();
         let display_text = ori_link.display_text.as_ref().unwrap();
-        let display_len = display_text.len();
-        let explicit_len = explicit_link.len();
 
-        if display_len == explicit_len {
+        if display_text.len() == explicit_link.len() {
             // Whether they are same or not, skip the resolve process.
             return;
         }
 
-        if (explicit_len >= display_len
-            && &explicit_link[(explicit_len - display_len)..] == display_text)
-            || (display_len >= explicit_len
-                && &display_text[(display_len - explicit_len)..] == explicit_link)
+        if explicit_link.ends_with(&display_text[..]) || display_text.ends_with(&explicit_link[..])
         {
             self.resolve_with_disambiguator_cached(
                 display_res_info,

--- a/src/librustdoc/passes/lint/redundant_explicit_links.rs
+++ b/src/librustdoc/passes/lint/redundant_explicit_links.rs
@@ -98,13 +98,8 @@ fn check_redundant_explicit_link<'md>(
 
                 let explicit_link = dest.to_string();
                 let display_link = link_data.resolvable_link.clone()?;
-                let explicit_len = explicit_link.len();
-                let display_len = display_link.len();
 
-                if (explicit_len >= display_len
-                    && &explicit_link[(explicit_len - display_len)..] == display_link)
-                    || (display_len >= explicit_len
-                        && &display_link[(display_len - explicit_len)..] == explicit_link)
+                if explicit_link.ends_with(&display_link) || display_link.ends_with(&explicit_link)
                 {
                     match link_type {
                         LinkType::Inline | LinkType::ReferenceUnknown => {

--- a/tests/rustdoc-ui/lints/redundant_explicit_links-utf8.rs
+++ b/tests/rustdoc-ui/lints/redundant_explicit_links-utf8.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+/// [`…foo`] [`…bar`] [`Err`]
+pub struct Broken {}
+
+/// [`…`] [`…`] [`Err`]
+pub struct Broken2 {}
+
+/// [`…`][…] [`…`][…] [`Err`]
+pub struct Broken3 {}
+
+/// […………………………][Broken3]
+pub struct Broken4 {}
+
+/// [Broken3][…………………………]
+pub struct Broken5 {}
+
+pub struct Err;


### PR DESCRIPTION
Fixes #115064
Fixes #115062
Fixes #115116