### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0191.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0191.md
@@ -7,8 +7,8 @@ trait Trait {
     type Bar;
 }
 
-type Foo = Trait; // error: the value of the associated type `Bar` (from
-                  //        the trait `Trait`) must be specified
+type Foo = dyn Trait; // error: the value of the associated type `Bar` (from
+                      //        the trait `Trait`) must be specified
 ```
 
 Trait objects need to have all associated types specified. Please verify that
@@ -20,5 +20,5 @@ trait Trait {
     type Bar;
 }
 
-type Foo = Trait<Bar=i32>; // ok!
+type Foo = dyn Trait<Bar=i32>; // ok!
 ```

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -1,6 +1,6 @@
 //! Module that implements the public interface to the Stable MIR.
 //!
-//! This module shall contain all type definitions and APIs that we expect 3P tools to invoke to
+//! This module shall contain all type definitions and APIs that we expect third-party tools to invoke to
 //! interact with the compiler.
 //!
 //! The goal is to eventually move this module to its own crate which shall be published on

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -822,6 +822,7 @@ impl f32 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[doc(alias = "log1p")]
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -822,6 +822,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-20);
     /// ```
+    #[doc(alias = "log1p")]
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Successful merges:

 - #115044 (stable_mir: docs clarification)
 - #115054 (Fix syntax in E0191 explanation.)
 - #115067 (docs: add alias log1p to ln_1p)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115044,115054,115067)
<!-- homu-ignore:end -->