### PR TITLE
Remove myself from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -505,7 +505,6 @@ compiler-team-contributors = [
     "@TaKO8Ki",
     "@WaffleLapkin",
     "@b-naber",
-    "@fee1-dead",
 ]
 compiler = [
     "compiler-team",


### PR DESCRIPTION
I'll.. still be around, just not as active as I had been. I'm not adding myself to `users_on_vacation`, because anyone should still feel free to r? me if they want a specific review from me. 