### PR TITLE
Always use `os-release` rather than `/lib` to detect `NixOS` (bootstrap)

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -644,7 +644,7 @@ class RustBuild(object):
                 return False
 
             # If the user has asked binaries to be patched for Nix, then
-            # don't check for NixOS or `/lib`.
+            # don't check for NixOS.
             if self.get_toml("patch-binaries-for-nix", "build") == "true":
                 return True
 
@@ -652,14 +652,9 @@ class RustBuild(object):
             # The latter one does not exist on NixOS when using tmpfs as root.
             try:
                 with open("/etc/os-release", "r") as f:
-                    if not any(ln.strip() in ("ID=nixos", "ID='nixos'", 'ID="nixos"') for ln in f):
-                        return False
+                    return any(ln.strip() in ("ID=nixos", "ID='nixos'", 'ID="nixos"') for ln in f)
             except FileNotFoundError:
                 return False
-            if os.path.exists("/lib"):
-                return False
-
-            return True
 
         answer = self._should_fix_bins_and_dylibs = get_answer()
         if answer:

--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -105,7 +105,7 @@ impl Config {
                     matches!(l.trim(), "ID=nixos" | "ID='nixos'" | "ID=\"nixos\"")
                 }),
             };
-            is_nixos && !Path::new("/lib").exists()
+            is_nixos
         });
         if val {
             eprintln!("info: You seem to be using Nix.");


### PR DESCRIPTION
[Two users over on zulip](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Bootstrapping.20on.20NixOS) bumped into issues where NixOS wasn't being properly detected.

I believe this was caused by the presence of `/lib` on their machines. `/lib` is not standard on NixOS but can still be created by users or scripts.

We are already checking `/etc/os-release`. The presence of `ID=nixos` in it's output should be trustworthy and we shouldn't then go on to also check for `/lib`. 