### PR TITLE
rust-gdbgui: remove excessive quotes

### DIFF
--- a/src/etc/rust-gdbgui
+++ b/src/etc/rust-gdbgui
@@ -55,9 +55,9 @@ RUST_GDBGUI="${RUST_GDBGUI:-gdbgui}"
 
 # These arguments get passed through to GDB and make it load the
 # Rust pretty printers.
-GDB_ARGS="--directory=\"$GDB_PYTHON_MODULE_DIRECTORY\"" \
-   "-iex \"add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY\"" \
-   "-iex \"set substitute-path /rustc/$RUSTC_COMMIT_HASH $RUSTC_SYSROOT/lib/rustlib/src/rust\""
+GDB_ARGS="--directory=\"$GDB_PYTHON_MODULE_DIRECTORY\" \
+   -iex \"add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY\" \
+   -iex \"set substitute-path /rustc/$RUSTC_COMMIT_HASH $RUSTC_SYSROOT/lib/rustlib/src/rust\""
 
 # Finally we execute gdbgui.
 PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" \


### PR DESCRIPTION
Removes the extra quotes introduced in commit https://github.com/rust-lang/rust/commit/8dd0ec6de7c8473e5730972c4e6206d5fb47b4e6.
Modified script tested and now works on Ubuntu w/ `dash`.

Fixes https://github.com/rust-lang/rust/issues/115097
