### PR TITLE
triagebot: add dependency licensing pings

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -470,6 +470,10 @@ Otherwise, you can ignore this comment.
 [mentions."src/tools/x"]
 message = "`src/tools/x` was changed. Bump version of Cargo.toml in `src/tools/x` so tidy will suggest installing the new version."
 
+[mentions."src/tools/tidy/src/deps.rs"]
+message = "Third-party dependency whitelist may have been modified! You must ensure that any new dependencies have compatible licenses before merging."
+cc = ["@davidtwco", "@wesleywiser"]
+
 [mentions."src/bootstrap/defaults/config.compiler.toml"]
 message = "This PR changes src/bootstrap/defaults/config.compiler.toml. If appropriate, please also update `config.codegen.toml` so the defaults are in sync."
 [mentions."src/bootstrap/defaults/config.codegen.toml"]


### PR DESCRIPTION
If a compiler dependency is added, it's probably worth having that double-checked by compiler co-leads to confirm the licensing is okay.

r? @wesleywiser 