### PR TITLE
ArchiveWrapper: handle LLVM API update

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/ArchiveWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/ArchiveWrapper.cpp
@@ -203,7 +203,12 @@ LLVMRustWriteArchive(char *Dst, size_t NumMembers,
     }
   }
 
+#if LLVM_VERSION_LT(18, 0)
   auto Result = writeArchive(Dst, Members, WriteSymbtab, Kind, true, false);
+#else
+  auto SymtabMode = WriteSymbtab ? SymtabWritingMode::NormalSymtab : SymtabWritingMode::NoSymtab;
+  auto Result = writeArchive(Dst, Members, SymtabMode, Kind, true, false);
+#endif
   if (!Result)
     return LLVMRustResult::Success;
   LLVMRustSetLastError(toString(std::move(Result)).c_str());


### PR DESCRIPTION
In llvm/llvm-project@f740bcb3707a17ed4ccd52157089011a586cc2a6 a boolean parameter changed to an enum.

r? @nikic
@rustbot label: +llvm-main