### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/ArchiveWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/ArchiveWrapper.cpp
@@ -203,7 +203,12 @@ LLVMRustWriteArchive(char *Dst, size_t NumMembers,
     }
   }
 
+#if LLVM_VERSION_LT(18, 0)
   auto Result = writeArchive(Dst, Members, WriteSymbtab, Kind, true, false);
+#else
+  auto SymtabMode = WriteSymbtab ? SymtabWritingMode::NormalSymtab : SymtabWritingMode::NoSymtab;
+  auto Result = writeArchive(Dst, Members, SymtabMode, Kind, true, false);
+#endif
   if (!Result)
     return LLVMRustResult::Success;
   LLVMRustSetLastError(toString(std::move(Result)).c_str());

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -90,7 +90,11 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> Body<'
     };
     debug!("make_shim({:?}) = untransformed {:?}", instance, result);
 
-    pm::run_passes(
+    // We don't validate MIR here because the shims may generate code that's
+    // only valid in a reveal-all param-env. However, since we do initial
+    // validation with the MirBuilt phase, which uses a user-facing param-env.
+    // This causes validation errors when TAITs are involved.
+    pm::run_passes_no_validate(
         tcx,
         &mut result,
         &[

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1276,7 +1276,8 @@ impl Config {
         }
 
         config.initial_rustc = if let Some(rustc) = build.rustc {
-            config.check_build_rustc_version(&rustc);
+            // FIXME(#115065): re-enable this check
+            // config.check_build_rustc_version(&rustc);
             PathBuf::from(rustc)
         } else {
             config.download_beta_toolchain();

--- a/tests/codegen/box-uninit-bytes.rs
+++ b/tests/codegen/box-uninit-bytes.rs
@@ -25,6 +25,20 @@ pub fn box_uninitialized2() -> Box<MaybeUninit<[usize; 1024 * 1024]>> {
     Box::new(MaybeUninit::uninit())
 }
 
+#[repr(align(1024))]
+pub struct LotsaPadding(usize);
+
+// Boxing a value with padding should not copy junk from the stack
+#[no_mangle]
+pub fn box_lotsa_padding() -> Box<LotsaPadding> {
+    // CHECK-LABEL: @box_lotsa_padding
+    // CHECK-NOT: alloca
+    // CHECK-NOT: getelementptr
+    // CHECK-NOT: memcpy
+    // CHECK-NOT: memset
+    Box::new(LotsaPadding(42))
+}
+
 // Hide the `allocalign` attribute in the declaration of __rust_alloc
 // from the CHECK-NOT above, and also verify the attributes got set reasonably.
 // CHECK: declare {{(dso_local )?}}noalias noundef ptr @__rust_alloc(i{{[0-9]+}} noundef, i{{[0-9]+}} allocalign noundef) unnamed_addr [[RUST_ALLOC_ATTRS:#[0-9]+]]

--- a/tests/ui/type-alias-impl-trait/auxiliary/drop-shim-relates-opaque-aux.rs
+++ b/tests/ui/type-alias-impl-trait/auxiliary/drop-shim-relates-opaque-aux.rs
@@ -1,0 +1,21 @@
+// crate foo
+
+#![feature(type_alias_impl_trait)]
+
+type Tait = impl Sized;
+fn _constrain() -> Tait {}
+
+struct WrapperWithDrop<T>(T);
+impl<T> Drop for WrapperWithDrop<T> {
+    fn drop(&mut self) {}
+}
+
+pub struct Foo(WrapperWithDrop<Tait>);
+
+trait Id {
+    type Id: ?Sized;
+}
+impl<T: ?Sized> Id for T {
+    type Id = T;
+}
+pub struct Bar(WrapperWithDrop<<Tait as Id>::Id>);

--- a/tests/ui/type-alias-impl-trait/drop-shim-relates-opaque-issue-114375.rs
+++ b/tests/ui/type-alias-impl-trait/drop-shim-relates-opaque-issue-114375.rs
@@ -1,0 +1,10 @@
+// aux-build:drop-shim-relates-opaque-aux.rs
+// compile-flags: -Zvalidate-mir --crate-type=lib
+// build-pass
+
+extern crate drop_shim_relates_opaque_aux;
+
+pub fn drop_foo(_: drop_shim_relates_opaque_aux::Foo) {}
+pub fn drop_bar(_: drop_shim_relates_opaque_aux::Bar) {}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #115005 (Don't do intra-pass validation on MIR shims)
 - #115096 (Add regression test for not `memcpy`ing padding bytes)
 - #115103 (Disable bootstrap rustc version check)
 - #115106 (ArchiveWrapper: handle LLVM API update)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115005,115096,115103,115106)
<!-- homu-ignore:end -->