### PR TITLE
compile rust-anaylzer with `x check` if it's enabled

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -353,10 +353,17 @@ pub struct RustAnalyzer {
 impl Step for RustAnalyzer {
     type Output = ();
     const ONLY_HOSTS: bool = true;
-    const DEFAULT: bool = false;
+    const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path("src/tools/rust-analyzer")
+        let builder = run.builder;
+        run.path("src/tools/rust-analyzer").default_condition(
+            builder
+                .config
+                .tools
+                .as_ref()
+                .map_or(true, |tools| tools.iter().any(|tool| tool == "rust-analyzer")),
+        )
     }
 
     fn make_run(run: RunConfig<'_>) {


### PR DESCRIPTION
By default, `x check` doesn't compile the rust-analyzer. But when it's enabled in the config's tools section, there's no reason not to do it. This change allows `x check` to compile rust-analyzer if it's enabled in config's tools section.

Helps to #115031