### PR TITLE
kmc-solid: Import `std::sync::PoisonError` in `std::sys::solid::os`

### DIFF
--- a/library/std/src/sys/solid/os.rs
+++ b/library/std/src/sys/solid/os.rs
@@ -8,7 +8,7 @@ use crate::os::{
     solid::ffi::{OsStrExt, OsStringExt},
 };
 use crate::path::{self, PathBuf};
-use crate::sync::RwLock;
+use crate::sync::{PoisonError, RwLock};
 use crate::sys::common::small_c_string::run_with_cstr;
 use crate::vec;
 


### PR DESCRIPTION
Follow-up to #114968. Fixes a missing import in [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html) Tier 3 targets.

```
 error[E0433]: failed to resolve: use of undeclared type `PoisonError`
 C:\Users\xxxxx\.rustup\toolchains\nightly-2023-08-23-x86_64-pc-windows-gnu\lib\rustlib\src\rust\library\std\src\sys\solid\os.rs(85,36)
   |
85 |     ENV_LOCK.read().unwrap_or_else(PoisonError::into_inner)
   |                                    ^^^^^^^^^^^ use of undeclared type `PoisonError`
   |
```