### PR TITLE
Use !exclude metadata instead of module-level inline asm

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -830,29 +830,6 @@ pub(crate) unsafe fn codegen(
     ))
 }
 
-fn create_section_with_flags_asm(section_name: &str, section_flags: &str, data: &[u8]) -> Vec<u8> {
-    let mut asm = format!(".section {section_name},\"{section_flags}\"\n").into_bytes();
-    asm.extend_from_slice(b".ascii \"");
-    asm.reserve(data.len());
-    for &byte in data {
-        if byte == b'\\' || byte == b'"' {
-            asm.push(b'\\');
-            asm.push(byte);
-        } else if byte < 0x20 || byte >= 0x80 {
-            // Avoid non UTF-8 inline assembly. Use octal escape sequence, because it is fixed
-            // width, while hex escapes will consume following characters.
-            asm.push(b'\\');
-            asm.push(b'0' + ((byte >> 6) & 0x7));
-            asm.push(b'0' + ((byte >> 3) & 0x7));
-            asm.push(b'0' + ((byte >> 0) & 0x7));
-        } else {
-            asm.push(byte);
-        }
-    }
-    asm.extend_from_slice(b"\"\n");
-    asm
-}
-
 /// Embed the bitcode of an LLVM module in the LLVM module itself.
 ///
 /// This is done primarily for iOS where it appears to be standard to compile C
@@ -909,64 +886,55 @@ unsafe fn embed_bitcode(
     //
     // * XCOFF - AIX linker ignores content in .ipa and .info if no auxiliary
     //   symbol associated with these sections.
-    //
-    // Unfortunately, LLVM provides no way to set custom section flags. For ELF
-    // and COFF we emit the sections using module level inline assembly for that
-    // reason (see issue #90326 for historical background).
+    let set_global_properties = |g: &llvm::Value| {
+        llvm::LLVMSetGlobalConstant(g, llvm::True);
+        llvm::LLVMRustSetLinkage(g, llvm::Linkage::PrivateLinkage);
+        llvm::LLVMGlobalSetMetadata(
+            g,
+            llvm::MD_exclude as c_uint,
+            llvm::LLVMValueAsMetadata(llvm::LLVMMDNodeInContext(llcx, std::ptr::null(), 0)),
+        );
+    };
+
     let is_aix = cgcx.opts.target_triple.triple().contains("-aix");
     let is_apple = cgcx.opts.target_triple.triple().contains("-ios")
         || cgcx.opts.target_triple.triple().contains("-darwin")
         || cgcx.opts.target_triple.triple().contains("-tvos")
         || cgcx.opts.target_triple.triple().contains("-watchos");
-    if is_apple
-        || is_aix
-        || cgcx.opts.target_triple.triple().starts_with("wasm")
-        || cgcx.opts.target_triple.triple().starts_with("asmjs")
-    {
-        // We don't need custom section flags, create LLVM globals.
-        let llconst = common::bytes_in_context(llcx, bitcode);
-        let llglobal = llvm::LLVMAddGlobal(
-            llmod,
-            common::val_ty(llconst),
-            "rustc.embedded.module\0".as_ptr().cast(),
-        );
-        llvm::LLVMSetInitializer(llglobal, llconst);
+    let llconst = common::bytes_in_context(llcx, bitcode);
+    let llglobal = llvm::LLVMAddGlobal(
+        llmod,
+        common::val_ty(llconst),
+        "rustc.embedded.module\0".as_ptr().cast(),
+    );
+    llvm::LLVMSetInitializer(llglobal, llconst);
 
-        let section = if is_apple {
-            "__LLVM,__bitcode\0"
-        } else if is_aix {
-            ".ipa\0"
-        } else {
-            ".llvmbc\0"
-        };
-        llvm::LLVMSetSection(llglobal, section.as_ptr().cast());
-        llvm::LLVMRustSetLinkage(llglobal, llvm::Linkage::PrivateLinkage);
-        llvm::LLVMSetGlobalConstant(llglobal, llvm::True);
-
-        let llconst = common::bytes_in_context(llcx, cmdline.as_bytes());
-        let llglobal = llvm::LLVMAddGlobal(
-            llmod,
-            common::val_ty(llconst),
-            "rustc.embedded.cmdline\0".as_ptr().cast(),
-        );
-        llvm::LLVMSetInitializer(llglobal, llconst);
-        let section = if is_apple {
-            "__LLVM,__cmdline\0"
-        } else if is_aix {
-            ".info\0"
-        } else {
-            ".llvmcmd\0"
-        };
-        llvm::LLVMSetSection(llglobal, section.as_ptr().cast());
-        llvm::LLVMRustSetLinkage(llglobal, llvm::Linkage::PrivateLinkage);
+    let section = if is_apple {
+        "__LLVM,__bitcode\0"
+    } else if is_aix {
+        ".ipa\0"
     } else {
-        // We need custom section flags, so emit module-level inline assembly.
-        let section_flags = if cgcx.is_pe_coff { "n" } else { "e" };
-        let asm = create_section_with_flags_asm(".llvmbc", section_flags, bitcode);
-        llvm::LLVMAppendModuleInlineAsm(llmod, asm.as_ptr().cast(), asm.len());
-        let asm = create_section_with_flags_asm(".llvmcmd", section_flags, cmdline.as_bytes());
-        llvm::LLVMAppendModuleInlineAsm(llmod, asm.as_ptr().cast(), asm.len());
-    }
+        ".llvmbc\0"
+    };
+    llvm::LLVMSetSection(llglobal, section.as_ptr().cast());
+    set_global_properties(llglobal);
+
+    let llconst = common::bytes_in_context(llcx, cmdline.as_bytes());
+    let llglobal = llvm::LLVMAddGlobal(
+        llmod,
+        common::val_ty(llconst),
+        "rustc.embedded.cmdline\0".as_ptr().cast(),
+    );
+    llvm::LLVMSetInitializer(llglobal, llconst);
+    let section = if is_apple {
+        "__LLVM,__cmdline\0"
+    } else if is_aix {
+        ".info\0"
+    } else {
+        ".llvmcmd\0"
+    };
+    llvm::LLVMSetSection(llglobal, section.as_ptr().cast());
+    set_global_properties(llglobal);
 }
 
 // Create a `__imp_<symbol> = &symbol` global for every public static `symbol`.

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -427,6 +427,7 @@ pub enum MetadataType {
     MD_type = 19,
     MD_vcall_visibility = 28,
     MD_noundef = 29,
+    MD_exclude = 33,
     MD_kcfi_type = 36,
 }
 


### PR DESCRIPTION
LLVM 15 added support for !exclude metadata on globals for setting the SHF_EXCLUDE / IMAGE_SCN_LNK_REMOVE section flags in ELF / COFF. As such, we no longer need the special case for embedding bitcode using module-level inline assembly.

r? @cuviper 