### PR TITLE
tests: re-enable pretty-std-collections on macOS

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1430,6 +1430,15 @@ impl<'test> TestCx<'test> {
             "^core::num::([a-z_]+::)*NonZero.+$",
         ];
 
+        // In newer versions of lldb, persistent results (the `$N =` part at the start of
+        // expressions you have evaluated that let you re-use the result) aren't printed, but lots
+        // of rustc's debuginfo tests rely on these, so re-enable this.
+        // See <https://reviews.llvm.org/rG385496385476fc9735da5fa4acabc34654e8b30d>.
+        script_str.push_str("command unalias print\n");
+        script_str.push_str("command alias print expr --\n");
+        script_str.push_str("command unalias p\n");
+        script_str.push_str("command alias p expr --\n");
+
         script_str
             .push_str(&format!("command script import {}\n", &rust_pp_module_abs_path[..])[..]);
         script_str.push_str("type synthetic add -l lldb_lookup.synthetic_lookup -x '.*' ");

--- a/tests/debuginfo/pretty-std-collections.rs
+++ b/tests/debuginfo/pretty-std-collections.rs
@@ -1,7 +1,6 @@
 // ignore-windows failing on win32 bot
 // ignore-freebsd: gdb package too new
 // ignore-android: FIXME(#10381)
-// ignore-macos: FIXME(#78665)
 // compile-flags:-g
 
 // The pretty printers being tested here require the patch from


### PR DESCRIPTION
Fixes #78665.

I made some small modifications to this test so that it would pass for me locally (though I was only able to test using lldb without built-in Rust support, but that seems to be the mode in which it would fail). I ran it a few hundred times with stage one and stage two to see if I could re-produce the spurious failures that were being reported in #78665 and couldn't. From the discussion in #78665, it seemed like this was related to Xcode versions and could be reproduced locally fairly easily. It's been a couple years since this was disabled so a lot has changed. If this starts failing spuriously again then we can disable it and I can look into that.

r? @wesleywiser (discussed in wg-debugging's triage meeting)