### PR TITLE
Rustdoc: Add unstable --no-html-source flag

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -273,6 +273,8 @@ pub(crate) struct RenderOptions {
     pub(crate) call_locations: AllCallLocations,
     /// If `true`, Context::init will not emit shared files.
     pub(crate) no_emit_shared: bool,
+    /// If `true`, HTML source code pages won't be generated.
+    pub(crate) html_no_source: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -686,6 +688,7 @@ impl Options {
         let generate_link_to_definition = matches.opt_present("generate-link-to-definition");
         let extern_html_root_takes_precedence =
             matches.opt_present("extern-html-root-takes-precedence");
+        let html_no_source = matches.opt_present("html-no-source");
 
         if generate_link_to_definition && (show_coverage || output_format != OutputFormat::Html) {
             diag.struct_err(
@@ -769,6 +772,7 @@ impl Options {
             generate_link_to_definition,
             call_locations,
             no_emit_shared: false,
+            html_no_source,
         };
         Ok((options, render_options))
     }

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -463,6 +463,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             generate_link_to_definition,
             call_locations,
             no_emit_shared,
+            html_no_source,
             ..
         } = options;
 
@@ -488,7 +489,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             scrape_examples_extension: !call_locations.is_empty(),
         };
         let mut issue_tracker_base_url = None;
-        let mut include_sources = true;
+        let mut include_sources = !html_no_source;
 
         // Crawl the crate attributes looking for attributes which control how we're
         // going to emit HTML

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -656,6 +656,9 @@ fn opts() -> Vec<RustcOptGroup> {
                 "[rust]",
             )
         }),
+        unstable("html-no-source", |o| {
+            o.optflag("", "html-no-source", "Disable HTML source code pages generation")
+        }),
     ]
 }
 

--- a/tests/run-make/issue-88756-default-output/output-default.stdout
+++ b/tests/run-make/issue-88756-default-output/output-default.stdout
@@ -191,6 +191,8 @@ Options:
                         removed, see issue #44136
                         <https://github.com/rust-lang/rust/issues/44136> for
                         more information
+        --html-no-source 
+                        Disable HTML source code pages generation
 
     @path               Read newline separated options from `path`
 

--- a/tests/rustdoc/html-no-source.rs
+++ b/tests/rustdoc/html-no-source.rs
@@ -1,0 +1,30 @@
+// compile-flags: -Zunstable-options --html-no-source
+
+// This test ensures that the `--html-no-source` flag disables
+// the creation of the `src` folder.
+
+#![feature(staged_api)]
+#![stable(feature = "bar", since = "1.0")]
+#![crate_name = "foo"]
+
+// Ensures that there is no items in the corresponding "src" folder.
+// @files 'src/foo' '[]'
+
+// @has foo/fn.foo.html
+// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · '
+// @!has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · source · '
+#[stable(feature = "bar", since = "1.0")]
+pub fn foo() {}
+
+// @has foo/struct.Bar.html
+// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · '
+// @!has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · source · '
+#[stable(feature = "bar", since = "1.0")]
+pub struct Bar;
+
+impl Bar {
+    // @has - '//*[@id="method.bar"]/*[@class="since rightside"]' '2.0'
+    // @!has - '//*[@id="method.bar"]/*[@class="rightside"]' '2.0 ·'
+    #[stable(feature = "foobar", since = "2.0")]
+    pub fn bar() {}
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/115060.

This is the equivalent of `#![doc(no_html_source)]` but on the command-line. It disables the generation of the source pages (and of the links pointing to them as well).

The motivation behind this is to enable to reduce documentation size when generating it in some locations without enforcing this to end users or adding a new feature to enable/disable the crate attribute.

r? @notriddle 