### PR TITLE
Do not convert copies of packed projections to moves.

### DIFF
--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -40,7 +40,7 @@ where
     }
 }
 
-fn is_within_packed<'tcx, L>(
+pub fn is_within_packed<'tcx, L>(
     tcx: TyCtxt<'tcx>,
     local_decls: &L,
     place: Place<'tcx>,

--- a/compiler/rustc_const_eval/src/util/mod.rs
+++ b/compiler/rustc_const_eval/src/util/mod.rs
@@ -5,7 +5,7 @@ mod check_validity_requirement;
 mod compare_types;
 mod type_name;
 
-pub use self::alignment::is_disaligned;
+pub use self::alignment::{is_disaligned, is_within_packed};
 pub use self::check_validity_requirement::check_validity_requirement;
 pub use self::compare_types::{is_equal_up_to_subtyping, is_subtype};
 pub use self::type_name::type_name;

--- a/tests/mir-opt/dead-store-elimination/call_arg_copy.move_packed.DeadStoreElimination.panic-abort.diff
+++ b/tests/mir-opt/dead-store-elimination/call_arg_copy.move_packed.DeadStoreElimination.panic-abort.diff
@@ -1,0 +1,15 @@
+- // MIR for `move_packed` before DeadStoreElimination
++ // MIR for `move_packed` after DeadStoreElimination
+  
+  fn move_packed(_1: Packed) -> () {
+      let mut _0: ();
+  
+      bb0: {
+          _0 = use_both(const 0_i32, (_1.1: i32)) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/dead-store-elimination/call_arg_copy.move_packed.DeadStoreElimination.panic-unwind.diff
+++ b/tests/mir-opt/dead-store-elimination/call_arg_copy.move_packed.DeadStoreElimination.panic-unwind.diff
@@ -1,0 +1,15 @@
+- // MIR for `move_packed` before DeadStoreElimination
++ // MIR for `move_packed` after DeadStoreElimination
+  
+  fn move_packed(_1: Packed) -> () {
+      let mut _0: ();
+  
+      bb0: {
+          _0 = use_both(const 0_i32, (_1.1: i32)) -> [return: bb1, unwind continue];
+      }
+  
+      bb1: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/dead-store-elimination/call_arg_copy.rs
+++ b/tests/mir-opt/dead-store-elimination/call_arg_copy.rs
@@ -2,6 +2,12 @@
 // unit-test: DeadStoreElimination
 // compile-flags: -Zmir-enable-passes=+CopyProp
 
+#![feature(core_intrinsics)]
+#![feature(custom_mir)]
+#![allow(internal_features)]
+
+use std::intrinsics::mir::*;
+
 #[inline(never)]
 fn use_both(_: i32, _: i32) {}
 
@@ -10,6 +16,26 @@ fn move_simple(x: i32) {
     use_both(x, x);
 }
 
+#[repr(packed)]
+struct Packed {
+    x: u8,
+    y: i32,
+}
+
+// EMIT_MIR call_arg_copy.move_packed.DeadStoreElimination.diff
+#[custom_mir(dialect = "analysis")]
+fn move_packed(packed: Packed) {
+    mir!(
+        {
+            Call(RET = use_both(0, packed.y), ret)
+        }
+        ret = {
+            Return()
+        }
+    )
+}
+
 fn main() {
     move_simple(1);
+    move_packed(Packed { x: 0, y: 1 });
 }


### PR DESCRIPTION
This code path was introduced in https://github.com/rust-lang/rust/pull/113758

After seeing https://rust-lang.zulipchat.com/#narrow/stream/136281-t-opsem/topic/Packed.20fields.20and.20in-place.20function.20argument.2Freturn.20passing, this may be UB, so should be disallowed.

This should not appear in normally-built MIR, which introduces temporary copies for packed projections.