### PR TITLE
Disable MIR SROA optimization by default

### DIFF
--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -12,7 +12,7 @@ pub struct ScalarReplacementOfAggregates;
 
 impl<'tcx> MirPass<'tcx> for ScalarReplacementOfAggregates {
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 2
+        sess.mir_opt_level() >= 3
     }
 
     #[instrument(level = "debug", skip(self, tcx, body))]

--- a/tests/incremental/hashes/match_expressions.rs
+++ b/tests/incremental/hashes/match_expressions.rs
@@ -227,7 +227,7 @@ pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
 
 // Ignore optimized_mir in cfail2, the only change to optimized MIR is a span.
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
 #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail6")]

--- a/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-abort.diff
@@ -33,36 +33,37 @@
 +                         debug ptr => _11;
 +                         scope 18 (inlined NonNull::<[u8]>::as_mut_ptr) {
 +                             debug self => _11;
-+                             let mut _15: std::ptr::NonNull<u8>;
++                             let mut _16: std::ptr::NonNull<u8>;
 +                             scope 19 (inlined NonNull::<[u8]>::as_non_null_ptr) {
 +                                 debug self => _11;
-+                                 let mut _16: *mut u8;
-+                                 let mut _17: *mut [u8];
++                                 let mut _17: *mut u8;
++                                 let mut _18: *mut [u8];
 +                                 scope 20 {
 +                                     scope 21 (inlined NonNull::<[u8]>::as_ptr) {
 +                                         debug self => _11;
-+                                         let mut _18: *const [u8];
++                                         let mut _19: *const [u8];
 +                                     }
 +                                     scope 22 (inlined ptr::mut_ptr::<impl *mut [u8]>::as_mut_ptr) {
-+                                         debug self => _17;
++                                         debug self => _18;
 +                                     }
 +                                     scope 23 (inlined NonNull::<u8>::new_unchecked) {
-+                                         debug ptr => _16;
-+                                         let mut _19: *const u8;
++                                         debug ptr => _17;
++                                         let mut _20: *const u8;
++                                         let mut _21: *mut u8;
 +                                         scope 24 {
 +                                             scope 25 (inlined NonNull::<T>::new_unchecked::runtime::<u8>) {
-+                                                 debug ptr => _16;
++                                                 debug ptr => _21;
 +                                                 scope 26 (inlined ptr::mut_ptr::<impl *mut u8>::is_null) {
-+                                                     debug self => _16;
-+                                                     let mut _20: *mut u8;
++                                                     debug self => _21;
++                                                     let mut _22: *mut u8;
 +                                                     scope 27 {
 +                                                         scope 28 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-+                                                             debug ptr => _20;
++                                                             debug ptr => _22;
 +                                                             scope 29 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-+                                                                 debug self => _20;
++                                                                 debug self => _22;
 +                                                                 scope 30 {
 +                                                                     scope 31 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-+                                                                         debug self => _20;
++                                                                         debug self => _22;
 +                                                                     }
 +                                                                 }
 +                                                             }
@@ -75,8 +76,8 @@
 +                                 }
 +                             }
 +                             scope 32 (inlined NonNull::<u8>::as_ptr) {
-+                                 debug self => _15;
-+                                 let mut _21: *const u8;
++                                 debug self => _16;
++                                 let mut _23: *const u8;
 +                             }
 +                         }
 +                     }
@@ -93,13 +94,14 @@
 +                         scope 10 {
 +                             scope 11 (inlined std::ptr::Alignment::new_unchecked) {
 +                                 debug align => _5;
++                                 let mut _15: usize;
 +                                 scope 12 {
 +                                     scope 14 (inlined std::ptr::Alignment::new_unchecked::runtime) {
-+                                         debug align => _5;
++                                         debug align => _15;
 +                                         scope 15 (inlined core::num::<impl usize>::is_power_of_two) {
-+                                             debug self => _5;
++                                             debug self => _15;
 +                                             scope 16 (inlined core::num::<impl usize>::count_ones) {
-+                                                 debug self => _5;
++                                                 debug self => _15;
 +                                             }
 +                                         }
 +                                     }
@@ -129,7 +131,9 @@
 +         StorageLive(_12);
 +         StorageLive(_13);
 +         StorageLive(_14);
++         StorageLive(_15);
 +         _14 = _5 as std::ptr::Alignment (Transmute);
++         StorageDead(_15);
 +         _8 = Layout { size: _4, align: move _14 };
 +         StorageDead(_14);
 +         StorageLive(_9);
@@ -153,27 +157,29 @@
 + 
 +     bb4: {
 +         _11 = ((_9 as Ok).0: std::ptr::NonNull<[u8]>);
-+         StorageLive(_15);
 +         StorageLive(_16);
 +         StorageLive(_17);
 +         StorageLive(_18);
-+         _18 = (_11.0: *const [u8]);
-+         _17 = move _18 as *mut [u8] (PtrToPtr);
-+         StorageDead(_18);
-+         _16 = _17 as *mut u8 (PtrToPtr);
-+         StorageDead(_17);
 +         StorageLive(_19);
-+         StorageLive(_20);
-+         _19 = _16 as *const u8 (PointerCoercion(MutToConstPointer));
-+         _15 = NonNull::<u8> { pointer: _19 };
-+         StorageDead(_20);
++         _19 = (_11.0: *const [u8]);
++         _18 = move _19 as *mut [u8] (PtrToPtr);
 +         StorageDead(_19);
-+         StorageDead(_16);
++         _17 = _18 as *mut u8 (PtrToPtr);
++         StorageDead(_18);
++         StorageLive(_20);
 +         StorageLive(_21);
-+         _21 = (_15.0: *const u8);
-+         _6 = move _21 as *mut u8 (PtrToPtr);
++         StorageLive(_22);
++         _20 = _17 as *const u8 (PointerCoercion(MutToConstPointer));
++         _16 = NonNull::<u8> { pointer: _20 };
++         StorageDead(_22);
 +         StorageDead(_21);
-+         StorageDead(_15);
++         StorageDead(_20);
++         StorageDead(_17);
++         StorageLive(_23);
++         _23 = (_16.0: *const u8);
++         _6 = move _23 as *mut u8 (PtrToPtr);
++         StorageDead(_23);
++         StorageDead(_16);
 +         StorageDead(_9);
 +         StorageDead(_13);
 +         StorageDead(_12);

--- a/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_into_box_place.main.Inline.panic-unwind.diff
@@ -33,36 +33,37 @@
 +                         debug ptr => _11;
 +                         scope 18 (inlined NonNull::<[u8]>::as_mut_ptr) {
 +                             debug self => _11;
-+                             let mut _15: std::ptr::NonNull<u8>;
++                             let mut _16: std::ptr::NonNull<u8>;
 +                             scope 19 (inlined NonNull::<[u8]>::as_non_null_ptr) {
 +                                 debug self => _11;
-+                                 let mut _16: *mut u8;
-+                                 let mut _17: *mut [u8];
++                                 let mut _17: *mut u8;
++                                 let mut _18: *mut [u8];
 +                                 scope 20 {
 +                                     scope 21 (inlined NonNull::<[u8]>::as_ptr) {
 +                                         debug self => _11;
-+                                         let mut _18: *const [u8];
++                                         let mut _19: *const [u8];
 +                                     }
 +                                     scope 22 (inlined ptr::mut_ptr::<impl *mut [u8]>::as_mut_ptr) {
-+                                         debug self => _17;
++                                         debug self => _18;
 +                                     }
 +                                     scope 23 (inlined NonNull::<u8>::new_unchecked) {
-+                                         debug ptr => _16;
-+                                         let mut _19: *const u8;
++                                         debug ptr => _17;
++                                         let mut _20: *const u8;
++                                         let mut _21: *mut u8;
 +                                         scope 24 {
 +                                             scope 25 (inlined NonNull::<T>::new_unchecked::runtime::<u8>) {
-+                                                 debug ptr => _16;
++                                                 debug ptr => _21;
 +                                                 scope 26 (inlined ptr::mut_ptr::<impl *mut u8>::is_null) {
-+                                                     debug self => _16;
-+                                                     let mut _20: *mut u8;
++                                                     debug self => _21;
++                                                     let mut _22: *mut u8;
 +                                                     scope 27 {
 +                                                         scope 28 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-+                                                             debug ptr => _20;
++                                                             debug ptr => _22;
 +                                                             scope 29 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-+                                                                 debug self => _20;
++                                                                 debug self => _22;
 +                                                                 scope 30 {
 +                                                                     scope 31 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-+                                                                         debug self => _20;
++                                                                         debug self => _22;
 +                                                                     }
 +                                                                 }
 +                                                             }
@@ -75,8 +76,8 @@
 +                                 }
 +                             }
 +                             scope 32 (inlined NonNull::<u8>::as_ptr) {
-+                                 debug self => _15;
-+                                 let mut _21: *const u8;
++                                 debug self => _16;
++                                 let mut _23: *const u8;
 +                             }
 +                         }
 +                     }
@@ -93,13 +94,14 @@
 +                         scope 10 {
 +                             scope 11 (inlined std::ptr::Alignment::new_unchecked) {
 +                                 debug align => _5;
++                                 let mut _15: usize;
 +                                 scope 12 {
 +                                     scope 14 (inlined std::ptr::Alignment::new_unchecked::runtime) {
-+                                         debug align => _5;
++                                         debug align => _15;
 +                                         scope 15 (inlined core::num::<impl usize>::is_power_of_two) {
-+                                             debug self => _5;
++                                             debug self => _15;
 +                                             scope 16 (inlined core::num::<impl usize>::count_ones) {
-+                                                 debug self => _5;
++                                                 debug self => _15;
 +                                             }
 +                                         }
 +                                     }
@@ -129,7 +131,9 @@
 +         StorageLive(_12);
 +         StorageLive(_13);
 +         StorageLive(_14);
++         StorageLive(_15);
 +         _14 = _5 as std::ptr::Alignment (Transmute);
++         StorageDead(_15);
 +         _8 = Layout { size: _4, align: move _14 };
 +         StorageDead(_14);
 +         StorageLive(_9);
@@ -170,27 +174,29 @@
 + 
 +     bb6: {
 +         _11 = ((_9 as Ok).0: std::ptr::NonNull<[u8]>);
-+         StorageLive(_15);
 +         StorageLive(_16);
 +         StorageLive(_17);
 +         StorageLive(_18);
-+         _18 = (_11.0: *const [u8]);
-+         _17 = move _18 as *mut [u8] (PtrToPtr);
-+         StorageDead(_18);
-+         _16 = _17 as *mut u8 (PtrToPtr);
-+         StorageDead(_17);
 +         StorageLive(_19);
-+         StorageLive(_20);
-+         _19 = _16 as *const u8 (PointerCoercion(MutToConstPointer));
-+         _15 = NonNull::<u8> { pointer: _19 };
-+         StorageDead(_20);
++         _19 = (_11.0: *const [u8]);
++         _18 = move _19 as *mut [u8] (PtrToPtr);
 +         StorageDead(_19);
-+         StorageDead(_16);
++         _17 = _18 as *mut u8 (PtrToPtr);
++         StorageDead(_18);
++         StorageLive(_20);
 +         StorageLive(_21);
-+         _21 = (_15.0: *const u8);
-+         _6 = move _21 as *mut u8 (PtrToPtr);
++         StorageLive(_22);
++         _20 = _17 as *const u8 (PointerCoercion(MutToConstPointer));
++         _16 = NonNull::<u8> { pointer: _20 };
++         StorageDead(_22);
 +         StorageDead(_21);
-+         StorageDead(_15);
++         StorageDead(_20);
++         StorageDead(_17);
++         StorageLive(_23);
++         _23 = (_16.0: *const u8);
++         _6 = move _23 as *mut u8 (PtrToPtr);
++         StorageDead(_23);
++         StorageDead(_16);
 +         StorageDead(_9);
 +         StorageDead(_13);
 +         StorageDead(_12);

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
@@ -7,10 +7,13 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
     scope 1 (inlined core::num::<impl u32>::checked_shl) {
         debug self => _1;
         debug rhs => _2;
-        let mut _7: bool;
+        let mut _7: (u32, bool);
+        let _8: u32;
+        let _9: bool;
+        let mut _10: bool;
         scope 2 {
-            debug a => _5;
-            debug b => _6;
+            debug a => _8;
+            debug b => _9;
         }
         scope 3 (inlined core::num::<impl u32>::overflowing_shl) {
             debug self => _1;
@@ -35,8 +38,10 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
     }
 
     bb0: {
+        StorageLive(_8);
+        StorageLive(_9);
+        StorageLive(_7);
         StorageLive(_5);
-        StorageLive(_6);
         StorageLive(_4);
         StorageLive(_3);
         _3 = const 31_u32;
@@ -44,17 +49,24 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
         StorageDead(_3);
         _5 = ShlUnchecked(_1, _4);
         StorageDead(_4);
+        StorageLive(_6);
         _6 = Ge(_2, const _);
-        StorageLive(_7);
-        _7 = unlikely(_6) -> [return: bb1, unwind unreachable];
+        _7 = (move _5, move _6);
+        StorageDead(_6);
+        StorageDead(_5);
+        _8 = (_7.0: u32);
+        _9 = (_7.1: bool);
+        StorageDead(_7);
+        StorageLive(_10);
+        _10 = unlikely(_9) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        switchInt(move _7) -> [0: bb2, otherwise: bb3];
+        switchInt(move _10) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        _0 = Option::<u32>::Some(_5);
+        _0 = Option::<u32>::Some(_8);
         goto -> bb4;
     }
 
@@ -64,9 +76,9 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
     }
 
     bb4: {
-        StorageDead(_7);
-        StorageDead(_6);
-        StorageDead(_5);
+        StorageDead(_10);
+        StorageDead(_9);
+        StorageDead(_8);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/mem_replace.mem_replace.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/mem_replace.mem_replace.PreCodegen.after.mir
@@ -15,18 +15,20 @@ fn mem_replace(_1: &mut u32, _2: u32) -> u32 {
                 scope 7 (inlined std::ptr::write::<u32>) {
                     debug dst => _4;
                     debug src => _2;
+                    let mut _6: *mut u32;
                     scope 8 {
                         scope 9 (inlined std::ptr::write::runtime::<u32>) {
-                            debug dst => _4;
+                            debug dst => _6;
                         }
                     }
                 }
             }
             scope 4 (inlined std::ptr::read::<u32>) {
                 debug src => _3;
+                let mut _5: *const u32;
                 scope 5 {
                     scope 6 (inlined std::ptr::read::runtime::<u32>) {
-                        debug src => _3;
+                        debug src => _5;
                     }
                 }
             }
@@ -36,11 +38,15 @@ fn mem_replace(_1: &mut u32, _2: u32) -> u32 {
     bb0: {
         StorageLive(_3);
         _3 = &raw const (*_1);
+        StorageLive(_5);
         _0 = (*_3);
+        StorageDead(_5);
         StorageDead(_3);
         StorageLive(_4);
         _4 = &raw mut (*_1);
+        StorageLive(_6);
         (*_4) = _2;
+        StorageDead(_6);
         StorageDead(_4);
         return;
     }

--- a/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
@@ -3,21 +3,24 @@
 fn ezmap(_1: Option<i32>) -> Option<i32> {
     debug x => _1;
     let mut _0: std::option::Option<i32>;
+    let mut _5: i32;
     scope 1 (inlined map::<i32, i32, [closure@$DIR/simple_option_map.rs:18:12: 18:15]>) {
         debug slf => _1;
         debug f => const ZeroSized: [closure@$DIR/simple_option_map.rs:18:12: 18:15];
         let mut _2: isize;
         let _3: i32;
-        let mut _4: i32;
+        let mut _4: (i32,);
+        let mut _6: i32;
         scope 2 {
             debug x => _3;
             scope 3 (inlined ezmap::{closure#0}) {
-                debug n => _3;
+                debug n => _5;
             }
         }
     }
 
     bb0: {
+        StorageLive(_3);
         _2 = discriminant(_1);
         switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
     }
@@ -29,14 +32,21 @@ fn ezmap(_1: Option<i32>) -> Option<i32> {
 
     bb2: {
         _3 = ((_1 as Some).0: i32);
+        StorageLive(_6);
         StorageLive(_4);
-        _4 = Add(_3, const 1_i32);
-        _0 = Option::<i32>::Some(move _4);
+        _4 = (move _3,);
+        StorageLive(_5);
+        _5 = move (_4.0: i32);
+        _6 = Add(_5, const 1_i32);
+        StorageDead(_5);
         StorageDead(_4);
+        _0 = Option::<i32>::Some(move _6);
+        StorageDead(_6);
         goto -> bb3;
     }
 
     bb3: {
+        StorageDead(_3);
         return;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
@@ -21,17 +21,19 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
                     debug self => _2;
                     debug slice => _6;
                     let mut _7: *mut u32;
+                    let mut _10: usize;
+                    let mut _11: *mut [u32];
                     scope 5 {
                         debug this => _2;
                         scope 6 {
                             scope 7 (inlined <usize as SliceIndex<[T]>>::get_unchecked_mut::runtime::<u32>) {
-                                debug this => _2;
-                                debug slice => _6;
+                                debug this => _10;
+                                debug slice => _11;
                                 scope 8 (inlined ptr::mut_ptr::<impl *mut [u32]>::len) {
-                                    debug self => _6;
-                                    let mut _10: *const [u32];
+                                    debug self => _11;
+                                    let mut _12: *const [u32];
                                     scope 9 (inlined std::ptr::metadata::<[u32]>) {
-                                        debug ptr => _10;
+                                        debug ptr => _12;
                                         scope 10 {
                                         }
                                     }
@@ -76,10 +78,14 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
         StorageLive(_6);
         _6 = &raw mut (*_1);
         StorageLive(_10);
+        StorageLive(_11);
+        StorageLive(_12);
         StorageLive(_7);
         _7 = _6 as *mut u32 (PtrToPtr);
         _8 = Offset(_7, _2);
         StorageDead(_7);
+        StorageDead(_12);
+        StorageDead(_11);
         StorageDead(_10);
         StorageDead(_6);
         _9 = &mut (*_8);

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
@@ -21,17 +21,19 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
                     debug self => _2;
                     debug slice => _6;
                     let mut _7: *mut u32;
+                    let mut _10: usize;
+                    let mut _11: *mut [u32];
                     scope 5 {
                         debug this => _2;
                         scope 6 {
                             scope 7 (inlined <usize as SliceIndex<[T]>>::get_unchecked_mut::runtime::<u32>) {
-                                debug this => _2;
-                                debug slice => _6;
+                                debug this => _10;
+                                debug slice => _11;
                                 scope 8 (inlined ptr::mut_ptr::<impl *mut [u32]>::len) {
-                                    debug self => _6;
-                                    let mut _10: *const [u32];
+                                    debug self => _11;
+                                    let mut _12: *const [u32];
                                     scope 9 (inlined std::ptr::metadata::<[u32]>) {
-                                        debug ptr => _10;
+                                        debug ptr => _12;
                                         scope 10 {
                                         }
                                     }
@@ -76,10 +78,14 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
         StorageLive(_6);
         _6 = &raw mut (*_1);
         StorageLive(_10);
+        StorageLive(_11);
+        StorageLive(_12);
         StorageLive(_7);
         _7 = _6 as *mut u32 (PtrToPtr);
         _8 = Offset(_7, _2);
         StorageDead(_7);
+        StorageDead(_12);
+        StorageDead(_11);
         StorageDead(_10);
         StorageDead(_6);
         _9 = &mut (*_8);

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
@@ -4,49 +4,49 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     debug slice => _1;
     debug index => _2;
     let mut _0: &mut [u32];
-    let mut _3: usize;
-    let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
         debug self => _1;
-        debug index => std::ops::Range<usize>{ .0 => _3, .1 => _4, };
-        let mut _5: *mut [u32];
-        let mut _13: *mut [u32];
+        debug index => _2;
+        let mut _3: *mut [u32];
+        let mut _14: *mut [u32];
         scope 2 {
             scope 3 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
-                debug self => std::ops::Range<usize>{ .0 => _3, .1 => _4, };
-                debug slice => _5;
+                debug self => _2;
+                debug slice => _3;
+                let mut _4: usize;
+                let mut _5: usize;
                 let mut _7: *mut u32;
-                let mut _8: *mut u32;
-                let _14: usize;
-                let _15: usize;
+                let mut _8: usize;
+                let mut _9: *mut u32;
+                let _15: std::ops::Range<usize>;
                 scope 4 {
-                    debug this => std::ops::Range<usize>{ .0 => _14, .1 => _15, };
+                    debug this => _15;
                     scope 5 {
                         let _6: usize;
                         scope 6 {
                             debug new_len => _6;
                             scope 7 (inlined ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) {
-                                debug self => _5;
+                                debug self => _3;
                             }
                             scope 8 (inlined ptr::mut_ptr::<impl *mut u32>::add) {
                                 debug self => _7;
-                                debug count => _3;
+                                debug count => _8;
                                 scope 9 {
                                 }
                             }
                             scope 10 (inlined slice_from_raw_parts_mut::<u32>) {
-                                debug data => _8;
+                                debug data => _9;
                                 debug len => _6;
-                                let mut _9: *mut ();
+                                let mut _10: *mut ();
                                 scope 11 (inlined ptr::mut_ptr::<impl *mut u32>::cast::<()>) {
-                                    debug self => _8;
+                                    debug self => _9;
                                 }
                                 scope 12 (inlined std::ptr::from_raw_parts_mut::<[u32]>) {
-                                    debug data_address => _9;
+                                    debug data_address => _10;
                                     debug metadata => _6;
-                                    let mut _10: *const ();
-                                    let mut _11: std::ptr::metadata::PtrComponents<[u32]>;
-                                    let mut _12: std::ptr::metadata::PtrRepr<[u32]>;
+                                    let mut _11: *const ();
+                                    let mut _12: std::ptr::metadata::PtrComponents<[u32]>;
+                                    let mut _13: std::ptr::metadata::PtrRepr<[u32]>;
                                     scope 13 {
                                     }
                                 }
@@ -59,40 +59,45 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     }
 
     bb0: {
-        _3 = move (_2.0: usize);
-        _4 = move (_2.1: usize);
-        StorageLive(_13);
-        StorageLive(_5);
-        _5 = &raw mut (*_1);
         StorageLive(_14);
+        StorageLive(_3);
+        _3 = &raw mut (*_1);
         StorageLive(_15);
         StorageLive(_6);
-        _6 = SubUnchecked(_4, _3);
-        StorageLive(_8);
-        StorageLive(_7);
-        _7 = _5 as *mut u32 (PtrToPtr);
-        _8 = Offset(_7, _3);
-        StorageDead(_7);
+        StorageLive(_4);
+        _4 = (_2.1: usize);
+        StorageLive(_5);
+        _5 = (_2.0: usize);
+        _6 = SubUnchecked(move _4, move _5);
+        StorageDead(_5);
+        StorageDead(_4);
         StorageLive(_9);
-        _9 = _8 as *mut () (PtrToPtr);
+        StorageLive(_7);
+        _7 = _3 as *mut u32 (PtrToPtr);
+        StorageLive(_8);
+        _8 = (_2.0: usize);
+        _9 = Offset(_7, _8);
+        StorageDead(_8);
+        StorageDead(_7);
+        StorageLive(_10);
+        _10 = _9 as *mut () (PtrToPtr);
+        StorageLive(_13);
         StorageLive(_12);
         StorageLive(_11);
-        StorageLive(_10);
-        _10 = _9 as *const () (PointerCoercion(MutToConstPointer));
-        _11 = ptr::metadata::PtrComponents::<[u32]> { data_address: move _10, metadata: _6 };
-        StorageDead(_10);
-        _12 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _11 };
+        _11 = _10 as *const () (PointerCoercion(MutToConstPointer));
+        _12 = ptr::metadata::PtrComponents::<[u32]> { data_address: move _11, metadata: _6 };
         StorageDead(_11);
-        _13 = (_12.1: *mut [u32]);
+        _13 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _12 };
         StorageDead(_12);
-        StorageDead(_9);
-        StorageDead(_8);
-        StorageDead(_6);
-        StorageDead(_14);
-        StorageDead(_15);
-        StorageDead(_5);
-        _0 = &mut (*_13);
+        _14 = (_13.1: *mut [u32]);
         StorageDead(_13);
+        StorageDead(_10);
+        StorageDead(_9);
+        StorageDead(_6);
+        StorageDead(_15);
+        StorageDead(_3);
+        _0 = &mut (*_14);
+        StorageDead(_14);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
@@ -4,49 +4,49 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     debug slice => _1;
     debug index => _2;
     let mut _0: &mut [u32];
-    let mut _3: usize;
-    let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
         debug self => _1;
-        debug index => std::ops::Range<usize>{ .0 => _3, .1 => _4, };
-        let mut _5: *mut [u32];
-        let mut _13: *mut [u32];
+        debug index => _2;
+        let mut _3: *mut [u32];
+        let mut _14: *mut [u32];
         scope 2 {
             scope 3 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
-                debug self => std::ops::Range<usize>{ .0 => _3, .1 => _4, };
-                debug slice => _5;
+                debug self => _2;
+                debug slice => _3;
+                let mut _4: usize;
+                let mut _5: usize;
                 let mut _7: *mut u32;
-                let mut _8: *mut u32;
-                let _14: usize;
-                let _15: usize;
+                let mut _8: usize;
+                let mut _9: *mut u32;
+                let _15: std::ops::Range<usize>;
                 scope 4 {
-                    debug this => std::ops::Range<usize>{ .0 => _14, .1 => _15, };
+                    debug this => _15;
                     scope 5 {
                         let _6: usize;
                         scope 6 {
                             debug new_len => _6;
                             scope 7 (inlined ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) {
-                                debug self => _5;
+                                debug self => _3;
                             }
                             scope 8 (inlined ptr::mut_ptr::<impl *mut u32>::add) {
                                 debug self => _7;
-                                debug count => _3;
+                                debug count => _8;
                                 scope 9 {
                                 }
                             }
                             scope 10 (inlined slice_from_raw_parts_mut::<u32>) {
-                                debug data => _8;
+                                debug data => _9;
                                 debug len => _6;
-                                let mut _9: *mut ();
+                                let mut _10: *mut ();
                                 scope 11 (inlined ptr::mut_ptr::<impl *mut u32>::cast::<()>) {
-                                    debug self => _8;
+                                    debug self => _9;
                                 }
                                 scope 12 (inlined std::ptr::from_raw_parts_mut::<[u32]>) {
-                                    debug data_address => _9;
+                                    debug data_address => _10;
                                     debug metadata => _6;
-                                    let mut _10: *const ();
-                                    let mut _11: std::ptr::metadata::PtrComponents<[u32]>;
-                                    let mut _12: std::ptr::metadata::PtrRepr<[u32]>;
+                                    let mut _11: *const ();
+                                    let mut _12: std::ptr::metadata::PtrComponents<[u32]>;
+                                    let mut _13: std::ptr::metadata::PtrRepr<[u32]>;
                                     scope 13 {
                                     }
                                 }
@@ -59,40 +59,45 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     }
 
     bb0: {
-        _3 = move (_2.0: usize);
-        _4 = move (_2.1: usize);
-        StorageLive(_13);
-        StorageLive(_5);
-        _5 = &raw mut (*_1);
         StorageLive(_14);
+        StorageLive(_3);
+        _3 = &raw mut (*_1);
         StorageLive(_15);
         StorageLive(_6);
-        _6 = SubUnchecked(_4, _3);
-        StorageLive(_8);
-        StorageLive(_7);
-        _7 = _5 as *mut u32 (PtrToPtr);
-        _8 = Offset(_7, _3);
-        StorageDead(_7);
+        StorageLive(_4);
+        _4 = (_2.1: usize);
+        StorageLive(_5);
+        _5 = (_2.0: usize);
+        _6 = SubUnchecked(move _4, move _5);
+        StorageDead(_5);
+        StorageDead(_4);
         StorageLive(_9);
-        _9 = _8 as *mut () (PtrToPtr);
+        StorageLive(_7);
+        _7 = _3 as *mut u32 (PtrToPtr);
+        StorageLive(_8);
+        _8 = (_2.0: usize);
+        _9 = Offset(_7, _8);
+        StorageDead(_8);
+        StorageDead(_7);
+        StorageLive(_10);
+        _10 = _9 as *mut () (PtrToPtr);
+        StorageLive(_13);
         StorageLive(_12);
         StorageLive(_11);
-        StorageLive(_10);
-        _10 = _9 as *const () (PointerCoercion(MutToConstPointer));
-        _11 = ptr::metadata::PtrComponents::<[u32]> { data_address: move _10, metadata: _6 };
-        StorageDead(_10);
-        _12 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _11 };
+        _11 = _10 as *const () (PointerCoercion(MutToConstPointer));
+        _12 = ptr::metadata::PtrComponents::<[u32]> { data_address: move _11, metadata: _6 };
         StorageDead(_11);
-        _13 = (_12.1: *mut [u32]);
+        _13 = ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _12 };
         StorageDead(_12);
-        StorageDead(_9);
-        StorageDead(_8);
-        StorageDead(_6);
-        StorageDead(_14);
-        StorageDead(_15);
-        StorageDead(_5);
-        _0 = &mut (*_13);
+        _14 = (_13.1: *mut [u32]);
         StorageDead(_13);
+        StorageDead(_10);
+        StorageDead(_9);
+        StorageDead(_6);
+        StorageDead(_15);
+        StorageDead(_3);
+        _0 = &mut (*_14);
+        StorageDead(_14);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
@@ -42,20 +42,21 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                         scope 13 (inlined NonNull::<T>::new_unchecked) {
                             debug ptr => _9;
                             let mut _10: *const T;
+                            let mut _24: *mut T;
                             scope 14 {
                                 scope 15 (inlined NonNull::<T>::new_unchecked::runtime::<T>) {
-                                    debug ptr => _9;
+                                    debug ptr => _24;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
-                                        debug self => _9;
-                                        let mut _24: *mut u8;
+                                        debug self => _24;
+                                        let mut _25: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _24;
+                                                debug ptr => _25;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _24;
+                                                    debug self => _25;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _24;
+                                                            debug self => _25;
                                                         }
                                                     }
                                                 }
@@ -131,8 +132,10 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
         StorageLive(_24);
+        StorageLive(_25);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
+        StorageDead(_25);
         StorageDead(_24);
         StorageDead(_10);
         StorageDead(_9);

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -42,20 +42,21 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                         scope 13 (inlined NonNull::<T>::new_unchecked) {
                             debug ptr => _9;
                             let mut _10: *const T;
+                            let mut _24: *mut T;
                             scope 14 {
                                 scope 15 (inlined NonNull::<T>::new_unchecked::runtime::<T>) {
-                                    debug ptr => _9;
+                                    debug ptr => _24;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
-                                        debug self => _9;
-                                        let mut _24: *mut u8;
+                                        debug self => _24;
+                                        let mut _25: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _24;
+                                                debug ptr => _25;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _24;
+                                                    debug self => _25;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _24;
+                                                            debug self => _25;
                                                         }
                                                     }
                                                 }
@@ -131,8 +132,10 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
         StorageLive(_24);
+        StorageLive(_25);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
+        StorageDead(_25);
         StorageDead(_24);
         StorageDead(_10);
         StorageDead(_9);

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -39,20 +39,21 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         scope 13 (inlined NonNull::<T>::new_unchecked) {
                             debug ptr => _9;
                             let mut _10: *const T;
+                            let mut _22: *mut T;
                             scope 14 {
                                 scope 15 (inlined NonNull::<T>::new_unchecked::runtime::<T>) {
-                                    debug ptr => _9;
+                                    debug ptr => _22;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
-                                        debug self => _9;
-                                        let mut _22: *mut u8;
+                                        debug self => _22;
+                                        let mut _23: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _22;
+                                                debug ptr => _23;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _22;
+                                                    debug self => _23;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _22;
+                                                            debug self => _23;
                                                         }
                                                     }
                                                 }
@@ -121,8 +122,10 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
         StorageLive(_22);
+        StorageLive(_23);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
+        StorageDead(_23);
         StorageDead(_22);
         StorageDead(_10);
         StorageDead(_9);

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -39,20 +39,21 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         scope 13 (inlined NonNull::<T>::new_unchecked) {
                             debug ptr => _9;
                             let mut _10: *const T;
+                            let mut _22: *mut T;
                             scope 14 {
                                 scope 15 (inlined NonNull::<T>::new_unchecked::runtime::<T>) {
-                                    debug ptr => _9;
+                                    debug ptr => _22;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
-                                        debug self => _9;
-                                        let mut _22: *mut u8;
+                                        debug self => _22;
+                                        let mut _23: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _22;
+                                                debug ptr => _23;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _22;
+                                                    debug self => _23;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _22;
+                                                            debug self => _23;
                                                         }
                                                     }
                                                 }
@@ -121,8 +122,10 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
         StorageLive(_22);
+        StorageLive(_23);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
+        StorageDead(_23);
         StorageDead(_22);
         StorageDead(_10);
         StorageDead(_9);

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -44,20 +44,21 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         scope 13 (inlined NonNull::<T>::new_unchecked) {
                             debug ptr => _9;
                             let mut _10: *const T;
+                            let mut _24: *mut T;
                             scope 14 {
                                 scope 15 (inlined NonNull::<T>::new_unchecked::runtime::<T>) {
-                                    debug ptr => _9;
+                                    debug ptr => _24;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
-                                        debug self => _9;
-                                        let mut _24: *mut u8;
+                                        debug self => _24;
+                                        let mut _25: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _24;
+                                                debug ptr => _25;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _24;
+                                                    debug self => _25;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _24;
+                                                            debug self => _25;
                                                         }
                                                     }
                                                 }
@@ -133,8 +134,10 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
         StorageLive(_24);
+        StorageLive(_25);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
+        StorageDead(_25);
         StorageDead(_24);
         StorageDead(_10);
         StorageDead(_9);

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -44,20 +44,21 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         scope 13 (inlined NonNull::<T>::new_unchecked) {
                             debug ptr => _9;
                             let mut _10: *const T;
+                            let mut _24: *mut T;
                             scope 14 {
                                 scope 15 (inlined NonNull::<T>::new_unchecked::runtime::<T>) {
-                                    debug ptr => _9;
+                                    debug ptr => _24;
                                     scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null) {
-                                        debug self => _9;
-                                        let mut _24: *mut u8;
+                                        debug self => _24;
+                                        let mut _25: *mut u8;
                                         scope 17 {
                                             scope 18 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
-                                                debug ptr => _24;
+                                                debug ptr => _25;
                                                 scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
-                                                    debug self => _24;
+                                                    debug self => _25;
                                                     scope 20 {
                                                         scope 21 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
-                                                            debug self => _24;
+                                                            debug self => _25;
                                                         }
                                                     }
                                                 }
@@ -133,8 +134,10 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         _9 = _4 as *mut T (PtrToPtr);
         StorageLive(_10);
         StorageLive(_24);
+        StorageLive(_25);
         _10 = _9 as *const T (PointerCoercion(MutToConstPointer));
         _11 = NonNull::<T> { pointer: _10 };
+        StorageDead(_25);
         StorageDead(_24);
         StorageDead(_10);
         StorageDead(_9);


### PR DESCRIPTION
Turn off the MIR SROA optimization by default to prevent incorrect debuginfo generation and rustc ICEs caused by invalid LLVM IR being created.

Related to #115113

r? @cuviper 
cc @saethlin 