### PR TITLE
Add `ParallelGuard` type to handle unwinding in parallel sections

### DIFF
--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -203,7 +203,7 @@ cfg_if! {
 
         #[macro_export]
         macro_rules! parallel {
-            ($($blocks:block),*) => {
+            ($($blocks:block),*) => {{
                 // We catch panics here ensuring that all the blocks execute.
                 // This makes behavior consistent with the parallel compiler.
                 let mut panic = None;
@@ -219,7 +219,7 @@ cfg_if! {
                 if let Some(panic) = panic {
                     ::std::panic::resume_unwind(panic);
                 }
-            }
+            }}
         }
 
         pub fn par_for_each_in<T: IntoIterator>(t: T, mut for_each: impl FnMut(T::Item) + Sync + Send) {

--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -41,6 +41,7 @@
 //! [^2] `MTLockRef` is a typedef.
 
 pub use crate::marker::*;
+use parking_lot::Mutex;
 use std::any::Any;
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
@@ -110,13 +111,13 @@ pub use mode::{is_dyn_thread_safe, set_dyn_thread_safe_mode};
 /// continuing with unwinding. It's also used for the non-parallel code to ensure error message
 /// output match the parallel compiler for testing purposes.
 pub struct ParallelGuard {
-    panic: Lock<Option<Box<dyn Any + std::marker::Send + 'static>>>,
+    panic: Mutex<Option<Box<dyn Any + std::marker::Send + 'static>>>,
 }
 
 impl ParallelGuard {
     #[inline]
     pub fn new() -> Self {
-        ParallelGuard { panic: Lock::new(None) }
+        ParallelGuard { panic: Mutex::new(None) }
     }
 
     pub fn run<R>(&self, f: impl FnOnce() -> R) -> Option<R> {
@@ -316,8 +317,6 @@ cfg_if! {
             }
         }
     } else {
-        use parking_lot::Mutex;
-
         pub use std::marker::Send as Send;
         pub use std::marker::Sync as Sync;
 

--- a/tests/ui/const-generics/late-bound-vars/in_closure.rs
+++ b/tests/ui/const-generics/late-bound-vars/in_closure.rs
@@ -1,4 +1,4 @@
-// failure-status: 101
+// failure-status: 1
 // known-bug: unknown
 // error-pattern:internal compiler error
 // normalize-stderr-test "internal compiler error.*" -> ""
@@ -22,7 +22,10 @@
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 
-const fn inner<'a>() -> usize where &'a (): Sized {
+const fn inner<'a>() -> usize
+where
+    &'a (): Sized,
+{
     3
 }
 


### PR DESCRIPTION
This adds a `ParallelGuard` type to handle unwinding in parallel sections instead of manually dealing with panics in each parallel operation. This also adds proper panic handling to the `join` operation.

cc @SparrowLii 