### PR TITLE
Suggest mutable borrow on read only for-loop that should be mutable

### DIFF
--- a/tests/ui/borrowck/suggest-mut-iterator.fixed
+++ b/tests/ui/borrowck/suggest-mut-iterator.fixed
@@ -1,0 +1,30 @@
+// run-rustfix
+struct Test {
+    a: u32
+}
+
+impl Test {
+    pub fn add(&mut self, value: u32) {
+        self.a += value;
+    }
+
+    pub fn print_value(&self) {
+        println!("Value of a is: {}", self.a);
+    }
+}
+
+fn main() {
+    let mut tests = Vec::new();
+    for i in 0..=10 {
+        tests.push(Test {a: i});
+    }
+    for test in &mut tests {
+        test.add(2); //~ ERROR cannot borrow `*test` as mutable, as it is behind a `&` reference
+    }
+    for test in &mut tests {
+        test.add(2);
+    }
+    for test in &tests {
+        test.print_value();
+    }
+}

--- a/tests/ui/borrowck/suggest-mut-iterator.rs
+++ b/tests/ui/borrowck/suggest-mut-iterator.rs
@@ -1,0 +1,30 @@
+// run-rustfix
+struct Test {
+    a: u32
+}
+
+impl Test {
+    pub fn add(&mut self, value: u32) {
+        self.a += value;
+    }
+
+    pub fn print_value(&self) {
+        println!("Value of a is: {}", self.a);
+    }
+}
+
+fn main() {
+    let mut tests = Vec::new();
+    for i in 0..=10 {
+        tests.push(Test {a: i});
+    }
+    for test in &tests {
+        test.add(2); //~ ERROR cannot borrow `*test` as mutable, as it is behind a `&` reference
+    }
+    for test in &mut tests {
+        test.add(2);
+    }
+    for test in &tests {
+        test.print_value();
+    }
+}

--- a/tests/ui/borrowck/suggest-mut-iterator.stderr
+++ b/tests/ui/borrowck/suggest-mut-iterator.stderr
@@ -1,0 +1,16 @@
+error[E0596]: cannot borrow `*test` as mutable, as it is behind a `&` reference
+  --> $DIR/suggest-mut-iterator.rs:22:9
+   |
+LL |     for test in &tests {
+   |                 ------ this iterator yields `&` references
+LL |         test.add(2);
+   |         ^^^^ `test` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |
+help: use a mutable iterator instead
+   |
+LL |     for test in &mut tests {
+   |                  +++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
```
error[E0596]: cannot borrow `*test` as mutable, as it is behind a `&` reference
  --> $DIR/suggest-mut-iterator.rs:22:9
   |
LL |     for test in &tests {
   |                 ------ this iterator yields `&` references
LL |         test.add(2);
   |         ^^^^ `test` is a `&` reference, so the data it refers to cannot be borrowed as mutable
   |
help: use a mutable iterator instead
   |
LL |     for test in &mut tests {
   |                  +++
```

Fix #114311.