### PR TITLE
refactor(lint): translate `RenamedOrRemovedLint`

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -158,12 +158,14 @@ lint_builtin_while_true = denote infinite loops with `loop {"{"} ... {"}"}`
 
 lint_check_name_deprecated = lint name `{$lint_name}` is deprecated and does not have an effect anymore. Use: {$new_name}
 
+lint_check_name_removed = lint `{$lint_name}` has been removed: {$reason}
+
+lint_check_name_renamed = lint `{$lint_name}` has been renamed to `{$replace}`
+
 lint_check_name_unknown = unknown lint: `{$lint_name}`
     .help = did you mean: `{$suggestion}`
 
 lint_check_name_unknown_tool = unknown lint tool: `{$tool_name}`
-
-lint_check_name_warning = {$msg}
 
 lint_command_line_source = `forbid` lint level was set on command line
 
@@ -484,8 +486,11 @@ lint_redundant_semicolons =
         *[false] this semicolon
     }
 
-lint_renamed_or_removed_lint = {$msg}
+lint_removed_lint = lint `{$name}` has been removed: {$reason}
+
+lint_renamed_lint = lint `{$name}` has been renamed to `{$replace}`
     .suggestion = use the new name
+    .help = use the new name `{$replace}`
 
 lint_requested_level = requested on the command line with `{$level} {$lint_name}`
 

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -343,33 +343,32 @@ impl LintStore {
             sess.emit_err(UnsupportedGroup { lint_group: crate::WARNINGS.name_lower() });
             return;
         }
-        let lint_name = lint_name.to_string();
         match self.check_lint_name(lint_name_only, tool_name, registered_tools) {
             CheckLintNameResult::Renamed(replace) => {
                 sess.emit_warning(CheckNameRenamed {
-                    lint_name: lint_name.clone(),
-                    replace,
+                    lint_name,
+                    replace: &replace,
                     sub: RequestedLevel { level, lint_name },
                 });
             }
             CheckLintNameResult::Removed(reason) => {
                 sess.emit_warning(CheckNameRemoved {
-                    lint_name: lint_name.clone(),
-                    reason,
+                    lint_name,
+                    reason: &reason,
                     sub: RequestedLevel { level, lint_name },
                 });
             }
             CheckLintNameResult::NoLint(suggestion) => {
                 sess.emit_err(CheckNameUnknown {
-                    lint_name: lint_name.clone(),
+                    lint_name,
                     suggestion,
                     sub: RequestedLevel { level, lint_name },
                 });
             }
             CheckLintNameResult::Tool(Err((Some(_), new_name))) => {
                 sess.emit_warning(CheckNameDeprecated {
-                    lint_name: lint_name.clone(),
-                    new_name,
+                    lint_name,
+                    new_name: &new_name,
                     sub: RequestedLevel { level, lint_name },
                 });
             }

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -17,8 +17,8 @@
 use self::TargetLint::*;
 
 use crate::errors::{
-    CheckNameDeprecated, CheckNameUnknown, CheckNameUnknownTool, CheckNameWarning, RequestedLevel,
-    UnsupportedGroup,
+    CheckNameDeprecated, CheckNameRemoved, CheckNameRenamed, CheckNameUnknown,
+    CheckNameUnknownTool, RequestedLevel, UnsupportedGroup,
 };
 use crate::levels::LintLevelsBuilder;
 use crate::passes::{EarlyLintPassObject, LateLintPassObject};
@@ -124,9 +124,10 @@ pub enum CheckLintNameResult<'a> {
     NoLint(Option<Symbol>),
     /// The lint refers to a tool that has not been registered.
     NoTool,
-    /// The lint is either renamed or removed. This is the warning
-    /// message, and an optional new name (`None` if removed).
-    Warning(String, Option<String>),
+    /// The lint has been renamed to a new name.
+    Renamed(String),
+    /// The lint has been removed due to the given reason.
+    Removed(String),
     /// The lint is from a tool. If the Option is None, then either
     /// the lint does not exist in the tool or the code was not
     /// compiled with the tool and therefore the lint was never
@@ -344,9 +345,17 @@ impl LintStore {
         }
         let lint_name = lint_name.to_string();
         match self.check_lint_name(lint_name_only, tool_name, registered_tools) {
-            CheckLintNameResult::Warning(msg, _) => {
-                sess.emit_warning(CheckNameWarning {
-                    msg,
+            CheckLintNameResult::Renamed(replace) => {
+                sess.emit_warning(CheckNameRenamed {
+                    lint_name: lint_name.clone(),
+                    replace,
+                    sub: RequestedLevel { level, lint_name },
+                });
+            }
+            CheckLintNameResult::Removed(reason) => {
+                sess.emit_warning(CheckNameRemoved {
+                    lint_name: lint_name.clone(),
+                    reason,
                     sub: RequestedLevel { level, lint_name },
                 });
             }
@@ -445,14 +454,8 @@ impl LintStore {
             }
         }
         match self.by_name.get(&complete_name) {
-            Some(Renamed(new_name, _)) => CheckLintNameResult::Warning(
-                format!("lint `{complete_name}` has been renamed to `{new_name}`"),
-                Some(new_name.to_owned()),
-            ),
-            Some(Removed(reason)) => CheckLintNameResult::Warning(
-                format!("lint `{complete_name}` has been removed: {reason}"),
-                None,
-            ),
+            Some(Renamed(new_name, _)) => CheckLintNameResult::Renamed(new_name.to_string()),
+            Some(Removed(reason)) => CheckLintNameResult::Removed(reason.to_string()),
             None => match self.lint_groups.get(&*complete_name) {
                 // If neither the lint, nor the lint group exists check if there is a `clippy::`
                 // variant of this lint

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -134,9 +134,19 @@ pub struct CheckNameUnknownTool {
 }
 
 #[derive(Diagnostic)]
-#[diag(lint_check_name_warning)]
-pub struct CheckNameWarning {
-    pub msg: String,
+#[diag(lint_check_name_renamed)]
+pub struct CheckNameRenamed {
+    pub lint_name: String,
+    pub replace: String,
+    #[subdiagnostic]
+    pub sub: RequestedLevel,
+}
+
+#[derive(Diagnostic)]
+#[diag(lint_check_name_removed)]
+pub struct CheckNameRemoved {
+    pub lint_name: String,
+    pub reason: String,
     #[subdiagnostic]
     pub sub: RequestedLevel,
 }

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -91,9 +91,9 @@ pub struct BuiltinEllipsisInclusiveRangePatterns {
 
 #[derive(Subdiagnostic)]
 #[note(lint_requested_level)]
-pub struct RequestedLevel {
+pub struct RequestedLevel<'a> {
     pub level: Level,
-    pub lint_name: String,
+    pub lint_name: &'a str,
 }
 
 #[derive(Diagnostic)]
@@ -102,13 +102,13 @@ pub struct UnsupportedGroup {
     pub lint_group: String,
 }
 
-pub struct CheckNameUnknown {
-    pub lint_name: String,
+pub struct CheckNameUnknown<'a> {
+    pub lint_name: &'a str,
     pub suggestion: Option<Symbol>,
-    pub sub: RequestedLevel,
+    pub sub: RequestedLevel<'a>,
 }
 
-impl IntoDiagnostic<'_> for CheckNameUnknown {
+impl IntoDiagnostic<'_> for CheckNameUnknown<'_> {
     fn into_diagnostic(
         self,
         handler: &Handler,
@@ -127,35 +127,35 @@ impl IntoDiagnostic<'_> for CheckNameUnknown {
 
 #[derive(Diagnostic)]
 #[diag(lint_check_name_unknown_tool, code = "E0602")]
-pub struct CheckNameUnknownTool {
+pub struct CheckNameUnknownTool<'a> {
     pub tool_name: Symbol,
     #[subdiagnostic]
-    pub sub: RequestedLevel,
+    pub sub: RequestedLevel<'a>,
 }
 
 #[derive(Diagnostic)]
 #[diag(lint_check_name_renamed)]
-pub struct CheckNameRenamed {
-    pub lint_name: String,
-    pub replace: String,
+pub struct CheckNameRenamed<'a> {
+    pub lint_name: &'a str,
+    pub replace: &'a str,
     #[subdiagnostic]
-    pub sub: RequestedLevel,
+    pub sub: RequestedLevel<'a>,
 }
 
 #[derive(Diagnostic)]
 #[diag(lint_check_name_removed)]
-pub struct CheckNameRemoved {
-    pub lint_name: String,
-    pub reason: String,
+pub struct CheckNameRemoved<'a> {
+    pub lint_name: &'a str,
+    pub reason: &'a str,
     #[subdiagnostic]
-    pub sub: RequestedLevel,
+    pub sub: RequestedLevel<'a>,
 }
 
 #[derive(Diagnostic)]
 #[diag(lint_check_name_deprecated)]
-pub struct CheckNameDeprecated {
-    pub lint_name: String,
-    pub new_name: String,
+pub struct CheckNameDeprecated<'a> {
+    pub lint_name: &'a str,
+    pub new_name: &'a str,
     #[subdiagnostic]
-    pub sub: RequestedLevel,
+    pub sub: RequestedLevel<'a>,
 }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1012,21 +1012,27 @@ pub struct DeprecatedLintName<'a> {
     pub replace: &'a str,
 }
 
-// FIXME: Non-translatable msg
 #[derive(LintDiagnostic)]
-#[diag(lint_renamed_or_removed_lint)]
-pub struct RenamedOrRemovedLint<'a> {
-    pub msg: &'a str,
+#[diag(lint_renamed_lint)]
+pub struct RenamedLint<'a> {
+    pub name: &'a str,
     #[subdiagnostic]
-    pub suggestion: Option<RenamedOrRemovedLintSuggestion<'a>>,
+    pub suggestion: RenamedLintSuggestion<'a>,
 }
 
 #[derive(Subdiagnostic)]
 #[suggestion(lint_suggestion, code = "{replace}", applicability = "machine-applicable")]
-pub struct RenamedOrRemovedLintSuggestion<'a> {
+pub struct RenamedLintSuggestion<'a> {
     #[primary_span]
     pub suggestion: Span,
     pub replace: &'a str,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(lint_removed_lint)]
+pub struct RemovedLint<'a> {
+    pub name: &'a str,
+    pub reason: &'a str,
 }
 
 #[derive(LintDiagnostic)]


### PR DESCRIPTION
I was trying to address <https://github.com/rust-lang/cargo/issues/12495> and found that maybe I should refactor relevant lints a bit.

This PR translates `RenamedOrRemovedLint` into fluent file. To make diagnostic types clearer and easier to organize, this PR splits it into two structs.

The second commit adds lifetime annotations for removing unnecessary clones. If people feel too noisy, we can revert such change.


### Possibly relevant UI tests:

* `tests/ui/lint-removed*`
* `tests/ui/lint-renamed*`
* `tests/ui/rustdoc-renamed.rs`
* `tests/rustdoc-ui/lints/unknown-renamed-lints.rs`