### PR TITLE
Make `RefMut` `Sync`

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1717,6 +1717,10 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     }
 }
 
+#[stable(feature = "refmut_sync", since = "CURRENT_RUSTC_VERSION")]
+// SAFETY: This is safe because all a `&RefMut` can do is to give `&T`s, it cannot change the borrow flags in any way.
+unsafe impl<T: ?Sized + Sync> Sync for RefMut<'_, T> {}
+
 struct BorrowRefMut<'b> {
     borrow: &'b Cell<BorrowFlag>,
 }


### PR DESCRIPTION
This is safe because a `&RefMut` cannot change the borrow flags.

We cannot impl `Send` for `RefMut` because of `map_split()`; we cannot impl `Sync` for `Ref` because of `clone()`.

This is insta-stable and needs a FCP.

This precludes the addition of an API that transforms `&RefMut` to `Ref`, so we need to choose what we want.