### PR TITLE
kmc-solid: I/O safety

### DIFF
--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -250,21 +250,21 @@ macro_rules! impl_owned_fd_traits {
         impl AsFd for net::$t {
             #[inline]
             fn as_fd(&self) -> BorrowedFd<'_> {
-                unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+                self.as_inner().socket().as_fd()
             }
         }
 
         impl From<net::$t> for OwnedFd {
             #[inline]
             fn from(socket: net::$t) -> OwnedFd {
-                unsafe { Self::from_raw_fd(socket.into_raw_fd()) }
+                socket.into_inner().into_socket().into_inner()
             }
         }
 
         impl From<OwnedFd> for net::$t {
             #[inline]
             fn from(owned_fd: OwnedFd) -> Self {
-                unsafe { Self::from_raw_fd(owned_fd.into_raw_fd()) }
+                Self::from_inner(FromInner::from_inner(FromInner::from_inner(owned_fd)))
             }
         }
     )*};

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -378,7 +378,7 @@ macro_rules! impl_as_raw_fd {
         impl AsRawFd for net::$t {
             #[inline]
             fn as_raw_fd(&self) -> RawFd {
-                *self.as_inner().socket().as_inner()
+                self.as_inner().socket().as_raw_fd()
             }
         }
     )*};
@@ -391,7 +391,7 @@ macro_rules! impl_from_raw_fd {
         impl FromRawFd for net::$t {
             #[inline]
             unsafe fn from_raw_fd(fd: RawFd) -> net::$t {
-                let socket = sys::net::Socket::from_inner(fd);
+                let socket = unsafe { sys::net::Socket::from_raw_fd(fd) };
                 net::$t::from_inner(sys_common::net::$t::from_inner(socket))
             }
         }
@@ -405,7 +405,7 @@ macro_rules! impl_into_raw_fd {
         impl IntoRawFd for net::$t {
             #[inline]
             fn into_raw_fd(self) -> RawFd {
-                self.into_inner().into_socket().into_inner()
+                self.into_inner().into_socket().into_raw_fd()
             }
         }
     )*};

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -3,12 +3,203 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(feature = "solid_ext", issue = "none")]
 
+use crate::fmt;
+use crate::marker::PhantomData;
+use crate::mem::forget;
 use crate::net;
 use crate::sys;
 use crate::sys_common::{self, AsInner, FromInner, IntoInner};
 
 /// Raw file descriptors.
 pub type RawFd = i32;
+
+/// A borrowed SOLID Sockets file descriptor.
+///
+/// This has a lifetime parameter to tie it to the lifetime of something that
+/// owns the socket.
+///
+/// This uses `repr(transparent)` and has the representation of a host file
+/// descriptor, so it can be used in FFI in places where a socket is passed as
+/// an argument, it is not captured or consumed, and it never has the value
+/// `SOLID_NET_INVALID_FD`.
+///
+/// This type's `.to_owned()` implementation returns another `BorrowedFd`
+/// rather than an `OwnedFd`. It just makes a trivial copy of the raw
+/// socket, which is then borrowed under the same lifetime.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+#[rustc_layout_scalar_valid_range_start(0)]
+// This is -2, in two's complement. -1 is `SOLID_NET_INVALID_FD`.
+#[rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)]
+#[rustc_nonnull_optimization_guaranteed]
+pub struct BorrowedFd<'socket> {
+    fd: RawFd,
+    _phantom: PhantomData<&'socket OwnedFd>,
+}
+
+/// An owned SOLID Sockets file descriptor.
+///
+/// This closes the file descriptor on drop.
+///
+/// This uses `repr(transparent)` and has the representation of a host file
+/// descriptor, so it can be used in FFI in places where a socket is passed as
+/// an argument, it is not captured or consumed, and it never has the value
+/// `SOLID_NET_INVALID_FD`.
+#[repr(transparent)]
+#[rustc_layout_scalar_valid_range_start(0)]
+// This is -2, in two's complement. -1 is `SOLID_NET_INVALID_FD`.
+#[rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)]
+#[rustc_nonnull_optimization_guaranteed]
+pub struct OwnedFd {
+    fd: RawFd,
+}
+
+impl BorrowedFd<'_> {
+    /// Return a `BorrowedFd` holding the given raw file descriptor.
+    ///
+    /// # Safety
+    ///
+    /// The resource pointed to by `fd` must remain open for the duration of
+    /// the returned `BorrowedFd`, and it must not have the value
+    /// `SOLID_NET_INVALID_FD`.
+    #[inline]
+    pub const unsafe fn borrow_raw(fd: RawFd) -> Self {
+        assert!(fd != -1 as RawFd);
+        // SAFETY: we just asserted that the value is in the valid range and
+        // isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
+        unsafe { Self { fd, _phantom: PhantomData } }
+    }
+}
+
+impl OwnedFd {
+    /// Creates a new `OwnedFd` instance that shares the same underlying file
+    /// description as the existing `OwnedFd` instance.
+    pub fn try_clone(&self) -> crate::io::Result<Self> {
+        self.as_fd().try_clone_to_owned()
+    }
+}
+
+impl BorrowedFd<'_> {
+    /// Creates a new `OwnedFd` instance that shares the same underlying file
+    /// description as the existing `BorrowedFd` instance.
+    pub fn try_clone_to_owned(&self) -> crate::io::Result<OwnedFd> {
+        let fd = sys::net::cvt(unsafe { sys::net::netc::dup(self.as_raw_fd()) })?;
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
+}
+
+impl AsRawFd for BorrowedFd<'_> {
+    #[inline]
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+impl AsRawFd for OwnedFd {
+    #[inline]
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+impl IntoRawFd for OwnedFd {
+    #[inline]
+    fn into_raw_fd(self) -> RawFd {
+        let fd = self.fd;
+        forget(self);
+        fd
+    }
+}
+
+impl FromRawFd for OwnedFd {
+    /// Constructs a new instance of `Self` from the given raw file descriptor.
+    ///
+    /// # Safety
+    ///
+    /// The resource pointed to by `fd` must be open and suitable for assuming
+    /// ownership. The resource must not require any cleanup other than `close`.
+    #[inline]
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        assert_ne!(fd, -1 as RawFd);
+        // SAFETY: we just asserted that the value is in the valid range and
+        // isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
+        unsafe { Self { fd } }
+    }
+}
+
+impl Drop for OwnedFd {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { sys::net::netc::close(self.fd) };
+    }
+}
+
+impl fmt::Debug for BorrowedFd<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BorrowedFd").field("fd", &self.fd).finish()
+    }
+}
+
+impl fmt::Debug for OwnedFd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OwnedFd").field("fd", &self.fd).finish()
+    }
+}
+
+macro_rules! impl_is_terminal {
+    ($($t:ty),*$(,)?) => {$(
+        #[unstable(feature = "sealed", issue = "none")]
+        impl crate::sealed::Sealed for $t {}
+
+        #[stable(feature = "is_terminal", since = "1.70.0")]
+        impl crate::io::IsTerminal for $t {
+            #[inline]
+            fn is_terminal(&self) -> bool {
+                crate::sys::io::is_terminal(self)
+            }
+        }
+    )*}
+}
+
+impl_is_terminal!(BorrowedFd<'_>, OwnedFd);
+
+/// A trait to borrow the SOLID Sockets file descriptor from an underlying
+/// object.
+pub trait AsFd {
+    /// Borrows the file descriptor.
+    fn as_fd(&self) -> BorrowedFd<'_>;
+}
+
+impl<T: AsFd> AsFd for &T {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        T::as_fd(self)
+    }
+}
+
+impl<T: AsFd> AsFd for &mut T {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        T::as_fd(self)
+    }
+}
+
+impl AsFd for BorrowedFd<'_> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        *self
+    }
+}
+
+impl AsFd for OwnedFd {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        // Safety: `OwnedFd` and `BorrowedFd` have the same validity
+        // invariants, and the `BorrowedFd` is bounded by the lifetime
+        // of `&self`.
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+    }
+}
 
 /// A trait to extract the raw SOLID Sockets file descriptor from an underlying
 /// object.

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -271,6 +271,39 @@ macro_rules! impl_owned_fd_traits {
 }
 impl_owned_fd_traits! { TcpStream TcpListener UdpSocket }
 
+/// This impl allows implementing traits that require `AsFd` on Arc.
+/// ```
+/// # #[cfg(target_os = "solid_asp3")] mod group_cfg {
+/// # use std::os::solid::io::AsFd;
+/// use std::net::UdpSocket;
+/// use std::sync::Arc;
+///
+/// trait MyTrait: AsFd {}
+/// impl MyTrait for Arc<UdpSocket> {}
+/// impl MyTrait for Box<UdpSocket> {}
+/// # }
+/// ```
+impl<T: AsFd> AsFd for crate::sync::Arc<T> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        (**self).as_fd()
+    }
+}
+
+impl<T: AsFd> AsFd for crate::rc::Rc<T> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        (**self).as_fd()
+    }
+}
+
+impl<T: AsFd> AsFd for Box<T> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        (**self).as_fd()
+    }
+}
+
 /// A trait to extract the raw SOLID Sockets file descriptor from an underlying
 /// object.
 pub trait AsRawFd {

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -245,6 +245,32 @@ impl AsFd for OwnedFd {
     }
 }
 
+macro_rules! impl_owned_fd_traits {
+    ($($t:ident)*) => {$(
+        impl AsFd for net::$t {
+            #[inline]
+            fn as_fd(&self) -> BorrowedFd<'_> {
+                unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+            }
+        }
+
+        impl From<net::$t> for OwnedFd {
+            #[inline]
+            fn from(socket: net::$t) -> OwnedFd {
+                unsafe { Self::from_raw_fd(socket.into_raw_fd()) }
+            }
+        }
+
+        impl From<OwnedFd> for net::$t {
+            #[inline]
+            fn from(owned_fd: OwnedFd) -> Self {
+                unsafe { Self::from_raw_fd(owned_fd.into_raw_fd()) }
+            }
+        }
+    )*};
+}
+impl_owned_fd_traits! { TcpStream TcpListener UdpSocket }
+
 /// A trait to extract the raw SOLID Sockets file descriptor from an underlying
 /// object.
 pub trait AsRawFd {

--- a/library/std/src/os/solid/mod.rs
+++ b/library/std/src/os/solid/mod.rs
@@ -13,5 +13,5 @@ pub mod prelude {
     pub use super::ffi::{OsStrExt, OsStringExt};
     #[doc(no_inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+    pub use super::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 }

--- a/library/std/src/sys/solid/net.rs
+++ b/library/std/src/sys/solid/net.rs
@@ -5,7 +5,7 @@ use crate::{
     io::{self, BorrowedBuf, BorrowedCursor, ErrorKind, IoSlice, IoSliceMut},
     mem,
     net::{Shutdown, SocketAddr},
-    os::solid::io::{AsRawFd, FromRawFd, IntoRawFd},
+    os::solid::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd},
     ptr, str,
     sys_common::net::{getsockopt, setsockopt, sockaddr_to_addr},
     sys_common::IntoInner,
@@ -27,95 +27,6 @@ const fn max_iov() -> usize {
     // Judging by the source code, it's unlimited, but specify a lower
     // value just in case.
     1024
-}
-
-/// A file descriptor.
-#[rustc_layout_scalar_valid_range_start(0)]
-// libstd/os/raw/mod.rs assures me that every libstd-supported platform has a
-// 32-bit c_int. Below is -2, in two's complement, but that only works out
-// because c_int is 32 bits.
-#[rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)]
-struct FileDesc {
-    fd: c_int,
-}
-
-impl FileDesc {
-    #[inline]
-    fn new(fd: c_int) -> FileDesc {
-        assert_ne!(fd, -1i32);
-        // Safety: we just asserted that the value is in the valid range and
-        // isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
-        unsafe { FileDesc { fd } }
-    }
-
-    #[inline]
-    fn raw(&self) -> c_int {
-        self.fd
-    }
-
-    /// Extracts the actual file descriptor without closing it.
-    #[inline]
-    fn into_raw(self) -> c_int {
-        let fd = self.fd;
-        mem::forget(self);
-        fd
-    }
-
-    fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-        let ret = cvt(unsafe {
-            netc::read(self.fd, buf.as_mut_ptr() as *mut c_void, cmp::min(buf.len(), READ_LIMIT))
-        })?;
-        Ok(ret as usize)
-    }
-
-    fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        let ret = cvt(unsafe {
-            netc::readv(
-                self.fd,
-                bufs.as_ptr() as *const netc::iovec,
-                cmp::min(bufs.len(), max_iov()) as c_int,
-            )
-        })?;
-        Ok(ret as usize)
-    }
-
-    #[inline]
-    fn is_read_vectored(&self) -> bool {
-        true
-    }
-
-    fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        let ret = cvt(unsafe {
-            netc::write(self.fd, buf.as_ptr() as *const c_void, cmp::min(buf.len(), READ_LIMIT))
-        })?;
-        Ok(ret as usize)
-    }
-
-    fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        let ret = cvt(unsafe {
-            netc::writev(
-                self.fd,
-                bufs.as_ptr() as *const netc::iovec,
-                cmp::min(bufs.len(), max_iov()) as c_int,
-            )
-        })?;
-        Ok(ret as usize)
-    }
-
-    #[inline]
-    fn is_write_vectored(&self) -> bool {
-        true
-    }
-
-    fn duplicate(&self) -> io::Result<FileDesc> {
-        cvt(unsafe { netc::dup(self.fd) }).map(Self::new)
-    }
-}
-
-impl Drop for FileDesc {
-    fn drop(&mut self) {
-        unsafe { netc::close(self.fd) };
-    }
 }
 
 #[doc(hidden)]
@@ -206,7 +117,7 @@ pub(super) fn decode_error_kind(er: abi::ER) -> ErrorKind {
 
 pub fn init() {}
 
-pub struct Socket(FileDesc);
+pub struct Socket(OwnedFd);
 
 impl Socket {
     pub fn new(addr: &SocketAddr, ty: c_int) -> io::Result<Socket> {
@@ -220,16 +131,13 @@ impl Socket {
     pub fn new_raw(fam: c_int, ty: c_int) -> io::Result<Socket> {
         unsafe {
             let fd = cvt(netc::socket(fam, ty, 0))?;
-            let fd = FileDesc::new(fd);
-            let socket = Socket(fd);
-
-            Ok(socket)
+            Ok(Self::from_raw_fd(fd))
         }
     }
 
     pub fn connect(&self, addr: &SocketAddr) -> io::Result<()> {
         let (addr, len) = addr.into_inner();
-        cvt(unsafe { netc::connect(self.0.raw(), addr.as_ptr(), len) })?;
+        cvt(unsafe { netc::connect(self.as_raw_fd(), addr.as_ptr(), len) })?;
         Ok(())
     }
 
@@ -258,14 +166,14 @@ impl Socket {
             timeout.tv_usec = 1;
         }
 
-        let fds = netc::fd_set { num_fds: 1, fds: [self.0.raw()] };
+        let fds = netc::fd_set { num_fds: 1, fds: [self.as_raw_fd()] };
 
         let mut writefds = fds;
         let mut errorfds = fds;
 
         let n = unsafe {
             cvt(netc::select(
-                self.0.raw() + 1,
+                self.as_raw_fd() + 1,
                 ptr::null_mut(),
                 &mut writefds,
                 &mut errorfds,
@@ -288,18 +196,17 @@ impl Socket {
     }
 
     pub fn accept(&self, storage: *mut sockaddr, len: *mut socklen_t) -> io::Result<Socket> {
-        let fd = cvt_r(|| unsafe { netc::accept(self.0.raw(), storage, len) })?;
-        let fd = FileDesc::new(fd);
-        Ok(Socket(fd))
+        let fd = cvt_r(|| unsafe { netc::accept(self.as_raw_fd(), storage, len) })?;
+        unsafe { Ok(Self::from_raw_fd(fd)) }
     }
 
     pub fn duplicate(&self) -> io::Result<Socket> {
-        self.0.duplicate().map(Socket)
+        Ok(Self(self.0.try_clone()?))
     }
 
     fn recv_with_flags(&self, mut buf: BorrowedCursor<'_>, flags: c_int) -> io::Result<()> {
         let ret = cvt(unsafe {
-            netc::recv(self.0.raw(), buf.as_mut().as_mut_ptr().cast(), buf.capacity(), flags)
+            netc::recv(self.as_raw_fd(), buf.as_mut().as_mut_ptr().cast(), buf.capacity(), flags)
         })?;
         unsafe {
             buf.advance(ret as usize);
@@ -324,12 +231,19 @@ impl Socket {
     }
 
     pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        self.0.read_vectored(bufs)
+        let ret = cvt(unsafe {
+            netc::readv(
+                self.as_raw_fd(),
+                bufs.as_ptr() as *const netc::iovec,
+                cmp::min(bufs.len(), max_iov()) as c_int,
+            )
+        })?;
+        Ok(ret as usize)
     }
 
     #[inline]
     pub fn is_read_vectored(&self) -> bool {
-        self.0.is_read_vectored()
+        true
     }
 
     fn recv_from_with_flags(
@@ -342,7 +256,7 @@ impl Socket {
 
         let n = cvt(unsafe {
             netc::recvfrom(
-                self.0.raw(),
+                self.as_raw_fd(),
                 buf.as_mut_ptr() as *mut c_void,
                 buf.len(),
                 flags,
@@ -362,16 +276,30 @@ impl Socket {
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        self.0.write(buf)
+        let ret = cvt(unsafe {
+            netc::write(
+                self.as_raw_fd(),
+                buf.as_ptr() as *const c_void,
+                cmp::min(buf.len(), READ_LIMIT),
+            )
+        })?;
+        Ok(ret as usize)
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        self.0.write_vectored(bufs)
+        let ret = cvt(unsafe {
+            netc::writev(
+                self.as_raw_fd(),
+                bufs.as_ptr() as *const netc::iovec,
+                cmp::min(bufs.len(), max_iov()) as c_int,
+            )
+        })?;
+        Ok(ret as usize)
     }
 
     #[inline]
     pub fn is_write_vectored(&self) -> bool {
-        self.0.is_write_vectored()
+        true
     }
 
     pub fn set_timeout(&self, dur: Option<Duration>, kind: c_int) -> io::Result<()> {
@@ -417,7 +345,7 @@ impl Socket {
             Shutdown::Read => netc::SHUT_RD,
             Shutdown::Both => netc::SHUT_RDWR,
         };
-        cvt(unsafe { netc::shutdown(self.0.raw(), how) })?;
+        cvt(unsafe { netc::shutdown(self.as_raw_fd(), how) })?;
         Ok(())
     }
 
@@ -448,7 +376,7 @@ impl Socket {
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         let mut nonblocking = nonblocking as c_int;
         cvt(unsafe {
-            netc::ioctl(self.0.raw(), netc::FIONBIO, (&mut nonblocking) as *mut c_int as _)
+            netc::ioctl(self.as_raw_fd(), netc::FIONBIO, (&mut nonblocking) as *mut c_int as _)
         })
         .map(drop)
     }
@@ -460,27 +388,27 @@ impl Socket {
 
     // This method is used by sys_common code to abstract over targets.
     pub fn as_raw(&self) -> c_int {
-        self.0.raw()
+        self.as_raw_fd()
     }
 }
 
 impl AsRawFd for Socket {
     #[inline]
     fn as_raw_fd(&self) -> c_int {
-        self.0.fd
+        self.0.as_raw_fd()
     }
 }
 
 impl FromRawFd for Socket {
     #[inline]
     unsafe fn from_raw_fd(fd: c_int) -> Socket {
-        Socket(FileDesc::new(fd))
+        unsafe { Self(FromRawFd::from_raw_fd(fd)) }
     }
 }
 
 impl IntoRawFd for Socket {
     #[inline]
     fn into_raw_fd(self) -> c_int {
-        self.0.into_raw()
+        self.0.into_raw_fd()
     }
 }

--- a/library/std/src/sys/solid/net.rs
+++ b/library/std/src/sys/solid/net.rs
@@ -5,10 +5,10 @@ use crate::{
     io::{self, BorrowedBuf, BorrowedCursor, ErrorKind, IoSlice, IoSliceMut},
     mem,
     net::{Shutdown, SocketAddr},
-    os::solid::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd},
+    os::solid::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd},
     ptr, str,
     sys_common::net::{getsockopt, setsockopt, sockaddr_to_addr},
-    sys_common::IntoInner,
+    sys_common::{FromInner, IntoInner},
     time::Duration,
 };
 
@@ -389,6 +389,27 @@ impl Socket {
     // This method is used by sys_common code to abstract over targets.
     pub fn as_raw(&self) -> c_int {
         self.as_raw_fd()
+    }
+}
+
+impl FromInner<OwnedFd> for Socket {
+    #[inline]
+    fn from_inner(sock: OwnedFd) -> Socket {
+        Socket(sock)
+    }
+}
+
+impl IntoInner<OwnedFd> for Socket {
+    #[inline]
+    fn into_inner(self) -> OwnedFd {
+        self.0
+    }
+}
+
+impl AsFd for Socket {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
     }
 }
 


### PR DESCRIPTION
Adds the I/O safety API (#87329) for socket file descriptors in [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html) Tier 3 targets. All new public items are gated by the `solid_ext` library feature.

This PR adds the following public types and traits:

    std::os::solid::io::AsFd
    std::os::solid::io::BorrowedFd
    std::os::solid::io::OwnedFd

    std::os::solid::prelude::AsFd (re-export)
    std::os::solid::prelude::BorrowedFd (re-export)
    std::os::solid::prelude::OwnedFd (re-export)

And trait implementations:

    From<std::net::TcpListener> for std::os::solid::io::OwnedFd
    From<std::net::TcpStream> for std::os::solid::io::OwnedFd
    From<std::net::UdpSocket> for std::os::solid::io::OwnedFd
    From<std::os::solid::io::OwnedFd> for std::net::TcpListener
    From<std::os::solid::io::OwnedFd> for std::net::TcpStream
    From<std::os::solid::io::OwnedFd> for std::net::UdpSocket
    std::fmt::Debug for std::os::solid::io::BorrowedFd<'_>
    std::fmt::Debug for std::os::solid::io::OwnedFd
    std::io::IsTerminal for std::os::solid::io::BorrowedFd<'_>
    std::io::IsTerminal for std::os::solid::io::OwnedFd
    std::os::fd::AsRawFd for std::os::solid::io::BorrowedFd<'_>
    std::os::fd::AsRawFd for std::os::solid::io::OwnedFd
    std::os::fd::FromRawFd for std::os::solid::io::OwnedFd
    std::os::fd::IntoRawFd for std::os::solid::io::OwnedFd
    std::os::solid::io::AsFd for &impl std::os::solid::io::AsFd
    std::os::solid::io::AsFd for &mut impl std::os::solid::io::AsFd
    std::os::solid::io::AsFd for Arc<impl std::os::solid::io::AsFd>
    std::os::solid::io::AsFd for Box<impl std::os::solid::io::AsFd>
    std::os::solid::io::AsFd for Rc<impl std::os::solid::io::AsFd>
    std::os::solid::io::AsFd for std::net::TcpListener
    std::os::solid::io::AsFd for std::net::TcpStream
    std::os::solid::io::AsFd for std::net::UdpSocket
    std::os::solid::io::AsFd for std::os::solid::io::BorrowedFd<'_>
    std::os::solid::io::AsFd for std::os::solid::io::OwnedFd

Taking advantage of the above change, this PR also refactors the internal details of `std::sys::solid::net` to match the design of other targets, e.g., by redefining `Socket` as a newtype of `OwnedFd`.