### PR TITLE
make query caches use `Sharded` only for multiple threads

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -731,6 +731,7 @@ pub fn create_global_ctxt<'tcx>(
                     extern_providers,
                     query_result_on_disk_cache,
                     incremental,
+                    !rustc_data_structures::sync::is_dyn_thread_safe(),
                 ),
             )
         })

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -103,6 +103,9 @@ impl QuerySideEffects {
 pub trait QueryContext: HasDepContext {
     fn next_job_id(self) -> QueryJobId;
 
+    #[cfg(parallel_compiler)]
+    fn single_thread(self) -> bool;
+
     /// Get the query information from the TLS context.
     fn current_query_job(self) -> Option<QueryJobId>;
 


### PR DESCRIPTION
This PR make query caches use `Sharded` only for multiple threads. This can improve spatial locality in single-threaded scenarios to improve performance

cc @Zoxc
r? @cjgillot 