### PR TITLE
Suggest construction for unit/empty tuples/structs

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -58,7 +58,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             || self.suggest_into(err, expr, expr_ty, expected)
             || self.suggest_floating_point_literal(err, expr, expected)
             || self.suggest_null_ptr_for_literal_zero_given_to_ptr_arg(err, expr, expected)
-            || self.suggest_coercing_result_via_try_operator(err, expr, expected, expr_ty);
+            || self.suggest_coercing_result_via_try_operator(err, expr, expected, expr_ty)
+            || self.suggest_unit_or_empty_struct_construction(err, expr, expected);
 
         if !suggested {
             self.note_source_of_type_mismatch_constraint(

--- a/src/tools/clippy/tests/ui/track-diagnostics.stderr
+++ b/src/tools/clippy/tests/ui/track-diagnostics.stderr
@@ -4,6 +4,11 @@ error[E0308]: mismatched types
 LL | const S: A = B;
    |              ^ expected `A`, found `B`
 -Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:LL:CC
+   |
+help: try directly constructing the struct instead
+   |
+LL | const S: A = A;
+   |              ~
 
 error: aborting due to previous error
 

--- a/tests/rustdoc-ui/track-diagnostics.stderr
+++ b/tests/rustdoc-ui/track-diagnostics.stderr
@@ -4,6 +4,11 @@ error[E0308]: mismatched types
 LL | const S: A = B;
    |              ^ expected `A`, found `B`
 -Ztrack-diagnostics: created at compiler/rustc_infer/src/infer/error_reporting/mod.rs:LL:CC
+   |
+help: try directly constructing the struct instead
+   |
+LL | const S: A = A;
+   |              ~
 
 error: aborting due to previous error
 

--- a/tests/ui/argument-suggestions/issue-101097.stderr
+++ b/tests/ui/argument-suggestions/issue-101097.stderr
@@ -149,6 +149,10 @@ LL |     c1: C,
    |     -----
 LL |     c2: C,
    |     -----
+help: try directly constructing the struct instead
+   |
+LL |     f(C, C, B, B, A, A);
+   |             ~
 help: did you mean
    |
 LL |     f(A, A, /* B */, B, C, C);

--- a/tests/ui/argument-suggestions/issue-109831.stderr
+++ b/tests/ui/argument-suggestions/issue-109831.stderr
@@ -39,6 +39,14 @@ note: function defined here
    |
 LL | fn f(b1: B, b2: B, a2: C) {}
    |    ^ -----  -----  -----
+help: try directly constructing the struct instead
+   |
+LL |     f(B, A, B, C);
+   |       ~
+help: try directly constructing the struct instead
+   |
+LL |     f(A, B, B, C);
+   |          ~
 help: remove the extra argument
    |
 LL -     f(A, A, B, C);

--- a/tests/ui/associated-types/associated-type-projection-from-supertrait.stderr
+++ b/tests/ui/associated-types/associated-type-projection-from-supertrait.stderr
@@ -11,6 +11,10 @@ note: function defined here
    |
 LL | fn dent<C:Car>(c: C, color: C::Color) { c.chip_paint(color) }
    |    ^^^^              ---------------
+help: try directly constructing the struct instead
+   |
+LL | fn b() { dent(ModelT, Black); }
+   |                       ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/associated-type-projection-from-supertrait.rs:28:23
@@ -25,6 +29,10 @@ note: function defined here
    |
 LL | fn dent<C:Car>(c: C, color: C::Color) { c.chip_paint(color) }
    |    ^^^^              ---------------
+help: try directly constructing the struct instead
+   |
+LL | fn c() { dent(ModelU, Blue); }
+   |                       ~~~~
 
 error[E0308]: mismatched types
   --> $DIR/associated-type-projection-from-supertrait.rs:32:28
@@ -39,6 +47,10 @@ note: method defined here
    |
 LL |     fn chip_paint(&self, c: Self::Color) { }
    |        ^^^^^^^^^^        --------------
+help: try directly constructing the struct instead
+   |
+LL | fn f() { ModelT.chip_paint(Black); }
+   |                            ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/associated-type-projection-from-supertrait.rs:33:28
@@ -53,6 +65,10 @@ note: method defined here
    |
 LL |     fn chip_paint(&self, c: Self::Color) { }
    |        ^^^^^^^^^^        --------------
+help: try directly constructing the struct instead
+   |
+LL | fn g() { ModelU.chip_paint(Blue); }
+   |                            ~~~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/associated-types/associated-types-eq-3.stderr
+++ b/tests/ui/associated-types/associated-types-eq-3.stderr
@@ -12,6 +12,10 @@ help: consider constraining the associated type `<I as Foo>::A` to `Bar`
    |
 LL | fn foo2<I: Foo<A = Bar>>(x: I) {
    |               +++++++++
+help: try directly constructing the struct instead
+   |
+LL |     let _: Bar = Bar;
+   |                  ~~~
 
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:38:10

--- a/tests/ui/const-generics/defaults/mismatch.stderr
+++ b/tests/ui/const-generics/defaults/mismatch.stderr
@@ -8,6 +8,10 @@ LL |     let e: Example<13> = ();
    |
    = note: expected struct `Example`
            found unit type `()`
+help: try directly constructing the struct instead
+   |
+LL |     let e: Example<13> = Example;
+   |                          ~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/mismatch.rs:10:32
@@ -52,6 +56,10 @@ LL |     let e: Example4<7> = ();
    |
    = note: expected struct `Example4<7>`
            found unit type `()`
+help: try directly constructing the struct instead
+   |
+LL |     let e: Example4<7> = Example4;
+   |                          ~~~~~~~~
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/const-generics/different_generic_args.full.stderr
+++ b/tests/ui/const-generics/different_generic_args.full.stderr
@@ -6,6 +6,10 @@ LL |     u = ConstUsize::<4> {};
    |
    = note: expected struct `ConstUsize<3>`
               found struct `ConstUsize<4>`
+help: try directly constructing the struct instead
+   |
+LL |     u = ConstUsize {};
+   |         ~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/different_generic_args.min.stderr
+++ b/tests/ui/const-generics/different_generic_args.min.stderr
@@ -6,6 +6,10 @@ LL |     u = ConstUsize::<4> {};
    |
    = note: expected struct `ConstUsize<3>`
               found struct `ConstUsize<4>`
+help: try directly constructing the struct instead
+   |
+LL |     u = ConstUsize {};
+   |         ~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/different_generic_args_array.stderr
+++ b/tests/ui/const-generics/different_generic_args_array.stderr
@@ -6,6 +6,10 @@ LL |     x = Const::<{ [4] }> {};
    |
    = note: expected struct `Const<[3]>`
               found struct `Const<[4]>`
+help: try directly constructing the struct instead
+   |
+LL |     x = Const {};
+   |         ~~~~~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/issue-66451.stderr
+++ b/tests/ui/const-generics/issue-66451.stderr
@@ -14,6 +14,10 @@ LL | |     }> = x;
    |
    = note: expected struct `Test<Foo { value: 3, nested: &Bar::<i32>(5) }>`
               found struct `Test<Foo { value: 3, nested: &Bar::<i32>(4) }>`
+help: try directly constructing the struct instead
+   |
+LL |     }> = Test;
+   |          ~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/slice-const-param-mismatch.full.stderr
+++ b/tests/ui/const-generics/slice-const-param-mismatch.full.stderr
@@ -8,6 +8,10 @@ LL |     let _: ConstString<"Hello"> = ConstString::<"World">;
    |
    = note: expected struct `ConstString<"Hello">`
               found struct `ConstString<"World">`
+help: try directly constructing the struct instead
+   |
+LL |     let _: ConstString<"Hello"> = ConstString;
+   |                                   ~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/slice-const-param-mismatch.rs:16:33
@@ -19,6 +23,10 @@ LL |     let _: ConstString<"ℇ㇈↦"> = ConstString::<"ℇ㇈↥">;
    |
    = note: expected struct `ConstString<"ℇ㇈↦">`
               found struct `ConstString<"ℇ㇈↥">`
+help: try directly constructing the struct instead
+   |
+LL |     let _: ConstString<"ℇ㇈↦"> = ConstString;
+   |                                  ~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/slice-const-param-mismatch.rs:18:33
@@ -30,6 +38,10 @@ LL |     let _: ConstBytes<b"AAA"> = ConstBytes::<b"BBB">;
    |
    = note: expected struct `ConstBytes<b"AAA">`
               found struct `ConstBytes<b"BBB">`
+help: try directly constructing the struct instead
+   |
+LL |     let _: ConstBytes<b"AAA"> = ConstBytes;
+   |                                 ~~~~~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/object-unsafe-trait-in-return-position-impl-trait.stderr
+++ b/tests/ui/impl-trait/object-unsafe-trait-in-return-position-impl-trait.stderr
@@ -6,6 +6,11 @@ LL | fn can() -> impl NotObjectSafe {
 ...
 LL |     B
    |     ^ expected `A`, found `B`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error[E0308]: mismatched types
   --> $DIR/object-unsafe-trait-in-return-position-impl-trait.rs:43:5
@@ -15,6 +20,11 @@ LL | fn cat() -> impl ObjectSafe {
 ...
 LL |     B
    |     ^ expected `A`, found `B`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-56943.stderr
+++ b/tests/ui/issues/issue-56943.stderr
@@ -5,6 +5,11 @@ LL |     let _: issue_56943::S = issue_56943::S2;
    |            --------------   ^^^^^^^^^^^^^^^ expected `S`, found `S2`
    |            |
    |            expected due to this
+   |
+help: try directly constructing the struct instead
+   |
+LL |     let _: issue_56943::S = issue_56943::S;
+   |                             ~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/mismatched_types/do-not-suggest-boxed-trait-objects-instead-of-impl-trait.stderr
+++ b/tests/ui/mismatched_types/do-not-suggest-boxed-trait-objects-instead-of-impl-trait.stderr
@@ -20,6 +20,11 @@ LL | |         false => Y,
    | |                  ^ expected `S`, found `Y`
 LL | |     }
    | |_____- `match` arms have incompatible types
+   |
+help: try directly constructing the struct instead
+   |
+LL |         false => S,
+   |                  ~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/mismatched_types/show_module.stderr
+++ b/tests/ui/mismatched_types/show_module.stderr
@@ -17,6 +17,10 @@ note: `baz::Foo` is defined in module `crate::blah::baz` of the current crate
    |
 LL |         pub struct Foo;
    |         ^^^^^^^^^^^^^^
+help: try directly constructing the struct instead
+   |
+LL |     blah::baz::Foo
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/mismatched_types/similar_paths_primitive.stderr
+++ b/tests/ui/mismatched_types/similar_paths_primitive.stderr
@@ -18,6 +18,10 @@ note: function defined here
    |
 LL | fn foo(_: bool) {}
    |    ^^^ -------
+help: try directly constructing the struct instead
+   |
+LL |     foo(bool);
+   |         ~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.fixed
+++ b/tests/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.fixed
@@ -21,7 +21,7 @@ fn foo() -> Box<dyn Trait> {
 fn bar() -> Box<dyn Trait> {
     match true {
         true => Box::new(S),
-        false => Box::new(Y), //~ ERROR `match` arms have incompatible types
+        false => Box::new(S), //~ ERROR `match` arms have incompatible types
     }
 }
 

--- a/tests/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.stderr
+++ b/tests/ui/mismatched_types/suggest-boxed-trait-objects-instead-of-impl-trait.stderr
@@ -41,6 +41,10 @@ help: if you change the return type to expect trait objects, box the returned ex
 LL ~         true => Box::new(S),
 LL ~         false => Box::new(Y),
    |
+help: try directly constructing the struct instead
+   |
+LL |         false => S,
+   |                  ~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/coercions.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/coercions.stderr
@@ -5,6 +5,11 @@ LL | fn cannot_coerce_empty_enum_to_anything(x: UninhabitedEnum) -> A {
    |                                                                - expected `A` because of return type
 LL |     x
    |     ^ expected `A`, found `UninhabitedEnum`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error[E0308]: mismatched types
   --> $DIR/coercions.rs:27:5
@@ -13,6 +18,11 @@ LL | fn cannot_coerce_empty_tuple_struct_to_anything(x: UninhabitedTupleStruct) 
    |                                                                               - expected `A` because of return type
 LL |     x
    |     ^ expected `A`, found `UninhabitedTupleStruct`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error[E0308]: mismatched types
   --> $DIR/coercions.rs:31:5
@@ -21,6 +31,11 @@ LL | fn cannot_coerce_empty_struct_to_anything(x: UninhabitedStruct) -> A {
    |                                                                    - expected `A` because of return type
 LL |     x
    |     ^ expected `A`, found `UninhabitedStruct`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error[E0308]: mismatched types
   --> $DIR/coercions.rs:35:5
@@ -29,6 +44,11 @@ LL | fn cannot_coerce_enum_with_empty_variants_to_anything(x: UninhabitedVariant
    |                                                                                  - expected `A` because of return type
 LL |     x
    |     ^ expected `A`, found `UninhabitedVariants`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/coercions_same_crate.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/coercions_same_crate.stderr
@@ -5,6 +5,11 @@ LL | fn cannot_coerce_empty_enum_to_anything(x: UninhabitedEnum) -> A {
    |                                                                - expected `A` because of return type
 LL |     x
    |     ^ expected `A`, found `UninhabitedEnum`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error[E0308]: mismatched types
   --> $DIR/coercions_same_crate.rs:34:5
@@ -13,6 +18,11 @@ LL | fn cannot_coerce_empty_tuple_struct_to_anything(x: UninhabitedTupleStruct) 
    |                                                                               - expected `A` because of return type
 LL |     x
    |     ^ expected `A`, found `UninhabitedTupleStruct`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error[E0308]: mismatched types
   --> $DIR/coercions_same_crate.rs:38:5
@@ -21,6 +31,11 @@ LL | fn cannot_coerce_empty_struct_to_anything(x: UninhabitedStruct) -> A {
    |                                                                    - expected `A` because of return type
 LL |     x
    |     ^ expected `A`, found `UninhabitedStruct`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error[E0308]: mismatched types
   --> $DIR/coercions_same_crate.rs:42:5
@@ -29,6 +44,11 @@ LL | fn cannot_coerce_enum_with_empty_variants_to_anything(x: UninhabitedVariant
    |                                                                                  - expected `A` because of return type
 LL |     x
    |     ^ expected `A`, found `UninhabitedVariants`
+   |
+help: try directly constructing the struct instead
+   |
+LL |     A
+   |     ~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.fixed
+++ b/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.fixed
@@ -4,7 +4,7 @@ fn wat<T: Clone>(t: &T) -> T {
 }
 
 #[derive(Clone)]
-struct Foo;
+struct Foo(usize);
 
 fn wut(t: &Foo) -> Foo {
     t.clone() //~ ERROR E0308
@@ -12,5 +12,5 @@ fn wut(t: &Foo) -> Foo {
 
 fn main() {
     wat(&42);
-    wut(&Foo);
+    wut(&Foo(42));
 }

--- a/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.rs
+++ b/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.rs
@@ -3,7 +3,7 @@ fn wat<T>(t: &T) -> T {
     t.clone() //~ ERROR E0308
 }
 
-struct Foo;
+struct Foo(usize);
 
 fn wut(t: &Foo) -> Foo {
     t.clone() //~ ERROR E0308
@@ -11,5 +11,5 @@ fn wut(t: &Foo) -> Foo {
 
 fn main() {
     wat(&42);
-    wut(&Foo);
+    wut(&Foo(42));
 }

--- a/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
+++ b/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
@@ -36,7 +36,7 @@ LL |     t.clone()
 help: consider annotating `Foo` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
-LL | struct Foo;
+LL | struct Foo(usize);
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/suggestions/issue-101465.stderr
+++ b/tests/ui/suggestions/issue-101465.stderr
@@ -19,6 +19,10 @@ help: if you change the return type to expect trait objects, box the returned ex
 LL ~         true => Box::new(B),
 LL ~         false => Box::new(C),
    |
+help: try directly constructing the struct instead
+   |
+LL |         false => B,
+   |                  ~
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/issue-106443-sugg-clone-for-arg.stderr
+++ b/tests/ui/suggestions/issue-106443-sugg-clone-for-arg.stderr
@@ -29,6 +29,10 @@ note: function defined here
    |
 LL | fn bar(_: T) {}
    |    ^^^ ----
+help: try directly constructing the struct instead
+   |
+LL |     bar(T);
+   |         ~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/suggest-unit-struct-construction.rs
+++ b/tests/ui/suggestions/suggest-unit-struct-construction.rs
@@ -1,0 +1,34 @@
+struct UnitStruct;
+struct WrappedUnitStruct(UnitStruct);
+struct StructWrappedUnitStruct {
+    inner: UnitStruct,
+}
+
+struct WrappedPhantomData(std::marker::PhantomData<()>);
+
+struct UnitTuple();
+struct WrappedUnitTuple(UnitTuple);
+
+struct EmptyStruct {}
+struct WrappedEmptyStruct(EmptyStruct);
+
+
+fn main() {
+    WrappedUnitStruct(());
+    //~^ mismatched types [E0308]
+    //~| try directly constructing the struct
+    StructWrappedUnitStruct {
+        inner: 0,
+        //~^ mismatched types [E0308]
+        //~| try directly constructing the struct
+    };
+    WrappedPhantomData(());
+    //~^ mismatched types [E0308]
+    //~| try directly constructing the struct
+    WrappedUnitTuple(());
+    //~^ mismatched types [E0308]
+    //~| try directly constructing the struct
+    WrappedEmptyStruct(());
+    //~^ mismatched types [E0308]
+    //~| try directly constructing the struct
+}

--- a/tests/ui/suggestions/suggest-unit-struct-construction.stderr
+++ b/tests/ui/suggestions/suggest-unit-struct-construction.stderr
@@ -1,0 +1,88 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-unit-struct-construction.rs:17:23
+   |
+LL |     WrappedUnitStruct(());
+   |     ----------------- ^^ expected `UnitStruct`, found `()`
+   |     |
+   |     arguments to this struct are incorrect
+   |
+note: tuple struct defined here
+  --> $DIR/suggest-unit-struct-construction.rs:2:8
+   |
+LL | struct WrappedUnitStruct(UnitStruct);
+   |        ^^^^^^^^^^^^^^^^^
+help: try directly constructing the struct instead
+   |
+LL |     WrappedUnitStruct(UnitStruct);
+   |                       ~~~~~~~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-unit-struct-construction.rs:21:16
+   |
+LL |         inner: 0,
+   |                ^ expected `UnitStruct`, found integer
+   |
+help: try directly constructing the struct instead
+   |
+LL |         inner: UnitStruct,
+   |                ~~~~~~~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-unit-struct-construction.rs:25:24
+   |
+LL |     WrappedPhantomData(());
+   |     ------------------ ^^ expected `PhantomData<()>`, found `()`
+   |     |
+   |     arguments to this struct are incorrect
+   |
+   = note: expected struct `PhantomData<()>`
+           found unit type `()`
+note: tuple struct defined here
+  --> $DIR/suggest-unit-struct-construction.rs:7:8
+   |
+LL | struct WrappedPhantomData(std::marker::PhantomData<()>);
+   |        ^^^^^^^^^^^^^^^^^^
+help: try directly constructing the struct instead
+   |
+LL |     WrappedPhantomData(std::marker::PhantomData);
+   |                        ~~~~~~~~~~~~~~~~~~~~~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-unit-struct-construction.rs:28:22
+   |
+LL |     WrappedUnitTuple(());
+   |     ---------------- ^^ expected `UnitTuple`, found `()`
+   |     |
+   |     arguments to this struct are incorrect
+   |
+note: tuple struct defined here
+  --> $DIR/suggest-unit-struct-construction.rs:10:8
+   |
+LL | struct WrappedUnitTuple(UnitTuple);
+   |        ^^^^^^^^^^^^^^^^
+help: try directly constructing the struct instead
+   |
+LL |     WrappedUnitTuple(UnitTuple());
+   |                      ~~~~~~~~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-unit-struct-construction.rs:31:24
+   |
+LL |     WrappedEmptyStruct(());
+   |     ------------------ ^^ expected `EmptyStruct`, found `()`
+   |     |
+   |     arguments to this struct are incorrect
+   |
+note: tuple struct defined here
+  --> $DIR/suggest-unit-struct-construction.rs:13:8
+   |
+LL | struct WrappedEmptyStruct(EmptyStruct);
+   |        ^^^^^^^^^^^^^^^^^^
+help: try directly constructing the struct instead
+   |
+LL |     WrappedEmptyStruct(EmptyStruct {});
+   |                        ~~~~~~~~~~~~~~
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type/type-mismatch-same-crate-name.stderr
+++ b/tests/ui/type/type-mismatch-same-crate-name.stderr
@@ -23,6 +23,10 @@ note: function defined here
    |
 LL | pub fn try_foo(x: Foo){}
    |        ^^^^^^^
+help: try directly constructing the struct instead
+   |
+LL |         a::try_foo(main::a::Foo);
+   |                    ~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-same-crate-name.rs:20:20

--- a/tests/ui/type/type-mismatch.stderr
+++ b/tests/ui/type/type-mismatch.stderr
@@ -11,6 +11,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: try directly constructing the struct instead
+   |
+LL |     want::<foo>(foo);
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:18:17
@@ -25,6 +29,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: try directly constructing the struct instead
+   |
+LL |     want::<bar>(bar);
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:19:24
@@ -149,6 +157,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: try directly constructing the struct instead
+   |
+LL |     want::<bar>(bar);
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:30:24
@@ -277,6 +289,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: try directly constructing the struct instead
+   |
+LL |     want::<foo>(foo);
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:41:17
@@ -293,6 +309,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: try directly constructing the struct instead
+   |
+LL |     want::<bar>(bar);
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:42:24
@@ -441,6 +461,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: try directly constructing the struct instead
+   |
+LL |     want::<foo>(foo);
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:54:17
@@ -457,6 +481,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: try directly constructing the struct instead
+   |
+LL |     want::<bar>(bar);
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:55:24
@@ -605,6 +633,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: try directly constructing the struct instead
+   |
+LL |     want::<foo>(foo);
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:67:17
@@ -621,6 +653,10 @@ note: function defined here
    |
 LL | fn want<T>(t: T) {}
    |    ^^^^    ----
+help: try directly constructing the struct instead
+   |
+LL |     want::<bar>(bar);
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:68:24

--- a/tests/ui/typeck/explain_clone_autoref.stderr
+++ b/tests/ui/typeck/explain_clone_autoref.stderr
@@ -12,6 +12,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |     nc.clone()
    |     ^^
+help: try directly constructing the struct instead
+   |
+LL |     NotClone
+   |
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -31,6 +35,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |     let nc: NotClone = nc.clone();
    |                        ^^
+help: try directly constructing the struct instead
+   |
+LL |     let nc: NotClone = NotClone;
+   |                        ~~~~~~~~
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -51,6 +59,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |     let nc = nc.clone();
    |              ^^
+help: try directly constructing the struct instead
+   |
+LL |     NotClone
+   |
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -71,6 +83,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |     let nc = nc.clone();
    |              ^^
+help: try directly constructing the struct instead
+   |
+LL |     NotClone
+   |
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -91,6 +107,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |     let nc = nc.clone();
    |              ^^
+help: try directly constructing the struct instead
+   |
+LL |     NotClone
+   |
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -111,6 +131,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |     let (ret, _) = (nc.clone(), 1);
    |                     ^^
+help: try directly constructing the struct instead
+   |
+LL |     NotClone
+   |
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -131,6 +155,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |     let ret = nc[0].clone();
    |               ^^^^^
+help: try directly constructing the struct instead
+   |
+LL |     NotClone
+   |
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -151,6 +179,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |         let a = nc.clone();
    |                 ^^
+help: try directly constructing the struct instead
+   |
+LL |     NotClone
+   |
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -171,6 +203,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |     let cl = || nc.clone();
    |                 ^^
+help: try directly constructing the struct instead
+   |
+LL |     NotClone
+   |
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -188,6 +224,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |         let a = nc.clone();
    |                 ^^
+help: try directly constructing the struct instead
+   |
+LL |     (NotClone, b)
+   |      ~~~~~~~~
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -205,6 +245,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |         (a, nc.clone())
    |             ^^
+help: try directly constructing the struct instead
+   |
+LL |     (a, NotClone)
+   |         ~~~~~~~~
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -225,6 +269,10 @@ note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
    |
 LL |         let a = nc.clone();
    |                 ^^
+help: try directly constructing the struct instead
+   |
+LL |     NotClone
+   |
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/typeck/issue-100246.stderr
+++ b/tests/ui/typeck/issue-100246.stderr
@@ -7,6 +7,10 @@ LL |     let other: Other = downcast()?;
    = note: `?` operator cannot convert from `&_` to `Other`
    = note: expected struct `Other`
            found reference `&_`
+help: try directly constructing the struct instead
+   |
+LL |     let other: Other = Other;
+   |                        ~~~~~
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This PR introduces a new suggestion for unit tuples, unit structs, empty tuples, or empty structs. If there's a type mismatch, then it's possible that the user is unaware of how to construct a unit struct. Instead, we can suggest a `MaybeIncorrect` fix that directly constructs an instance of the type instead. 

Originally, this was specifically meant for newtyping a `PhantomData<T>`, but that seems excessively narrow. If we're at the point where `rustc` can determine both what the expected type is and that it is also a empty or unit type, then directly constructing one is guaranteed to be valid for all types, not just `PhantomData<T>`. This also works for (const) generics, since at this phase `rustc` has already inferred all the generics types.

As a result, the majority of changes here actually stem from a nontrivial amount of tests that construct and generate type errors for unit structs. This is expected. However, there are a few concerns that I'd like feedback on:
 1. In tests such as `tests/ui/mismatched_types/show_module.stderr`, this suggest simply generates an ambiguous snippet, where it looks like it's a type path. This makes sense but I'm wondering if this is too ambiguous to be meaningful. On the other hand, I'm not sure what's the best way to express that this is a constructor.
 2. Error phrasing -- `try directly constructing the struct instead` is my best effort, but this doesn't sound like it would be in diag messages.

I also had to sidestep `tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.rs` since it appears that we can't selectively chose which diag messages to ignore. The fixed version of this test without modifications resulted in an unused variable, which fails in a `rustfix` test. This seems like a limitation of the testing framework.

Fixes #115155.