### PR TITLE
remove some unnecessary ignore-debug clauses

### DIFF
--- a/tests/mir-opt/pre-codegen/chained_comparison.rs
+++ b/tests/mir-opt/pre-codegen/chained_comparison.rs
@@ -1,5 +1,4 @@
 // compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=2
-// ignore-debug
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/pre-codegen/checked_ops.rs
+++ b/tests/mir-opt/pre-codegen/checked_ops.rs
@@ -1,6 +1,5 @@
 // compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=2
 // needs-unwind
-// ignore-debug
 // only-x86_64
 
 #![crate_type = "lib"]

--- a/tests/mir-opt/pre-codegen/intrinsics.rs
+++ b/tests/mir-opt/pre-codegen/intrinsics.rs
@@ -1,6 +1,5 @@
 // compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
 // only-64bit
-// ignore-debug
 
 // Checks that we do not have any branches in the MIR for the two tested functions.
 

--- a/tests/mir-opt/pre-codegen/loops.rs
+++ b/tests/mir-opt/pre-codegen/loops.rs
@@ -1,6 +1,5 @@
 // compile-flags: -O -Zmir-opt-level=2 -g
 // needs-unwind
-// ignore-debug
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/pre-codegen/mem_replace.rs
+++ b/tests/mir-opt/pre-codegen/mem_replace.rs
@@ -1,6 +1,6 @@
 // compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
 // only-64bit
-// ignore-debug
+// ignore-debug the standard library debug assertions leak into this test
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/pre-codegen/range_iter.rs
+++ b/tests/mir-opt/pre-codegen/range_iter.rs
@@ -1,6 +1,5 @@
 // compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
 // only-64bit
-// ignore-debug
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]

--- a/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
@@ -3,9 +3,9 @@
 fn ezmap(_1: Option<i32>) -> Option<i32> {
     debug x => _1;
     let mut _0: std::option::Option<i32>;
-    scope 1 (inlined map::<i32, i32, [closure@$DIR/simple_option_map.rs:18:12: 18:15]>) {
+    scope 1 (inlined map::<i32, i32, [closure@$DIR/simple_option_map.rs:17:12: 17:15]>) {
         debug slf => _1;
-        debug f => const ZeroSized: [closure@$DIR/simple_option_map.rs:18:12: 18:15];
+        debug f => const ZeroSized: [closure@$DIR/simple_option_map.rs:17:12: 17:15];
         let mut _2: isize;
         let _3: i32;
         let mut _4: i32;

--- a/tests/mir-opt/pre-codegen/simple_option_map.rs
+++ b/tests/mir-opt/pre-codegen/simple_option_map.rs
@@ -1,6 +1,5 @@
 // compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
 // only-64bit
-// ignore-debug
 
 #[inline(always)]
 fn map<T, U, F>(slf: Option<T>, f: F) -> Option<U>

--- a/tests/mir-opt/pre-codegen/slice_index.rs
+++ b/tests/mir-opt/pre-codegen/slice_index.rs
@@ -1,6 +1,6 @@
 // compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
 // only-64bit
-// ignore-debug
+// ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]

--- a/tests/mir-opt/pre-codegen/slice_iter.rs
+++ b/tests/mir-opt/pre-codegen/slice_iter.rs
@@ -1,6 +1,6 @@
 // compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
 // only-64bit
-// ignore-debug
+// ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]

--- a/tests/mir-opt/pre-codegen/try_identity.rs
+++ b/tests/mir-opt/pre-codegen/try_identity.rs
@@ -1,6 +1,5 @@
 // compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
 // only-64bit
-// ignore-debug
 
 // Track the status of MIR optimizations simplifying `Ok(res?)` for both the old and new desugarings
 // of that syntax.

--- a/tests/ui/consts/std/alloc.32bit.stderr
+++ b/tests/ui/consts/std/alloc.32bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/alloc.rs:12:1
+  --> $DIR/alloc.rs:11:1
    |
 LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchecked(0x1000, 0x00) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .align.0.<enum-tag>: encountered 0x00000000, but expected a valid enum tag
@@ -10,7 +10,7 @@ LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchec
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/alloc.rs:16:1
+  --> $DIR/alloc.rs:15:1
    |
 LL | const LAYOUT_INVALID_THREE: Layout = unsafe { Layout::from_size_align_unchecked(9, 3) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .align.0.<enum-tag>: encountered 0x00000003, but expected a valid enum tag

--- a/tests/ui/consts/std/alloc.64bit.stderr
+++ b/tests/ui/consts/std/alloc.64bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/alloc.rs:12:1
+  --> $DIR/alloc.rs:11:1
    |
 LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchecked(0x1000, 0x00) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .align.0.<enum-tag>: encountered 0x0000000000000000, but expected a valid enum tag
@@ -10,7 +10,7 @@ LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchec
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/alloc.rs:16:1
+  --> $DIR/alloc.rs:15:1
    |
 LL | const LAYOUT_INVALID_THREE: Layout = unsafe { Layout::from_size_align_unchecked(9, 3) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .align.0.<enum-tag>: encountered 0x0000000000000003, but expected a valid enum tag

--- a/tests/ui/consts/std/alloc.rs
+++ b/tests/ui/consts/std/alloc.rs
@@ -1,5 +1,4 @@
 // stderr-per-bitwidth
-// ignore-debug (the debug assertions change the error)
 // Strip out raw byte dumps to make comparison platform-independent:
 // normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 // normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*a(lloc)?[0-9]+(\+[a-z0-9]+)?─*╼ )+ *│.*" -> "HEX_DUMP"


### PR DESCRIPTION
ignore-debug is only needed when the debug assertions *in the standard library* somehow affect the test. This can happen with inlining but otherwise should be rare. ignore-debug is problematic since PR CI is only run with debug assertions.

r? @cjgillot since it looks like you added most of these