### PR TITLE
miri ABI compatibility check: accept u32 and i32

### DIFF
--- a/src/tools/miri/tests/pass/function_calls/abi_compat.rs
+++ b/src/tools/miri/tests/pass/function_calls/abi_compat.rs
@@ -1,0 +1,27 @@
+use std::num;
+use std::mem;
+
+fn test_abi_compat<T, U>(t: T, u: U) {
+    fn id<T>(x: T) -> T { x }
+    
+    // This checks ABI compatibility both for arguments and return values,
+    // in both directions.
+    let f: fn(T) -> T = id;
+    let f: fn(U) -> U = unsafe { std::mem::transmute(f) };
+    drop(f(u));
+    
+    let f: fn(U) -> U = id;
+    let f: fn(T) -> T = unsafe { std::mem::transmute(f) };
+    drop(f(t));
+}
+
+fn main() {
+    test_abi_compat(0u32, 'x');
+    test_abi_compat(&0u32, &([true; 4], [0u32; 0]));
+    test_abi_compat(0u32, mem::MaybeUninit::new(0u32));
+    test_abi_compat(42u32, num::NonZeroU32::new(1).unwrap());
+    test_abi_compat(0u32, Some(num::NonZeroU32::new(1).unwrap()));
+    test_abi_compat(0u32, 0i32);
+    // Note that `bool` and `u8` are *not* compatible!
+    // One of them has `arg_ext: Zext`, the other does not.
+}


### PR DESCRIPTION
If only the sign differs, then surely these types are compatible. (We do still check that `arg_ext` is the same, just in case.)

Also I made it so that the ABI check must *imply* that size and alignment are the same, but it doesn't actively check that itself. With how crazy ABI constraints get, having equal size and align really shouldn't be used as a signal for anything I think...