### PR TITLE
Record allocation spans inside force_allocation

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -472,6 +472,9 @@ pub trait Machine<'mir, 'tcx: 'mir>: Sized {
         Ok(StackPopJump::Normal)
     }
 
+    /// Called immediately after actual memory was allocated for a local
+    /// but before the local's stack frame is updated to point to that memory.
+    #[inline(always)]
     fn after_local_allocated(
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,
         _frame: usize,

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -18,7 +18,7 @@ use crate::const_eval::CheckAlignment;
 
 use super::{
     AllocBytes, AllocId, AllocRange, Allocation, ConstAllocation, FnArg, Frame, ImmTy, InterpCx,
-    InterpResult, MemoryKind, OpTy, Operand, PlaceTy, Pointer, Provenance, Scalar,
+    InterpResult, MPlaceTy, MemoryKind, OpTy, Operand, PlaceTy, Pointer, Provenance, Scalar,
 };
 
 /// Data returned by Machine::stack_pop,
@@ -470,6 +470,15 @@ pub trait Machine<'mir, 'tcx: 'mir>: Sized {
         // By default, we do not support unwinding from panics
         assert!(!unwinding);
         Ok(StackPopJump::Normal)
+    }
+
+    fn after_local_allocated(
+        _ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        _frame: usize,
+        _local: mir::Local,
+        _mplace: &MPlaceTy<'tcx, Self::Provenance>,
+    ) -> InterpResult<'tcx> {
+        Ok(())
     }
 }
 

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -1405,4 +1405,22 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for MiriMachine<'mir, 'tcx> {
         }
         res
     }
+
+    fn after_local_allocated(
+        ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        frame: usize,
+        local: mir::Local,
+        mplace: &MPlaceTy<'tcx, Provenance>
+    ) -> InterpResult<'tcx> {
+        let Some(Provenance::Concrete { alloc_id, .. }) = mplace.ptr.provenance else {
+            panic!("after_local_allocated should only be called on fresh allocations");
+        };
+        let local_decl = &ecx.active_thread_stack()[frame].body.local_decls[local];
+        let span = local_decl.source_info.span;
+        ecx.machine
+            .allocation_spans
+            .borrow_mut()
+            .insert(alloc_id, (span, None));
+        Ok(())
+    }
 }

--- a/src/tools/miri/tests/fail/dangling_pointers/dangling_primitive.rs
+++ b/src/tools/miri/tests/fail/dangling_pointers/dangling_primitive.rs
@@ -1,0 +1,13 @@
+// The interpreter tries to delay allocating locals until their address is taken.
+// This test checks that we correctly use the span associated with the local itself, not the span
+// where we take the address of the local and force it to be allocated.
+
+fn main() {
+    let ptr = {
+        let x = 0usize; // This line should appear in the helps
+        &x as *const usize // This line should NOT appear in the helps
+    };
+    unsafe {
+        dbg!(*ptr); //~ ERROR: has been freed
+    }
+}

--- a/src/tools/miri/tests/fail/dangling_pointers/dangling_primitive.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/dangling_primitive.stderr
@@ -1,23 +1,24 @@
 error: Undefined Behavior: dereferencing pointer failed: ALLOC has been freed, so this pointer is dangling
-  --> $DIR/stack_temporary.rs:LL:CC
+  --> $DIR/dangling_primitive.rs:LL:CC
    |
-LL |         let val = *x;
-   |                   ^^ dereferencing pointer failed: ALLOC has been freed, so this pointer is dangling
+LL |         dbg!(*ptr);
+   |         ^^^^^^^^^^ dereferencing pointer failed: ALLOC has been freed, so this pointer is dangling
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
 help: ALLOC was allocated here:
-  --> $DIR/stack_temporary.rs:LL:CC
+  --> $DIR/dangling_primitive.rs:LL:CC
    |
-LL |         let x = make_ref(&mut 0); // The temporary storing "0" is deallocated at the ";"!
-   |                               ^
+LL |         let x = 0usize; // This line should appear in the helps
+   |             ^
 help: ALLOC was deallocated here:
-  --> $DIR/stack_temporary.rs:LL:CC
+  --> $DIR/dangling_primitive.rs:LL:CC
    |
-LL |         let x = make_ref(&mut 0); // The temporary storing "0" is deallocated at the ";"!
-   |                                 ^
+LL |     };
+   |     ^
    = note: BACKTRACE (of the first span):
-   = note: inside `main` at $DIR/stack_temporary.rs:LL:CC
+   = note: inside `main` at RUSTLIB/std/src/macros.rs:LL:CC
+   = note: this error originates in the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/dangling_pointers/deref-partially-dangling.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/deref-partially-dangling.stderr
@@ -6,7 +6,12 @@ LL |     let val = unsafe { (*xptr).1 };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/deref-partially-dangling.rs:LL:CC
+   |
+LL |     let x = (1, 13);
+   |         ^
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/deref-partially-dangling.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/src/tools/miri/tests/fail/dangling_pointers/dyn_size.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/dyn_size.stderr
@@ -6,7 +6,12 @@ LL |     let _ptr = unsafe { &*ptr };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/dyn_size.rs:LL:CC
+   |
+LL |     let buf = [0u32; 1];
+   |         ^^^
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/dyn_size.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/src/tools/miri/tests/fail/intrinsics/out_of_bounds_ptr_1.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/out_of_bounds_ptr_1.stderr
@@ -6,7 +6,12 @@ LL |     let x = unsafe { x.offset(5) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/out_of_bounds_ptr_1.rs:LL:CC
+   |
+LL |     let v = [0i8; 4];
+   |         ^
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/out_of_bounds_ptr_1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/src/tools/miri/tests/fail/intrinsics/out_of_bounds_ptr_3.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/out_of_bounds_ptr_3.stderr
@@ -6,7 +6,12 @@ LL |     let x = unsafe { x.offset(-1) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/out_of_bounds_ptr_3.rs:LL:CC
+   |
+LL |     let v = [0i8; 4];
+   |         ^
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/out_of_bounds_ptr_3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace


### PR DESCRIPTION
This expands https://github.com/rust-lang/miri/pull/2940 to cover locals

r? @RalfJung 