### PR TITLE
don't use force-unstable-if-unmarked with x test in standard library doctests

### DIFF
--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -52,9 +52,14 @@ fn main() {
     // Force all crates compiled by this compiler to (a) be unstable and (b)
     // allow the `rustc_private` feature to link to other unstable crates
     // also in the sysroot.
-    if env::var_os("RUSTC_FORCE_UNSTABLE").is_some() {
+    if env::var_os("RUSTC_FORCE_UNSTABLE").is_some()
+        // We don't want to enable this flag on std as this makes bootstrap ignoring the doctests
+        // errors.
+        && env::var_os("__CARGO_DEFAULT_LIB_METADATA") != Some(OsString::from("devstd"))
+    {
         cmd.arg("-Z").arg("force-unstable-if-unmarked");
     }
+
     if let Some(linker) = env::var_os("RUSTDOC_LINKER") {
         let mut arg = OsString::from("-Clinker=");
         arg.push(&linker);


### PR DESCRIPTION
Using `force-unstable-if-unmarked` on `library/` makes bootstrap ignoring doctests errors, potentially leading to the merging of PRs that do not compile successfully.


For testing this change, apply the following patch(or remove one of the `error_in_core` in `library/core/src/error.rs`):

```diff
diff --git a/library/core/src/error.rs b/library/core/src/error.rs
index 1170221c10c..b0ab2b04032 100644
--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -130,7 +130,6 @@ fn cause(&self) -> Option<&dyn Error> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
-    /// #![feature(error_in_core)]
     /// use core::fmt;
     /// use core::error::{request_ref, Request};
     ///
@@ -361,7 +360,6 @@ pub fn sources(&self) -> Source<'_> {
 ///
 /// ```rust
 /// # #![feature(error_generic_member_access)]
-/// # #![feature(error_in_core)]
 /// use std::error::Error;
 /// use core::error::request_value;
 ///
@@ -385,7 +383,6 @@ pub fn request_value<'a, T>(err: &'a (impl Error + ?Sized)) -> Option<T>
 ///
 /// ```rust
 /// # #![feature(error_generic_member_access)]
-/// # #![feature(error_in_core)]
 /// use core::error::Error;
 /// use core::error::request_ref;
 ///
@@ -457,7 +454,6 @@ fn request_by_type_tag<'a, I>(err: &'a (impl Error + ?Sized)) -> Option<I::Reifi
 ///
 /// ```
 /// #![feature(error_generic_member_access)]
-/// #![feature(error_in_core)]
 /// use core::fmt;
 /// use core::error::Request;
 /// use core::error::request_ref;
@@ -528,7 +524,6 @@ fn new<'b>(erased: &'b mut (dyn Erased<'a> + 'a)) -> &'b mut Request<'a> {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
-    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -563,7 +558,6 @@ pub fn provide_value<T>(&mut self, value: T) -> &mut Self
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
-    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -599,7 +593,6 @@ pub fn provide_value_with<T>(&mut self, fulfil: impl FnOnce() -> T) -> &mut Self
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
-    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -632,7 +625,6 @@ pub fn provide_ref<T: ?Sized + 'static>(&mut self, value: &'a T) -> &mut Self {
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
-    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     ///
@@ -698,7 +690,6 @@ fn provide_with<I>(&mut self, fulfil: impl FnOnce() -> I::Reified) -> &mut Self
     /// it.
     ///
     /// ```rust
-    /// #![feature(error_generic_member_access)]
     /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
@@ -787,7 +778,6 @@ pub fn would_be_satisfied_by_value_of<T>(&self) -> bool
     ///
     /// ```rust
     /// #![feature(error_generic_member_access)]
-    /// #![feature(error_in_core)]
     ///
     /// use core::error::Request;
     /// use core::error::request_ref;
```

then run `x test library/core --doc`

Related #114838