### PR TITLE
Add stable for Constant in smir

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -481,7 +481,19 @@ impl<'tcx> Stable<'tcx> for mir::Operand<'tcx> {
         match self {
             Copy(place) => stable_mir::mir::Operand::Copy(place.stable(tables)),
             Move(place) => stable_mir::mir::Operand::Move(place.stable(tables)),
-            Constant(c) => stable_mir::mir::Operand::Constant(c.to_string()),
+            Constant(c) => stable_mir::mir::Operand::Constant(c.stable(tables)),
+        }
+    }
+}
+
+impl<'tcx> Stable<'tcx> for mir::Constant<'tcx> {
+    type T = stable_mir::mir::Constant;
+
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        stable_mir::mir::Constant {
+            span: self.span.stable(tables),
+            user_ty: self.user_ty.map(|u| u.as_usize()).or(None),
+            literal: self.literal.stable(tables),
         }
     }
 }

--- a/compiler/rustc_smir/src/stable_mir/mir/body.rs
+++ b/compiler/rustc_smir/src/stable_mir/mir/body.rs
@@ -1,8 +1,8 @@
 use crate::rustc_internal::Opaque;
 use crate::stable_mir::ty::{
-    AdtDef, ClosureDef, Const, GeneratorDef, GenericArgs, Movability, Region,
+    AdtDef, ClosureDef, Const, ConstantKind, GeneratorDef, GenericArgs, Movability, Region,
 };
-use crate::stable_mir::{self, ty::Ty};
+use crate::stable_mir::{self, ty::Ty, Span};
 
 #[derive(Clone, Debug)]
 pub struct Body {
@@ -359,7 +359,7 @@ pub enum AggregateKind {
 pub enum Operand {
     Copy(Place),
     Move(Place),
-    Constant(String),
+    Constant(Constant),
 }
 
 #[derive(Clone, Debug)]
@@ -382,6 +382,13 @@ type FieldIdx = usize;
 pub type VariantIdx = usize;
 
 type UserTypeAnnotationIndex = usize;
+
+#[derive(Clone, Debug)]
+pub struct Constant {
+    pub span: Span,
+    pub user_ty: Option<UserTypeAnnotationIndex>,
+    pub literal: ConstantKind,
+}
 
 #[derive(Clone, Debug)]
 pub struct SwitchTarget {


### PR DESCRIPTION
Previously https://github.com/rust-lang/rust/pull/114587 we covered much of the groundwork needed to cover Const in smir, so there is no reason keep `Constant` as String.

r? @spastorino 