### PR TITLE
adapt codegen test to also work with v0 symbol mangling

### DIFF
--- a/tests/codegen/debuginfo-inline-callsite-location.rs
+++ b/tests/codegen/debuginfo-inline-callsite-location.rs
@@ -4,9 +4,10 @@
 // can correctly merge the debug info if it merges the inlined code (e.g., for merging of tail
 // calls to panic.
 
-// CHECK:       tail call void @_ZN4core9panicking5panic17h{{([0-9a-z]{16})}}E
+// Handle both legacy and v0 symbol mangling.
+// CHECK:       tail call void @{{.*core9panicking5panic}}
 // CHECK-SAME:  !dbg ![[#first_dbg:]]
-// CHECK:       tail call void @_ZN4core9panicking5panic17h{{([0-9a-z]{16})}}E
+// CHECK:       tail call void @{{.*core9panicking5panic}}
 // CHECK-SAME:  !dbg ![[#second_dbg:]]
 
 // CHECK:       ![[#func_dbg:]] = distinct !DISubprogram(name: "unwrap<i32>"


### PR DESCRIPTION
No functional changes intended.

This test was failing under `new-symbol-mangling = true`. Adapted similarly to https://github.com/rust-lang/rust/pull/106002.