### PR TITLE
Add missing high-level stable_mir::generics_of fn

### DIFF
--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -109,6 +109,10 @@ pub fn trait_impl(trait_impl: &ImplDef) -> ImplTrait {
     with(|cx| cx.trait_impl(trait_impl))
 }
 
+pub fn generics_of(generic_def: &GenericDef) -> Generics {
+    with(|cx| cx.generics_of(generic_def))
+}
+
 pub fn predicates_of(trait_def: &TraitDef) -> GenericPredicates {
     with(|cx| cx.predicates_of(trait_def))
 }


### PR DESCRIPTION
We forgot to add this function in https://github.com/rust-lang/rust/pull/115092, as we have done on https://github.com/rust-lang/rust/pull/115084 and other high level APIs.

At some point I think we should re-organize the structure of the code but this is what we have for now.

r? @compiler-errors 
Would have assigned @oli-obk but he is still on vacations