### PR TITLE
Remove assert that checks type equality

### DIFF
--- a/tests/ui/codegen/subtyping-enforces-type-equality.rs
+++ b/tests/ui/codegen/subtyping-enforces-type-equality.rs
@@ -1,0 +1,48 @@
+// ignore-pass
+// build-pass
+// edition:2021
+use std::future::Future;
+use std::pin::Pin;
+
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
+
+fn main() {
+    let _ = wrapper_call(handler);
+}
+
+async fn wrapper_call(handler: impl Handler) {
+    handler.call().await;
+}
+async fn handler() {
+    f(&()).await;
+}
+async fn f<'a>(db: impl Acquire<'a>) {
+    db.acquire().await;
+}
+
+trait Handler {
+    type Future: Future;
+    fn call(self) -> Self::Future;
+}
+
+impl<Fut, F> Handler for F
+where
+    F: Fn() -> Fut,
+    Fut: Future,
+{
+    type Future = Fut;
+    fn call(self) -> Self::Future {
+        loop {}
+    }
+}
+
+trait Acquire<'a> {
+    type Connection;
+    fn acquire(self) -> BoxFuture<Self::Connection>;
+}
+impl<'a> Acquire<'a> for &'a () {
+    type Connection = Self;
+    fn acquire(self) -> BoxFuture<Self> {
+        loop {}
+    }
+}

--- a/tests/ui/codegen/subtyping-enforces-type-equality.stderr
+++ b/tests/ui/codegen/subtyping-enforces-type-equality.stderr
@@ -1,0 +1,1 @@
+WARN rustc_codegen_ssa::mir::locals Unexpected initial operand type. See the issues/114858


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/112307 although this prevented `unsound` issues it also seems to introduce regressions https://github.com/rust-lang/rust/issues/114858 is example of this regression. I locally tested this https://github.com/rust-lang/rust/issues/114858#issuecomment-1686502262 issue and failing assert is [this](https://www.diffchecker.com/cjb7jSQm/).

This is also related to https://github.com/rust-lang/rust/pull/115025 
