### PR TITLE
target tier policy: require ability to produce object code

### DIFF
--- a/src/doc/rustc/src/target-tier-policy.md
+++ b/src/doc/rustc/src/target-tier-policy.md
@@ -246,6 +246,8 @@ approved by the appropriate team for that shared code before acceptance.
     introducing unconditional uses of features that another variation of the
     target may not have; use conditional compilation or runtime detection, as
     appropriate, to let each target run code supported by that target.
+- Tier 3 targets must be able to produce object code using at least one of
+  rustc's supported backends.
 
 If a tier 3 target stops meeting these requirements, or the target maintainers
 no longer have interest or time, or the target shows no signs of activity and


### PR DESCRIPTION
Update target tier policy to require that targets be able to produce object code with a supported backend.

In the discussions around rust-lang/compiler-team#655, there was an open question of what exact requirement to make of tier three targets should be - require a test producing assembly which can be cross-compiled, or just require that it is possible at all. I've opted for the latter in this pull request, just because that's simpler to start with, once we have assembly tests for every existing target, we could update this.

r? @wesleywiser 