### PR TITLE
add rustc_abi debugging attribute

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -814,6 +814,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(TEST, rustc_strict_coherence, Normal, template!(Word), WarnFollowing),
     rustc_attr!(TEST, rustc_variance, Normal, template!(Word), WarnFollowing),
     rustc_attr!(TEST, rustc_layout, Normal, template!(List: "field1, field2, ..."), WarnFollowing),
+    rustc_attr!(TEST, rustc_abi, Normal, template!(List: "field1, field2, ..."), WarnFollowing),
     rustc_attr!(TEST, rustc_regions, Normal, template!(Word), WarnFollowing),
     rustc_attr!(
         TEST, rustc_error, Normal,

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -22,7 +22,7 @@ use rustc_middle::query::{ExternProviders, Providers};
 use rustc_middle::ty::{self, GlobalCtxt, RegisteredTools, TyCtxt};
 use rustc_mir_build as mir_build;
 use rustc_parse::{parse_crate_from_file, parse_crate_from_source_str, validate_attr};
-use rustc_passes::{self, hir_stats, layout_test};
+use rustc_passes::{self, abi_test, hir_stats, layout_test};
 use rustc_plugin_impl as plugin;
 use rustc_resolve::Resolver;
 use rustc_session::code_stats::VTableSizeInfo;
@@ -818,6 +818,7 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
     }
 
     sess.time("layout_testing", || layout_test::test_layout(tcx));
+    sess.time("abi_testing", || abi_test::test_abi(tcx));
 
     // Avoid overwhelming user with errors if borrow checking failed.
     // I'm not sure how helpful this is, to be honest, but it avoids a

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -7,6 +7,9 @@
 passes_abi =
     abi: {$abi}
 
+passes_abi_of =
+    fn_abi_of_instance({$fn_name}) = {$fn_abi}
+
 passes_align =
     align: {$align}
 

--- a/compiler/rustc_passes/src/abi_test.rs
+++ b/compiler/rustc_passes/src/abi_test.rs
@@ -1,0 +1,93 @@
+use rustc_ast::Attribute;
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::DefId;
+use rustc_middle::ty::layout::{FnAbiError, LayoutError};
+use rustc_middle::ty::{self, GenericArgs, Instance, TyCtxt};
+use rustc_span::source_map::Spanned;
+use rustc_span::symbol::sym;
+
+use crate::errors::{AbiOf, UnrecognizedField};
+
+pub fn test_abi(tcx: TyCtxt<'_>) {
+    if !tcx.features().rustc_attrs {
+        // if the `rustc_attrs` feature is not enabled, don't bother testing ABI
+        return;
+    }
+    for id in tcx.hir().items() {
+        match tcx.def_kind(id.owner_id) {
+            DefKind::Fn => {
+                for attr in tcx.get_attrs(id.owner_id, sym::rustc_abi) {
+                    dump_abi_of(tcx, id.owner_id.def_id.into(), attr);
+                }
+            }
+            DefKind::Impl { .. } => {
+                // To find associated functions we need to go into the child items here.
+                for &id in tcx.associated_item_def_ids(id.owner_id) {
+                    if matches!(tcx.def_kind(id), DefKind::AssocFn) {
+                        for attr in tcx.get_attrs(id, sym::rustc_abi) {
+                            dump_abi_of(tcx, id, attr);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn dump_abi_of(tcx: TyCtxt<'_>, item_def_id: DefId, attr: &Attribute) {
+    let param_env = tcx.param_env(item_def_id);
+    let args = GenericArgs::identity_for_item(tcx, item_def_id);
+    let instance = match Instance::resolve(tcx, param_env, item_def_id, args) {
+        Ok(Some(instance)) => instance,
+        Ok(None) => {
+            // Not sure what to do here, but `LayoutError::Unknown` seems reasonable?
+            let ty = tcx.type_of(item_def_id).instantiate_identity();
+            tcx.sess.emit_fatal(Spanned {
+                node: LayoutError::Unknown(ty).into_diagnostic(),
+
+                span: tcx.def_span(item_def_id),
+            });
+        }
+        Err(_guaranteed) => return,
+    };
+    match tcx.fn_abi_of_instance(param_env.and((instance, /* extra_args */ ty::List::empty()))) {
+        Ok(abi) => {
+            // Check out the `#[rustc_abi(..)]` attribute to tell what to dump.
+            // The `..` are the names of fields to dump.
+            let meta_items = attr.meta_item_list().unwrap_or_default();
+            for meta_item in meta_items {
+                match meta_item.name_or_empty() {
+                    sym::debug => {
+                        let fn_name = tcx.item_name(item_def_id);
+                        tcx.sess.emit_err(AbiOf {
+                            span: tcx.def_span(item_def_id),
+                            fn_name,
+                            fn_abi: format!("{:#?}", abi),
+                        });
+                    }
+
+                    name => {
+                        tcx.sess.emit_err(UnrecognizedField { span: meta_item.span(), name });
+                    }
+                }
+            }
+        }
+
+        Err(FnAbiError::Layout(layout_error)) => {
+            tcx.sess.emit_fatal(Spanned {
+                node: layout_error.into_diagnostic(),
+                span: tcx.def_span(item_def_id),
+            });
+        }
+        Err(FnAbiError::AdjustForForeignAbi(e)) => {
+            // Sadly there seems to be no `into_diagnostic` for this case... and I am not sure if
+            // this can even be reached. Anyway this is a perma-unstable debug attribute, an ICE
+            // isn't the worst thing. Also this matches what codegen does.
+            span_bug!(
+                tcx.def_span(item_def_id),
+                "error computing fn_abi_of_instance, cannot adjust for foreign ABI: {e:?}",
+            )
+        }
+    }
+}

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -914,6 +914,15 @@ pub struct LayoutOf {
 }
 
 #[derive(Diagnostic)]
+#[diag(passes_abi_of)]
+pub struct AbiOf {
+    #[primary_span]
+    pub span: Span,
+    pub fn_name: Symbol,
+    pub fn_abi: String,
+}
+
+#[derive(Diagnostic)]
 #[diag(passes_unrecognized_field)]
 pub struct UnrecognizedField {
     #[primary_span]

--- a/compiler/rustc_passes/src/layout_test.rs
+++ b/compiler/rustc_passes/src/layout_test.rs
@@ -11,16 +11,17 @@ use rustc_target::abi::{HasDataLayout, TargetDataLayout};
 use crate::errors::{Abi, Align, HomogeneousAggregate, LayoutOf, Size, UnrecognizedField};
 
 pub fn test_layout(tcx: TyCtxt<'_>) {
-    if tcx.features().rustc_attrs {
+    if !tcx.features().rustc_attrs {
         // if the `rustc_attrs` feature is not enabled, don't bother testing layout
-        for id in tcx.hir().items() {
-            if matches!(
-                tcx.def_kind(id.owner_id),
-                DefKind::TyAlias { .. } | DefKind::Enum | DefKind::Struct | DefKind::Union
-            ) {
-                for attr in tcx.get_attrs(id.owner_id, sym::rustc_layout) {
-                    dump_layout_of(tcx, id.owner_id.def_id, attr);
-                }
+        return;
+    }
+    for id in tcx.hir().items() {
+        if matches!(
+            tcx.def_kind(id.owner_id),
+            DefKind::TyAlias { .. } | DefKind::Enum | DefKind::Struct | DefKind::Union
+        ) {
+            for attr in tcx.get_attrs(id.owner_id, sym::rustc_layout) {
+                dump_layout_of(tcx, id.owner_id.def_id, attr);
             }
         }
     }

--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -24,6 +24,7 @@ use rustc_errors::{DiagnosticMessage, SubdiagnosticMessage};
 use rustc_fluent_macro::fluent_messages;
 use rustc_middle::query::Providers;
 
+pub mod abi_test;
 mod check_attr;
 mod check_const;
 pub mod dead;

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1281,6 +1281,7 @@ symbols! {
         rust_eh_catch_typeinfo,
         rust_eh_personality,
         rustc,
+        rustc_abi,
         rustc_allocator,
         rustc_allocator_zeroed,
         rustc_allow_const_fn_unstable,

--- a/tests/ui/abi/debug.rs
+++ b/tests/ui/abi/debug.rs
@@ -1,0 +1,23 @@
+// normalize-stderr-test "(abi|pref|unadjusted_abi_align): Align\([1-8] bytes\)" -> "$1: $$SOME_ALIGN"
+// normalize-stderr-test "(size): Size\([48] bytes\)" -> "$1: $$SOME_SIZE"
+// normalize-stderr-test "(can_unwind): (true|false)" -> "$1: $$SOME_BOOL"
+// normalize-stderr-test "(valid_range): 0\.\.=(4294967295|18446744073709551615)" -> "$1: $$FULL"
+// This pattern is prepared for when we account for alignment in the niche.
+// normalize-stderr-test "(valid_range): [1-9]\.\.=(429496729[0-9]|1844674407370955161[0-9])" -> "$1: $$NON_NULL"
+// Some attributes are only computed for release builds:
+// compile-flags: -O
+#![feature(rustc_attrs)]
+#![crate_type = "lib"]
+
+#[rustc_abi(debug)]
+fn test(_x: u8) -> bool { true } //~ ERROR: fn_abi
+
+
+#[rustc_abi(debug)]
+fn test_generic<T>(_x: *const T) { } //~ ERROR: fn_abi
+
+struct S(u16);
+impl S {
+    #[rustc_abi(debug)]
+    fn assoc_test(&self) { } //~ ERROR: fn_abi
+}

--- a/tests/ui/abi/debug.stderr
+++ b/tests/ui/abi/debug.stderr
@@ -1,0 +1,260 @@
+error: fn_abi_of_instance(test) = FnAbi {
+           args: [
+               ArgAbi {
+                   layout: TyAndLayout {
+                       ty: u8,
+                       layout: Layout {
+                           size: Size(1 bytes),
+                           align: AbiAndPrefAlign {
+                               abi: $SOME_ALIGN,
+                               pref: $SOME_ALIGN,
+                           },
+                           abi: Scalar(
+                               Initialized {
+                                   value: Int(
+                                       I8,
+                                       false,
+                                   ),
+                                   valid_range: 0..=255,
+                               },
+                           ),
+                           fields: Primitive,
+                           largest_niche: None,
+                           variants: Single {
+                               index: 0,
+                           },
+                           max_repr_align: None,
+                           unadjusted_abi_align: $SOME_ALIGN,
+                       },
+                   },
+                   mode: Direct(
+                       ArgAttributes {
+                           regular: NoUndef,
+                           arg_ext: None,
+                           pointee_size: Size(0 bytes),
+                           pointee_align: None,
+                       },
+                   ),
+               },
+           ],
+           ret: ArgAbi {
+               layout: TyAndLayout {
+                   ty: bool,
+                   layout: Layout {
+                       size: Size(1 bytes),
+                       align: AbiAndPrefAlign {
+                           abi: $SOME_ALIGN,
+                           pref: $SOME_ALIGN,
+                       },
+                       abi: Scalar(
+                           Initialized {
+                               value: Int(
+                                   I8,
+                                   false,
+                               ),
+                               valid_range: 0..=1,
+                           },
+                       ),
+                       fields: Primitive,
+                       largest_niche: Some(
+                           Niche {
+                               offset: Size(0 bytes),
+                               value: Int(
+                                   I8,
+                                   false,
+                               ),
+                               valid_range: 0..=1,
+                           },
+                       ),
+                       variants: Single {
+                           index: 0,
+                       },
+                       max_repr_align: None,
+                       unadjusted_abi_align: $SOME_ALIGN,
+                   },
+               },
+               mode: Direct(
+                   ArgAttributes {
+                       regular: NoUndef,
+                       arg_ext: Zext,
+                       pointee_size: Size(0 bytes),
+                       pointee_align: None,
+                   },
+               ),
+           },
+           c_variadic: false,
+           fixed_count: 1,
+           conv: Rust,
+           can_unwind: $SOME_BOOL,
+       }
+  --> $DIR/debug.rs:13:1
+   |
+LL | fn test(_x: u8) -> bool { true }
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: fn_abi_of_instance(test_generic) = FnAbi {
+           args: [
+               ArgAbi {
+                   layout: TyAndLayout {
+                       ty: *const T,
+                       layout: Layout {
+                           size: $SOME_SIZE,
+                           align: AbiAndPrefAlign {
+                               abi: $SOME_ALIGN,
+                               pref: $SOME_ALIGN,
+                           },
+                           abi: Scalar(
+                               Initialized {
+                                   value: Pointer(
+                                       AddressSpace(
+                                           0,
+                                       ),
+                                   ),
+                                   valid_range: $FULL,
+                               },
+                           ),
+                           fields: Primitive,
+                           largest_niche: None,
+                           variants: Single {
+                               index: 0,
+                           },
+                           max_repr_align: None,
+                           unadjusted_abi_align: $SOME_ALIGN,
+                       },
+                   },
+                   mode: Direct(
+                       ArgAttributes {
+                           regular: NoUndef,
+                           arg_ext: None,
+                           pointee_size: Size(0 bytes),
+                           pointee_align: None,
+                       },
+                   ),
+               },
+           ],
+           ret: ArgAbi {
+               layout: TyAndLayout {
+                   ty: (),
+                   layout: Layout {
+                       size: Size(0 bytes),
+                       align: AbiAndPrefAlign {
+                           abi: $SOME_ALIGN,
+                           pref: $SOME_ALIGN,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       fields: Arbitrary {
+                           offsets: [],
+                           memory_index: [],
+                       },
+                       largest_niche: None,
+                       variants: Single {
+                           index: 0,
+                       },
+                       max_repr_align: None,
+                       unadjusted_abi_align: $SOME_ALIGN,
+                   },
+               },
+               mode: Ignore,
+           },
+           c_variadic: false,
+           fixed_count: 1,
+           conv: Rust,
+           can_unwind: $SOME_BOOL,
+       }
+  --> $DIR/debug.rs:17:1
+   |
+LL | fn test_generic<T>(_x: *const T) { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: fn_abi_of_instance(assoc_test) = FnAbi {
+           args: [
+               ArgAbi {
+                   layout: TyAndLayout {
+                       ty: &S,
+                       layout: Layout {
+                           size: $SOME_SIZE,
+                           align: AbiAndPrefAlign {
+                               abi: $SOME_ALIGN,
+                               pref: $SOME_ALIGN,
+                           },
+                           abi: Scalar(
+                               Initialized {
+                                   value: Pointer(
+                                       AddressSpace(
+                                           0,
+                                       ),
+                                   ),
+                                   valid_range: $NON_NULL,
+                               },
+                           ),
+                           fields: Primitive,
+                           largest_niche: Some(
+                               Niche {
+                                   offset: Size(0 bytes),
+                                   value: Pointer(
+                                       AddressSpace(
+                                           0,
+                                       ),
+                                   ),
+                                   valid_range: $NON_NULL,
+                               },
+                           ),
+                           variants: Single {
+                               index: 0,
+                           },
+                           max_repr_align: None,
+                           unadjusted_abi_align: $SOME_ALIGN,
+                       },
+                   },
+                   mode: Direct(
+                       ArgAttributes {
+                           regular: NoAlias | NonNull | ReadOnly | NoUndef,
+                           arg_ext: None,
+                           pointee_size: Size(2 bytes),
+                           pointee_align: Some(
+                               Align(2 bytes),
+                           ),
+                       },
+                   ),
+               },
+           ],
+           ret: ArgAbi {
+               layout: TyAndLayout {
+                   ty: (),
+                   layout: Layout {
+                       size: Size(0 bytes),
+                       align: AbiAndPrefAlign {
+                           abi: $SOME_ALIGN,
+                           pref: $SOME_ALIGN,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       fields: Arbitrary {
+                           offsets: [],
+                           memory_index: [],
+                       },
+                       largest_niche: None,
+                       variants: Single {
+                           index: 0,
+                       },
+                       max_repr_align: None,
+                       unadjusted_abi_align: $SOME_ALIGN,
+                   },
+               },
+               mode: Ignore,
+           },
+           c_variadic: false,
+           fixed_count: 1,
+           conv: Rust,
+           can_unwind: $SOME_BOOL,
+       }
+  --> $DIR/debug.rs:22:5
+   |
+LL |     fn assoc_test(&self) { }
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/layout/debug.rs
+++ b/tests/ui/layout/debug.rs
@@ -1,4 +1,4 @@
-// normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
+// normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
 #![feature(never_type, rustc_attrs, type_alias_impl_trait, repr_simd)]
 #![crate_type = "lib"]
 

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -2,7 +2,7 @@ error: layout_of(E) = Layout {
            size: Size(12 bytes),
            align: AbiAndPrefAlign {
                abi: Align(4 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Aggregate {
                sized: true,
@@ -40,7 +40,7 @@ error: layout_of(E) = Layout {
                        size: Size(4 bytes),
                        align: AbiAndPrefAlign {
                            abi: Align(1 bytes),
-                           pref: $PREF_ALIGN,
+                           pref: $SOME_ALIGN,
                        },
                        abi: Aggregate {
                            sized: true,
@@ -60,7 +60,7 @@ error: layout_of(E) = Layout {
                        size: Size(12 bytes),
                        align: AbiAndPrefAlign {
                            abi: Align(4 bytes),
-                           pref: $PREF_ALIGN,
+                           pref: $SOME_ALIGN,
                        },
                        abi: Uninhabited,
                        fields: Arbitrary {
@@ -96,7 +96,7 @@ error: layout_of(S) = Layout {
            size: Size(8 bytes),
            align: AbiAndPrefAlign {
                abi: Align(4 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: ScalarPair(
                Initialized {
@@ -142,7 +142,7 @@ error: layout_of(U) = Layout {
            size: Size(8 bytes),
            align: AbiAndPrefAlign {
                abi: Align(4 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Aggregate {
                sized: true,
@@ -166,7 +166,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
            size: Size(8 bytes),
            align: AbiAndPrefAlign {
                abi: Align(4 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: ScalarPair(
                Initialized {
@@ -217,7 +217,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        size: Size(8 bytes),
                        align: AbiAndPrefAlign {
                            abi: Align(4 bytes),
-                           pref: $PREF_ALIGN,
+                           pref: $SOME_ALIGN,
                        },
                        abi: ScalarPair(
                            Initialized {
@@ -254,7 +254,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        size: Size(8 bytes),
                        align: AbiAndPrefAlign {
                            abi: Align(4 bytes),
-                           pref: $PREF_ALIGN,
+                           pref: $SOME_ALIGN,
                        },
                        abi: ScalarPair(
                            Initialized {
@@ -301,7 +301,7 @@ error: layout_of(i32) = Layout {
            size: Size(4 bytes),
            align: AbiAndPrefAlign {
                abi: Align(4 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Scalar(
                Initialized {
@@ -329,7 +329,7 @@ error: layout_of(V) = Layout {
            size: Size(2 bytes),
            align: AbiAndPrefAlign {
                abi: Align(2 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Aggregate {
                sized: true,
@@ -353,7 +353,7 @@ error: layout_of(W) = Layout {
            size: Size(2 bytes),
            align: AbiAndPrefAlign {
                abi: Align(2 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Aggregate {
                sized: true,
@@ -377,7 +377,7 @@ error: layout_of(Y) = Layout {
            size: Size(0 bytes),
            align: AbiAndPrefAlign {
                abi: Align(2 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Aggregate {
                sized: true,
@@ -401,7 +401,7 @@ error: layout_of(P1) = Layout {
            size: Size(4 bytes),
            align: AbiAndPrefAlign {
                abi: Align(1 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Aggregate {
                sized: true,
@@ -425,7 +425,7 @@ error: layout_of(P2) = Layout {
            size: Size(8 bytes),
            align: AbiAndPrefAlign {
                abi: Align(1 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Aggregate {
                sized: true,
@@ -449,7 +449,7 @@ error: layout_of(P3) = Layout {
            size: Size(16 bytes),
            align: AbiAndPrefAlign {
                abi: Align(1 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Aggregate {
                sized: true,
@@ -473,7 +473,7 @@ error: layout_of(P4) = Layout {
            size: Size(12 bytes),
            align: AbiAndPrefAlign {
                abi: Align(1 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Aggregate {
                sized: true,
@@ -497,7 +497,7 @@ error: layout_of(P5) = Layout {
            size: Size(1 bytes),
            align: AbiAndPrefAlign {
                abi: Align(1 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Scalar(
                Union {
@@ -526,7 +526,7 @@ error: layout_of(std::mem::MaybeUninit<u8>) = Layout {
            size: Size(1 bytes),
            align: AbiAndPrefAlign {
                abi: Align(1 bytes),
-               pref: $PREF_ALIGN,
+               pref: $SOME_ALIGN,
            },
            abi: Scalar(
                Union {


### PR DESCRIPTION
This is the call ABI equivalent of `rustc_layout(debug)`.

Fixes https://github.com/rust-lang/rust/issues/115168
r? @bjorn3 