### PR TITLE
On method chain expression failure, look for missing method in earlier segments of the chain

### DIFF
--- a/tests/ui/structs/method-chain-expression-failure.rs
+++ b/tests/ui/structs/method-chain-expression-failure.rs
@@ -1,0 +1,31 @@
+struct A;
+struct B;
+struct C;
+struct D;
+struct E;
+
+impl A {
+    fn b(&self) -> B { B }
+    fn foo(&self) {}
+}
+
+impl B {
+    fn c(&self) -> C { C }
+}
+
+impl C {
+    fn d(&self) -> D { D }
+    fn foo(&self) {}
+}
+
+impl D {
+    fn e(&self) -> E { E }
+}
+
+impl E {
+    fn f(&self) {}
+}
+fn main() {
+    A.b().c().d().e().foo();
+//~^ ERROR no method named `foo` found for struct `E` in the current scope
+}

--- a/tests/ui/structs/method-chain-expression-failure.stderr
+++ b/tests/ui/structs/method-chain-expression-failure.stderr
@@ -1,0 +1,15 @@
+error[E0599]: no method named `foo` found for struct `E` in the current scope
+  --> $DIR/method-chain-expression-failure.rs:29:23
+   |
+LL | struct E;
+   | -------- method `foo` not found for this struct
+...
+LL |     A.b().c().d().e().foo();
+   |     -     ---         ^^^ method not found in `E`
+   |     |     |
+   |     |     method `foo` is available on `&C`
+   |     method `foo` is available on `&A`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/suggestions/chain-method-call-mutation-in-place.stderr
+++ b/tests/ui/suggestions/chain-method-call-mutation-in-place.stderr
@@ -18,7 +18,10 @@ error[E0599]: no method named `sort` found for unit type `()` in the current sco
   --> $DIR/chain-method-call-mutation-in-place.rs:3:72
    |
 LL |     vec![1, 2, 3].into_iter().collect::<Vec<i32>>().sort_by_key(|i| i).sort();
-   |                                                                        ^^^^ method not found in `()`
+   |     -------------             ---------------------                    ^^^^ method not found in `()`
+   |     |                         |
+   |     |                         method `sort` is available on `&mut [i32]`
+   |     method `sort` is available on `Vec<i32>`
    |
 note: method `sort_by_key` modifies its receiver in-place, it is not meant to be used in method chains.
   --> $DIR/chain-method-call-mutation-in-place.rs:3:53


### PR DESCRIPTION
This PR tries to fix the issue: https://github.com/rust-lang/rust/issues/115222

As suggested by @estebank , I did the following:
1. Add new test `tests/ui/structs/method-chain-expression-failure.rs`
2. In `compiler/rusct_hir_tycheck/src/method/suggest.rs` 
   walking up the method chain and calling `probe_for_name` with the method name. But the call fails to return `Ok`. 
