### PR TITLE
Remove some wasm/emscripten ignores

### DIFF
--- a/tests/codegen/tuple-layout-opt.rs
+++ b/tests/codegen/tuple-layout-opt.rs
@@ -1,4 +1,3 @@
-// ignore-emscripten
 // compile-flags: -C no-prepopulate-passes -Copt-level=0
 
 // Test that tuples get optimized layout, in particular with a ZST in the last field (#63244)

--- a/tests/mir-opt/const_prop/boxes.rs
+++ b/tests/mir-opt/const_prop/boxes.rs
@@ -1,8 +1,6 @@
 // unit-test: ConstProp
 // compile-flags: -O
-// ignore-emscripten compiled with panic=abort by default
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-// ignore-wasm64
 
 #![feature(rustc_attrs, stmt_expr_attributes)]
 

--- a/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-abort.mir
@@ -1,21 +1,21 @@
 // MIR for `outer` after PreCodegen
 
 fn outer(_1: u8) -> u8 {
-    debug v => _1;                       // in scope 0 at $DIR/spans.rs:10:14: 10:15
-    let mut _0: u8;                      // return place in scope 0 at $DIR/spans.rs:10:24: 10:26
-    let mut _2: &u8;                     // in scope 0 at $DIR/spans.rs:11:11: 11:13
+    debug v => _1;                       // in scope 0 at $DIR/spans.rs:9:14: 9:15
+    let mut _0: u8;                      // return place in scope 0 at $DIR/spans.rs:9:24: 9:26
+    let mut _2: &u8;                     // in scope 0 at $DIR/spans.rs:10:11: 10:13
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/spans.rs:11:11: 11:13
-        _2 = &_1;                        // scope 0 at $DIR/spans.rs:11:11: 11:13
-        _0 = inner(move _2) -> [return: bb1, unwind unreachable]; // scope 0 at $DIR/spans.rs:11:5: 11:14
+        StorageLive(_2);                 // scope 0 at $DIR/spans.rs:10:11: 10:13
+        _2 = &_1;                        // scope 0 at $DIR/spans.rs:10:11: 10:13
+        _0 = inner(move _2) -> [return: bb1, unwind unreachable]; // scope 0 at $DIR/spans.rs:10:5: 10:14
                                          // mir::Constant
-                                         // + span: $DIR/spans.rs:11:5: 11:10
+                                         // + span: $DIR/spans.rs:10:5: 10:10
                                          // + literal: Const { ty: for<'a> fn(&'a u8) -> u8 {inner}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_2);                 // scope 0 at $DIR/spans.rs:11:13: 11:14
-        return;                          // scope 0 at $DIR/spans.rs:12:2: 12:2
+        StorageDead(_2);                 // scope 0 at $DIR/spans.rs:10:13: 10:14
+        return;                          // scope 0 at $DIR/spans.rs:11:2: 11:2
     }
 }

--- a/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-unwind.mir
@@ -1,21 +1,21 @@
 // MIR for `outer` after PreCodegen
 
 fn outer(_1: u8) -> u8 {
-    debug v => _1;                       // in scope 0 at $DIR/spans.rs:10:14: 10:15
-    let mut _0: u8;                      // return place in scope 0 at $DIR/spans.rs:10:24: 10:26
-    let mut _2: &u8;                     // in scope 0 at $DIR/spans.rs:11:11: 11:13
+    debug v => _1;                       // in scope 0 at $DIR/spans.rs:9:14: 9:15
+    let mut _0: u8;                      // return place in scope 0 at $DIR/spans.rs:9:24: 9:26
+    let mut _2: &u8;                     // in scope 0 at $DIR/spans.rs:10:11: 10:13
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/spans.rs:11:11: 11:13
-        _2 = &_1;                        // scope 0 at $DIR/spans.rs:11:11: 11:13
-        _0 = inner(move _2) -> [return: bb1, unwind continue]; // scope 0 at $DIR/spans.rs:11:5: 11:14
+        StorageLive(_2);                 // scope 0 at $DIR/spans.rs:10:11: 10:13
+        _2 = &_1;                        // scope 0 at $DIR/spans.rs:10:11: 10:13
+        _0 = inner(move _2) -> [return: bb1, unwind continue]; // scope 0 at $DIR/spans.rs:10:5: 10:14
                                          // mir::Constant
-                                         // + span: $DIR/spans.rs:11:5: 11:10
+                                         // + span: $DIR/spans.rs:10:5: 10:10
                                          // + literal: Const { ty: for<'a> fn(&'a u8) -> u8 {inner}, val: Value(<ZST>) }
     }
 
     bb1: {
-        StorageDead(_2);                 // scope 0 at $DIR/spans.rs:11:13: 11:14
-        return;                          // scope 0 at $DIR/spans.rs:12:2: 12:2
+        StorageDead(_2);                 // scope 0 at $DIR/spans.rs:10:13: 10:14
+        return;                          // scope 0 at $DIR/spans.rs:11:2: 11:2
     }
 }

--- a/tests/mir-opt/pre-codegen/spans.rs
+++ b/tests/mir-opt/pre-codegen/spans.rs
@@ -2,7 +2,6 @@
 //
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // compile-flags: -Zmir-include-spans
-// ignore-wasm32
 
 #![crate_type = "lib"]
 


### PR DESCRIPTION
I'm planning on landing a few PRs like this that remove ignores that aren't required. This just covers mir-opt and codegen tests.