### PR TITLE
Migrate GUI colors test to original CSS color format

### DIFF
--- a/tests/rustdoc-gui/warning-block.goml
+++ b/tests/rustdoc-gui/warning-block.goml
@@ -4,7 +4,7 @@ show-text: true
 
 define-function: (
     "check-warning",
-    (theme, color, border_color, background_color),
+    (theme, color, border_color),
     block {
         set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
         reload:
@@ -27,19 +27,19 @@ define-function: (
 
 call-function: ("check-warning", {
     "theme": "ayu",
-    "color": "rgb(197, 197, 197)",
-    "border_color": "rgb(255, 142, 0)",
-    "background_color": "rgba(0, 0, 0, 0)",
+    "color": "#c5c5c5",
+    "border_color": "#ff8e00",
+    "background_color": "transparent",
 })
 call-function: ("check-warning", {
     "theme": "dark",
-    "color": "rgb(221, 221, 221)",
-    "border_color": "rgb(255, 142, 0)",
-    "background_color": "rgba(0, 0, 0, 0)",
+    "color": "#ddd",
+    "border_color": "#ff8e00",
+    "background_color": "transparent",
 })
 call-function: ("check-warning", {
     "theme": "light",
-    "color": "rgb(0, 0, 0)",
-    "border_color": "rgb(255, 142, 0)",
-    "background_color": "rgba(0, 0, 0, 0)",
+    "color": "black",
+    "border_color": "#ff8e00",
+    "background_color": "transparent",
 })

--- a/tests/rustdoc-gui/warning-block.goml
+++ b/tests/rustdoc-gui/warning-block.goml
@@ -14,13 +14,13 @@ define-function: (
             "margin-bottom": "12px",
             "color": |color|,
             "border-left": "2px solid " + |border_color|,
-            "background-color": |background_color|,
+            "background-color": "transparent",
         })
         assert-css: ("#doc-warning-2", {
             "margin-bottom": "0px",
             "color": |color|,
             "border-left": "2px solid " + |border_color|,
-            "background-color": |background_color|,
+            "background-color": "transparent",
         })
     },
 )
@@ -29,17 +29,14 @@ call-function: ("check-warning", {
     "theme": "ayu",
     "color": "#c5c5c5",
     "border_color": "#ff8e00",
-    "background_color": "transparent",
 })
 call-function: ("check-warning", {
     "theme": "dark",
     "color": "#ddd",
     "border_color": "#ff8e00",
-    "background_color": "transparent",
 })
 call-function: ("check-warning", {
     "theme": "light",
     "color": "black",
     "border_color": "#ff8e00",
-    "background_color": "transparent",
 })


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/111459.

r? @notriddle