### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -77,6 +77,7 @@ macro marker_impls {
 #[cfg_attr(not(test), rustc_diagnostic_item = "Send")]
 #[rustc_on_unimplemented(
     on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
+    on(_Self = "alloc::rc::Rc<T, A>", note = "use `alloc::sync::Arc` instead of `alloc::rc::Rc`"),
     message = "`{Self}` cannot be sent between threads safely",
     label = "`{Self}` cannot be sent between threads safely",
     note = "consider using `std::sync::Arc<{Self}>`; for more information visit \
@@ -632,6 +633,7 @@ impl<T: ?Sized> Copy for &T {}
         note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead",
     ),
     on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
+    on(_Self = "alloc::rc::Rc<T, A>", note = "use `alloc::sync::Arc` instead of `alloc::rc::Rc`"),
     message = "`{Self}` cannot be shared between threads safely",
     label = "`{Self}` cannot be shared between threads safely",
     note = "consider using `std::sync::Arc<{Self}>`; for more information visit \

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -1856,13 +1856,7 @@ impl fmt::Display for Ipv6Addr {
         if f.precision().is_none() && f.width().is_none() {
             let segments = self.segments();
 
-            // Special case for :: and ::1; otherwise they get written with the
-            // IPv4 formatter
-            if self.is_unspecified() {
-                f.write_str("::")
-            } else if self.is_loopback() {
-                f.write_str("::1")
-            } else if let Some(ipv4) = self.to_ipv4_mapped() {
+            if let Some(ipv4) = self.to_ipv4_mapped() {
                 write!(f, "::ffff:{}", ipv4)
             } else {
                 #[derive(Copy, Clone, Default)]

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -313,7 +313,7 @@ target | std | host | notes
 [`riscv64-linux-android`](platform-support/android.md) |   |   | RISC-V 64-bit Android
 `s390x-unknown-linux-musl` |  |  | S390x Linux (kernel 3.2, MUSL)
 `sparc-unknown-linux-gnu` | ✓ |  | 32-bit SPARC Linux
-[`sparc-unknown-none-elf`](./platform-support/sparc-unknown-none-elf.md) | * | Bare 32-bit SPARC V7+
+[`sparc-unknown-none-elf`](./platform-support/sparc-unknown-none-elf.md) | * |  | Bare 32-bit SPARC V7+
 [`sparc64-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | NetBSD/sparc64
 [`sparc64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | OpenBSD/sparc64
 `thumbv4t-none-eabi` | * |  | Thumb-mode Bare ARMv4T

--- a/tests/rustdoc-gui/warning-block.goml
+++ b/tests/rustdoc-gui/warning-block.goml
@@ -4,7 +4,7 @@ show-text: true
 
 define-function: (
     "check-warning",
-    (theme, color, border_color, background_color),
+    (theme, color, border_color),
     block {
         set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
         reload:
@@ -27,19 +27,19 @@ define-function: (
 
 call-function: ("check-warning", {
     "theme": "ayu",
-    "color": "rgb(197, 197, 197)",
-    "border_color": "rgb(255, 142, 0)",
-    "background_color": "rgba(0, 0, 0, 0)",
+    "color": "#c5c5c5",
+    "border_color": "#ff8e00",
+    "background_color": "transparent",
 })
 call-function: ("check-warning", {
     "theme": "dark",
-    "color": "rgb(221, 221, 221)",
-    "border_color": "rgb(255, 142, 0)",
-    "background_color": "rgba(0, 0, 0, 0)",
+    "color": "#ddd",
+    "border_color": "#ff8e00",
+    "background_color": "transparent",
 })
 call-function: ("check-warning", {
     "theme": "light",
-    "color": "rgb(0, 0, 0)",
-    "border_color": "rgb(255, 142, 0)",
-    "background_color": "rgba(0, 0, 0, 0)",
+    "color": "black",
+    "border_color": "#ff8e00",
+    "background_color": "transparent",
 })

--- a/tests/rustdoc-gui/warning-block.goml
+++ b/tests/rustdoc-gui/warning-block.goml
@@ -14,13 +14,13 @@ define-function: (
             "margin-bottom": "12px",
             "color": |color|,
             "border-left": "2px solid " + |border_color|,
-            "background-color": |background_color|,
+            "background-color": "transparent",
         })
         assert-css: ("#doc-warning-2", {
             "margin-bottom": "0px",
             "color": |color|,
             "border-left": "2px solid " + |border_color|,
-            "background-color": |background_color|,
+            "background-color": "transparent",
         })
     },
 )
@@ -29,17 +29,14 @@ call-function: ("check-warning", {
     "theme": "ayu",
     "color": "#c5c5c5",
     "border_color": "#ff8e00",
-    "background_color": "transparent",
 })
 call-function: ("check-warning", {
     "theme": "dark",
     "color": "#ddd",
     "border_color": "#ff8e00",
-    "background_color": "transparent",
 })
 call-function: ("check-warning", {
     "theme": "light",
     "color": "black",
     "border_color": "#ff8e00",
-    "background_color": "transparent",
 })


### PR DESCRIPTION
Successful merges:

 - #115197 (Remove special cases that are no longer needed due to #112606)
 - #115210 (Make `rustc_on_unimplemented` std-agnostic for `alloc::rc`)
 - #115237 (Fixup sparc-unknown-none-elf table spacing)
 - #115244 (Migrate GUI colors test to original CSS color format)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115197,115210,115237,115244)
<!-- homu-ignore:end -->