### PR TITLE
Represent MIR composite debuginfo as projections instead of aggregates

### DIFF
--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -554,10 +554,7 @@ fn write_scope_tree(
             continue;
         }
 
-        let indented_debug_info = format!(
-            "{0:1$}debug {2} => {3:?};",
-            INDENT, indent, var_debug_info.name, var_debug_info.value,
-        );
+        let indented_debug_info = format!("{0:1$}debug {2:?};", INDENT, indent, var_debug_info);
 
         if tcx.sess.opts.unstable_opts.mir_include_spans {
             writeln!(

--- a/compiler/rustc_mir_build/src/build/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse.rs
@@ -241,6 +241,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             let dbginfo = VarDebugInfo {
                 name,
                 source_info: SourceInfo { span, scope: self.source_scope },
+                composite: None,
                 argument_index: None,
                 value,
             };

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -2287,6 +2287,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             name,
             source_info: debug_source_info,
             value: VarDebugInfoContents::Place(for_arm_body.into()),
+            composite: None,
             argument_index: None,
         });
         let locals = if has_guard.0 {
@@ -2306,6 +2307,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 name,
                 source_info: debug_source_info,
                 value: VarDebugInfoContents::Place(ref_for_guard.into()),
+                composite: None,
                 argument_index: None,
             });
             LocalsForNode::ForGuard { ref_for_guard, for_arm_body }

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -823,6 +823,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     name,
                     source_info: SourceInfo::outermost(captured_place.var_ident.span),
                     value: VarDebugInfoContents::Place(use_place),
+                    composite: None,
                     argument_index: None,
                 });
 
@@ -852,6 +853,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     name,
                     source_info,
                     value: VarDebugInfoContents::Place(arg_local.into()),
+                    composite: None,
                     argument_index: Some(argument_index as u16 + 1),
                 });
             }

--- a/compiler/rustc_mir_transform/src/remove_zsts.rs
+++ b/compiler/rustc_mir_transform/src/remove_zsts.rs
@@ -87,11 +87,6 @@ impl<'tcx> MutVisitor<'tcx> for Replacer<'_, 'tcx> {
                     var_debug_info.value = VarDebugInfoContents::Const(self.make_zst(place_ty))
                 }
             }
-            VarDebugInfoContents::Composite { ty, fragments: _ } => {
-                if self.known_to_be_zst(ty) {
-                    var_debug_info.value = VarDebugInfoContents::Const(self.make_zst(ty))
-                }
-            }
         }
     }
 

--- a/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -33,14 +33,22 @@
                           let _15: bool;
                           let _16: u32;
                           scope 6 {
-                              debug f => (bool, bool, u32){ .0 => _14, .1 => _15, .2 => _16, };
+-                             debug ((f: (bool, bool, u32)).0: bool) => _14;
+-                             debug ((f: (bool, bool, u32)).1: bool) => _15;
+-                             debug ((f: (bool, bool, u32)).2: u32) => _16;
++                             debug ((f: (bool, bool, u32)).0: bool) => const true;
++                             debug ((f: (bool, bool, u32)).1: bool) => const false;
++                             debug ((f: (bool, bool, u32)).2: u32) => const 123_u32;
                               let _10: std::option::Option<u16>;
                               scope 7 {
                                   debug o => _10;
                                   let _17: u32;
                                   let _18: u32;
                                   scope 8 {
-                                      debug p => Point{ .0 => _17, .1 => _18, };
+-                                     debug ((p: Point).0: u32) => _17;
+-                                     debug ((p: Point).1: u32) => _18;
++                                     debug ((p: Point).0: u32) => const 32_u32;
++                                     debug ((p: Point).1: u32) => const 32_u32;
                                       let _11: u32;
                                       scope 9 {
 -                                         debug a => _11;

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
@@ -8,19 +8,22 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
         debug self => _1;
-        debug index => std::ops::Range<usize>{ .0 => _3, .1 => _4, };
+        debug ((index: std::ops::Range<usize>).0: usize) => _3;
+        debug ((index: std::ops::Range<usize>).1: usize) => _4;
         let mut _5: *mut [u32];
         let mut _13: *mut [u32];
         scope 2 {
             scope 3 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
-                debug self => std::ops::Range<usize>{ .0 => _3, .1 => _4, };
+                debug ((self: std::ops::Range<usize>).0: usize) => _3;
+                debug ((self: std::ops::Range<usize>).1: usize) => _4;
                 debug slice => _5;
                 let mut _7: *mut u32;
                 let mut _8: *mut u32;
                 let _15: usize;
                 let _16: usize;
                 scope 4 {
-                    debug this => std::ops::Range<usize>{ .0 => _15, .1 => _16, };
+                    debug ((this: std::ops::Range<usize>).0: usize) => _15;
+                    debug ((this: std::ops::Range<usize>).1: usize) => _16;
                     scope 5 {
                         let _6: usize;
                         scope 6 {
@@ -53,7 +56,8 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
                             }
                         }
                         scope 7 (inlined <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked_mut::runtime::<u32>) {
-                            debug this => std::ops::Range<usize>{ .0 => _15, .1 => _16, };
+                            debug ((this: std::ops::Range<usize>).0: usize) => _15;
+                            debug ((this: std::ops::Range<usize>).1: usize) => _16;
                             debug slice => _5;
                             scope 8 (inlined ptr::mut_ptr::<impl *mut [u32]>::len) {
                                 debug self => _5;

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
@@ -8,19 +8,22 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
         debug self => _1;
-        debug index => std::ops::Range<usize>{ .0 => _3, .1 => _4, };
+        debug ((index: std::ops::Range<usize>).0: usize) => _3;
+        debug ((index: std::ops::Range<usize>).1: usize) => _4;
         let mut _5: *mut [u32];
         let mut _13: *mut [u32];
         scope 2 {
             scope 3 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
-                debug self => std::ops::Range<usize>{ .0 => _3, .1 => _4, };
+                debug ((self: std::ops::Range<usize>).0: usize) => _3;
+                debug ((self: std::ops::Range<usize>).1: usize) => _4;
                 debug slice => _5;
                 let mut _7: *mut u32;
                 let mut _8: *mut u32;
                 let _15: usize;
                 let _16: usize;
                 scope 4 {
-                    debug this => std::ops::Range<usize>{ .0 => _15, .1 => _16, };
+                    debug ((this: std::ops::Range<usize>).0: usize) => _15;
+                    debug ((this: std::ops::Range<usize>).1: usize) => _16;
                     scope 5 {
                         let _6: usize;
                         scope 6 {
@@ -53,7 +56,8 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
                             }
                         }
                         scope 7 (inlined <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked_mut::runtime::<u32>) {
-                            debug this => std::ops::Range<usize>{ .0 => _15, .1 => _16, };
+                            debug ((this: std::ops::Range<usize>).0: usize) => _15;
+                            debug ((this: std::ops::Range<usize>).1: usize) => _16;
                             debug slice => _5;
                             scope 8 (inlined ptr::mut_ptr::<impl *mut [u32]>::len) {
                                 debug self => _5;

--- a/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
@@ -33,7 +33,8 @@
 +     let _32: u32;
       scope 1 {
 -         debug foo => _1;
-+         debug foo => Foo<T>{ .0 => _31, .1 => _32, };
++         debug ((foo: Foo<T>).0: std::result::Result<std::boxed::Box<dyn std::fmt::Display>, <T as Err>::Err>) => _31;
++         debug ((foo: Foo<T>).1: u32) => _32;
           let _5: std::result::Result<std::boxed::Box<dyn std::fmt::Display>, <T as Err>::Err>;
           scope 2 {
               debug x => _5;

--- a/tests/mir-opt/sroa/structs.constant.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/structs.constant.ScalarReplacementOfAggregates.diff
@@ -8,7 +8,8 @@
 +     let _5: u8;
       scope 1 {
 -         debug y => _1;
-+         debug y => (usize, u8){ .0 => _4, .1 => _5, };
++         debug ((y: (usize, u8)).0: usize) => _4;
++         debug ((y: (usize, u8)).1: u8) => _5;
           let _2: usize;
           scope 2 {
               debug t => _2;

--- a/tests/mir-opt/sroa/structs.copies.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/structs.copies.ScalarReplacementOfAggregates.diff
@@ -11,7 +11,10 @@
 +     let _14: std::option::Option<isize>;
       scope 1 {
 -         debug y => _2;
-+         debug y => Foo{ .0 => _11, .1 => _12, .2 => _13, .3 => _14, };
++         debug ((y: Foo).0: u8) => _11;
++         debug ((y: Foo).1: ()) => _12;
++         debug ((y: Foo).2: &str) => _13;
++         debug ((y: Foo).3: std::option::Option<isize>) => _14;
           let _3: u8;
           scope 2 {
               debug t => _3;
@@ -25,7 +28,10 @@
 +                 let _10: std::option::Option<isize>;
                   scope 4 {
 -                     debug z => _5;
-+                     debug z => Foo{ .0 => _7, .1 => _8, .2 => _9, .3 => _10, };
++                     debug ((z: Foo).0: u8) => _7;
++                     debug ((z: Foo).1: ()) => _8;
++                     debug ((z: Foo).2: &str) => _9;
++                     debug ((z: Foo).3: std::option::Option<isize>) => _10;
                       let _6: ();
                       scope 5 {
                           debug a => _6;

--- a/tests/mir-opt/sroa/structs.ref_copies.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/structs.ref_copies.ScalarReplacementOfAggregates.diff
@@ -11,7 +11,10 @@
 +     let _8: std::option::Option<isize>;
       scope 1 {
 -         debug y => _2;
-+         debug y => Foo{ .0 => _5, .1 => _6, .2 => _7, .3 => _8, };
++         debug ((y: Foo).0: u8) => _5;
++         debug ((y: Foo).1: ()) => _6;
++         debug ((y: Foo).2: &str) => _7;
++         debug ((y: Foo).3: std::option::Option<isize>) => _8;
           let _3: u8;
           scope 2 {
               debug t => _3;


### PR DESCRIPTION
Composite debuginfo for MIR is currently represented as
```
debug name => Type { projection1 => place1, projection2 => place2 };
```
ie. a single `VarDebugInfo` object with that name, and its value a `VarDebugInfoContents::Composite`.

This PR proposes to reverse the representation to be
```
debug name.projection1 => place1;
debug name.projection2 => place2;
```
ie. multiple `VarDebugInfo` objects with each their projection.

This simplifies the handling of composite debuginfo by the compiler by avoiding weird nesting.

Based on https://github.com/rust-lang/rust/pull/115139