### PR TITLE
EXPERIMENT: Use rust-cold for `reserve_for_push`

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -190,6 +190,7 @@
 #![feature(negative_impls)]
 #![feature(never_type)]
 #![feature(pointer_is_aligned)]
+#![feature(rust_cold_cc)]
 #![feature(rustc_allow_const_fn_unstable)]
 #![feature(rustc_attrs)]
 #![feature(slice_internals)]

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -298,7 +298,7 @@ impl<T, A: Allocator> RawVec<T, A> {
     /// oft-instantiated `Vec::push()`, which does its own capacity check.
     #[cfg(not(no_global_oom_handling))]
     #[inline(never)]
-    pub fn reserve_for_push(&mut self, len: usize) {
+    pub extern "rust-cold" fn reserve_for_push(&mut self, len: usize) {
         handle_reserve(self.grow_amortized(len, 1));
     }
 


### PR DESCRIPTION
This is *probably* bad, since it means `reserve_for_push` ends up needing to save all the xmm* registers, but it also reduces register pressure in the code calling `push`, so it'll depend on what the balance is between reallocating pushes and existing-capacity pushes.

This cc [blocks inlining](https://llvm.org/docs/LangRef.html#calling-conventions), but the function is already `inline(never)`.

r? @ghost