### PR TITLE
Unify CSS color formats a bit more

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -31,7 +31,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--codeblock-error-color: rgba(255, 0, 0, .5);
 	--codeblock-ignore-hover-color: rgb(255, 142, 0);
 	--codeblock-ignore-color: rgba(255, 142, 0, .6);
-	--warning-border-color: rgb(255, 142, 0);
+	--warning-border-color: #ff8e00;
 	--type-link-color: #ffa0a5;
 	--trait-link-color: #39afd7;
 	--assoc-item-link-color: #39afd7;
@@ -96,8 +96,8 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--codeblock-link-background: #333;
 	--scrape-example-toggle-line-background: #999;
 	--scrape-example-toggle-line-hover-background: #c5c5c5;
-	--scrape-example-code-line-highlight: rgb(91, 59, 1);
-	--scrape-example-code-line-highlight-focus: rgb(124, 75, 15);
+	--scrape-example-code-line-highlight: #5b3b01;
+	--scrape-example-code-line-highlight-focus: #7c4b0f;
 	--scrape-example-help-border-color: #aaa;
 	--scrape-example-help-color: #eee;
 	--scrape-example-help-hover-border-color: #fff;

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -26,7 +26,7 @@
 	--codeblock-error-color: rgba(255, 0, 0, .5);
 	--codeblock-ignore-hover-color: rgb(255, 142, 0);
 	--codeblock-ignore-color: rgba(255, 142, 0, .6);
-	--warning-border-color: rgb(255, 142, 0);
+	--warning-border-color: #ff8e00;
 	--type-link-color: #2dbfb8;
 	--trait-link-color: #b78cf2;
 	--assoc-item-link-color: #d2991d;
@@ -69,7 +69,7 @@
 	--test-arrow-color: #dedede;
 	--test-arrow-background-color: rgba(78, 139, 202, 0.2);
 	--test-arrow-hover-color: #dedede;
-	--test-arrow-hover-background-color: rgb(78, 139, 202);
+	--test-arrow-hover-background-color: #4e8bca;
 	--target-background-color: #494a3d;
 	--target-border-color: #bb7410;
 	--kbd-color: #000;
@@ -87,12 +87,12 @@
 	--crate-search-hover-border: #2196f3;
 	--src-sidebar-background-selected: #333;
 	--src-sidebar-background-hover: #444;
-	--table-alt-row-background-color: #2A2A2A;
+	--table-alt-row-background-color: #2a2a2a;
 	--codeblock-link-background: #333;
 	--scrape-example-toggle-line-background: #999;
 	--scrape-example-toggle-line-hover-background: #c5c5c5;
-	--scrape-example-code-line-highlight: rgb(91, 59, 1);
-	--scrape-example-code-line-highlight-focus: rgb(124, 75, 15);
+	--scrape-example-code-line-highlight: #5b3b01;
+	--scrape-example-code-line-highlight-focus: #7c4b0f;
 	--scrape-example-help-border-color: #aaa;
 	--scrape-example-help-color: #eee;
 	--scrape-example-help-hover-border-color: #fff;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -5,9 +5,9 @@
 	--settings-input-border-color: #717171;
 	--settings-button-color: #000;
 	--settings-button-border-focus: #717171;
-	--sidebar-background-color: #F5F5F5;
-	--sidebar-background-color-hover: #E0E0E0;
-	--code-block-background-color: #F5F5F5;
+	--sidebar-background-color: #f5f5f5;
+	--sidebar-background-color-hover: #e0e0e0;
+	--code-block-background-color: #f5f5f5;
 	--scrollbar-track-background-color: #dcdcdc;
 	--scrollbar-thumb-background-color: rgba(36, 37, 39, 0.6);
 	--scrollbar-color: rgba(36, 37, 39, 0.6) #d9d9d9;
@@ -26,7 +26,7 @@
 	--codeblock-error-color: rgba(255, 0, 0, .5);
 	--codeblock-ignore-hover-color: rgb(255, 142, 0);
 	--codeblock-ignore-color: rgba(255, 142, 0, .6);
-	--warning-border-color: rgb(255, 142, 0);
+	--warning-border-color: #ff8e00;
 	--type-link-color: #ad378a;
 	--trait-link-color: #6e4fc9;
 	--assoc-item-link-color: #3873ad;
@@ -47,7 +47,7 @@
 	--search-tab-button-not-selected-border-top-color: #e6e6e6;
 	--search-tab-button-not-selected-background: #e6e6e6;
 	--search-tab-button-selected-border-top-color: #0089ff;
-	--search-tab-button-selected-background: #ffffff;
+	--search-tab-button-selected-background: #fff;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--code-highlight-kw-color: #8959a8;
@@ -84,7 +84,7 @@
 	--crate-search-hover-border: #717171;
 	--src-sidebar-background-selected: #fff;
 	--src-sidebar-background-hover: #e0e0e0;
-	--table-alt-row-background-color: #F5F5F5;
+	--table-alt-row-background-color: #f5f5f5;
 	--codeblock-link-background: #eee;
 	--scrape-example-toggle-line-background: #ccc;
 	--scrape-example-toggle-line-hover-background: #999;


### PR DESCRIPTION
When `rgb` format doesn't have an `rgba` equivalent, I turned it into hex format. I also "decapitalized" hex formats.

r? @notriddle 