### PR TITLE
tell people what to do when removing an error code

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -516,7 +516,8 @@ E0793: include_str!("./error_codes/E0793.md"),
 E0794: include_str!("./error_codes/E0794.md"),
 }
 
-// Undocumented removed error codes. Note that many removed error codes are documented.
+// Undocumented removed error codes. Note that many removed error codes are kept in the list above
+// and marked as no-longer emitted with a note in the markdown file (see E0001 for an example).
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard
 //  E0019, // merged into E0015

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -357,7 +357,8 @@ fn check_error_codes_used(
             errors.push(format!(
                 "Error code `{code}` exists, but is not emitted by the compiler!\n\
                 Please mark the code as no longer emitted by adding the following note to the top of the `EXXXX.md` file:\n\
-                `#### Note: this error code is no longer emitted by the compiler`"
+                `#### Note: this error code is no longer emitted by the compiler`\n\
+                Also, do not forget to mark doctests that no longer apply as `ignore (error is no longer emitted)`."
             ));
         }
 

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -354,7 +354,11 @@ fn check_error_codes_used(
 
     for code in error_codes {
         if !found_codes.contains(code) && !no_longer_emitted.contains(code) {
-            errors.push(format!("Error code `{code}` exists, but is not emitted by the compiler!"))
+            errors.push(format!(
+                "Error code `{code}` exists, but is not emitted by the compiler!\n\
+                Please mark the code as no longer emitted by adding the following note to the top of the `EXXXX.md` file:\n\
+                `#### Note: this error code is no longer emitted by the compiler`"
+            ));
         }
 
         if found_codes.contains(code) && no_longer_emitted.contains(code) {


### PR DESCRIPTION
Currently tidy and CI send developers on a wild goose chase:
- you edit the code
- CI/tidy tells you that an error code is gone, so you remove it from the list
- CI/tidy tells you that the markdown file is stale, so you remove that as well
- CI (but not tidy) tells you not to remove an error description and copy what E0001 does

Let's be nice to people and directly tell them what to do rather than making them follow misleading breadcrumbs.

r? @GuillaumeGomez