### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -516,7 +516,8 @@ E0793: include_str!("./error_codes/E0793.md"),
 E0794: include_str!("./error_codes/E0794.md"),
 }
 
-// Undocumented removed error codes. Note that many removed error codes are documented.
+// Undocumented removed error codes. Note that many removed error codes are kept in the list above
+// and marked as no-longer emitted with a note in the markdown file (see E0001 for an example).
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard
 //  E0019, // merged into E0015

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -821,7 +821,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(profile_emit, Some(PathBuf::from("abc")));
     tracked!(profile_sample_use, Some(PathBuf::from("abc")));
     tracked!(profiler_runtime, "abc".to_string());
-    tracked!(relax_elf_relocations, Some(false));
+    tracked!(relax_elf_relocations, Some(true));
     tracked!(relro_level, Some(RelroLevel::Full));
     tracked!(remap_cwd_prefix, Some(PathBuf::from("abc")));
     tracked!(report_delayed_bugs, true);

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2216,7 +2216,7 @@ impl Default for TargetOptions {
             mcount: "mcount".into(),
             llvm_mcount_intrinsic: None,
             llvm_abiname: "".into(),
-            relax_elf_relocations: true,
+            relax_elf_relocations: false,
             llvm_args: cvs![],
             use_ctors_section: false,
             eh_frame_header: true,

--- a/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
+++ b/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
@@ -69,6 +69,7 @@ pub fn target() -> Target {
         position_independent_executables: true,
         pre_link_args,
         override_export_symbols: Some(EXPORT_SYMBOLS.iter().cloned().map(Cow::from).collect()),
+        relax_elf_relocations: true,
         ..Default::default()
     };
     Target {

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -395,9 +395,10 @@ pub mod __alloc_error_handler {
         if unsafe { __rust_alloc_error_handler_should_panic != 0 } {
             panic!("memory allocation of {size} bytes failed")
         } else {
-            core::panicking::panic_nounwind_fmt(format_args!(
-                "memory allocation of {size} bytes failed"
-            ))
+            core::panicking::panic_nounwind_fmt(
+                format_args!("memory allocation of {size} bytes failed"),
+                /* force_no_backtrace */ false,
+            )
         }
     }
 }

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -28,6 +28,7 @@ pub struct PanicInfo<'a> {
     message: Option<&'a fmt::Arguments<'a>>,
     location: &'a Location<'a>,
     can_unwind: bool,
+    force_no_backtrace: bool,
 }
 
 impl<'a> PanicInfo<'a> {
@@ -42,9 +43,10 @@ impl<'a> PanicInfo<'a> {
         message: Option<&'a fmt::Arguments<'a>>,
         location: &'a Location<'a>,
         can_unwind: bool,
+        force_no_backtrace: bool,
     ) -> Self {
         struct NoPayload;
-        PanicInfo { location, message, payload: &NoPayload, can_unwind }
+        PanicInfo { location, message, payload: &NoPayload, can_unwind, force_no_backtrace }
     }
 
     #[unstable(
@@ -140,6 +142,17 @@ impl<'a> PanicInfo<'a> {
     #[unstable(feature = "panic_can_unwind", issue = "92988")]
     pub fn can_unwind(&self) -> bool {
         self.can_unwind
+    }
+
+    #[unstable(
+        feature = "panic_internals",
+        reason = "internal details of the implementation of the `panic!` and related macros",
+        issue = "none"
+    )]
+    #[doc(hidden)]
+    #[inline]
+    pub fn force_no_backtrace(&self) -> bool {
+        self.force_no_backtrace
     }
 }
 

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -400,7 +400,12 @@ constructs. For example, a macro use `foo!(a, b, c)` can be parsed like a
 function call (ignoring the `!`), so format it using the rules for function
 calls.
 
-### Special case macros
+The style guide defines specific formatting for particular macros in the
+language or standard library. The style guide does not define formatting for
+any third-party macros, even if similar to those in the language or standard
+library.
+
+### Format string macros
 
 For macros which take a format string, if all other arguments are *small*,
 format the arguments before the format string on a single line if they fit, and

--- a/src/tools/miri/tests/fail/panic/double_panic.stderr
+++ b/src/tools/miri/tests/fail/panic/double_panic.stderr
@@ -6,7 +6,6 @@ second
 stack backtrace:
 thread 'main' panicked at RUSTLIB/core/src/panicking.rs:LL:CC:
 panic in a destructor during cleanup
-stack backtrace:
 thread caused non-unwinding panic. aborting.
 error: abnormal termination: the program aborted execution
   --> RUSTLIB/std/src/sys/PLATFORM/mod.rs:LL:CC
@@ -19,7 +18,7 @@ LL |     ABORT();
    = note: inside closure at RUSTLIB/std/src/panicking.rs:LL:CC
    = note: inside `std::sys_common::backtrace::__rust_end_short_backtrace::<[closure@std::panicking::begin_panic_handler::{closure#0}], !>` at RUSTLIB/std/src/sys_common/backtrace.rs:LL:CC
    = note: inside `std::panicking::begin_panic_handler` at RUSTLIB/std/src/panicking.rs:LL:CC
-   = note: inside `core::panicking::panic_nounwind` at RUSTLIB/core/src/panicking.rs:LL:CC
+   = note: inside `core::panicking::panic_nounwind_nobacktrace` at RUSTLIB/core/src/panicking.rs:LL:CC
    = note: inside `core::panicking::panic_in_cleanup` at RUSTLIB/core/src/panicking.rs:LL:CC
 note: inside `main`
   --> $DIR/double_panic.rs:LL:CC

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -357,7 +357,8 @@ fn check_error_codes_used(
             errors.push(format!(
                 "Error code `{code}` exists, but is not emitted by the compiler!\n\
                 Please mark the code as no longer emitted by adding the following note to the top of the `EXXXX.md` file:\n\
-                `#### Note: this error code is no longer emitted by the compiler`"
+                `#### Note: this error code is no longer emitted by the compiler`\n\
+                Also, do not forget to mark doctests that no longer apply as `ignore (error is no longer emitted)`."
             ));
         }
 

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -354,7 +354,11 @@ fn check_error_codes_used(
 
     for code in error_codes {
         if !found_codes.contains(code) && !no_longer_emitted.contains(code) {
-            errors.push(format!("Error code `{code}` exists, but is not emitted by the compiler!"))
+            errors.push(format!(
+                "Error code `{code}` exists, but is not emitted by the compiler!\n\
+                Please mark the code as no longer emitted by adding the following note to the top of the `EXXXX.md` file:\n\
+                `#### Note: this error code is no longer emitted by the compiler`"
+            ));
         }
 
         if found_codes.contains(code) && no_longer_emitted.contains(code) {

--- a/tests/ui/panics/panic-in-cleanup.rs
+++ b/tests/ui/panics/panic-in-cleanup.rs
@@ -4,6 +4,7 @@
 // error-pattern: panic in a destructor during cleanup
 // normalize-stderr-test: "\n +[0-9]+:[^\n]+" -> ""
 // normalize-stderr-test: "\n +at [^\n]+" -> ""
+// normalize-stderr-test: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"
 // needs-unwind
 // ignore-emscripten "RuntimeError" junk in output
 // ignore-msvc SEH doesn't do panic-during-cleanup the same way as everyone else

--- a/tests/ui/panics/panic-in-cleanup.run.stderr
+++ b/tests/ui/panics/panic-in-cleanup.run.stderr
@@ -1,10 +1,9 @@
-thread 'main' panicked at $DIR/panic-in-cleanup.rs:21:5:
+thread 'main' panicked at $DIR/panic-in-cleanup.rs:22:5:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-thread 'main' panicked at $DIR/panic-in-cleanup.rs:15:9:
+thread 'main' panicked at $DIR/panic-in-cleanup.rs:16:9:
 BOOM
 stack backtrace:
-thread 'main' panicked at library/core/src/panicking.rs:126:5:
+thread 'main' panicked at library/core/src/panicking.rs:$LINE:$COL:
 panic in a destructor during cleanup
-stack backtrace:
 thread caused non-unwinding panic. aborting.

--- a/tests/ui/panics/panic-in-ffi.rs
+++ b/tests/ui/panics/panic-in-ffi.rs
@@ -4,6 +4,7 @@
 // error-pattern: panic in a function that cannot unwind
 // normalize-stderr-test: "\n +[0-9]+:[^\n]+" -> ""
 // normalize-stderr-test: "\n +at [^\n]+" -> ""
+// normalize-stderr-test: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"
 // needs-unwind
 // ignore-emscripten "RuntimeError" junk in output
 #![feature(c_unwind)]

--- a/tests/ui/panics/panic-in-ffi.run.stderr
+++ b/tests/ui/panics/panic-in-ffi.run.stderr
@@ -1,7 +1,7 @@
-thread 'main' panicked at $DIR/panic-in-ffi.rs:12:5:
+thread 'main' panicked at $DIR/panic-in-ffi.rs:13:5:
 Test
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-thread 'main' panicked at library/core/src/panicking.rs:126:5:
+thread 'main' panicked at library/core/src/panicking.rs:$LINE:$COL:
 panic in a function that cannot unwind
 stack backtrace:
 thread caused non-unwinding panic. aborting.


### PR DESCRIPTION
Successful merges:

 - #114919 (style-guide: Add guidance for defining formatting for specific macros)
 - #115254 (wasi: round up the size for `aligned_alloc`)
 - #115267 (Revert relax_elf_relocations default change)
 - #115278 (tell people what to do when removing an error code)
 - #115280 (avoid triple-backtrace due to panic-during-cleanup)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114919,115254,115267,115278,115280)
<!-- homu-ignore:end -->