### PR TITLE
More precisely detect cycle errors from type_of on opaque

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -56,6 +56,7 @@ pub fn provide(providers: &mut Providers) {
     resolve_bound_vars::provide(providers);
     *providers = Providers {
         type_of: type_of::type_of,
+        type_of_opaque: type_of::type_of_opaque,
         item_bounds: item_bounds::item_bounds,
         explicit_item_bounds: item_bounds::explicit_item_bounds,
         generics_of: generics_of::generics_of,

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -1,4 +1,5 @@
 use crate::mir;
+use crate::query::CyclePlaceholder;
 use crate::traits;
 use crate::ty::{self, Ty};
 use std::mem::{size_of, transmute_copy, MaybeUninit};
@@ -140,6 +141,10 @@ impl EraseType for Result<Option<ty::ValTree<'_>>, mir::interpret::ErrorHandled>
 impl EraseType for Result<&'_ ty::List<Ty<'_>>, ty::util::AlwaysRequiresDrop> {
     type Result =
         [u8; size_of::<Result<&'static ty::List<Ty<'static>>, ty::util::AlwaysRequiresDrop>>()];
+}
+
+impl EraseType for Result<ty::EarlyBinder<Ty<'_>>, CyclePlaceholder> {
+    type Result = [u8; size_of::<Result<ty::EarlyBinder<Ty<'_>>, CyclePlaceholder>>()];
 }
 
 impl<T> EraseType for Option<&'_ T> {

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -19,7 +19,7 @@ use rustc_query_system::dep_graph::SerializedDepNodeIndex;
 pub(crate) use rustc_query_system::query::QueryJobId;
 use rustc_query_system::query::*;
 use rustc_query_system::HandleCycleError;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{ErrorGuaranteed, Span, DUMMY_SP};
 use std::ops::Deref;
 
 pub struct QueryKeyStringCache {
@@ -52,7 +52,8 @@ pub struct DynamicQuery<'tcx, C: QueryCache> {
     pub loadable_from_disk:
         fn(tcx: TyCtxt<'tcx>, key: &C::Key, index: SerializedDepNodeIndex) -> bool,
     pub hash_result: HashResult<C::Value>,
-    pub value_from_cycle_error: fn(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>]) -> C::Value,
+    pub value_from_cycle_error:
+        fn(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>], guar: ErrorGuaranteed) -> C::Value,
     pub format_value: fn(&C::Value) -> String,
 }
 

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -630,3 +630,6 @@ impl<'tcx> TyCtxtAt<'tcx> {
             .unwrap_or_else(|| bug!("def_kind: unsupported node: {:?}", def_id))
     }
 }
+
+#[derive(Copy, Clone, Debug, HashStable)]
+pub struct CyclePlaceholder(pub ErrorGuaranteed);

--- a/compiler/rustc_middle/src/values.rs
+++ b/compiler/rustc_middle/src/values.rs
@@ -8,20 +8,28 @@ use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_query_system::query::QueryInfo;
 use rustc_query_system::Value;
 use rustc_span::def_id::LocalDefId;
-use rustc_span::Span;
+use rustc_span::{ErrorGuaranteed, Span};
 
 use std::fmt::Write;
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for Ty<'_> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, _: &[QueryInfo<DepKind>]) -> Self {
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        _: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
+    ) -> Self {
         // SAFETY: This is never called when `Self` is not `Ty<'tcx>`.
         // FIXME: Represent the above fact in the trait system somehow.
-        unsafe { std::mem::transmute::<Ty<'tcx>, Ty<'_>>(Ty::new_misc_error(tcx)) }
+        unsafe { std::mem::transmute::<Ty<'tcx>, Ty<'_>>(Ty::new_error(tcx, guar)) }
     }
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::SymbolName<'_> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, _: &[QueryInfo<DepKind>]) -> Self {
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        _: &[QueryInfo<DepKind>],
+        _guar: ErrorGuaranteed,
+    ) -> Self {
         // SAFETY: This is never called when `Self` is not `SymbolName<'tcx>`.
         // FIXME: Represent the above fact in the trait system somehow.
         unsafe {
@@ -33,8 +41,12 @@ impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::SymbolName<'_> {
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::Binder<'_, ty::FnSig<'_>> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, stack: &[QueryInfo<DepKind>]) -> Self {
-        let err = Ty::new_misc_error(tcx);
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        stack: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
+    ) -> Self {
+        let err = Ty::new_error(tcx, guar);
 
         let arity = if let Some(frame) = stack.get(0)
             && frame.query.dep_kind == DepKind::fn_sig
@@ -63,7 +75,11 @@ impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::Binder<'_, ty::FnSig<'_>> {
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for Representability {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>]) -> Self {
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        cycle: &[QueryInfo<DepKind>],
+        _guar: ErrorGuaranteed,
+    ) -> Self {
         let mut item_and_field_ids = Vec::new();
         let mut representable_ids = FxHashSet::default();
         for info in cycle {
@@ -95,22 +111,35 @@ impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for Representability {
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::EarlyBinder<Ty<'_>> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>]) -> Self {
-        ty::EarlyBinder::bind(Ty::from_cycle_error(tcx, cycle))
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        cycle: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
+    ) -> Self {
+        ty::EarlyBinder::bind(Ty::from_cycle_error(tcx, cycle, guar))
     }
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::EarlyBinder<ty::Binder<'_, ty::FnSig<'_>>> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>]) -> Self {
-        ty::EarlyBinder::bind(ty::Binder::from_cycle_error(tcx, cycle))
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        cycle: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
+    ) -> Self {
+        ty::EarlyBinder::bind(ty::Binder::from_cycle_error(tcx, cycle, guar))
     }
 }
 
 impl<'tcx, T> Value<TyCtxt<'tcx>, DepKind> for Result<T, &'_ ty::layout::LayoutError<'_>> {
-    fn from_cycle_error(_tcx: TyCtxt<'tcx>, _cycle: &[QueryInfo<DepKind>]) -> Self {
+    fn from_cycle_error(
+        _tcx: TyCtxt<'tcx>,
+        _cycle: &[QueryInfo<DepKind>],
+        _guar: ErrorGuaranteed,
+    ) -> Self {
         // tcx.arena.alloc cannot be used because we are not allowed to use &'tcx LayoutError under
         // min_specialization. Since this is an error path anyways, leaking doesn't matter (and really,
         // tcx.arena.alloc is pretty much equal to leaking).
+        // FIXME: `Cycle` should carry the ErrorGuaranteed
         Err(Box::leak(Box::new(ty::layout::LayoutError::Cycle)))
     }
 }

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -41,7 +41,7 @@ use rustc_query_system::query::{
 };
 use rustc_query_system::HandleCycleError;
 use rustc_query_system::Value;
-use rustc_span::Span;
+use rustc_span::{ErrorGuaranteed, Span};
 
 #[macro_use]
 mod plumbing;
@@ -146,8 +146,9 @@ where
         self,
         tcx: TyCtxt<'tcx>,
         cycle: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
     ) -> Self::Value {
-        (self.dynamic.value_from_cycle_error)(tcx, cycle)
+        (self.dynamic.value_from_cycle_error)(tcx, cycle, guar)
     }
 
     #[inline(always)]

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -605,8 +605,8 @@ macro_rules! define_queries {
                     } {
                         |_tcx, _key, _prev_index, _index| None
                     }),
-                    value_from_cycle_error: |tcx, cycle| {
-                        let result: queries::$name::Value<'tcx> = Value::from_cycle_error(tcx, cycle);
+                    value_from_cycle_error: |tcx, cycle, guar| {
+                        let result: queries::$name::Value<'tcx> = Value::from_cycle_error(tcx, cycle, guar);
                         erase(result)
                     },
                     loadable_from_disk: |_tcx, _key, _index| {

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -8,6 +8,7 @@ use crate::query::DepNodeIndex;
 use crate::query::{QueryContext, QueryInfo, QueryState};
 
 use rustc_data_structures::fingerprint::Fingerprint;
+use rustc_span::ErrorGuaranteed;
 use std::fmt::Debug;
 use std::hash::Hash;
 
@@ -57,6 +58,7 @@ pub trait QueryConfig<Qcx: QueryContext>: Copy {
         self,
         tcx: Qcx::DepContext,
         cycle: &[QueryInfo<Qcx::DepKind>],
+        guar: ErrorGuaranteed,
     ) -> Self::Value;
 
     fn anon(self) -> bool;

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -148,8 +148,8 @@ where
     use HandleCycleError::*;
     match query.handle_cycle_error() {
         Error => {
-            error.emit();
-            query.value_from_cycle_error(*qcx.dep_context(), &cycle_error.cycle)
+            let guar = error.emit();
+            query.value_from_cycle_error(*qcx.dep_context(), &cycle_error.cycle, guar)
         }
         Fatal => {
             error.emit();
@@ -157,8 +157,8 @@ where
             unreachable!()
         }
         DelayBug => {
-            error.delay_as_bug();
-            query.value_from_cycle_error(*qcx.dep_context(), &cycle_error.cycle)
+            let guar = error.delay_as_bug();
+            query.value_from_cycle_error(*qcx.dep_context(), &cycle_error.cycle, guar)
         }
     }
 }

--- a/compiler/rustc_query_system/src/values.rs
+++ b/compiler/rustc_query_system/src/values.rs
@@ -1,12 +1,14 @@
+use rustc_span::ErrorGuaranteed;
+
 use crate::dep_graph::{DepContext, DepKind};
 use crate::query::QueryInfo;
 
 pub trait Value<Tcx: DepContext, D: DepKind>: Sized {
-    fn from_cycle_error(tcx: Tcx, cycle: &[QueryInfo<D>]) -> Self;
+    fn from_cycle_error(tcx: Tcx, cycle: &[QueryInfo<D>], guar: ErrorGuaranteed) -> Self;
 }
 
 impl<Tcx: DepContext, T, D: DepKind> Value<Tcx, D> for T {
-    default fn from_cycle_error(tcx: Tcx, cycle: &[QueryInfo<D>]) -> T {
+    default fn from_cycle_error(tcx: Tcx, cycle: &[QueryInfo<D>], _guar: ErrorGuaranteed) -> T {
         tcx.sess().abort_if_errors();
         // Ideally we would use `bug!` here. But bug! is only defined in rustc_middle, and it's
         // non-trivial to define it earlier.

--- a/tests/ui/async-await/future-contains-err-issue-115188.rs
+++ b/tests/ui/async-await/future-contains-err-issue-115188.rs
@@ -1,0 +1,17 @@
+// edition: 2021
+
+// Makes sure we don't spew a bunch of unrelated opaque errors when the reason
+// for this error is just a missing struct field in `foo`.
+
+async fn foo() {
+    let y = Wrapper { };
+    //~^ ERROR missing field `t` in initializer of `Wrapper<_>`
+}
+
+struct Wrapper<T> { t: T }
+
+fn is_send<T: Send>(_: T) {}
+
+fn main() {
+    is_send(foo());
+}

--- a/tests/ui/async-await/future-contains-err-issue-115188.stderr
+++ b/tests/ui/async-await/future-contains-err-issue-115188.stderr
@@ -1,0 +1,9 @@
+error[E0063]: missing field `t` in initializer of `Wrapper<_>`
+  --> $DIR/future-contains-err-issue-115188.rs:7:13
+   |
+LL |     let y = Wrapper { };
+   |             ^^^^^^^ missing `t`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0063`.

--- a/tests/ui/generator/layout-error.rs
+++ b/tests/ui/generator/layout-error.rs
@@ -24,6 +24,5 @@ fn main() {
     type F = impl Future;
     // Check that statics are inhabited computes they layout.
     static POOL: Task<F> = Task::new();
-    //~^ ERROR: cannot check whether the hidden type of `layout_error[b009]::main::F::{opaque#0}` satisfies auto traits
     Task::spawn(&POOL, || cb());
 }

--- a/tests/ui/generator/layout-error.stderr
+++ b/tests/ui/generator/layout-error.stderr
@@ -4,24 +4,6 @@ error[E0425]: cannot find value `Foo` in this scope
 LL |         let a = Foo;
    |                 ^^^ not found in this scope
 
-error: cannot check whether the hidden type of `layout_error[b009]::main::F::{opaque#0}` satisfies auto traits
-  --> $DIR/layout-error.rs:26:18
-   |
-LL |     static POOL: Task<F> = Task::new();
-   |                  ^^^^^^^
-   |
-note: opaque type is declared here
-  --> $DIR/layout-error.rs:24:14
-   |
-LL |     type F = impl Future;
-   |              ^^^^^^^^^^^
-note: required because it appears within the type `Task<F>`
-  --> $DIR/layout-error.rs:9:12
-   |
-LL | pub struct Task<F: Future>(F);
-   |            ^^^^
-   = note: shared static variables must have a type that implements `Sync`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/impl-trait/auto-trait-leak.rs
+++ b/tests/ui/impl-trait/auto-trait-leak.rs
@@ -12,7 +12,6 @@ fn cycle1() -> impl Clone {
     //~^ ERROR cycle detected
     //~| ERROR cycle detected
     send(cycle2().clone());
-    //~^ ERROR: cannot check whether the hidden type of opaque type satisfies auto traits
 
     Rc::new(Cell::new(5))
 }

--- a/tests/ui/impl-trait/auto-trait-leak.stderr
+++ b/tests/ui/impl-trait/auto-trait-leak.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when computing type of `cycle1::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `cycle1::{opaque#0}`
   --> $DIR/auto-trait-leak.rs:11:16
    |
 LL | fn cycle1() -> impl Clone {
@@ -10,32 +10,26 @@ note: ...which requires type-checking `cycle1`...
 LL |     send(cycle2().clone());
    |     ^^^^
    = note: ...which requires evaluating trait selection obligation `cycle2::{opaque#0}: core::marker::Send`...
-note: ...which requires computing type of `cycle2::{opaque#0}`...
-  --> $DIR/auto-trait-leak.rs:20:16
+note: ...which requires computing type of opaque `cycle2::{opaque#0}`...
+  --> $DIR/auto-trait-leak.rs:19:16
    |
 LL | fn cycle2() -> impl Clone {
    |                ^^^^^^^^^^
 note: ...which requires type-checking `cycle2`...
-  --> $DIR/auto-trait-leak.rs:21:5
+  --> $DIR/auto-trait-leak.rs:20:5
    |
 LL |     send(cycle1().clone());
    |     ^^^^
    = note: ...which requires evaluating trait selection obligation `cycle1::{opaque#0}: core::marker::Send`...
-   = note: ...which again requires computing type of `cycle1::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/auto-trait-leak.rs:1:1
+   = note: ...which again requires computing type of opaque `cycle1::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `cycle1::{opaque#0}`
+  --> $DIR/auto-trait-leak.rs:11:16
    |
-LL | / use std::cell::Cell;
-LL | | use std::rc::Rc;
-LL | |
-LL | | fn send<T: Send>(_: T) {}
-...  |
-LL | |     Rc::new(String::from("foo"))
-LL | | }
-   | |_^
+LL | fn cycle1() -> impl Clone {
+   |                ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `cycle1::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `cycle1::{opaque#0}`
   --> $DIR/auto-trait-leak.rs:11:16
    |
 LL | fn cycle1() -> impl Clone {
@@ -47,32 +41,26 @@ note: ...which requires type-checking `cycle1`...
 LL |     send(cycle2().clone());
    |     ^^^^
    = note: ...which requires evaluating trait selection obligation `cycle2::{opaque#0}: core::marker::Send`...
-note: ...which requires computing type of `cycle2::{opaque#0}`...
-  --> $DIR/auto-trait-leak.rs:20:16
+note: ...which requires computing type of opaque `cycle2::{opaque#0}`...
+  --> $DIR/auto-trait-leak.rs:19:16
    |
 LL | fn cycle2() -> impl Clone {
    |                ^^^^^^^^^^
 note: ...which requires type-checking `cycle2`...
-  --> $DIR/auto-trait-leak.rs:20:1
+  --> $DIR/auto-trait-leak.rs:19:1
    |
 LL | fn cycle2() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires computing type of `cycle1::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/auto-trait-leak.rs:1:1
+   = note: ...which again requires computing type of opaque `cycle1::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `cycle1::{opaque#0}`
+  --> $DIR/auto-trait-leak.rs:11:16
    |
-LL | / use std::cell::Cell;
-LL | | use std::rc::Rc;
-LL | |
-LL | | fn send<T: Send>(_: T) {}
-...  |
-LL | |     Rc::new(String::from("foo"))
-LL | | }
-   | |_^
+LL | fn cycle1() -> impl Clone {
+   |                ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of opaque type satisfies auto traits
-  --> $DIR/auto-trait-leak.rs:21:10
+  --> $DIR/auto-trait-leak.rs:20:10
    |
 LL |     send(cycle1().clone());
    |     ---- ^^^^^^^^^^^^^^^^
@@ -85,7 +73,7 @@ note: opaque type is declared here
 LL | fn cycle1() -> impl Clone {
    |                ^^^^^^^^^^
 note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/auto-trait-leak.rs:20:4
+  --> $DIR/auto-trait-leak.rs:19:4
    |
 LL | fn cycle2() -> impl Clone {
    |    ^^^^^^
@@ -95,30 +83,6 @@ note: required by a bound in `send`
 LL | fn send<T: Send>(_: T) {}
    |            ^^^^ required by this bound in `send`
 
-error: cannot check whether the hidden type of opaque type satisfies auto traits
-  --> $DIR/auto-trait-leak.rs:14:10
-   |
-LL |     send(cycle2().clone());
-   |     ---- ^^^^^^^^^^^^^^^^
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: opaque type is declared here
-  --> $DIR/auto-trait-leak.rs:20:16
-   |
-LL | fn cycle2() -> impl Clone {
-   |                ^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/auto-trait-leak.rs:11:4
-   |
-LL | fn cycle1() -> impl Clone {
-   |    ^^^^^^
-note: required by a bound in `send`
-  --> $DIR/auto-trait-leak.rs:4:12
-   |
-LL | fn send<T: Send>(_: T) {}
-   |            ^^^^ required by this bound in `send`
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/issue-103181-2.rs
+++ b/tests/ui/impl-trait/issue-103181-2.rs
@@ -24,8 +24,6 @@ where
     B: Send, // <- a second bound
 {
     normalize(broken_fut(), ());
-    //~^ ERROR: cannot check whether the hidden type of opaque type satisfies auto traits
-    //~| ERROR: cannot check whether the hidden type of opaque type satisfies auto traits
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issue-103181-2.stderr
+++ b/tests/ui/impl-trait/issue-103181-2.stderr
@@ -4,61 +4,6 @@ error[E0425]: cannot find value `ident_error` in this scope
 LL |     ident_error;
    |     ^^^^^^^^^^^ not found in this scope
 
-error: cannot check whether the hidden type of opaque type satisfies auto traits
-  --> $DIR/issue-103181-2.rs:26:15
-   |
-LL |     normalize(broken_fut(), ());
-   |     --------- ^^^^^^^^^^^^
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: opaque type is declared here
-  --> $DIR/issue-103181-2.rs:11:23
-   |
-LL | async fn broken_fut() {
-   |                       ^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/issue-103181-2.rs:20:10
-   |
-LL | async fn iceice<A, B>()
-   |          ^^^^^^
-note: required for `impl Future<Output = ()>` to implement `SendFuture`
-  --> $DIR/issue-103181-2.rs:7:17
-   |
-LL | impl<Fut: Send> SendFuture for Fut {
-   |           ----  ^^^^^^^^^^     ^^^
-   |           |
-   |           unsatisfied trait bound introduced here
-note: required by a bound in `normalize`
-  --> $DIR/issue-103181-2.rs:18:19
-   |
-LL | fn normalize<Fut: SendFuture>(_: Fut, _: Fut::Output) {}
-   |                   ^^^^^^^^^^ required by this bound in `normalize`
-
-error: cannot check whether the hidden type of opaque type satisfies auto traits
-  --> $DIR/issue-103181-2.rs:26:5
-   |
-LL |     normalize(broken_fut(), ());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: opaque type is declared here
-  --> $DIR/issue-103181-2.rs:11:23
-   |
-LL | async fn broken_fut() {
-   |                       ^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/issue-103181-2.rs:20:10
-   |
-LL | async fn iceice<A, B>()
-   |          ^^^^^^
-note: required for `impl Future<Output = ()>` to implement `SendFuture`
-  --> $DIR/issue-103181-2.rs:7:17
-   |
-LL | impl<Fut: Send> SendFuture for Fut {
-   |           ----  ^^^^^^^^^^     ^^^
-   |           |
-   |           unsatisfied trait bound introduced here
-
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/impl-trait/issues/issue-86800.stderr
+++ b/tests/ui/impl-trait/issues/issue-86800.stderr
@@ -7,6 +7,6 @@ LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResu
 error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
-#0 [type_of] computing type of `TransactionFuture::{opaque#0}`
-#1 [check_mod_item_types] checking item types in top-level module
+#0 [type_of_opaque] computing type of opaque `TransactionFuture::{opaque#0}`
+#1 [type_of] computing type of `TransactionFuture::{opaque#0}`
 end of query stack

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage3.rs
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage3.rs
@@ -5,8 +5,8 @@
 
 mod m {
     pub type Foo = impl std::fmt::Debug;
-    //~^ ERROR: cycle detected when computing type of `m::Foo::{opaque#0}` [E0391]
-    //~| ERROR: cycle detected when computing type of `m::Foo::{opaque#0}` [E0391]
+    //~^ ERROR: cycle detected when computing type of opaque `m::Foo::{opaque#0}` [E0391]
+    //~| ERROR: cycle detected when computing type of opaque `m::Foo::{opaque#0}` [E0391]
 
     pub fn foo() -> Foo {
         22_u32

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage3.stderr
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage3.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when computing type of `m::Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `m::Foo::{opaque#0}`
   --> $DIR/auto-trait-leakage3.rs:7:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
@@ -10,15 +10,15 @@ note: ...which requires type-checking `m::bar`...
 LL |         is_send(foo());
    |         ^^^^^^^
    = note: ...which requires evaluating trait selection obligation `m::Foo: core::marker::Send`...
-   = note: ...which again requires computing type of `m::Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in module `m`
-  --> $DIR/auto-trait-leakage3.rs:6:1
+   = note: ...which again requires computing type of opaque `m::Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `m::Foo::{opaque#0}`
+  --> $DIR/auto-trait-leakage3.rs:7:20
    |
-LL | mod m {
-   | ^^^^^
+LL |     pub type Foo = impl std::fmt::Debug;
+   |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `m::Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `m::Foo::{opaque#0}`
   --> $DIR/auto-trait-leakage3.rs:7:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
@@ -29,12 +29,12 @@ note: ...which requires type-checking `m::bar`...
    |
 LL |     pub fn bar() {
    |     ^^^^^^^^^^^^
-   = note: ...which again requires computing type of `m::Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in module `m`
-  --> $DIR/auto-trait-leakage3.rs:6:1
+   = note: ...which again requires computing type of opaque `m::Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `m::Foo::{opaque#0}`
+  --> $DIR/auto-trait-leakage3.rs:7:20
    |
-LL | mod m {
-   | ^^^^^
+LL |     pub type Foo = impl std::fmt::Debug;
+   |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of `auto_trait_leakage3[211d]::m::Foo::{opaque#0}` satisfies auto traits

--- a/tests/ui/type-alias-impl-trait/inference-cycle.stderr
+++ b/tests/ui/type-alias-impl-trait/inference-cycle.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when computing type of `m::Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `m::Foo::{opaque#0}`
   --> $DIR/inference-cycle.rs:5:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
@@ -10,15 +10,15 @@ note: ...which requires type-checking `m::bar`...
 LL |         is_send(foo()); // Today: error
    |         ^^^^^^^
    = note: ...which requires evaluating trait selection obligation `m::Foo: core::marker::Send`...
-   = note: ...which again requires computing type of `m::Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in module `m`
-  --> $DIR/inference-cycle.rs:4:1
+   = note: ...which again requires computing type of opaque `m::Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `m::Foo::{opaque#0}`
+  --> $DIR/inference-cycle.rs:5:20
    |
-LL | mod m {
-   | ^^^^^
+LL |     pub type Foo = impl std::fmt::Debug;
+   |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `m::Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `m::Foo::{opaque#0}`
   --> $DIR/inference-cycle.rs:5:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
@@ -29,12 +29,12 @@ note: ...which requires type-checking `m::bar`...
    |
 LL |     pub fn bar() {
    |     ^^^^^^^^^^^^
-   = note: ...which again requires computing type of `m::Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in module `m`
-  --> $DIR/inference-cycle.rs:4:1
+   = note: ...which again requires computing type of opaque `m::Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `m::Foo::{opaque#0}`
+  --> $DIR/inference-cycle.rs:5:20
    |
-LL | mod m {
-   | ^^^^^
+LL |     pub type Foo = impl std::fmt::Debug;
+   |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of `inference_cycle[4ecc]::m::Foo::{opaque#0}` satisfies auto traits

--- a/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
@@ -4,6 +4,11 @@ error[E0391]: cycle detected when computing type of `Bug::{opaque#0}`
 LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
    |                  ^^^^^^^^^^^^^^^^^^^^^^
    |
+note: ...which requires computing type of opaque `Bug::{opaque#0}`...
+  --> $DIR/issue-53092-2.rs:4:18
+   |
+LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires type-checking `CONST_BUG`...
   --> $DIR/issue-53092-2.rs:6:1
    |

--- a/tests/ui/type-alias-impl-trait/reveal_local.stderr
+++ b/tests/ui/type-alias-impl-trait/reveal_local.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when computing type of `Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `Foo::{opaque#0}`
   --> $DIR/reveal_local.rs:5:12
    |
 LL | type Foo = impl Debug;
@@ -10,21 +10,15 @@ note: ...which requires type-checking `not_good`...
 LL |     is_send::<Foo>();
    |     ^^^^^^^^^^^^^^
    = note: ...which requires evaluating trait selection obligation `Foo: core::marker::Send`...
-   = note: ...which again requires computing type of `Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/reveal_local.rs:1:1
+   = note: ...which again requires computing type of opaque `Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Foo::{opaque#0}`
+  --> $DIR/reveal_local.rs:5:12
    |
-LL | / #![feature(type_alias_impl_trait)]
-LL | |
-LL | | use std::fmt::Debug;
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | type Foo = impl Debug;
+   |            ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `Foo::{opaque#0}`
   --> $DIR/reveal_local.rs:5:12
    |
 LL | type Foo = impl Debug;
@@ -35,18 +29,12 @@ note: ...which requires type-checking `not_good`...
    |
 LL | fn not_good() {
    | ^^^^^^^^^^^^^
-   = note: ...which again requires computing type of `Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/reveal_local.rs:1:1
+   = note: ...which again requires computing type of opaque `Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Foo::{opaque#0}`
+  --> $DIR/reveal_local.rs:5:12
    |
-LL | / #![feature(type_alias_impl_trait)]
-LL | |
-LL | | use std::fmt::Debug;
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | type Foo = impl Debug;
+   |            ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits
@@ -71,7 +59,7 @@ note: required by a bound in `is_send`
 LL | fn is_send<T: Send>() {}
    |               ^^^^ required by this bound in `is_send`
 
-error[E0391]: cycle detected when computing type of `Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `Foo::{opaque#0}`
   --> $DIR/reveal_local.rs:5:12
    |
 LL | type Foo = impl Debug;
@@ -82,18 +70,12 @@ note: ...which requires type-checking `not_gooder`...
    |
 LL | fn not_gooder() -> Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires computing type of `Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/reveal_local.rs:1:1
+   = note: ...which again requires computing type of opaque `Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Foo::{opaque#0}`
+  --> $DIR/reveal_local.rs:5:12
    |
-LL | / #![feature(type_alias_impl_trait)]
-LL | |
-LL | | use std::fmt::Debug;
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | type Foo = impl Debug;
+   |            ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits


### PR DESCRIPTION
Not sure if this still needs work. Just putting it up for initial impressions, since it seems that a few people are frustrated with the increased error verbosity due to #113320.

Essentially we introduce a new sub-query for `type_of` specifically for opaques which returns a value that is able to distinguish "has errors" from "due to cycle recovery".

Fixes #115188

r? @oli-obk