### PR TITLE
Allow file names to end with '>'

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -305,7 +305,6 @@ pub enum FileName {
 
 impl From<PathBuf> for FileName {
     fn from(p: PathBuf) -> Self {
-        assert!(!p.to_string_lossy().ends_with('>'));
         FileName::Real(RealFileName::LocalPath(p))
     }
 }

--- a/tests/run-make/silly-file-names/Makefile
+++ b/tests/run-make/silly-file-names/Makefile
@@ -1,0 +1,18 @@
+# ignore-cross-compile we need to execute the binary
+# ignore-windows we create files with < and > in their names
+
+include ../tools.mk
+
+ifdef RUSTC_BLESS_TEST
+    RUSTC_TEST_OP = cp
+else
+    RUSTC_TEST_OP = $(DIFF)
+endif
+
+all:
+	echo '"comes from a file with a name that begins with <"' > "$(TMPDIR)/<leading-lt"
+	echo '"comes from a file with a name that ends with >"' > "$(TMPDIR)/trailing-gt>"
+	cp silly-file-names.rs "$(TMPDIR)/silly-file-names.rs"
+	$(RUSTC) "$(TMPDIR)/silly-file-names.rs" -o "$(TMPDIR)/silly-file-names"
+	"$(TMPDIR)/silly-file-names" > "$(TMPDIR)/silly-file-names.run.stdout"
+	$(RUSTC_TEST_OP) "$(TMPDIR)/silly-file-names.run.stdout" silly-file-names.run.stdout

--- a/tests/run-make/silly-file-names/silly-file-names.rs
+++ b/tests/run-make/silly-file-names/silly-file-names.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!(include!("<leading-lt"));
+    println!(include!("trailing-gt>"));
+}

--- a/tests/run-make/silly-file-names/silly-file-names.run.stdout
+++ b/tests/run-make/silly-file-names/silly-file-names.run.stdout
@@ -1,0 +1,2 @@
+comes from a file with a name that begins with <
+comes from a file with a name that ends with >


### PR DESCRIPTION
The [`rustc_span::FileName`](https://doc.rust-lang.org/stable/nightly-rustc/rustc_span/enum.FileName.html) enum already differentiates between real files and "fake" files such as `<anon>`. We do not need to artificially forbid real file names from ending in `>`.

Closes #73419