### PR TITLE
fix(sys/hermit): remove obsolete network initialization

### DIFF
--- a/library/std/src/sys/hermit/mod.rs
+++ b/library/std/src/sys/hermit/mod.rs
@@ -101,7 +101,6 @@ pub extern "C" fn __rust_abort() {
 // SAFETY: must be called only once during runtime initialization.
 // NOTE: this is not guaranteed to run, for example when Rust code is called externally.
 pub unsafe fn init(argc: isize, argv: *const *const u8, _sigpipe: u8) {
-    let _ = net::init();
     args::init(argc, argv);
 }
 

--- a/library/std/src/sys/hermit/net.rs
+++ b/library/std/src/sys/hermit/net.rs
@@ -33,13 +33,7 @@ pub fn cvt_gai(err: i32) -> io::Result<()> {
     ))
 }
 
-/// Checks whether the HermitCore's socket interface has been started already, and
-/// if not, starts it.
-pub fn init() {
-    if unsafe { netc::network_init() } < 0 {
-        panic!("Unable to initialize network interface");
-    }
-}
+pub fn init() {}
 
 #[derive(Debug)]
 pub struct Socket(FileDesc);


### PR DESCRIPTION
This function does not exist as of hermit-sys 0.4.1 ([`e38f246`]). Once std does not call this function, we can remove it entirely.

CC: @stlankes 

[`e38f246`]: https://github.com/hermitcore/hermit-rs/commit/e38f246e046c3ad50bd2f5e33d8d810d33891cbd#diff-a9b7fa816defab285f0d4fe69d4df4a0cbbcf1c89913000df3273aded949f257R10