### PR TITLE
fix(sys/hermit): add is_interrupted

### DIFF
--- a/library/std/src/sys/hermit/mod.rs
+++ b/library/std/src/sys/hermit/mod.rs
@@ -130,6 +130,11 @@ pub unsafe extern "C" fn runtime_entry(
     abi::exit(result);
 }
 
+#[inline]
+pub(crate) fn is_interrupted(errno: i32) -> bool {
+    errno == abi::errno::EINTR
+}
+
 pub fn decode_error_kind(errno: i32) -> ErrorKind {
     match errno {
         abi::errno::EACCES => ErrorKind::PermissionDenied,


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/115228 broke compilation for Hermit by not adding a Hermit implementation of is_interrupted.