### PR TITLE
Make `get_return_block()` return `Some` only for HIR nodes in body

### DIFF
--- a/tests/ui/typeck/issue-114918/const-in-fn-return-type.rs
+++ b/tests/ui/typeck/issue-114918/const-in-fn-return-type.rs
@@ -1,0 +1,10 @@
+// Regression test for #114918
+// Test that a const generic enclosed in a block within a return type
+// produces a type mismatch error instead of triggering a const eval cycle
+
+#[allow(unused_braces)]
+fn func() -> [u8; { () } ] { //~ ERROR mismatched types
+    loop {}
+}
+
+fn main() {}

--- a/tests/ui/typeck/issue-114918/const-in-fn-return-type.stderr
+++ b/tests/ui/typeck/issue-114918/const-in-fn-return-type.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/const-in-fn-return-type.rs:6:21
+   |
+LL | fn func() -> [u8; { () } ] {
+   |                     ^^ expected `usize`, found `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.rs
+++ b/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.rs
@@ -1,0 +1,20 @@
+// Regression test for #114918
+// Test that a const generic enclosed in a block within the return type
+// of an impl fn produces a type mismatch error instead of triggering
+// a const eval cycle
+
+
+trait Trait {
+    fn func<const N: u32>() -> [ (); N ];
+}
+
+struct S {}
+
+#[allow(unused_braces)]
+impl Trait for S {
+    fn func<const N: u32>() -> [ (); { () }] { //~ ERROR mismatched types
+        N
+    }
+}
+
+fn main() {}

--- a/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.stderr
+++ b/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/const-in-impl-fn-return-type.rs:15:40
+   |
+LL |     fn func<const N: u32>() -> [ (); { () }] {
+   |                                        ^^ expected `usize`, found `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/issue-114918/const-in-struct-type-arg.rs
+++ b/tests/ui/typeck/issue-114918/const-in-struct-type-arg.rs
@@ -1,0 +1,12 @@
+// Regression test for #114918
+// Test that a const generic enclosed in a block in a struct's type arg
+// produces a type mismatch error instead of triggering a const eval cycle
+
+#[allow(unused_braces)]
+struct S<const N: usize> {
+        arr: [u8; N]
+}
+
+fn main() {
+    let s = S::<{ () }> { arr: [5, 6, 7]}; //~ ERROR mismatched types
+}

--- a/tests/ui/typeck/issue-114918/const-in-struct-type-arg.stderr
+++ b/tests/ui/typeck/issue-114918/const-in-struct-type-arg.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/const-in-struct-type-arg.rs:11:19
+   |
+LL |     let s = S::<{ () }> { arr: [5, 6, 7]};
+   |                   ^^ expected `usize`, found `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/issue-114918/const-in-trait-fn-return-type.rs
+++ b/tests/ui/typeck/issue-114918/const-in-trait-fn-return-type.rs
@@ -1,0 +1,13 @@
+// Regression test for #114918
+// Test that a const generic enclosed in a block within the return type
+// of a trait method produces a type mismatch error instead of triggering
+// a const eval cycle
+
+#[allow(unused_braces)]
+trait Trait {
+    fn func<const N: u32>() -> [ (); { () }] { //~ ERROR mismatched types
+        N
+    }
+}
+
+fn main() {}

--- a/tests/ui/typeck/issue-114918/const-in-trait-fn-return-type.stderr
+++ b/tests/ui/typeck/issue-114918/const-in-trait-fn-return-type.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/const-in-trait-fn-return-type.rs:8:40
+   |
+LL |     fn func<const N: u32>() -> [ (); { () }] {
+   |                                        ^^ expected `usize`, found `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #114918 

The issue occurred while compiling the following input:

```rust
fn uwu() -> [(); { () }] {
    loop {}
}
```

It was caused by the code below trying to suggest a missing return type which resulted in a const eval cycle: https://github.com/rust-lang/rust/blob/1bd043098e05839afb557bd7a2858cb09a4054ca/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs#L68-L75

The root cause was `get_return_block()` returning an `Fn` node for a node in the return type (i.e. the second `()` in the return type `[(); { () }]` of the input) although it is supposed to do so only for nodes that lie in the body of the function and return `None` otherwise (at least as per my understanding).

The PR fixes the issue by fixing this behaviour of `get_return_block()`.