### PR TITLE
Reference uplifted clippy lints' rustc name in the release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,7 +11,7 @@ Language
 - [Stabilize inline asm for LoongArch64](https://github.com/rust-lang/rust/pull/111235/)
 - [Uplift `clippy::undropped_manually_drops` lint](https://github.com/rust-lang/rust/pull/111530/)
 - [Uplift `clippy::invalid_utf8_in_unchecked` lint](https://github.com/rust-lang/rust/pull/111543/) as `invalid_from_utf8_unchecked` and `invalid_from_utf8`
-- [Uplift `clippy::cast_ref_to_mut` lint](https://github.com/rust-lang/rust/pull/111567/)
+- [Uplift `clippy::cast_ref_to_mut` lint](https://github.com/rust-lang/rust/pull/111567/) as `invalid_reference_casting`
 - [Uplift `clippy::cmp_nan` lint](https://github.com/rust-lang/rust/pull/111818/) as `invalid_nan_comparisons`
 - [resolve: Remove artificial import ambiguity errors](https://github.com/rust-lang/rust/pull/112086/)
 - [Don't require associated types with Self: Sized bounds in `dyn Trait` objects](https://github.com/rust-lang/rust/pull/112319/)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,9 +10,9 @@ Language
 - [expand: Change how `#![cfg(FALSE)]` behaves on crate root](https://github.com/rust-lang/rust/pull/110141/)
 - [Stabilize inline asm for LoongArch64](https://github.com/rust-lang/rust/pull/111235/)
 - [Uplift `clippy::undropped_manually_drops` lint](https://github.com/rust-lang/rust/pull/111530/)
-- [Uplift `clippy::invalid_utf8_in_unchecked` lint](https://github.com/rust-lang/rust/pull/111543/)
+- [Uplift `clippy::invalid_utf8_in_unchecked` lint](https://github.com/rust-lang/rust/pull/111543/) as `invalid_from_utf8_unchecked` and `invalid_from_utf8`
 - [Uplift `clippy::cast_ref_to_mut` lint](https://github.com/rust-lang/rust/pull/111567/)
-- [Uplift `clippy::cmp_nan` lint](https://github.com/rust-lang/rust/pull/111818/)
+- [Uplift `clippy::cmp_nan` lint](https://github.com/rust-lang/rust/pull/111818/) as `invalid_nan_comparisons`
 - [resolve: Remove artificial import ambiguity errors](https://github.com/rust-lang/rust/pull/112086/)
 - [Don't require associated types with Self: Sized bounds in `dyn Trait` objects](https://github.com/rust-lang/rust/pull/112319/)
 


### PR DESCRIPTION
I updated to Rust 1.72.0, got a new warning from rustc, wanted to read more about it, so I went to RELEASES.md and searched for the new lint's name as shown in the warning I got.

I found no results because the relevant entry in RELEASES only contained the lint's old Clippy name, not its new rustc name.

This adds the rustc name for lints so that someone doing the same thing I did will have more success.

Some of the uplifted lints didn't have a name change, so I didn't add the rustc name as a search for it will succeed.