### PR TITLE
Tweak output of `to_pretty_impl_header` involving only anon lifetimes

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -472,17 +472,11 @@ pub(crate) fn to_pretty_impl_header(tcx: TyCtxt<'_>, impl_def_id: DefId) -> Opti
     let mut types_without_default_bounds = FxIndexSet::default();
     let sized_trait = tcx.lang_items().sized_trait();
 
-    if !args.is_empty() {
+    let arg_names = args.iter().map(|k| k.to_string()).filter(|k| k != "'_").collect::<Vec<_>>();
+    if !arg_names.is_empty() {
         types_without_default_bounds.extend(args.types());
         w.push('<');
-        w.push_str(
-            &args
-                .iter()
-                .map(|k| k.to_string())
-                .filter(|k| k != "'_")
-                .collect::<Vec<_>>()
-                .join(", "),
-        );
+        w.push_str(&arg_names.join(", "));
         w.push('>');
     }
 

--- a/tests/ui/inference/issue-72616.stderr
+++ b/tests/ui/inference/issue-72616.stderr
@@ -23,7 +23,7 @@ LL |         if String::from("a") == "a".try_into().unwrap() {}
    |                                     ^^^^^^^^
    |
    = note: multiple `impl`s satisfying `_: TryFrom<&str>` found in the following crates: `core`, `std`:
-           - impl<> TryFrom<&str> for std::sys_common::net::LookupHost;
+           - impl TryFrom<&str> for std::sys_common::net::LookupHost;
            - impl<T, U> TryFrom<U> for T
              where U: Into<T>;
    = note: required for `&str` to implement `TryInto<_>`

--- a/tests/ui/inference/issue-72690.stderr
+++ b/tests/ui/inference/issue-72690.stderr
@@ -5,8 +5,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:7:22
@@ -74,8 +74,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:21:22
@@ -100,8 +100,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:28:22
@@ -126,8 +126,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:37:22
@@ -152,8 +152,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:46:22
@@ -178,8 +178,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:53:22
@@ -204,8 +204,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:62:22


### PR DESCRIPTION
Do not print `impl<> Foo for &Bar`.