### PR TITLE
avoid stdout redirection on `curl` executions

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -104,16 +104,15 @@ def _download(path, url, probably_big, verbose, exception):
         # If curl is not present on Win32, we should not sys.exit
         #   but raise `CalledProcessError` or `OSError` instead
         require(["curl", "--version"], exception=platform_is_win32())
-        with open(path, "wb") as outfile:
-            run(["curl", option,
-                "-L", # Follow redirect.
-                "-y", "30", "-Y", "10",    # timeout if speed is < 10 bytes/sec for > 30 seconds
-                "--connect-timeout", "30",  # timeout if cannot connect within 30 seconds
-                "--retry", "3", "-SRf", url],
-                stdout=outfile,    #Implements cli redirect operator '>'
-                verbose=verbose,
-                exception=True, # Will raise RuntimeError on failure
-            )
+        run(["curl", option,
+            "-L", # Follow redirect.
+            "-y", "30", "-Y", "10",    # timeout if speed is < 10 bytes/sec for > 30 seconds
+            "--connect-timeout", "30",  # timeout if cannot connect within 30 seconds
+            "-o", path,
+            "--retry", "3", "-SRf", url],
+            verbose=verbose,
+            exception=True, # Will raise RuntimeError on failure
+        )
     except (subprocess.CalledProcessError, OSError, RuntimeError):
         # see http://serverfault.com/questions/301128/how-to-download
         if platform_is_win32():

--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -216,6 +216,8 @@ impl Config {
             "10", // timeout if speed is < 10 bytes/sec for > 30 seconds
             "--connect-timeout",
             "30", // timeout if cannot connect within 30 seconds
+            "-o",
+            tempfile.to_str().unwrap(),
             "--retry",
             "3",
             "-SRf",
@@ -227,8 +229,6 @@ impl Config {
             curl.arg("--progress-bar");
         }
         curl.arg(url);
-        let f = File::create(tempfile).unwrap();
-        curl.stdout(Stdio::from(f));
         if !self.check_run(&mut curl) {
             if self.build.contains("windows-msvc") {
                 eprintln!("Fallback to PowerShell");


### PR DESCRIPTION
Avoid redirecting the curl output directly to the stdout. This alteration affects the integrity of the file during the retry process, as it also redirects the logs from the retries. Consequently, this leads to the bootstrap process failing because of an invalid checksum.

For more information, see the [zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/checksum.20errors)

Fixes #115275