### PR TITLE
Suggest removing redundant arguments in format!()

### DIFF
--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -137,8 +137,6 @@ builtin_macros_format_positional_after_named = positional arguments cannot follo
     .label = positional arguments must be before named arguments
     .named_args = named argument
 
-builtin_macros_format_remove_raw_ident = remove the `r#`
-
 builtin_macros_format_redundant_args = redundant {$n ->
     [one] argument
     *[more] arguments
@@ -152,6 +150,8 @@ builtin_macros_format_redundant_args = redundant {$n ->
         *[more] the formatting specifiers are referencing the bindings already
     }
     .suggestion = this can be removed
+
+builtin_macros_format_remove_raw_ident = remove the `r#`
 
 builtin_macros_format_requires_string = requires at least a format string argument
 

--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -139,6 +139,17 @@ builtin_macros_format_positional_after_named = positional arguments cannot follo
 
 builtin_macros_format_remove_raw_ident = remove the `r#`
 
+builtin_macros_format_redundant_args = redundant argument
+    .help = {$n ->
+        [one] the formatting string already captures the binding directly, it doesn't need to be included in the argument list
+        *[more] the formatting strings already captures the bindings directly, they don't need to be included in the argument list
+    }
+    .note = {$n ->
+        [one] the formatting specifier is referencing the binding already
+        *[more] the formatting specifiers are referencing the bindings already
+    }
+    .suggestion = this can be removed
+
 builtin_macros_format_requires_string = requires at least a format string argument
 
 builtin_macros_format_string_invalid = invalid format string: {$desc}

--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -139,7 +139,10 @@ builtin_macros_format_positional_after_named = positional arguments cannot follo
 
 builtin_macros_format_remove_raw_ident = remove the `r#`
 
-builtin_macros_format_redundant_args = redundant argument
+builtin_macros_format_redundant_args = redundant {$n ->
+    [one] argument
+    *[more] arguments
+    }
     .help = {$n ->
         [one] the formatting string already captures the binding directly, it doesn't need to be included in the argument list
         *[more] the formatting strings already captures the bindings directly, they don't need to be included in the argument list

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -647,6 +647,27 @@ pub(crate) struct FormatPositionalMismatch {
 }
 
 #[derive(Diagnostic)]
+#[diag(builtin_macros_format_redundant_args)]
+pub(crate) struct FormatRedundantArgs {
+    #[primary_span]
+    pub(crate) fmt_span: Span,
+    pub(crate) n: usize,
+
+    #[note]
+    pub(crate) note: MultiSpan,
+
+    #[subdiagnostic]
+    pub(crate) sugg: FormatRedundantArgsSugg,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(builtin_macros_suggestion, applicability = "machine-applicable")]
+pub(crate) struct FormatRedundantArgsSugg {
+    #[suggestion_part(code = "")]
+    pub(crate) spans: Vec<Span>,
+}
+
+#[derive(Diagnostic)]
 #[diag(builtin_macros_test_case_non_item)]
 pub(crate) struct TestCaseNonItem {
     #[primary_span]

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -650,7 +650,7 @@ pub(crate) struct FormatPositionalMismatch {
 #[diag(builtin_macros_format_redundant_args)]
 pub(crate) struct FormatRedundantArgs {
     #[primary_span]
-    pub(crate) fmt_span: Span,
+    pub(crate) span: MultiSpan,
     pub(crate) n: usize,
 
     #[note]

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -657,7 +657,7 @@ pub(crate) struct FormatRedundantArgs {
     pub(crate) note: MultiSpan,
 
     #[subdiagnostic]
-    pub(crate) sugg: FormatRedundantArgsSugg,
+    pub(crate) sugg: Option<FormatRedundantArgsSugg>,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -619,7 +619,7 @@ fn report_missing_placeholders(
 
     if !placeholders.is_empty() {
         if let Some(mut new_diag) =
-            report_redundant_format_arguments(ecx, fmt_span, &args, used, placeholders)
+            report_redundant_format_arguments(ecx, &args, used, placeholders)
         {
             diag.cancel();
             new_diag.emit();
@@ -718,7 +718,6 @@ fn report_missing_placeholders(
 /// redundant due to implicit captures (e.g. `format!("{x}", x)`).
 fn report_redundant_format_arguments<'a>(
     ecx: &mut ExtCtxt<'a>,
-    fmt_span: Span,
     args: &FormatArguments,
     used: &[bool],
     placeholders: Vec<(Span, &str)>,
@@ -769,9 +768,9 @@ fn report_redundant_format_arguments<'a>(
         }
 
         return Some(ecx.create_err(errors::FormatRedundantArgs {
-            fmt_span,
-            note: multispan,
             n: args_spans.len(),
+            span: MultiSpan::from(args_spans),
+            note: multispan,
             sugg: errors::FormatRedundantArgsSugg { spans: suggestion_spans },
         }));
     }

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -767,11 +767,17 @@ fn report_redundant_format_arguments<'a>(
             suggestion_spans.push(span);
         }
 
+        let sugg = if args.named_args().len() == 0 {
+            Some(errors::FormatRedundantArgsSugg { spans: suggestion_spans })
+        } else {
+            None
+        };
+
         return Some(ecx.create_err(errors::FormatRedundantArgs {
             n: args_spans.len(),
             span: MultiSpan::from(args_spans),
             note: multispan,
-            sugg: errors::FormatRedundantArgsSugg { spans: suggestion_spans },
+            sugg,
         }));
     }
 

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -616,7 +616,7 @@ fn report_missing_placeholders(
         .collect::<Vec<_>>();
 
     if !placeholders.is_empty() {
-        report_redundant_placeholders(ecx, fmt_span, &args, used, placeholders);
+        report_redundant_format_arguments(ecx, fmt_span, &args, used, placeholders);
         diag.cancel();
         return;
     }
@@ -708,7 +708,7 @@ fn report_missing_placeholders(
     diag.emit();
 }
 
-fn report_redundant_placeholders(
+fn report_redundant_format_arguments(
     ecx: &mut ExtCtxt<'_>,
     fmt_span: Span,
     args: &FormatArguments,

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -720,7 +720,6 @@ fn report_redundant_format_arguments(
     let mut fmt_arg_indices = vec![];
     let mut args_spans = vec![];
     let mut fmt_spans = vec![];
-    let mut bindings = vec![];
 
     for (i, unnamed_arg) in args.unnamed_args().iter().enumerate().rev() {
         let Some(ty) = unnamed_arg.expr.to_ty() else { continue };
@@ -734,17 +733,17 @@ fn report_redundant_format_arguments(
         let matching_placeholders = placeholders
             .iter()
             .filter(|(_, inline_binding)| argument_binding == *inline_binding)
+            .map(|(span, _)| span)
             .collect::<Vec<_>>();
 
         if !matching_placeholders.is_empty() {
             fmt_arg_indices.push(i);
             args_spans.push(unnamed_arg.expr.span);
-            for (span, binding) in &matching_placeholders {
-                if fmt_spans.contains(span) {
+            for span in &matching_placeholders {
+                if fmt_spans.contains(*span) {
                     continue;
                 }
-                fmt_spans.push(*span);
-                bindings.push(binding);
+                fmt_spans.push(**span);
             }
         }
     }

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -708,6 +708,8 @@ fn report_missing_placeholders(
     diag.emit();
 }
 
+/// This function detects and reports unused format!() arguments that are
+/// redundant due to implicit captures (e.g. `format!("{x}", x)`).
 fn report_redundant_format_arguments(
     ecx: &mut ExtCtxt<'_>,
     fmt_span: Span,

--- a/tests/ui/did_you_mean/issue-105225-named-args.rs
+++ b/tests/ui/did_you_mean/issue-105225-named-args.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let x = "x";
+    let y = "y";
+
+    println!("{x}", x, x = y);
+    //~^ ERROR: redundant argument
+
+    println!("{x}", x = y, x = y);
+    //~^ ERROR: duplicate argument named `x`
+}

--- a/tests/ui/did_you_mean/issue-105225-named-args.stderr
+++ b/tests/ui/did_you_mean/issue-105225-named-args.stderr
@@ -1,0 +1,22 @@
+error: redundant argument
+  --> $DIR/issue-105225-named-args.rs:5:21
+   |
+LL |     println!("{x}", x, x = y);
+   |                     ^
+   |
+note: the formatting specifier is referencing the binding already
+  --> $DIR/issue-105225-named-args.rs:5:16
+   |
+LL |     println!("{x}", x, x = y);
+   |                ^
+
+error: duplicate argument named `x`
+  --> $DIR/issue-105225-named-args.rs:8:28
+   |
+LL |     println!("{x}", x = y, x = y);
+   |                     -      ^ duplicate argument
+   |                     |
+   |                     previously here
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/did_you_mean/issue-105225.fixed
+++ b/tests/ui/did_you_mean/issue-105225.fixed
@@ -1,8 +1,8 @@
 // run-rustfix
 
 fn main() {
-    let x = 0;
-    let y = 0;
+    let x = "x";
+    let y = "y";
 
     println!("{x}", );
     //~^ ERROR: redundant argument

--- a/tests/ui/did_you_mean/issue-105225.fixed
+++ b/tests/ui/did_you_mean/issue-105225.fixed
@@ -4,18 +4,18 @@ fn main() {
     let x = 0;
     let y = 0;
 
-    println!("{x}", x);
+    println!("{x}", );
     //~^ ERROR: redundant argument
 
-    println!("{x} {}", x, x);
+    println!("{x} {}", x, );
     //~^ ERROR: redundant argument
 
-    println!("{} {x}", x, x);
+    println!("{} {x}", x, );
     //~^ ERROR: redundant argument
 
-    println!("{x} {y}", x, y);
+    println!("{x} {y}", );
     //~^ ERROR: redundant arguments
 
-    println!("{} {} {x} {y} {}", x, x, x, y, y);
+    println!("{} {} {x} {y} {}", x, x, x, );
     //~^ ERROR: redundant arguments
 }

--- a/tests/ui/did_you_mean/issue-105225.rs
+++ b/tests/ui/did_you_mean/issue-105225.rs
@@ -1,8 +1,8 @@
 // run-rustfix
 
 fn main() {
-    let x = 0;
-    let y = 0;
+    let x = "x";
+    let y = "y";
 
     println!("{x}", x);
     //~^ ERROR: redundant argument

--- a/tests/ui/did_you_mean/issue-105225.rs
+++ b/tests/ui/did_you_mean/issue-105225.rs
@@ -1,0 +1,19 @@
+fn main() {
+    let x = 0;
+    println!("{x}", x);
+    //~^ ERROR: argument never used
+
+    println!("{x} {}", x, x);
+    //~^ ERROR: argument never used
+
+    println!("{} {x}", x, x);
+    //~^ ERROR: argument never used
+
+    let y = 0;
+    println!("{x} {y}", x, y);
+    //~^ ERROR: multiple unused formatting arguments
+
+    let y = 0;
+    println!("{} {} {x} {y} {}", x, x, x, y, y);
+    //~^ ERROR: multiple unused formatting arguments
+}

--- a/tests/ui/did_you_mean/issue-105225.rs
+++ b/tests/ui/did_you_mean/issue-105225.rs
@@ -1,19 +1,19 @@
 fn main() {
     let x = 0;
     println!("{x}", x);
-    //~^ ERROR: argument never used
+    //~^ ERROR: redundant argument
 
     println!("{x} {}", x, x);
-    //~^ ERROR: argument never used
+    //~^ ERROR: redundant argument
 
     println!("{} {x}", x, x);
-    //~^ ERROR: argument never used
+    //~^ ERROR: redundant argument
 
     let y = 0;
     println!("{x} {y}", x, y);
-    //~^ ERROR: multiple unused formatting arguments
+    //~^ ERROR: redundant argument
 
     let y = 0;
     println!("{} {} {x} {y} {}", x, x, x, y, y);
-    //~^ ERROR: multiple unused formatting arguments
+    //~^ ERROR: redundant argument
 }

--- a/tests/ui/did_you_mean/issue-105225.rs
+++ b/tests/ui/did_you_mean/issue-105225.rs
@@ -1,5 +1,7 @@
 fn main() {
     let x = 0;
+    let y = 0;
+
     println!("{x}", x);
     //~^ ERROR: redundant argument
 
@@ -9,11 +11,9 @@ fn main() {
     println!("{} {x}", x, x);
     //~^ ERROR: redundant argument
 
-    let y = 0;
     println!("{x} {y}", x, y);
-    //~^ ERROR: redundant argument
+    //~^ ERROR: redundant arguments
 
-    let y = 0;
     println!("{} {} {x} {y} {}", x, x, x, y, y);
-    //~^ ERROR: redundant argument
+    //~^ ERROR: redundant arguments
 }

--- a/tests/ui/did_you_mean/issue-105225.stderr
+++ b/tests/ui/did_you_mean/issue-105225.stderr
@@ -1,0 +1,81 @@
+error: argument never used
+  --> $DIR/issue-105225.rs:3:21
+   |
+LL |     println!("{x}", x);
+   |                     ^ argument never used
+   |
+help: the formatting string already captures the binding directly, it doesn't need to be included in the argument list
+  --> $DIR/issue-105225.rs:3:21
+   |
+LL |     println!("{x}", x);
+   |                -    ^ this can be removed
+   |                |
+   |                this formatting specifier is referencing the `x` binding
+
+error: argument never used
+  --> $DIR/issue-105225.rs:6:27
+   |
+LL |     println!("{x} {}", x, x);
+   |                           ^ argument never used
+   |
+help: the formatting string already captures the binding directly, it doesn't need to be included in the argument list
+  --> $DIR/issue-105225.rs:6:27
+   |
+LL |     println!("{x} {}", x, x);
+   |                -          ^ this can be removed
+   |                |
+   |                this formatting specifier is referencing the `x` binding
+
+error: argument never used
+  --> $DIR/issue-105225.rs:9:27
+   |
+LL |     println!("{} {x}", x, x);
+   |                           ^ argument never used
+   |
+help: the formatting string already captures the binding directly, it doesn't need to be included in the argument list
+  --> $DIR/issue-105225.rs:9:27
+   |
+LL |     println!("{} {x}", x, x);
+   |                   -       ^ this can be removed
+   |                   |
+   |                   this formatting specifier is referencing the `x` binding
+
+error: multiple unused formatting arguments
+  --> $DIR/issue-105225.rs:13:25
+   |
+LL |     println!("{x} {y}", x, y);
+   |              ---------  ^  ^ argument never used
+   |              |          |
+   |              |          argument never used
+   |              multiple missing formatting specifiers
+   |
+help: the formatting strings already captures the bindings directly, they don't need to be included in the argument list
+  --> $DIR/issue-105225.rs:13:25
+   |
+LL |     println!("{x} {y}", x, y);
+   |                -   -    ^  ^ this can be removed
+   |                |   |    |
+   |                |   |    this can be removed
+   |                |   this formatting specifier is referencing the `y` binding
+   |                this formatting specifier is referencing the `x` binding
+
+error: multiple unused formatting arguments
+  --> $DIR/issue-105225.rs:17:43
+   |
+LL |     println!("{} {} {x} {y} {}", x, x, x, y, y);
+   |              ------------------           ^  ^ argument never used
+   |              |                            |
+   |              |                            argument never used
+   |              multiple missing formatting specifiers
+   |
+help: the formatting string already captures the binding directly, it doesn't need to be included in the argument list
+  --> $DIR/issue-105225.rs:17:43
+   |
+LL |     println!("{} {} {x} {y} {}", x, x, x, y, y);
+   |                          -                ^  ^ this can be removed
+   |                          |                |
+   |                          |                this can be removed
+   |                          this formatting specifier is referencing the `y` binding
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/did_you_mean/issue-105225.stderr
+++ b/tests/ui/did_you_mean/issue-105225.stderr
@@ -1,81 +1,72 @@
-error: argument never used
-  --> $DIR/issue-105225.rs:3:21
+error: redundant argument
+  --> $DIR/issue-105225.rs:3:14
    |
 LL |     println!("{x}", x);
-   |                     ^ argument never used
+   |              ^^^^^  - help: this can be removed
    |
-help: the formatting string already captures the binding directly, it doesn't need to be included in the argument list
-  --> $DIR/issue-105225.rs:3:21
+note: the formatting specifier is referencing the binding already
+  --> $DIR/issue-105225.rs:3:16
    |
 LL |     println!("{x}", x);
-   |                -    ^ this can be removed
-   |                |
-   |                this formatting specifier is referencing the `x` binding
+   |                ^
 
-error: argument never used
-  --> $DIR/issue-105225.rs:6:27
+error: redundant argument
+  --> $DIR/issue-105225.rs:6:14
    |
 LL |     println!("{x} {}", x, x);
-   |                           ^ argument never used
+   |              ^^^^^^^^     - help: this can be removed
    |
-help: the formatting string already captures the binding directly, it doesn't need to be included in the argument list
-  --> $DIR/issue-105225.rs:6:27
+note: the formatting specifier is referencing the binding already
+  --> $DIR/issue-105225.rs:6:16
    |
 LL |     println!("{x} {}", x, x);
-   |                -          ^ this can be removed
-   |                |
-   |                this formatting specifier is referencing the `x` binding
+   |                ^
 
-error: argument never used
-  --> $DIR/issue-105225.rs:9:27
+error: redundant argument
+  --> $DIR/issue-105225.rs:9:14
    |
 LL |     println!("{} {x}", x, x);
-   |                           ^ argument never used
+   |              ^^^^^^^^     - help: this can be removed
    |
-help: the formatting string already captures the binding directly, it doesn't need to be included in the argument list
-  --> $DIR/issue-105225.rs:9:27
+note: the formatting specifier is referencing the binding already
+  --> $DIR/issue-105225.rs:9:19
    |
 LL |     println!("{} {x}", x, x);
-   |                   -       ^ this can be removed
-   |                   |
-   |                   this formatting specifier is referencing the `x` binding
+   |                   ^
 
-error: multiple unused formatting arguments
-  --> $DIR/issue-105225.rs:13:25
+error: redundant argument
+  --> $DIR/issue-105225.rs:13:14
    |
 LL |     println!("{x} {y}", x, y);
-   |              ---------  ^  ^ argument never used
-   |              |          |
-   |              |          argument never used
-   |              multiple missing formatting specifiers
+   |              ^^^^^^^^^
    |
-help: the formatting strings already captures the bindings directly, they don't need to be included in the argument list
-  --> $DIR/issue-105225.rs:13:25
+note: the formatting specifiers are referencing the bindings already
+  --> $DIR/issue-105225.rs:13:16
    |
 LL |     println!("{x} {y}", x, y);
-   |                -   -    ^  ^ this can be removed
-   |                |   |    |
-   |                |   |    this can be removed
-   |                |   this formatting specifier is referencing the `y` binding
-   |                this formatting specifier is referencing the `x` binding
+   |                ^   ^
+help: this can be removed
+   |
+LL -     println!("{x} {y}", x, y);
+LL +     println!("{x} {y}", );
+   |
 
-error: multiple unused formatting arguments
-  --> $DIR/issue-105225.rs:17:43
+error: redundant argument
+  --> $DIR/issue-105225.rs:17:14
    |
 LL |     println!("{} {} {x} {y} {}", x, x, x, y, y);
-   |              ------------------           ^  ^ argument never used
-   |              |                            |
-   |              |                            argument never used
-   |              multiple missing formatting specifiers
+   |              ^^^^^^^^^^^^^^^^^^
    |
-help: the formatting string already captures the binding directly, it doesn't need to be included in the argument list
-  --> $DIR/issue-105225.rs:17:43
+note: the formatting specifiers are referencing the bindings already
+  --> $DIR/issue-105225.rs:17:26
    |
 LL |     println!("{} {} {x} {y} {}", x, x, x, y, y);
-   |                          -                ^  ^ this can be removed
-   |                          |                |
-   |                          |                this can be removed
-   |                          this formatting specifier is referencing the `y` binding
+   |                          ^
+help: this can be removed
+   |
+LL -     println!("{} {} {x} {y} {}", x, x, x, y, y);
+LL +     println!("{} {} {x} {y} {}", x, x, x, );
+   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/did_you_mean/issue-105225.stderr
+++ b/tests/ui/did_you_mean/issue-105225.stderr
@@ -1,47 +1,47 @@
 error: redundant argument
-  --> $DIR/issue-105225.rs:5:21
+  --> $DIR/issue-105225.rs:7:21
    |
 LL |     println!("{x}", x);
    |                     ^ help: this can be removed
    |
 note: the formatting specifier is referencing the binding already
-  --> $DIR/issue-105225.rs:5:16
+  --> $DIR/issue-105225.rs:7:16
    |
 LL |     println!("{x}", x);
    |                ^
 
 error: redundant argument
-  --> $DIR/issue-105225.rs:8:27
+  --> $DIR/issue-105225.rs:10:27
    |
 LL |     println!("{x} {}", x, x);
    |                           ^ help: this can be removed
    |
 note: the formatting specifier is referencing the binding already
-  --> $DIR/issue-105225.rs:8:16
+  --> $DIR/issue-105225.rs:10:16
    |
 LL |     println!("{x} {}", x, x);
    |                ^
 
 error: redundant argument
-  --> $DIR/issue-105225.rs:11:27
+  --> $DIR/issue-105225.rs:13:27
    |
 LL |     println!("{} {x}", x, x);
    |                           ^ help: this can be removed
    |
 note: the formatting specifier is referencing the binding already
-  --> $DIR/issue-105225.rs:11:19
+  --> $DIR/issue-105225.rs:13:19
    |
 LL |     println!("{} {x}", x, x);
    |                   ^
 
 error: redundant arguments
-  --> $DIR/issue-105225.rs:14:25
+  --> $DIR/issue-105225.rs:16:25
    |
 LL |     println!("{x} {y}", x, y);
    |                         ^  ^
    |
 note: the formatting specifiers are referencing the bindings already
-  --> $DIR/issue-105225.rs:14:16
+  --> $DIR/issue-105225.rs:16:16
    |
 LL |     println!("{x} {y}", x, y);
    |                ^   ^
@@ -52,13 +52,13 @@ LL +     println!("{x} {y}", );
    |
 
 error: redundant arguments
-  --> $DIR/issue-105225.rs:17:43
+  --> $DIR/issue-105225.rs:19:43
    |
 LL |     println!("{} {} {x} {y} {}", x, x, x, y, y);
    |                                           ^  ^
    |
 note: the formatting specifiers are referencing the bindings already
-  --> $DIR/issue-105225.rs:17:26
+  --> $DIR/issue-105225.rs:19:26
    |
 LL |     println!("{} {} {x} {y} {}", x, x, x, y, y);
    |                          ^

--- a/tests/ui/did_you_mean/issue-105225.stderr
+++ b/tests/ui/did_you_mean/issue-105225.stderr
@@ -34,7 +34,7 @@ note: the formatting specifier is referencing the binding already
 LL |     println!("{} {x}", x, x);
    |                   ^
 
-error: redundant argument
+error: redundant arguments
   --> $DIR/issue-105225.rs:13:14
    |
 LL |     println!("{x} {y}", x, y);
@@ -51,7 +51,7 @@ LL -     println!("{x} {y}", x, y);
 LL +     println!("{x} {y}", );
    |
 
-error: redundant argument
+error: redundant arguments
   --> $DIR/issue-105225.rs:17:14
    |
 LL |     println!("{} {} {x} {y} {}", x, x, x, y, y);

--- a/tests/ui/did_you_mean/issue-105225.stderr
+++ b/tests/ui/did_you_mean/issue-105225.stderr
@@ -1,47 +1,47 @@
 error: redundant argument
-  --> $DIR/issue-105225.rs:3:14
+  --> $DIR/issue-105225.rs:5:21
    |
 LL |     println!("{x}", x);
-   |              ^^^^^  - help: this can be removed
+   |                     ^ help: this can be removed
    |
 note: the formatting specifier is referencing the binding already
-  --> $DIR/issue-105225.rs:3:16
+  --> $DIR/issue-105225.rs:5:16
    |
 LL |     println!("{x}", x);
    |                ^
 
 error: redundant argument
-  --> $DIR/issue-105225.rs:6:14
+  --> $DIR/issue-105225.rs:8:27
    |
 LL |     println!("{x} {}", x, x);
-   |              ^^^^^^^^     - help: this can be removed
+   |                           ^ help: this can be removed
    |
 note: the formatting specifier is referencing the binding already
-  --> $DIR/issue-105225.rs:6:16
+  --> $DIR/issue-105225.rs:8:16
    |
 LL |     println!("{x} {}", x, x);
    |                ^
 
 error: redundant argument
-  --> $DIR/issue-105225.rs:9:14
+  --> $DIR/issue-105225.rs:11:27
    |
 LL |     println!("{} {x}", x, x);
-   |              ^^^^^^^^     - help: this can be removed
+   |                           ^ help: this can be removed
    |
 note: the formatting specifier is referencing the binding already
-  --> $DIR/issue-105225.rs:9:19
+  --> $DIR/issue-105225.rs:11:19
    |
 LL |     println!("{} {x}", x, x);
    |                   ^
 
 error: redundant arguments
-  --> $DIR/issue-105225.rs:13:14
+  --> $DIR/issue-105225.rs:14:25
    |
 LL |     println!("{x} {y}", x, y);
-   |              ^^^^^^^^^
+   |                         ^  ^
    |
 note: the formatting specifiers are referencing the bindings already
-  --> $DIR/issue-105225.rs:13:16
+  --> $DIR/issue-105225.rs:14:16
    |
 LL |     println!("{x} {y}", x, y);
    |                ^   ^
@@ -52,10 +52,10 @@ LL +     println!("{x} {y}", );
    |
 
 error: redundant arguments
-  --> $DIR/issue-105225.rs:17:14
+  --> $DIR/issue-105225.rs:17:43
    |
 LL |     println!("{} {} {x} {y} {}", x, x, x, y, y);
-   |              ^^^^^^^^^^^^^^^^^^
+   |                                           ^  ^
    |
 note: the formatting specifiers are referencing the bindings already
   --> $DIR/issue-105225.rs:17:26


### PR DESCRIPTION
Closes #105225. This is also a follow-up to #105635, which seems to have become stale.

r? @estebank 