### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_codegen_gcc/src/abi.rs
+++ b/compiler/rustc_codegen_gcc/src/abi.rs
@@ -125,8 +125,8 @@ impl<'gcc, 'tcx> FnAbiGccExt<'gcc, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
                 PassMode::Ignore => continue,
                 PassMode::Direct(_) => arg.layout.immediate_gcc_type(cx),
                 PassMode::Pair(..) => {
-                    argument_tys.push(arg.layout.scalar_pair_element_gcc_type(cx, 0, true));
-                    argument_tys.push(arg.layout.scalar_pair_element_gcc_type(cx, 1, true));
+                    argument_tys.push(arg.layout.scalar_pair_element_gcc_type(cx, 0));
+                    argument_tys.push(arg.layout.scalar_pair_element_gcc_type(cx, 1));
                     continue;
                 }
                 PassMode::Indirect { extra_attrs: Some(_), .. } => {

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -821,7 +821,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
 
                 let mut load = |i, scalar: &abi::Scalar, align| {
                     let llptr = self.struct_gep(pair_type, place.llval, i as u64);
-                    let llty = place.layout.scalar_pair_element_gcc_type(self, i, false);
+                    let llty = place.layout.scalar_pair_element_gcc_type(self, i);
                     let load = self.load(llty, llptr, align);
                     scalar_load_metadata(self, load, scalar);
                     if scalar.is_bool() { self.trunc(load, self.type_i1()) } else { load }

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -3,7 +3,7 @@ use crate::context::TypeLowering;
 use crate::type_::Type;
 use rustc_codegen_ssa::traits::*;
 use rustc_middle::bug;
-use rustc_middle::ty::layout::{FnAbiOf, LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
 use rustc_middle::ty::{self, Ty, TypeVisitableExt};
 use rustc_target::abi::HasDataLayout;
@@ -215,20 +215,16 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
     /// of that field's type - this is useful for taking the address of
     /// that field and ensuring the struct has the right alignment.
     fn llvm_type<'a>(&self, cx: &CodegenCx<'a, 'tcx>) -> &'a Type {
+        // This must produce the same result for `repr(transparent)` wrappers as for the inner type!
+        // In other words, this should generally not look at the type at all, but only at the
+        // layout.
         if let Abi::Scalar(scalar) = self.abi {
             // Use a different cache for scalars because pointers to DSTs
             // can be either fat or thin (data pointers of fat pointers).
             if let Some(&llty) = cx.scalar_lltypes.borrow().get(&self.ty) {
                 return llty;
             }
-            let llty = match *self.ty.kind() {
-                ty::Ref(..) | ty::RawPtr(_) => cx.type_ptr(),
-                ty::Adt(def, _) if def.is_box() => cx.type_ptr(),
-                ty::FnPtr(sig) => {
-                    cx.fn_ptr_backend_type(cx.fn_abi_of_fn_ptr(sig, ty::List::empty()))
-                }
-                _ => self.scalar_llvm_type_at(cx, scalar),
-            };
+            let llty = self.scalar_llvm_type_at(cx, scalar);
             cx.scalar_lltypes.borrow_mut().insert(self.ty, llty);
             return llty;
         }

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -20,6 +20,8 @@ use rustc_mir_dataflow::{Analysis, ResultsCursor};
 use rustc_target::abi::{Size, FIRST_VARIANT};
 use rustc_target::spec::abi::Abi;
 
+use crate::util::is_within_packed;
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum EdgeKind {
     Unwind,
@@ -93,6 +95,7 @@ impl<'tcx> MirPass<'tcx> for Validator {
         cfg_checker.visit_body(body);
         cfg_checker.check_cleanup_control_flow();
 
+        // Also run the TypeChecker.
         for (location, msg) in validate_types(tcx, self.mir_phase, param_env, body) {
             cfg_checker.fail(location, msg);
         }
@@ -418,14 +421,34 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
                 self.check_unwind_edge(location, *unwind);
 
                 // The call destination place and Operand::Move place used as an argument might be
-                // passed by a reference to the callee. Consequently they must be non-overlapping.
-                // Currently this simply checks for duplicate places.
+                // passed by a reference to the callee. Consequently they must be non-overlapping
+                // and cannot be packed. Currently this simply checks for duplicate places.
                 self.place_cache.clear();
                 self.place_cache.insert(destination.as_ref());
+                if is_within_packed(self.tcx, &self.body.local_decls, *destination).is_some() {
+                    // This is bad! The callee will expect the memory to be aligned.
+                    self.fail(
+                        location,
+                        format!(
+                            "encountered packed place in `Call` terminator destination: {:?}",
+                            terminator.kind,
+                        ),
+                    );
+                }
                 let mut has_duplicates = false;
                 for arg in args {
                     if let Operand::Move(place) = arg {
                         has_duplicates |= !self.place_cache.insert(place.as_ref());
+                        if is_within_packed(self.tcx, &self.body.local_decls, *place).is_some() {
+                            // This is bad! The callee will expect the memory to be aligned.
+                            self.fail(
+                                location,
+                                format!(
+                                    "encountered `Move` of a packed place in `Call` terminator: {:?}",
+                                    terminator.kind,
+                                ),
+                            );
+                        }
                     }
                 }
 
@@ -433,7 +456,7 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
                     self.fail(
                         location,
                         format!(
-                            "encountered overlapping memory in `Call` terminator: {:?}",
+                            "encountered overlapping memory in `Move` arguments to `Call` terminator: {:?}",
                             terminator.kind,
                         ),
                     );
@@ -532,6 +555,8 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
     }
 }
 
+/// A faster version of the validation pass that only checks those things which may break when apply
+/// generic substitutions.
 pub fn validate_types<'tcx>(
     tcx: TyCtxt<'tcx>,
     mir_phase: MirPhase,

--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -34,13 +34,14 @@ where
             false
         }
         _ => {
+            // We cannot figure out the layout. Conservatively assume that this is disaligned.
             debug!("is_disaligned({:?}) - true", place);
             true
         }
     }
 }
 
-fn is_within_packed<'tcx, L>(
+pub fn is_within_packed<'tcx, L>(
     tcx: TyCtxt<'tcx>,
     local_decls: &L,
     place: Place<'tcx>,

--- a/compiler/rustc_const_eval/src/util/mod.rs
+++ b/compiler/rustc_const_eval/src/util/mod.rs
@@ -5,7 +5,7 @@ mod check_validity_requirement;
 mod compare_types;
 mod type_name;
 
-pub use self::alignment::is_disaligned;
+pub use self::alignment::{is_disaligned, is_within_packed};
 pub use self::check_validity_requirement::check_validity_requirement;
 pub use self::compare_types::{is_equal_up_to_subtyping, is_subtype};
 pub use self::type_name::type_name;

--- a/compiler/rustc_data_structures/src/graph/implementation/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/implementation/mod.rs
@@ -20,7 +20,6 @@
 //! the field `next_edge`). Each of those fields is an array that should
 //! be indexed by the direction (see the type `Direction`).
 
-use crate::snapshot_vec::{SnapshotVec, SnapshotVecDelegate};
 use rustc_index::bit_set::BitSet;
 use std::fmt::Debug;
 
@@ -28,8 +27,8 @@ use std::fmt::Debug;
 mod tests;
 
 pub struct Graph<N, E> {
-    nodes: SnapshotVec<Node<N>>,
-    edges: SnapshotVec<Edge<E>>,
+    nodes: Vec<Node<N>>,
+    edges: Vec<Edge<E>>,
 }
 
 pub struct Node<N> {
@@ -43,20 +42,6 @@ pub struct Edge<E> {
     source: NodeIndex,
     target: NodeIndex,
     pub data: E,
-}
-
-impl<N> SnapshotVecDelegate for Node<N> {
-    type Value = Node<N>;
-    type Undo = ();
-
-    fn reverse(_: &mut Vec<Node<N>>, _: ()) {}
-}
-
-impl<N> SnapshotVecDelegate for Edge<N> {
-    type Value = Edge<N>;
-    type Undo = ();
-
-    fn reverse(_: &mut Vec<Edge<N>>, _: ()) {}
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -86,11 +71,11 @@ impl NodeIndex {
 
 impl<N: Debug, E: Debug> Graph<N, E> {
     pub fn new() -> Graph<N, E> {
-        Graph { nodes: SnapshotVec::new(), edges: SnapshotVec::new() }
+        Graph { nodes: Vec::new(), edges: Vec::new() }
     }
 
     pub fn with_capacity(nodes: usize, edges: usize) -> Graph<N, E> {
-        Graph { nodes: SnapshotVec::with_capacity(nodes), edges: SnapshotVec::with_capacity(edges) }
+        Graph { nodes: Vec::with_capacity(nodes), edges: Vec::with_capacity(edges) }
     }
 
     // # Simple accessors

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -56,6 +56,7 @@ pub fn provide(providers: &mut Providers) {
     resolve_bound_vars::provide(providers);
     *providers = Providers {
         type_of: type_of::type_of,
+        type_of_opaque: type_of::type_of_opaque,
         item_bounds: item_bounds::item_bounds,
         explicit_item_bounds: item_bounds::explicit_item_bounds,
         generics_of: generics_of::generics_of,

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -1,4 +1,5 @@
 use crate::mir;
+use crate::query::CyclePlaceholder;
 use crate::traits;
 use crate::ty::{self, Ty};
 use std::mem::{size_of, transmute_copy, MaybeUninit};
@@ -140,6 +141,10 @@ impl EraseType for Result<Option<ty::ValTree<'_>>, mir::interpret::ErrorHandled>
 impl EraseType for Result<&'_ ty::List<Ty<'_>>, ty::util::AlwaysRequiresDrop> {
     type Result =
         [u8; size_of::<Result<&'static ty::List<Ty<'static>>, ty::util::AlwaysRequiresDrop>>()];
+}
+
+impl EraseType for Result<ty::EarlyBinder<Ty<'_>>, CyclePlaceholder> {
+    type Result = [u8; size_of::<Result<ty::EarlyBinder<Ty<'_>>, CyclePlaceholder>>()];
 }
 
 impl<T> EraseType for Option<&'_ T> {

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -19,7 +19,7 @@ use rustc_query_system::dep_graph::SerializedDepNodeIndex;
 pub(crate) use rustc_query_system::query::QueryJobId;
 use rustc_query_system::query::*;
 use rustc_query_system::HandleCycleError;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{ErrorGuaranteed, Span, DUMMY_SP};
 use std::ops::Deref;
 
 pub struct QueryKeyStringCache {
@@ -52,7 +52,8 @@ pub struct DynamicQuery<'tcx, C: QueryCache> {
     pub loadable_from_disk:
         fn(tcx: TyCtxt<'tcx>, key: &C::Key, index: SerializedDepNodeIndex) -> bool,
     pub hash_result: HashResult<C::Value>,
-    pub value_from_cycle_error: fn(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>]) -> C::Value,
+    pub value_from_cycle_error:
+        fn(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>], guar: ErrorGuaranteed) -> C::Value,
     pub format_value: fn(&C::Value) -> String,
 }
 

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -630,3 +630,6 @@ impl<'tcx> TyCtxtAt<'tcx> {
             .unwrap_or_else(|| bug!("def_kind: unsupported node: {:?}", def_id))
     }
 }
+
+#[derive(Copy, Clone, Debug, HashStable)]
+pub struct CyclePlaceholder(pub ErrorGuaranteed);

--- a/compiler/rustc_middle/src/values.rs
+++ b/compiler/rustc_middle/src/values.rs
@@ -8,20 +8,28 @@ use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_query_system::query::QueryInfo;
 use rustc_query_system::Value;
 use rustc_span::def_id::LocalDefId;
-use rustc_span::Span;
+use rustc_span::{ErrorGuaranteed, Span};
 
 use std::fmt::Write;
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for Ty<'_> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, _: &[QueryInfo<DepKind>]) -> Self {
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        _: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
+    ) -> Self {
         // SAFETY: This is never called when `Self` is not `Ty<'tcx>`.
         // FIXME: Represent the above fact in the trait system somehow.
-        unsafe { std::mem::transmute::<Ty<'tcx>, Ty<'_>>(Ty::new_misc_error(tcx)) }
+        unsafe { std::mem::transmute::<Ty<'tcx>, Ty<'_>>(Ty::new_error(tcx, guar)) }
     }
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::SymbolName<'_> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, _: &[QueryInfo<DepKind>]) -> Self {
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        _: &[QueryInfo<DepKind>],
+        _guar: ErrorGuaranteed,
+    ) -> Self {
         // SAFETY: This is never called when `Self` is not `SymbolName<'tcx>`.
         // FIXME: Represent the above fact in the trait system somehow.
         unsafe {
@@ -33,8 +41,12 @@ impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::SymbolName<'_> {
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::Binder<'_, ty::FnSig<'_>> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, stack: &[QueryInfo<DepKind>]) -> Self {
-        let err = Ty::new_misc_error(tcx);
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        stack: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
+    ) -> Self {
+        let err = Ty::new_error(tcx, guar);
 
         let arity = if let Some(frame) = stack.get(0)
             && frame.query.dep_kind == DepKind::fn_sig
@@ -63,7 +75,11 @@ impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::Binder<'_, ty::FnSig<'_>> {
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for Representability {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>]) -> Self {
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        cycle: &[QueryInfo<DepKind>],
+        _guar: ErrorGuaranteed,
+    ) -> Self {
         let mut item_and_field_ids = Vec::new();
         let mut representable_ids = FxHashSet::default();
         for info in cycle {
@@ -95,22 +111,35 @@ impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for Representability {
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::EarlyBinder<Ty<'_>> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>]) -> Self {
-        ty::EarlyBinder::bind(Ty::from_cycle_error(tcx, cycle))
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        cycle: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
+    ) -> Self {
+        ty::EarlyBinder::bind(Ty::from_cycle_error(tcx, cycle, guar))
     }
 }
 
 impl<'tcx> Value<TyCtxt<'tcx>, DepKind> for ty::EarlyBinder<ty::Binder<'_, ty::FnSig<'_>>> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, cycle: &[QueryInfo<DepKind>]) -> Self {
-        ty::EarlyBinder::bind(ty::Binder::from_cycle_error(tcx, cycle))
+    fn from_cycle_error(
+        tcx: TyCtxt<'tcx>,
+        cycle: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
+    ) -> Self {
+        ty::EarlyBinder::bind(ty::Binder::from_cycle_error(tcx, cycle, guar))
     }
 }
 
 impl<'tcx, T> Value<TyCtxt<'tcx>, DepKind> for Result<T, &'_ ty::layout::LayoutError<'_>> {
-    fn from_cycle_error(_tcx: TyCtxt<'tcx>, _cycle: &[QueryInfo<DepKind>]) -> Self {
+    fn from_cycle_error(
+        _tcx: TyCtxt<'tcx>,
+        _cycle: &[QueryInfo<DepKind>],
+        _guar: ErrorGuaranteed,
+    ) -> Self {
         // tcx.arena.alloc cannot be used because we are not allowed to use &'tcx LayoutError under
         // min_specialization. Since this is an error path anyways, leaking doesn't matter (and really,
         // tcx.arena.alloc is pretty much equal to leaking).
+        // FIXME: `Cycle` should carry the ErrorGuaranteed
         Err(Box::leak(Box::new(ty::layout::LayoutError::Cycle)))
     }
 }

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -41,7 +41,7 @@ use rustc_query_system::query::{
 };
 use rustc_query_system::HandleCycleError;
 use rustc_query_system::Value;
-use rustc_span::Span;
+use rustc_span::{ErrorGuaranteed, Span};
 
 #[macro_use]
 mod plumbing;
@@ -146,8 +146,9 @@ where
         self,
         tcx: TyCtxt<'tcx>,
         cycle: &[QueryInfo<DepKind>],
+        guar: ErrorGuaranteed,
     ) -> Self::Value {
-        (self.dynamic.value_from_cycle_error)(tcx, cycle)
+        (self.dynamic.value_from_cycle_error)(tcx, cycle, guar)
     }
 
     #[inline(always)]

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -605,8 +605,8 @@ macro_rules! define_queries {
                     } {
                         |_tcx, _key, _prev_index, _index| None
                     }),
-                    value_from_cycle_error: |tcx, cycle| {
-                        let result: queries::$name::Value<'tcx> = Value::from_cycle_error(tcx, cycle);
+                    value_from_cycle_error: |tcx, cycle, guar| {
+                        let result: queries::$name::Value<'tcx> = Value::from_cycle_error(tcx, cycle, guar);
                         erase(result)
                     },
                     loadable_from_disk: |_tcx, _key, _index| {

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -8,6 +8,7 @@ use crate::query::DepNodeIndex;
 use crate::query::{QueryContext, QueryInfo, QueryState};
 
 use rustc_data_structures::fingerprint::Fingerprint;
+use rustc_span::ErrorGuaranteed;
 use std::fmt::Debug;
 use std::hash::Hash;
 
@@ -57,6 +58,7 @@ pub trait QueryConfig<Qcx: QueryContext>: Copy {
         self,
         tcx: Qcx::DepContext,
         cycle: &[QueryInfo<Qcx::DepKind>],
+        guar: ErrorGuaranteed,
     ) -> Self::Value;
 
     fn anon(self) -> bool;

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -148,8 +148,8 @@ where
     use HandleCycleError::*;
     match query.handle_cycle_error() {
         Error => {
-            error.emit();
-            query.value_from_cycle_error(*qcx.dep_context(), &cycle_error.cycle)
+            let guar = error.emit();
+            query.value_from_cycle_error(*qcx.dep_context(), &cycle_error.cycle, guar)
         }
         Fatal => {
             error.emit();
@@ -157,8 +157,8 @@ where
             unreachable!()
         }
         DelayBug => {
-            error.delay_as_bug();
-            query.value_from_cycle_error(*qcx.dep_context(), &cycle_error.cycle)
+            let guar = error.delay_as_bug();
+            query.value_from_cycle_error(*qcx.dep_context(), &cycle_error.cycle, guar)
         }
     }
 }

--- a/compiler/rustc_query_system/src/values.rs
+++ b/compiler/rustc_query_system/src/values.rs
@@ -1,12 +1,14 @@
+use rustc_span::ErrorGuaranteed;
+
 use crate::dep_graph::{DepContext, DepKind};
 use crate::query::QueryInfo;
 
 pub trait Value<Tcx: DepContext, D: DepKind>: Sized {
-    fn from_cycle_error(tcx: Tcx, cycle: &[QueryInfo<D>]) -> Self;
+    fn from_cycle_error(tcx: Tcx, cycle: &[QueryInfo<D>], guar: ErrorGuaranteed) -> Self;
 }
 
 impl<Tcx: DepContext, T, D: DepKind> Value<Tcx, D> for T {
-    default fn from_cycle_error(tcx: Tcx, cycle: &[QueryInfo<D>]) -> T {
+    default fn from_cycle_error(tcx: Tcx, cycle: &[QueryInfo<D>], _guar: ErrorGuaranteed) -> T {
         tcx.sess().abort_if_errors();
         // Ideally we would use `bug!` here. But bug! is only defined in rustc_middle, and it's
         // non-trivial to define it earlier.

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2743,12 +2743,6 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             }
             ObligationCauseCode::BindingObligation(item_def_id, span)
             | ObligationCauseCode::ExprBindingObligation(item_def_id, span, ..) => {
-                if self.tcx.is_diagnostic_item(sym::Send, item_def_id)
-                    || self.tcx.lang_items().sync_trait() == Some(item_def_id)
-                {
-                    return;
-                }
-
                 let item_name = tcx.def_path_str(item_def_id);
                 let short_item_name = with_forced_trimmed_paths!(tcx.def_path_str(item_def_id));
                 let mut multispan = MultiSpan::from(span);

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -472,17 +472,11 @@ pub(crate) fn to_pretty_impl_header(tcx: TyCtxt<'_>, impl_def_id: DefId) -> Opti
     let mut types_without_default_bounds = FxIndexSet::default();
     let sized_trait = tcx.lang_items().sized_trait();
 
-    if !args.is_empty() {
+    let arg_names = args.iter().map(|k| k.to_string()).filter(|k| k != "'_").collect::<Vec<_>>();
+    if !arg_names.is_empty() {
         types_without_default_bounds.extend(args.types());
         w.push('<');
-        w.push_str(
-            &args
-                .iter()
-                .map(|k| k.to_string())
-                .filter(|k| k != "'_")
-                .collect::<Vec<_>>()
-                .join(", "),
-        );
+        w.push_str(&arg_names.join(", "));
         w.push('>');
     }
 

--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -79,10 +79,12 @@ macro_rules! vec {
 ///
 /// The first argument `format!` receives is a format string. This must be a string
 /// literal. The power of the formatting string is in the `{}`s contained.
-///
 /// Additional parameters passed to `format!` replace the `{}`s within the
 /// formatting string in the order given unless named or positional parameters
-/// are used; see [`std::fmt`] for more information.
+/// are used.
+///
+/// See [the formatting syntax documentation in `std::fmt`](../std/fmt/index.html)
+/// for details.
 ///
 /// A common use for `format!` is concatenation and interpolation of strings.
 /// The same convention is used with [`print!`] and [`write!`] macros,
@@ -91,7 +93,6 @@ macro_rules! vec {
 /// To convert a single value to a string, use the [`to_string`] method. This
 /// will use the [`Display`] formatting trait.
 ///
-/// [`std::fmt`]: ../std/fmt/index.html
 /// [`print!`]: ../std/macro.print.html
 /// [`write!`]: core::write
 /// [`to_string`]: crate::string::ToString

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -849,7 +849,8 @@ pub(crate) mod builtin {
     /// assert_eq!(display, debug);
     /// ```
     ///
-    /// For more information, see the documentation in [`std::fmt`].
+    /// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+    /// for details of the macro argument syntax, and further information.
     ///
     /// [`Display`]: crate::fmt::Display
     /// [`Debug`]: crate::fmt::Debug

--- a/library/core/src/macros/panic.md
+++ b/library/core/src/macros/panic.md
@@ -8,8 +8,8 @@ tests. `panic!` is closely tied with the `unwrap` method of both
 [`Option`][ounwrap] and [`Result`][runwrap] enums. Both implementations call
 `panic!` when they are set to [`None`] or [`Err`] variants.
 
-When using `panic!()` you can specify a string payload, that is built using
-the [`format!` syntax]. That payload is used when injecting the panic into
+When using `panic!()` you can specify a string payload that is built using
+[formatting syntax]. That payload is used when injecting the panic into
 the calling Rust thread, causing the thread to panic entirely.
 
 The behavior of the default `std` hook, i.e. the code that runs directly
@@ -18,6 +18,7 @@ after the panic is invoked, is to print the message payload to
 call. You can override the panic hook using [`std::panic::set_hook()`].
 Inside the hook a panic can be accessed as a `&dyn Any + Send`,
 which contains either a `&str` or `String` for regular `panic!()` invocations.
+(Whether a particular invocation contains the payload at type `&str` or `String` is unspecified and can change.)
 To panic with a value of another other type, [`panic_any`] can be used.
 
 See also the macro [`compile_error!`], for raising errors during compilation.
@@ -66,22 +67,26 @@ program with code `101`.
 
 # Editions
 
-In Rust Editions prior to 2021, `std::panic!(x)` with a single
-argument is equivalent to
-[`std::panic::panic_any(x)`](../std/panic/fn.panic_any.html).
-This is true even if the argument is a string literal.
+Behavior of the panic macros changed over editions.
 
-For example, in Rust 2015 `panic!("problem: {reason}")` panics with a
-payload of literally `"problem: {reason}"` (a `&'static str`), which
-is probably not what was intended.  In current Rust this usage 
-captures and formats a variable `reason` from the surrounding scope.
-
-In Rust editions prior to 2021, `core::panic!(x)` requires that
-`x` be `&str`, but does not require it to be a literal.  In Rust 2021,
-these cases must be written `panic!("{}", x)`.
+## 2021 and later
 
 In Rust 2021 and later, `panic!` always requires a format string and
 the applicable format arguments, and is the same in `core` and `std`.
+Use [`std::panic::panic_any(x)`](../std/panic/fn.panic_any.html) to
+panic with an arbitrary payload.
+
+## 2018 and 2015
+
+In Rust Editions prior to 2021, `std::panic!(x)` with a single
+argument directly uses that argument as a payload.
+This is true even if the argument is a string literal.
+For example, `panic!("problem: {reason}")` panics with a
+payload of literally `"problem: {reason}"` (a `&'static str`).
+
+`core::panic!(x)` with a single argument requires that `x` be `&str`,
+but otherwise behaves like `std::panic!`. In particular, the string
+need not be a literal, and is not interpreted as a format string.
 
 # Examples
 

--- a/library/core/src/macros/panic.md
+++ b/library/core/src/macros/panic.md
@@ -9,7 +9,7 @@ tests. `panic!` is closely tied with the `unwrap` method of both
 `panic!` when they are set to [`None`] or [`Err`] variants.
 
 When using `panic!()` you can specify a string payload, that is built using
-the [`format!`] syntax. That payload is used when injecting the panic into
+the [`format!` syntax]. That payload is used when injecting the panic into
 the calling Rust thread, causing the thread to panic entirely.
 
 The behavior of the default `std` hook, i.e. the code that runs directly
@@ -55,7 +55,7 @@ For more detailed information about error handling check out the [book] or the
 [`panic_any`]: ../std/panic/fn.panic_any.html
 [`Box`]: ../std/boxed/struct.Box.html
 [`Any`]: crate::any::Any
-[`format!`]: ../std/macro.format.html
+[`format!` syntax]: ../std/fmt/index.html
 [book]: ../book/ch09-00-error-handling.html
 [`std::result`]: ../std/result/index.html
 

--- a/library/core/src/macros/panic.md
+++ b/library/core/src/macros/panic.md
@@ -64,6 +64,25 @@ For more detailed information about error handling check out the [book] or the
 If the main thread panics it will terminate all your threads and end your
 program with code `101`.
 
+# Editions
+
+In Rust Editions prior to 2021, `std::panic!(x)` with a single
+argument is equivalent to
+[`std::panic::panic_any(x)`](../std/panic/fn.panic_any.html).
+This is true even if the argument is a string literal.
+
+For example, in Rust 2015 `panic!("problem: {reason}")` panics with a
+payload of literally `"problem: {reason}"` (a `&'static str`), which
+is probably not what was intended.  In current Rust this usage 
+captures and formats a variable `reason` from the surrounding scope.
+
+In Rust editions prior to 2021, `core::panic!(x)` requires that
+`x` be `&str`, but does not require it to be a literal.  In Rust 2021,
+these cases must be written `panic!("{}", x)`.
+
+In Rust 2021 and later, `panic!` always requires a format string and
+the applicable format arguments, and is the same in `core` and `std`.
+
 # Examples
 
 ```should_panic

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -76,11 +76,8 @@ macro marker_impls {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Send")]
 #[rustc_on_unimplemented(
-    on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
     message = "`{Self}` cannot be sent between threads safely",
-    label = "`{Self}` cannot be sent between threads safely",
-    note = "consider using `std::sync::Arc<{Self}>`; for more information visit \
-            <https://doc.rust-lang.org/book/ch16-03-shared-state.html>"
+    label = "`{Self}` cannot be sent between threads safely"
 )]
 pub unsafe auto trait Send {
     // empty.
@@ -631,11 +628,8 @@ impl<T: ?Sized> Copy for &T {}
         any(_Self = "core::cell::RefCell<T>", _Self = "std::cell::RefCell<T>"),
         note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead",
     ),
-    on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
     message = "`{Self}` cannot be shared between threads safely",
-    label = "`{Self}` cannot be shared between threads safely",
-    note = "consider using `std::sync::Arc<{Self}>`; for more information visit \
-            <https://doc.rust-lang.org/book/ch16-03-shared-state.html>"
+    label = "`{Self}` cannot be shared between threads safely"
 )]
 pub unsafe auto trait Sync {
     // FIXME(estebank): once support to add notes in `rustc_on_unimplemented`

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -77,7 +77,6 @@ macro marker_impls {
 #[cfg_attr(not(test), rustc_diagnostic_item = "Send")]
 #[rustc_on_unimplemented(
     on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
-    on(_Self = "alloc::rc::Rc<T, A>", note = "use `alloc::sync::Arc` instead of `alloc::rc::Rc`"),
     message = "`{Self}` cannot be sent between threads safely",
     label = "`{Self}` cannot be sent between threads safely",
     note = "consider using `std::sync::Arc<{Self}>`; for more information visit \
@@ -633,7 +632,6 @@ impl<T: ?Sized> Copy for &T {}
         note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead",
     ),
     on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
-    on(_Self = "alloc::rc::Rc<T, A>", note = "use `alloc::sync::Arc` instead of `alloc::rc::Rc`"),
     message = "`{Self}` cannot be shared between threads safely",
     label = "`{Self}` cannot be shared between threads safely",
     note = "consider using `std::sync::Arc<{Self}>`; for more information visit \

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -41,6 +41,9 @@ macro_rules! panic {
 /// Use `print!` only for the primary output of your program. Use
 /// [`eprint!`] instead to print error and progress messages.
 ///
+/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// for details of the macro argument syntax.
+///
 /// [flush]: crate::io::Write::flush
 /// [`println!`]: crate::println
 /// [`eprint!`]: crate::eprint
@@ -103,6 +106,9 @@ macro_rules! print {
 /// Use `println!` only for the primary output of your program. Use
 /// [`eprintln!`] instead to print error and progress messages.
 ///
+/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// for details of the macro argument syntax.
+///
 /// [`std::fmt`]: crate::fmt
 /// [`eprintln!`]: crate::eprintln
 /// [lock]: crate::io::Stdout
@@ -150,6 +156,9 @@ macro_rules! println {
 /// [`io::stderr`]: crate::io::stderr
 /// [`io::stdout`]: crate::io::stdout
 ///
+/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// for details of the macro argument syntax.
+///
 /// # Panics
 ///
 /// Panics if writing to `io::stderr` fails.
@@ -180,6 +189,9 @@ macro_rules! eprint {
 ///
 /// Use `eprintln!` only for error and progress messages. Use `println!`
 /// instead for the primary output of your program.
+///
+/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// for details of the macro argument syntax.
 ///
 /// [`io::stderr`]: crate::io::stderr
 /// [`io::stdout`]: crate::io::stdout

--- a/tests/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/tests/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -5,7 +5,6 @@ LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8
    |                                    ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
-   = note: consider using `std::sync::Arc<<<Self as Case1>::C as Iterator>::Item>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Send {
@@ -30,7 +29,6 @@ LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8
    |                                                                                             ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
-   = note: consider using `std::sync::Arc<<<Self as Case1>::C as Iterator>::Item>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Sync {

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
@@ -14,7 +14,6 @@ LL |     is_send(foo::<T>());
    |             ^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>>`
-   = note: consider using `std::sync::Arc<impl Future<Output = Result<(), ()>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/basic.rs:13:5
    |

--- a/tests/ui/async-await/async-await-let-else.drop_tracking.stderr
+++ b/tests/ui/async-await/async-await-let-else.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     is_send(foo(Some(true)));
    |             ^^^^^^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:11:15
    |
@@ -33,7 +32,6 @@ LL |     is_send(foo2(Some(true)));
    |     required by a bound introduced by this call
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this `async fn` body
   --> $DIR/async-await-let-else.rs:27:29
    |
@@ -66,7 +64,6 @@ LL |     is_send(foo3(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo3` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:33:29
    |
@@ -88,7 +85,6 @@ LL |     is_send(foo4(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo4` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:41:15
    |

--- a/tests/ui/async-await/async-await-let-else.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/async-await-let-else.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     is_send(foo(Some(true)));
    |             ^^^^^^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:11:15
    |
@@ -31,7 +30,6 @@ LL |     is_send(foo2(Some(true)));
    |     required by a bound introduced by this call
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this `async fn` body
   --> $DIR/async-await-let-else.rs:27:29
    |
@@ -64,7 +62,6 @@ LL |     is_send(foo3(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo3` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:33:29
    |
@@ -85,7 +82,6 @@ LL |     is_send(foo4(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo4` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:41:15
    |

--- a/tests/ui/async-await/async-await-let-else.no_drop_tracking.stderr
+++ b/tests/ui/async-await/async-await-let-else.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     is_send(foo(Some(true)));
    |             ^^^^^^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:11:15
    |
@@ -28,7 +27,6 @@ LL |     is_send(foo2(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo2` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:23:27
    |
@@ -51,7 +49,6 @@ LL |     is_send(foo3(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo3` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:33:29
    |
@@ -73,7 +70,6 @@ LL |     is_send(foo4(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo4` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:41:15
    |

--- a/tests/ui/async-await/async-fn-nonsend.drop_tracking.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(non_send_temporary_in_match());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:36:26
    |
@@ -29,7 +28,6 @@ LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:49:15
    |

--- a/tests/ui/async-await/async-fn-nonsend.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(non_send_temporary_in_match());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:36:26
    |
@@ -26,7 +25,6 @@ LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:49:15
    |

--- a/tests/ui/async-await/async-fn-nonsend.no_drop_tracking.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(local_dropped_before_await());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `local_dropped_before_await` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:27:11
    |
@@ -29,7 +28,6 @@ LL |     assert_send(non_send_temporary_in_match());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:36:26
    |
@@ -53,7 +51,6 @@ LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:49:15
    |
@@ -78,7 +75,6 @@ LL |     assert_send(non_sync_with_method_call_panic());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call_panic` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:56:15
    |
@@ -103,7 +99,6 @@ LL |     assert_send(non_sync_with_method_call_infinite_loop());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call_infinite_loop` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:63:15
    |

--- a/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking.stderr
+++ b/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/drop-track-field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/drop-track-field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/drop-track-field-assign-nonsend.no_drop_tracking.stderr
+++ b/tests/ui/async-await/drop-track-field-assign-nonsend.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/drop-track-field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/field-assign-nonsend.drop_tracking.stderr
+++ b/tests/ui/async-await/field-assign-nonsend.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/field-assign-nonsend.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/field-assign-nonsend.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/field-assign-nonsend.no_drop_tracking.stderr
+++ b/tests/ui/async-await/field-assign-nonsend.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/future-contains-err-issue-115188.rs
+++ b/tests/ui/async-await/future-contains-err-issue-115188.rs
@@ -1,0 +1,17 @@
+// edition: 2021
+
+// Makes sure we don't spew a bunch of unrelated opaque errors when the reason
+// for this error is just a missing struct field in `foo`.
+
+async fn foo() {
+    let y = Wrapper { };
+    //~^ ERROR missing field `t` in initializer of `Wrapper<_>`
+}
+
+struct Wrapper<T> { t: T }
+
+fn is_send<T: Send>(_: T) {}
+
+fn main() {
+    is_send(foo());
+}

--- a/tests/ui/async-await/future-contains-err-issue-115188.stderr
+++ b/tests/ui/async-await/future-contains-err-issue-115188.stderr
@@ -1,0 +1,9 @@
+error[E0063]: missing field `t` in initializer of `Wrapper<_>`
+  --> $DIR/future-contains-err-issue-115188.rs:7:13
+   |
+LL |     let y = Wrapper { };
+   |             ^^^^^^^ missing `t`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0063`.

--- a/tests/ui/async-await/in-trait/missing-send-bound.stderr
+++ b/tests/ui/async-await/in-trait/missing-send-bound.stderr
@@ -5,7 +5,6 @@ LL |     assert_is_send(test::<T>());
    |                    ^^^^^^^^^^^ future returned by `test` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `impl Future<Output = ()>`
-   = note: consider using `std::sync::Arc<impl Future<Output = ()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/missing-send-bound.rs:10:5
    |

--- a/tests/ui/async-await/issue-64130-1-sync.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
    = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:18:11
    |

--- a/tests/ui/async-await/issue-64130-1-sync.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
    = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:18:11
    |

--- a/tests/ui/async-await/issue-64130-1-sync.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
    = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:18:11
    |

--- a/tests/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL | pub fn foo() -> impl Future + Send {
    |                 ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `(dyn Any + Send + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Any + Send + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-4-async-move.rs:27:23
    |

--- a/tests/ui/async-await/issue-64130-non-send-future-diags.stderr
+++ b/tests/ui/async-await/issue-64130-non-send-future-diags.stderr
@@ -5,7 +5,6 @@ LL |     is_send(foo());
    |             ^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, u32>`
-   = note: consider using `std::sync::Arc<MutexGuard<'_, u32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-non-send-future-diags.rs:17:11
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking.stderr
@@ -10,7 +10,6 @@ LL | |     });
    | |_____^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-67252-unnamed-future.rs:21:11: 25:6]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:23:17
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     spawn(async {
    |     ^^^^^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-67252-unnamed-future.rs:21:11: 25:6]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:23:17
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.no_drop_tracking.stderr
@@ -10,7 +10,6 @@ LL | |     });
    | |_____^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-67252-unnamed-future.rs:21:11: 25:6]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:23:17
    |

--- a/tests/ui/async-await/issue-70818.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70818.drop_tracking.stderr
@@ -4,7 +4,6 @@ error: future cannot be sent between threads safely
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<U>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send`
   --> $DIR/issue-70818.rs:9:18
    |

--- a/tests/ui/async-await/issue-70818.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-70818.drop_tracking_mir.stderr
@@ -4,7 +4,6 @@ error: future cannot be sent between threads safely
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<U>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send`
   --> $DIR/issue-70818.rs:9:18
    |

--- a/tests/ui/async-await/issue-70818.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70818.no_drop_tracking.stderr
@@ -4,7 +4,6 @@ error: future cannot be sent between threads safely
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<U>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send`
   --> $DIR/issue-70818.rs:9:18
    |

--- a/tests/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`

--- a/tests/ui/async-await/issue-70935-complex-spans.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`

--- a/tests/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-70935-complex-spans.rs:24:12
    |

--- a/tests/ui/async-await/issue-71137.stderr
+++ b/tests/ui/async-await/issue-71137.stderr
@@ -5,7 +5,6 @@ LL |   fake_spawn(wrong_mutex());
    |              ^^^^^^^^^^^^^ future returned by `wrong_mutex` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, i32>`
-   = note: consider using `std::sync::Arc<MutexGuard<'_, i32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-71137.rs:14:26
    |

--- a/tests/ui/async-await/issue-86507.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-86507.drop_tracking.stderr
@@ -8,7 +8,6 @@ LL | |                 }
 LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/issue-86507.rs:22:29
    |

--- a/tests/ui/async-await/issue-86507.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-86507.drop_tracking_mir.stderr
@@ -8,7 +8,6 @@ LL | |                 }
 LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/issue-86507.rs:22:29
    |

--- a/tests/ui/async-await/issue-86507.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-86507.no_drop_tracking.stderr
@@ -8,7 +8,6 @@ LL | |                 }
 LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/issue-86507.rs:22:29
    |

--- a/tests/ui/async-await/issues/issue-65436-raw-ptr-not-send.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issues/issue-65436-raw-ptr-not-send.no_drop_tracking.stderr
@@ -9,7 +9,6 @@ LL | |     })
    | |_____^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-65436-raw-ptr-not-send.rs:17:17: 20:6]`, the trait `Send` is not implemented for `*const u8`
-   = note: consider using `std::sync::Arc<*const u8>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-65436-raw-ptr-not-send.rs:19:36
    |

--- a/tests/ui/async-await/issues/issue-67893.stderr
+++ b/tests/ui/async-await/issues/issue-67893.stderr
@@ -5,7 +5,6 @@ LL |     g(issue_67893::run())
    |       ^^^^^^^^^^^^^^^^^^ future is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, ()>`
-   = note: consider using `std::sync::Arc<MutexGuard<'_, ()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/auxiliary/issue_67893.rs:12:27
    |

--- a/tests/ui/async-await/partial-drop-partial-reinit.drop_tracking.stderr
+++ b/tests/ui/async-await/partial-drop-partial-reinit.drop_tracking.stderr
@@ -10,11 +10,10 @@ LL | async fn foo() {
    |                - within this `impl Future<Output = ()>`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(NotSend,)`
    = note: required because it captures the following types: `ResumeTy`, `(NotSend,)`, `()`, `impl Future<Output = ()>`
 note: required because it's used within this `async fn` body
-  --> $DIR/partial-drop-partial-reinit.rs:32:16
+  --> $DIR/partial-drop-partial-reinit.rs:31:16
    |
 LL |   async fn foo() {
    |  ________________^
@@ -26,7 +25,7 @@ LL | |     bar().await;
 LL | | }
    | |_^
 note: required by a bound in `gimme_send`
-  --> $DIR/partial-drop-partial-reinit.rs:18:18
+  --> $DIR/partial-drop-partial-reinit.rs:17:18
    |
 LL | fn gimme_send<T: Send>(t: T) {
    |                  ^^^^ required by this bound in `gimme_send`

--- a/tests/ui/async-await/partial-drop-partial-reinit.no_drop_tracking.stderr
+++ b/tests/ui/async-await/partial-drop-partial-reinit.no_drop_tracking.stderr
@@ -10,11 +10,10 @@ LL | async fn foo() {
    |                - within this `impl Future<Output = ()>`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(NotSend,)`
    = note: required because it captures the following types: `ResumeTy`, `(NotSend,)`, `impl Future<Output = ()>`, `()`
 note: required because it's used within this `async fn` body
-  --> $DIR/partial-drop-partial-reinit.rs:32:16
+  --> $DIR/partial-drop-partial-reinit.rs:31:16
    |
 LL |   async fn foo() {
    |  ________________^
@@ -26,7 +25,7 @@ LL | |     bar().await;
 LL | | }
    | |_^
 note: required by a bound in `gimme_send`
-  --> $DIR/partial-drop-partial-reinit.rs:18:18
+  --> $DIR/partial-drop-partial-reinit.rs:17:18
    |
 LL | fn gimme_send<T: Send>(t: T) {
    |                  ^^^^ required by this bound in `gimme_send`

--- a/tests/ui/async-await/partial-drop-partial-reinit.rs
+++ b/tests/ui/async-await/partial-drop-partial-reinit.rs
@@ -12,7 +12,6 @@ fn main() {
     //~| NOTE bound introduced by
     //~| NOTE appears within the type
     //~| NOTE captures the following types
-    //~| NOTE consider using `std::sync::Arc<NotSend>`
 }
 
 fn gimme_send<T: Send>(t: T) {

--- a/tests/ui/auto-traits/issue-83857-ub.stderr
+++ b/tests/ui/auto-traits/issue-83857-ub.stderr
@@ -5,7 +5,6 @@ LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo<T, U>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Foo<T, U>`
-   = note: consider using `std::sync::Arc<Foo<T, U>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `Foo<T, U>` to implement `WithAssoc`
   --> $DIR/issue-83857-ub.rs:15:15
    |

--- a/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T: Sync+'static> Foo for (T,) { }
    |                                ^^^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(T,)`
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-double-superkind.rs:4:13
@@ -22,7 +21,6 @@ error[E0277]: `T` cannot be shared between threads safely
 LL | impl <T: Send> Foo for (T,T) { }
    |                        ^^^^^ `T` cannot be shared between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(T, T)`
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-double-superkind.rs:4:18

--- a/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
    |                                                        ^^^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `X<T>`
   --> $DIR/builtin-superkinds-in-metadata.rs:9:8
    |

--- a/tests/ui/builtin-superkinds/builtin-superkinds-simple.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-simple.stderr
@@ -5,7 +5,6 @@ LL | impl Foo for std::rc::Rc<i8> { }
    |              ^^^^^^^^^^^^^^^ `Rc<i8>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Rc<i8>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-simple.rs:4:13
    |

--- a/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T: Sync+'static> Foo for T { }
    |                                ^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-typaram-not-send.rs:3:13
    |

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -4,7 +4,6 @@ error[E0277]: `F` cannot be sent between threads safely
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
    |                      ^^^^ `F` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<F>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `X`
   --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:1:43
    |

--- a/tests/ui/closures/closure-bounds-subtype.stderr
+++ b/tests/ui/closures/closure-bounds-subtype.stderr
@@ -6,7 +6,6 @@ LL |     take_const_owned(f);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<F>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `take_const_owned`
   --> $DIR/closure-bounds-subtype.rs:4:50
    |

--- a/tests/ui/closures/closure-move-sync.stderr
+++ b/tests/ui/closures/closure-move-sync.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
-   = note: consider using `std::sync::Arc<std::sync::mpsc::Receiver<()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&std::sync::mpsc::Receiver<()>` to implement `Send`
 note: required because it's used within this closure
   --> $DIR/closure-move-sync.rs:6:27

--- a/tests/ui/error-codes/E0277-2.stderr
+++ b/tests/ui/error-codes/E0277-2.stderr
@@ -5,7 +5,6 @@ LL |     is_send::<Foo>();
    |               ^^^ `*const u8` cannot be sent between threads safely
    |
    = help: within `Foo`, the trait `Send` is not implemented for `*const u8`
-   = note: consider using `std::sync::Arc<*const u8>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Baz`
   --> $DIR/E0277-2.rs:9:8
    |

--- a/tests/ui/extern/extern-type-diag-not-similar.stderr
+++ b/tests/ui/extern/extern-type-diag-not-similar.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<Foo>()
    |                   ^^^ `Foo` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/extern-type-diag-not-similar.rs:17:19
    |

--- a/tests/ui/extern/extern-types-not-sync-send.stderr
+++ b/tests/ui/extern/extern-types-not-sync-send.stderr
@@ -5,7 +5,6 @@ LL |     assert_sync::<A>();
    |                   ^ `A` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `A`
-   = note: consider using `std::sync::Arc<A>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_sync`
   --> $DIR/extern-types-not-sync-send.rs:9:28
    |
@@ -19,7 +18,6 @@ LL |     assert_send::<A>();
    |                   ^ `A` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `A`
-   = note: consider using `std::sync::Arc<A>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/extern-types-not-sync-send.rs:10:28
    |

--- a/tests/ui/fmt/send-sync.stderr
+++ b/tests/ui/fmt/send-sync.stderr
@@ -7,7 +7,6 @@ LL |     send(format_args!("{:?}", c));
    |     required by a bound introduced by this call
    |
    = help: within `[core::fmt::rt::Argument<'_>]`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
-   = note: consider using `std::sync::Arc<core::fmt::rt::Opaque>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
 note: required because it appears within the type `Argument<'_>`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
@@ -30,7 +29,6 @@ LL |     sync(format_args!("{:?}", c));
    |     required by a bound introduced by this call
    |
    = help: within `Arguments<'_>`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
-   = note: consider using `std::sync::Arc<core::fmt::rt::Opaque>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
 note: required because it appears within the type `Argument<'_>`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL

--- a/tests/ui/generator/drop-tracking-parent-expression.drop_tracking.stderr
+++ b/tests/ui/generator/drop-tracking-parent-expression.drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -57,7 +56,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -100,7 +98,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |

--- a/tests/ui/generator/drop-tracking-parent-expression.drop_tracking_mir.stderr
+++ b/tests/ui/generator/drop-tracking-parent-expression.drop_tracking_mir.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -55,7 +54,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -96,7 +94,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |

--- a/tests/ui/generator/drop-tracking-parent-expression.no_drop_tracking.stderr
+++ b/tests/ui/generator/drop-tracking-parent-expression.no_drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -57,7 +56,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |
@@ -99,7 +97,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -142,7 +139,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |
@@ -184,7 +180,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -227,7 +222,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |
@@ -269,7 +263,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -312,7 +305,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |

--- a/tests/ui/generator/drop-yield-twice.stderr
+++ b/tests/ui/generator/drop-yield-twice.stderr
@@ -11,7 +11,6 @@ LL | |     })
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/drop-yield-twice.rs:7:17: 7:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-yield-twice.rs:9:9
    |

--- a/tests/ui/generator/issue-57017.no_drop_tracking.stderr
+++ b/tests/ui/generator/issue-57017.no_drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `copy::unsync::Client`
-   = note: consider using `std::sync::Arc<copy::unsync::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:30:28
    |
@@ -56,7 +55,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/issue-57017.rs:41:21: 41:28]`, the trait `Send` is not implemented for `copy::unsend::Client`
-   = note: consider using `std::sync::Arc<copy::unsend::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:42:28
    |
@@ -98,7 +96,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `derived_drop::unsync::Client`
-   = note: consider using `std::sync::Arc<derived_drop::unsync::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:30:28
    |
@@ -140,7 +137,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/issue-57017.rs:41:21: 41:28]`, the trait `Send` is not implemented for `derived_drop::unsend::Client`
-   = note: consider using `std::sync::Arc<derived_drop::unsend::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:42:28
    |
@@ -182,7 +178,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `significant_drop::unsync::Client`
-   = note: consider using `std::sync::Arc<significant_drop::unsync::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:30:28
    |
@@ -224,7 +219,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/issue-57017.rs:41:21: 41:28]`, the trait `Send` is not implemented for `significant_drop::unsend::Client`
-   = note: consider using `std::sync::Arc<significant_drop::unsend::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:42:28
    |

--- a/tests/ui/generator/issue-57478.no_drop_tracking.stderr
+++ b/tests/ui/generator/issue-57478.no_drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     })
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/issue-57478.rs:13:17: 13:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57478.rs:17:9
    |

--- a/tests/ui/generator/layout-error.rs
+++ b/tests/ui/generator/layout-error.rs
@@ -24,6 +24,5 @@ fn main() {
     type F = impl Future;
     // Check that statics are inhabited computes they layout.
     static POOL: Task<F> = Task::new();
-    //~^ ERROR: cannot check whether the hidden type of `layout_error[b009]::main::F::{opaque#0}` satisfies auto traits
     Task::spawn(&POOL, || cb());
 }

--- a/tests/ui/generator/layout-error.stderr
+++ b/tests/ui/generator/layout-error.stderr
@@ -4,24 +4,6 @@ error[E0425]: cannot find value `Foo` in this scope
 LL |         let a = Foo;
    |                 ^^^ not found in this scope
 
-error: cannot check whether the hidden type of `layout_error[b009]::main::F::{opaque#0}` satisfies auto traits
-  --> $DIR/layout-error.rs:26:18
-   |
-LL |     static POOL: Task<F> = Task::new();
-   |                  ^^^^^^^
-   |
-note: opaque type is declared here
-  --> $DIR/layout-error.rs:24:14
-   |
-LL |     type F = impl Future;
-   |              ^^^^^^^^^^^
-note: required because it appears within the type `Task<F>`
-  --> $DIR/layout-error.rs:9:12
-   |
-LL | pub struct Task<F: Future>(F);
-   |            ^^^^
-   = note: shared static variables must have a type that implements `Sync`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/generator/not-send-sync.drop_tracking.stderr
+++ b/tests/ui/generator/not-send-sync.drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:17:17: 17:19]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:20:9
    |
@@ -41,7 +40,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:24:17: 24:19]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:27:9
    |

--- a/tests/ui/generator/not-send-sync.drop_tracking_mir.stderr
+++ b/tests/ui/generator/not-send-sync.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ generator is not `Sync`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:17:17: 17:19]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:20:9
    |
@@ -26,7 +25,6 @@ LL |     assert_send(|| {
    |     ^^^^^^^^^^^ generator is not `Send`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:24:17: 24:19]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:27:9
    |

--- a/tests/ui/generator/not-send-sync.no_drop_tracking.stderr
+++ b/tests/ui/generator/not-send-sync.no_drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:17:17: 17:19]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:20:9
    |
@@ -41,7 +40,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:24:17: 24:19]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:27:9
    |

--- a/tests/ui/generator/parent-expression.drop_tracking.stderr
+++ b/tests/ui/generator/parent-expression.drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -57,7 +56,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -100,7 +98,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |

--- a/tests/ui/generator/parent-expression.drop_tracking_mir.stderr
+++ b/tests/ui/generator/parent-expression.drop_tracking_mir.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -55,7 +54,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -96,7 +94,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |

--- a/tests/ui/generator/parent-expression.no_drop_tracking.stderr
+++ b/tests/ui/generator/parent-expression.no_drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -57,7 +56,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |
@@ -99,7 +97,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -142,7 +139,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |
@@ -184,7 +180,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -227,7 +222,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |
@@ -269,7 +263,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -312,7 +305,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |

--- a/tests/ui/generator/partial-drop.drop_tracking.stderr
+++ b/tests/ui/generator/partial-drop.drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:17:17: 17:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:21:9
    |
@@ -42,7 +41,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:24:17: 24:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:29:9
    |

--- a/tests/ui/generator/partial-drop.no_drop_tracking.stderr
+++ b/tests/ui/generator/partial-drop.no_drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:17:17: 17:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:21:9
    |
@@ -42,7 +41,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:24:17: 24:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:29:9
    |

--- a/tests/ui/generator/print/generator-print-verbose-2.drop_tracking.stderr
+++ b/tests/ui/generator/print/generator-print-verbose-2.drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[main::{closure#0} upvar_tys=() {NotSync, ()}]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:23:9
    |
@@ -41,7 +40,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[main::{closure#1} upvar_tys=() {NotSend, ()}]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:30:9
    |

--- a/tests/ui/generator/print/generator-print-verbose-2.drop_tracking_mir.stderr
+++ b/tests/ui/generator/print/generator-print-verbose-2.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ generator is not `Sync`
    |
    = help: within `[main::{closure#0} upvar_tys=() [main::{closure#0}]]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:23:9
    |
@@ -26,7 +25,6 @@ LL |     assert_send(|| {
    |     ^^^^^^^^^^^ generator is not `Send`
    |
    = help: within `[main::{closure#1} upvar_tys=() [main::{closure#1}]]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:30:9
    |

--- a/tests/ui/generator/print/generator-print-verbose-2.no_drop_tracking.stderr
+++ b/tests/ui/generator/print/generator-print-verbose-2.no_drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[main::{closure#0} upvar_tys=() {NotSync, ()}]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:23:9
    |
@@ -41,7 +40,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[main::{closure#1} upvar_tys=() {NotSend, ()}]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:30:9
    |

--- a/tests/ui/generator/ref-upvar-not-send.rs
+++ b/tests/ui/generator/ref-upvar-not-send.rs
@@ -15,7 +15,6 @@ fn main() {
     assert_send(move || {
         //~^ ERROR generator cannot be sent between threads safely
         //~| NOTE generator is not `Send`
-        //~| NOTE consider using `std::sync::Arc
         yield;
         let _x = x;
     });
@@ -24,7 +23,6 @@ fn main() {
     assert_send(move || {
         //~^ ERROR generator cannot be sent between threads safely
         //~| NOTE generator is not `Send`
-        //~| NOTE consider using `std::sync::Arc
         yield;
         let _y = y;
     });

--- a/tests/ui/generator/ref-upvar-not-send.stderr
+++ b/tests/ui/generator/ref-upvar-not-send.stderr
@@ -5,16 +5,14 @@ LL |       assert_send(move || {
    |  _________________^
 LL | |
 LL | |
-LL | |
 LL | |         yield;
 LL | |         let _x = x;
 LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-  --> $DIR/ref-upvar-not-send.rs:20:18
+  --> $DIR/ref-upvar-not-send.rs:19:18
    |
 LL |         let _x = x;
    |                  ^ has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
@@ -25,11 +23,10 @@ LL | fn assert_send<T: Send>(_: T) {}
    |                   ^^^^ required by this bound in `assert_send`
 
 error: generator cannot be sent between threads safely
-  --> $DIR/ref-upvar-not-send.rs:24:17
+  --> $DIR/ref-upvar-not-send.rs:23:17
    |
 LL |       assert_send(move || {
    |  _________________^
-LL | |
 LL | |
 LL | |
 LL | |         yield;
@@ -37,10 +34,9 @@ LL | |         let _y = y;
 LL | |     });
    | |_____^ generator is not `Send`
    |
-   = help: within `[generator@$DIR/ref-upvar-not-send.rs:24:17: 24:24]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = help: within `[generator@$DIR/ref-upvar-not-send.rs:23:17: 23:24]`, the trait `Send` is not implemented for `*mut ()`
 note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
-  --> $DIR/ref-upvar-not-send.rs:29:18
+  --> $DIR/ref-upvar-not-send.rs:27:18
    |
 LL |         let _y = y;
    |                  ^ has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`

--- a/tests/ui/impl-trait/auto-trait-leak.rs
+++ b/tests/ui/impl-trait/auto-trait-leak.rs
@@ -12,7 +12,6 @@ fn cycle1() -> impl Clone {
     //~^ ERROR cycle detected
     //~| ERROR cycle detected
     send(cycle2().clone());
-    //~^ ERROR: cannot check whether the hidden type of opaque type satisfies auto traits
 
     Rc::new(Cell::new(5))
 }

--- a/tests/ui/impl-trait/auto-trait-leak.stderr
+++ b/tests/ui/impl-trait/auto-trait-leak.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when computing type of `cycle1::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `cycle1::{opaque#0}`
   --> $DIR/auto-trait-leak.rs:11:16
    |
 LL | fn cycle1() -> impl Clone {
@@ -10,32 +10,26 @@ note: ...which requires type-checking `cycle1`...
 LL |     send(cycle2().clone());
    |     ^^^^
    = note: ...which requires evaluating trait selection obligation `cycle2::{opaque#0}: core::marker::Send`...
-note: ...which requires computing type of `cycle2::{opaque#0}`...
-  --> $DIR/auto-trait-leak.rs:20:16
+note: ...which requires computing type of opaque `cycle2::{opaque#0}`...
+  --> $DIR/auto-trait-leak.rs:19:16
    |
 LL | fn cycle2() -> impl Clone {
    |                ^^^^^^^^^^
 note: ...which requires type-checking `cycle2`...
-  --> $DIR/auto-trait-leak.rs:21:5
+  --> $DIR/auto-trait-leak.rs:20:5
    |
 LL |     send(cycle1().clone());
    |     ^^^^
    = note: ...which requires evaluating trait selection obligation `cycle1::{opaque#0}: core::marker::Send`...
-   = note: ...which again requires computing type of `cycle1::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/auto-trait-leak.rs:1:1
+   = note: ...which again requires computing type of opaque `cycle1::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `cycle1::{opaque#0}`
+  --> $DIR/auto-trait-leak.rs:11:16
    |
-LL | / use std::cell::Cell;
-LL | | use std::rc::Rc;
-LL | |
-LL | | fn send<T: Send>(_: T) {}
-...  |
-LL | |     Rc::new(String::from("foo"))
-LL | | }
-   | |_^
+LL | fn cycle1() -> impl Clone {
+   |                ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `cycle1::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `cycle1::{opaque#0}`
   --> $DIR/auto-trait-leak.rs:11:16
    |
 LL | fn cycle1() -> impl Clone {
@@ -47,32 +41,26 @@ note: ...which requires type-checking `cycle1`...
 LL |     send(cycle2().clone());
    |     ^^^^
    = note: ...which requires evaluating trait selection obligation `cycle2::{opaque#0}: core::marker::Send`...
-note: ...which requires computing type of `cycle2::{opaque#0}`...
-  --> $DIR/auto-trait-leak.rs:20:16
+note: ...which requires computing type of opaque `cycle2::{opaque#0}`...
+  --> $DIR/auto-trait-leak.rs:19:16
    |
 LL | fn cycle2() -> impl Clone {
    |                ^^^^^^^^^^
 note: ...which requires type-checking `cycle2`...
-  --> $DIR/auto-trait-leak.rs:20:1
+  --> $DIR/auto-trait-leak.rs:19:1
    |
 LL | fn cycle2() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires computing type of `cycle1::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/auto-trait-leak.rs:1:1
+   = note: ...which again requires computing type of opaque `cycle1::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `cycle1::{opaque#0}`
+  --> $DIR/auto-trait-leak.rs:11:16
    |
-LL | / use std::cell::Cell;
-LL | | use std::rc::Rc;
-LL | |
-LL | | fn send<T: Send>(_: T) {}
-...  |
-LL | |     Rc::new(String::from("foo"))
-LL | | }
-   | |_^
+LL | fn cycle1() -> impl Clone {
+   |                ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of opaque type satisfies auto traits
-  --> $DIR/auto-trait-leak.rs:21:10
+  --> $DIR/auto-trait-leak.rs:20:10
    |
 LL |     send(cycle1().clone());
    |     ---- ^^^^^^^^^^^^^^^^
@@ -85,7 +73,7 @@ note: opaque type is declared here
 LL | fn cycle1() -> impl Clone {
    |                ^^^^^^^^^^
 note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/auto-trait-leak.rs:20:4
+  --> $DIR/auto-trait-leak.rs:19:4
    |
 LL | fn cycle2() -> impl Clone {
    |    ^^^^^^
@@ -95,30 +83,6 @@ note: required by a bound in `send`
 LL | fn send<T: Send>(_: T) {}
    |            ^^^^ required by this bound in `send`
 
-error: cannot check whether the hidden type of opaque type satisfies auto traits
-  --> $DIR/auto-trait-leak.rs:14:10
-   |
-LL |     send(cycle2().clone());
-   |     ---- ^^^^^^^^^^^^^^^^
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: opaque type is declared here
-  --> $DIR/auto-trait-leak.rs:20:16
-   |
-LL | fn cycle2() -> impl Clone {
-   |                ^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/auto-trait-leak.rs:11:4
-   |
-LL | fn cycle1() -> impl Clone {
-   |    ^^^^^^
-note: required by a bound in `send`
-  --> $DIR/auto-trait-leak.rs:4:12
-   |
-LL | fn send<T: Send>(_: T) {}
-   |            ^^^^ required by this bound in `send`
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/auto-trait-leak2.rs
+++ b/tests/ui/impl-trait/auto-trait-leak2.rs
@@ -21,13 +21,11 @@ fn main() {
     //~^ ERROR `Rc<Cell<i32>>` cannot be sent between threads safely
     //~| NOTE `Rc<Cell<i32>>` cannot be sent between threads safely
     //~| NOTE required by a bound
-    //~| NOTE use `std::sync::Arc` instead
 
     send(after());
     //~^ ERROR `Rc<Cell<i32>>` cannot be sent between threads safely
     //~| NOTE `Rc<Cell<i32>>` cannot be sent between threads safely
     //~| NOTE required by a bound
-    //~| NOTE use `std::sync::Arc` instead
 }
 
 // Deferred path, main has to wait until typeck finishes,

--- a/tests/ui/impl-trait/auto-trait-leak2.stderr
+++ b/tests/ui/impl-trait/auto-trait-leak2.stderr
@@ -10,7 +10,6 @@ LL |     send(before());
    |     required by a bound introduced by this call
    |
    = help: within `impl Fn(i32)`, the trait `Send` is not implemented for `Rc<Cell<i32>>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this closure
   --> $DIR/auto-trait-leak2.rs:10:5
    |
@@ -28,7 +27,7 @@ LL | fn send<T: Send>(_: T) {}
    |            ^^^^ required by this bound in `send`
 
 error[E0277]: `Rc<Cell<i32>>` cannot be sent between threads safely
-  --> $DIR/auto-trait-leak2.rs:26:10
+  --> $DIR/auto-trait-leak2.rs:25:10
    |
 LL |     send(after());
    |     ---- ^^^^^^^ `Rc<Cell<i32>>` cannot be sent between threads safely
@@ -39,14 +38,13 @@ LL | fn after() -> impl Fn(i32) {
    |               ------------ within this `impl Fn(i32)`
    |
    = help: within `impl Fn(i32)`, the trait `Send` is not implemented for `Rc<Cell<i32>>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this closure
-  --> $DIR/auto-trait-leak2.rs:40:5
+  --> $DIR/auto-trait-leak2.rs:38:5
    |
 LL |     move |x| p.set(x)
    |     ^^^^^^^^
 note: required because it appears within the type `impl Fn(i32)`
-  --> $DIR/auto-trait-leak2.rs:35:15
+  --> $DIR/auto-trait-leak2.rs:33:15
    |
 LL | fn after() -> impl Fn(i32) {
    |               ^^^^^^^^^^^^

--- a/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.stderr
@@ -5,7 +5,6 @@ LL |     fn bar() -> Wrapper<impl Sized>;
    |                 ^^^^^^^^^^^^^^^^^^^ `impl Sized` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `impl Sized`
-   = note: consider using `std::sync::Arc<impl Sized>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Wrapper`
   --> $DIR/check-wf-on-non-defaulted-rpitit.rs:3:19
    |

--- a/tests/ui/impl-trait/issue-103181-2.rs
+++ b/tests/ui/impl-trait/issue-103181-2.rs
@@ -24,8 +24,6 @@ where
     B: Send, // <- a second bound
 {
     normalize(broken_fut(), ());
-    //~^ ERROR: cannot check whether the hidden type of opaque type satisfies auto traits
-    //~| ERROR: cannot check whether the hidden type of opaque type satisfies auto traits
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issue-103181-2.stderr
+++ b/tests/ui/impl-trait/issue-103181-2.stderr
@@ -4,61 +4,6 @@ error[E0425]: cannot find value `ident_error` in this scope
 LL |     ident_error;
    |     ^^^^^^^^^^^ not found in this scope
 
-error: cannot check whether the hidden type of opaque type satisfies auto traits
-  --> $DIR/issue-103181-2.rs:26:15
-   |
-LL |     normalize(broken_fut(), ());
-   |     --------- ^^^^^^^^^^^^
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: opaque type is declared here
-  --> $DIR/issue-103181-2.rs:11:23
-   |
-LL | async fn broken_fut() {
-   |                       ^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/issue-103181-2.rs:20:10
-   |
-LL | async fn iceice<A, B>()
-   |          ^^^^^^
-note: required for `impl Future<Output = ()>` to implement `SendFuture`
-  --> $DIR/issue-103181-2.rs:7:17
-   |
-LL | impl<Fut: Send> SendFuture for Fut {
-   |           ----  ^^^^^^^^^^     ^^^
-   |           |
-   |           unsatisfied trait bound introduced here
-note: required by a bound in `normalize`
-  --> $DIR/issue-103181-2.rs:18:19
-   |
-LL | fn normalize<Fut: SendFuture>(_: Fut, _: Fut::Output) {}
-   |                   ^^^^^^^^^^ required by this bound in `normalize`
-
-error: cannot check whether the hidden type of opaque type satisfies auto traits
-  --> $DIR/issue-103181-2.rs:26:5
-   |
-LL |     normalize(broken_fut(), ());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: opaque type is declared here
-  --> $DIR/issue-103181-2.rs:11:23
-   |
-LL | async fn broken_fut() {
-   |                       ^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/issue-103181-2.rs:20:10
-   |
-LL | async fn iceice<A, B>()
-   |          ^^^^^^
-note: required for `impl Future<Output = ()>` to implement `SendFuture`
-  --> $DIR/issue-103181-2.rs:7:17
-   |
-LL | impl<Fut: Send> SendFuture for Fut {
-   |           ----  ^^^^^^^^^^     ^^^
-   |           |
-   |           unsatisfied trait bound introduced here
-
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/impl-trait/issues/issue-86800.stderr
+++ b/tests/ui/impl-trait/issues/issue-86800.stderr
@@ -7,6 +7,6 @@ LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResu
 error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
-#0 [type_of] computing type of `TransactionFuture::{opaque#0}`
-#1 [check_mod_item_types] checking item types in top-level module
+#0 [type_of_opaque] computing type of opaque `TransactionFuture::{opaque#0}`
+#1 [type_of] computing type of `TransactionFuture::{opaque#0}`
 end of query stack

--- a/tests/ui/inference/issue-72616.stderr
+++ b/tests/ui/inference/issue-72616.stderr
@@ -23,7 +23,7 @@ LL |         if String::from("a") == "a".try_into().unwrap() {}
    |                                     ^^^^^^^^
    |
    = note: multiple `impl`s satisfying `_: TryFrom<&str>` found in the following crates: `core`, `std`:
-           - impl<> TryFrom<&str> for std::sys_common::net::LookupHost;
+           - impl TryFrom<&str> for std::sys_common::net::LookupHost;
            - impl<T, U> TryFrom<U> for T
              where U: Into<T>;
    = note: required for `&str` to implement `TryInto<_>`

--- a/tests/ui/inference/issue-72690.stderr
+++ b/tests/ui/inference/issue-72690.stderr
@@ -5,8 +5,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:7:22
@@ -74,8 +74,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:21:22
@@ -100,8 +100,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:28:22
@@ -126,8 +126,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:37:22
@@ -152,8 +152,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:46:22
@@ -178,8 +178,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:53:22
@@ -204,8 +204,8 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
+           - impl From<&String> for String;
+           - impl From<&str> for String;
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:62:22

--- a/tests/ui/issues/issue-21763.stderr
+++ b/tests/ui/issues/issue-21763.stderr
@@ -5,7 +5,6 @@ LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    |           ^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
    |
    = help: within `(Rc<()>, Rc<()>)`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
    = note: required because it appears within the type `(Rc<()>, Rc<()>)`
    = note: required for `hashbrown::raw::RawTable<(Rc<()>, Rc<()>)>` to implement `Send`
 note: required because it appears within the type `HashMap<Rc<()>, Rc<()>, RandomState>`

--- a/tests/ui/issues/issue-24446.stderr
+++ b/tests/ui/issues/issue-24446.stderr
@@ -13,7 +13,6 @@ LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    |                 ^^^^^^^^^^^^^^^ `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Fn() -> u32 + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Fn() -> u32 + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: shared static variables must have a type that implements `Sync`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/issues/issue-40827.stderr
+++ b/tests/ui/issues/issue-40827.stderr
@@ -7,7 +7,6 @@ LL |     f(Foo(Arc::new(Bar::B(None))));
    |     required by a bound introduced by this call
    |
    = help: within `Bar`, the trait `Sync` is not implemented for `Rc<Foo>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Bar`
   --> $DIR/issue-40827.rs:6:6
    |
@@ -34,7 +33,6 @@ LL |     f(Foo(Arc::new(Bar::B(None))));
    |     required by a bound introduced by this call
    |
    = help: within `Bar`, the trait `Send` is not implemented for `Rc<Foo>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Bar`
   --> $DIR/issue-40827.rs:6:6
    |

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `S<T>` to implement `Gettable<T>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |
@@ -43,7 +42,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `S<T>` to implement `Gettable<T>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |

--- a/tests/ui/kindck/kindck-nonsendable-1.stderr
+++ b/tests/ui/kindck/kindck-nonsendable-1.stderr
@@ -9,7 +9,6 @@ LL |     bar(move|| foo(x));
    |     required by a bound introduced by this call
    |
    = help: within `[closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15]`, the trait `Send` is not implemented for `Rc<usize>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this closure
   --> $DIR/kindck-nonsendable-1.rs:9:9
    |

--- a/tests/ui/kindck/kindck-send-object.stderr
+++ b/tests/ui/kindck/kindck-send-object.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<&'static (dyn Dummy + 'static)>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object.rs:5:18
@@ -20,7 +19,6 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
-   = note: consider using `std::sync::Arc<dyn Dummy>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<&'a dyn Dummy>();
    |                   ^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'a)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'a)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&'a (dyn Dummy + 'a)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object1.rs:5:18
@@ -20,7 +19,6 @@ LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |                   ^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'a)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<(dyn Dummy + 'a)>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-object2.stderr
+++ b/tests/ui/kindck/kindck-send-object2.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<&'static dyn Dummy>();
    |                   ^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object2.rs:3:18
@@ -20,7 +19,6 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
-   = note: consider using `std::sync::Arc<dyn Dummy>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-owned.stderr
+++ b/tests/ui/kindck/kindck-send-owned.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<Box<*mut u8>>();
    |                   ^^^^^^^^^^^^ `*mut u8` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut u8`
-   = note: consider using `std::sync::Arc<*mut u8>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<*mut u8>` to implement `Send`
 note: required because it appears within the type `Box<*mut u8>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-unsafe.stderr
+++ b/tests/ui/kindck/kindck-send-unsafe.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<*mut isize>();
    |                   ^^^^^^^^^^ `*mut isize` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut isize`
-   = note: consider using `std::sync::Arc<*mut isize>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-unsafe.rs:3:19
    |
@@ -19,7 +18,6 @@ LL |     assert_send::<*mut &'a isize>();
    |                   ^^^^^^^^^^^^^^ `*mut &'a isize` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut &'a isize`
-   = note: consider using `std::sync::Arc<*mut &'a isize>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-unsafe.rs:3:19
    |

--- a/tests/ui/mut/mutable-enum-indirect.stderr
+++ b/tests/ui/mut/mutable-enum-indirect.stderr
@@ -7,7 +7,6 @@ LL |     bar(&x);
    |     required by a bound introduced by this call
    |
    = help: within `&Foo`, the trait `Sync` is not implemented for `NoSync`
-   = note: consider using `std::sync::Arc<NoSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/mutable-enum-indirect.rs:11:6
    |

--- a/tests/ui/no-send-res-ports.stderr
+++ b/tests/ui/no-send-res-ports.stderr
@@ -14,7 +14,6 @@ LL | |     });
    | |_____^ `Rc<()>` cannot be sent between threads safely
    |
    = help: within `[closure@$DIR/no-send-res-ports.rs:25:19: 25:25]`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Port<()>`
   --> $DIR/no-send-res-ports.rs:5:8
    |

--- a/tests/ui/no_send-enum.stderr
+++ b/tests/ui/no_send-enum.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: within `Foo`, the trait `Send` is not implemented for `NoSend`
-   = note: consider using `std::sync::Arc<NoSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/no_send-enum.rs:8:6
    |

--- a/tests/ui/no_send-rc.stderr
+++ b/tests/ui/no_send-rc.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Rc<{integer}>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required by a bound in `bar`
   --> $DIR/no_send-rc.rs:3:11
    |

--- a/tests/ui/no_share-enum.stderr
+++ b/tests/ui/no_share-enum.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: within `Foo`, the trait `Sync` is not implemented for `NoSync`
-   = note: consider using `std::sync::Arc<NoSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/no_share-enum.rs:8:6
    |

--- a/tests/ui/no_share-struct.stderr
+++ b/tests/ui/no_share-struct.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `bar`
   --> $DIR/no_share-struct.rs:8:11
    |

--- a/tests/ui/phantom-auto-trait.stderr
+++ b/tests/ui/phantom-auto-trait.stderr
@@ -6,7 +6,6 @@ LL |     is_zen(x)
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `&T` to implement `Zen`
   --> $DIR/phantom-auto-trait.rs:10:24
    |
@@ -37,7 +36,6 @@ LL |     is_zen(x)
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `&T` to implement `Zen`
   --> $DIR/phantom-auto-trait.rs:10:24
    |

--- a/tests/ui/recursion/recursive-requirements.stderr
+++ b/tests/ui/recursion/recursive-requirements.stderr
@@ -5,7 +5,6 @@ LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Bar` cannot be shared between threads safely
    |
    = help: within `Foo`, the trait `Sync` is not implemented for `*const Bar`
-   = note: consider using `std::sync::Arc<*const Bar>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/recursive-requirements.rs:5:12
    |
@@ -24,7 +23,6 @@ LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Foo` cannot be shared between threads safely
    |
    = help: within `Foo`, the trait `Sync` is not implemented for `*const Foo`
-   = note: consider using `std::sync::Arc<*const Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Bar`
   --> $DIR/recursive-requirements.rs:10:12
    |

--- a/tests/ui/statics/issue-17718-static-sync.stderr
+++ b/tests/ui/statics/issue-17718-static-sync.stderr
@@ -5,7 +5,6 @@ LL | static BAR: Foo = Foo;
    |             ^^^ `Foo` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: shared static variables must have a type that implements `Sync`
 
 error: aborting due to previous error

--- a/tests/ui/stdlib-unit-tests/not-sync.stderr
+++ b/tests/ui/stdlib-unit-tests/not-sync.stderr
@@ -33,7 +33,6 @@ LL |     test::<Rc<i32>>();
    |            ^^^^^^^ `Rc<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Rc<i32>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required by a bound in `test`
   --> $DIR/not-sync.rs:5:12
    |
@@ -47,7 +46,6 @@ LL |     test::<Weak<i32>>();
    |            ^^^^^^^^^ `std::rc::Weak<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::rc::Weak<i32>`
-   = note: consider using `std::sync::Arc<std::rc::Weak<i32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/not-sync.rs:5:12
    |
@@ -61,7 +59,6 @@ LL |     test::<Receiver<i32>>();
    |            ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<i32>`
-   = note: consider using `std::sync::Arc<std::sync::mpsc::Receiver<i32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/not-sync.rs:5:12
    |

--- a/tests/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
+++ b/tests/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
@@ -7,7 +7,6 @@ LL |     assert_is_send(&bar);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
-   = note: consider using `std::sync::Arc<<impl Foo as Foo>::Bar>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_is_send`
   --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:30:22
    |
@@ -27,7 +26,6 @@ LL |     assert_is_send(&bar);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
-   = note: consider using `std::sync::Arc<<impl Foo as Foo>::Bar>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_is_send`
   --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:30:22
    |

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -71,7 +71,6 @@ LL |     f_send(rc);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Rc<{integer}>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required by a bound in `f_send`
   --> $DIR/issue-84973-blacklist.rs:10:14
    |

--- a/tests/ui/suggestions/restrict-type-argument.stderr
+++ b/tests/ui/suggestions/restrict-type-argument.stderr
@@ -6,7 +6,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<impl Sync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -25,7 +24,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -44,7 +42,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -63,7 +60,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -82,7 +78,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -101,7 +96,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |

--- a/tests/ui/traits/alias/cross-crate.stderr
+++ b/tests/ui/traits/alias/cross-crate.stderr
@@ -5,7 +5,6 @@ LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `Rc<u32>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Rc<u32>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
    = note: required for `Rc<u32>` to implement `SendSync`
 note: required by a bound in `use_alias`
   --> $DIR/cross-crate.rs:10:17
@@ -20,7 +19,6 @@ LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `Rc<u32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Rc<u32>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
    = note: required for `Rc<u32>` to implement `SendSync`
 note: required by a bound in `use_alias`
   --> $DIR/cross-crate.rs:10:17

--- a/tests/ui/traits/bad-method-typaram-kind.stderr
+++ b/tests/ui/traits/bad-method-typaram-kind.stderr
@@ -6,7 +6,6 @@ LL |     1.bar::<T>();
    |       |
    |       required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Bar::bar`
   --> $DIR/bad-method-typaram-kind.rs:6:14
    |

--- a/tests/ui/traits/inductive-overflow/two-traits.stderr
+++ b/tests/ui/traits/inductive-overflow/two-traits.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be shared between threads safely
 LL |     type X = Self;
    |              ^^^^ `T` cannot be shared between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Magic::X`
   --> $DIR/two-traits.rs:8:13
    |

--- a/tests/ui/traits/issue-7013.stderr
+++ b/tests/ui/traits/issue-7013.stderr
@@ -5,7 +5,6 @@ LL |     let a = A {v: Box::new(B{v: None}) as Box<dyn Foo + Send>};
    |                   ^^^^^^^^^^^^^^^^^^^^ `Rc<RefCell<A>>` cannot be sent between threads safely
    |
    = help: within `B`, the trait `Send` is not implemented for `Rc<RefCell<A>>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Option<Rc<RefCell<A>>>`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 note: required because it appears within the type `B`

--- a/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -7,7 +7,6 @@ LL |     Outer(TestType);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy::TestType`
-   = note: consider using `std::sync::Arc<dummy::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Outer`
   --> $DIR/negated-auto-traits-error.rs:10:17
    |
@@ -21,7 +20,6 @@ LL |     Outer(TestType);
    |     ^^^^^^^^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dummy::TestType`
-   = note: consider using `std::sync::Arc<dummy::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Outer`
   --> $DIR/negated-auto-traits-error.rs:10:17
    |
@@ -37,7 +35,6 @@ LL |     is_send(TestType);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy1b::TestType`
-   = note: consider using `std::sync::Arc<dummy1b::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
    |
@@ -53,7 +50,6 @@ LL |     is_send((8, TestType));
    |     required by a bound introduced by this call
    |
    = help: within `({integer}, dummy1c::TestType)`, the trait `Send` is not implemented for `dummy1c::TestType`
-   = note: consider using `std::sync::Arc<dummy1c::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `({integer}, TestType)`
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
@@ -92,7 +88,6 @@ LL |     is_send(Box::new(Outer2(TestType)));
    |     required by a bound introduced by this call
    |
    = help: within `Outer2<dummy3::TestType>`, the trait `Send` is not implemented for `dummy3::TestType`
-   = note: consider using `std::sync::Arc<dummy3::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Outer2<TestType>`
   --> $DIR/negated-auto-traits-error.rs:12:8
    |
@@ -116,7 +111,6 @@ LL |     is_sync(Outer2(TestType));
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `main::TestType`
-   = note: consider using `std::sync::Arc<main::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `Outer2<main::TestType>` to implement `Sync`
   --> $DIR/negated-auto-traits-error.rs:14:22
    |

--- a/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
+++ b/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
@@ -7,7 +7,6 @@ LL |     is_send(foo());
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `impl Future<Output = ()>`
-   = note: consider using `std::sync::Arc<impl Future<Output = ()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/auto-with-drop_tracking_mir.rs:24:24
    |

--- a/tests/ui/traits/no_send-struct.stderr
+++ b/tests/ui/traits/no_send-struct.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `bar`
   --> $DIR/no_send-struct.rs:11:11
    |

--- a/tests/ui/traits/non_lifetime_binders/fail.stderr
+++ b/tests/ui/traits/non_lifetime_binders/fail.stderr
@@ -29,7 +29,6 @@ LL |     auto_trait();
    |     ^^^^^^^^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `T`
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `auto_trait`
   --> $DIR/fail.rs:15:15
    |

--- a/tests/ui/traits/unsend-future.stderr
+++ b/tests/ui/traits/unsend-future.stderr
@@ -5,7 +5,6 @@ LL |     require_handler(handler)
    |                     ^^^^^^^ future returned by `handler` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `*const i32`
-   = note: consider using `std::sync::Arc<*const i32>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/unsend-future.rs:15:14
    |

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage2.rs
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage2.rs
@@ -22,5 +22,4 @@ fn main() {
     //~^ ERROR: `Rc<u32>` cannot be sent between threads safely [E0277]
     //~| NOTE cannot be sent
     //~| NOTE required by a bound
-    //~| NOTE use `std::sync::Arc` instead
 }

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage2.stderr
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage2.stderr
@@ -10,7 +10,6 @@ LL |     is_send(m::foo());
    |     required by a bound introduced by this call
    |
    = help: within `Foo`, the trait `Send` is not implemented for `Rc<u32>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Foo`
   --> $DIR/auto-trait-leakage2.rs:7:16
    |

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage3.rs
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage3.rs
@@ -5,8 +5,8 @@
 
 mod m {
     pub type Foo = impl std::fmt::Debug;
-    //~^ ERROR: cycle detected when computing type of `m::Foo::{opaque#0}` [E0391]
-    //~| ERROR: cycle detected when computing type of `m::Foo::{opaque#0}` [E0391]
+    //~^ ERROR: cycle detected when computing type of opaque `m::Foo::{opaque#0}` [E0391]
+    //~| ERROR: cycle detected when computing type of opaque `m::Foo::{opaque#0}` [E0391]
 
     pub fn foo() -> Foo {
         22_u32

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage3.stderr
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage3.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when computing type of `m::Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `m::Foo::{opaque#0}`
   --> $DIR/auto-trait-leakage3.rs:7:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
@@ -10,15 +10,15 @@ note: ...which requires type-checking `m::bar`...
 LL |         is_send(foo());
    |         ^^^^^^^
    = note: ...which requires evaluating trait selection obligation `m::Foo: core::marker::Send`...
-   = note: ...which again requires computing type of `m::Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in module `m`
-  --> $DIR/auto-trait-leakage3.rs:6:1
+   = note: ...which again requires computing type of opaque `m::Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `m::Foo::{opaque#0}`
+  --> $DIR/auto-trait-leakage3.rs:7:20
    |
-LL | mod m {
-   | ^^^^^
+LL |     pub type Foo = impl std::fmt::Debug;
+   |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `m::Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `m::Foo::{opaque#0}`
   --> $DIR/auto-trait-leakage3.rs:7:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
@@ -29,12 +29,12 @@ note: ...which requires type-checking `m::bar`...
    |
 LL |     pub fn bar() {
    |     ^^^^^^^^^^^^
-   = note: ...which again requires computing type of `m::Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in module `m`
-  --> $DIR/auto-trait-leakage3.rs:6:1
+   = note: ...which again requires computing type of opaque `m::Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `m::Foo::{opaque#0}`
+  --> $DIR/auto-trait-leakage3.rs:7:20
    |
-LL | mod m {
-   | ^^^^^
+LL |     pub type Foo = impl std::fmt::Debug;
+   |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of `auto_trait_leakage3[211d]::m::Foo::{opaque#0}` satisfies auto traits

--- a/tests/ui/type-alias-impl-trait/inference-cycle.stderr
+++ b/tests/ui/type-alias-impl-trait/inference-cycle.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when computing type of `m::Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `m::Foo::{opaque#0}`
   --> $DIR/inference-cycle.rs:5:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
@@ -10,15 +10,15 @@ note: ...which requires type-checking `m::bar`...
 LL |         is_send(foo()); // Today: error
    |         ^^^^^^^
    = note: ...which requires evaluating trait selection obligation `m::Foo: core::marker::Send`...
-   = note: ...which again requires computing type of `m::Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in module `m`
-  --> $DIR/inference-cycle.rs:4:1
+   = note: ...which again requires computing type of opaque `m::Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `m::Foo::{opaque#0}`
+  --> $DIR/inference-cycle.rs:5:20
    |
-LL | mod m {
-   | ^^^^^
+LL |     pub type Foo = impl std::fmt::Debug;
+   |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `m::Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `m::Foo::{opaque#0}`
   --> $DIR/inference-cycle.rs:5:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
@@ -29,12 +29,12 @@ note: ...which requires type-checking `m::bar`...
    |
 LL |     pub fn bar() {
    |     ^^^^^^^^^^^^
-   = note: ...which again requires computing type of `m::Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in module `m`
-  --> $DIR/inference-cycle.rs:4:1
+   = note: ...which again requires computing type of opaque `m::Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `m::Foo::{opaque#0}`
+  --> $DIR/inference-cycle.rs:5:20
    |
-LL | mod m {
-   | ^^^^^
+LL |     pub type Foo = impl std::fmt::Debug;
+   |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of `inference_cycle[4ecc]::m::Foo::{opaque#0}` satisfies auto traits

--- a/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
@@ -4,6 +4,11 @@ error[E0391]: cycle detected when computing type of `Bug::{opaque#0}`
 LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
    |                  ^^^^^^^^^^^^^^^^^^^^^^
    |
+note: ...which requires computing type of opaque `Bug::{opaque#0}`...
+  --> $DIR/issue-53092-2.rs:4:18
+   |
+LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires type-checking `CONST_BUG`...
   --> $DIR/issue-53092-2.rs:6:1
    |

--- a/tests/ui/type-alias-impl-trait/reveal_local.stderr
+++ b/tests/ui/type-alias-impl-trait/reveal_local.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when computing type of `Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `Foo::{opaque#0}`
   --> $DIR/reveal_local.rs:5:12
    |
 LL | type Foo = impl Debug;
@@ -10,21 +10,15 @@ note: ...which requires type-checking `not_good`...
 LL |     is_send::<Foo>();
    |     ^^^^^^^^^^^^^^
    = note: ...which requires evaluating trait selection obligation `Foo: core::marker::Send`...
-   = note: ...which again requires computing type of `Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/reveal_local.rs:1:1
+   = note: ...which again requires computing type of opaque `Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Foo::{opaque#0}`
+  --> $DIR/reveal_local.rs:5:12
    |
-LL | / #![feature(type_alias_impl_trait)]
-LL | |
-LL | | use std::fmt::Debug;
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | type Foo = impl Debug;
+   |            ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `Foo::{opaque#0}`
   --> $DIR/reveal_local.rs:5:12
    |
 LL | type Foo = impl Debug;
@@ -35,18 +29,12 @@ note: ...which requires type-checking `not_good`...
    |
 LL | fn not_good() {
    | ^^^^^^^^^^^^^
-   = note: ...which again requires computing type of `Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/reveal_local.rs:1:1
+   = note: ...which again requires computing type of opaque `Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Foo::{opaque#0}`
+  --> $DIR/reveal_local.rs:5:12
    |
-LL | / #![feature(type_alias_impl_trait)]
-LL | |
-LL | | use std::fmt::Debug;
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | type Foo = impl Debug;
+   |            ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits
@@ -71,7 +59,7 @@ note: required by a bound in `is_send`
 LL | fn is_send<T: Send>() {}
    |               ^^^^ required by this bound in `is_send`
 
-error[E0391]: cycle detected when computing type of `Foo::{opaque#0}`
+error[E0391]: cycle detected when computing type of opaque `Foo::{opaque#0}`
   --> $DIR/reveal_local.rs:5:12
    |
 LL | type Foo = impl Debug;
@@ -82,18 +70,12 @@ note: ...which requires type-checking `not_gooder`...
    |
 LL | fn not_gooder() -> Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires computing type of `Foo::{opaque#0}`, completing the cycle
-note: cycle used when checking item types in top-level module
-  --> $DIR/reveal_local.rs:1:1
+   = note: ...which again requires computing type of opaque `Foo::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Foo::{opaque#0}`
+  --> $DIR/reveal_local.rs:5:12
    |
-LL | / #![feature(type_alias_impl_trait)]
-LL | |
-LL | | use std::fmt::Debug;
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | type Foo = impl Debug;
+   |            ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits

--- a/tests/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
@@ -5,7 +5,6 @@ LL |     is_send::<T::AssocType>();
    |               ^^^^^^^^^^^^ `<T as Trait>::AssocType` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `<T as Trait>::AssocType`
-   = note: consider using `std::sync::Arc<<T as Trait>::AssocType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-assoc-type.rs:14:14
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-negation-send.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-negation-send.stderr
@@ -5,7 +5,6 @@ LL |     is_send::<MyNotSendable>();
    |               ^^^^^^^^^^^^^ `MyNotSendable` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `MyNotSendable`
-   = note: consider using `std::sync::Arc<MyNotSendable>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-negation-send.rs:15:15
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
@@ -5,7 +5,6 @@ LL |     is_sync::<MyNotSync>();
    |               ^^^^^^^^^ `MyNotSync` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `MyNotSync`
-   = note: consider using `std::sync::Arc<MyNotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_sync`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:15
    |
@@ -19,7 +18,6 @@ LL |     is_sync::<MyTypeWUnsafe>();
    |               ^^^^^^^^^^^^^ `UnsafeCell<u8>` cannot be shared between threads safely
    |
    = help: within `MyTypeWUnsafe`, the trait `Sync` is not implemented for `UnsafeCell<u8>`
-   = note: consider using `std::sync::Arc<UnsafeCell<u8>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `MyTypeWUnsafe`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:21:8
    |
@@ -38,7 +36,6 @@ LL |     is_sync::<MyTypeManaged>();
    |               ^^^^^^^^^^^^^ `Managed` cannot be shared between threads safely
    |
    = help: within `MyTypeManaged`, the trait `Sync` is not implemented for `Managed`
-   = note: consider using `std::sync::Arc<Managed>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `MyTypeManaged`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:25:8
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     is_send::<T>()
    |               ^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-send-param.rs:8:14
    |

--- a/tests/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/tests/ui/typeck/typeck-unsafe-always-share.stderr
@@ -7,7 +7,6 @@ LL |     test(us);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<MySync<{integer}>>`
-   = note: consider using `std::sync::Arc<UnsafeCell<MySync<{integer}>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |
@@ -23,7 +22,6 @@ LL |     test(uns);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<NoSync>`
-   = note: consider using `std::sync::Arc<UnsafeCell<NoSync>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |
@@ -39,7 +37,6 @@ LL |     test(ms);
    |     required by a bound introduced by this call
    |
    = help: within `MySync<NoSync>`, the trait `Sync` is not implemented for `UnsafeCell<NoSync>`
-   = note: consider using `std::sync::Arc<UnsafeCell<NoSync>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `MySync<NoSync>`
   --> $DIR/typeck-unsafe-always-share.rs:8:8
    |
@@ -60,7 +57,6 @@ LL |     test(NoSync);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `NoSync`
-   = note: consider using `std::sync::Arc<NoSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -585,7 +585,7 @@ cc = ["@nnethercote"]
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
-users_on_vacation = ["jyn514", "clubby789", "oli-obk"]
+users_on_vacation = ["jyn514", "clubby789"]
 
 [assign.adhoc_groups]
 compiler-team = [


### PR DESCRIPTION
Successful merges:

 - #115164 (MIR validation: reject in-place argument/return for packed fields)
 - #115240 (codegen_llvm/llvm_type: avoid matching on the Rust type)
 - #115294 (More precisely detect cycle errors from type_of on opaque)
 - #115310 (Document panic behavior across editions, and improve xrefs)
 - #115311 (Revert "Suggest using `Arc` on `!Send`/`!Sync` types")
 - #115317 (Devacationize oli-obk)
 - #115319 (don't use SnapshotVec in Graph implementation, as it looks unused; use Vec instead)
 - #115322 (Tweak output of `to_pretty_impl_header` involving only anon lifetimes)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115164,115240,115294,115310,115311,115317,115319,115322)
<!-- homu-ignore:end -->