### PR TITLE
Ensure `lookup_source_file_idx` has a sorted list of source files to use

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(round_char_boundary)]
 #![feature(read_buf)]
 #![feature(new_uninit)]
+#![feature(is_sorted)]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
 #![allow(internal_features)]


### PR DESCRIPTION
This fixes a race condition where `lookup_source_file_idx` assumes that the list of source files is sorted, but that wasn't ensured with concurrent insertions of source files. This adds a new sorted source file list (`sorted_files`) dedicated for use in `lookup_source_file_idx`.