### PR TITLE
Add `fmease` to rustdoc review rotations

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -626,6 +626,7 @@ rustdoc = [
     "@jsha",
     "@GuillaumeGomez",
     "@notriddle",
+    "@fmease",
 ]
 docs = [
     "@ehuss",


### PR DESCRIPTION
@fmease asked me if it was okay for them to be part of the rustdoc review rotation. Since they are already reviewing a lot of rustdoc PRs, I think it's fine to add them to the rotation.

What do you think @rust-lang/rustdoc ?

r? rust-lang/rustdoc