### PR TITLE
suggest removing `impl` in generic trait bound position

### DIFF
--- a/tests/ui/associated-type-bounds/suggest-removing-impl.rs
+++ b/tests/ui/associated-type-bounds/suggest-removing-impl.rs
@@ -1,0 +1,14 @@
+trait Tr {
+    type Assoc: impl Sized;
+    //~^ ERROR expected a trait, found type
+    //~| HELP use the trait bounds directly
+
+    fn fn_with_generics<T>()
+    where
+        T: impl Sized
+        //~^ ERROR expected a trait, found type
+        //~| HELP use the trait bounds directly
+    {}
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/suggest-removing-impl.stderr
+++ b/tests/ui/associated-type-bounds/suggest-removing-impl.stderr
@@ -1,0 +1,26 @@
+error: expected a trait, found type
+  --> $DIR/suggest-removing-impl.rs:2:17
+   |
+LL |     type Assoc: impl Sized;
+   |                 ^^^^^^^^^^
+   |
+help: use the trait bounds directly
+   |
+LL -     type Assoc: impl Sized;
+LL +     type Assoc: Sized;
+   |
+
+error: expected a trait, found type
+  --> $DIR/suggest-removing-impl.rs:8:12
+   |
+LL |         T: impl Sized
+   |            ^^^^^^^^^^
+   |
+help: use the trait bounds directly
+   |
+LL -         T: impl Sized
+LL +         T: Sized
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
rustc already does this recovery in type param position (`<T: impl Trait>` -> `<T: Trait>`).
This PR also adds that suggestion in trait bound position (e.g. `where T: impl Trait` or `trait Trait { type Assoc: impl Trait; }`)