### PR TITLE
new solver: handle edge case of a recursion limit of 0

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
@@ -53,7 +53,7 @@ impl<'tcx> SearchGraph<'tcx> {
     pub(super) fn new(tcx: TyCtxt<'tcx>, mode: SolverMode) -> SearchGraph<'tcx> {
         Self {
             mode,
-            local_overflow_limit: tcx.recursion_limit().0.ilog2() as usize,
+            local_overflow_limit: tcx.recursion_limit().0.checked_ilog2().unwrap_or(0) as usize,
             stack: Default::default(),
             provisional_cache: ProvisionalCache::empty(),
         }

--- a/tests/ui/traits/new-solver/overflow/recursion-limit-zero-issue-115351.rs
+++ b/tests/ui/traits/new-solver/overflow/recursion-limit-zero-issue-115351.rs
@@ -1,0 +1,12 @@
+//~ ERROR overflow evaluating the requirement `Self well-formed`
+//~| ERROR overflow evaluating the requirement `Self: Trait`
+
+// This is a non-regression test for issue #115351, where a recursion limit of 0 caused an ICE.
+// compile-flags: -Ztrait-solver=next --crate-type=lib
+// check-fail
+
+#![recursion_limit = "0"]
+trait Trait {}
+impl Trait for u32 {}
+//~^ ERROR overflow evaluating the requirement `u32: Trait`
+//~| ERROR overflow evaluating the requirement `u32 well-formed`

--- a/tests/ui/traits/new-solver/overflow/recursion-limit-zero-issue-115351.stderr
+++ b/tests/ui/traits/new-solver/overflow/recursion-limit-zero-issue-115351.stderr
@@ -1,0 +1,27 @@
+error[E0275]: overflow evaluating the requirement `Self: Trait`
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "2"]` attribute to your crate (`recursion_limit_zero_issue_115351`)
+
+error[E0275]: overflow evaluating the requirement `Self well-formed`
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "2"]` attribute to your crate (`recursion_limit_zero_issue_115351`)
+
+error[E0275]: overflow evaluating the requirement `u32: Trait`
+  --> $DIR/recursion-limit-zero-issue-115351.rs:10:16
+   |
+LL | impl Trait for u32 {}
+   |                ^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "2"]` attribute to your crate (`recursion_limit_zero_issue_115351`)
+
+error[E0275]: overflow evaluating the requirement `u32 well-formed`
+  --> $DIR/recursion-limit-zero-issue-115351.rs:10:16
+   |
+LL | impl Trait for u32 {}
+   |                ^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "2"]` attribute to your crate (`recursion_limit_zero_issue_115351`)
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Apparently a recursion limit of 0 is possible/valid/useful/used/cute, the more you know 🌟 .

(It's somewhat interesting to me that the old solver seemingly handles this, and that the new solver currently requires a recursion limit of 2 here)

r? @compiler-errors.

Fixes #115351.