### PR TITLE
Capture lifetimes for associated type bounds destined to be lowered to opaques

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1109,6 +1109,7 @@ impl<'a: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast,
                 }
             },
             AssocConstraintKind::Bound { ref bounds } => {
+                self.record_lifetime_params_for_impl_trait(constraint.id);
                 walk_list!(self, visit_param_bound, bounds, BoundKind::Bound);
             }
         }

--- a/tests/ui/impl-trait/in-trait/lifetime-in-associated-trait-bound.rs
+++ b/tests/ui/impl-trait/in-trait/lifetime-in-associated-trait-bound.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![feature(associated_type_bounds, return_position_impl_trait_in_trait)]
+
+trait Trait {
+    type Type;
+
+    fn method(&self) -> impl Trait<Type: '_>;
+}
+
+impl Trait for () {
+    type Type = ();
+
+    fn method(&self) -> impl Trait<Type: '_> {
+        ()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Some associated type bounds get lowered to opaques, but they're not represented in the AST as opaques.

That means that we never collect lifetimes for them (`record_lifetime_params_for_impl_trait`) which are used currently for RPITITs, which capture all of their in-scope lifetimes[^1]. This means that the nested RPITITs that arise from some type like `impl Foo<Type: Bar>` (~> `impl Foo<Type = impl Bar>`) don't capture any lifetimes, leading to ICEs.

This PR makes sure we collect the lifetimes for associated type bounds as well, and make sure that they are set up correctly for opaque type lowering later.

Fixes #115360

[^1]: #114489