### PR TITLE
Make if let guard parsing consistent with normal guards

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2477,9 +2477,7 @@ impl<'a> Parser<'a> {
         } else {
             self.expect(&token::Eq)?;
         }
-        let expr = self.with_res(self.restrictions | Restrictions::NO_STRUCT_LITERAL, |this| {
-            this.parse_expr_assoc_with(1 + prec_let_scrutinee_needs_par(), None.into())
-        })?;
+        let expr = self.parse_expr_assoc_with(1 + prec_let_scrutinee_needs_par(), None.into())?;
         let span = lo.to(expr.span);
         self.sess.gated_spans.gate(sym::let_chains, span);
         Ok(self.mk_expr(span, ExprKind::Let(pat, expr, span)))

--- a/tests/ui/parser/struct-literal-in-if.rs
+++ b/tests/ui/parser/struct-literal-in-if.rs
@@ -14,4 +14,9 @@ fn main() {
     }.hi() {
         println!("yo");
     }
+    if let true = Foo { //~ ERROR struct literals are not allowed here
+        x: 3
+    }.hi() {
+        println!("yo");
+    }
 }

--- a/tests/ui/parser/struct-literal-in-if.stderr
+++ b/tests/ui/parser/struct-literal-in-if.stderr
@@ -14,5 +14,21 @@ LL |         x: 3
 LL ~     }).hi() {
    |
 
-error: aborting due to previous error
+error: struct literals are not allowed here
+  --> $DIR/struct-literal-in-if.rs:17:19
+   |
+LL |       if let true = Foo {
+   |  ___________________^
+LL | |         x: 3
+LL | |     }.hi() {
+   | |_____^
+   |
+help: surround the struct literal with parentheses
+   |
+LL ~     if let true = (Foo {
+LL |         x: 3
+LL ~     }).hi() {
+   |
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/struct-literal-in-match-guard.rs
+++ b/tests/ui/parser/struct-literal-in-match-guard.rs
@@ -3,6 +3,8 @@
 // Unlike `if` condition, `match` guards accept struct literals.
 // This is detected in <https://github.com/rust-lang/rust/pull/74566#issuecomment-663613705>.
 
+#![feature(if_let_guard)]
+
 #[derive(PartialEq)]
 struct Foo {
     x: isize,
@@ -11,6 +13,7 @@ struct Foo {
 fn foo(f: Foo) {
     match () {
         () if f == Foo { x: 42 } => {}
+        () if let Foo { x: 0.. } = Foo { x: 42 } => {}
         _ => {}
     }
 }

--- a/tests/ui/parser/struct-literal-in-while.rs
+++ b/tests/ui/parser/struct-literal-in-while.rs
@@ -14,4 +14,9 @@ fn main() {
     }.hi() {
         println!("yo");
     }
+    while let true = Foo { //~ ERROR struct literals are not allowed here
+        x: 3
+    }.hi() {
+        println!("yo");
+    }
 }

--- a/tests/ui/parser/struct-literal-in-while.stderr
+++ b/tests/ui/parser/struct-literal-in-while.stderr
@@ -14,5 +14,21 @@ LL |         x: 3
 LL ~     }).hi() {
    |
 
-error: aborting due to previous error
+error: struct literals are not allowed here
+  --> $DIR/struct-literal-in-while.rs:17:22
+   |
+LL |       while let true = Foo {
+   |  ______________________^
+LL | |         x: 3
+LL | |     }.hi() {
+   | |_____^
+   |
+help: surround the struct literal with parentheses
+   |
+LL ~     while let true = (Foo {
+LL |         x: 3
+LL ~     }).hi() {
+   |
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
- Add tests that struct expressions are not allowed in `if let` and `while let` (no change, consistent with `if` and `while`)
- Allow struct expressions in `if let` guards (consistent with `if` guards).

r? @cjgillot 

Closes #93817
cc #51114