### PR TITLE
Fix bors missing a commit when merging #115355

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
@@ -51,13 +51,9 @@ pub(super) struct SearchGraph<'tcx> {
 
 impl<'tcx> SearchGraph<'tcx> {
     pub(super) fn new(tcx: TyCtxt<'tcx>, mode: SolverMode) -> SearchGraph<'tcx> {
-        let local_overflow_limit = {
-            let recursion_limit = tcx.recursion_limit().0;
-            if recursion_limit == 0 { 0 } else { recursion_limit.ilog2() as usize }
-        };
         Self {
             mode,
-            local_overflow_limit,
+            local_overflow_limit: tcx.recursion_limit().0.checked_ilog2().unwrap_or(0) as usize,
             stack: Default::default(),
             provisional_cache: ProvisionalCache::empty(),
         }


### PR DESCRIPTION
bors incorrectly merged an outdated version of PR #115355 (via rollup #115370): 
- it [recorded r+](https://github.com/rust-lang/rust/pull/115355#issuecomment-1698372365) as approving commit https://github.com/rust-lang/rust/commit/325b585259871c99093b2a2e9463f941b8aa0ceb, and thus merged the original revision https://github.com/rust-lang/rust/commit/7762ac7bb5ac10046a5a9ee838480a78bf150237
- but the branch at the time was at commit https://github.com/rust-lang/rust/commit/eefa07d69baad3207ad520da8590fb44ef989416, so bors missed the `compiler/rustc_trait_selection/src/solve/search_graph/mod.rs` cleanup in commit https://github.com/rust-lang/rust/pull/115355/commits/0e1e964a349681504e7103d4ec70aca5616222fc 😓 

Thankfully the change that bors missed was small, and this new PR corrects the situation (as I'd rather avoid having confusing multiple merge commits of PR #115355 in the git history)

r? @compiler-errors 
