### PR TITLE
Make `termcolor` types public in `rustc_errors`

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -55,7 +55,7 @@ use std::num::NonZeroUsize;
 use std::panic;
 use std::path::{Path, PathBuf};
 
-use termcolor::{Color, ColorSpec};
+pub use termcolor::{Color, ColorSpec, WriteColor};
 
 pub mod annotate_snippet_emitter_writer;
 mod diagnostic;


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/114104, `rust-gpu` is unable to create a custom `Emitter` as the bounds have changed to include `WriteColor`.

I was able to work around this by adding `termcolor` as a direct dependency, but I believe this should be exposed as part of `rustc_errors` proper.

See https://github.com/rust-lang/rust/pull/102992 for why `rust-gpu` needs to create a custom emitter.