### PR TITLE
Add support to return value in StableMIR interface and not crash due to compilation error

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -1456,6 +1456,6 @@ impl<'tcx> Stable<'tcx> for rustc_span::Span {
 
 impl From<ErrorGuaranteed> for CompilerError {
     fn from(_error: ErrorGuaranteed) -> Self {
-        CompilerError
+        CompilerError::CompilationFailed
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -1454,7 +1454,7 @@ impl<'tcx> Stable<'tcx> for rustc_span::Span {
     }
 }
 
-impl From<ErrorGuaranteed> for CompilerError {
+impl<T> From<ErrorGuaranteed> for CompilerError<T> {
     fn from(_error: ErrorGuaranteed) -> Self {
         CompilerError::CompilationFailed
     }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -10,12 +10,13 @@
 use crate::rustc_internal::{self, opaque};
 use crate::stable_mir::mir::{CopyNonOverlapping, UserTypeProjection, VariantIdx};
 use crate::stable_mir::ty::{FloatTy, GenericParamDef, IntTy, Movability, RigidTy, TyKind, UintTy};
-use crate::stable_mir::{self, Context};
+use crate::stable_mir::{self, CompilerError, Context};
 use rustc_hir as hir;
 use rustc_middle::mir::interpret::{alloc_range, AllocId};
 use rustc_middle::mir::{self, ConstantKind};
 use rustc_middle::ty::{self, Ty, TyCtxt, Variance};
 use rustc_span::def_id::{CrateNum, DefId, LOCAL_CRATE};
+use rustc_span::ErrorGuaranteed;
 use rustc_target::abi::FieldIdx;
 use tracing::debug;
 
@@ -1450,5 +1451,11 @@ impl<'tcx> Stable<'tcx> for rustc_span::Span {
     fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
         // FIXME: add a real implementation of stable spans
         opaque(self)
+    }
+}
+
+impl From<ErrorGuaranteed> for CompilerError {
+    fn from(_error: ErrorGuaranteed) -> Self {
+        CompilerError
     }
 }

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -56,6 +56,10 @@ pub type TraitDecls = Vec<TraitDef>;
 /// A list of impl trait decls.
 pub type ImplTraitDecls = Vec<ImplDef>;
 
+/// An error type used to represent an error that has already been reported by the compiler.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CompilerError;
+
 /// Holds information about a crate.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Crate {

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -58,7 +58,12 @@ pub type ImplTraitDecls = Vec<ImplDef>;
 
 /// An error type used to represent an error that has already been reported by the compiler.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct CompilerError;
+pub enum CompilerError {
+    /// Internal compiler error (I.e.: Compiler crashed).
+    ICE,
+    /// Compilation failed.
+    CompilationFailed,
+}
 
 /// Holds information about a crate.
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -58,11 +58,16 @@ pub type ImplTraitDecls = Vec<ImplDef>;
 
 /// An error type used to represent an error that has already been reported by the compiler.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CompilerError {
+pub enum CompilerError<T> {
     /// Internal compiler error (I.e.: Compiler crashed).
     ICE,
     /// Compilation failed.
     CompilationFailed,
+    /// Compilation was interrupted.
+    Interrupted(T),
+    /// Compilation skipped. This happens when users invoke rustc to retrieve information such as
+    /// --version.
+    Skipped,
 }
 
 /// Holds information about a crate.

--- a/tests/ui-fulldeps/stable-mir/compilation-result.rs
+++ b/tests/ui-fulldeps/stable-mir/compilation-result.rs
@@ -1,0 +1,77 @@
+// run-pass
+// Test StableMIR behavior when different results are given
+
+// ignore-stage1
+// ignore-cross-compile
+// ignore-remote
+// edition: 2021
+
+#![feature(rustc_private)]
+#![feature(assert_matches)]
+
+extern crate rustc_middle;
+extern crate rustc_smir;
+
+use rustc_middle::ty::TyCtxt;
+use rustc_smir::{rustc_internal, stable_mir};
+use std::io::Write;
+use std::ops::ControlFlow;
+
+/// This test will generate and analyze a dummy crate using the stable mir.
+/// For that, it will first write the dummy crate into a file.
+/// Then it will create a `StableMir` using custom arguments and then
+/// it will run the compiler.
+fn main() {
+    let path = "input_compilation_result_test.rs";
+    generate_input(&path).unwrap();
+    let args = vec!["rustc".to_string(), path.to_string()];
+    test_continue(args.clone());
+    test_break(args.clone());
+    test_failed(args.clone());
+    test_skipped(args);
+}
+
+fn test_continue(args: Vec<String>) {
+    let continue_fn = |_: TyCtxt| ControlFlow::Continue::<(), bool>(true);
+    let result = rustc_internal::StableMir::new(args, continue_fn).run();
+    assert_eq!(result, Ok(true));
+}
+
+fn test_break(args: Vec<String>) {
+    let continue_fn = |_: TyCtxt| ControlFlow::Break::<bool, i32>(false);
+    let result = rustc_internal::StableMir::new(args, continue_fn).run();
+    assert_eq!(result, Err(stable_mir::CompilerError::Interrupted(false)));
+}
+
+fn test_skipped(mut args: Vec<String>) {
+    args.push("--version".to_string());
+    let unreach_fn = |_: TyCtxt| -> ControlFlow<()> { unreachable!() };
+    let result = rustc_internal::StableMir::new(args, unreach_fn).run();
+    assert_eq!(result, Err(stable_mir::CompilerError::Skipped));
+}
+
+fn test_failed(mut args: Vec<String>) {
+    args.push("--cfg=broken".to_string());
+    let unreach_fn = |_: TyCtxt| -> ControlFlow<()> { unreachable!() };
+    let result = rustc_internal::StableMir::new(args, unreach_fn).run();
+    assert_eq!(result, Err(stable_mir::CompilerError::CompilationFailed));
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write!(
+        file,
+        r#"
+    // This should trigger a compilation failure when enabled.
+    #[cfg(broken)]
+    mod broken_mod {{
+        fn call_invalid() {{
+            invalid_fn();
+        }}
+    }}
+
+    fn main() {{}}
+    "#
+    )?;
+    Ok(())
+}

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -18,11 +18,12 @@ use rustc_middle::ty::TyCtxt;
 use rustc_smir::{rustc_internal, stable_mir};
 use std::assert_matches::assert_matches;
 use std::io::Write;
+use std::ops::ControlFlow;
 
 const CRATE_NAME: &str = "input";
 
 /// This function uses the Stable MIR APIs to get information about the test crate.
-fn test_stable_mir(tcx: TyCtxt<'_>) {
+fn test_stable_mir(tcx: TyCtxt<'_>) -> ControlFlow<()> {
     // Get the local crate using stable_mir API.
     let local = stable_mir::local_crate();
     assert_eq!(&local.name, CRATE_NAME);
@@ -108,6 +109,8 @@ fn test_stable_mir(tcx: TyCtxt<'_>) {
         stable_mir::mir::Terminator::Assert { .. } => {}
         other => panic!("{other:?}"),
     }
+
+    ControlFlow::Continue(())
 }
 
 // Use internal API to find a function in a crate.

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -136,7 +136,7 @@ fn main() {
         CRATE_NAME.to_string(),
         path.to_string(),
     ];
-    rustc_internal::StableMir::new(args, test_stable_mir).run();
+    rustc_internal::StableMir::new(args, test_stable_mir).run().unwrap();
 }
 
 fn generate_input(path: &str) -> std::io::Result<()> {


### PR DESCRIPTION
Invoking `StableMir::run()` on a crate that has any compilation error was crashing the entire process. Instead, return a `CompilerError` so the user knows compilation did not succeed. I believe ICE will also be converted to `CompilerError`.

I'm also adding a possibility for the callback to return a value. I think it will be handy for users (at least it was for my current task of implementing a tool to validate stable-mir). However, if people disagree, I can remove that.