### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -55,7 +55,7 @@ use std::num::NonZeroUsize;
 use std::panic;
 use std::path::{Path, PathBuf};
 
-use termcolor::{Color, ColorSpec};
+pub use termcolor::{Color, ColorSpec, WriteColor};
 
 pub mod annotate_snippet_emitter_writer;
 mod diagnostic;

--- a/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/search_graph/mod.rs
@@ -51,13 +51,9 @@ pub(super) struct SearchGraph<'tcx> {
 
 impl<'tcx> SearchGraph<'tcx> {
     pub(super) fn new(tcx: TyCtxt<'tcx>, mode: SolverMode) -> SearchGraph<'tcx> {
-        let local_overflow_limit = {
-            let recursion_limit = tcx.recursion_limit().0;
-            if recursion_limit == 0 { 0 } else { recursion_limit.ilog2() as usize }
-        };
         Self {
             mode,
-            local_overflow_limit,
+            local_overflow_limit: tcx.recursion_limit().0.checked_ilog2().unwrap_or(0) as usize,
             stack: Default::default(),
             provisional_cache: ProvisionalCache::empty(),
         }

--- a/tests/run-make/pgo-branch-weights/Makefile
+++ b/tests/run-make/pgo-branch-weights/Makefile
@@ -1,5 +1,6 @@
 # needs-profiler-support
 # ignore-windows-gnu
+# ignore-cross-compile
 
 # FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
 # properly. Since we only have GCC on the CI ignore the test for now.

--- a/tests/run-make/pgo-gen-lto/Makefile
+++ b/tests/run-make/pgo-gen-lto/Makefile
@@ -1,5 +1,6 @@
 # needs-profiler-support
 # ignore-windows-gnu
+# ignore-cross-compile
 
 # FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
 # properly. Since we only have GCC on the CI ignore the test for now.

--- a/tests/run-make/pgo-gen/Makefile
+++ b/tests/run-make/pgo-gen/Makefile
@@ -1,5 +1,6 @@
 # needs-profiler-support
 # ignore-windows-gnu
+# ignore-cross-compile
 
 # FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
 # properly. Since we only have GCC on the CI ignore the test for now.

--- a/tests/run-make/pgo-indirect-call-promotion/Makefile
+++ b/tests/run-make/pgo-indirect-call-promotion/Makefile
@@ -1,5 +1,6 @@
 # needs-profiler-support
 # ignore-windows-gnu
+# ignore-cross-compile
 
 # FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
 # properly. Since we only have GCC on the CI ignore the test for now.

--- a/tests/run-make/pgo-use/Makefile
+++ b/tests/run-make/pgo-use/Makefile
@@ -1,5 +1,6 @@
 # needs-profiler-support
 # ignore-windows-gnu
+# ignore-cross-compile
 
 # FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
 # properly. Since we only have GCC on the CI ignore the test for now.

--- a/tests/run-make/pointer-auth-link-with-c/Makefile
+++ b/tests/run-make/pointer-auth-link-with-c/Makefile
@@ -1,6 +1,7 @@
 include ../tools.mk
 
 # only-aarch64
+# ignore-cross-compile
 
 all:
 	$(COMPILE_OBJ) $(TMPDIR)/test.o test.c

--- a/tests/run-make/profile/Makefile
+++ b/tests/run-make/profile/Makefile
@@ -1,4 +1,5 @@
 # needs-profiler-support
+# ignore-cross-compile
 
 include ../tools.mk
 


### PR DESCRIPTION
Successful merges:

 - #115373 (Fix bors missing a commit when merging #115355)
 - #115378 (`ignore-cross-compile` remaining tests that run binaries)
 - #115393 (Make `termcolor` types public in `rustc_errors`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115373,115378,115393)
<!-- homu-ignore:end -->