### PR TITLE
Expose tests for {f32,f64}.total_cmp in docs

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1424,9 +1424,17 @@ impl f32 {
     /// ];
     ///
     /// bois.sort_by(|a, b| a.weight.total_cmp(&b.weight));
-    /// # assert!(bois.into_iter().map(|b| b.weight)
-    /// #     .zip([-5.0, 0.1, 10.0, 99.0, f32::INFINITY, f32::NAN].iter())
-    /// #     .all(|(a, b)| a.to_bits() == b.to_bits()))
+    ///
+    /// // `f32::NAN` could be positive or negative, which will affect the sort order.
+    /// if f32::NAN.is_sign_negative() {
+    ///     assert!(bois.into_iter().map(|b| b.weight)
+    ///         .zip([f32::NAN, -5.0, 0.1, 10.0, 99.0, f32::INFINITY].iter())
+    ///         .all(|(a, b)| a.to_bits() == b.to_bits()))
+    /// } else {
+    ///     assert!(bois.into_iter().map(|b| b.weight)
+    ///         .zip([-5.0, 0.1, 10.0, 99.0, f32::INFINITY, f32::NAN].iter())
+    ///         .all(|(a, b)| a.to_bits() == b.to_bits()))
+    /// }
     /// ```
     #[stable(feature = "total_cmp", since = "1.62.0")]
     #[must_use]

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1422,9 +1422,17 @@ impl f64 {
     /// ];
     ///
     /// bois.sort_by(|a, b| a.weight.total_cmp(&b.weight));
-    /// # assert!(bois.into_iter().map(|b| b.weight)
-    /// #     .zip([-5.0, 0.1, 10.0, 99.0, f64::INFINITY, f64::NAN].iter())
-    /// #     .all(|(a, b)| a.to_bits() == b.to_bits()))
+    ///
+    /// // `f64::NAN` could be positive or negative, which will affect the sort order.
+    /// if f64::NAN.is_sign_negative() {
+    ///     assert!(bois.into_iter().map(|b| b.weight)
+    ///         .zip([f64::NAN, -5.0, 0.1, 10.0, 99.0, f64::INFINITY].iter())
+    ///         .all(|(a, b)| a.to_bits() == b.to_bits()))
+    /// } else {
+    ///     assert!(bois.into_iter().map(|b| b.weight)
+    ///         .zip([-5.0, 0.1, 10.0, 99.0, f64::INFINITY, f64::NAN].iter())
+    ///         .all(|(a, b)| a.to_bits() == b.to_bits()))
+    /// }
     /// ```
     #[stable(feature = "total_cmp", since = "1.62.0")]
     #[must_use]


### PR DESCRIPTION
Expose tests for {f32,f64}.total_cmp in docs
    
Uncomment the helpful `assert_eq!` line, which is stripped out completely in docs, and leaves the reader to mentally play through the algorithm, or go to the playground and add a println!, to see what the result will be.
    
(If these tests are known to fail on some platforms, is there some mechanism to conditionalize this or escape the test so the `assert_eq!` source will be visible on the web? I am a newbie, which is why I was reading docs ;)