### PR TITLE
Improve error output when encountering git conflict markers

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2705,13 +2705,13 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    pub fn is_diff_marker(&mut self, long_kind: &TokenKind, short_kind: &TokenKind) -> bool {
+    pub fn is_conflict_marker(&mut self, long_kind: &TokenKind, short_kind: &TokenKind) -> bool {
         (0..3).all(|i| self.look_ahead(i, |tok| tok == long_kind))
             && self.look_ahead(3, |tok| tok == short_kind)
     }
 
-    fn diff_marker(&mut self, long_kind: &TokenKind, short_kind: &TokenKind) -> Option<Span> {
-        if self.is_diff_marker(long_kind, short_kind) {
+    fn conflict_marker(&mut self, long_kind: &TokenKind, short_kind: &TokenKind) -> Option<Span> {
+        if self.is_conflict_marker(long_kind, short_kind) {
             let lo = self.token.span;
             for _ in 0..4 {
                 self.bump();
@@ -2721,8 +2721,8 @@ impl<'a> Parser<'a> {
         None
     }
 
-    pub fn recover_diff_marker(&mut self) {
-        let Some(start) = self.diff_marker(&TokenKind::BinOp(token::Shl), &TokenKind::Lt) else {
+    pub fn recover_conflict_marker(&mut self) {
+        let Some(start) = self.conflict_marker(&TokenKind::BinOp(token::Shl), &TokenKind::Lt) else {
             return;
         };
         let mut spans = Vec::with_capacity(3);
@@ -2734,13 +2734,13 @@ impl<'a> Parser<'a> {
             if self.token.kind == TokenKind::Eof {
                 break;
             }
-            if let Some(span) = self.diff_marker(&TokenKind::OrOr, &TokenKind::BinOp(token::Or)) {
+            if let Some(span) = self.conflict_marker(&TokenKind::OrOr, &TokenKind::BinOp(token::Or)) {
                 middlediff3 = Some(span);
             }
-            if let Some(span) = self.diff_marker(&TokenKind::EqEq, &TokenKind::Eq) {
+            if let Some(span) = self.conflict_marker(&TokenKind::EqEq, &TokenKind::Eq) {
                 middle = Some(span);
             }
-            if let Some(span) = self.diff_marker(&TokenKind::BinOp(token::Shr), &TokenKind::Gt) {
+            if let Some(span) = self.conflict_marker(&TokenKind::BinOp(token::Shr), &TokenKind::Gt) {
                 spans.push(span);
                 end = Some(span);
                 break;

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3276,7 +3276,7 @@ impl<'a> Parser<'a> {
     /// Parses `ident (COLON expr)?`.
     fn parse_expr_field(&mut self) -> PResult<'a, ExprField> {
         let attrs = self.parse_outer_attributes()?;
-        self.recover_diff_marker();
+        self.recover_conflict_marker();
         self.collect_tokens_trailing_token(attrs, ForceCollect::No, |this, attrs| {
             let lo = this.token.span;
 

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -552,8 +552,8 @@ impl<'a> Parser<'a> {
             if self.token == token::Eof {
                 break;
             }
-            if self.is_diff_marker(&TokenKind::BinOp(token::Shl), &TokenKind::Lt) {
-                // Account for `<<<<<<<` diff markers. We can't proactively error here because
+            if self.is_conflict_marker(&TokenKind::BinOp(token::Shl), &TokenKind::Lt) {
+                // Account for `<<<<<<<` conflict markers. We can't proactively error here because
                 // that can be a valid path start, so we snapshot and reparse only we've
                 // encountered another parse error.
                 snapshot = Some(self.create_snapshot_for_diagnostic());
@@ -561,7 +561,7 @@ impl<'a> Parser<'a> {
             let stmt = match self.parse_full_stmt(recover) {
                 Err(mut err) if recover.yes() => {
                     if let Some(ref mut snapshot) = snapshot {
-                        snapshot.recover_diff_marker();
+                        snapshot.recover_conflict_marker();
                     }
                     if self.token == token::Colon {
                         // if next token is following a colon, it's likely a path

--- a/tests/ui/parser/diff-markers/enum-2.rs
+++ b/tests/ui/parser/diff-markers/enum-2.rs
@@ -1,6 +1,6 @@
 enum E {
     Foo {
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
         x: u8,
 |||||||
         z: (),

--- a/tests/ui/parser/diff-markers/enum-2.stderr
+++ b/tests/ui/parser/diff-markers/enum-2.stderr
@@ -1,21 +1,21 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/enum-2.rs:3:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `|||||||` is the code that we're merging into
 LL |         x: u8,
 LL | |||||||
-   | -------
+   | ------- between this marker and `=======` is the base code (what the two refs diverged from)
 LL |         z: (),
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL |         y: i8,
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/enum.rs
+++ b/tests/ui/parser/diff-markers/enum.rs
@@ -1,5 +1,5 @@
 enum E {
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
     Foo(u8),
 =======
     Bar(i8),

--- a/tests/ui/parser/diff-markers/enum.stderr
+++ b/tests/ui/parser/diff-markers/enum.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/enum.rs:2:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL |     Foo(u8),
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL |     Bar(i8),
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/fn-arg.rs
+++ b/tests/ui/parser/diff-markers/fn-arg.rs
@@ -1,6 +1,6 @@
 trait T {
     fn foo(
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
         x: u8,
 =======
         x: i8,

--- a/tests/ui/parser/diff-markers/fn-arg.stderr
+++ b/tests/ui/parser/diff-markers/fn-arg.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/fn-arg.rs:3:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL |         x: u8,
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL |         x: i8,
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/item-with-attr.rs
+++ b/tests/ui/parser/diff-markers/item-with-attr.rs
@@ -1,5 +1,5 @@
 #[attribute]
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
 fn foo() {}
 =======
 fn bar() {}

--- a/tests/ui/parser/diff-markers/item-with-attr.stderr
+++ b/tests/ui/parser/diff-markers/item-with-attr.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/item-with-attr.rs:2:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL | fn foo() {}
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL | fn bar() {}
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/item.rs
+++ b/tests/ui/parser/diff-markers/item.rs
@@ -1,4 +1,4 @@
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
 fn foo() {}
 =======
 fn bar() {}

--- a/tests/ui/parser/diff-markers/item.stderr
+++ b/tests/ui/parser/diff-markers/item.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/item.rs:1:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL | fn foo() {}
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL | fn bar() {}
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/statement.rs
+++ b/tests/ui/parser/diff-markers/statement.rs
@@ -7,7 +7,7 @@ struct S;
 impl T for S {}
 
 fn main() {
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
     S::foo();
 =======
     S::bar();

--- a/tests/ui/parser/diff-markers/statement.stderr
+++ b/tests/ui/parser/diff-markers/statement.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/statement.rs:10:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL |     S::foo();
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL |     S::bar();
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/struct-expr.rs
+++ b/tests/ui/parser/diff-markers/struct-expr.rs
@@ -3,7 +3,7 @@ struct S {
 }
 fn main() {
     let _ = S {
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
         x: 42,
 =======
         x: 0,

--- a/tests/ui/parser/diff-markers/struct-expr.stderr
+++ b/tests/ui/parser/diff-markers/struct-expr.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/struct-expr.rs:6:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL |         x: 42,
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL |         x: 0,
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/struct.rs
+++ b/tests/ui/parser/diff-markers/struct.rs
@@ -1,5 +1,5 @@
 struct S {
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
     x: u8,
 =======
     x: i8,

--- a/tests/ui/parser/diff-markers/struct.stderr
+++ b/tests/ui/parser/diff-markers/struct.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/struct.rs:2:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL |     x: u8,
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL |     x: i8,
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/trait-item.rs
+++ b/tests/ui/parser/diff-markers/trait-item.rs
@@ -1,5 +1,5 @@
 trait T {
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
     fn foo() {}
 =======
     fn bar() {}

--- a/tests/ui/parser/diff-markers/trait-item.stderr
+++ b/tests/ui/parser/diff-markers/trait-item.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/trait-item.rs:2:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL |     fn foo() {}
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL |     fn bar() {}
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/tuple-struct.rs
+++ b/tests/ui/parser/diff-markers/tuple-struct.rs
@@ -1,5 +1,5 @@
 struct S(
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
     u8,
 =======
     i8,

--- a/tests/ui/parser/diff-markers/tuple-struct.stderr
+++ b/tests/ui/parser/diff-markers/tuple-struct.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/tuple-struct.rs:2:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL |     u8,
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL |     i8,
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/diff-markers/use-statement.rs
+++ b/tests/ui/parser/diff-markers/use-statement.rs
@@ -1,5 +1,5 @@
 use foo::{
-<<<<<<< HEAD //~ ERROR encountered diff marker
+<<<<<<< HEAD //~ ERROR encountered git conflict marker
     bar,
 =======
     baz,

--- a/tests/ui/parser/diff-markers/use-statement.stderr
+++ b/tests/ui/parser/diff-markers/use-statement.stderr
@@ -1,18 +1,18 @@
-error: encountered diff marker
+error: encountered git conflict marker
   --> $DIR/use-statement.rs:2:1
    |
 LL | <<<<<<< HEAD
-   | ^^^^^^^ after this is the code before the merge
+   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
 LL |     bar,
 LL | =======
-   | -------
+   | ------- between this marker and `>>>>>>>` is the incoming code
 LL |     baz,
 LL | >>>>>>> branch
-   | ^^^^^^^ above this are the incoming code changes
+   | ^^^^^^^
    |
-   = help: if you're having merge conflicts after pulling new code, the top section is the code you already had and the bottom section is the remote code
-   = help: if you're in the middle of a rebase, the top section is the code being rebased onto and the bottom section is the code coming from the current commit being rebased
-   = note: for an explanation on these markers from the `git` documentation, visit <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
+   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
+   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
+   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Applied suggestions in #113826 with minor modifications.

The current output is as follows:
```
error: encountered git conflict marker
  --> $DIR/enum-2.rs:3:1
   |
LL | <<<<<<< HEAD
   | ^^^^^^^ between this marker and `|||||||` is the code that we're merging into
LL |         x: u8,
LL | |||||||
   | ------- between this marker and `=======` is the base code (what the two refs diverged from)
LL |         z: (),
LL | =======
   | ------- between this marker and `>>>>>>>` is the incoming code
LL |         y: i8,
LL | >>>>>>> branch
   | ^^^^^^^
   |
   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>

error: aborting due to previous error
```

w/o diff3
```
error: encountered git conflict marker
  --> $DIR/enum.rs:2:1
   |
LL | <<<<<<< HEAD
   | ^^^^^^^ between this marker and `=======` is the code that we're merging into
LL |     Foo(u8),
LL | =======
   | ------- between this marker and `>>>>>>>` is the incoming code
LL |     Bar(i8),
LL | >>>>>>> branch
   | ^^^^^^^
   |
   = help: conflict markers indicate that a merge was started but could not be completed due to merge conflicts
   = help: to resolve a conflict, keep only the code you want and then delete the lines containing conflict markers
   = note: for more information, visit the `git` documentation <https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts>

error: aborting due to previous error
```

r? @estebank 