### PR TITLE
Improve #[repr(align(...))] syntax error message

### DIFF
--- a/compiler/rustc_attr/messages.ftl
+++ b/compiler/rustc_attr/messages.ftl
@@ -25,7 +25,7 @@ attr_incorrect_meta_item =
     incorrect meta item
 
 attr_incorrect_repr_format_align_one_arg =
-    incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
+    incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses, namely the number of desired alignment bytes
 
 attr_incorrect_repr_format_generic =
     incorrect `repr({$repr_arg})` attribute format


### PR DESCRIPTION
Today, if you write `#[repr(align(u32))]` (instead of the correct `#[repr(align(4))]`), the result is a confusing error message about how you needed to give `align` one argument in parentheses - which was already done!

This PR changes that error message to explain that what goes in the parentheses should be the number of desired alignment bytes.