### PR TITLE
Remove duplicate bounds check in MemDecoder::read_array

### DIFF
--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -354,7 +354,8 @@ impl<'a> MemDecoder<'a> {
 
     #[inline]
     pub fn read_array<const N: usize>(&mut self) -> [u8; N] {
-        self.read_raw_bytes(N).try_into().unwrap()
+        // SAFETY: read_raw_bytes(N) returns a slice with length N.
+        unsafe { self.read_raw_bytes(N).try_into().unwrap_unchecked() }
     }
 
     /// While we could manually expose manipulation of the decoder position,


### PR DESCRIPTION
This removes a duplicative bounds check I'm seeing in local builds; it looks like LLVM fails to remove the panic path for `.try_into().unwrap()`.

r? @ghost