### PR TITLE
kmc-solid: Fix `is_interrupted`

### DIFF
--- a/library/std/src/sys/solid/error.rs
+++ b/library/std/src/sys/solid/error.rs
@@ -31,11 +31,6 @@ pub fn error_name(er: abi::ER) -> Option<&'static str> {
     }
 }
 
-#[inline]
-fn is_interrupted(er: abi::ER) -> bool {
-    false
-}
-
 pub fn decode_error_kind(er: abi::ER) -> ErrorKind {
     match er {
         // Success

--- a/library/std/src/sys/solid/mod.rs
+++ b/library/std/src/sys/solid/mod.rs
@@ -74,7 +74,7 @@ pub fn unsupported_err() -> crate::io::Error {
 
 #[inline]
 pub fn is_interrupted(code: i32) -> bool {
-    error::is_interrupted(code)
+    net::is_interrupted(code)
 }
 
 pub fn decode_error_kind(code: i32) -> crate::io::ErrorKind {

--- a/library/std/src/sys/solid/net.rs
+++ b/library/std/src/sys/solid/net.rs
@@ -183,8 +183,7 @@ pub(super) fn error_name(er: abi::ER) -> Option<&'static str> {
 
 #[inline]
 pub fn is_interrupted(er: abi::ER) -> bool {
-    let errno = netc::SOLID_NET_ERR_BASE - er;
-    errno as libc::c_int == libc::EINTR
+    er == netc::SOLID_NET_ERR_BASE - libc::EINTR
 }
 
 pub(super) fn decode_error_kind(er: abi::ER) -> ErrorKind {


### PR DESCRIPTION
Follow-up to #115228. Fixes a build error in [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html) Tier 3 targets.

```
error[E0603]: function `is_interrupted` is private
  --> library\std\src\sys\solid\mod.rs:77:12
   |
77 |     error::is_interrupted(code)
   |            ^^^^^^^^^^^^^^ private function
   |
note: the function `is_interrupted` is defined here
  --> library\std\src\sys\solid\error.rs:35:1
   |
35 | fn is_interrupted(er: abi::ER) -> bool {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```