### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -405,7 +405,11 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
 
         // Vectors, even for non-power-of-two sizes, have the same layout as
         // arrays but don't count as aggregate types
+        // While LLVM theoretically supports non-power-of-two sizes, and they
+        // often work fine, sometimes x86-isel deals with them horribly
+        // (see #115212) so for now only use power-of-two ones.
         if let FieldsShape::Array { count, .. } = self.layout.fields()
+            && count.is_power_of_two()
             && let element = self.field(cx, 0)
             && element.ty.is_integral()
         {

--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -435,9 +435,23 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             bx.store(place.llval, alloca.llval, alloca.align);
 
             // Point the debug info to `*alloca` for the current variable
-            bx.dbg_var_addr(dbg_var, dbg_loc, alloca.llval, Size::ZERO, &[Size::ZERO], None);
+            bx.dbg_var_addr(
+                dbg_var,
+                dbg_loc,
+                alloca.llval,
+                Size::ZERO,
+                &[Size::ZERO],
+                var.fragment,
+            );
         } else {
-            bx.dbg_var_addr(dbg_var, dbg_loc, base.llval, direct_offset, &indirect_offsets, None);
+            bx.dbg_var_addr(
+                dbg_var,
+                dbg_loc,
+                base.llval,
+                direct_offset,
+                &indirect_offsets,
+                var.fragment,
+            );
         }
     }
 

--- a/compiler/rustc_passes/src/reachable.rs
+++ b/compiler/rustc_passes/src/reachable.rs
@@ -98,15 +98,11 @@ impl<'tcx> Visitor<'tcx> for ReachableContext<'tcx> {
                 self.worklist.push(def_id);
             } else {
                 match res {
-                    // If this path leads to a constant, then we need to
-                    // recurse into the constant to continue finding
-                    // items that are reachable.
-                    Res::Def(DefKind::Const | DefKind::AssocConst, _) => {
+                    // Reachable constants and reachable statics can have their contents inlined
+                    // into other crates. Mark them as reachable and recurse into their body.
+                    Res::Def(DefKind::Const | DefKind::AssocConst | DefKind::Static(_), _) => {
                         self.worklist.push(def_id);
                     }
-
-                    // If this wasn't a static, then the destination is
-                    // surely reachable.
                     _ => {
                         self.reachable_symbols.insert(def_id);
                     }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2743,12 +2743,6 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             }
             ObligationCauseCode::BindingObligation(item_def_id, span)
             | ObligationCauseCode::ExprBindingObligation(item_def_id, span, ..) => {
-                if self.tcx.is_diagnostic_item(sym::Send, item_def_id)
-                    || self.tcx.lang_items().sync_trait() == Some(item_def_id)
-                {
-                    return;
-                }
-
                 let item_name = tcx.def_path_str(item_def_id);
                 let short_item_name = with_forced_trimmed_paths!(tcx.def_path_str(item_def_id));
                 let mut multispan = MultiSpan::from(span);

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -76,11 +76,8 @@ macro marker_impls {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Send")]
 #[rustc_on_unimplemented(
-    on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
     message = "`{Self}` cannot be sent between threads safely",
-    label = "`{Self}` cannot be sent between threads safely",
-    note = "consider using `std::sync::Arc<{Self}>`; for more information visit \
-            <https://doc.rust-lang.org/book/ch16-03-shared-state.html>"
+    label = "`{Self}` cannot be sent between threads safely"
 )]
 pub unsafe auto trait Send {
     // empty.
@@ -631,11 +628,8 @@ impl<T: ?Sized> Copy for &T {}
         any(_Self = "core::cell::RefCell<T>", _Self = "std::cell::RefCell<T>"),
         note = "if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead",
     ),
-    on(_Self = "std::rc::Rc<T, A>", note = "use `std::sync::Arc` instead of `std::rc::Rc`"),
     message = "`{Self}` cannot be shared between threads safely",
-    label = "`{Self}` cannot be shared between threads safely",
-    note = "consider using `std::sync::Arc<{Self}>`; for more information visit \
-            <https://doc.rust-lang.org/book/ch16-03-shared-state.html>"
+    label = "`{Self}` cannot be shared between threads safely"
 )]
 pub unsafe auto trait Sync {
     // FIXME(estebank): once support to add notes in `rustc_on_unimplemented`

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1430,20 +1430,15 @@ impl LinkCollector<'_, '_> {
         // Otherwise, check if 2 links are same, if so, skip the resolve process.
         //
         // Notice that this algorithm is passive, might possibly miss actual redudant cases.
-        let explicit_link = &explicit_link.to_string();
+        let explicit_link = explicit_link.to_string();
         let display_text = ori_link.display_text.as_ref().unwrap();
-        let display_len = display_text.len();
-        let explicit_len = explicit_link.len();
 
-        if display_len == explicit_len {
+        if display_text.len() == explicit_link.len() {
             // Whether they are same or not, skip the resolve process.
             return;
         }
 
-        if (explicit_len >= display_len
-            && &explicit_link[(explicit_len - display_len)..] == display_text)
-            || (display_len >= explicit_len
-                && &display_text[(display_len - explicit_len)..] == explicit_link)
+        if explicit_link.ends_with(&display_text[..]) || display_text.ends_with(&explicit_link[..])
         {
             self.resolve_with_disambiguator_cached(
                 display_res_info,

--- a/src/librustdoc/passes/lint/redundant_explicit_links.rs
+++ b/src/librustdoc/passes/lint/redundant_explicit_links.rs
@@ -98,13 +98,8 @@ fn check_redundant_explicit_link<'md>(
 
                 let explicit_link = dest.to_string();
                 let display_link = link_data.resolvable_link.clone()?;
-                let explicit_len = explicit_link.len();
-                let display_len = display_link.len();
 
-                if (explicit_len >= display_len
-                    && &explicit_link[(explicit_len - display_len)..] == display_link)
-                    || (display_len >= explicit_len
-                        && &display_link[(display_len - explicit_len)..] == explicit_link)
+                if explicit_link.ends_with(&display_link) || display_link.ends_with(&explicit_link)
                 {
                     match link_type {
                         LinkType::Inline | LinkType::ReferenceUnknown => {

--- a/tests/codegen/mem-replace-simple-type.rs
+++ b/tests/codegen/mem-replace-simple-type.rs
@@ -33,12 +33,21 @@ pub fn replace_ref_str<'a>(r: &mut &'a str, v: &'a str) -> &'a str {
 }
 
 #[no_mangle]
-// CHECK-LABEL: @replace_short_array(
-pub fn replace_short_array(r: &mut [u32; 3], v: [u32; 3]) -> [u32; 3] {
+// CHECK-LABEL: @replace_short_array_3(
+pub fn replace_short_array_3(r: &mut [u32; 3], v: [u32; 3]) -> [u32; 3] {
     // CHECK-NOT: alloca
-    // CHECK: %[[R:.+]] = load <3 x i32>, ptr %r, align 4
-    // CHECK: store <3 x i32> %[[R]], ptr %result
-    // CHECK: %[[V:.+]] = load <3 x i32>, ptr %v, align 4
-    // CHECK: store <3 x i32> %[[V]], ptr %r
+    // CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 4 %result, ptr align 4 %r, i64 12, i1 false)
+    // CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 4 %r, ptr align 4 %v, i64 12, i1 false)
+    std::mem::replace(r, v)
+}
+
+#[no_mangle]
+// CHECK-LABEL: @replace_short_array_4(
+pub fn replace_short_array_4(r: &mut [u32; 4], v: [u32; 4]) -> [u32; 4] {
+    // CHECK-NOT: alloca
+    // CHECK: %[[R:.+]] = load <4 x i32>, ptr %r, align 4
+    // CHECK: store <4 x i32> %[[R]], ptr %result
+    // CHECK: %[[V:.+]] = load <4 x i32>, ptr %v, align 4
+    // CHECK: store <4 x i32> %[[V]], ptr %r
     std::mem::replace(r, v)
 }

--- a/tests/codegen/sroa-fragment-debuginfo.rs
+++ b/tests/codegen/sroa-fragment-debuginfo.rs
@@ -3,25 +3,43 @@
 
 #![crate_type = "lib"]
 
-pub struct Endian;
-
-#[allow(dead_code)]
-pub struct EndianSlice<'input> {
+pub struct ExtraSlice<'input> {
     slice: &'input [u8],
-    endian: Endian,
+    extra: u32,
 }
 
 #[no_mangle]
-pub fn test(s: &[u8]) {
-// CHECK: void @test(
-// CHECK: %slice.dbg.spill1 = alloca { ptr, i64 },
-// CHECK: %slice.dbg.spill = alloca %Endian,
+pub fn extra(s: &[u8]) {
+// CHECK: void @extra(
+// CHECK: %slice.dbg.spill1 = alloca i32,
+// CHECK: %slice.dbg.spill = alloca { ptr, i64 },
 // CHECK: %s.dbg.spill = alloca { ptr, i64 },
-// CHECK: call void @llvm.dbg.declare(metadata ptr %s.dbg.spill, metadata ![[S:.*]], metadata !DIExpression()),
-// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill, metadata ![[SLICE:.*]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 0)),
-// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill1, metadata ![[SLICE]], metadata !DIExpression()),
-    let slice = EndianSlice { slice: s, endian: Endian };
+// CHECK: call void @llvm.dbg.declare(metadata ptr %s.dbg.spill, metadata ![[S_EXTRA:.*]], metadata !DIExpression()),
+// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill, metadata ![[SLICE_EXTRA:.*]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 128)),
+// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill1, metadata ![[SLICE_EXTRA]], metadata !DIExpression(DW_OP_LLVM_fragment, 128, 32)),
+    let slice = ExtraSlice { slice: s, extra: s.len() as u32 };
 }
 
-// CHECK: ![[S]] = !DILocalVariable(name: "s",
-// CHECK: ![[SLICE]] = !DILocalVariable(name: "slice",
+struct Zst;
+
+pub struct ZstSlice<'input> {
+    slice: &'input [u8],
+    extra: Zst,
+}
+
+#[no_mangle]
+pub fn zst(s: &[u8]) {
+// CHECK: void @zst(
+// CHECK: %slice.dbg.spill1 = alloca { ptr, i64 },
+// CHECK: %slice.dbg.spill = alloca %Zst,
+// CHECK: %s.dbg.spill = alloca { ptr, i64 },
+// CHECK: call void @llvm.dbg.declare(metadata ptr %s.dbg.spill, metadata ![[S_ZST:.*]], metadata !DIExpression()),
+// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill, metadata ![[SLICE_ZST:.*]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 0)),
+// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill1, metadata ![[SLICE_ZST]], metadata !DIExpression()),
+    let slice = ZstSlice { slice: s, extra: Zst };
+}
+
+// CHECK: ![[S_EXTRA]] = !DILocalVariable(name: "s",
+// CHECK: ![[SLICE_EXTRA]] = !DILocalVariable(name: "slice",
+// CHECK: ![[S_ZST]] = !DILocalVariable(name: "s",
+// CHECK: ![[SLICE_ZST]] = !DILocalVariable(name: "slice",

--- a/tests/codegen/sroa-fragment-debuginfo.rs
+++ b/tests/codegen/sroa-fragment-debuginfo.rs
@@ -1,5 +1,8 @@
 // compile-flags: -g -Zmir-opt-level=0 -Zmir-enable-passes=+ScalarReplacementOfAggregates
 // compile-flags: -Cno-prepopulate-passes
+//
+// Tested offsets are only correct for x86_64.
+// only-x86_64
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/sroa-fragment-debuginfo.rs
+++ b/tests/codegen/sroa-fragment-debuginfo.rs
@@ -1,0 +1,27 @@
+// compile-flags: -g -Zmir-opt-level=0 -Zmir-enable-passes=+ScalarReplacementOfAggregates
+// compile-flags: -Cno-prepopulate-passes
+
+#![crate_type = "lib"]
+
+pub struct Endian;
+
+#[allow(dead_code)]
+pub struct EndianSlice<'input> {
+    slice: &'input [u8],
+    endian: Endian,
+}
+
+#[no_mangle]
+pub fn test(s: &[u8]) {
+// CHECK: void @test(
+// CHECK: %slice.dbg.spill1 = alloca { ptr, i64 },
+// CHECK: %slice.dbg.spill = alloca %Endian,
+// CHECK: %s.dbg.spill = alloca { ptr, i64 },
+// CHECK: call void @llvm.dbg.declare(metadata ptr %s.dbg.spill, metadata ![[S:.*]], metadata !DIExpression()),
+// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill, metadata ![[SLICE:.*]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 0)),
+// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill1, metadata ![[SLICE]], metadata !DIExpression()),
+    let slice = EndianSlice { slice: s, endian: Endian };
+}
+
+// CHECK: ![[S]] = !DILocalVariable(name: "s",
+// CHECK: ![[SLICE]] = !DILocalVariable(name: "slice",

--- a/tests/codegen/sroa-fragment-debuginfo.rs
+++ b/tests/codegen/sroa-fragment-debuginfo.rs
@@ -29,17 +29,15 @@ pub struct ZstSlice<'input> {
 
 #[no_mangle]
 pub fn zst(s: &[u8]) {
+    // The field `extra` is a ZST. The fragment for the field `slice` encompasses the whole
+    // variable, so is not a fragment. In that case, the variable must have no fragment.
+
 // CHECK: void @zst(
-// CHECK: %slice.dbg.spill1 = alloca { ptr, i64 },
-// CHECK: %slice.dbg.spill = alloca %Zst,
-// CHECK: %s.dbg.spill = alloca { ptr, i64 },
-// CHECK: call void @llvm.dbg.declare(metadata ptr %s.dbg.spill, metadata ![[S_ZST:.*]], metadata !DIExpression()),
-// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill, metadata ![[SLICE_ZST:.*]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 0)),
-// CHECK: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill1, metadata ![[SLICE_ZST]], metadata !DIExpression()),
+// CHECK-NOT: call void @llvm.dbg.declare(metadata ptr %slice.dbg.spill, metadata !{}, metadata !DIExpression(DW_OP_LLVM_fragment,
+// CHECK: call void @llvm.dbg.declare(metadata ptr %{{.*}}, metadata ![[SLICE_ZST:.*]], metadata !DIExpression()),
+// CHECK-NOT: call void @llvm.dbg.declare(metadata ptr %{{.*}}, metadata ![[SLICE_ZST]],
     let slice = ZstSlice { slice: s, extra: Zst };
 }
 
 // CHECK: ![[S_EXTRA]] = !DILocalVariable(name: "s",
 // CHECK: ![[SLICE_EXTRA]] = !DILocalVariable(name: "slice",
-// CHECK: ![[S_ZST]] = !DILocalVariable(name: "s",
-// CHECK: ![[SLICE_ZST]] = !DILocalVariable(name: "slice",

--- a/tests/codegen/swap-small-types.rs
+++ b/tests/codegen/swap-small-types.rs
@@ -11,11 +11,12 @@ type RGB48 = [u16; 3];
 // CHECK-LABEL: @swap_rgb48_manually(
 #[no_mangle]
 pub fn swap_rgb48_manually(x: &mut RGB48, y: &mut RGB48) {
-    // CHECK-NOT: alloca
-    // CHECK: %[[TEMP0:.+]] = load <3 x i16>, ptr %x, align 2
-    // CHECK: %[[TEMP1:.+]] = load <3 x i16>, ptr %y, align 2
-    // CHECK: store <3 x i16> %[[TEMP1]], ptr %x, align 2
-    // CHECK: store <3 x i16> %[[TEMP0]], ptr %y, align 2
+    // FIXME: See #115212 for why this has an alloca again
+
+    // CHECK: alloca [3 x i16], align 2
+    // CHECK: call void @llvm.memcpy.p0.p0.i64({{.+}}, i64 6, i1 false)
+    // CHECK: call void @llvm.memcpy.p0.p0.i64({{.+}}, i64 6, i1 false)
+    // CHECK: call void @llvm.memcpy.p0.p0.i64({{.+}}, i64 6, i1 false)
 
     let temp = *x;
     *x = *y;
@@ -25,11 +26,25 @@ pub fn swap_rgb48_manually(x: &mut RGB48, y: &mut RGB48) {
 // CHECK-LABEL: @swap_rgb48
 #[no_mangle]
 pub fn swap_rgb48(x: &mut RGB48, y: &mut RGB48) {
+    // FIXME: See #115212 for why this has an alloca again
+
+    // CHECK: alloca [3 x i16], align 2
+    // CHECK: call void @llvm.memcpy.p0.p0.i64({{.+}}, i64 6, i1 false)
+    // CHECK: call void @llvm.memcpy.p0.p0.i64({{.+}}, i64 6, i1 false)
+    // CHECK: call void @llvm.memcpy.p0.p0.i64({{.+}}, i64 6, i1 false)
+    swap(x, y)
+}
+
+type RGBA64 = [u16; 4];
+
+// CHECK-LABEL: @swap_rgba64
+#[no_mangle]
+pub fn swap_rgba64(x: &mut RGBA64, y: &mut RGBA64) {
     // CHECK-NOT: alloca
-    // CHECK: load <3 x i16>
-    // CHECK: load <3 x i16>
-    // CHECK: store <3 x i16>
-    // CHECK: store <3 x i16>
+    // CHECK-DAG: %[[XVAL:.+]] = load <4 x i16>, ptr %x, align 2
+    // CHECK-DAG: %[[YVAL:.+]] = load <4 x i16>, ptr %y, align 2
+    // CHECK-DAG: store <4 x i16> %[[YVAL]], ptr %x, align 2
+    // CHECK-DAG: store <4 x i16> %[[XVAL]], ptr %y, align 2
     swap(x, y)
 }
 

--- a/tests/rustdoc-ui/lints/redundant_explicit_links-utf8.rs
+++ b/tests/rustdoc-ui/lints/redundant_explicit_links-utf8.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+/// [`…foo`] [`…bar`] [`Err`]
+pub struct Broken {}
+
+/// [`…`] [`…`] [`Err`]
+pub struct Broken2 {}
+
+/// [`…`][…] [`…`][…] [`Err`]
+pub struct Broken3 {}
+
+/// […………………………][Broken3]
+pub struct Broken4 {}
+
+/// [Broken3][…………………………]
+pub struct Broken5 {}
+
+pub struct Err;

--- a/tests/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/tests/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -5,7 +5,6 @@ LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8
    |                                    ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
-   = note: consider using `std::sync::Arc<<<Self as Case1>::C as Iterator>::Item>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Send {
@@ -30,7 +29,6 @@ LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8
    |                                                                                             ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
-   = note: consider using `std::sync::Arc<<<Self as Case1>::C as Iterator>::Item>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Sync {

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
@@ -14,7 +14,6 @@ LL |     is_send(foo::<T>());
    |             ^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>>`
-   = note: consider using `std::sync::Arc<impl Future<Output = Result<(), ()>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/basic.rs:13:5
    |

--- a/tests/ui/async-await/async-await-let-else.drop_tracking.stderr
+++ b/tests/ui/async-await/async-await-let-else.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     is_send(foo(Some(true)));
    |             ^^^^^^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:11:15
    |
@@ -33,7 +32,6 @@ LL |     is_send(foo2(Some(true)));
    |     required by a bound introduced by this call
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this `async fn` body
   --> $DIR/async-await-let-else.rs:27:29
    |
@@ -66,7 +64,6 @@ LL |     is_send(foo3(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo3` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:33:29
    |
@@ -88,7 +85,6 @@ LL |     is_send(foo4(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo4` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:41:15
    |

--- a/tests/ui/async-await/async-await-let-else.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/async-await-let-else.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     is_send(foo(Some(true)));
    |             ^^^^^^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:11:15
    |
@@ -31,7 +30,6 @@ LL |     is_send(foo2(Some(true)));
    |     required by a bound introduced by this call
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this `async fn` body
   --> $DIR/async-await-let-else.rs:27:29
    |
@@ -64,7 +62,6 @@ LL |     is_send(foo3(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo3` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:33:29
    |
@@ -85,7 +82,6 @@ LL |     is_send(foo4(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo4` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:41:15
    |

--- a/tests/ui/async-await/async-await-let-else.no_drop_tracking.stderr
+++ b/tests/ui/async-await/async-await-let-else.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     is_send(foo(Some(true)));
    |             ^^^^^^^^^^^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:11:15
    |
@@ -28,7 +27,6 @@ LL |     is_send(foo2(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo2` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:23:27
    |
@@ -51,7 +49,6 @@ LL |     is_send(foo3(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo3` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:33:29
    |
@@ -73,7 +70,6 @@ LL |     is_send(foo4(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo4` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:41:15
    |

--- a/tests/ui/async-await/async-fn-nonsend.drop_tracking.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(non_send_temporary_in_match());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:36:26
    |
@@ -29,7 +28,6 @@ LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:49:15
    |

--- a/tests/ui/async-await/async-fn-nonsend.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(non_send_temporary_in_match());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:36:26
    |
@@ -26,7 +25,6 @@ LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:49:15
    |

--- a/tests/ui/async-await/async-fn-nonsend.no_drop_tracking.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(local_dropped_before_await());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `local_dropped_before_await` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:27:11
    |
@@ -29,7 +28,6 @@ LL |     assert_send(non_send_temporary_in_match());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:36:26
    |
@@ -53,7 +51,6 @@ LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:49:15
    |
@@ -78,7 +75,6 @@ LL |     assert_send(non_sync_with_method_call_panic());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call_panic` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:56:15
    |
@@ -103,7 +99,6 @@ LL |     assert_send(non_sync_with_method_call_infinite_loop());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call_infinite_loop` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
-   = note: consider using `std::sync::Arc<dyn std::fmt::Write>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:63:15
    |

--- a/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking.stderr
+++ b/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/drop-track-field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/drop-track-field-assign-nonsend.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/drop-track-field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/drop-track-field-assign-nonsend.no_drop_tracking.stderr
+++ b/tests/ui/async-await/drop-track-field-assign-nonsend.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/drop-track-field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/field-assign-nonsend.drop_tracking.stderr
+++ b/tests/ui/async-await/field-assign-nonsend.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/field-assign-nonsend.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/field-assign-nonsend.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/field-assign-nonsend.no_drop_tracking.stderr
+++ b/tests/ui/async-await/field-assign-nonsend.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: future is not `Send` as this value is used across an await
   --> $DIR/field-assign-nonsend.rs:23:39
    |

--- a/tests/ui/async-await/in-trait/missing-send-bound.stderr
+++ b/tests/ui/async-await/in-trait/missing-send-bound.stderr
@@ -5,7 +5,6 @@ LL |     assert_is_send(test::<T>());
    |                    ^^^^^^^^^^^ future returned by `test` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `impl Future<Output = ()>`
-   = note: consider using `std::sync::Arc<impl Future<Output = ()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/missing-send-bound.rs:10:5
    |

--- a/tests/ui/async-await/issue-64130-1-sync.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
    = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:18:11
    |

--- a/tests/ui/async-await/issue-64130-1-sync.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
    = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:18:11
    |

--- a/tests/ui/async-await/issue-64130-1-sync.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
    = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:18:11
    |

--- a/tests/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-64130-4-async-move.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL | pub fn foo() -> impl Future + Send {
    |                 ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `(dyn Any + Send + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Any + Send + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-4-async-move.rs:27:23
    |

--- a/tests/ui/async-await/issue-64130-non-send-future-diags.stderr
+++ b/tests/ui/async-await/issue-64130-non-send-future-diags.stderr
@@ -5,7 +5,6 @@ LL |     is_send(foo());
    |             ^^^^^ future returned by `foo` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, u32>`
-   = note: consider using `std::sync::Arc<MutexGuard<'_, u32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-non-send-future-diags.rs:17:11
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking.stderr
@@ -10,7 +10,6 @@ LL | |     });
    | |_____^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-67252-unnamed-future.rs:21:11: 25:6]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:23:17
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     spawn(async {
    |     ^^^^^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-67252-unnamed-future.rs:21:11: 25:6]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:23:17
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.no_drop_tracking.stderr
@@ -10,7 +10,6 @@ LL | |     });
    | |_____^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-67252-unnamed-future.rs:21:11: 25:6]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:23:17
    |

--- a/tests/ui/async-await/issue-70818.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70818.drop_tracking.stderr
@@ -4,7 +4,6 @@ error: future cannot be sent between threads safely
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<U>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send`
   --> $DIR/issue-70818.rs:9:18
    |

--- a/tests/ui/async-await/issue-70818.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-70818.drop_tracking_mir.stderr
@@ -4,7 +4,6 @@ error: future cannot be sent between threads safely
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<U>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send`
   --> $DIR/issue-70818.rs:9:18
    |

--- a/tests/ui/async-await/issue-70818.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70818.no_drop_tracking.stderr
@@ -4,7 +4,6 @@ error: future cannot be sent between threads safely
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<U>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send`
   --> $DIR/issue-70818.rs:9:18
    |

--- a/tests/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.drop_tracking.stderr
@@ -5,7 +5,6 @@ LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`

--- a/tests/ui/async-await/issue-70935-complex-spans.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`

--- a/tests/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.no_drop_tracking.stderr
@@ -5,7 +5,6 @@ LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-70935-complex-spans.rs:24:12
    |

--- a/tests/ui/async-await/issue-71137.stderr
+++ b/tests/ui/async-await/issue-71137.stderr
@@ -5,7 +5,6 @@ LL |   fake_spawn(wrong_mutex());
    |              ^^^^^^^^^^^^^ future returned by `wrong_mutex` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, i32>`
-   = note: consider using `std::sync::Arc<MutexGuard<'_, i32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-71137.rs:14:26
    |

--- a/tests/ui/async-await/issue-86507.drop_tracking.stderr
+++ b/tests/ui/async-await/issue-86507.drop_tracking.stderr
@@ -8,7 +8,6 @@ LL | |                 }
 LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/issue-86507.rs:22:29
    |

--- a/tests/ui/async-await/issue-86507.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/issue-86507.drop_tracking_mir.stderr
@@ -8,7 +8,6 @@ LL | |                 }
 LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/issue-86507.rs:22:29
    |

--- a/tests/ui/async-await/issue-86507.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issue-86507.no_drop_tracking.stderr
@@ -8,7 +8,6 @@ LL | |                 }
 LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/issue-86507.rs:22:29
    |

--- a/tests/ui/async-await/issues/issue-65436-raw-ptr-not-send.no_drop_tracking.stderr
+++ b/tests/ui/async-await/issues/issue-65436-raw-ptr-not-send.no_drop_tracking.stderr
@@ -9,7 +9,6 @@ LL | |     })
    | |_____^ future created by async block is not `Send`
    |
    = help: within `[async block@$DIR/issue-65436-raw-ptr-not-send.rs:17:17: 20:6]`, the trait `Send` is not implemented for `*const u8`
-   = note: consider using `std::sync::Arc<*const u8>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-65436-raw-ptr-not-send.rs:19:36
    |

--- a/tests/ui/async-await/issues/issue-67893.stderr
+++ b/tests/ui/async-await/issues/issue-67893.stderr
@@ -5,7 +5,6 @@ LL |     g(issue_67893::run())
    |       ^^^^^^^^^^^^^^^^^^ future is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, ()>`
-   = note: consider using `std::sync::Arc<MutexGuard<'_, ()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/auxiliary/issue_67893.rs:12:27
    |

--- a/tests/ui/async-await/partial-drop-partial-reinit.drop_tracking.stderr
+++ b/tests/ui/async-await/partial-drop-partial-reinit.drop_tracking.stderr
@@ -10,11 +10,10 @@ LL | async fn foo() {
    |                - within this `impl Future<Output = ()>`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(NotSend,)`
    = note: required because it captures the following types: `ResumeTy`, `(NotSend,)`, `()`, `impl Future<Output = ()>`
 note: required because it's used within this `async fn` body
-  --> $DIR/partial-drop-partial-reinit.rs:32:16
+  --> $DIR/partial-drop-partial-reinit.rs:31:16
    |
 LL |   async fn foo() {
    |  ________________^
@@ -26,7 +25,7 @@ LL | |     bar().await;
 LL | | }
    | |_^
 note: required by a bound in `gimme_send`
-  --> $DIR/partial-drop-partial-reinit.rs:18:18
+  --> $DIR/partial-drop-partial-reinit.rs:17:18
    |
 LL | fn gimme_send<T: Send>(t: T) {
    |                  ^^^^ required by this bound in `gimme_send`

--- a/tests/ui/async-await/partial-drop-partial-reinit.no_drop_tracking.stderr
+++ b/tests/ui/async-await/partial-drop-partial-reinit.no_drop_tracking.stderr
@@ -10,11 +10,10 @@ LL | async fn foo() {
    |                - within this `impl Future<Output = ()>`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(NotSend,)`
    = note: required because it captures the following types: `ResumeTy`, `(NotSend,)`, `impl Future<Output = ()>`, `()`
 note: required because it's used within this `async fn` body
-  --> $DIR/partial-drop-partial-reinit.rs:32:16
+  --> $DIR/partial-drop-partial-reinit.rs:31:16
    |
 LL |   async fn foo() {
    |  ________________^
@@ -26,7 +25,7 @@ LL | |     bar().await;
 LL | | }
    | |_^
 note: required by a bound in `gimme_send`
-  --> $DIR/partial-drop-partial-reinit.rs:18:18
+  --> $DIR/partial-drop-partial-reinit.rs:17:18
    |
 LL | fn gimme_send<T: Send>(t: T) {
    |                  ^^^^ required by this bound in `gimme_send`

--- a/tests/ui/async-await/partial-drop-partial-reinit.rs
+++ b/tests/ui/async-await/partial-drop-partial-reinit.rs
@@ -12,7 +12,6 @@ fn main() {
     //~| NOTE bound introduced by
     //~| NOTE appears within the type
     //~| NOTE captures the following types
-    //~| NOTE consider using `std::sync::Arc<NotSend>`
 }
 
 fn gimme_send<T: Send>(t: T) {

--- a/tests/ui/auto-traits/issue-83857-ub.stderr
+++ b/tests/ui/auto-traits/issue-83857-ub.stderr
@@ -5,7 +5,6 @@ LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo<T, U>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Foo<T, U>`
-   = note: consider using `std::sync::Arc<Foo<T, U>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `Foo<T, U>` to implement `WithAssoc`
   --> $DIR/issue-83857-ub.rs:15:15
    |

--- a/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T: Sync+'static> Foo for (T,) { }
    |                                ^^^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(T,)`
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-double-superkind.rs:4:13
@@ -22,7 +21,6 @@ error[E0277]: `T` cannot be shared between threads safely
 LL | impl <T: Send> Foo for (T,T) { }
    |                        ^^^^^ `T` cannot be shared between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `(T, T)`
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-double-superkind.rs:4:18

--- a/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
    |                                                        ^^^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `X<T>`
   --> $DIR/builtin-superkinds-in-metadata.rs:9:8
    |

--- a/tests/ui/builtin-superkinds/builtin-superkinds-simple.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-simple.stderr
@@ -5,7 +5,6 @@ LL | impl Foo for std::rc::Rc<i8> { }
    |              ^^^^^^^^^^^^^^^ `Rc<i8>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Rc<i8>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-simple.rs:4:13
    |

--- a/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T: Sync+'static> Foo for T { }
    |                                ^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Foo`
   --> $DIR/builtin-superkinds-typaram-not-send.rs:3:13
    |

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -4,7 +4,6 @@ error[E0277]: `F` cannot be sent between threads safely
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
    |                      ^^^^ `F` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<F>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `X`
   --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:1:43
    |

--- a/tests/ui/closures/closure-bounds-subtype.stderr
+++ b/tests/ui/closures/closure-bounds-subtype.stderr
@@ -6,7 +6,6 @@ LL |     take_const_owned(f);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<F>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `take_const_owned`
   --> $DIR/closure-bounds-subtype.rs:4:50
    |

--- a/tests/ui/closures/closure-move-sync.stderr
+++ b/tests/ui/closures/closure-move-sync.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
-   = note: consider using `std::sync::Arc<std::sync::mpsc::Receiver<()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&std::sync::mpsc::Receiver<()>` to implement `Send`
 note: required because it's used within this closure
   --> $DIR/closure-move-sync.rs:6:27

--- a/tests/ui/cross-crate/auxiliary/static_init_aux.rs
+++ b/tests/ui/cross-crate/auxiliary/static_init_aux.rs
@@ -1,10 +1,14 @@
 pub static V: &u32 = &X;
 pub static F: fn() = f;
+pub static G: fn() = G0;
 
 static X: u32 = 42;
+static G0: fn() = g;
 
 pub fn v() -> *const u32 {
     V
 }
 
 fn f() {}
+
+fn g() {}

--- a/tests/ui/cross-crate/static-init.rs
+++ b/tests/ui/cross-crate/static-init.rs
@@ -1,9 +1,11 @@
+// Regression test for #84455 and #115052.
 // run-pass
 // aux-build:static_init_aux.rs
 extern crate static_init_aux as aux;
 
 static V: &u32 = aux::V;
 static F: fn() = aux::F;
+static G: fn() = aux::G;
 
 fn v() -> *const u32 {
     V
@@ -12,4 +14,5 @@ fn v() -> *const u32 {
 fn main() {
     assert_eq!(aux::v(), crate::v());
     F();
+    G();
 }

--- a/tests/ui/debuginfo/sroa-fragment-debuginfo.rs
+++ b/tests/ui/debuginfo/sroa-fragment-debuginfo.rs
@@ -1,0 +1,31 @@
+// Verify that we do not trigger a LLVM assertion by creating zero-sized DWARF fragments.
+//
+// build-pass
+// compile-flags: -g -Zmir-opt-level=0 -Zmir-enable-passes=+ScalarReplacementOfAggregates
+// compile-flags: -Cno-prepopulate-passes
+
+#![crate_type = "lib"]
+
+pub struct ExtraSlice<'input> {
+    slice: &'input [u8],
+    extra: u32,
+}
+
+#[no_mangle]
+pub fn extra(s: &[u8]) {
+    let slice = ExtraSlice { slice: s, extra: s.len() as u32 };
+}
+
+struct Zst;
+
+pub struct ZstSlice<'input> {
+    slice: &'input [u8],
+    extra: Zst,
+}
+
+#[no_mangle]
+pub fn zst(s: &[u8]) {
+    // The field `extra` is a ZST. The fragment for the field `slice` encompasses the whole
+    // variable, so is not a fragment. In that case, the variable must have no fragment.
+    let slice = ZstSlice { slice: s, extra: Zst };
+}

--- a/tests/ui/error-codes/E0277-2.stderr
+++ b/tests/ui/error-codes/E0277-2.stderr
@@ -5,7 +5,6 @@ LL |     is_send::<Foo>();
    |               ^^^ `*const u8` cannot be sent between threads safely
    |
    = help: within `Foo`, the trait `Send` is not implemented for `*const u8`
-   = note: consider using `std::sync::Arc<*const u8>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Baz`
   --> $DIR/E0277-2.rs:9:8
    |

--- a/tests/ui/extern/extern-type-diag-not-similar.stderr
+++ b/tests/ui/extern/extern-type-diag-not-similar.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<Foo>()
    |                   ^^^ `Foo` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/extern-type-diag-not-similar.rs:17:19
    |

--- a/tests/ui/extern/extern-types-not-sync-send.stderr
+++ b/tests/ui/extern/extern-types-not-sync-send.stderr
@@ -5,7 +5,6 @@ LL |     assert_sync::<A>();
    |                   ^ `A` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `A`
-   = note: consider using `std::sync::Arc<A>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_sync`
   --> $DIR/extern-types-not-sync-send.rs:9:28
    |
@@ -19,7 +18,6 @@ LL |     assert_send::<A>();
    |                   ^ `A` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `A`
-   = note: consider using `std::sync::Arc<A>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/extern-types-not-sync-send.rs:10:28
    |

--- a/tests/ui/fmt/send-sync.stderr
+++ b/tests/ui/fmt/send-sync.stderr
@@ -7,7 +7,6 @@ LL |     send(format_args!("{:?}", c));
    |     required by a bound introduced by this call
    |
    = help: within `[core::fmt::rt::Argument<'_>]`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
-   = note: consider using `std::sync::Arc<core::fmt::rt::Opaque>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
 note: required because it appears within the type `Argument<'_>`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
@@ -30,7 +29,6 @@ LL |     sync(format_args!("{:?}", c));
    |     required by a bound introduced by this call
    |
    = help: within `Arguments<'_>`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
-   = note: consider using `std::sync::Arc<core::fmt::rt::Opaque>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
 note: required because it appears within the type `Argument<'_>`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL

--- a/tests/ui/generator/drop-tracking-parent-expression.drop_tracking.stderr
+++ b/tests/ui/generator/drop-tracking-parent-expression.drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -57,7 +56,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -100,7 +98,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |

--- a/tests/ui/generator/drop-tracking-parent-expression.drop_tracking_mir.stderr
+++ b/tests/ui/generator/drop-tracking-parent-expression.drop_tracking_mir.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -55,7 +54,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -96,7 +94,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |

--- a/tests/ui/generator/drop-tracking-parent-expression.no_drop_tracking.stderr
+++ b/tests/ui/generator/drop-tracking-parent-expression.no_drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -57,7 +56,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |
@@ -99,7 +97,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -142,7 +139,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |
@@ -184,7 +180,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -227,7 +222,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |
@@ -269,7 +263,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:25:22
    |
@@ -312,7 +305,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/drop-tracking-parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:38:22
    |

--- a/tests/ui/generator/drop-yield-twice.stderr
+++ b/tests/ui/generator/drop-yield-twice.stderr
@@ -11,7 +11,6 @@ LL | |     })
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/drop-yield-twice.rs:7:17: 7:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/drop-yield-twice.rs:9:9
    |

--- a/tests/ui/generator/issue-57017.no_drop_tracking.stderr
+++ b/tests/ui/generator/issue-57017.no_drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `copy::unsync::Client`
-   = note: consider using `std::sync::Arc<copy::unsync::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:30:28
    |
@@ -56,7 +55,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/issue-57017.rs:41:21: 41:28]`, the trait `Send` is not implemented for `copy::unsend::Client`
-   = note: consider using `std::sync::Arc<copy::unsend::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:42:28
    |
@@ -98,7 +96,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `derived_drop::unsync::Client`
-   = note: consider using `std::sync::Arc<derived_drop::unsync::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:30:28
    |
@@ -140,7 +137,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/issue-57017.rs:41:21: 41:28]`, the trait `Send` is not implemented for `derived_drop::unsend::Client`
-   = note: consider using `std::sync::Arc<derived_drop::unsend::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:42:28
    |
@@ -182,7 +178,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: the trait `Sync` is not implemented for `significant_drop::unsync::Client`
-   = note: consider using `std::sync::Arc<significant_drop::unsync::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:30:28
    |
@@ -224,7 +219,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/issue-57017.rs:41:21: 41:28]`, the trait `Send` is not implemented for `significant_drop::unsend::Client`
-   = note: consider using `std::sync::Arc<significant_drop::unsend::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57017.rs:42:28
    |

--- a/tests/ui/generator/issue-57478.no_drop_tracking.stderr
+++ b/tests/ui/generator/issue-57478.no_drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     })
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/issue-57478.rs:13:17: 13:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/issue-57478.rs:17:9
    |

--- a/tests/ui/generator/not-send-sync.drop_tracking.stderr
+++ b/tests/ui/generator/not-send-sync.drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:17:17: 17:19]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:20:9
    |
@@ -41,7 +40,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:24:17: 24:19]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:27:9
    |

--- a/tests/ui/generator/not-send-sync.drop_tracking_mir.stderr
+++ b/tests/ui/generator/not-send-sync.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ generator is not `Sync`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:17:17: 17:19]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:20:9
    |
@@ -26,7 +25,6 @@ LL |     assert_send(|| {
    |     ^^^^^^^^^^^ generator is not `Send`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:24:17: 24:19]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:27:9
    |

--- a/tests/ui/generator/not-send-sync.no_drop_tracking.stderr
+++ b/tests/ui/generator/not-send-sync.no_drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:17:17: 17:19]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:20:9
    |
@@ -41,7 +40,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/not-send-sync.rs:24:17: 24:19]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:27:9
    |

--- a/tests/ui/generator/parent-expression.drop_tracking.stderr
+++ b/tests/ui/generator/parent-expression.drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -57,7 +56,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -100,7 +98,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |

--- a/tests/ui/generator/parent-expression.drop_tracking_mir.stderr
+++ b/tests/ui/generator/parent-expression.drop_tracking_mir.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -55,7 +54,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -96,7 +94,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |

--- a/tests/ui/generator/parent-expression.no_drop_tracking.stderr
+++ b/tests/ui/generator/parent-expression.no_drop_tracking.stderr
@@ -14,7 +14,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -57,7 +56,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `copy::Client`
-   = note: consider using `std::sync::Arc<copy::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |
@@ -99,7 +97,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -142,7 +139,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `derived_drop::Client`
-   = note: consider using `std::sync::Arc<derived_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |
@@ -184,7 +180,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -227,7 +222,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `significant_drop::Client`
-   = note: consider using `std::sync::Arc<significant_drop::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |
@@ -269,7 +263,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:21:21: 21:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:25:22
    |
@@ -312,7 +305,6 @@ LL | |     );
    | |_____- in this macro invocation
    |
    = help: within `[generator@$DIR/parent-expression.rs:37:21: 37:28]`, the trait `Send` is not implemented for `insignificant_dtor::Client`
-   = note: consider using `std::sync::Arc<insignificant_dtor::Client>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:38:22
    |

--- a/tests/ui/generator/partial-drop.drop_tracking.stderr
+++ b/tests/ui/generator/partial-drop.drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:17:17: 17:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:21:9
    |
@@ -42,7 +41,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:24:17: 24:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:29:9
    |

--- a/tests/ui/generator/partial-drop.no_drop_tracking.stderr
+++ b/tests/ui/generator/partial-drop.no_drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:17:17: 17:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:21:9
    |
@@ -42,7 +41,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[generator@$DIR/partial-drop.rs:24:17: 24:19]`, the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/partial-drop.rs:29:9
    |

--- a/tests/ui/generator/print/generator-print-verbose-2.drop_tracking.stderr
+++ b/tests/ui/generator/print/generator-print-verbose-2.drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[main::{closure#0} upvar_tys=() {NotSync, ()}]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:23:9
    |
@@ -41,7 +40,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[main::{closure#1} upvar_tys=() {NotSend, ()}]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:30:9
    |

--- a/tests/ui/generator/print/generator-print-verbose-2.drop_tracking_mir.stderr
+++ b/tests/ui/generator/print/generator-print-verbose-2.drop_tracking_mir.stderr
@@ -5,7 +5,6 @@ LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ generator is not `Sync`
    |
    = help: within `[main::{closure#0} upvar_tys=() [main::{closure#0}]]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:23:9
    |
@@ -26,7 +25,6 @@ LL |     assert_send(|| {
    |     ^^^^^^^^^^^ generator is not `Send`
    |
    = help: within `[main::{closure#1} upvar_tys=() [main::{closure#1}]]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:30:9
    |

--- a/tests/ui/generator/print/generator-print-verbose-2.no_drop_tracking.stderr
+++ b/tests/ui/generator/print/generator-print-verbose-2.no_drop_tracking.stderr
@@ -11,7 +11,6 @@ LL | |     });
    | |_____^ generator is not `Sync`
    |
    = help: within `[main::{closure#0} upvar_tys=() {NotSync, ()}]`, the trait `Sync` is not implemented for `NotSync`
-   = note: consider using `std::sync::Arc<NotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Sync` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:23:9
    |
@@ -41,7 +40,6 @@ LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: within `[main::{closure#1} upvar_tys=() {NotSend, ()}]`, the trait `Send` is not implemented for `NotSend`
-   = note: consider using `std::sync::Arc<NotSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: generator is not `Send` as this value is used across a yield
   --> $DIR/generator-print-verbose-2.rs:30:9
    |

--- a/tests/ui/generator/ref-upvar-not-send.rs
+++ b/tests/ui/generator/ref-upvar-not-send.rs
@@ -15,7 +15,6 @@ fn main() {
     assert_send(move || {
         //~^ ERROR generator cannot be sent between threads safely
         //~| NOTE generator is not `Send`
-        //~| NOTE consider using `std::sync::Arc
         yield;
         let _x = x;
     });
@@ -24,7 +23,6 @@ fn main() {
     assert_send(move || {
         //~^ ERROR generator cannot be sent between threads safely
         //~| NOTE generator is not `Send`
-        //~| NOTE consider using `std::sync::Arc
         yield;
         let _y = y;
     });

--- a/tests/ui/generator/ref-upvar-not-send.stderr
+++ b/tests/ui/generator/ref-upvar-not-send.stderr
@@ -5,16 +5,14 @@ LL |       assert_send(move || {
    |  _________________^
 LL | |
 LL | |
-LL | |
 LL | |         yield;
 LL | |         let _x = x;
 LL | |     });
    | |_____^ generator is not `Send`
    |
    = help: the trait `Sync` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-  --> $DIR/ref-upvar-not-send.rs:20:18
+  --> $DIR/ref-upvar-not-send.rs:19:18
    |
 LL |         let _x = x;
    |                  ^ has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
@@ -25,11 +23,10 @@ LL | fn assert_send<T: Send>(_: T) {}
    |                   ^^^^ required by this bound in `assert_send`
 
 error: generator cannot be sent between threads safely
-  --> $DIR/ref-upvar-not-send.rs:24:17
+  --> $DIR/ref-upvar-not-send.rs:23:17
    |
 LL |       assert_send(move || {
    |  _________________^
-LL | |
 LL | |
 LL | |
 LL | |         yield;
@@ -37,10 +34,9 @@ LL | |         let _y = y;
 LL | |     });
    | |_____^ generator is not `Send`
    |
-   = help: within `[generator@$DIR/ref-upvar-not-send.rs:24:17: 24:24]`, the trait `Send` is not implemented for `*mut ()`
-   = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
+   = help: within `[generator@$DIR/ref-upvar-not-send.rs:23:17: 23:24]`, the trait `Send` is not implemented for `*mut ()`
 note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
-  --> $DIR/ref-upvar-not-send.rs:29:18
+  --> $DIR/ref-upvar-not-send.rs:27:18
    |
 LL |         let _y = y;
    |                  ^ has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`

--- a/tests/ui/impl-trait/auto-trait-leak2.rs
+++ b/tests/ui/impl-trait/auto-trait-leak2.rs
@@ -21,13 +21,11 @@ fn main() {
     //~^ ERROR `Rc<Cell<i32>>` cannot be sent between threads safely
     //~| NOTE `Rc<Cell<i32>>` cannot be sent between threads safely
     //~| NOTE required by a bound
-    //~| NOTE use `std::sync::Arc` instead
 
     send(after());
     //~^ ERROR `Rc<Cell<i32>>` cannot be sent between threads safely
     //~| NOTE `Rc<Cell<i32>>` cannot be sent between threads safely
     //~| NOTE required by a bound
-    //~| NOTE use `std::sync::Arc` instead
 }
 
 // Deferred path, main has to wait until typeck finishes,

--- a/tests/ui/impl-trait/auto-trait-leak2.stderr
+++ b/tests/ui/impl-trait/auto-trait-leak2.stderr
@@ -10,7 +10,6 @@ LL |     send(before());
    |     required by a bound introduced by this call
    |
    = help: within `impl Fn(i32)`, the trait `Send` is not implemented for `Rc<Cell<i32>>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this closure
   --> $DIR/auto-trait-leak2.rs:10:5
    |
@@ -28,7 +27,7 @@ LL | fn send<T: Send>(_: T) {}
    |            ^^^^ required by this bound in `send`
 
 error[E0277]: `Rc<Cell<i32>>` cannot be sent between threads safely
-  --> $DIR/auto-trait-leak2.rs:26:10
+  --> $DIR/auto-trait-leak2.rs:25:10
    |
 LL |     send(after());
    |     ---- ^^^^^^^ `Rc<Cell<i32>>` cannot be sent between threads safely
@@ -39,14 +38,13 @@ LL | fn after() -> impl Fn(i32) {
    |               ------------ within this `impl Fn(i32)`
    |
    = help: within `impl Fn(i32)`, the trait `Send` is not implemented for `Rc<Cell<i32>>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this closure
-  --> $DIR/auto-trait-leak2.rs:40:5
+  --> $DIR/auto-trait-leak2.rs:38:5
    |
 LL |     move |x| p.set(x)
    |     ^^^^^^^^
 note: required because it appears within the type `impl Fn(i32)`
-  --> $DIR/auto-trait-leak2.rs:35:15
+  --> $DIR/auto-trait-leak2.rs:33:15
    |
 LL | fn after() -> impl Fn(i32) {
    |               ^^^^^^^^^^^^

--- a/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/check-wf-on-non-defaulted-rpitit.stderr
@@ -5,7 +5,6 @@ LL |     fn bar() -> Wrapper<impl Sized>;
    |                 ^^^^^^^^^^^^^^^^^^^ `impl Sized` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `impl Sized`
-   = note: consider using `std::sync::Arc<impl Sized>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Wrapper`
   --> $DIR/check-wf-on-non-defaulted-rpitit.rs:3:19
    |

--- a/tests/ui/issues/issue-21763.stderr
+++ b/tests/ui/issues/issue-21763.stderr
@@ -5,7 +5,6 @@ LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    |           ^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
    |
    = help: within `(Rc<()>, Rc<()>)`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
    = note: required because it appears within the type `(Rc<()>, Rc<()>)`
    = note: required for `hashbrown::raw::RawTable<(Rc<()>, Rc<()>)>` to implement `Send`
 note: required because it appears within the type `HashMap<Rc<()>, Rc<()>, RandomState>`

--- a/tests/ui/issues/issue-24446.stderr
+++ b/tests/ui/issues/issue-24446.stderr
@@ -13,7 +13,6 @@ LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    |                 ^^^^^^^^^^^^^^^ `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Fn() -> u32 + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Fn() -> u32 + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: shared static variables must have a type that implements `Sync`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/issues/issue-40827.stderr
+++ b/tests/ui/issues/issue-40827.stderr
@@ -7,7 +7,6 @@ LL |     f(Foo(Arc::new(Bar::B(None))));
    |     required by a bound introduced by this call
    |
    = help: within `Bar`, the trait `Sync` is not implemented for `Rc<Foo>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Bar`
   --> $DIR/issue-40827.rs:6:6
    |
@@ -34,7 +33,6 @@ LL |     f(Foo(Arc::new(Bar::B(None))));
    |     required by a bound introduced by this call
    |
    = help: within `Bar`, the trait `Send` is not implemented for `Rc<Foo>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Bar`
   --> $DIR/issue-40827.rs:6:6
    |

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     let a = &t as &dyn Gettable<T>;
    |             ^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `S<T>` to implement `Gettable<T>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |
@@ -43,7 +42,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     let a: &dyn Gettable<T> = &t;
    |                               ^^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `S<T>` to implement `Gettable<T>`
   --> $DIR/kindck-impl-type-params.rs:12:32
    |

--- a/tests/ui/kindck/kindck-nonsendable-1.stderr
+++ b/tests/ui/kindck/kindck-nonsendable-1.stderr
@@ -9,7 +9,6 @@ LL |     bar(move|| foo(x));
    |     required by a bound introduced by this call
    |
    = help: within `[closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15]`, the trait `Send` is not implemented for `Rc<usize>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it's used within this closure
   --> $DIR/kindck-nonsendable-1.rs:9:9
    |

--- a/tests/ui/kindck/kindck-send-object.stderr
+++ b/tests/ui/kindck/kindck-send-object.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<&'static (dyn Dummy + 'static)>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object.rs:5:18
@@ -20,7 +19,6 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
-   = note: consider using `std::sync::Arc<dyn Dummy>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<&'a dyn Dummy>();
    |                   ^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'a)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'a)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&'a (dyn Dummy + 'a)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object1.rs:5:18
@@ -20,7 +19,6 @@ LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |                   ^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'a)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<(dyn Dummy + 'a)>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-object2.stderr
+++ b/tests/ui/kindck/kindck-send-object2.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<&'static dyn Dummy>();
    |                   ^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
-   = note: consider using `std::sync::Arc<(dyn Dummy + 'static)>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object2.rs:3:18
@@ -20,7 +19,6 @@ LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
-   = note: consider using `std::sync::Arc<dyn Dummy>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-owned.stderr
+++ b/tests/ui/kindck/kindck-send-owned.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<Box<*mut u8>>();
    |                   ^^^^^^^^^^^^ `*mut u8` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut u8`
-   = note: consider using `std::sync::Arc<*mut u8>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required for `Unique<*mut u8>` to implement `Send`
 note: required because it appears within the type `Box<*mut u8>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-unsafe.stderr
+++ b/tests/ui/kindck/kindck-send-unsafe.stderr
@@ -5,7 +5,6 @@ LL |     assert_send::<*mut isize>();
    |                   ^^^^^^^^^^ `*mut isize` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut isize`
-   = note: consider using `std::sync::Arc<*mut isize>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-unsafe.rs:3:19
    |
@@ -19,7 +18,6 @@ LL |     assert_send::<*mut &'a isize>();
    |                   ^^^^^^^^^^^^^^ `*mut &'a isize` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut &'a isize`
-   = note: consider using `std::sync::Arc<*mut &'a isize>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-unsafe.rs:3:19
    |

--- a/tests/ui/mut/mutable-enum-indirect.stderr
+++ b/tests/ui/mut/mutable-enum-indirect.stderr
@@ -7,7 +7,6 @@ LL |     bar(&x);
    |     required by a bound introduced by this call
    |
    = help: within `&Foo`, the trait `Sync` is not implemented for `NoSync`
-   = note: consider using `std::sync::Arc<NoSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/mutable-enum-indirect.rs:11:6
    |

--- a/tests/ui/no-send-res-ports.stderr
+++ b/tests/ui/no-send-res-ports.stderr
@@ -14,7 +14,6 @@ LL | |     });
    | |_____^ `Rc<()>` cannot be sent between threads safely
    |
    = help: within `[closure@$DIR/no-send-res-ports.rs:25:19: 25:25]`, the trait `Send` is not implemented for `Rc<()>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Port<()>`
   --> $DIR/no-send-res-ports.rs:5:8
    |

--- a/tests/ui/no_send-enum.stderr
+++ b/tests/ui/no_send-enum.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: within `Foo`, the trait `Send` is not implemented for `NoSend`
-   = note: consider using `std::sync::Arc<NoSend>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/no_send-enum.rs:8:6
    |

--- a/tests/ui/no_send-rc.stderr
+++ b/tests/ui/no_send-rc.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Rc<{integer}>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required by a bound in `bar`
   --> $DIR/no_send-rc.rs:3:11
    |

--- a/tests/ui/no_share-enum.stderr
+++ b/tests/ui/no_share-enum.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: within `Foo`, the trait `Sync` is not implemented for `NoSync`
-   = note: consider using `std::sync::Arc<NoSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/no_share-enum.rs:8:6
    |

--- a/tests/ui/no_share-struct.stderr
+++ b/tests/ui/no_share-struct.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `bar`
   --> $DIR/no_share-struct.rs:8:11
    |

--- a/tests/ui/phantom-auto-trait.stderr
+++ b/tests/ui/phantom-auto-trait.stderr
@@ -6,7 +6,6 @@ LL |     is_zen(x)
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `&T` to implement `Zen`
   --> $DIR/phantom-auto-trait.rs:10:24
    |
@@ -37,7 +36,6 @@ LL |     is_zen(x)
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `&T` to implement `Zen`
   --> $DIR/phantom-auto-trait.rs:10:24
    |

--- a/tests/ui/recursion/recursive-requirements.stderr
+++ b/tests/ui/recursion/recursive-requirements.stderr
@@ -5,7 +5,6 @@ LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Bar` cannot be shared between threads safely
    |
    = help: within `Foo`, the trait `Sync` is not implemented for `*const Bar`
-   = note: consider using `std::sync::Arc<*const Bar>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Foo`
   --> $DIR/recursive-requirements.rs:5:12
    |
@@ -24,7 +23,6 @@ LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Foo` cannot be shared between threads safely
    |
    = help: within `Foo`, the trait `Sync` is not implemented for `*const Foo`
-   = note: consider using `std::sync::Arc<*const Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Bar`
   --> $DIR/recursive-requirements.rs:10:12
    |

--- a/tests/ui/statics/issue-17718-static-sync.stderr
+++ b/tests/ui/statics/issue-17718-static-sync.stderr
@@ -5,7 +5,6 @@ LL | static BAR: Foo = Foo;
    |             ^^^ `Foo` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: shared static variables must have a type that implements `Sync`
 
 error: aborting due to previous error

--- a/tests/ui/stdlib-unit-tests/not-sync.stderr
+++ b/tests/ui/stdlib-unit-tests/not-sync.stderr
@@ -33,7 +33,6 @@ LL |     test::<Rc<i32>>();
    |            ^^^^^^^ `Rc<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Rc<i32>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required by a bound in `test`
   --> $DIR/not-sync.rs:5:12
    |
@@ -47,7 +46,6 @@ LL |     test::<Weak<i32>>();
    |            ^^^^^^^^^ `std::rc::Weak<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::rc::Weak<i32>`
-   = note: consider using `std::sync::Arc<std::rc::Weak<i32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/not-sync.rs:5:12
    |
@@ -61,7 +59,6 @@ LL |     test::<Receiver<i32>>();
    |            ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<i32>`
-   = note: consider using `std::sync::Arc<std::sync::mpsc::Receiver<i32>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/not-sync.rs:5:12
    |

--- a/tests/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
+++ b/tests/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
@@ -7,7 +7,6 @@ LL |     assert_is_send(&bar);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
-   = note: consider using `std::sync::Arc<<impl Foo as Foo>::Bar>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_is_send`
   --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:30:22
    |
@@ -27,7 +26,6 @@ LL |     assert_is_send(&bar);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
-   = note: consider using `std::sync::Arc<<impl Foo as Foo>::Bar>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `assert_is_send`
   --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:30:22
    |

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -71,7 +71,6 @@ LL |     f_send(rc);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Rc<{integer}>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required by a bound in `f_send`
   --> $DIR/issue-84973-blacklist.rs:10:14
    |

--- a/tests/ui/suggestions/restrict-type-argument.stderr
+++ b/tests/ui/suggestions/restrict-type-argument.stderr
@@ -6,7 +6,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<impl Sync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -25,7 +24,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -44,7 +42,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -63,7 +60,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -82,7 +78,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |
@@ -101,7 +96,6 @@ LL |     is_send(val);
    |     |
    |     required by a bound introduced by this call
    |
-   = note: consider using `std::sync::Arc<S>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
    |

--- a/tests/ui/traits/alias/cross-crate.stderr
+++ b/tests/ui/traits/alias/cross-crate.stderr
@@ -5,7 +5,6 @@ LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `Rc<u32>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Rc<u32>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
    = note: required for `Rc<u32>` to implement `SendSync`
 note: required by a bound in `use_alias`
   --> $DIR/cross-crate.rs:10:17
@@ -20,7 +19,6 @@ LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `Rc<u32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Rc<u32>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
    = note: required for `Rc<u32>` to implement `SendSync`
 note: required by a bound in `use_alias`
   --> $DIR/cross-crate.rs:10:17

--- a/tests/ui/traits/bad-method-typaram-kind.stderr
+++ b/tests/ui/traits/bad-method-typaram-kind.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     1.bar::<T>();
    |             ^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Bar::bar`
   --> $DIR/bad-method-typaram-kind.rs:6:14
    |

--- a/tests/ui/traits/inductive-overflow/two-traits.stderr
+++ b/tests/ui/traits/inductive-overflow/two-traits.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be shared between threads safely
 LL |     type X = Self;
    |              ^^^^ `T` cannot be shared between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Magic::X`
   --> $DIR/two-traits.rs:8:13
    |

--- a/tests/ui/traits/issue-7013.stderr
+++ b/tests/ui/traits/issue-7013.stderr
@@ -5,7 +5,6 @@ LL |     let a = A {v: Box::new(B{v: None}) as Box<dyn Foo + Send>};
    |                   ^^^^^^^^^^^^^^^^^^^^ `Rc<RefCell<A>>` cannot be sent between threads safely
    |
    = help: within `B`, the trait `Send` is not implemented for `Rc<RefCell<A>>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Option<Rc<RefCell<A>>>`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 note: required because it appears within the type `B`

--- a/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -7,7 +7,6 @@ LL |     Outer(TestType);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy::TestType`
-   = note: consider using `std::sync::Arc<dummy::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Outer`
   --> $DIR/negated-auto-traits-error.rs:10:17
    |
@@ -21,7 +20,6 @@ LL |     Outer(TestType);
    |     ^^^^^^^^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dummy::TestType`
-   = note: consider using `std::sync::Arc<dummy::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `Outer`
   --> $DIR/negated-auto-traits-error.rs:10:17
    |
@@ -37,7 +35,6 @@ LL |     is_send(TestType);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy1b::TestType`
-   = note: consider using `std::sync::Arc<dummy1b::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
    |
@@ -53,7 +50,6 @@ LL |     is_send((8, TestType));
    |     required by a bound introduced by this call
    |
    = help: within `({integer}, dummy1c::TestType)`, the trait `Send` is not implemented for `dummy1c::TestType`
-   = note: consider using `std::sync::Arc<dummy1c::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
    = note: required because it appears within the type `({integer}, TestType)`
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
@@ -92,7 +88,6 @@ LL |     is_send(Box::new(Outer2(TestType)));
    |     required by a bound introduced by this call
    |
    = help: within `Outer2<dummy3::TestType>`, the trait `Send` is not implemented for `dummy3::TestType`
-   = note: consider using `std::sync::Arc<dummy3::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Outer2<TestType>`
   --> $DIR/negated-auto-traits-error.rs:12:8
    |
@@ -116,7 +111,6 @@ LL |     is_sync(Outer2(TestType));
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `main::TestType`
-   = note: consider using `std::sync::Arc<main::TestType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required for `Outer2<main::TestType>` to implement `Sync`
   --> $DIR/negated-auto-traits-error.rs:14:22
    |

--- a/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
+++ b/tests/ui/traits/new-solver/auto-with-drop_tracking_mir.fail.stderr
@@ -7,7 +7,6 @@ LL |     is_send(foo());
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `impl Future<Output = ()>`
-   = note: consider using `std::sync::Arc<impl Future<Output = ()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/auto-with-drop_tracking_mir.rs:24:24
    |

--- a/tests/ui/traits/no_send-struct.stderr
+++ b/tests/ui/traits/no_send-struct.stderr
@@ -7,7 +7,6 @@ LL |     bar(x);
    |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Foo`
-   = note: consider using `std::sync::Arc<Foo>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `bar`
   --> $DIR/no_send-struct.rs:11:11
    |

--- a/tests/ui/traits/non_lifetime_binders/fail.stderr
+++ b/tests/ui/traits/non_lifetime_binders/fail.stderr
@@ -29,7 +29,6 @@ LL |     auto_trait();
    |     ^^^^^^^^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `T`
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `auto_trait`
   --> $DIR/fail.rs:15:15
    |

--- a/tests/ui/traits/unsend-future.stderr
+++ b/tests/ui/traits/unsend-future.stderr
@@ -5,7 +5,6 @@ LL |     require_handler(handler)
    |                     ^^^^^^^ future returned by `handler` is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `*const i32`
-   = note: consider using `std::sync::Arc<*const i32>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: future is not `Send` as this value is used across an await
   --> $DIR/unsend-future.rs:15:14
    |

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage2.rs
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage2.rs
@@ -22,5 +22,4 @@ fn main() {
     //~^ ERROR: `Rc<u32>` cannot be sent between threads safely [E0277]
     //~| NOTE cannot be sent
     //~| NOTE required by a bound
-    //~| NOTE use `std::sync::Arc` instead
 }

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage2.stderr
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage2.stderr
@@ -10,7 +10,6 @@ LL |     is_send(m::foo());
    |     required by a bound introduced by this call
    |
    = help: within `Foo`, the trait `Send` is not implemented for `Rc<u32>`
-   = note: use `std::sync::Arc` instead of `std::rc::Rc`
 note: required because it appears within the type `Foo`
   --> $DIR/auto-trait-leakage2.rs:7:16
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
@@ -5,7 +5,6 @@ LL |     is_send::<T::AssocType>();
    |               ^^^^^^^^^^^^ `<T as Trait>::AssocType` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `<T as Trait>::AssocType`
-   = note: consider using `std::sync::Arc<<T as Trait>::AssocType>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-assoc-type.rs:14:14
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-negation-send.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-negation-send.stderr
@@ -5,7 +5,6 @@ LL |     is_send::<MyNotSendable>();
    |               ^^^^^^^^^^^^^ `MyNotSendable` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `MyNotSendable`
-   = note: consider using `std::sync::Arc<MyNotSendable>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-negation-send.rs:15:15
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
@@ -5,7 +5,6 @@ LL |     is_sync::<MyNotSync>();
    |               ^^^^^^^^^ `MyNotSync` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `MyNotSync`
-   = note: consider using `std::sync::Arc<MyNotSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_sync`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:15
    |
@@ -19,7 +18,6 @@ LL |     is_sync::<MyTypeWUnsafe>();
    |               ^^^^^^^^^^^^^ `UnsafeCell<u8>` cannot be shared between threads safely
    |
    = help: within `MyTypeWUnsafe`, the trait `Sync` is not implemented for `UnsafeCell<u8>`
-   = note: consider using `std::sync::Arc<UnsafeCell<u8>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `MyTypeWUnsafe`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:21:8
    |
@@ -38,7 +36,6 @@ LL |     is_sync::<MyTypeManaged>();
    |               ^^^^^^^^^^^^^ `Managed` cannot be shared between threads safely
    |
    = help: within `MyTypeManaged`, the trait `Sync` is not implemented for `Managed`
-   = note: consider using `std::sync::Arc<Managed>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `MyTypeManaged`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:25:8
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -4,7 +4,6 @@ error[E0277]: `T` cannot be sent between threads safely
 LL |     is_send::<T>()
    |               ^ `T` cannot be sent between threads safely
    |
-   = note: consider using `std::sync::Arc<T>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `is_send`
   --> $DIR/typeck-default-trait-impl-send-param.rs:8:14
    |

--- a/tests/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/tests/ui/typeck/typeck-unsafe-always-share.stderr
@@ -7,7 +7,6 @@ LL |     test(us);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<MySync<{integer}>>`
-   = note: consider using `std::sync::Arc<UnsafeCell<MySync<{integer}>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |
@@ -23,7 +22,6 @@ LL |     test(uns);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<NoSync>`
-   = note: consider using `std::sync::Arc<UnsafeCell<NoSync>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |
@@ -39,7 +37,6 @@ LL |     test(ms);
    |     required by a bound introduced by this call
    |
    = help: within `MySync<NoSync>`, the trait `Sync` is not implemented for `UnsafeCell<NoSync>`
-   = note: consider using `std::sync::Arc<UnsafeCell<NoSync>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `MySync<NoSync>`
   --> $DIR/typeck-unsafe-always-share.rs:8:8
    |
@@ -60,7 +57,6 @@ LL |     test(NoSync);
    |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `NoSync`
-   = note: consider using `std::sync::Arc<NoSync>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required by a bound in `test`
   --> $DIR/typeck-unsafe-always-share.rs:15:12
    |


### PR DESCRIPTION
- Contents of reachable statics is reachable #115114 
- Revert "Suggest using `Arc` on `!Send`/`!Sync` types" #115311 
- Stop emitting non-power-of-two vectors in (non-portable-SIMD) codegen #115236 
- Do not forget to pass DWARF fragment information to LLVM. #115139 
- rustdoc: use unicode-aware checks for redundant explicit link fastpath #115070 

r? cuviper