### PR TITLE
fix version for abi_thiscall to 1.73.0, which was forgotten to change when stabilized and (later) moved to beta

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -54,7 +54,7 @@ declare_features! (
     /// instead of just the platforms on which it is the C ABI.
     (accepted, abi_sysv64, "1.24.0", Some(36167), None),
     /// Allows using the `thiscall` ABI.
-    (accepted, abi_thiscall, "1.19.0", None, None),
+    (accepted, abi_thiscall, "1.73.0", None, None),
     /// Allows using ADX intrinsics from `core::arch::{x86, x86_64}`.
     (accepted, adx_target_feature, "1.61.0", Some(44839), None),
     /// Allows explicit discriminants on non-unit enum variants.


### PR DESCRIPTION
See:

https://github.com/rust-lang/rust/pull/114562#issuecomment-1669424749
https://github.com/rust-lang/rust/pull/115056#issuecomment-1686316608
https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/1.2E72.2E0/near/387695644

Should be backported to beta too.