### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -367,7 +367,7 @@ impl<'a> LlvmArchiveBuilder<'a> {
                 match addition {
                     Addition::File { path, name_in_archive } => {
                         let path = CString::new(path.to_str().unwrap())?;
-                        let name = CString::new(name_in_archive.clone())?;
+                        let name = CString::new(name_in_archive.as_bytes())?;
                         members.push(llvm::LLVMRustArchiveMemberNew(
                             path.as_ptr(),
                             name.as_ptr(),

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -441,7 +441,7 @@ fn thin_lto(
 
         for (i, (name, buffer)) in modules.into_iter().enumerate() {
             info!("local module: {} - {}", i, name);
-            let cname = CString::new(name.clone()).unwrap();
+            let cname = CString::new(name.as_bytes()).unwrap();
             thin_modules.push(llvm::ThinLTOModule {
                 identifier: cname.as_ptr(),
                 data: buffer.data().as_ptr(),

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -55,6 +55,8 @@ use std::num::NonZeroUsize;
 use std::panic;
 use std::path::{Path, PathBuf};
 
+// Used by external projects such as `rust-gpu`.
+// See https://github.com/rust-lang/rust/pull/115393.
 pub use termcolor::{Color, ColorSpec, WriteColor};
 
 pub mod annotate_snippet_emitter_writer;

--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -54,7 +54,7 @@ declare_features! (
     /// instead of just the platforms on which it is the C ABI.
     (accepted, abi_sysv64, "1.24.0", Some(36167), None),
     /// Allows using the `thiscall` ABI.
-    (accepted, abi_thiscall, "1.19.0", None, None),
+    (accepted, abi_thiscall, "1.73.0", None, None),
     /// Allows using ADX intrinsics from `core::arch::{x86, x86_64}`.
     (accepted, adx_target_feature, "1.61.0", Some(44839), None),
     /// Allows explicit discriminants on non-unit enum variants.

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -228,6 +228,7 @@ impl<'a, T: EarlyLintPass> ast_visit::Visitor<'a> for EarlyContextAndPass<'a, T>
             }) => self.check_id(closure_id),
             _ => {}
         }
+        lint_callback!(self, check_expr_post, e);
     }
 
     fn visit_generic_arg(&mut self, arg: &'a ast::GenericArg) {

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -153,6 +153,7 @@ macro_rules! early_lint_methods {
             fn check_pat(a: &ast::Pat);
             fn check_pat_post(a: &ast::Pat);
             fn check_expr(a: &ast::Expr);
+            fn check_expr_post(a: &ast::Expr);
             fn check_ty(a: &ast::Ty);
             fn check_generic_arg(a: &ast::GenericArg);
             fn check_generic_param(a: &ast::GenericParam);

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1119,7 +1119,7 @@ impl EarlyLintPass for UnusedParens {
             let ast::TyKind::Paren(_) = &ty.kind
         {
             let id = self.parens_in_cast_in_lt.pop().expect("check_expr and check_expr_post must balance");
-            assert_eq!(id, ty.id, "check_expr and check_expr_post is a depth-first tree traversal");
+            assert_eq!(id, ty.id, "check_expr, check_ty, and check_expr_post are called, in that order, by the visitor");
         }
     }
 

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -955,11 +955,14 @@ declare_lint! {
 
 pub struct UnusedParens {
     with_self_ty_parens: bool,
+    /// `1 as (i32) < 2` parses to ExprKind::Lt
+    /// `1 as i32 < 2` parses to i32::<2[missing angle bracket]
+    parens_in_cast_in_lt: Vec<ast::NodeId>,
 }
 
 impl UnusedParens {
     pub fn new() -> Self {
-        Self { with_self_ty_parens: false }
+        Self { with_self_ty_parens: false, parens_in_cast_in_lt: Vec::new() }
     }
 }
 
@@ -1055,6 +1058,14 @@ impl UnusedParens {
 impl EarlyLintPass for UnusedParens {
     #[inline]
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &ast::Expr) {
+        if let ExprKind::Binary(op, lhs, _rhs) = &e.kind &&
+            (op.node == ast::BinOpKind::Lt || op.node == ast::BinOpKind::Shl) &&
+            let ExprKind::Cast(_expr, ty) = &lhs.kind &&
+            let ast::TyKind::Paren(_) = &ty.kind
+        {
+            self.parens_in_cast_in_lt.push(ty.id);
+        }
+
         match e.kind {
             ExprKind::Let(ref pat, _, _) | ExprKind::ForLoop(ref pat, ..) => {
                 self.check_unused_parens_pat(cx, pat, false, false, (true, true));
@@ -1101,6 +1112,17 @@ impl EarlyLintPass for UnusedParens {
         <Self as UnusedDelimLint>::check_expr(self, cx, e)
     }
 
+    fn check_expr_post(&mut self, _cx: &EarlyContext<'_>, e: &ast::Expr) {
+        if let ExprKind::Binary(op, lhs, _rhs) = &e.kind &&
+            (op.node == ast::BinOpKind::Lt || op.node == ast::BinOpKind::Shl) &&
+            let ExprKind::Cast(_expr, ty) = &lhs.kind &&
+            let ast::TyKind::Paren(_) = &ty.kind
+        {
+            let id = self.parens_in_cast_in_lt.pop().expect("check_expr and check_expr_post must balance");
+            assert_eq!(id, ty.id, "check_expr and check_expr_post is a depth-first tree traversal");
+        }
+    }
+
     fn check_pat(&mut self, cx: &EarlyContext<'_>, p: &ast::Pat) {
         use ast::{Mutability, PatKind::*};
         let keep_space = (false, false);
@@ -1141,6 +1163,11 @@ impl EarlyLintPass for UnusedParens {
     }
 
     fn check_ty(&mut self, cx: &EarlyContext<'_>, ty: &ast::Ty) {
+        if let ast::TyKind::Paren(_) = ty.kind &&
+            Some(&ty.id) == self.parens_in_cast_in_lt.last()
+        {
+            return;
+        }
         match &ty.kind {
             ast::TyKind::Array(_, len) => {
                 self.check_unused_delims_expr(

--- a/src/tools/miri/tests/pass/function_calls/abi_compat.rs
+++ b/src/tools/miri/tests/pass/function_calls/abi_compat.rs
@@ -1,7 +1,5 @@
-#![feature(portable_simd)]
 use std::mem;
 use std::num;
-use std::simd;
 
 #[derive(Copy, Clone)]
 struct Zst;
@@ -56,8 +54,7 @@ fn test_abi_newtype<T: Copy>(t: T) {
 
 fn main() {
     // Here we check:
-    // - unsigned vs signed integer is allowed
-    // - u32/i32 vs char is allowed
+    // - u32 vs char is allowed
     // - u32 vs NonZeroU32/Option<NonZeroU32> is allowed
     // - reference vs raw pointer is allowed
     // - references to things of the same size and alignment are allowed
@@ -65,10 +62,7 @@ fn main() {
     // these would be stably guaranteed. Code that relies on this is equivalent to code that relies
     // on the layout of `repr(Rust)` types. They are also fragile: the same mismatches in the fields
     // of a struct (even with `repr(C)`) will not always be accepted by Miri.
-    test_abi_compat(0u32, 0i32);
-    test_abi_compat(simd::u32x8::splat(1), simd::i32x8::splat(1));
     test_abi_compat(0u32, 'x');
-    test_abi_compat(0i32, 'x');
     test_abi_compat(42u32, num::NonZeroU32::new(1).unwrap());
     test_abi_compat(0u32, Some(num::NonZeroU32::new(1).unwrap()));
     test_abi_compat(&0u32, &0u32 as *const u32);
@@ -83,9 +77,6 @@ fn main() {
     test_abi_newtype(0u32);
     test_abi_newtype(0f32);
     test_abi_newtype((0u32, 1u32, 2u32));
-    // FIXME: skipping the array tests on mips64 due to https://github.com/rust-lang/rust/issues/115404
-    if !cfg!(target_arch = "mips64") {
-        test_abi_newtype([0u32, 1u32, 2u32]);
-        test_abi_newtype([0i32; 0]);
-    }
+    test_abi_newtype([0u32, 1u32, 2u32]);
+    test_abi_newtype([0i32; 0]);
 }

--- a/src/tools/miri/tests/pass/function_calls/abi_compat.rs
+++ b/src/tools/miri/tests/pass/function_calls/abi_compat.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use std::num;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct Zst;
 
 fn test_abi_compat<T: Copy, U: Copy>(t: T, u: U) {
@@ -31,7 +31,7 @@ fn test_abi_compat<T: Copy, U: Copy>(t: T, u: U) {
 }
 
 /// Ensure that `T` is compatible with various repr(transparent) wrappers around `T`.
-fn test_abi_newtype<T: Copy>(t: T) {
+fn test_abi_newtype<T: Copy + Default>() {
     #[repr(transparent)]
     #[derive(Copy, Clone)]
     struct Wrapper1<T>(T);
@@ -45,6 +45,7 @@ fn test_abi_newtype<T: Copy>(t: T) {
     #[derive(Copy, Clone)]
     struct Wrapper3<T>(Zst, T, [u8; 0]);
 
+    let t = T::default();
     test_abi_compat(t, Wrapper1(t));
     test_abi_compat(t, Wrapper2(t, ()));
     test_abi_compat(t, Wrapper2a((), t));
@@ -62,21 +63,24 @@ fn main() {
     // these would be stably guaranteed. Code that relies on this is equivalent to code that relies
     // on the layout of `repr(Rust)` types. They are also fragile: the same mismatches in the fields
     // of a struct (even with `repr(C)`) will not always be accepted by Miri.
+    // Note that `bool` and `u8` are *not* compatible, at least on x86-64!
+    // One of them has `arg_ext: Zext`, the other does not.
+    // Similarly, `i32` and `u32` are not compatible on s390x due to different `arg_ext`.
     test_abi_compat(0u32, 'x');
     test_abi_compat(42u32, num::NonZeroU32::new(1).unwrap());
     test_abi_compat(0u32, Some(num::NonZeroU32::new(1).unwrap()));
     test_abi_compat(&0u32, &0u32 as *const u32);
     test_abi_compat(&0u32, &([true; 4], [0u32; 0]));
-    // Note that `bool` and `u8` are *not* compatible, at least on x86-64!
-    // One of them has `arg_ext: Zext`, the other does not.
 
     // These must work for *any* type, since we guarantee that `repr(transparent)` is ABI-compatible
     // with the wrapped field.
-    test_abi_newtype(());
-    // FIXME: this still fails! test_abi_newtype(Zst);
-    test_abi_newtype(0u32);
-    test_abi_newtype(0f32);
-    test_abi_newtype((0u32, 1u32, 2u32));
-    test_abi_newtype([0u32, 1u32, 2u32]);
-    test_abi_newtype([0i32; 0]);
+    test_abi_newtype::<()>();
+    test_abi_newtype::<Zst>();
+    test_abi_newtype::<u32>();
+    test_abi_newtype::<f32>();
+    test_abi_newtype::<(u8, u16, f32)>();
+    test_abi_newtype::<[u8; 0]>();
+    test_abi_newtype::<[u32; 0]>();
+    test_abi_newtype::<[u32; 2]>();
+    test_abi_newtype::<[u32; 32]>();
 }

--- a/tests/ui/lint/unused/unused-parens-issue-106413.rs
+++ b/tests/ui/lint/unused/unused-parens-issue-106413.rs
@@ -1,0 +1,32 @@
+// check-pass
+#![warn(unused_parens)]
+
+fn id<T>(t: T) -> T { t }
+
+fn main() {
+    // This should not warn
+    let _ = 1 as (i32) < 2;
+    let _ = id(1 as (i32) < 2);
+    let _ = id(1 as i32)
+        as (i32) < 2;
+    // These should warn
+    let _ = 1 as ((i32)) < 2; //~WARN unnecessary parentheses
+    let _ = 1 as (i32); //~WARN unnecessary parentheses
+    let _ = 1 as (i32) > 2; //~WARN unnecessary parentheses
+    let _ = id(1 as (i32)) //~WARN unnecessary parentheses
+        as (i32) < 2;
+    let _ = id(1 as (i32)) < 2; //~WARN unnecessary parentheses
+
+    // This should not warn
+    let _ = 1 as (i32) << 2;
+    let _ = id(1 as (i32) << 2);
+    let _ = id(1 as i32)
+        as (i32) << 2;
+    // These should warn
+    let _ = 1 as ((i32)) << 2; //~WARN unnecessary parentheses
+    let _ = 1 as (i32); //~WARN unnecessary parentheses
+    let _ = 1 as (i32) >> 2; //~WARN unnecessary parentheses
+    let _ = id(1 as (i32)) //~WARN unnecessary parentheses
+        as (i32) << 2;
+    let _ = id(1 as (i32)) << 2; //~WARN unnecessary parentheses
+}

--- a/tests/ui/lint/unused/unused-parens-issue-106413.stderr
+++ b/tests/ui/lint/unused/unused-parens-issue-106413.stderr
@@ -1,0 +1,127 @@
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:13:19
+   |
+LL |     let _ = 1 as ((i32)) < 2;
+   |                   ^   ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-parens-issue-106413.rs:2:9
+   |
+LL | #![warn(unused_parens)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     let _ = 1 as ((i32)) < 2;
+LL +     let _ = 1 as (i32) < 2;
+   |
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:14:18
+   |
+LL |     let _ = 1 as (i32);
+   |                  ^   ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = 1 as (i32);
+LL +     let _ = 1 as i32;
+   |
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:15:18
+   |
+LL |     let _ = 1 as (i32) > 2;
+   |                  ^   ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = 1 as (i32) > 2;
+LL +     let _ = 1 as i32 > 2;
+   |
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:16:21
+   |
+LL |     let _ = id(1 as (i32))
+   |                     ^   ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = id(1 as (i32))
+LL +     let _ = id(1 as i32)
+   |
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:18:21
+   |
+LL |     let _ = id(1 as (i32)) < 2;
+   |                     ^   ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = id(1 as (i32)) < 2;
+LL +     let _ = id(1 as i32) < 2;
+   |
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:26:19
+   |
+LL |     let _ = 1 as ((i32)) << 2;
+   |                   ^   ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = 1 as ((i32)) << 2;
+LL +     let _ = 1 as (i32) << 2;
+   |
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:27:18
+   |
+LL |     let _ = 1 as (i32);
+   |                  ^   ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = 1 as (i32);
+LL +     let _ = 1 as i32;
+   |
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:28:18
+   |
+LL |     let _ = 1 as (i32) >> 2;
+   |                  ^   ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = 1 as (i32) >> 2;
+LL +     let _ = 1 as i32 >> 2;
+   |
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:29:21
+   |
+LL |     let _ = id(1 as (i32))
+   |                     ^   ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = id(1 as (i32))
+LL +     let _ = id(1 as i32)
+   |
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-issue-106413.rs:31:21
+   |
+LL |     let _ = id(1 as (i32)) << 2;
+   |                     ^   ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = id(1 as (i32)) << 2;
+LL +     let _ = id(1 as i32) << 2;
+   |
+
+warning: 10 warnings emitted
+


### PR DESCRIPTION
Successful merges:

 - #115411 (miri ABI check: fix handling of 1-ZST; don't accept sign differences)
 - #115424 (diagnostics: avoid wrong `unused_parens` on `x as (T) < y`)
 - #115425 (remove unnecessary heap allocation)
 - #115446 (fix version for abi_thiscall to 1.73.0, which was forgotten to change when stabilized and (later) moved to beta)
 - #115447 (Add comment so pub items are not removed)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115411,115424,115425,115446,115447)
<!-- homu-ignore:end -->