### PR TITLE
Stabilize `io_error_other` feature

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -527,8 +527,6 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// #![feature(io_error_other)]
-    ///
     /// use std::io::Error;
     ///
     /// // errors can be created from strings
@@ -537,7 +535,7 @@ impl Error {
     /// // errors can also be created from other errors
     /// let custom_error2 = Error::other(custom_error);
     /// ```
-    #[unstable(feature = "io_error_other", issue = "91946")]
+    #[stable(feature = "io_error_other", since = "CURRENT_RUSTC_VERSION")]
     pub fn other<E>(error: E) -> Error
     where
         E: Into<Box<dyn error::Error + Send + Sync>>,


### PR DESCRIPTION
Per the FCP for https://github.com/rust-lang/rust/issues/91946.