### PR TITLE
Clarify example in docs of str::char_slice

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -806,7 +806,7 @@ impl str {
     /// assert_eq!(Some((0, 'y')), char_indices.next()); // not (0, 'y̆')
     /// assert_eq!(Some((1, '\u{0306}')), char_indices.next());
     ///
-    /// // note the 3 here - the last character took up two bytes
+    /// // note the 3 here - the previous character took up two bytes
     /// assert_eq!(Some((3, 'e')), char_indices.next());
     /// assert_eq!(Some((4, 's')), char_indices.next());
     ///


### PR DESCRIPTION
Just a one word improvement.

“Last” can be misread as meaning the last (third) instead of the previous (first).