### PR TITLE
Don't panic in `<BorrowedCursor as io::Write>::write`

### DIFF
--- a/library/std/src/io/readbuf.rs
+++ b/library/std/src/io/readbuf.rs
@@ -306,8 +306,9 @@ impl<'a> BorrowedCursor<'a> {
 
 impl<'a> Write for BorrowedCursor<'a> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.append(buf);
-        Ok(buf.len())
+        let amt = cmp::min(buf.len(), self.capacity());
+        self.append(&buf[..amt]);
+        Ok(amt)
     }
 
     #[inline]


### PR DESCRIPTION
Instead of panicking if the BorrowedCursor does not have enough capacity for the whole buffer, just return a short write, [like `<&mut [u8] as io::Write>::write` does](https://doc.rust-lang.org/src/std/io/impls.rs.html#349).

(cc @ChayimFriedman2 https://github.com/rust-lang/rust/issues/78485#issuecomment-1493129588)

(I'm not sure if this needs an ACP? since it's not changing the "API", just what the function does)