### PR TITLE
Add explanatory note to 'expected item' error

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -73,12 +73,16 @@ impl<'a> Parser<'a> {
             if !self.maybe_consume_incorrect_semicolon(&items) {
                 let msg = format!("expected item, found {token_str}");
                 let mut err = self.struct_span_err(self.token.span, msg);
-                let label = if self.is_kw_followed_by_ident(kw::Let) {
-                    "consider using `const` or `static` instead of `let` for global variables"
+                let span = self.token.span;
+                if self.is_kw_followed_by_ident(kw::Let) {
+                    err.span_label(
+                        span,
+                        "consider using `const` or `static` instead of `let` for global variables",
+                    );
                 } else {
-                    "expected item"
+                    err.span_label(span, "expected item")
+                        .note("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>");
                 };
-                err.span_label(self.token.span, label);
                 return Err(err);
             }
         }

--- a/tests/ui/fn/keyword-order.stderr
+++ b/tests/ui/fn/keyword-order.stderr
@@ -11,6 +11,8 @@ error: expected item, found keyword `pub`
    |
 LL | default pub const async unsafe extern fn err() {}
    |         ^^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/default-unmatched.stderr
+++ b/tests/ui/parser/default-unmatched.stderr
@@ -11,6 +11,8 @@ error: expected item, found reserved keyword `do`
    |
 LL |     default do
    |             ^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/impl-parsing.stderr
+++ b/tests/ui/parser/impl-parsing.stderr
@@ -35,6 +35,8 @@ error: expected item, found keyword `unsafe`
    |
 LL | default unsafe FAIL
    |         ^^^^^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/parser/issue-101477-enum.stderr
+++ b/tests/ui/parser/issue-101477-enum.stderr
@@ -11,6 +11,8 @@ error: expected item, found `==`
    |
 LL |     B == 2
    |       ^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/issue-113110-non-item-at-module-root.rs
+++ b/tests/ui/parser/issues/issue-113110-non-item-at-module-root.rs
@@ -1,0 +1,1 @@
+ 5 //~ ERROR expected item, found `5`

--- a/tests/ui/parser/issues/issue-113110-non-item-at-module-root.stderr
+++ b/tests/ui/parser/issues/issue-113110-non-item-at-module-root.stderr
@@ -1,8 +1,8 @@
-error: expected item, found reserved keyword `virtual`
-  --> $DIR/virtual-structs.rs:3:1
+error: expected item, found `5`
+  --> $DIR/issue-113110-non-item-at-module-root.rs:1:2
    |
-LL | virtual struct SuperStruct {
-   | ^^^^^^^ expected item
+LL |  5
+   |  ^ expected item
    |
    = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 

--- a/tests/ui/parser/issues/issue-17904-2.stderr
+++ b/tests/ui/parser/issues/issue-17904-2.stderr
@@ -3,6 +3,8 @@ error: expected item, found keyword `where`
    |
 LL | struct Bar<T> { x: T } where T: Copy
    |                        ^^^^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/issues/issue-43196.stderr
+++ b/tests/ui/parser/issues/issue-43196.stderr
@@ -11,6 +11,8 @@ error: expected item, found `|`
    |
 LL | |
    | ^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/issue-62913.stderr
+++ b/tests/ui/parser/issues/issue-62913.stderr
@@ -17,6 +17,8 @@ error: expected item, found `"\u\"`
    |
 LL | "\u\"
    | ^^^^^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/issues/issue-68890.stderr
+++ b/tests/ui/parser/issues/issue-68890.stderr
@@ -15,6 +15,8 @@ error: expected item, found `)`
    |
 LL | enum e{A((?'a a+?+l))}
    |                     ^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/shebang/shebang-doc-comment.stderr
+++ b/tests/ui/parser/shebang/shebang-doc-comment.stderr
@@ -3,6 +3,8 @@ error: expected item, found `[`
    |
 LL | [allow(unused_variables)]
    | ^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to previous error
 

--- a/tests/ui/pub/pub-restricted-error-fn.stderr
+++ b/tests/ui/pub/pub-restricted-error-fn.stderr
@@ -11,6 +11,8 @@ error: expected item, found `(`
    |
 LL | pub(crate) () fn foo() {}
    |            ^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #113110 

It changes the diagnostic from this:

```
error: expected item, found `5`
 --> ../test.rs:1:1
  |
1 | 5
  | ^ expected item
 ```
to this:
```
error: expected item, found `5`
 --> ../test.rs:1:1
  |
1 | 5
  | ^ expected item
  |
  = note: items are things that can appear at the root of a module
  = note: for a full list see https://doc.rust-lang.org/reference/items.html
```
