### PR TITLE
Emit unused doc comment warnings for pat and expr fields

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1001,8 +1001,22 @@ impl EarlyLintPass for UnusedDocComment {
         warn_if_doc(cx, arm_span, "match arms", &arm.attrs);
     }
 
+    fn check_pat(&mut self, cx: &EarlyContext<'_>, pat: &ast::Pat) {
+        if let ast::PatKind::Struct(_, _, fields, _) = &pat.kind {
+            for field in fields {
+                warn_if_doc(cx, field.span, "pattern fields", &field.attrs);
+            }
+        }
+    }
+
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &ast::Expr) {
         warn_if_doc(cx, expr.span, "expressions", &expr.attrs);
+
+        if let ExprKind::Struct(s) = &expr.kind {
+            for field in &s.fields {
+                warn_if_doc(cx, field.span, "expression fields", &field.attrs);
+            }
+        }
     }
 
     fn check_generic_param(&mut self, cx: &EarlyContext<'_>, param: &ast::GenericParam) {

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -555,8 +555,8 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                             subpattern: pattern,
                             ascription: Ascription {
                                 annotation,
-                                /// Note that use `Contravariant` here. See the
-                                /// `variance` field documentation for details.
+                                // Note that use `Contravariant` here. See the
+                                // `variance` field documentation for details.
                                 variance: ty::Variance::Contravariant,
                             },
                         },

--- a/tests/ui/lint/unused/unused-doc-comments-edge-cases.rs
+++ b/tests/ui/lint/unused/unused-doc-comments-edge-cases.rs
@@ -26,6 +26,32 @@ fn doc_comment_on_expr(num: u8) -> bool {
     num == 3
 }
 
+fn doc_comment_on_expr_field() -> bool {
+    struct S { foo: i32 }
+
+    let x = S {
+        /// useless doc comment
+        //~^ ERROR: unused doc comment
+        foo: 3
+    };
+
+    true
+}
+
+fn doc_comment_on_pat_field() -> bool {
+    struct S { foo: i32 }
+
+    let S {
+        /// useless doc comment
+        //~^ ERROR: unused doc comment
+        foo
+    } = S {
+        foo: 3
+    };
+
+    true
+}
+
 fn doc_comment_on_generic<#[doc = "x"] T>(val: T) {}
 //~^ ERROR: unused doc comment
 

--- a/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
+++ b/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
@@ -42,7 +42,29 @@ LL |     num == 3
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:29:27
+  --> $DIR/unused-doc-comments-edge-cases.rs:33:9
+   |
+LL |         /// useless doc comment
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         foo: 3
+   |         ------ rustdoc does not generate documentation for expression fields
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:45:9
+   |
+LL |         /// useless doc comment
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         foo
+   |         --- rustdoc does not generate documentation for pattern fields
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:55:27
    |
 LL | fn doc_comment_on_generic<#[doc = "x"] T>(val: T) {}
    |                           ^^^^^^^^^^^^ - rustdoc does not generate documentation for generic parameters
@@ -50,7 +72,7 @@ LL | fn doc_comment_on_generic<#[doc = "x"] T>(val: T) {}
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:33:5
+  --> $DIR/unused-doc-comments-edge-cases.rs:59:5
    |
 LL |       /// unused doc comment
    |       ^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +85,7 @@ LL | |     }
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:40:1
+  --> $DIR/unused-doc-comments-edge-cases.rs:66:1
    |
 LL |   /// unused doc comment
    |   ^^^^^^^^^^^^^^^^^^^^^^
@@ -89,7 +111,7 @@ help: you might have meant to return this value
 LL |         return true;
    |         ++++++     +
 
-error: aborting due to 8 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0308, E0658.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #115462
