### PR TITLE
Take `&mut Results` in `ResultsVisitor`

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -603,7 +603,7 @@ impl<'cx, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx, R> for MirBorro
 
     fn visit_statement_before_primary_effect(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         flow_state: &Flows<'cx, 'tcx>,
         stmt: &'cx Statement<'tcx>,
         location: Location,
@@ -673,7 +673,7 @@ impl<'cx, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx, R> for MirBorro
 
     fn visit_terminator_before_primary_effect(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         flow_state: &Flows<'cx, 'tcx>,
         term: &'cx Terminator<'tcx>,
         loc: Location,
@@ -784,7 +784,7 @@ impl<'cx, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx, R> for MirBorro
 
     fn visit_terminator_after_primary_effect(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         flow_state: &Flows<'cx, 'tcx>,
         term: &'cx Terminator<'tcx>,
         loc: Location,

--- a/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
@@ -538,7 +538,7 @@ where
 
     fn visit_block_start(
         &mut self,
-        _results: &Results<'tcx, A>,
+        _results: &mut Results<'tcx, A>,
         state: &Self::FlowState,
         _block_data: &mir::BasicBlockData<'tcx>,
         _block: BasicBlock,
@@ -550,7 +550,7 @@ where
 
     fn visit_block_end(
         &mut self,
-        _results: &Results<'tcx, A>,
+        _results: &mut Results<'tcx, A>,
         state: &Self::FlowState,
         _block_data: &mir::BasicBlockData<'tcx>,
         _block: BasicBlock,
@@ -562,7 +562,7 @@ where
 
     fn visit_statement_before_primary_effect(
         &mut self,
-        results: &Results<'tcx, A>,
+        results: &mut Results<'tcx, A>,
         state: &Self::FlowState,
         _statement: &mir::Statement<'tcx>,
         _location: Location,
@@ -575,7 +575,7 @@ where
 
     fn visit_statement_after_primary_effect(
         &mut self,
-        results: &Results<'tcx, A>,
+        results: &mut Results<'tcx, A>,
         state: &Self::FlowState,
         _statement: &mir::Statement<'tcx>,
         _location: Location,
@@ -586,7 +586,7 @@ where
 
     fn visit_terminator_before_primary_effect(
         &mut self,
-        results: &Results<'tcx, A>,
+        results: &mut Results<'tcx, A>,
         state: &Self::FlowState,
         _terminator: &mir::Terminator<'tcx>,
         _location: Location,
@@ -599,7 +599,7 @@ where
 
     fn visit_terminator_after_primary_effect(
         &mut self,
-        results: &Results<'tcx, A>,
+        results: &mut Results<'tcx, A>,
         state: &Self::FlowState,
         _terminator: &mir::Terminator<'tcx>,
         _location: Location,

--- a/compiler/rustc_mir_dataflow/src/framework/visitor.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/visitor.rs
@@ -35,7 +35,7 @@ pub trait ResultsVisitor<'mir, 'tcx, R> {
 
     fn visit_block_start(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         _state: &Self::FlowState,
         _block_data: &'mir mir::BasicBlockData<'tcx>,
         _block: BasicBlock,
@@ -46,7 +46,7 @@ pub trait ResultsVisitor<'mir, 'tcx, R> {
     /// its `statement_effect`.
     fn visit_statement_before_primary_effect(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         _state: &Self::FlowState,
         _statement: &'mir mir::Statement<'tcx>,
         _location: Location,
@@ -57,7 +57,7 @@ pub trait ResultsVisitor<'mir, 'tcx, R> {
     /// statement applied to `state`.
     fn visit_statement_after_primary_effect(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         _state: &Self::FlowState,
         _statement: &'mir mir::Statement<'tcx>,
         _location: Location,
@@ -68,7 +68,7 @@ pub trait ResultsVisitor<'mir, 'tcx, R> {
     /// its `terminator_effect`.
     fn visit_terminator_before_primary_effect(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         _state: &Self::FlowState,
         _terminator: &'mir mir::Terminator<'tcx>,
         _location: Location,
@@ -81,7 +81,7 @@ pub trait ResultsVisitor<'mir, 'tcx, R> {
     /// The `call_return_effect` (if one exists) will *not* be applied to `state`.
     fn visit_terminator_after_primary_effect(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         _state: &Self::FlowState,
         _terminator: &'mir mir::Terminator<'tcx>,
         _location: Location,
@@ -90,7 +90,7 @@ pub trait ResultsVisitor<'mir, 'tcx, R> {
 
     fn visit_block_end(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         _state: &Self::FlowState,
         _block_data: &'mir mir::BasicBlockData<'tcx>,
         _block: BasicBlock,

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -401,7 +401,7 @@ impl<'mir, 'tcx>
 
     fn visit_statement_before_primary_effect(
         &mut self,
-        results: &Results<'tcx, ValueAnalysisWrapper<ConstAnalysis<'_, 'tcx>>>,
+        results: &mut Results<'tcx, ValueAnalysisWrapper<ConstAnalysis<'_, 'tcx>>>,
         state: &Self::FlowState,
         statement: &'mir Statement<'tcx>,
         location: Location,
@@ -417,7 +417,7 @@ impl<'mir, 'tcx>
 
     fn visit_statement_after_primary_effect(
         &mut self,
-        results: &Results<'tcx, ValueAnalysisWrapper<ConstAnalysis<'_, 'tcx>>>,
+        results: &mut Results<'tcx, ValueAnalysisWrapper<ConstAnalysis<'_, 'tcx>>>,
         state: &Self::FlowState,
         statement: &'mir Statement<'tcx>,
         location: Location,
@@ -443,7 +443,7 @@ impl<'mir, 'tcx>
 
     fn visit_terminator_before_primary_effect(
         &mut self,
-        results: &Results<'tcx, ValueAnalysisWrapper<ConstAnalysis<'_, 'tcx>>>,
+        results: &mut Results<'tcx, ValueAnalysisWrapper<ConstAnalysis<'_, 'tcx>>>,
         state: &Self::FlowState,
         terminator: &'mir Terminator<'tcx>,
         location: Location,

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -814,7 +814,7 @@ impl<'mir, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'mir, 'tcx, R>
 
     fn visit_statement_before_primary_effect(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         state: &Self::FlowState,
         _statement: &'mir Statement<'tcx>,
         loc: Location,
@@ -824,7 +824,7 @@ impl<'mir, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'mir, 'tcx, R>
 
     fn visit_terminator_before_primary_effect(
         &mut self,
-        _results: &R,
+        _results: &mut R,
         state: &Self::FlowState,
         _terminator: &'mir Terminator<'tcx>,
         loc: Location,


### PR DESCRIPTION
This fixes a small oversight from #108293.