### PR TITLE
Migrate GUI colors test to original CSS color format

### DIFF
--- a/tests/rustdoc-gui/code-color.goml
+++ b/tests/rustdoc-gui/code-color.goml
@@ -21,16 +21,16 @@ define-function: (
 
 call-function: ("check-colors", {
     "theme": "ayu",
-    "doc_code_color": "rgb(230, 225, 207)",
-    "doc_inline_code_color": "rgb(255, 180, 84)",
+    "doc_code_color": "#e6e1cf",
+    "doc_inline_code_color": "#ffb454",
 })
 call-function: ("check-colors", {
     "theme": "dark",
-    "doc_code_color": "rgb(221, 221, 221)",
-    "doc_inline_code_color": "rgb(221, 221, 221)",
+    "doc_code_color": "#ddd",
+    "doc_inline_code_color": "#ddd",
 })
 call-function: ("check-colors", {
     "theme": "light",
-    "doc_code_color": "rgb(0, 0, 0)",
-    "doc_inline_code_color": "rgb(0, 0, 0)",
+    "doc_code_color": "black",
+    "doc_inline_code_color": "black",
 })

--- a/tests/rustdoc-gui/code-color.goml
+++ b/tests/rustdoc-gui/code-color.goml
@@ -19,6 +19,18 @@ define-function: (
     },
 )
 
-call-function: ("check-colors", ("ayu", "rgb(230, 225, 207)", "rgb(255, 180, 84)"))
-call-function: ("check-colors", ("dark", "rgb(221, 221, 221)", "rgb(221, 221, 221)"))
-call-function: ("check-colors", ("light", "rgb(0, 0, 0)", "rgb(0, 0, 0)"))
+call-function: ("check-colors", {
+    "theme": "ayu",
+    "doc_code_color": "rgb(230, 225, 207)",
+    "doc_inline_code_color": "rgb(255, 180, 84)",
+})
+call-function: ("check-colors", {
+    "theme": "dark",
+    "doc_code_color": "rgb(221, 221, 221)",
+    "doc_inline_code_color": "rgb(221, 221, 221)",
+})
+call-function: ("check-colors", {
+    "theme": "light",
+    "doc_code_color": "rgb(0, 0, 0)",
+    "doc_inline_code_color": "rgb(0, 0, 0)",
+})


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/111459.

r? @notriddle