### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1001,8 +1001,22 @@ impl EarlyLintPass for UnusedDocComment {
         warn_if_doc(cx, arm_span, "match arms", &arm.attrs);
     }
 
+    fn check_pat(&mut self, cx: &EarlyContext<'_>, pat: &ast::Pat) {
+        if let ast::PatKind::Struct(_, _, fields, _) = &pat.kind {
+            for field in fields {
+                warn_if_doc(cx, field.span, "pattern fields", &field.attrs);
+            }
+        }
+    }
+
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &ast::Expr) {
         warn_if_doc(cx, expr.span, "expressions", &expr.attrs);
+
+        if let ExprKind::Struct(s) = &expr.kind {
+            for field in &s.fields {
+                warn_if_doc(cx, field.span, "expression fields", &field.attrs);
+            }
+        }
     }
 
     fn check_generic_param(&mut self, cx: &EarlyContext<'_>, param: &ast::GenericParam) {

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -555,8 +555,8 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                             subpattern: pattern,
                             ascription: Ascription {
                                 annotation,
-                                /// Note that use `Contravariant` here. See the
-                                /// `variance` field documentation for details.
+                                // Note that use `Contravariant` here. See the
+                                // `variance` field documentation for details.
                                 variance: ty::Variance::Contravariant,
                             },
                         },

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2486,18 +2486,25 @@ ${item.displayPath}<span class="${type}">${name}</span>\
             let crateSize = 0;
 
             /**
-             * The raw search data for a given crate. `n`, `t`, `d`, and `q`, `i`, and `f`
-             * are arrays with the same length. n[i] contains the name of an item.
-             * t[i] contains the type of that item (as a string of characters that represent an
-             * offset in `itemTypes`). d[i] contains the description of that item.
+             * The raw search data for a given crate. `n`, `t`, `d`, `i`, and `f`
+             * are arrays with the same length. `q`, `a`, and `c` use a sparse
+             * representation for compactness.
              *
-             * q[i] contains the full path of the item, or an empty string indicating
-             * "same as q[i-1]".
+             * `n[i]` contains the name of an item.
              *
-             * i[i] contains an item's parent, usually a module. For compactness,
+             * `t[i]` contains the type of that item
+             * (as a string of characters that represent an offset in `itemTypes`).
+             *
+             * `d[i]` contains the description of that item.
+             *
+             * `q` contains the full paths of the items. For compactness, it is a set of
+             * (index, path) pairs used to create a map. If a given index `i` is
+             * not present, this indicates "same as the last index present".
+             *
+             * `i[i]` contains an item's parent, usually a module. For compactness,
              * it is a set of indexes into the `p` array.
              *
-             * f[i] contains function signatures, or `0` if the item isn't a function.
+             * `f[i]` contains function signatures, or `0` if the item isn't a function.
              * Functions are themselves encoded as arrays. The first item is a list of
              * types representing the function's inputs, and the second list item is a list
              * of types representing the function's output. Tuples are flattened.
@@ -2510,6 +2517,8 @@ ${item.displayPath}<span class="${type}">${name}</span>\
              * `doc` contains the description of the crate.
              *
              * `p` is a list of path/type pairs. It is used for parents and function parameters.
+             *
+             * `c` is an array of item indices that are deprecated.
              *
              * @type {{
              *   doc: string,

--- a/tests/rustdoc-gui/code-color.goml
+++ b/tests/rustdoc-gui/code-color.goml
@@ -21,16 +21,16 @@ define-function: (
 
 call-function: ("check-colors", {
     "theme": "ayu",
-    "doc_code_color": "rgb(230, 225, 207)",
-    "doc_inline_code_color": "rgb(255, 180, 84)",
+    "doc_code_color": "#e6e1cf",
+    "doc_inline_code_color": "#ffb454",
 })
 call-function: ("check-colors", {
     "theme": "dark",
-    "doc_code_color": "rgb(221, 221, 221)",
-    "doc_inline_code_color": "rgb(221, 221, 221)",
+    "doc_code_color": "#ddd",
+    "doc_inline_code_color": "#ddd",
 })
 call-function: ("check-colors", {
     "theme": "light",
-    "doc_code_color": "rgb(0, 0, 0)",
-    "doc_inline_code_color": "rgb(0, 0, 0)",
+    "doc_code_color": "black",
+    "doc_inline_code_color": "black",
 })

--- a/tests/rustdoc-gui/code-color.goml
+++ b/tests/rustdoc-gui/code-color.goml
@@ -19,6 +19,18 @@ define-function: (
     },
 )
 
-call-function: ("check-colors", ("ayu", "rgb(230, 225, 207)", "rgb(255, 180, 84)"))
-call-function: ("check-colors", ("dark", "rgb(221, 221, 221)", "rgb(221, 221, 221)"))
-call-function: ("check-colors", ("light", "rgb(0, 0, 0)", "rgb(0, 0, 0)"))
+call-function: ("check-colors", {
+    "theme": "ayu",
+    "doc_code_color": "rgb(230, 225, 207)",
+    "doc_inline_code_color": "rgb(255, 180, 84)",
+})
+call-function: ("check-colors", {
+    "theme": "dark",
+    "doc_code_color": "rgb(221, 221, 221)",
+    "doc_inline_code_color": "rgb(221, 221, 221)",
+})
+call-function: ("check-colors", {
+    "theme": "light",
+    "doc_code_color": "rgb(0, 0, 0)",
+    "doc_inline_code_color": "rgb(0, 0, 0)",
+})

--- a/tests/ui/lint/unused/unused-doc-comments-edge-cases.rs
+++ b/tests/ui/lint/unused/unused-doc-comments-edge-cases.rs
@@ -26,6 +26,32 @@ fn doc_comment_on_expr(num: u8) -> bool {
     num == 3
 }
 
+fn doc_comment_on_expr_field() -> bool {
+    struct S { foo: i32 }
+
+    let x = S {
+        /// useless doc comment
+        //~^ ERROR: unused doc comment
+        foo: 3
+    };
+
+    true
+}
+
+fn doc_comment_on_pat_field() -> bool {
+    struct S { foo: i32 }
+
+    let S {
+        /// useless doc comment
+        //~^ ERROR: unused doc comment
+        foo
+    } = S {
+        foo: 3
+    };
+
+    true
+}
+
 fn doc_comment_on_generic<#[doc = "x"] T>(val: T) {}
 //~^ ERROR: unused doc comment
 

--- a/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
+++ b/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
@@ -42,7 +42,29 @@ LL |     num == 3
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:29:27
+  --> $DIR/unused-doc-comments-edge-cases.rs:33:9
+   |
+LL |         /// useless doc comment
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         foo: 3
+   |         ------ rustdoc does not generate documentation for expression fields
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:45:9
+   |
+LL |         /// useless doc comment
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         foo
+   |         --- rustdoc does not generate documentation for pattern fields
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:55:27
    |
 LL | fn doc_comment_on_generic<#[doc = "x"] T>(val: T) {}
    |                           ^^^^^^^^^^^^ - rustdoc does not generate documentation for generic parameters
@@ -50,7 +72,7 @@ LL | fn doc_comment_on_generic<#[doc = "x"] T>(val: T) {}
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:33:5
+  --> $DIR/unused-doc-comments-edge-cases.rs:59:5
    |
 LL |       /// unused doc comment
    |       ^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +85,7 @@ LL | |     }
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:40:1
+  --> $DIR/unused-doc-comments-edge-cases.rs:66:1
    |
 LL |   /// unused doc comment
    |   ^^^^^^^^^^^^^^^^^^^^^^
@@ -89,7 +111,7 @@ help: you might have meant to return this value
 LL |         return true;
    |         ++++++     +
 
-error: aborting due to 8 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0308, E0658.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #115478 (Emit unused doc comment warnings for pat and expr fields)
 - #115490 (rustdoc: update comment in search.js for #107629)
 - #115503 (Migrate GUI colors test to original CSS color format)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115478,115490,115503)
<!-- homu-ignore:end -->