### PR TITLE
Don't forget to normalize the translated message

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2346,7 +2346,13 @@ impl FileWithAnnotatedLines {
                 }
 
                 let label = label.as_ref().map(|m| {
-                    emitter.translate_message(m, args).map_err(Report::new).unwrap().to_string()
+                    normalize_whitespace(
+                        &emitter
+                            .translate_message(m, &args)
+                            .map_err(Report::new)
+                            .unwrap()
+                            .to_string(),
+                    )
                 });
 
                 if lo.line != hi.line {

--- a/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.rs
+++ b/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.rs
@@ -1,0 +1,5 @@
+#![crate_type = "lib"]
+
+struct Bug([u8; panic!{"\t"}]);
+//~^ ERROR evaluation of constant value failed
+//~| NOTE: in this expansion of panic!

--- a/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
+++ b/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
@@ -1,0 +1,11 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const_panic-normalize-tabs-115498.rs:3:17
+   |
+LL | struct Bug([u8; panic!{"\t"}]);
+   |                 ^^^^^^^^^^^^ the evaluated program panicked at '    ', $DIR/const_panic-normalize-tabs-115498.rs:3:17
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
This PR adds a missing call to `normalize_whitespace` after translating an label.

Fixes https://github.com/rust-lang/rust/issues/115498