### PR TITLE
Don't ICE on associated type projection without feature gate in new solver

### DIFF
--- a/tests/ui/traits/new-solver/dont-ice-on-assoc-projection.rs
+++ b/tests/ui/traits/new-solver/dont-ice-on-assoc-projection.rs
@@ -1,0 +1,19 @@
+// compile-flags: -Ztrait-solver=next-coherence
+
+// Makes sure we don't ICE on associated const projection when the feature gate
+// is not enabled, since we should avoid encountering ICEs on stable if possible.
+
+trait Bar {
+    const ASSOC: usize;
+}
+impl Bar for () {
+    const ASSOC: usize = 1;
+}
+
+trait Foo {}
+impl Foo for () {}
+impl<T> Foo for T where T: Bar<ASSOC = 0> {}
+//~^ ERROR associated const equality is incomplete
+//~| ERROR conflicting implementations of trait `Foo` for type `()`
+
+fn main() {}

--- a/tests/ui/traits/new-solver/dont-ice-on-assoc-projection.stderr
+++ b/tests/ui/traits/new-solver/dont-ice-on-assoc-projection.stderr
@@ -1,0 +1,21 @@
+error[E0658]: associated const equality is incomplete
+  --> $DIR/dont-ice-on-assoc-projection.rs:15:32
+   |
+LL | impl<T> Foo for T where T: Bar<ASSOC = 0> {}
+   |                                ^^^^^^^^^
+   |
+   = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
+   = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+
+error[E0119]: conflicting implementations of trait `Foo` for type `()`
+  --> $DIR/dont-ice-on-assoc-projection.rs:15:1
+   |
+LL | impl Foo for () {}
+   | --------------- first implementation here
+LL | impl<T> Foo for T where T: Bar<ASSOC = 0> {}
+   | ^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0658.
+For more information about an error, try `rustc --explain E0119`.


### PR DESCRIPTION
Self-explanatory, we should avoid ICEs when the feature gate is not enabled. Continue to ICE when the feature gate *is* enabled, though.

Fixes #115500