### PR TITLE
Don't require `Drop` for `[PhantomData<T>; N]` where `N` and `T` are generic, if `T` requires `Drop`

### DIFF
--- a/tests/ui/consts/drop-maybe_uninit.rs
+++ b/tests/ui/consts/drop-maybe_uninit.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+pub const fn f<T, const N: usize>(_: [std::mem::MaybeUninit<T>; N]) {}
+
+pub struct Blubb<T>(*const T);
+
+pub const fn g<T, const N: usize>(_: [Blubb<T>; N]) {}
+
+pub struct Blorb<const N: usize>([String; N]);
+
+pub const fn h(_: Blorb<0>) {}
+
+pub struct Wrap(Blorb<0>);
+
+pub const fn i(_: Wrap) {}
+
+fn main() {}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/115403
fixes https://github.com/rust-lang/rust/issues/115410

This was accidentally regressed in https://github.com/rust-lang/rust/pull/114134, because it was accidentally stabilized in #102204 (cc @rust-lang/lang, seems like an innocent stabilization, considering this PR is more of a bugfix than a feature).

While we have a whole month to beta backport this change before the regression hits stable, I'd still prefer not to go through an FCP on this PR (which fixes a regression), if T-lang wants an FCP, I can can open an issue about the change itself.