### PR TITLE
Fix error report for size overflow from transmute

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2920,6 +2920,16 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     rustc_transmute::Reason::DstIsTooBig => {
                         format!("The size of `{src}` is smaller than the size of `{dst}`")
                     }
+                    rustc_transmute::Reason::SrcSizeOverflow => {
+                        format!(
+                            "values of the type `{src}` are too big for the current architecture"
+                        )
+                    }
+                    rustc_transmute::Reason::DstSizeOverflow => {
+                        format!(
+                            "values of the type `{dst}` are too big for the current architecture"
+                        )
+                    }
                     rustc_transmute::Reason::DstHasStricterAlignment {
                         src_min_align,
                         dst_min_align,

--- a/compiler/rustc_transmute/src/layout/tree.rs
+++ b/compiler/rustc_transmute/src/layout/tree.rs
@@ -189,6 +189,8 @@ pub(crate) mod rustc {
         Unspecified,
         /// This error will be surfaced elsewhere by rustc, so don't surface it.
         UnknownLayout,
+        /// Overflow size
+        SizeOverflow,
         TypeError(ErrorGuaranteed),
     }
 
@@ -196,6 +198,7 @@ pub(crate) mod rustc {
         fn from(err: &LayoutError<'tcx>) -> Self {
             match err {
                 LayoutError::Unknown(..) | LayoutError::ReferencesError(..) => Self::UnknownLayout,
+                LayoutError::SizeOverflow(..) => Self::SizeOverflow,
                 err => unimplemented!("{:?}", err),
             }
         }

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -64,6 +64,10 @@ pub enum Reason {
     SrcLayoutUnknown,
     /// The layout of dst is unknown
     DstLayoutUnknown,
+    /// The size of src is overflow
+    SrcSizeOverflow,
+    /// The size of dst is overflow
+    DstSizeOverflow,
 }
 
 #[cfg(feature = "rustc")]

--- a/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
@@ -85,6 +85,8 @@ mod rustc {
                 (_, Err(Err::UnknownLayout)) => Answer::No(Reason::DstLayoutUnknown),
                 (Err(Err::Unspecified), _) => Answer::No(Reason::SrcIsUnspecified),
                 (_, Err(Err::Unspecified)) => Answer::No(Reason::DstIsUnspecified),
+                (Err(Err::SizeOverflow), _) => Answer::No(Reason::SrcSizeOverflow),
+                (_, Err(Err::SizeOverflow)) => Answer::No(Reason::DstSizeOverflow),
                 (Ok(src), Ok(dst)) => {
                     MaybeTransmutableQuery { src, dst, scope, assume, context }.answer()
                 }

--- a/tests/ui/transmute/issue-115402-overflow-size.rs
+++ b/tests/ui/transmute/issue-115402-overflow-size.rs
@@ -1,0 +1,27 @@
+#![crate_type = "lib"]
+#![feature(transmutability)]
+mod assert {
+    use std::mem::BikeshedIntrinsicFrom;
+    struct Context;
+
+    pub fn is_maybe_transmutable<Src, Dst>()
+    where
+        Dst: BikeshedIntrinsicFrom<Src, Context>,
+    {
+    }
+}
+
+fn main() {
+    pub union Uninit {
+        a: [u8; usize::MAX],
+    }
+
+    #[repr(C)]
+    struct ExplicitlyPadded(Uninit);
+
+    assert::is_maybe_transmutable::<(), ExplicitlyPadded>();
+    //~^ ERROR `()` cannot be safely transmuted into `ExplicitlyPadded`
+
+    assert::is_maybe_transmutable::<ExplicitlyPadded, ()>();
+    //~^ ERROR `ExplicitlyPadded` cannot be safely transmuted into `()`
+}

--- a/tests/ui/transmute/issue-115402-overflow-size.stderr
+++ b/tests/ui/transmute/issue-115402-overflow-size.stderr
@@ -1,0 +1,33 @@
+error[E0277]: `()` cannot be safely transmuted into `ExplicitlyPadded` in the defining scope of `assert::Context`
+  --> $DIR/issue-115402-overflow-size.rs:22:41
+   |
+LL |     assert::is_maybe_transmutable::<(), ExplicitlyPadded>();
+   |                                         ^^^^^^^^^^^^^^^^ values of the type `ExplicitlyPadded` are too big for the current architecture
+   |
+note: required by a bound in `is_maybe_transmutable`
+  --> $DIR/issue-115402-overflow-size.rs:9:14
+   |
+LL |     pub fn is_maybe_transmutable<Src, Dst>()
+   |            --------------------- required by a bound in this function
+LL |     where
+LL |         Dst: BikeshedIntrinsicFrom<Src, Context>,
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+
+error[E0277]: `ExplicitlyPadded` cannot be safely transmuted into `()` in the defining scope of `assert::Context`
+  --> $DIR/issue-115402-overflow-size.rs:25:55
+   |
+LL |     assert::is_maybe_transmutable::<ExplicitlyPadded, ()>();
+   |                                                       ^^ values of the type `ExplicitlyPadded` are too big for the current architecture
+   |
+note: required by a bound in `is_maybe_transmutable`
+  --> $DIR/issue-115402-overflow-size.rs:9:14
+   |
+LL |     pub fn is_maybe_transmutable<Src, Dst>()
+   |            --------------------- required by a bound in this function
+LL |     where
+LL |         Dst: BikeshedIntrinsicFrom<Src, Context>,
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #115402 

The span in the error reporting always points to the `dst`, this is an old issue, I may open another PR to fix it.