### PR TITLE
read_via_copy: don't prematurely optimize away the read

### DIFF
--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -176,23 +176,22 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                             } else {
                                 span_bug!(terminator.source_info.span, "Only passing a local is supported");
                             };
+                        // Add new statement at the end of the block that does the read, and patch
+                        // up the terminator.
+                        block.statements.push(Statement {
+                            source_info: terminator.source_info,
+                            kind: StatementKind::Assign(Box::new((
+                                *destination,
+                                Rvalue::Use(Operand::Copy(derefed_place)),
+                            ))),
+                        });
                         terminator.kind = match *target {
                             None => {
                                 // No target means this read something uninhabited,
-                                // so it must be unreachable, and we don't need to
-                                // preserve the assignment either.
+                                // so it must be unreachable.
                                 TerminatorKind::Unreachable
                             }
-                            Some(target) => {
-                                block.statements.push(Statement {
-                                    source_info: terminator.source_info,
-                                    kind: StatementKind::Assign(Box::new((
-                                        *destination,
-                                        Rvalue::Use(Operand::Copy(derefed_place)),
-                                    ))),
-                                });
-                                TerminatorKind::Goto { target }
-                            }
+                            Some(target) => TerminatorKind::Goto { target },
                         }
                     }
                     sym::write_via_move => {

--- a/tests/mir-opt/lower_intrinsics.read_via_copy_uninhabited.LowerIntrinsics.panic-abort.diff
+++ b/tests/mir-opt/lower_intrinsics.read_via_copy_uninhabited.LowerIntrinsics.panic-abort.diff
@@ -12,6 +12,7 @@
           StorageLive(_2);
           _2 = &raw const (*_1);
 -         _0 = read_via_copy::<Never>(move _2) -> unwind unreachable;
++         _0 = (*_2);
 +         unreachable;
       }
   }

--- a/tests/mir-opt/lower_intrinsics.read_via_copy_uninhabited.LowerIntrinsics.panic-unwind.diff
+++ b/tests/mir-opt/lower_intrinsics.read_via_copy_uninhabited.LowerIntrinsics.panic-unwind.diff
@@ -12,6 +12,7 @@
           StorageLive(_2);
           _2 = &raw const (*_1);
 -         _0 = read_via_copy::<Never>(move _2) -> unwind unreachable;
++         _0 = (*_2);
 +         unreachable;
       }
   }

--- a/tests/ui/consts/const-eval/ub-uninhabit.rs
+++ b/tests/ui/consts/const-eval/ub-uninhabit.rs
@@ -1,7 +1,10 @@
 // Strip out raw byte dumps to make comparison platform-independent:
 // normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 // normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*a(lloc)?[0-9]+(\+[a-z0-9]+)?─*╼ )+ *│.*" -> "HEX_DUMP"
+#![feature(core_intrinsics)]
+#![feature(never_type)]
 
+use std::intrinsics;
 use std::mem;
 
 #[derive(Copy, Clone)]
@@ -15,11 +18,24 @@ union MaybeUninit<T: Copy> {
 
 const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
 //~^ ERROR evaluation of constant value failed
+//~| constructing invalid value
 
 const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
 //~^ ERROR it is undefined behavior to use this value
+//~| constructing invalid value
 
 const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };
 //~^ ERROR evaluation of constant value failed
+//~| constructing invalid value
+
+
+const READ_NEVER: () = unsafe {
+    let mem = [0u32; 8];
+    let ptr = mem.as_ptr().cast::<!>();
+    let _val = intrinsics::read_via_copy(ptr);
+    //~^ ERROR evaluation of constant value failed
+    //~| constructing invalid value
+};
+
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-uninhabit.stderr
+++ b/tests/ui/consts/const-eval/ub-uninhabit.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-uninhabit.rs:16:35
+  --> $DIR/ub-uninhabit.rs:19:35
    |
 LL | const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a value of uninhabited type `Bar`
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:19:1
+  --> $DIR/ub-uninhabit.rs:23:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to uninhabited type Bar
@@ -16,11 +16,17 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-uninhabit.rs:22:42
+  --> $DIR/ub-uninhabit.rs:27:42
    |
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at [0]: encountered a value of uninhabited type `Bar`
 
-error: aborting due to 3 previous errors
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-uninhabit.rs:35:16
+   |
+LL |     let _val = intrinsics::read_via_copy(ptr);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a value of the never type `!`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
Always do the read to ensure consistent UB error messages in const-eval/Miri.

r? @scottmcm 