### PR TITLE
Mirror the rustc-perf source

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -60,7 +60,7 @@ ENV CC=clang CXX=clang++
 # rustc-perf version from 2023-05-30
 # Should also be changed in the opt-dist tool for other environments.
 ENV PERF_COMMIT 8b2ac3042e1ff2c0074455a0a3618adef97156b1
-RUN curl -LS -o perf.zip https://github.com/rust-lang/rustc-perf/archive/$PERF_COMMIT.zip && \
+RUN curl -LS -o perf.zip https://ci-mirrors.rust-lang.org/rustc/rustc-perf-$PERF_COMMIT.zip && \
     unzip perf.zip && \
     mv rustc-perf-$PERF_COMMIT rustc-perf && \
     rm perf.zip

--- a/src/tools/opt-dist/src/environment/windows.rs
+++ b/src/tools/opt-dist/src/environment/windows.rs
@@ -42,7 +42,7 @@ impl Environment for WindowsEnvironment {
         // rustc-perf version from 2023-05-30
         const PERF_COMMIT: &str = "8b2ac3042e1ff2c0074455a0a3618adef97156b1";
 
-        let url = format!("https://github.com/rust-lang/rustc-perf/archive/{PERF_COMMIT}.zip");
+        let url = format!("https://ci-mirrors.rust-lang.org/rustc/rustc-perf-{PERF_COMMIT}.zip");
         let response = reqwest::blocking::get(url)?.error_for_status()?.bytes()?.to_vec();
 
         let mut archive = ZipArchive::new(Cursor::new(response))?;


### PR DESCRIPTION
This avoids issues with the GitHub /archive/ links which can be somewhat unreliable and are currently causing CI issues.