### PR TITLE
support `{disable,enable}-patch-binaries-for-nix` in configure.py

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -58,6 +58,7 @@ o("clang", "llvm.clang", "build clang")
 o("missing-tools", "dist.missing-tools", "allow failures when building tools")
 o("use-libcxx", "llvm.use-libcxx", "build LLVM with libc++")
 o("control-flow-guard", "rust.control-flow-guard", "Enable Control Flow Guard")
+o("patch-binaries-for-nix", "build.patch-binaries-for-nix", "whether patch binaries for usage with Nix toolchains")
 
 v("llvm-cflags", "llvm.cflags", "build LLVM with these extra compiler flags")
 v("llvm-cxxflags", "llvm.cxxflags", "build LLVM with these extra compiler flags")


### PR DESCRIPTION
Provide the control of `patch-binaries-for-nix` flag from configure.py without requiring manual editing.

It's useful when:

https://github.com/rust-lang/rust/blob/bf1e3f31f95c0f75b9bf51a58e8684f750f919f2/src/bootstrap/bootstrap.py#L661-L667