### PR TITLE
Weaken needlessly restrictive orderings on Arc::*_count

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1616,7 +1616,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
     #[must_use]
     #[stable(feature = "arc_counts", since = "1.15.0")]
     pub fn weak_count(this: &Self) -> usize {
-        let cnt = this.inner().weak.load(Acquire);
+        let cnt = this.inner().weak.load(Relaxed);
         // If the weak count is currently locked, the value of the
         // count was 0 just before taking the lock.
         if cnt == usize::MAX { 0 } else { cnt - 1 }
@@ -1646,7 +1646,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
     #[must_use]
     #[stable(feature = "arc_counts", since = "1.15.0")]
     pub fn strong_count(this: &Self) -> usize {
-        this.inner().strong.load(Acquire)
+        this.inner().strong.load(Relaxed)
     }
 
     /// Increments the strong reference count on the `Arc<T>` associated with the
@@ -2801,7 +2801,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     #[must_use]
     #[stable(feature = "weak_counts", since = "1.41.0")]
     pub fn strong_count(&self) -> usize {
-        if let Some(inner) = self.inner() { inner.strong.load(Acquire) } else { 0 }
+        if let Some(inner) = self.inner() { inner.strong.load(Relaxed) } else { 0 }
     }
 
     /// Gets an approximation of the number of `Weak` pointers pointing to this
@@ -2820,7 +2820,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     pub fn weak_count(&self) -> usize {
         if let Some(inner) = self.inner() {
             let weak = inner.weak.load(Acquire);
-            let strong = inner.strong.load(Acquire);
+            let strong = inner.strong.load(Relaxed);
             if strong == 0 {
                 0
             } else {


### PR DESCRIPTION
Follow up to https://github.com/rust-lang/rust/pull/95183 from this zulip: https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Why.20does.20Arc.3A.3Astrong_count.20use.20Acquire.20instead.20of.20Relaxed.3F/near/386213850

I'd like to use the strong_count for a lockless algorithm I'm writing, but I don't need acquire semantics so that's pointlessly restrictive on arm/risc-v. 