### PR TITLE
Build `rustc` with a single CGU on x64 Linux

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -84,7 +84,8 @@ ENV RUST_CONFIGURE_ARGS \
       --set llvm.ninja=false \
       --set rust.jemalloc \
       --set rust.use-lld=true \
-      --set rust.lto=thin
+      --set rust.lto=thin \
+      --set rust.codegen-units=1
 
 ENV SCRIPT python3 ../x.py build --set rust.debug=true opt-dist && \
     ./build/$HOSTS/stage0-tools-bin/opt-dist linux-ci -- python3 ../x.py dist \


### PR DESCRIPTION
This PR adds the `rust.codegen-units=1` setting when compiling the 64-bit Linux `rustc` artifact (the one used for try builds and Linux rustup distribution). This had mixed results in the past, however after the bump to LLVM 17, the results now seem pretty [incredible](https://github.com/rust-lang/rust/pull/115554#issuecomment-1706518199). Instruction counts, cycles, wall time, max RSS and even artifact sizes see large improvements.

The last [try build](https://github.com/rust-lang-ci/rust/actions/runs/6077686494/job/16487768049) with this setting took 1h 8m, which is basically the same duration for try builds that we have seen recently. So there shouldn't be any large hit to CI/build time.

I hope that this could potentially also reduce codegen noise of `rustc` a little bit, since small changes within a single `rustc` crate should no longer perturb optimizations because of CGU movement. We still do cross-crate LTO, so it won't eliminate it though.

r? @Mark-Simulacrum