### PR TITLE
implied bounds: do not ICE on unconstrained region vars

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -57,16 +57,12 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
         let ty = OpportunisticRegionResolver::new(self).fold_ty(ty);
 
         // We do not expect existential variables in implied bounds.
-        // We may however encounter unconstrained lifetime variables in invalid
-        // code. See #110161 for context.
+        // We may however encounter unconstrained lifetime variables
+        // in very rare cases.
+        //
+        // See `ui/implied-bounds/implied-bounds-unconstrained-2.rs` for
+        // an example.
         assert!(!ty.has_non_region_infer());
-        if ty.has_infer() {
-            self.tcx.sess.delay_span_bug(
-                self.tcx.def_span(body_id),
-                "skipped implied_outlives_bounds due to unconstrained lifetimes",
-            );
-            return vec![];
-        }
 
         let mut canonical_var_values = OriginalQueryValues::default();
         let canonical_ty =

--- a/tests/ui/implied-bounds/implied-bounds-unconstrained-1.rs
+++ b/tests/ui/implied-bounds/implied-bounds-unconstrained-1.rs
@@ -1,0 +1,28 @@
+// check-pass
+
+// Regression test for #112832.
+pub trait QueryDb {
+    type Db;
+}
+
+pub struct QueryTable<Q, DB> {
+    db: DB,
+    storage: Q,
+}
+
+// We normalize `<Q as QueryDb>::Db` to `<Q as AsyncQueryFunction<'d>>::SendDb`
+// using the where-bound. 'd is an unconstrained region variable which previously
+// triggered an assert.
+impl<Q> QueryTable<Q, <Q as QueryDb>::Db> where Q: for<'d> AsyncQueryFunction<'d> {}
+
+pub trait AsyncQueryFunction<'d>: QueryDb<Db = <Self as AsyncQueryFunction<'d>>::SendDb> {
+    type SendDb: 'd;
+}
+
+pub trait QueryStorageOpsAsync<Q>
+where
+    Q: for<'d> AsyncQueryFunction<'d>,
+{
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/implied-bounds-unconstrained-2.rs
+++ b/tests/ui/implied-bounds/implied-bounds-unconstrained-2.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+// Another minimized regression test for #112832.
+trait Trait {
+    type Assoc;
+}
+
+trait Sub<'a>: Trait<Assoc = <Self as Sub<'a>>::SubAssoc> {
+    type SubAssoc;
+}
+
+// By using the where-clause we normalize `<T as Trait>::Assoc` to
+// `<T as Sub<'a>>::SubAssoc` where `'a` is an unconstrained region
+// variable.
+fn foo<T>(x: <T as Trait>::Assoc)
+where
+    for<'a> T: Sub<'a>,
+{}
+
+fn main() {}


### PR DESCRIPTION
fixes #112832

see tests/ui/implied-bounds/implied-bounds-unconstrained-2.rs for a minimal example showing why this is necessary.

r? types

cc @compiler-errors @aliemjay https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types/topic/assoc.20type.20bound.20in.20super.20trait