### PR TITLE
Make `PanicInfo::message` infallible

### DIFF
--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -25,7 +25,7 @@ use crate::panic::Location;
 #[derive(Debug)]
 pub struct PanicInfo<'a> {
     payload: &'a (dyn Any + Send),
-    message: &'a fmt::Arguments<'a>,
+    message: fmt::Arguments<'a>,
     location: &'a Location<'a>,
     can_unwind: bool,
     force_no_backtrace: bool,
@@ -40,7 +40,7 @@ impl<'a> PanicInfo<'a> {
     #[doc(hidden)]
     #[inline]
     pub fn internal_constructor(
-        message: &'a fmt::Arguments<'a>,
+        message: fmt::Arguments<'a>,
         location: &'a Location<'a>,
         can_unwind: bool,
         force_no_backtrace: bool,
@@ -92,7 +92,7 @@ impl<'a> PanicInfo<'a> {
     /// returns that message ready to be used for example with [`fmt::write`]
     #[must_use]
     #[unstable(feature = "panic_info_message", issue = "66745")]
-    pub fn message(&self) -> &fmt::Arguments<'_> {
+    pub fn message(&self) -> fmt::Arguments<'_> {
         self.message
     }
 
@@ -162,7 +162,7 @@ impl fmt::Display for PanicInfo<'_> {
         formatter.write_str("panicked at ")?;
         self.location.fmt(formatter)?;
         formatter.write_str(":\n")?;
-        formatter.write_fmt(*self.message)?;
+        formatter.write_fmt(self.message)?;
         // NOTE: we cannot use downcast_ref::<String>() here
         // since String is not available in core!
         // The payload is a String when `std::panic!` is called with multiple arguments,

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -62,7 +62,7 @@ pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
     }
 
     let pi = PanicInfo::internal_constructor(
-        Some(&fmt),
+        &fmt,
         Location::caller(),
         /* can_unwind */ true,
         /* force_no_backtrace */ false,
@@ -96,7 +96,7 @@ pub fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: bool) -> 
 
     // PanicInfo with the `can_unwind` flag set to false forces an abort.
     let pi = PanicInfo::internal_constructor(
-        Some(&fmt),
+        &fmt,
         Location::caller(),
         /* can_unwind */ false,
         force_no_backtrace,

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -62,7 +62,7 @@ pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
     }
 
     let pi = PanicInfo::internal_constructor(
-        &fmt,
+        fmt,
         Location::caller(),
         /* can_unwind */ true,
         /* force_no_backtrace */ false,
@@ -96,7 +96,7 @@ pub fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: bool) -> 
 
     // PanicInfo with the `can_unwind` flag set to false forces an abort.
     let pi = PanicInfo::internal_constructor(
-        &fmt,
+        fmt,
         Location::caller(),
         /* can_unwind */ false,
         force_no_backtrace,

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -292,6 +292,7 @@
 #![feature(float_gamma)]
 #![feature(float_minimum_maximum)]
 #![feature(float_next_up_down)]
+#![feature(fmt_internals)]
 #![feature(hasher_prefixfree_extras)]
 #![feature(hashmap_internals)]
 #![feature(ip)]

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -629,7 +629,7 @@ pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
             );
         } else {
             rust_panic_with_hook(
-                &mut PanicPayload::new(msg),
+                &mut PanicPayload::new(&msg),
                 info.message(),
                 loc,
                 info.can_unwind(),
@@ -662,7 +662,7 @@ pub const fn begin_panic<M: Any + Send>(msg: M) -> ! {
             *(&msg as &dyn Any).downcast_ref::<&'static str>().unwrap_or(&"<non-str payload>");
         rust_panic_with_hook(
             &mut PanicPayload::new(msg),
-            &core::fmt::Arguments::new_v1(&[message], &[]),
+            core::fmt::Arguments::new_v1(&[message], &[]),
             loc,
             /* can_unwind */ true,
             /* force_no_backtrace */ false,
@@ -709,7 +709,7 @@ pub const fn begin_panic<M: Any + Send>(msg: M) -> ! {
 /// abort or unwind.
 fn rust_panic_with_hook(
     payload: &mut dyn BoxMeUp,
-    message: &fmt::Arguments<'_>,
+    message: fmt::Arguments<'_>,
     location: &Location<'_>,
     can_unwind: bool,
     force_no_backtrace: bool,

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -615,7 +615,7 @@ pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
     }
 
     let loc = info.location().unwrap(); // The current implementation always returns Some
-    let msg = info.message(); // The current implementation always returns Some
+    let msg = info.message();
     crate::sys_common::backtrace::__rust_end_short_backtrace(move || {
         // FIXME: can we just pass `info` along rather than taking it apart here, only to have
         // `rust_panic_with_hook` construct a new `PanicInfo`?

--- a/tests/run-make/wasm-exceptions-nostd/src/panicking.rs
+++ b/tests/run-make/wasm-exceptions-nostd/src/panicking.rs
@@ -17,11 +17,8 @@ fn panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
     use alloc::boxed::Box;
     use alloc::string::ToString;
 
-    let msg = info
-        .message()
-        .map(|msg| msg.to_string())
-        .unwrap_or("(no message)".to_string());
-    let exception = Box::new(msg.to_string());
+    let msg = info.message().to_string();
+    let exception = Box::new(msg);
     unsafe {
         let exception_raw = Box::into_raw(exception);
         wasm_throw(exception_raw as *mut u8);

--- a/tests/ui/panics/panic_info_message.rs
+++ b/tests/ui/panics/panic_info_message.rs
@@ -1,0 +1,11 @@
+// revisions: e2015 e2018 e2021
+//[e2018] compile-flags: --edition=2018
+//[e2021] compile-flags: --edition=2021
+// run-pass
+
+#![feature(panic_info_message)]
+
+fn main() {
+    std::panic::set_hook(Box::new(|info| assert_eq!(info.message().as_str().unwrap(), "cake")));
+    let _ = std::panic::catch_unwind(|| panic!("cake"));
+}


### PR DESCRIPTION
addresses the remaining T-libs-api concern in https://github.com/rust-lang/rust/issues/66745

I picked `<non-str payload>` as the fallback message

r? libs-api 