### PR TITLE
llvm-wrapper: adapt for LLVM API change

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -1202,7 +1202,11 @@ LLVMRustCreateThinLTOData(LLVMRustThinLTOModule *modules,
 
     Ret->ModuleMap[module->identifier] = mem_buffer;
 
+#if LLVM_VERSION_GE(18, 0)
+    if (Error Err = readModuleSummaryIndex(mem_buffer, Ret->Index)) {
+#else
     if (Error Err = readModuleSummaryIndex(mem_buffer, Ret->Index, i)) {
+#endif
       LLVMRustSetLastError(toString(std::move(Err)).c_str());
       return nullptr;
     }


### PR DESCRIPTION
No functional changes intended.

Adapts the wrapper for https://github.com/llvm/llvm-project/commit/bbe8cd13335300958b04db5318c31ff52714f96f.

Found by our experimental rust + llvm @ HEAD CI: https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/22055#018a6495-8dd9-41df-9381-5e7b0009ce0a/274-575