### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_lint/src/traits.rs
+++ b/compiler/rustc_lint/src/traits.rs
@@ -96,7 +96,7 @@ impl<'tcx> LateLintPass<'tcx> for DropTraitConstraints {
             };
             let def_id = trait_predicate.trait_ref.def_id;
             if cx.tcx.lang_items().drop_trait() == Some(def_id) {
-                // Explicitly allow `impl Drop`, a drop-guards-as-Voldemort-type pattern.
+                // Explicitly allow `impl Drop`, a drop-guards-as-unnameable-type pattern.
                 if trait_predicate.trait_ref.self_ty().is_impl_trait() {
                     continue;
                 }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2857,7 +2857,7 @@ impl<'tcx> Ty<'tcx> {
             | ty::Uint(..)
             | ty::Float(..) => true,
 
-            // The voldemort ZSTs are fine.
+            // ZST which can't be named are fine.
             ty::FnDef(..) => true,
 
             ty::Array(element_ty, _len) => element_ty.is_trivially_pure_clone_copy(),

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2477,9 +2477,7 @@ impl<'a> Parser<'a> {
         } else {
             self.expect(&token::Eq)?;
         }
-        let expr = self.with_res(self.restrictions | Restrictions::NO_STRUCT_LITERAL, |this| {
-            this.parse_expr_assoc_with(1 + prec_let_scrutinee_needs_par(), None.into())
-        })?;
+        let expr = self.parse_expr_assoc_with(1 + prec_let_scrutinee_needs_par(), None.into())?;
         let span = lo.to(expr.span);
         self.sess.gated_spans.gate(sym::let_chains, span);
         Ok(self.mk_expr(span, ExprKind::Let(pat, expr, span)))

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -1123,7 +1123,7 @@ impl<'tcx> Stable<'tcx> for ty::Const<'tcx> {
                         tables,
                     ))
                 }
-                ty::ParamCt(param) => stable_mir::ty::ConstantKind::ParamCt(opaque(&param)),
+                ty::ParamCt(param) => stable_mir::ty::ConstantKind::Param(param.stable(tables)),
                 ty::ErrorCt(_) => unreachable!(),
                 ty::InferCt(_) => unreachable!(),
                 ty::BoundCt(_, _) => unimplemented!(),
@@ -1139,6 +1139,14 @@ impl<'tcx> Stable<'tcx> for ty::Const<'tcx> {
             },
             ty: tables.intern_ty(self.ty()),
         }
+    }
+}
+
+impl<'tcx> Stable<'tcx> for ty::ParamConst {
+    type T = stable_mir::ty::ParamConst;
+    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+        use stable_mir::ty::ParamConst;
+        ParamConst { index: self.index, name: self.name.to_string() }
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -72,8 +72,8 @@ impl<'tcx> Context for Tables<'tcx> {
         impl_trait.stable(self)
     }
 
-    fn mir_body(&mut self, item: &stable_mir::CrateItem) -> stable_mir::mir::Body {
-        let def_id = self[item.0];
+    fn mir_body(&mut self, item: stable_mir::DefId) -> stable_mir::mir::Body {
+        let def_id = self[item];
         let mir = self.tcx.optimized_mir(def_id);
         stable_mir::mir::Body {
             blocks: mir

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -1210,22 +1210,26 @@ impl<'tcx> Stable<'tcx> for ty::TraitDef {
 }
 
 impl<'tcx> Stable<'tcx> for rustc_middle::mir::ConstantKind<'tcx> {
-    type T = stable_mir::ty::ConstantKind;
+    type T = stable_mir::ty::Const;
 
     fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
         match *self {
-            ConstantKind::Ty(c) => c.stable(tables).literal,
-            ConstantKind::Unevaluated(unev_const, ty) => {
-                stable_mir::ty::ConstantKind::Unevaluated(stable_mir::ty::UnevaluatedConst {
-                    ty: tables.intern_ty(ty),
-                    def: tables.const_def(unev_const.def),
-                    args: unev_const.args.stable(tables),
-                    promoted: unev_const.promoted.map(|u| u.as_u32()),
-                })
-            }
-            ConstantKind::Val(val, ty) => {
-                stable_mir::ty::ConstantKind::Allocated(alloc::new_allocation(ty, val, tables))
-            }
+            ConstantKind::Ty(c) => c.stable(tables),
+            ConstantKind::Unevaluated(unev_const, ty) => stable_mir::ty::Const {
+                literal: stable_mir::ty::ConstantKind::Unevaluated(
+                    stable_mir::ty::UnevaluatedConst {
+                        ty: tables.intern_ty(ty),
+                        def: tables.const_def(unev_const.def),
+                        args: unev_const.args.stable(tables),
+                        promoted: unev_const.promoted.map(|u| u.as_u32()),
+                    },
+                ),
+            },
+            ConstantKind::Val(val, ty) => stable_mir::ty::Const {
+                literal: stable_mir::ty::ConstantKind::Allocated(alloc::new_allocation(
+                    ty, val, tables,
+                )),
+            },
         }
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -97,8 +97,13 @@ impl<'tcx> Context for Tables<'tcx> {
     }
 
     fn ty_kind(&mut self, ty: crate::stable_mir::ty::Ty) -> TyKind {
-        let ty = self.types[ty.0];
-        ty.stable(self)
+        self.types[ty.0].clone().stable(self)
+    }
+
+    fn mk_ty(&mut self, kind: TyKind) -> stable_mir::ty::Ty {
+        let n = self.types.len();
+        self.types.push(MaybeStable::Stable(kind));
+        stable_mir::ty::Ty(n)
     }
 
     fn generics_of(&mut self, def_id: stable_mir::DefId) -> stable_mir::ty::Generics {
@@ -122,20 +127,47 @@ impl<'tcx> Context for Tables<'tcx> {
     }
 }
 
+#[derive(Clone)]
+pub enum MaybeStable<S, R> {
+    Stable(S),
+    Rustc(R),
+}
+
+impl<'tcx, S, R> MaybeStable<S, R> {
+    fn stable(self, tables: &mut Tables<'tcx>) -> S
+    where
+        R: Stable<'tcx, T = S>,
+    {
+        match self {
+            MaybeStable::Stable(s) => s,
+            MaybeStable::Rustc(r) => r.stable(tables),
+        }
+    }
+}
+
+impl<S, R: PartialEq> PartialEq<R> for MaybeStable<S, R> {
+    fn eq(&self, other: &R) -> bool {
+        match self {
+            MaybeStable::Stable(_) => false,
+            MaybeStable::Rustc(r) => r == other,
+        }
+    }
+}
+
 pub struct Tables<'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub def_ids: Vec<DefId>,
     pub alloc_ids: Vec<AllocId>,
-    pub types: Vec<Ty<'tcx>>,
+    pub types: Vec<MaybeStable<stable_mir::ty::TyKind, Ty<'tcx>>>,
 }
 
 impl<'tcx> Tables<'tcx> {
     fn intern_ty(&mut self, ty: Ty<'tcx>) -> stable_mir::ty::Ty {
-        if let Some(id) = self.types.iter().position(|&t| t == ty) {
+        if let Some(id) = self.types.iter().position(|t| *t == ty) {
             return stable_mir::ty::Ty(id);
         }
         let id = self.types.len();
-        self.types.push(ty);
+        self.types.push(MaybeStable::Rustc(ty));
         stable_mir::ty::Ty(id)
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -1130,7 +1130,6 @@ impl<'tcx> Stable<'tcx> for ty::Const<'tcx> {
                 ty::PlaceholderCt(_) => unimplemented!(),
                 ty::Unevaluated(uv) => {
                     stable_mir::ty::ConstantKind::Unevaluated(stable_mir::ty::UnevaluatedConst {
-                        ty: tables.intern_ty(self.ty()),
                         def: tables.const_def(uv.def),
                         args: uv.args.stable(tables),
                         promoted: None,
@@ -1138,6 +1137,7 @@ impl<'tcx> Stable<'tcx> for ty::Const<'tcx> {
                 }
                 ty::ExprCt(_) => unimplemented!(),
             },
+            ty: tables.intern_ty(self.ty()),
         }
     }
 }
@@ -1218,17 +1218,18 @@ impl<'tcx> Stable<'tcx> for rustc_middle::mir::ConstantKind<'tcx> {
             ConstantKind::Unevaluated(unev_const, ty) => stable_mir::ty::Const {
                 literal: stable_mir::ty::ConstantKind::Unevaluated(
                     stable_mir::ty::UnevaluatedConst {
-                        ty: tables.intern_ty(ty),
                         def: tables.const_def(unev_const.def),
                         args: unev_const.args.stable(tables),
                         promoted: unev_const.promoted.map(|u| u.as_u32()),
                     },
                 ),
+                ty: tables.intern_ty(ty),
             },
             ConstantKind::Val(val, ty) => stable_mir::ty::Const {
                 literal: stable_mir::ty::ConstantKind::Allocated(alloc::new_allocation(
                     ty, val, tables,
                 )),
+                ty: tables.intern_ty(ty),
             },
         }
     }

--- a/compiler/rustc_smir/src/stable_mir/fold.rs
+++ b/compiler/rustc_smir/src/stable_mir/fold.rs
@@ -51,6 +51,7 @@ impl Foldable for Const {
             super::ty::ConstantKind::Unevaluated(uv) => *uv = uv.fold(folder)?,
             super::ty::ConstantKind::ParamCt(param) => *param = param.fold(folder)?,
         }
+        this.ty = this.ty.fold(folder)?;
         ControlFlow::Continue(this)
     }
 }
@@ -69,9 +70,8 @@ impl Foldable for Allocation {
 
 impl Foldable for UnevaluatedConst {
     fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
-        let UnevaluatedConst { ty, def, args, promoted } = self;
+        let UnevaluatedConst { def, args, promoted } = self;
         ControlFlow::Continue(UnevaluatedConst {
-            ty: ty.fold(folder)?,
             def: def.fold(folder)?,
             args: args.fold(folder)?,
             promoted: promoted.fold(folder)?,

--- a/compiler/rustc_smir/src/stable_mir/fold.rs
+++ b/compiler/rustc_smir/src/stable_mir/fold.rs
@@ -1,0 +1,207 @@
+use std::ops::ControlFlow;
+
+use crate::rustc_internal::Opaque;
+
+use super::ty::{
+    Allocation, Binder, Const, ConstDef, ExistentialPredicate, FnSig, GenericArgKind, GenericArgs,
+    Promoted, RigidTy, TermKind, Ty, UnevaluatedConst,
+};
+
+pub trait Folder: Sized {
+    type Break;
+    fn visit_ty(&mut self, ty: &Ty) -> ControlFlow<Self::Break, Ty> {
+        ty.super_fold(self)
+    }
+    fn fold_const(&mut self, c: &Const) -> ControlFlow<Self::Break, Const> {
+        c.super_fold(self)
+    }
+}
+
+pub trait Foldable: Sized + Clone {
+    fn fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        self.super_fold(folder)
+    }
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self>;
+}
+
+impl Foldable for Ty {
+    fn fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        folder.visit_ty(self)
+    }
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let mut kind = self.kind();
+        match &mut kind {
+            super::ty::TyKind::RigidTy(ty) => *ty = ty.fold(folder)?,
+            super::ty::TyKind::Alias(_, alias) => alias.args = alias.args.fold(folder)?,
+            super::ty::TyKind::Param(_) => {}
+            super::ty::TyKind::Bound(_, _) => {}
+        }
+        ControlFlow::Continue(kind.into())
+    }
+}
+
+impl Foldable for Const {
+    fn fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        folder.fold_const(self)
+    }
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let mut this = self.clone();
+        match &mut this.literal {
+            super::ty::ConstantKind::Allocated(alloc) => *alloc = alloc.fold(folder)?,
+            super::ty::ConstantKind::Unevaluated(uv) => *uv = uv.fold(folder)?,
+            super::ty::ConstantKind::ParamCt(param) => *param = param.fold(folder)?,
+        }
+        ControlFlow::Continue(this)
+    }
+}
+
+impl Foldable for Opaque {
+    fn super_fold<V: Folder>(&self, _folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(self.clone())
+    }
+}
+
+impl Foldable for Allocation {
+    fn super_fold<V: Folder>(&self, _folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(self.clone())
+    }
+}
+
+impl Foldable for UnevaluatedConst {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let UnevaluatedConst { ty, def, args, promoted } = self;
+        ControlFlow::Continue(UnevaluatedConst {
+            ty: ty.fold(folder)?,
+            def: def.fold(folder)?,
+            args: args.fold(folder)?,
+            promoted: promoted.fold(folder)?,
+        })
+    }
+}
+
+impl Foldable for ConstDef {
+    fn super_fold<V: Folder>(&self, _folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(self.clone())
+    }
+}
+
+impl<T: Foldable> Foldable for Option<T> {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(match self {
+            Some(val) => Some(val.fold(folder)?),
+            None => None,
+        })
+    }
+}
+
+impl Foldable for Promoted {
+    fn super_fold<V: Folder>(&self, _folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(self.clone())
+    }
+}
+
+impl Foldable for GenericArgs {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(GenericArgs(self.0.fold(folder)?))
+    }
+}
+
+impl Foldable for GenericArgKind {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let mut this = self.clone();
+        match &mut this {
+            GenericArgKind::Lifetime(lt) => *lt = lt.fold(folder)?,
+            GenericArgKind::Type(t) => *t = t.fold(folder)?,
+            GenericArgKind::Const(c) => *c = c.fold(folder)?,
+        }
+        ControlFlow::Continue(this)
+    }
+}
+
+impl Foldable for RigidTy {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let mut this = self.clone();
+        match &mut this {
+            RigidTy::Bool
+            | RigidTy::Char
+            | RigidTy::Int(_)
+            | RigidTy::Uint(_)
+            | RigidTy::Float(_)
+            | RigidTy::Never
+            | RigidTy::Foreign(_)
+            | RigidTy::Str => {}
+            RigidTy::Array(t, c) => {
+                *t = t.fold(folder)?;
+                *c = c.fold(folder)?;
+            }
+            RigidTy::Slice(inner) => *inner = inner.fold(folder)?,
+            RigidTy::RawPtr(ty, _) => *ty = ty.fold(folder)?,
+            RigidTy::Ref(_, ty, _) => *ty = ty.fold(folder)?,
+            RigidTy::FnDef(_, args) => *args = args.fold(folder)?,
+            RigidTy::FnPtr(sig) => *sig = sig.fold(folder)?,
+            RigidTy::Closure(_, args) => *args = args.fold(folder)?,
+            RigidTy::Generator(_, args, _) => *args = args.fold(folder)?,
+            RigidTy::Dynamic(pred, r, _) => {
+                *pred = pred.fold(folder)?;
+                *r = r.fold(folder)?;
+            }
+            RigidTy::Tuple(fields) => *fields = fields.fold(folder)?,
+            RigidTy::Adt(_, args) => *args = args.fold(folder)?,
+        }
+        ControlFlow::Continue(this)
+    }
+}
+
+impl<T: Foldable> Foldable for Vec<T> {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let mut this = self.clone();
+        for arg in &mut this {
+            *arg = arg.fold(folder)?;
+        }
+        ControlFlow::Continue(this)
+    }
+}
+
+impl<T: Foldable> Foldable for Binder<T> {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(Self {
+            value: self.value.fold(folder)?,
+            bound_vars: self.bound_vars.clone(),
+        })
+    }
+}
+
+impl Foldable for ExistentialPredicate {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let mut this = self.clone();
+        match &mut this {
+            ExistentialPredicate::Trait(tr) => tr.generic_args = tr.generic_args.fold(folder)?,
+            ExistentialPredicate::Projection(p) => {
+                p.term = p.term.fold(folder)?;
+                p.generic_args = p.generic_args.fold(folder)?;
+            }
+            ExistentialPredicate::AutoTrait(_) => {}
+        }
+        ControlFlow::Continue(this)
+    }
+}
+
+impl Foldable for TermKind {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(match self {
+            TermKind::Type(t) => TermKind::Type(t.fold(folder)?),
+            TermKind::Const(c) => TermKind::Const(c.fold(folder)?),
+        })
+    }
+}
+
+impl Foldable for FnSig {
+    fn super_fold<V: Folder>(&self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(Self {
+            inputs_and_output: self.inputs_and_output.fold(folder)?,
+            c_variadic: self.c_variadic,
+            unsafety: self.unsafety,
+            abi: self.abi.clone(),
+        })
+    }
+}

--- a/compiler/rustc_smir/src/stable_mir/fold.rs
+++ b/compiler/rustc_smir/src/stable_mir/fold.rs
@@ -49,7 +49,7 @@ impl Foldable for Const {
         match &mut this.literal {
             super::ty::ConstantKind::Allocated(alloc) => *alloc = alloc.fold(folder)?,
             super::ty::ConstantKind::Unevaluated(uv) => *uv = uv.fold(folder)?,
-            super::ty::ConstantKind::ParamCt(param) => *param = param.fold(folder)?,
+            super::ty::ConstantKind::Param(_) => {}
         }
         this.ty = this.ty.fold(folder)?;
         ControlFlow::Continue(this)

--- a/compiler/rustc_smir/src/stable_mir/mir/body.rs
+++ b/compiler/rustc_smir/src/stable_mir/mir/body.rs
@@ -1,6 +1,6 @@
 use crate::rustc_internal::Opaque;
 use crate::stable_mir::ty::{
-    AdtDef, ClosureDef, Const, ConstantKind, GeneratorDef, GenericArgs, Movability, Region,
+    AdtDef, ClosureDef, Const, GeneratorDef, GenericArgs, Movability, Region,
 };
 use crate::stable_mir::{self, ty::Ty, Span};
 
@@ -352,7 +352,7 @@ type UserTypeAnnotationIndex = usize;
 pub struct Constant {
     pub span: Span,
     pub user_ty: Option<UserTypeAnnotationIndex>,
-    pub literal: ConstantKind,
+    pub literal: Const,
 }
 
 #[derive(Clone, Debug)]

--- a/compiler/rustc_smir/src/stable_mir/mir/body.rs
+++ b/compiler/rustc_smir/src/stable_mir/mir/body.rs
@@ -391,7 +391,7 @@ pub enum Mutability {
     Mut,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Safety {
     Unsafe,
     Normal,

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -62,7 +62,7 @@ pub struct CrateItem(pub(crate) DefId);
 
 impl CrateItem {
     pub fn body(&self) -> mir::Body {
-        with(|cx| cx.mir_body(self))
+        with(|cx| cx.mir_body(self.0))
     }
 }
 
@@ -113,7 +113,7 @@ pub trait Context {
     fn entry_fn(&mut self) -> Option<CrateItem>;
     /// Retrieve all items of the local crate that have a MIR associated with them.
     fn all_local_items(&mut self) -> CrateItems;
-    fn mir_body(&mut self, item: &CrateItem) -> mir::Body;
+    fn mir_body(&mut self, item: DefId) -> mir::Body;
     fn all_trait_decls(&mut self) -> TraitDecls;
     fn trait_decl(&mut self, trait_def: &TraitDef) -> TraitDecl;
     fn all_trait_impls(&mut self) -> ImplTraitDecls;

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -18,6 +18,7 @@ use self::ty::{
 };
 use crate::rustc_smir::Tables;
 
+pub mod fold;
 pub mod mir;
 pub mod ty;
 pub mod visitor;
@@ -129,6 +130,9 @@ pub trait Context {
 
     /// Obtain the representation of a type.
     fn ty_kind(&mut self, ty: Ty) -> TyKind;
+
+    /// Create a new `Ty` from scratch without information from rustc.
+    fn mk_ty(&mut self, kind: TyKind) -> Ty;
 
     /// HACK: Until we have fully stable consumers, we need an escape hatch
     /// to get `DefId`s out of `CrateItem`s.

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -10,6 +10,12 @@ impl Ty {
     }
 }
 
+impl From<TyKind> for Ty {
+    fn from(value: TyKind) -> Self {
+        with(|context| context.mk_ty(value))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Const {
     pub literal: ConstantKind,

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -138,11 +138,49 @@ pub struct ImplDef(pub(crate) DefId);
 #[derive(Clone, Debug)]
 pub struct GenericArgs(pub Vec<GenericArgKind>);
 
+impl std::ops::Index<ParamTy> for GenericArgs {
+    type Output = Ty;
+
+    fn index(&self, index: ParamTy) -> &Self::Output {
+        self.0[index.index as usize].expect_ty()
+    }
+}
+
+impl std::ops::Index<ParamConst> for GenericArgs {
+    type Output = Const;
+
+    fn index(&self, index: ParamConst) -> &Self::Output {
+        self.0[index.index as usize].expect_const()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum GenericArgKind {
     Lifetime(Region),
     Type(Ty),
     Const(Const),
+}
+
+impl GenericArgKind {
+    /// Panic if this generic argument is not a type, otherwise
+    /// return the type.
+    #[track_caller]
+    pub fn expect_ty(&self) -> &Ty {
+        match self {
+            GenericArgKind::Type(ty) => ty,
+            _ => panic!("{self:?}"),
+        }
+    }
+
+    /// Panic if this generic argument is not a const, otherwise
+    /// return the const.
+    #[track_caller]
+    pub fn expect_const(&self) -> &Const {
+        match self {
+            GenericArgKind::Const(c) => c,
+            _ => panic!("{self:?}"),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -19,6 +19,7 @@ impl From<TyKind> for Ty {
 #[derive(Debug, Clone)]
 pub struct Const {
     pub literal: ConstantKind,
+    pub ty: Ty,
 }
 
 type Ident = Opaque;
@@ -298,7 +299,6 @@ pub enum ConstantKind {
 
 #[derive(Clone, Debug)]
 pub struct UnevaluatedConst {
-    pub ty: Ty,
     pub def: ConstDef,
     pub args: GenericArgs,
     pub promoted: Option<Promoted>,

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -294,7 +294,13 @@ pub struct Allocation {
 pub enum ConstantKind {
     Allocated(Allocation),
     Unevaluated(UnevaluatedConst),
-    ParamCt(Opaque),
+    Param(ParamConst),
+}
+
+#[derive(Clone, Debug)]
+pub struct ParamConst {
+    pub index: u32,
+    pub name: String,
 }
 
 #[derive(Clone, Debug)]

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -1,4 +1,8 @@
-use super::{mir::Mutability, mir::Safety, with, AllocId, DefId};
+use super::{
+    mir::Safety,
+    mir::{Body, Mutability},
+    with, AllocId, DefId,
+};
 use crate::rustc_internal::Opaque;
 
 #[derive(Copy, Clone, Debug)]
@@ -94,6 +98,12 @@ pub struct ForeignDef(pub(crate) DefId);
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct FnDef(pub(crate) DefId);
+
+impl FnDef {
+    pub fn body(&self) -> Body {
+        with(|ctx| ctx.mir_body(self.0))
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ClosureDef(pub(crate) DefId);

--- a/compiler/rustc_smir/src/stable_mir/visitor.rs
+++ b/compiler/rustc_smir/src/stable_mir/visitor.rs
@@ -30,11 +30,12 @@ impl Visitable for Ty {
     }
     fn super_visit<V: Visitor>(&self, visitor: &mut V) -> ControlFlow<V::Break> {
         match self.kind() {
-            super::ty::TyKind::RigidTy(ty) => ty.visit(visitor),
-            super::ty::TyKind::Alias(_, alias) => alias.args.visit(visitor),
-            super::ty::TyKind::Param(_) => todo!(),
-            super::ty::TyKind::Bound(_, _) => todo!(),
+            super::ty::TyKind::RigidTy(ty) => ty.visit(visitor)?,
+            super::ty::TyKind::Alias(_, alias) => alias.args.visit(visitor)?,
+            super::ty::TyKind::Param(_) => {}
+            super::ty::TyKind::Bound(_, _) => {}
         }
+        ControlFlow::Continue(())
     }
 }
 
@@ -44,10 +45,10 @@ impl Visitable for Const {
     }
     fn super_visit<V: Visitor>(&self, visitor: &mut V) -> ControlFlow<V::Break> {
         match &self.literal {
-            super::ty::ConstantKind::Allocated(alloc) => alloc.visit(visitor),
-            super::ty::ConstantKind::Unevaluated(uv) => uv.visit(visitor),
-            super::ty::ConstantKind::ParamCt(param) => param.visit(visitor),
-        }?;
+            super::ty::ConstantKind::Allocated(alloc) => alloc.visit(visitor)?,
+            super::ty::ConstantKind::Unevaluated(uv) => uv.visit(visitor)?,
+            super::ty::ConstantKind::Param(_) => {}
+        }
         self.ty.visit(visitor)
     }
 }

--- a/compiler/rustc_smir/src/stable_mir/visitor.rs
+++ b/compiler/rustc_smir/src/stable_mir/visitor.rs
@@ -47,7 +47,8 @@ impl Visitable for Const {
             super::ty::ConstantKind::Allocated(alloc) => alloc.visit(visitor),
             super::ty::ConstantKind::Unevaluated(uv) => uv.visit(visitor),
             super::ty::ConstantKind::ParamCt(param) => param.visit(visitor),
-        }
+        }?;
+        self.ty.visit(visitor)
     }
 }
 
@@ -65,8 +66,7 @@ impl Visitable for Allocation {
 
 impl Visitable for UnevaluatedConst {
     fn super_visit<V: Visitor>(&self, visitor: &mut V) -> ControlFlow<V::Break> {
-        let UnevaluatedConst { ty, def, args, promoted } = self;
-        ty.visit(visitor)?;
+        let UnevaluatedConst { def, args, promoted } = self;
         def.visit(visitor)?;
         args.visit(visitor)?;
         promoted.visit(visitor)

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -57,16 +57,12 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
         let ty = OpportunisticRegionResolver::new(self).fold_ty(ty);
 
         // We do not expect existential variables in implied bounds.
-        // We may however encounter unconstrained lifetime variables in invalid
-        // code. See #110161 for context.
+        // We may however encounter unconstrained lifetime variables
+        // in very rare cases.
+        //
+        // See `ui/implied-bounds/implied-bounds-unconstrained-2.rs` for
+        // an example.
         assert!(!ty.has_non_region_infer());
-        if ty.has_infer() {
-            self.tcx.sess.delay_span_bug(
-                self.tcx.def_span(body_id),
-                "skipped implied_outlives_bounds due to unconstrained lifetimes",
-            );
-            return vec![];
-        }
 
         let mut canonical_var_values = OriginalQueryValues::default();
         let canonical_ty =

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2709,6 +2709,9 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 ///
 /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
 ///
+/// * `src` must remain valid for reads even after `dst` is written, and vice versa.
+///   (In other words, there cannot be aliasing restrictions on the use of these pointers.)
+///
 /// * Both `src` and `dst` must be properly aligned.
 ///
 /// Like [`read`], `copy` creates a bitwise copy of `T`, regardless of

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2706,12 +2706,12 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 /// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes, and must remain valid even
-///   if `dst` is written for `count * size_of::<T>()` bytes. (This means if the memory ranges
+///   when `dst` is written for `count * size_of::<T>()` bytes. (This means if the memory ranges
 ///   overlap, the two pointers must not be subject to aliasing restrictions relative to each
 ///   other.)
 ///
 /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes, and must remain valid even
-///   if `src` is read for `count * size_of::<T>()` bytes.
+///   when `src` is read for `count * size_of::<T>()` bytes.
 ///
 /// * Both `src` and `dst` must be properly aligned.
 ///

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2705,12 +2705,13 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes.
+/// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes, and must remain valid even
+///   if `dst` is written for `count * size_of::<T>()` bytes. (This means if the memory ranges
+///   overlap, the two pointers must not be subject to aliasing restrictions relative to each
+///   other.)
 ///
-/// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
-///
-/// * `src` must remain valid for reads even after `dst` is written, and vice versa.
-///   (In other words, there cannot be aliasing restrictions on the use of these pointers.)
+/// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes, and must remain valid even
+///   if `src` is read for `count * size_of::<T>()` bytes.
 ///
 /// * Both `src` and `dst` must be properly aligned.
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -795,7 +795,7 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * Both `x` and `y` must be [valid] for both reads and writes. They must remain valid even if the
+/// * Both `x` and `y` must be [valid] for both reads and writes. They must remain valid even when the
 ///   other pointer is written. (This means if the memory ranges overlap, the two pointers must not
 ///   be subject to aliasing restrictions relative to each other.)
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -795,10 +795,9 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * Both `x` and `y` must be [valid] for both reads and writes.
-///
-/// * `x` must remain valid for reads and writes even after `y` is read/written, and vice versa.
-///   (In other words, there cannot be aliasing restrictions on the use of these pointers.)
+/// * Both `x` and `y` must be [valid] for both reads and writes. They must remain valid even if the
+///   other pointer is written. (This means if the memory ranges overlap, the two pointers must not
+///   be subject to aliasing restrictions relative to each other.)
 ///
 /// * Both `x` and `y` must be properly aligned.
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -797,6 +797,9 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 ///
 /// * Both `x` and `y` must be [valid] for both reads and writes.
 ///
+/// * `x` must remain valid for reads and writes even after `y` is read/written, and vice versa.
+///   (In other words, there cannot be aliasing restrictions on the use of these pointers.)
+///
 /// * Both `x` and `y` must be properly aligned.
 ///
 /// Note that even if `T` has size `0`, the pointers must be non-null and properly aligned.

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -113,7 +113,7 @@ fn test_stable_mir(tcx: TyCtxt<'_>) {
     for block in monomorphic.body().blocks {
         match &block.terminator {
             stable_mir::mir::Terminator::Call { func, .. } => match func {
-                stable_mir::mir::Operand::Constant(c) => match &c.literal {
+                stable_mir::mir::Operand::Constant(c) => match &c.literal.literal {
                     stable_mir::ty::ConstantKind::Allocated(alloc) => {
                         assert!(alloc.bytes.is_empty())
                     }

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -108,6 +108,23 @@ fn test_stable_mir(tcx: TyCtxt<'_>) {
         stable_mir::mir::Terminator::Assert { .. } => {}
         other => panic!("{other:?}"),
     }
+
+    let monomorphic = get_item(tcx, &items, (DefKind::Fn, "monomorphic")).unwrap();
+    for block in monomorphic.body().blocks {
+        match &block.terminator {
+            stable_mir::mir::Terminator::Call { func, .. } => match func {
+                stable_mir::mir::Operand::Constant(c) => match &c.literal {
+                    stable_mir::ty::ConstantKind::Allocated(alloc) => {
+                        assert!(alloc.bytes.is_empty())
+                    }
+                    other => panic!("{other:?}"),
+                },
+                other => panic!("{other:?}"),
+            },
+            stable_mir::mir::Terminator::Return => {}
+            other => panic!("{other:?}"),
+        }
+    }
 }
 
 // Use internal API to find a function in a crate.
@@ -144,6 +161,16 @@ fn generate_input(path: &str) -> std::io::Result<()> {
     write!(
         file,
         r#"
+    fn generic<T, const U: usize>(t: T) -> [(); U] {{
+        _ = t;
+        [(); U]
+    }}
+
+    pub fn monomorphic() {{
+        generic::<(), 5>(());
+        generic::<u32, 0>(45);
+    }}
+
     mod foo {{
         pub fn bar(i: i32) -> i64 {{
             i as i64

--- a/tests/ui/drop-bounds/drop-bounds-impl-drop.rs
+++ b/tests/ui/drop-bounds/drop-bounds-impl-drop.rs
@@ -2,6 +2,7 @@
 #![deny(drop_bounds)]
 // As a special exemption, `impl Drop` in the return position raises no error.
 // This allows a convenient way to return an unnamed drop guard.
+// Voldemort here refers to types that are unnameable.
 fn voldemort_type() -> impl Drop {
   struct Voldemort;
   impl Drop for Voldemort {

--- a/tests/ui/implied-bounds/implied-bounds-unconstrained-1.rs
+++ b/tests/ui/implied-bounds/implied-bounds-unconstrained-1.rs
@@ -1,0 +1,28 @@
+// check-pass
+
+// Regression test for #112832.
+pub trait QueryDb {
+    type Db;
+}
+
+pub struct QueryTable<Q, DB> {
+    db: DB,
+    storage: Q,
+}
+
+// We normalize `<Q as QueryDb>::Db` to `<Q as AsyncQueryFunction<'d>>::SendDb`
+// using the where-bound. 'd is an unconstrained region variable which previously
+// triggered an assert.
+impl<Q> QueryTable<Q, <Q as QueryDb>::Db> where Q: for<'d> AsyncQueryFunction<'d> {}
+
+pub trait AsyncQueryFunction<'d>: QueryDb<Db = <Self as AsyncQueryFunction<'d>>::SendDb> {
+    type SendDb: 'd;
+}
+
+pub trait QueryStorageOpsAsync<Q>
+where
+    Q: for<'d> AsyncQueryFunction<'d>,
+{
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/implied-bounds-unconstrained-2.rs
+++ b/tests/ui/implied-bounds/implied-bounds-unconstrained-2.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+// Another minimized regression test for #112832.
+trait Trait {
+    type Assoc;
+}
+
+trait Sub<'a>: Trait<Assoc = <Self as Sub<'a>>::SubAssoc> {
+    type SubAssoc;
+}
+
+// By using the where-clause we normalize `<T as Trait>::Assoc` to
+// `<T as Sub<'a>>::SubAssoc` where `'a` is an unconstrained region
+// variable.
+fn foo<T>(x: <T as Trait>::Assoc)
+where
+    for<'a> T: Sub<'a>,
+{}
+
+fn main() {}

--- a/tests/ui/parser/struct-literal-in-if.rs
+++ b/tests/ui/parser/struct-literal-in-if.rs
@@ -14,4 +14,9 @@ fn main() {
     }.hi() {
         println!("yo");
     }
+    if let true = Foo { //~ ERROR struct literals are not allowed here
+        x: 3
+    }.hi() {
+        println!("yo");
+    }
 }

--- a/tests/ui/parser/struct-literal-in-if.stderr
+++ b/tests/ui/parser/struct-literal-in-if.stderr
@@ -14,5 +14,21 @@ LL |         x: 3
 LL ~     }).hi() {
    |
 
-error: aborting due to previous error
+error: struct literals are not allowed here
+  --> $DIR/struct-literal-in-if.rs:17:19
+   |
+LL |       if let true = Foo {
+   |  ___________________^
+LL | |         x: 3
+LL | |     }.hi() {
+   | |_____^
+   |
+help: surround the struct literal with parentheses
+   |
+LL ~     if let true = (Foo {
+LL |         x: 3
+LL ~     }).hi() {
+   |
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/struct-literal-in-match-guard.rs
+++ b/tests/ui/parser/struct-literal-in-match-guard.rs
@@ -3,6 +3,8 @@
 // Unlike `if` condition, `match` guards accept struct literals.
 // This is detected in <https://github.com/rust-lang/rust/pull/74566#issuecomment-663613705>.
 
+#![feature(if_let_guard)]
+
 #[derive(PartialEq)]
 struct Foo {
     x: isize,
@@ -11,6 +13,7 @@ struct Foo {
 fn foo(f: Foo) {
     match () {
         () if f == Foo { x: 42 } => {}
+        () if let Foo { x: 0.. } = Foo { x: 42 } => {}
         _ => {}
     }
 }

--- a/tests/ui/parser/struct-literal-in-while.rs
+++ b/tests/ui/parser/struct-literal-in-while.rs
@@ -14,4 +14,9 @@ fn main() {
     }.hi() {
         println!("yo");
     }
+    while let true = Foo { //~ ERROR struct literals are not allowed here
+        x: 3
+    }.hi() {
+        println!("yo");
+    }
 }

--- a/tests/ui/parser/struct-literal-in-while.stderr
+++ b/tests/ui/parser/struct-literal-in-while.stderr
@@ -14,5 +14,21 @@ LL |         x: 3
 LL ~     }).hi() {
    |
 
-error: aborting due to previous error
+error: struct literals are not allowed here
+  --> $DIR/struct-literal-in-while.rs:17:22
+   |
+LL |       while let true = Foo {
+   |  ______________________^
+LL | |         x: 3
+LL | |     }.hi() {
+   | |_____^
+   |
+help: surround the struct literal with parentheses
+   |
+LL ~     while let true = (Foo {
+LL |         x: 3
+LL ~     }).hi() {
+   |
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #114794 (clarify safety documentation of ptr::swap and ptr::copy)
 - #115371 (Make if let guard parsing consistent with normal guards)
 - #115532 (Implement SMIR generic parameter instantiation)
 - #115559 (implied bounds: do not ICE on unconstrained region vars)
 - #115570 (Make Voldemort comments less cryptic)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114794,115371,115532,115559,115570)
<!-- homu-ignore:end -->