### PR TITLE
Replace `rustc_data_structures` dependency with `rustc_index` in `rustc_parse_format`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4157,7 +4157,7 @@ dependencies = [
 name = "rustc_parse_format"
 version = "0.0.0"
 dependencies = [
- "rustc_data_structures",
+ "rustc_index",
  "rustc_lexer",
 ]
 

--- a/compiler/rustc_parse_format/Cargo.toml
+++ b/compiler/rustc_parse_format/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 rustc_lexer = { path = "../rustc_lexer" }
-rustc_data_structures = { path = "../rustc_data_structures" }
+rustc_index = { path = "../rustc_index", default-features = false }

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -1011,7 +1011,7 @@ fn unescape_string(string: &str) -> Option<string::String> {
 
 // Assert a reasonable size for `Piece`
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Piece<'_>, 16);
+rustc_index::static_assert_size!(Piece<'_>, 16);
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
`rustc_data_structures` is only used for the `static_assert_size` macro, yet that is defined in `rustc_index` and merely re-exported. `rustc_index` is a lot more lightweight than `rustc_data_structures` which would make this a lot more reusable for rust-analyzer.