### PR TITLE
Add a `default` flag for enum documentation

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1716,6 +1716,9 @@ fn item_variants(
         if let clean::VariantKind::Tuple(ref s) = variant_data.kind {
             write!(w, "({})", print_tuple_struct_fields(cx, s));
         }
+        if variant.attrs.other_attrs.iter().any(|a| a.has_name(kw::Default)) {
+            write!(w, "{}", chip("Default", "default"));
+        }
         w.write_str("</h3></section>");
 
         let heading_and_fields = match &variant_data.kind {
@@ -2367,4 +2370,14 @@ fn document_non_exhaustive<'a>(item: &'a clean::Item) -> impl fmt::Display + 'a 
 
 fn pluralize(count: usize) -> &'static str {
     if count > 1 { "s" } else { "" }
+}
+
+fn chip<'a, 'cx: 'a>(
+    inner: &'a str,
+    extra_classes: &'a str,
+) -> impl fmt::Display + 'a + Captures<'cx> {
+    display_fn(move |f| {
+        f.write_fmt(format_args!(" <span class=\"chip {extra_classes}\">{inner}</span>"))?;
+        Ok(())
+    })
 }

--- a/src/librustdoc/html/static/css/noscript.css
+++ b/src/librustdoc/html/static/css/noscript.css
@@ -84,6 +84,7 @@ nav.sub {
 	--search-tab-button-not-selected-background: #e6e6e6;
 	--search-tab-button-selected-border-top-color: #0089ff;
 	--search-tab-button-selected-background: #fff;
+	--chip-background-color: #fff5d6;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--code-highlight-kw-color: #8959a8;
@@ -187,6 +188,7 @@ nav.sub {
 		--search-tab-button-not-selected-background: #252525;
 		--search-tab-button-selected-border-top-color: #0089ff;
 		--search-tab-button-selected-background: #353535;
+		--chip-background-color: #314559;
 		--stab-background-color: #314559;
 		--stab-code-color: #e6e1cf;
 		--code-highlight-kw-color: #ab8ac1;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -213,7 +213,6 @@ a.anchor,
 .mobile-topbar h2 a,
 h1 a,
 .search-results a,
-.stab,
 .result-name i {
 	color: var(--main-color);
 }
@@ -1083,6 +1082,25 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	padding: 0 20px 20px 17px;
 }
 
+.chip {
+	padding: 0 4px;
+	background-color: var(--chip-background-color);
+}
+
+.stab, .chip {
+	font-size: 0.875rem;
+	font-weight: normal;
+	color: var(--main-color);
+	width: fit-content;
+	white-space: pre-wrap;
+	border-radius: 3px;
+	display: inline;
+	vertical-align: baseline;
+}
+.stab {
+	padding: 0 2px;
+	background-color: var(--stab-background-color);
+}
 .item-info .stab {
 	/* This min-height is needed to unify the height of the stab elements because some of them
 	   have emojis.
@@ -1096,18 +1114,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 }
 .item-name .stab {
 	margin-left: 0.3125em;
-}
-.stab {
-	padding: 0 2px;
-	font-size: 0.875rem;
-	font-weight: normal;
-	color: var(--main-color);
-	background-color: var(--stab-background-color);
-	width: fit-content;
-	white-space: pre-wrap;
-	border-radius: 3px;
-	display: inline;
-	vertical-align: baseline;
 }
 
 .stab.portability > code {
@@ -2226,6 +2232,7 @@ in src-script.js
 	--search-tab-button-not-selected-background: #e6e6e6;
 	--search-tab-button-selected-border-top-color: #0089ff;
 	--search-tab-button-selected-background: #fff;
+	--chip-background-color: #fff5d6;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--code-highlight-kw-color: #8959a8;
@@ -2328,6 +2335,7 @@ in src-script.js
 	--search-tab-button-not-selected-background: #252525;
 	--search-tab-button-selected-border-top-color: #0089ff;
 	--search-tab-button-selected-background: #353535;
+	--chip-background-color: #314559;
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--code-highlight-kw-color: #ab8ac1;
@@ -2437,6 +2445,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--search-tab-button-not-selected-background: transparent !important;
 	--search-tab-button-selected-border-top-color: none;
 	--search-tab-button-selected-background: #141920 !important;
+	--chip-background-color: #314559;
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--code-highlight-kw-color: #ff7733;

--- a/tests/rustdoc-gui/src/theme_css/custom-theme.css
+++ b/tests/rustdoc-gui/src/theme_css/custom-theme.css
@@ -48,6 +48,7 @@
 	--search-tab-button-not-selected-background: #e6e6e6;
 	--search-tab-button-selected-border-top-color: #0089ff;
 	--search-tab-button-selected-background: #fff;
+	--chip-background-color: #fff5d6;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--code-highlight-kw-color: #8959a8;

--- a/tests/rustdoc/attributes.rs
+++ b/tests/rustdoc/attributes.rs
@@ -11,3 +11,12 @@ pub extern "C" fn g() {}
 // @has foo/struct.Repr.html '//pre[@class="rust item-decl"]' '#[repr(C, align(8))]'
 #[repr(C, align(8))]
 pub struct Repr;
+
+// checking for the presence of the "Default" chip on the variant
+// @has foo/enum.Enum2.html '//section[@id="variant.Foo"]' 'Default'
+#[derive(Default)]
+pub enum Enum2 {
+    #[default]
+    Foo,
+    Bar,
+}


### PR DESCRIPTION
fixes #115438

Disclaimer: It's my first PR, I don't know the regulation here yet 🙏🏼
I'm not sure if there are some styling standards, who's responsible for that and also I couldn't find tests for enum docs, for example if an enum is non_exhaustive or not.
I also don't know how I can test the code I've written, in general!