### PR TITLE
document when atomic loads are guaranteed read-only

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -103,8 +103,7 @@
 //! | `target_arch` | Size limit |
 //! |---------------|---------|
 //! | `x86`, `arm`, `mips`, `mips32r6, `powerpc`, `riscv32`, `sparc`, `hexagon` | 4 bytes |
-//! | `x86_64`, `aarch64`, `loongarch64`, `mips64`, `mips64r6`, `powerpc64`, `riscv64`, `sparc64` | 8 bytes |
-//! | `s390x`, `powerpc64` with `target_feature = "quadword-atomics"` | 16 bytes |
+//! | `x86_64`, `aarch64`, `loongarch64`, `mips64`, `mips64r6`, `powerpc64`, `riscv64`, `sparc64`, `s390x` | 8 bytes |
 //!
 //! Atomics loads that are larger than this limit as well as atomic loads with ordering other
 //! than `Relaxed`, as well as *all* atomic loads on targets not listed in the table, might still be

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -100,12 +100,11 @@
 //! Undefined Behavior. The exact size limit for what makes a load "sufficiently small" varies
 //! depending on the target:
 //!
-//! | Target triple prefix (regular expression) | Size limit |
+//! | `target_arch` | Size limit |
 //! |---------------|---------|
-//! | `i(3|5|6)86-`, `arm`, `thumb`, `mips(|el)-`, `powerpc-`, `riscv32`, `sparc-`    | 4 bytes |
-//! | `x86_64-`, `aarch64-`, `loongarch64-`, `mips64(|el)-`, `powerpc64-`, `riscv64`  | 8 bytes |
-//! | `powerpc64le-` | 16 bytes |
-//! | `s390x-`       | 16 bytes |
+//! | `x86`, `arm`, `mips`, `mips32r6, `powerpc`, `riscv32`, `sparc`, `hexagon` | 4 bytes |
+//! | `x86_64`, `aarch64`, `loongarch64`, `mips64`, `mips64r6`, `powerpc64`, `riscv64`, `sparc64` | 8 bytes |
+//! | `s390x`, `powerpc64` with `target_feature = "quadword-atomics"` | 16 bytes |
 //!
 //! Atomics loads that are larger than this limit as well as atomic loads with ordering other
 //! than `Relaxed`, as well as *all* atomic loads on targets not listed in the table, might still be

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -112,6 +112,9 @@
 //! read-only under certain conditions, but that is not a stable guarantee and should not be relied
 //! upon.
 //!
+//! If you need to do an acquire load on read-only memory, you can do a relaxed load followed by an
+//! acquire fence instead.
+//!
 //! # Examples
 //!
 //! A simple spinlock:

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -87,18 +87,21 @@
 //! atomic `load`s might be implemented using compare-exchange operations, even a `load` can fault
 //! on read-only memory.
 //!
-//! For the purpose of this section, "read-only memory" is defined as memory that is read-only in
+//! (For the purpose of this section, "read-only memory" is defined as memory that is read-only in
 //! the underlying target, i.e., the pages are mapped with a read-only flag and any attempt to write
 //! will cause a page fault. In particular, an `&u128` reference that points to memory that is
 //! read-write mapped is *not* considered to point to "read-only memory". In Rust, almost all memory
 //! is read-write; the only exceptions are memory created by `const` items or `static` items without
-//! interior mutability.
+//! interior mutability, and memory that was specifically marked as read-only by the operating
+//! system via platform-specific APIs.)
 //!
-//! However, as an exception from this general rule, Rust guarantees that "sufficiently small"
-//! atomic loads are implemented in a way that works on read-only memory. This threshold of
-//! "sufficiently small" depends on the architecture:
+//! However, as an exception from this general rule, "sufficiently small" atomic loads are
+//! implemented in a way that works on read-only memory. The exact threshold for what makes a load
+//! "sufficiently small" varies depending on the architecture and feature flags, but Rust guarantees
+//! that atomic loads that do not exceed the size documented in the following table are guaranteed
+//! to be read-only:
 //!
-//! | Target architecture | Maximal atomic `load` size that is guaranteed read-only |
+//! | Target architecture | Atomic loads no larger than this are guaranteed read-only |
 //! |---------------|---------|
 //! | `x86`         | 4 bytes |
 //! | `x86_64`      | 8 bytes |
@@ -106,10 +109,11 @@
 //! | `aarch64`     | 8 bytes |
 //! | `riscv32`     | 4 bytes |
 //! | `riscv64`     | 8 bytes |
-//! | `powerpc64le` | 8 bytes |
+//! | `powerpc64`   | 8 bytes |
 //!
-//! Any atomic `load` on read-only memory larger than the given size are Undefined Behavior. For
-//! architectures not listed above, all atomic `load` on read-only memory are Undefined Behavior.
+//! Atomics loads that are larger than this threshold (and *all* atomic loads on targets not listed
+//! in the table) might still be read-only under certain conditions, but that is not a stable
+//! guarantee and should not be relied upon.
 //!
 //! # Examples
 //!

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -87,33 +87,30 @@
 //! atomic `load`s might be implemented using compare-exchange operations, even a `load` can fault
 //! on read-only memory.
 //!
-//! (For the purpose of this section, "read-only memory" is defined as memory that is read-only in
+//! For the purpose of this section, "read-only memory" is defined as memory that is read-only in
 //! the underlying target, i.e., the pages are mapped with a read-only flag and any attempt to write
 //! will cause a page fault. In particular, an `&u128` reference that points to memory that is
 //! read-write mapped is *not* considered to point to "read-only memory". In Rust, almost all memory
 //! is read-write; the only exceptions are memory created by `const` items or `static` items without
 //! interior mutability, and memory that was specifically marked as read-only by the operating
-//! system via platform-specific APIs.)
+//! system via platform-specific APIs.
 //!
-//! However, as an exception from this general rule, "sufficiently small" atomic loads are
-//! implemented in a way that works on read-only memory. The exact threshold for what makes a load
-//! "sufficiently small" varies depending on the architecture and feature flags, but Rust guarantees
-//! that atomic loads that do not exceed the size documented in the following table are guaranteed
-//! to be read-only:
+//! As an exception from the general rule stated above, "sufficiently small" atomic loads with
+//! `Ordering::Relaxed` are implemented in a way that works on read-only memory, and are hence not
+//! Undefined Behavior. The exact size limit for what makes a load "sufficiently small" varies
+//! depending on the target:
 //!
-//! | Target architecture | Atomic loads no larger than this are guaranteed read-only |
+//! | Target triple prefix (regular expression) | Size limit |
 //! |---------------|---------|
-//! | `x86`         | 4 bytes |
-//! | `x86_64`      | 8 bytes |
-//! | `arm`         | 4 bytes |
-//! | `aarch64`     | 8 bytes |
-//! | `riscv32`     | 4 bytes |
-//! | `riscv64`     | 8 bytes |
-//! | `powerpc64`   | 8 bytes |
+//! | `i(3|5|6)86-`, `arm`, `thumb`, `mips(|el)-`, `powerpc-`, `riscv32`, `sparc-`    | 4 bytes |
+//! | `x86_64-`, `aarch64-`, `loongarch64-`, `mips64(|el)-`, `powerpc64-`, `riscv64`  | 8 bytes |
+//! | `powerpc64le-` | 16 bytes |
+//! | `s390x-`       | 16 bytes |
 //!
-//! Atomics loads that are larger than this threshold (and *all* atomic loads on targets not listed
-//! in the table) might still be read-only under certain conditions, but that is not a stable
-//! guarantee and should not be relied upon.
+//! Atomics loads that are larger than this limit as well as atomic loads with ordering other
+//! than `Relaxed`, as well as *all* atomic loads on targets not listed in the table, might still be
+//! read-only under certain conditions, but that is not a stable guarantee and should not be relied
+//! upon.
 //!
 //! # Examples
 //!

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -92,13 +92,14 @@
 //! "sufficiently small" depends on the architecture:
 //!
 //! | Target architecture | Maximal atomic `load` size that is guaranteed read-only |
-//! |-----------|---------|
-//! | `x86`     | 4 bytes |
-//! | `x86_64`  | 8 bytes |
-//! | `arm`     | 4 bytes |
-//! | `aarch64` | 8 bytes |
-//! | `riscv32` | 4 bytes |
-//! | `riscv64` | 8 bytes |
+//! |---------------|---------|
+//! | `x86`         | 4 bytes |
+//! | `x86_64`      | 8 bytes |
+//! | `arm`         | 4 bytes |
+//! | `aarch64`     | 8 bytes |
+//! | `riscv32`     | 4 bytes |
+//! | `riscv64`     | 8 bytes |
+//! | `powerpc64le` | 8 bytes |
 //!
 //! Any atomic `load` on read-only memory larger than the given size are Undefined Behavior. For
 //! architectures not listed above, all atomic `load` on read-only memory are Undefined Behavior.

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -92,9 +92,13 @@
 //! "sufficiently small" depends on the architecture:
 //!
 //! | Target architecture | Maximal atomic `load` size that is guaranteed read-only |
-//! |----------|---------|
-//! | `x86`    | 4 bytes |
-//! | `x86_64` | 8 bytes |
+//! |-----------|---------|
+//! | `x86`     | 4 bytes |
+//! | `x86_64`  | 8 bytes |
+//! | `arm`     | 4 bytes |
+//! | `aarch64` | 8 bytes |
+//! | `riscv32` | 4 bytes |
+//! | `riscv64` | 8 bytes |
 //!
 //! Any atomic `load` on read-only memory larger than the given size are Undefined Behavior. For
 //! architectures not listed above, all atomic `load` on read-only memory are Undefined Behavior.

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -81,11 +81,18 @@
 //!
 //! # Atomic accesses to read-only memory
 //!
-//! In general, atomic accesses on read-only memory are Undefined Behavior. For instance, attempting
+//! In general, *all* atomic accesses on read-only memory are Undefined Behavior. For instance, attempting
 //! to do a `compare_exchange` that will definitely fail (making it conceptually a read-only
 //! operation) can still cause a page fault if the underlying memory page is mapped read-only. Since
 //! atomic `load`s might be implemented using compare-exchange operations, even a `load` can fault
 //! on read-only memory.
+//!
+//! For the purpose of this section, "read-only memory" is defined as memory that is read-only in
+//! the underlying target, i.e., the pages are mapped with a read-only flag and any attempt to write
+//! will cause a page fault. In particular, an `&u128` reference that points to memory that is
+//! read-write mapped is *not* considered to point to "read-only memory". In Rust, almost all memory
+//! is read-write; the only exceptions are memory created by `const` items or `static` items without
+//! interior mutability.
 //!
 //! However, as an exception from this general rule, Rust guarantees that "sufficiently small"
 //! atomic loads are implemented in a way that works on read-only memory. This threshold of

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -79,6 +79,26 @@
 //!
 //! [lock-free]: https://en.wikipedia.org/wiki/Non-blocking_algorithm
 //!
+//! # Atomic accesses to read-only memory
+//!
+//! In general, atomic accesses on read-only memory are Undefined Behavior. For instance, attempting
+//! to do a `compare_exchange` that will definitely fail (making it conceptually a read-only
+//! operation) can still cause a page fault if the underlying memory page is mapped read-only. Since
+//! atomic `load`s might be implemented using compare-exchange operations, even a `load` can fault
+//! on read-only memory.
+//!
+//! However, as an exception from this general rule, Rust guarantees that "sufficiently small"
+//! atomic loads are implemented in a way that works on read-only memory. This threshold of
+//! "sufficiently small" depends on the architecture:
+//!
+//! | Target architecture | Maximal atomic `load` size that is guaranteed read-only |
+//! |----------|---------|
+//! | `x86`    | 4 bytes |
+//! | `x86_64` | 8 bytes |
+//!
+//! Any atomic `load` on read-only memory larger than the given size are Undefined Behavior. For
+//! architectures not listed above, all atomic `load` on read-only memory are Undefined Behavior.
+//!
 //! # Examples
 //!
 //! A simple spinlock:


### PR DESCRIPTION
Based on this [discussion in Zulip](https://rust-lang.zulipchat.com/#narrow/stream/136281-t-opsem/topic/Can.20.60Atomic*.3A.3Aload.60.20perform.20a.20write).

The values for x86 and x86_64 are complete guesswork on my side, and I have no clue what the values might be for other architectures. I hope we can get the right people to chime in to gather the required information. :)

I'll update Miri to respect these rules once we have more data.