### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -1456,6 +1456,6 @@ impl<'tcx> Stable<'tcx> for rustc_span::Span {
 
 impl From<ErrorGuaranteed> for CompilerError {
     fn from(_error: ErrorGuaranteed) -> Self {
-        CompilerError
+        CompilerError::CompilationFailed
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -1454,7 +1454,7 @@ impl<'tcx> Stable<'tcx> for rustc_span::Span {
     }
 }
 
-impl From<ErrorGuaranteed> for CompilerError {
+impl<T> From<ErrorGuaranteed> for CompilerError<T> {
     fn from(_error: ErrorGuaranteed) -> Self {
         CompilerError::CompilationFailed
     }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -10,12 +10,13 @@
 use crate::rustc_internal::{self, opaque};
 use crate::stable_mir::mir::{CopyNonOverlapping, UserTypeProjection, VariantIdx};
 use crate::stable_mir::ty::{FloatTy, GenericParamDef, IntTy, Movability, RigidTy, TyKind, UintTy};
-use crate::stable_mir::{self, Context};
+use crate::stable_mir::{self, CompilerError, Context};
 use rustc_hir as hir;
 use rustc_middle::mir::interpret::{alloc_range, AllocId};
 use rustc_middle::mir::{self, ConstantKind};
 use rustc_middle::ty::{self, Ty, TyCtxt, Variance};
 use rustc_span::def_id::{CrateNum, DefId, LOCAL_CRATE};
+use rustc_span::ErrorGuaranteed;
 use rustc_target::abi::FieldIdx;
 use tracing::debug;
 
@@ -1450,5 +1451,11 @@ impl<'tcx> Stable<'tcx> for rustc_span::Span {
     fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
         // FIXME: add a real implementation of stable spans
         opaque(self)
+    }
+}
+
+impl From<ErrorGuaranteed> for CompilerError {
+    fn from(_error: ErrorGuaranteed) -> Self {
+        CompilerError
     }
 }

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -56,6 +56,10 @@ pub type TraitDecls = Vec<TraitDef>;
 /// A list of impl trait decls.
 pub type ImplTraitDecls = Vec<ImplDef>;
 
+/// An error type used to represent an error that has already been reported by the compiler.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CompilerError;
+
 /// Holds information about a crate.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Crate {

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -58,7 +58,12 @@ pub type ImplTraitDecls = Vec<ImplDef>;
 
 /// An error type used to represent an error that has already been reported by the compiler.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct CompilerError;
+pub enum CompilerError {
+    /// Internal compiler error (I.e.: Compiler crashed).
+    ICE,
+    /// Compilation failed.
+    CompilationFailed,
+}
 
 /// Holds information about a crate.
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -58,11 +58,16 @@ pub type ImplTraitDecls = Vec<ImplDef>;
 
 /// An error type used to represent an error that has already been reported by the compiler.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CompilerError {
+pub enum CompilerError<T> {
     /// Internal compiler error (I.e.: Compiler crashed).
     ICE,
     /// Compilation failed.
     CompilationFailed,
+    /// Compilation was interrupted.
+    Interrupted(T),
+    /// Compilation skipped. This happens when users invoke rustc to retrieve information such as
+    /// --version.
+    Skipped,
 }
 
 /// Holds information about a crate.

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -57,16 +57,12 @@ impl<'a, 'tcx: 'a> InferCtxtExt<'a, 'tcx> for InferCtxt<'tcx> {
         let ty = OpportunisticRegionResolver::new(self).fold_ty(ty);
 
         // We do not expect existential variables in implied bounds.
-        // We may however encounter unconstrained lifetime variables in invalid
-        // code. See #110161 for context.
+        // We may however encounter unconstrained lifetime variables
+        // in very rare cases.
+        //
+        // See `ui/implied-bounds/implied-bounds-unconstrained-2.rs` for
+        // an example.
         assert!(!ty.has_non_region_infer());
-        if ty.has_infer() {
-            self.tcx.sess.delay_span_bug(
-                self.tcx.def_span(body_id),
-                "skipped implied_outlives_bounds due to unconstrained lifetimes",
-            );
-            return vec![];
-        }
 
         let mut canonical_var_values = OriginalQueryValues::default();
         let canonical_ty =

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2709,6 +2709,9 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 ///
 /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
 ///
+/// * `src` must remain valid for reads even after `dst` is written, and vice versa.
+///   (In other words, there cannot be aliasing restrictions on the use of these pointers.)
+///
 /// * Both `src` and `dst` must be properly aligned.
 ///
 /// Like [`read`], `copy` creates a bitwise copy of `T`, regardless of

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2706,12 +2706,12 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 /// Behavior is undefined if any of the following conditions are violated:
 ///
 /// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes, and must remain valid even
-///   if `dst` is written for `count * size_of::<T>()` bytes. (This means if the memory ranges
+///   when `dst` is written for `count * size_of::<T>()` bytes. (This means if the memory ranges
 ///   overlap, the two pointers must not be subject to aliasing restrictions relative to each
 ///   other.)
 ///
 /// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes, and must remain valid even
-///   if `src` is read for `count * size_of::<T>()` bytes.
+///   when `src` is read for `count * size_of::<T>()` bytes.
 ///
 /// * Both `src` and `dst` must be properly aligned.
 ///

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2705,12 +2705,13 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes.
+/// * `src` must be [valid] for reads of `count * size_of::<T>()` bytes, and must remain valid even
+///   if `dst` is written for `count * size_of::<T>()` bytes. (This means if the memory ranges
+///   overlap, the two pointers must not be subject to aliasing restrictions relative to each
+///   other.)
 ///
-/// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes.
-///
-/// * `src` must remain valid for reads even after `dst` is written, and vice versa.
-///   (In other words, there cannot be aliasing restrictions on the use of these pointers.)
+/// * `dst` must be [valid] for writes of `count * size_of::<T>()` bytes, and must remain valid even
+///   if `src` is read for `count * size_of::<T>()` bytes.
 ///
 /// * Both `src` and `dst` must be properly aligned.
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -795,7 +795,7 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * Both `x` and `y` must be [valid] for both reads and writes. They must remain valid even if the
+/// * Both `x` and `y` must be [valid] for both reads and writes. They must remain valid even when the
 ///   other pointer is written. (This means if the memory ranges overlap, the two pointers must not
 ///   be subject to aliasing restrictions relative to each other.)
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -795,10 +795,9 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * Both `x` and `y` must be [valid] for both reads and writes.
-///
-/// * `x` must remain valid for reads and writes even after `y` is read/written, and vice versa.
-///   (In other words, there cannot be aliasing restrictions on the use of these pointers.)
+/// * Both `x` and `y` must be [valid] for both reads and writes. They must remain valid even if the
+///   other pointer is written. (This means if the memory ranges overlap, the two pointers must not
+///   be subject to aliasing restrictions relative to each other.)
 ///
 /// * Both `x` and `y` must be properly aligned.
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -797,6 +797,9 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 ///
 /// * Both `x` and `y` must be [valid] for both reads and writes.
 ///
+/// * `x` must remain valid for reads and writes even after `y` is read/written, and vice versa.
+///   (In other words, there cannot be aliasing restrictions on the use of these pointers.)
+///
 /// * Both `x` and `y` must be properly aligned.
 ///
 /// Note that even if `T` has size `0`, the pointers must be non-null and properly aligned.

--- a/tests/ui-fulldeps/stable-mir/compilation-result.rs
+++ b/tests/ui-fulldeps/stable-mir/compilation-result.rs
@@ -1,0 +1,77 @@
+// run-pass
+// Test StableMIR behavior when different results are given
+
+// ignore-stage1
+// ignore-cross-compile
+// ignore-remote
+// edition: 2021
+
+#![feature(rustc_private)]
+#![feature(assert_matches)]
+
+extern crate rustc_middle;
+extern crate rustc_smir;
+
+use rustc_middle::ty::TyCtxt;
+use rustc_smir::{rustc_internal, stable_mir};
+use std::io::Write;
+use std::ops::ControlFlow;
+
+/// This test will generate and analyze a dummy crate using the stable mir.
+/// For that, it will first write the dummy crate into a file.
+/// Then it will create a `StableMir` using custom arguments and then
+/// it will run the compiler.
+fn main() {
+    let path = "input_compilation_result_test.rs";
+    generate_input(&path).unwrap();
+    let args = vec!["rustc".to_string(), path.to_string()];
+    test_continue(args.clone());
+    test_break(args.clone());
+    test_failed(args.clone());
+    test_skipped(args);
+}
+
+fn test_continue(args: Vec<String>) {
+    let continue_fn = |_: TyCtxt| ControlFlow::Continue::<(), bool>(true);
+    let result = rustc_internal::StableMir::new(args, continue_fn).run();
+    assert_eq!(result, Ok(true));
+}
+
+fn test_break(args: Vec<String>) {
+    let continue_fn = |_: TyCtxt| ControlFlow::Break::<bool, i32>(false);
+    let result = rustc_internal::StableMir::new(args, continue_fn).run();
+    assert_eq!(result, Err(stable_mir::CompilerError::Interrupted(false)));
+}
+
+fn test_skipped(mut args: Vec<String>) {
+    args.push("--version".to_string());
+    let unreach_fn = |_: TyCtxt| -> ControlFlow<()> { unreachable!() };
+    let result = rustc_internal::StableMir::new(args, unreach_fn).run();
+    assert_eq!(result, Err(stable_mir::CompilerError::Skipped));
+}
+
+fn test_failed(mut args: Vec<String>) {
+    args.push("--cfg=broken".to_string());
+    let unreach_fn = |_: TyCtxt| -> ControlFlow<()> { unreachable!() };
+    let result = rustc_internal::StableMir::new(args, unreach_fn).run();
+    assert_eq!(result, Err(stable_mir::CompilerError::CompilationFailed));
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write!(
+        file,
+        r#"
+    // This should trigger a compilation failure when enabled.
+    #[cfg(broken)]
+    mod broken_mod {{
+        fn call_invalid() {{
+            invalid_fn();
+        }}
+    }}
+
+    fn main() {{}}
+    "#
+    )?;
+    Ok(())
+}

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -18,11 +18,12 @@ use rustc_middle::ty::TyCtxt;
 use rustc_smir::{rustc_internal, stable_mir};
 use std::assert_matches::assert_matches;
 use std::io::Write;
+use std::ops::ControlFlow;
 
 const CRATE_NAME: &str = "input";
 
 /// This function uses the Stable MIR APIs to get information about the test crate.
-fn test_stable_mir(tcx: TyCtxt<'_>) {
+fn test_stable_mir(tcx: TyCtxt<'_>) -> ControlFlow<()> {
     // Get the local crate using stable_mir API.
     let local = stable_mir::local_crate();
     assert_eq!(&local.name, CRATE_NAME);
@@ -108,6 +109,8 @@ fn test_stable_mir(tcx: TyCtxt<'_>) {
         stable_mir::mir::Terminator::Assert { .. } => {}
         other => panic!("{other:?}"),
     }
+
+    ControlFlow::Continue(())
 }
 
 // Use internal API to find a function in a crate.

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -136,7 +136,7 @@ fn main() {
         CRATE_NAME.to_string(),
         path.to_string(),
     ];
-    rustc_internal::StableMir::new(args, test_stable_mir).run();
+    rustc_internal::StableMir::new(args, test_stable_mir).run().unwrap();
 }
 
 fn generate_input(path: &str) -> std::io::Result<()> {

--- a/tests/ui/implied-bounds/implied-bounds-unconstrained-1.rs
+++ b/tests/ui/implied-bounds/implied-bounds-unconstrained-1.rs
@@ -1,0 +1,28 @@
+// check-pass
+
+// Regression test for #112832.
+pub trait QueryDb {
+    type Db;
+}
+
+pub struct QueryTable<Q, DB> {
+    db: DB,
+    storage: Q,
+}
+
+// We normalize `<Q as QueryDb>::Db` to `<Q as AsyncQueryFunction<'d>>::SendDb`
+// using the where-bound. 'd is an unconstrained region variable which previously
+// triggered an assert.
+impl<Q> QueryTable<Q, <Q as QueryDb>::Db> where Q: for<'d> AsyncQueryFunction<'d> {}
+
+pub trait AsyncQueryFunction<'d>: QueryDb<Db = <Self as AsyncQueryFunction<'d>>::SendDb> {
+    type SendDb: 'd;
+}
+
+pub trait QueryStorageOpsAsync<Q>
+where
+    Q: for<'d> AsyncQueryFunction<'d>,
+{
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/implied-bounds-unconstrained-2.rs
+++ b/tests/ui/implied-bounds/implied-bounds-unconstrained-2.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+// Another minimized regression test for #112832.
+trait Trait {
+    type Assoc;
+}
+
+trait Sub<'a>: Trait<Assoc = <Self as Sub<'a>>::SubAssoc> {
+    type SubAssoc;
+}
+
+// By using the where-clause we normalize `<T as Trait>::Assoc` to
+// `<T as Sub<'a>>::SubAssoc` where `'a` is an unconstrained region
+// variable.
+fn foo<T>(x: <T as Trait>::Assoc)
+where
+    for<'a> T: Sub<'a>,
+{}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #114794 (clarify safety documentation of ptr::swap and ptr::copy)
 - #115397 (Add support to return value in StableMIR interface and not crash due to compilation error)
 - #115559 (implied bounds: do not ICE on unconstrained region vars)

Failed merges:

 - #115532 (Implement SMIR generic parameter instantiation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114794,115397,115559)
<!-- homu-ignore:end -->