### PR TITLE
Implement refinement lint for RPITIT

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -44,7 +44,7 @@ use rustc_fluent_macro::fluent_messages;
 pub use rustc_lint_defs::{pluralize, Applicability};
 use rustc_span::source_map::SourceMap;
 pub use rustc_span::ErrorGuaranteed;
-use rustc_span::{Loc, Span};
+use rustc_span::{Loc, Span, DUMMY_SP};
 
 use std::borrow::Cow;
 use std::error::Report;
@@ -1754,7 +1754,7 @@ impl DelayedDiagnostic {
             BacktraceStatus::Captured => {
                 let inner = &self.inner;
                 self.inner.subdiagnostic(DelayedAtWithNewline {
-                    span: inner.span.primary_span().unwrap(),
+                    span: inner.span.primary_span().unwrap_or(DUMMY_SP),
                     emitted_at: inner.emitted_at.clone(),
                     note: self.note,
                 });
@@ -1764,7 +1764,7 @@ impl DelayedDiagnostic {
             _ => {
                 let inner = &self.inner;
                 self.inner.subdiagnostic(DelayedAtWithoutNewline {
-                    span: inner.span.primary_span().unwrap(),
+                    span: inner.span.primary_span().unwrap_or(DUMMY_SP),
                     emitted_at: inner.emitted_at.clone(),
                     note: self.note,
                 });

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -226,6 +226,7 @@ hir_analysis_rpitit_refined = impl trait in impl method signature does not match
     .suggestion = replace the return type so that it matches the trait
     .label = return type from trait method defined here
     .unmatched_bound_label = this bound is stronger than that defined on the trait
+    .note = add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
 
 hir_analysis_self_in_impl_self =
     `Self` is not valid in the self type of an impl block

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -222,6 +222,11 @@ hir_analysis_return_type_notation_on_non_rpitit =
     .note = function returns `{$ty}`, which is not compatible with associated type return bounds
     .label = this function must be `async` or return `impl Trait`
 
+hir_analysis_rpitit_refined = impl trait in impl method signature does not match trait method signature
+    .suggestion = replace the return type so that it matches the trait
+    .label = return type from trait method defined here
+    .unmatched_bound_label = this bound is stronger than that defined on the trait
+
 hir_analysis_self_in_impl_self =
     `Self` is not valid in the self type of an impl block
     .note = replace `Self` with a different type

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -28,6 +28,8 @@ use rustc_trait_selection::traits::{
 use std::borrow::Cow;
 use std::iter;
 
+mod refine;
+
 /// Checks that a method from an impl conforms to the signature of
 /// the same method as declared in the trait.
 ///
@@ -53,6 +55,12 @@ pub(super) fn compare_impl_method<'tcx>(
             impl_trait_ref,
             CheckImpliedWfMode::Check,
         )?;
+        refine::check_refining_return_position_impl_trait_in_trait(
+            tcx,
+            impl_m,
+            trait_m,
+            impl_trait_ref,
+        );
     };
 }
 

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -1,0 +1,271 @@
+use rustc_data_structures::fx::FxIndexSet;
+use rustc_hir as hir;
+use rustc_hir::def_id::DefId;
+use rustc_infer::infer::{outlives::env::OutlivesEnvironment, TyCtxtInferExt};
+use rustc_lint_defs::builtin::REFINING_IMPL_TRAIT;
+use rustc_middle::traits::{ObligationCause, Reveal};
+use rustc_middle::ty::{
+    self, Ty, TyCtxt, TypeFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitor,
+};
+use rustc_span::{Span, DUMMY_SP};
+use rustc_trait_selection::traits::{
+    elaborate, normalize_param_env_or_error, outlives_bounds::InferCtxtExt, ObligationCtxt,
+};
+use std::ops::ControlFlow;
+
+/// Check that an implementation does not refine an RPITIT from a trait method signature.
+pub(super) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    impl_m: ty::AssocItem,
+    trait_m: ty::AssocItem,
+    impl_trait_ref: ty::TraitRef<'tcx>,
+) {
+    if !tcx.impl_method_has_trait_impl_trait_tys(impl_m.def_id) {
+        return;
+    }
+
+    let impl_def_id = impl_m.container_id(tcx);
+    let impl_m_args = ty::GenericArgs::identity_for_item(tcx, impl_m.def_id);
+    let trait_m_to_impl_m_args = impl_m_args.rebase_onto(tcx, impl_def_id, impl_trait_ref.args);
+    let bound_trait_m_sig = tcx.fn_sig(trait_m.def_id).instantiate(tcx, trait_m_to_impl_m_args);
+    let trait_m_sig = tcx.liberate_late_bound_regions(impl_m.def_id, bound_trait_m_sig);
+
+    let Ok(hidden_tys) = tcx.collect_return_position_impl_trait_in_trait_tys(impl_m.def_id) else {
+        // Error already emitted, no need to delay another.
+        return;
+    };
+
+    let mut collector = ImplTraitInTraitCollector { tcx, types: FxIndexSet::default() };
+    trait_m_sig.visit_with(&mut collector);
+
+    // Bound that we find on RPITITs in the trait signature.
+    let mut trait_bounds = vec![];
+    // Bounds that we find on the RPITITs in the impl signature.
+    let mut impl_bounds = vec![];
+
+    for trait_projection in collector.types.into_iter().rev() {
+        let impl_opaque_args = trait_projection.args.rebase_onto(tcx, trait_m.def_id, impl_m_args);
+        let hidden_ty = hidden_tys[&trait_projection.def_id].instantiate(tcx, impl_opaque_args);
+
+        // If the hidden type is not an opaque, then we have "refined" the trait signature.
+        let ty::Alias(ty::Opaque, impl_opaque) = *hidden_ty.kind() else {
+            report_mismatched_rpitit_signature(
+                tcx,
+                trait_m_sig,
+                trait_m.def_id,
+                impl_m.def_id,
+                None,
+            );
+            return;
+        };
+
+        // This opaque also needs to be from the impl method -- otherwise,
+        // it's a refinement to a TAIT.
+        if !tcx.hir().get_if_local(impl_opaque.def_id).map_or(false, |node| {
+            matches!(
+                node.expect_item().expect_opaque_ty().origin,
+                hir::OpaqueTyOrigin::AsyncFn(def_id)  | hir::OpaqueTyOrigin::FnReturn(def_id)
+                    if def_id == impl_m.def_id.expect_local()
+            )
+        }) {
+            report_mismatched_rpitit_signature(
+                tcx,
+                trait_m_sig,
+                trait_m.def_id,
+                impl_m.def_id,
+                None,
+            );
+            return;
+        }
+
+        trait_bounds.extend(
+            tcx.item_bounds(trait_projection.def_id).iter_instantiated(tcx, trait_projection.args),
+        );
+        impl_bounds.extend(elaborate(
+            tcx,
+            tcx.explicit_item_bounds(impl_opaque.def_id)
+                .iter_instantiated_copied(tcx, impl_opaque.args),
+        ));
+    }
+
+    let hybrid_preds = tcx
+        .predicates_of(impl_def_id)
+        .instantiate_identity(tcx)
+        .into_iter()
+        .chain(tcx.predicates_of(trait_m.def_id).instantiate_own(tcx, trait_m_to_impl_m_args))
+        .map(|(clause, _)| clause);
+    let param_env = ty::ParamEnv::new(tcx.mk_clauses_from_iter(hybrid_preds), Reveal::UserFacing);
+    let param_env = normalize_param_env_or_error(tcx, param_env, ObligationCause::dummy());
+
+    let ref infcx = tcx.infer_ctxt().build();
+    let ocx = ObligationCtxt::new(infcx);
+
+    // Normalize the bounds. This has two purposes:
+    //
+    // 1. Project the RPITIT projections from the trait to the opaques on the impl,
+    //    which means that they don't need to be mapped manually.
+    //
+    // 2. Project any other projections that show up in the bound. That makes sure that
+    //    we don't consider `tests/ui/async-await/in-trait/async-associated-types.rs`
+    //    to be refining.
+    let (trait_bounds, impl_bounds) =
+        ocx.normalize(&ObligationCause::dummy(), param_env, (trait_bounds, impl_bounds));
+
+    // Since we've normalized things, we need to resolve regions, since we'll
+    // possibly have introduced region vars during projection. We don't expect
+    // this resolution to have incurred any region errors -- but if we do, then
+    // just delay a bug.
+    let mut implied_wf_types = FxIndexSet::default();
+    implied_wf_types.extend(trait_m_sig.inputs_and_output);
+    implied_wf_types.extend(ocx.normalize(
+        &ObligationCause::dummy(),
+        param_env,
+        trait_m_sig.inputs_and_output,
+    ));
+    if !ocx.select_all_or_error().is_empty() {
+        tcx.sess.delay_span_bug(
+            DUMMY_SP,
+            "encountered errors when checking RPITIT refinement (selection)",
+        );
+        return;
+    }
+    let outlives_env = OutlivesEnvironment::with_bounds(
+        param_env,
+        infcx.implied_bounds_tys(param_env, impl_m.def_id.expect_local(), implied_wf_types),
+    );
+    let errors = infcx.resolve_regions(&outlives_env);
+    if !errors.is_empty() {
+        tcx.sess.delay_span_bug(
+            DUMMY_SP,
+            "encountered errors when checking RPITIT refinement (regions)",
+        );
+        return;
+    }
+    // Resolve any lifetime variables that may have been introduced during normalization.
+    let Ok((trait_bounds, impl_bounds)) = infcx.fully_resolve((trait_bounds, impl_bounds)) else {
+        tcx.sess.delay_span_bug(
+            DUMMY_SP,
+            "encountered errors when checking RPITIT refinement (resolution)",
+        );
+        return;
+    };
+
+    // For quicker lookup, use an `IndexSet`
+    // (we don't use one earlier because it's not foldable..)
+    let trait_bounds = FxIndexSet::from_iter(trait_bounds);
+
+    // Find any clauses that are present in the impl's RPITITs that are not
+    // present in the trait's RPITITs. This will trigger on trivial predicates,
+    // too, since we *do not* use the trait solver to prove that the RPITIT's
+    // bounds are not stronger -- we're doing a simple, syntactic compatibility
+    // check between bounds. This is strictly forwards compatible, though.
+    for (clause, span) in impl_bounds {
+        if !trait_bounds.contains(&clause) {
+            report_mismatched_rpitit_signature(
+                tcx,
+                trait_m_sig,
+                trait_m.def_id,
+                impl_m.def_id,
+                Some(span),
+            );
+            return;
+        }
+    }
+}
+
+struct ImplTraitInTraitCollector<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    types: FxIndexSet<ty::AliasTy<'tcx>>,
+}
+
+impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitCollector<'tcx> {
+    type BreakTy = !;
+
+    fn visit_ty(&mut self, ty: Ty<'tcx>) -> std::ops::ControlFlow<Self::BreakTy> {
+        if let ty::Alias(ty::Projection, proj) = *ty.kind()
+            && self.tcx.is_impl_trait_in_trait(proj.def_id)
+        {
+            if self.types.insert(proj) {
+                for (pred, _) in self
+                    .tcx
+                    .explicit_item_bounds(proj.def_id)
+                    .iter_instantiated_copied(self.tcx, proj.args)
+                {
+                    pred.visit_with(self)?;
+                }
+            }
+            ControlFlow::Continue(())
+        } else {
+            ty.super_visit_with(self)
+        }
+    }
+}
+
+fn report_mismatched_rpitit_signature<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    trait_m_sig: ty::FnSig<'tcx>,
+    trait_m_def_id: DefId,
+    impl_m_def_id: DefId,
+    unmatched_bound: Option<Span>,
+) {
+    let mapping = std::iter::zip(
+        tcx.fn_sig(trait_m_def_id).skip_binder().bound_vars(),
+        tcx.fn_sig(impl_m_def_id).skip_binder().bound_vars(),
+    )
+    .filter_map(|(impl_bv, trait_bv)| {
+        if let ty::BoundVariableKind::Region(impl_bv) = impl_bv
+            && let ty::BoundVariableKind::Region(trait_bv) = trait_bv
+        {
+            Some((impl_bv, trait_bv))
+        } else {
+            None
+        }
+    })
+    .collect();
+
+    let mut return_ty =
+        trait_m_sig.output().fold_with(&mut super::RemapLateBound { tcx, mapping: &mapping });
+
+    if tcx.asyncness(impl_m_def_id).is_async() && tcx.asyncness(trait_m_def_id).is_async() {
+        let ty::Alias(ty::Projection, future_ty) = return_ty.kind() else {
+            bug!();
+        };
+        let Some(future_output_ty) = tcx
+            .explicit_item_bounds(future_ty.def_id)
+            .iter_instantiated_copied(tcx, future_ty.args)
+            .find_map(|(clause, _)| match clause.kind().no_bound_vars()? {
+                ty::ClauseKind::Projection(proj) => proj.term.ty(),
+                _ => None,
+            })
+        else {
+            bug!()
+        };
+        return_ty = future_output_ty;
+    }
+
+    let (span, impl_return_span, pre, post) =
+        match tcx.hir().get_by_def_id(impl_m_def_id.expect_local()).fn_decl().unwrap().output {
+            hir::FnRetTy::DefaultReturn(span) => (tcx.def_span(impl_m_def_id), span, "-> ", " "),
+            hir::FnRetTy::Return(ty) => (ty.span, ty.span, "", ""),
+        };
+    let trait_return_span =
+        tcx.hir().get_if_local(trait_m_def_id).map(|node| match node.fn_decl().unwrap().output {
+            hir::FnRetTy::DefaultReturn(_) => tcx.def_span(trait_m_def_id),
+            hir::FnRetTy::Return(ty) => ty.span,
+        });
+
+    let span = unmatched_bound.unwrap_or(span);
+    tcx.emit_spanned_lint(
+        REFINING_IMPL_TRAIT,
+        tcx.local_def_id_to_hir_id(impl_m_def_id.expect_local()),
+        span,
+        crate::errors::ReturnPositionImplTraitInTraitRefined {
+            impl_return_span,
+            trait_return_span,
+            pre,
+            post,
+            return_ty,
+            unmatched_bound,
+        },
+    );
+}

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -919,6 +919,21 @@ pub struct UnusedAssociatedTypeBounds {
     pub span: Span,
 }
 
+#[derive(LintDiagnostic)]
+#[diag(hir_analysis_rpitit_refined)]
+pub(crate) struct ReturnPositionImplTraitInTraitRefined<'tcx> {
+    #[suggestion(applicability = "maybe-incorrect", code = "{pre}{return_ty}{post}")]
+    pub impl_return_span: Span,
+    #[label]
+    pub trait_return_span: Option<Span>,
+    #[label(hir_analysis_unmatched_bound_label)]
+    pub unmatched_bound: Option<Span>,
+
+    pub pre: &'static str,
+    pub post: &'static str,
+    pub return_ty: Ty<'tcx>,
+}
+
 #[derive(Diagnostic)]
 #[diag(hir_analysis_assoc_bound_on_const)]
 #[note]

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -921,6 +921,7 @@ pub struct UnusedAssociatedTypeBounds {
 
 #[derive(LintDiagnostic)]
 #[diag(hir_analysis_rpitit_refined)]
+#[note]
 pub(crate) struct ReturnPositionImplTraitInTraitRefined<'tcx> {
     #[suggestion(applicability = "maybe-incorrect", code = "{pre}{return_ty}{post}")]
     pub impl_return_span: Span,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4496,7 +4496,7 @@ declare_lint! {
     ///
     /// use std::fmt::Display;
     ///
-    /// trait AsDisplay {
+    /// pub trait AsDisplay {
     ///     fn as_display(&self) -> impl Display;
     /// }
     ///

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3381,6 +3381,7 @@ declare_lint_pass! {
         PROC_MACRO_BACK_COMPAT,
         PROC_MACRO_DERIVE_RESOLUTION_FALLBACK,
         PUB_USE_OF_PRIVATE_EXTERN_CRATE,
+        REFINING_IMPL_TRAIT,
         RENAMED_AND_REMOVED_LINTS,
         REPR_TRANSPARENT_EXTERNAL_PRIVATE_FIELDS,
         RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
@@ -4448,7 +4449,6 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,compile_fail
-    ///
     /// #![deny(ambiguous_glob_imports)]
     /// pub fn foo() -> u32 {
     ///     use sub::*;
@@ -4482,6 +4482,50 @@ declare_lint! {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #114095 <https://github.com/rust-lang/rust/issues/114095>",
     };
+}
+
+declare_lint! {
+    /// The `refining_impl_trait` lint detects usages of return-position impl
+    /// traits in trait signatures which are refined by implementations.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![feature(return_position_impl_trait_in_trait)]
+    /// #![deny(refining_impl_trait)]
+    ///
+    /// use std::fmt::Display;
+    ///
+    /// trait AsDisplay {
+    ///     fn as_display(&self) -> impl Display;
+    /// }
+    ///
+    /// impl<'s> AsDisplay for &'s str {
+    ///     fn as_display(&self) -> Self {
+    ///         *self
+    ///     }
+    /// }
+    ///
+    /// fn main() {
+    ///     // users can observe that the return type of
+    ///     // `<&str as AsDisplay>::as_display()` is `&str`.
+    ///     let x: &str = "".as_display();
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Return-position impl trait in traits (RPITITs) desugar to associated types,
+    /// and callers of methods for types where the implementation is known are
+    /// able to observe the types written in the impl signature. This may be
+    /// intended behavior, but may also pose a semver hazard for authors of libraries
+    /// who do not wish to make stronger guarantees about the types than what is
+    /// written in the trait signature.
+    pub REFINING_IMPL_TRAIT,
+    Warn,
+    "impl trait in impl method signature does not match trait method signature",
 }
 
 declare_lint! {

--- a/compiler/rustc_middle/src/ty/generic_args.rs
+++ b/compiler/rustc_middle/src/ty/generic_args.rs
@@ -440,7 +440,7 @@ impl<'tcx> GenericArgs<'tcx> {
         target_args: GenericArgsRef<'tcx>,
     ) -> GenericArgsRef<'tcx> {
         let defs = tcx.generics_of(source_ancestor);
-        tcx.mk_args_from_iter(target_args.iter().chain(self.iter().skip(defs.params.len())))
+        tcx.mk_args_from_iter(target_args.iter().chain(self.iter().skip(defs.count())))
     }
 
     pub fn truncate_to(&self, tcx: TyCtxt<'tcx>, generics: &ty::Generics) -> GenericArgsRef<'tcx> {

--- a/tests/ui/async-await/in-trait/async-example-desugared-extra.rs
+++ b/tests/ui/async-await/in-trait/async-example-desugared-extra.rs
@@ -2,14 +2,14 @@
 // edition: 2021
 
 #![feature(async_fn_in_trait)]
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, lint_reasons)]
 #![allow(incomplete_features)]
 
 use std::future::Future;
 use std::pin::Pin;
 use std::task::Poll;
 
-trait MyTrait {
+pub trait MyTrait {
     async fn foo(&self) -> i32;
 }
 
@@ -27,7 +27,7 @@ impl Future for MyFuture {
 }
 
 impl MyTrait for i32 {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn foo(&self) -> impl Future<Output = i32> + Clone {
         MyFuture(*self)
     }

--- a/tests/ui/async-await/in-trait/async-example-desugared-extra.rs
+++ b/tests/ui/async-await/in-trait/async-example-desugared-extra.rs
@@ -27,8 +27,7 @@ impl Future for MyFuture {
 }
 
 impl MyTrait for i32 {
-    // FIXME: this should eventually require `#[refine]` to compile, because it also provides
-    // `Clone`.
+    #[allow(refining_impl_trait)]
     fn foo(&self) -> impl Future<Output = i32> + Clone {
         MyFuture(*self)
     }

--- a/tests/ui/async-await/in-trait/async-example-desugared.rs
+++ b/tests/ui/async-await/in-trait/async-example-desugared.rs
@@ -12,7 +12,7 @@ trait MyTrait {
 }
 
 impl MyTrait for i32 {
-    fn foo(&self) -> impl Future<Output = i32> + '_ {
+    fn foo(&self) -> impl Future<Output = i32> {
         async { *self }
     }
 }

--- a/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
@@ -8,6 +8,7 @@ pub trait Foo {
 
 pub struct Foreign;
 impl Foo for Foreign {
+    #[allow(refining_impl_trait)]
     fn bar(self) -> &'static () {
         &()
     }

--- a/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
@@ -1,4 +1,4 @@
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, lint_reasons)]
 
 use std::ops::Deref;
 
@@ -8,7 +8,7 @@ pub trait Foo {
 
 pub struct Foreign;
 impl Foo for Foreign {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn bar(self) -> &'static () {
         &()
     }

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
@@ -17,6 +17,7 @@ impl<'a, I: 'a + Iterable> Iterable for &'a I {
     //~^ ERROR impl has stricter requirements than trait
 
     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
+        //~^ WARN impl trait in impl method signature does not match trait method signature
         (*self).iter()
     }
 }

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.rs
@@ -2,7 +2,7 @@
 
 #![feature(return_position_impl_trait_in_trait)]
 
-trait Iterable {
+pub trait Iterable {
     type Item<'a>
     where
         Self: 'a;

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -24,8 +24,8 @@ LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
    = note: `#[warn(refining_impl_trait)]` on by default
 help: replace the return type so that it matches the trait
    |
-LL |     fn iter(&self) -> impl Iterator<Item = <&'a I as Iterable>::Item<'_>> + '_ {
-   |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     fn iter(&self) -> impl Iterator<Item = <Self as Iterable>::Item<'_>> + '_ {
+   |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -12,6 +12,21 @@ help: copy the `where` clause predicates from the trait
 LL |     where Self: 'b;
    |     ~~~~~~~~~~~~~~
 
-error: aborting due to previous error
+warning: impl trait in impl method signature does not match trait method signature
+  --> $DIR/bad-item-bound-within-rpitit.rs:19:28
+   |
+LL |     fn iter(&self) -> impl '_ + Iterator<Item = Self::Item<'_>>;
+   |                       ----------------------------------------- return type from trait method defined here
+...
+LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
+   |                            ^^ this bound is stronger than that defined on the trait
+   |
+   = note: `#[warn(refining_impl_trait)]` on by default
+help: replace the return type so that it matches the trait
+   |
+LL |     fn iter(&self) -> impl Iterator<Item = <&'a I as Iterable>::Item<'_>> + '_ {
+   |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0276`.

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -21,6 +21,7 @@ LL |     fn iter(&self) -> impl '_ + Iterator<Item = Self::Item<'_>>;
 LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
    |                            ^^ this bound is stronger than that defined on the trait
    |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
    = note: `#[warn(refining_impl_trait)]` on by default
 help: replace the return type so that it matches the trait
    |

--- a/tests/ui/impl-trait/in-trait/deep-match-works.rs
+++ b/tests/ui/impl-trait/in-trait/deep-match-works.rs
@@ -1,16 +1,16 @@
 // check-pass
 
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, lint_reasons)]
 #![allow(incomplete_features)]
 
-struct Wrapper<T>(T);
+pub struct Wrapper<T>(T);
 
-trait Foo {
+pub trait Foo {
     fn bar() -> Wrapper<impl Sized>;
 }
 
 impl Foo for () {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn bar() -> Wrapper<i32> {
         Wrapper(0)
     }

--- a/tests/ui/impl-trait/in-trait/deep-match-works.rs
+++ b/tests/ui/impl-trait/in-trait/deep-match-works.rs
@@ -10,6 +10,7 @@ trait Foo {
 }
 
 impl Foo for () {
+    #[allow(refining_impl_trait)]
     fn bar() -> Wrapper<i32> {
         Wrapper(0)
     }

--- a/tests/ui/impl-trait/in-trait/foreign.rs
+++ b/tests/ui/impl-trait/in-trait/foreign.rs
@@ -1,15 +1,25 @@
 // check-pass
 // aux-build: rpitit.rs
 
+#![feature(lint_reasons)]
+
 extern crate rpitit;
 
 use rpitit::{Foo, Foreign};
 use std::sync::Arc;
 
 // Implement an RPITIT from another crate.
-struct Local;
+pub struct Local;
 impl Foo for Local {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
+    fn bar(self) -> Arc<String> {
+        Arc::new(String::new())
+    }
+}
+
+struct LocalIgnoreRefining;
+impl Foo for LocalIgnoreRefining {
+    #[deny(refining_impl_trait)]
     fn bar(self) -> Arc<String> {
         Arc::new(String::new())
     }
@@ -24,4 +34,5 @@ fn main() {
     let &() = Foreign.bar();
 
     let x: Arc<String> = Local.bar();
+    let x: Arc<String> = LocalIgnoreRefining.bar();
 }

--- a/tests/ui/impl-trait/in-trait/foreign.rs
+++ b/tests/ui/impl-trait/in-trait/foreign.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 // Implement an RPITIT from another crate.
 struct Local;
 impl Foo for Local {
+    #[allow(refining_impl_trait)]
     fn bar(self) -> Arc<String> {
         Arc::new(String::new())
     }

--- a/tests/ui/impl-trait/in-trait/issue-102571.rs
+++ b/tests/ui/impl-trait/in-trait/issue-102571.rs
@@ -8,14 +8,6 @@ trait Foo {
     fn bar(self) -> impl Deref<Target = impl Display + ?Sized>;
 }
 
-struct A;
-
-impl Foo for A {
-    fn bar(self) -> &'static str {
-        "Hello, world"
-    }
-}
-
 fn foo<T: Foo>(t: T) {
     let () = t.bar();
     //~^ ERROR mismatched types

--- a/tests/ui/impl-trait/in-trait/issue-102571.stderr
+++ b/tests/ui/impl-trait/in-trait/issue-102571.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-102571.rs:20:9
+  --> $DIR/issue-102571.rs:12:9
    |
 LL |     let () = t.bar();
    |         ^^   ------- this expression has type `impl Deref<Target = impl std::fmt::Display + ?Sized>`

--- a/tests/ui/impl-trait/in-trait/nested-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/nested-rpitit.rs
@@ -1,28 +1,28 @@
 // check-pass
 
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, lint_reasons)]
 #![allow(incomplete_features)]
 
 use std::fmt::Display;
 use std::ops::Deref;
 
-trait Foo {
+pub trait Foo {
     fn bar(self) -> impl Deref<Target = impl Display + ?Sized>;
 }
 
-struct A;
+pub struct A;
 
 impl Foo for A {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn bar(self) -> &'static str {
         "Hello, world"
     }
 }
 
-struct B;
+pub struct B;
 
 impl Foo for B {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn bar(self) -> Box<i32> {
         Box::new(42)
     }

--- a/tests/ui/impl-trait/in-trait/nested-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/nested-rpitit.rs
@@ -13,6 +13,7 @@ trait Foo {
 struct A;
 
 impl Foo for A {
+    #[allow(refining_impl_trait)]
     fn bar(self) -> &'static str {
         "Hello, world"
     }
@@ -21,6 +22,7 @@ impl Foo for A {
 struct B;
 
 impl Foo for B {
+    #[allow(refining_impl_trait)]
     fn bar(self) -> Box<i32> {
         Box::new(42)
     }

--- a/tests/ui/impl-trait/in-trait/object-safety.rs
+++ b/tests/ui/impl-trait/in-trait/object-safety.rs
@@ -8,7 +8,7 @@ trait Foo {
 }
 
 impl Foo for u32 {
-    fn baz(&self) -> u32 {
+    fn baz(&self) -> impl Debug {
         32
     }
 }

--- a/tests/ui/impl-trait/in-trait/refine.rs
+++ b/tests/ui/impl-trait/in-trait/refine.rs
@@ -1,33 +1,45 @@
 #![feature(return_position_impl_trait_in_trait, async_fn_in_trait)]
 #![deny(refining_impl_trait)]
 
-trait Foo {
+pub trait Foo {
     fn bar() -> impl Sized;
 }
 
-struct A;
+pub struct A;
 impl Foo for A {
     fn bar() -> impl Copy {}
     //~^ ERROR impl method signature does not match trait method signature
 }
 
-struct B;
+pub struct B;
 impl Foo for B {
     fn bar() {}
     //~^ ERROR impl method signature does not match trait method signature
 }
 
-struct C;
+pub struct C;
 impl Foo for C {
     fn bar() -> () {}
     //~^ ERROR impl method signature does not match trait method signature
 }
 
-trait Late {
+struct Private;
+impl Foo for Private {
+    fn bar() -> () {}
+}
+
+pub trait Arg<A> {
+    fn bar() -> impl Sized;
+}
+impl Arg<Private> for A {
+    fn bar() -> () {}
+}
+
+pub trait Late {
     fn bar<'a>(&'a self) -> impl Sized + 'a;
 }
 
-struct D;
+pub struct D;
 impl Late for D {
     fn bar(&self) -> impl Copy + '_ {}
     //~^ ERROR impl method signature does not match trait method signature

--- a/tests/ui/impl-trait/in-trait/refine.rs
+++ b/tests/ui/impl-trait/in-trait/refine.rs
@@ -1,0 +1,36 @@
+#![feature(return_position_impl_trait_in_trait, async_fn_in_trait)]
+#![deny(refining_impl_trait)]
+
+trait Foo {
+    fn bar() -> impl Sized;
+}
+
+struct A;
+impl Foo for A {
+    fn bar() -> impl Copy {}
+    //~^ ERROR impl method signature does not match trait method signature
+}
+
+struct B;
+impl Foo for B {
+    fn bar() {}
+    //~^ ERROR impl method signature does not match trait method signature
+}
+
+struct C;
+impl Foo for C {
+    fn bar() -> () {}
+    //~^ ERROR impl method signature does not match trait method signature
+}
+
+trait Late {
+    fn bar<'a>(&'a self) -> impl Sized + 'a;
+}
+
+struct D;
+impl Late for D {
+    fn bar(&self) -> impl Copy + '_ {}
+    //~^ ERROR impl method signature does not match trait method signature
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/refine.stderr
+++ b/tests/ui/impl-trait/in-trait/refine.stderr
@@ -46,7 +46,7 @@ LL |     fn bar() -> impl Sized {}
    |                 ~~~~~~~~~~
 
 error: impl trait in impl method signature does not match trait method signature
-  --> $DIR/refine.rs:32:27
+  --> $DIR/refine.rs:44:27
    |
 LL |     fn bar<'a>(&'a self) -> impl Sized + 'a;
    |                             --------------- return type from trait method defined here

--- a/tests/ui/impl-trait/in-trait/refine.stderr
+++ b/tests/ui/impl-trait/in-trait/refine.stderr
@@ -7,6 +7,7 @@ LL |     fn bar() -> impl Sized;
 LL |     fn bar() -> impl Copy {}
    |                      ^^^^ this bound is stronger than that defined on the trait
    |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
 note: the lint level is defined here
   --> $DIR/refine.rs:2:9
    |
@@ -26,6 +27,7 @@ LL |     fn bar() -> impl Sized;
 LL |     fn bar() {}
    |     ^^^^^^^^
    |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
 help: replace the return type so that it matches the trait
    |
 LL |     fn bar() -> impl Sized {}
@@ -40,6 +42,7 @@ LL |     fn bar() -> impl Sized;
 LL |     fn bar() -> () {}
    |                 ^^
    |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
 help: replace the return type so that it matches the trait
    |
 LL |     fn bar() -> impl Sized {}
@@ -54,6 +57,7 @@ LL |     fn bar<'a>(&'a self) -> impl Sized + 'a;
 LL |     fn bar(&self) -> impl Copy + '_ {}
    |                           ^^^^ this bound is stronger than that defined on the trait
    |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
 help: replace the return type so that it matches the trait
    |
 LL |     fn bar(&self) -> impl Sized + '_ {}

--- a/tests/ui/impl-trait/in-trait/refine.stderr
+++ b/tests/ui/impl-trait/in-trait/refine.stderr
@@ -1,0 +1,63 @@
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine.rs:10:22
+   |
+LL |     fn bar() -> impl Sized;
+   |                 ---------- return type from trait method defined here
+...
+LL |     fn bar() -> impl Copy {}
+   |                      ^^^^ this bound is stronger than that defined on the trait
+   |
+note: the lint level is defined here
+  --> $DIR/refine.rs:2:9
+   |
+LL | #![deny(refining_impl_trait)]
+   |         ^^^^^^^^^^^^^^^^^^^
+help: replace the return type so that it matches the trait
+   |
+LL |     fn bar() -> impl Sized {}
+   |                 ~~~~~~~~~~
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine.rs:16:5
+   |
+LL |     fn bar() -> impl Sized;
+   |                 ---------- return type from trait method defined here
+...
+LL |     fn bar() {}
+   |     ^^^^^^^^
+   |
+help: replace the return type so that it matches the trait
+   |
+LL |     fn bar() -> impl Sized {}
+   |              +++++++++++++
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine.rs:22:17
+   |
+LL |     fn bar() -> impl Sized;
+   |                 ---------- return type from trait method defined here
+...
+LL |     fn bar() -> () {}
+   |                 ^^
+   |
+help: replace the return type so that it matches the trait
+   |
+LL |     fn bar() -> impl Sized {}
+   |                 ~~~~~~~~~~
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine.rs:32:27
+   |
+LL |     fn bar<'a>(&'a self) -> impl Sized + 'a;
+   |                             --------------- return type from trait method defined here
+...
+LL |     fn bar(&self) -> impl Copy + '_ {}
+   |                           ^^^^ this bound is stronger than that defined on the trait
+   |
+help: replace the return type so that it matches the trait
+   |
+LL |     fn bar(&self) -> impl Sized + '_ {}
+   |                      ~~~~~~~~~~~~~~~
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/impl-trait/in-trait/reveal.rs
+++ b/tests/ui/impl-trait/in-trait/reveal.rs
@@ -1,14 +1,14 @@
 // check-pass
 
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, lint_reasons)]
 #![allow(incomplete_features)]
 
-trait Foo {
+pub trait Foo {
     fn f() -> Box<impl Sized>;
 }
 
 impl Foo for () {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn f() -> Box<String> {
         Box::new(String::new())
     }

--- a/tests/ui/impl-trait/in-trait/reveal.rs
+++ b/tests/ui/impl-trait/in-trait/reveal.rs
@@ -8,6 +8,7 @@ trait Foo {
 }
 
 impl Foo for () {
+    #[allow(refining_impl_trait)]
     fn f() -> Box<String> {
         Box::new(String::new())
     }

--- a/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
+++ b/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
@@ -1,6 +1,6 @@
 // issue: 113903
 
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, lint_reasons)]
 
 use std::ops::Deref;
 
@@ -10,7 +10,7 @@ pub trait Tr {
 }
 
 impl Tr for () {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn w() -> &'static () {
         &()
     }

--- a/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
+++ b/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
@@ -10,6 +10,7 @@ pub trait Tr {
 }
 
 impl Tr for () {
+    #[allow(refining_impl_trait)]
     fn w() -> &'static () {
         &()
     }

--- a/tests/ui/impl-trait/in-trait/signature-mismatch.failure.stderr
+++ b/tests/ui/impl-trait/in-trait/signature-mismatch.failure.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/signature-mismatch.rs:77:10
+  --> $DIR/signature-mismatch.rs:79:10
    |
 LL |         &'a self,
    |         -------- this parameter and the return type are declared with different lifetimes...

--- a/tests/ui/impl-trait/in-trait/signature-mismatch.rs
+++ b/tests/ui/impl-trait/in-trait/signature-mismatch.rs
@@ -2,17 +2,17 @@
 // revisions: success failure
 //[success] check-pass
 
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, lint_reasons)]
 
 use std::future::Future;
 
-trait Captures<'a> {}
+pub trait Captures<'a> {}
 impl<T> Captures<'_> for T {}
 
-trait Captures2<'a, 'b> {}
+pub trait Captures2<'a, 'b> {}
 impl<T> Captures2<'_, '_> for T {}
 
-trait AsyncTrait {
+pub trait AsyncTrait {
     #[cfg(success)]
     fn async_fn(&self, buff: &[u8]) -> impl Future<Output = Vec<u8>>;
 
@@ -44,7 +44,7 @@ impl AsyncTrait for Struct {
     // Does not capture more lifetimes that trait def'n, since trait def'n
     // implicitly captures all in-scope lifetimes.
     #[cfg(success)]
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn async_fn<'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
         async move { buff.to_vec() }
     }
@@ -52,7 +52,7 @@ impl AsyncTrait for Struct {
     // Does not capture more lifetimes that trait def'n, since trait def'n
     // implicitly captures all in-scope lifetimes.
     #[cfg(success)]
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn async_fn_early<'a: 'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
         async move { buff.to_vec() }
     }
@@ -60,7 +60,7 @@ impl AsyncTrait for Struct {
     // Does not capture more lifetimes that trait def'n, since trait def'n
     // implicitly captures all in-scope lifetimes.
     #[cfg(success)]
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn async_fn_multiple<'a, 'b>(
         &'a self,
         buff: &'b [u8],

--- a/tests/ui/impl-trait/in-trait/signature-mismatch.rs
+++ b/tests/ui/impl-trait/in-trait/signature-mismatch.rs
@@ -3,7 +3,6 @@
 //[success] check-pass
 
 #![feature(return_position_impl_trait_in_trait)]
-#![allow(incomplete_features)]
 
 use std::future::Future;
 
@@ -45,6 +44,7 @@ impl AsyncTrait for Struct {
     // Does not capture more lifetimes that trait def'n, since trait def'n
     // implicitly captures all in-scope lifetimes.
     #[cfg(success)]
+    #[allow(refining_impl_trait)]
     fn async_fn<'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
         async move { buff.to_vec() }
     }
@@ -52,6 +52,7 @@ impl AsyncTrait for Struct {
     // Does not capture more lifetimes that trait def'n, since trait def'n
     // implicitly captures all in-scope lifetimes.
     #[cfg(success)]
+    #[allow(refining_impl_trait)]
     fn async_fn_early<'a: 'a>(&self, buff: &'a [u8]) -> impl Future<Output = Vec<u8>> + 'a {
         async move { buff.to_vec() }
     }
@@ -59,6 +60,7 @@ impl AsyncTrait for Struct {
     // Does not capture more lifetimes that trait def'n, since trait def'n
     // implicitly captures all in-scope lifetimes.
     #[cfg(success)]
+    #[allow(refining_impl_trait)]
     fn async_fn_multiple<'a, 'b>(
         &'a self,
         buff: &'b [u8],

--- a/tests/ui/impl-trait/in-trait/specialization-substs-remap.rs
+++ b/tests/ui/impl-trait/in-trait/specialization-substs-remap.rs
@@ -12,6 +12,7 @@ impl<U> Foo for U
 where
     U: Copy,
 {
+    #[allow(refining_impl_trait)]
     fn bar(&self) -> U {
         *self
     }

--- a/tests/ui/impl-trait/in-trait/specialization-substs-remap.rs
+++ b/tests/ui/impl-trait/in-trait/specialization-substs-remap.rs
@@ -1,10 +1,10 @@
 // check-pass
 
 #![feature(specialization)]
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, lint_reasons)]
 #![allow(incomplete_features)]
 
-trait Foo {
+pub trait Foo {
     fn bar(&self) -> impl Sized;
 }
 
@@ -12,7 +12,7 @@ impl<U> Foo for U
 where
     U: Copy,
 {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn bar(&self) -> U {
         *self
     }

--- a/tests/ui/impl-trait/in-trait/success.rs
+++ b/tests/ui/impl-trait/in-trait/success.rs
@@ -1,32 +1,32 @@
 // check-pass
 
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, lint_reasons)]
 #![allow(incomplete_features)]
 
 use std::fmt::Display;
 
-trait Foo {
+pub trait Foo {
     fn bar(&self) -> impl Display;
 }
 
 impl Foo for i32 {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn bar(&self) -> i32 {
         *self
     }
 }
 
 impl Foo for &'static str {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn bar(&self) -> &'static str {
         *self
     }
 }
 
-struct Yay;
+pub struct Yay;
 
 impl Foo for Yay {
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn bar(&self) -> String {
         String::from(":^)")
     }

--- a/tests/ui/impl-trait/in-trait/success.rs
+++ b/tests/ui/impl-trait/in-trait/success.rs
@@ -10,12 +10,14 @@ trait Foo {
 }
 
 impl Foo for i32 {
+    #[allow(refining_impl_trait)]
     fn bar(&self) -> i32 {
         *self
     }
 }
 
 impl Foo for &'static str {
+    #[allow(refining_impl_trait)]
     fn bar(&self) -> &'static str {
         *self
     }
@@ -24,6 +26,7 @@ impl Foo for &'static str {
 struct Yay;
 
 impl Foo for Yay {
+    #[allow(refining_impl_trait)]
     fn bar(&self) -> String {
         String::from(":^)")
     }


### PR DESCRIPTION
Implements a lint that warns against accidentally refining an RPITIT in an implementation. This is not a hard error, and can be suppressed with `#[allow(refining_impl_trait)]`, since this behavior may be desirable -- the lint just serves as an acknowledgement from the impl author that they understand that the types they write in the implementation are an API guarantee.

This compares bounds syntactically, not semantically -- semantic implication is more difficult and essentially relies on adding the ability to keep the RPITIT hidden in the trait system so that things can be proven about the type that shows up in the impl without its own bounds leaking through, either via a new reveal mode or something else. This was experimentally implemented in #111931.

Somewhat opinionated choices:
1. Putting the lint behind `refining_impl_trait` rather than a blanket `refine` lint. This could be changed, but I like keeping the lint specialized to RPITITs so the explanation can be tailored to it.
2. This PR does not include the `#[refine]` attribute or the feature gate, since it's kind of orthogonal and can be added in a separate PR.

r? @oli-obk