### PR TITLE
fix #115348

### DIFF
--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -483,7 +483,7 @@ fn unsafety_check_result(tcx: TyCtxt<'_>, def: LocalDefId) -> &UnsafetyCheckResu
     // `mir_built` force this.
     let body = &tcx.mir_built(def).borrow();
 
-    if body.is_custom_mir() {
+    if body.is_custom_mir() || body.tainted_by_errors.is_some() {
         return tcx.arena.alloc(UnsafetyCheckResult {
             violations: Vec::new(),
             used_unsafe_blocks: Default::default(),

--- a/tests/ui/unsafe/issue-115348-false-positive-warning-of-unnecessary-unsafe.rs
+++ b/tests/ui/unsafe/issue-115348-false-positive-warning-of-unnecessary-unsafe.rs
@@ -1,0 +1,16 @@
+// Regression test for #115348.
+
+unsafe fn uwu() {}
+
+// Tests that the false-positive warning "unnecessary `unsafe` block"
+// should not be reported, when the error "non-exhaustive patterns"
+// appears.
+
+fn foo(x: Option<u32>) {
+    match x {
+        //~^ ERROR non-exhaustive patterns: `None` not covered
+        Some(_) => unsafe { uwu() },
+    }
+}
+
+fn main() {}

--- a/tests/ui/unsafe/issue-115348-false-positive-warning-of-unnecessary-unsafe.stderr
+++ b/tests/ui/unsafe/issue-115348-false-positive-warning-of-unnecessary-unsafe.stderr
@@ -1,0 +1,21 @@
+error[E0004]: non-exhaustive patterns: `None` not covered
+  --> $DIR/issue-115348-false-positive-warning-of-unnecessary-unsafe.rs:10:11
+   |
+LL |     match x {
+   |           ^ pattern `None` not covered
+   |
+note: `Option<u32>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<u32>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         Some(_) => unsafe { uwu() },
+LL ~         None => todo!(),
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
fix #115348 
It looks that:

- In `rustc_mir_build::build`, the body of function will not be built, when the `tcx.check_match(def)` fails due to `non-exhaustive patterns`
- In `rustc_mir_transform::check_unsafety`, the `UnsafetyChecker` collects all `used_unsafe_blocks` in the MIR of a function, and the `UnusedUnsafeVisitor` will visit all `UnsafeBlock`s in the HIR and collect `unused_unsafes`, which are not contained in `used_unsafe_blocks`, and report `unnecessary_unsafe`s
- So the unsafe block in the issue example code will be reported as `unnecessary_unsafe`.