### PR TITLE
Fix log formatting in bootstrap

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1019,7 +1019,7 @@ impl Build {
 
     fn info(&self, msg: &str) {
         match self.config.dry_run {
-            DryRun::SelfCheck => return,
+            DryRun::SelfCheck => (),
             DryRun::Disabled | DryRun::UserSelected => {
                 println!("{msg}");
             }

--- a/src/bootstrap/llvm.rs
+++ b/src/bootstrap/llvm.rs
@@ -598,9 +598,9 @@ fn configure_cmake(
         } else if target.contains("linux") {
             cfg.define("CMAKE_SYSTEM_NAME", "Linux");
         } else {
-            builder.info(
+            builder.info(&format!(
                 "could not determine CMAKE_SYSTEM_NAME from the target `{target}`, build may fail",
-            );
+            ));
         }
 
         // When cross-compiling we should also set CMAKE_SYSTEM_VERSION, but in


### PR DESCRIPTION
`format!()` was missing, so log was just showing `{target}` verbatim.

(I also applied a small clippy suggestion in `builder.info()`)