### PR TITLE
replaced occurrences of "is a `&`" to "is an `&`" for grammatical correctness.

### DIFF
--- a/src/tools/clippy/CHANGELOG.md
+++ b/src/tools/clippy/CHANGELOG.md
@@ -2541,7 +2541,7 @@ Released 2021-06-17
 * [`len_without_is_empty`]: Also lint if function signatures of `len` and
   `is_empty` don't match
   [#6980](https://github.com/rust-lang/rust-clippy/pull/6980)
-* [`redundant_pattern_matching`]: Also lint if the pattern is a `&` pattern
+* [`redundant_pattern_matching`]: Also lint if the pattern is an `&' pattern
   [#6991](https://github.com/rust-lang/rust-clippy/pull/6991)
 * [`clone_on_copy`]: Also lint on chained method calls taking `self` by value
   [#7000](https://github.com/rust-lang/rust-clippy/pull/7000)

--- a/src/tools/clippy/CHANGELOG.md
+++ b/src/tools/clippy/CHANGELOG.md
@@ -2541,7 +2541,7 @@ Released 2021-06-17
 * [`len_without_is_empty`]: Also lint if function signatures of `len` and
   `is_empty` don't match
   [#6980](https://github.com/rust-lang/rust-clippy/pull/6980)
-* [`redundant_pattern_matching`]: Also lint if the pattern is an `&' pattern
+* [`redundant_pattern_matching`]: Also lint if the pattern is an `&` pattern
   [#6991](https://github.com/rust-lang/rust-clippy/pull/6991)
 * [`clone_on_copy`]: Also lint on chained method calls taking `self` by value
   [#7000](https://github.com/rust-lang/rust-clippy/pull/7000)

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_none.fixed
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_none.fixed
@@ -25,7 +25,7 @@ fn main() {
     let s1 = String::from("hello world");
     let s2 = String::from("world");
 
-    // caller of `find()` is a `&`static str`
+    // caller of `find()` is an `&'static str`
     let _ = !"hello world".contains("world");
     let _ = !"hello world".contains(&s2);
     let _ = !"hello world".contains(&s2[2..]);

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_none.fixed
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_none.fixed
@@ -25,7 +25,7 @@ fn main() {
     let s1 = String::from("hello world");
     let s2 = String::from("world");
 
-    // caller of `find()` is an `&'static str`
+    // caller of `find()` is an `&`static str`
     let _ = !"hello world".contains("world");
     let _ = !"hello world".contains(&s2);
     let _ = !"hello world".contains(&s2[2..]);

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_none.rs
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_none.rs
@@ -27,7 +27,7 @@ fn main() {
     let s1 = String::from("hello world");
     let s2 = String::from("world");
 
-    // caller of `find()` is a `&`static str`
+    // caller of `find()` is an `&'static str`
     let _ = "hello world".find("world").is_none();
     let _ = "hello world".find(&s2).is_none();
     let _ = "hello world".find(&s2[2..]).is_none();

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_none.rs
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_none.rs
@@ -27,7 +27,7 @@ fn main() {
     let s1 = String::from("hello world");
     let s2 = String::from("world");
 
-    // caller of `find()` is an `&'static str`
+    // caller of `find()` is an `&`static str`
     let _ = "hello world".find("world").is_none();
     let _ = "hello world".find(&s2).is_none();
     let _ = "hello world".find(&s2[2..]).is_none();

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_some.fixed
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_some.fixed
@@ -25,7 +25,7 @@ fn main() {
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
-    // caller of `find()` is a `&`static str`
+    // caller of `find()` is an `&'static str`
     let _ = "hello world".contains("world");
     let _ = "hello world".contains(&s2);
     let _ = "hello world".contains(&s2[2..]);

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_some.fixed
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_some.fixed
@@ -25,7 +25,7 @@ fn main() {
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
-    // caller of `find()` is an `&'static str`
+    // caller of `find()` is an `&`static str`
     let _ = "hello world".contains("world");
     let _ = "hello world".contains(&s2);
     let _ = "hello world".contains(&s2[2..]);

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_some.rs
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_some.rs
@@ -26,7 +26,7 @@ fn main() {
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
-    // caller of `find()` is an `&'static str`
+    // caller of `find()` is an `&`static str`
     let _ = "hello world".find("world").is_some();
     let _ = "hello world".find(&s2).is_some();
     let _ = "hello world".find(&s2[2..]).is_some();

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_some.rs
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_some.rs
@@ -26,7 +26,7 @@ fn main() {
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
-    // caller of `find()` is a `&`static str`
+    // caller of `find()` is an `&'static str`
     let _ = "hello world".find("world").is_some();
     let _ = "hello world".find(&s2).is_some();
     let _ = "hello world".find(&s2[2..]).is_some();

--- a/tests/ui/array-slice-vec/slice-mut-2.stderr
+++ b/tests/ui/array-slice-vec/slice-mut-2.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/slice-mut-2.rs:7:18
    |
 LL |     let _ = &mut x[2..4];
-   |                  ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/array-slice-vec/slice-mut-2.stderr
+++ b/tests/ui/array-slice-vec/slice-mut-2.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/slice-mut-2.rs:7:18
    |
 LL |     let _ = &mut x[2..4];
-   |                  ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
+++ b/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrow-raw-address-of-deref-mutability.rs:8:13
    |
 LL |     let q = &raw mut *x;
-   |             ^^^^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
+++ b/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrow-raw-address-of-deref-mutability.rs:8:13
    |
 LL |     let q = &raw mut *x;
-   |             ^^^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -30,7 +30,7 @@ error[E0596]: cannot borrow `*ref_x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-access-permissions.rs:30:19
    |
 LL |         let _y1 = &mut *ref_x;
-   |                   ^^^^^^^^^^^ `ref_x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^^^^^^^^^ `ref_x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -52,7 +52,7 @@ error[E0596]: cannot borrow `*foo_ref.f` as mutable, as it is behind a `&` refer
   --> $DIR/borrowck-access-permissions.rs:48:18
    |
 LL |         let _y = &mut *foo_ref.f;
-   |                  ^^^^^^^^^^^^^^^ `foo_ref` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^^^^^^^^^^^^^^^ `foo_ref` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -30,7 +30,7 @@ error[E0596]: cannot borrow `*ref_x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-access-permissions.rs:30:19
    |
 LL |         let _y1 = &mut *ref_x;
-   |                   ^^^^^^^^^^^ `ref_x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^^^^^^^^^ `ref_x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -52,7 +52,7 @@ error[E0596]: cannot borrow `*foo_ref.f` as mutable, as it is behind a `&` refer
   --> $DIR/borrowck-access-permissions.rs:48:18
    |
 LL |         let _y = &mut *foo_ref.f;
-   |                  ^^^^^^^^^^^^^^^ `foo_ref` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^^^^^^^^^^^^^^^ `foo_ref` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:9:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:17:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:9:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:17:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `**t1`, which is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:9:5
    |
 LL |     **t1 = 22;
-   |     ^^^^^^^^^ `t1` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `t1` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |
@@ -23,7 +23,7 @@ error[E0596]: cannot borrow `**t0` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:19:26
    |
 LL |     let x:  &mut isize = &mut **t0;
-   |                          ^^^^^^^^^ `t0` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                          ^^^^^^^^^ `t0` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `**t1`, which is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:9:5
    |
 LL |     **t1 = 22;
-   |     ^^^^^^^^^ `t1` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `t1` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |
@@ -23,7 +23,7 @@ error[E0596]: cannot borrow `**t0` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:19:26
    |
 LL |     let x:  &mut isize = &mut **t0;
-   |                          ^^^^^^^^^ `t0` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                          ^^^^^^^^^ `t0` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-issue-14498.stderr
+++ b/tests/ui/borrowck/borrowck-issue-14498.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `***p`, which is behind a `&` reference
   --> $DIR/borrowck-issue-14498.rs:16:5
    |
 LL |     ***p = 2;
-   |     ^^^^^^^^ `p` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `p` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-issue-14498.stderr
+++ b/tests/ui/borrowck/borrowck-issue-14498.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `***p`, which is behind a `&` reference
   --> $DIR/borrowck-issue-14498.rs:16:5
    |
 LL |     ***p = 2;
-   |     ^^^^^^^^ `p` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `p` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
+++ b/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
@@ -106,7 +106,7 @@ error[E0596]: cannot borrow `foo.bar1` as mutable, as it is behind a `&` referen
   --> $DIR/borrowck-reborrow-from-mut.rs:88:17
    |
 LL |     let _bar1 = &mut foo.bar1;
-   |                 ^^^^^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
+++ b/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
@@ -106,7 +106,7 @@ error[E0596]: cannot borrow `foo.bar1` as mutable, as it is behind a `&` referen
   --> $DIR/borrowck-reborrow-from-mut.rs:88:17
    |
 LL |     let _bar1 = &mut foo.bar1;
-   |                 ^^^^^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^^ `foo` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
+++ b/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
@@ -5,7 +5,7 @@ LL |     for item in &mut std::iter::empty::<&'static ()>() {
    |                 -------------------------------------- this iterator yields `&` references
 LL |
 LL |         *item = ();
-   |         ^^^^^^^^^^ `item` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^ `item` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
+++ b/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
@@ -5,7 +5,7 @@ LL |     for item in &mut std::iter::empty::<&'static ()>() {
    |                 -------------------------------------- this iterator yields `&` references
 LL |
 LL |         *item = ();
-   |         ^^^^^^^^^^ `item` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^ `item` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-82032.stderr
+++ b/tests/ui/borrowck/issue-82032.stderr
@@ -7,7 +7,7 @@ LL |         for v in self.0.values() {
    |                  |      help: use mutable method: `values_mut()`
    |                  this iterator yields `&` references
 LL |             v.flush();
-   |             ^ `v` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^ `v` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-82032.stderr
+++ b/tests/ui/borrowck/issue-82032.stderr
@@ -7,7 +7,7 @@ LL |         for v in self.0.values() {
    |                  |      help: use mutable method: `values_mut()`
    |                  this iterator yields `&` references
 LL |             v.flush();
-   |             ^ `v` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |             ^ `v` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
@@ -10,7 +10,7 @@ fn main() {
         //~^ NOTE this iterator yields `&` references
         *v -= 1;
         //~^ ERROR cannot assign to `*v`, which is behind a `&` reference
-        //~| NOTE `v` is an `&' reference, so the data it refers to cannot be written
+        //~| NOTE `v` is an `&` reference, so the data it refers to cannot be written
     }
 }
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
@@ -10,7 +10,7 @@ fn main() {
         //~^ NOTE this iterator yields `&` references
         *v -= 1;
         //~^ ERROR cannot assign to `*v`, which is behind a `&` reference
-        //~| NOTE `v` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `v` is an `&' reference, so the data it refers to cannot be written
     }
 }
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
@@ -5,7 +5,7 @@ LL |     for v in Query.iter_mut() {
    |              ---------------- this iterator yields `&` references
 LL |
 LL |         *v -= 1;
-   |         ^^^^^^^ `v` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `v` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
@@ -5,7 +5,7 @@ LL |     for v in Query.iter_mut() {
    |              ---------------- this iterator yields `&` references
 LL |
 LL |         *v -= 1;
-   |         ^^^^^^^ `v` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `v` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-85765-closure.rs
+++ b/tests/ui/borrowck/issue-85765-closure.rs
@@ -5,27 +5,27 @@ fn main() {
         //~^ HELP consider changing this binding's type
         rofl.push(Vec::new());
         //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-        //~| NOTE `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+        //~| NOTE `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 
         let mut mutvar = 42;
         let r = &mutvar;
         //~^ HELP consider changing this to be a mutable reference
         *r = 0;
         //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-        //~| NOTE `r` is an `&' reference, so the data it refers to cannot be written
+        //~| NOTE `r` is an `&` reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let x: &usize = &mut{0};
         //~^ HELP consider changing this binding's type
         *x = 1;
         //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-        //~| NOTE `x` is an `&' reference, so the data it refers to cannot be written
+        //~| NOTE `x` is an `&` reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let y: &usize = &mut(0);
         //~^ HELP consider changing this binding's type
         *y = 1;
         //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-        //~| NOTE `y` is an `&' reference, so the data it refers to cannot be written
+        //~| NOTE `y` is an `&` reference, so the data it refers to cannot be written
     };
 }

--- a/tests/ui/borrowck/issue-85765-closure.rs
+++ b/tests/ui/borrowck/issue-85765-closure.rs
@@ -5,27 +5,27 @@ fn main() {
         //~^ HELP consider changing this binding's type
         rofl.push(Vec::new());
         //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-        //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+        //~| NOTE `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 
         let mut mutvar = 42;
         let r = &mutvar;
         //~^ HELP consider changing this to be a mutable reference
         *r = 0;
         //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-        //~| NOTE `r` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `r` is an `&' reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let x: &usize = &mut{0};
         //~^ HELP consider changing this binding's type
         *x = 1;
         //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-        //~| NOTE `x` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `x` is an `&' reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let y: &usize = &mut(0);
         //~^ HELP consider changing this binding's type
         *y = 1;
         //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-        //~| NOTE `y` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `y` is an `&' reference, so the data it refers to cannot be written
     };
 }

--- a/tests/ui/borrowck/issue-85765-closure.stderr
+++ b/tests/ui/borrowck/issue-85765-closure.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:6:9
    |
 LL |         rofl.push(Vec::new());
-   |         ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:13:9
    |
 LL |         *r = 0;
-   |         ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^ `r` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:20:9
    |
 LL |         *x = 1;
-   |         ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:27:9
    |
 LL |         *y = 1;
-   |         ^^^^^^ `y` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^ `y` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-85765-closure.stderr
+++ b/tests/ui/borrowck/issue-85765-closure.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:6:9
    |
 LL |         rofl.push(Vec::new());
-   |         ^^^^ `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:13:9
    |
 LL |         *r = 0;
-   |         ^^^^^^ `r` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^ `r` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:20:9
    |
 LL |         *x = 1;
-   |         ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:27:9
    |
 LL |         *y = 1;
-   |         ^^^^^^ `y` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^ `y` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-85765.rs
+++ b/tests/ui/borrowck/issue-85765.rs
@@ -4,26 +4,26 @@ fn main() {
     //~^ HELP consider changing this binding's type
     rofl.push(Vec::new());
     //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-    //~| NOTE `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 
     let mut mutvar = 42;
     let r = &mutvar;
     //~^ HELP consider changing this to be a mutable reference
     *r = 0;
     //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-    //~| NOTE `r` is an `&' reference, so the data it refers to cannot be written
+    //~| NOTE `r` is an `&` reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let x: &usize = &mut{0};
     //~^ HELP consider changing this binding's type
     *x = 1;
     //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-    //~| NOTE `x` is an `&' reference, so the data it refers to cannot be written
+    //~| NOTE `x` is an `&` reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let y: &usize = &mut(0);
     //~^ HELP consider changing this binding's type
     *y = 1;
     //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-    //~| NOTE `y` is an `&' reference, so the data it refers to cannot be written
+    //~| NOTE `y` is an `&` reference, so the data it refers to cannot be written
 }

--- a/tests/ui/borrowck/issue-85765.rs
+++ b/tests/ui/borrowck/issue-85765.rs
@@ -4,26 +4,26 @@ fn main() {
     //~^ HELP consider changing this binding's type
     rofl.push(Vec::new());
     //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-    //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 
     let mut mutvar = 42;
     let r = &mutvar;
     //~^ HELP consider changing this to be a mutable reference
     *r = 0;
     //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-    //~| NOTE `r` is a `&` reference, so the data it refers to cannot be written
+    //~| NOTE `r` is an `&' reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let x: &usize = &mut{0};
     //~^ HELP consider changing this binding's type
     *x = 1;
     //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-    //~| NOTE `x` is a `&` reference, so the data it refers to cannot be written
+    //~| NOTE `x` is an `&' reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let y: &usize = &mut(0);
     //~^ HELP consider changing this binding's type
     *y = 1;
     //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-    //~| NOTE `y` is a `&` reference, so the data it refers to cannot be written
+    //~| NOTE `y` is an `&' reference, so the data it refers to cannot be written
 }

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765.rs:5:5
    |
 LL |     rofl.push(Vec::new());
-   |     ^^^^ `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:12:5
    |
 LL |     *r = 0;
-   |     ^^^^^^ `r` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^ `r` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:19:5
    |
 LL |     *x = 1;
-   |     ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:26:5
    |
 LL |     *y = 1;
-   |     ^^^^^^ `y` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^ `y` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765.rs:5:5
    |
 LL |     rofl.push(Vec::new());
-   |     ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:12:5
    |
 LL |     *r = 0;
-   |     ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `r` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:19:5
    |
 LL |     *x = 1;
-   |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:26:5
    |
 LL |     *y = 1;
-   |     ^^^^^^ `y` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `y` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-91206.rs
+++ b/tests/ui/borrowck/issue-91206.rs
@@ -12,5 +12,5 @@ fn main() {
     //~^ HELP consider specifying this binding's type
     inner.clear();
     //~^ ERROR cannot borrow `*inner` as mutable, as it is behind a `&` reference [E0596]
-    //~| NOTE `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `inner` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 }

--- a/tests/ui/borrowck/issue-91206.rs
+++ b/tests/ui/borrowck/issue-91206.rs
@@ -12,5 +12,5 @@ fn main() {
     //~^ HELP consider specifying this binding's type
     inner.clear();
     //~^ ERROR cannot borrow `*inner` as mutable, as it is behind a `&` reference [E0596]
-    //~| NOTE `inner` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `inner` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 }

--- a/tests/ui/borrowck/issue-91206.stderr
+++ b/tests/ui/borrowck/issue-91206.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
   --> $DIR/issue-91206.rs:13:5
    |
 LL |     inner.clear();
-   |     ^^^^^ `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^ `inner` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-91206.stderr
+++ b/tests/ui/borrowck/issue-91206.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
   --> $DIR/issue-91206.rs:13:5
    |
 LL |     inner.clear();
-   |     ^^^^^ `inner` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^ `inner` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-92015.stderr
+++ b/tests/ui/borrowck/issue-92015.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-92015.rs:6:5
    |
 LL |     *foo = 1;
-   |     ^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `foo` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-92015.stderr
+++ b/tests/ui/borrowck/issue-92015.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-92015.rs:6:5
    |
 LL |     *foo = 1;
-   |     ^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-93093.stderr
+++ b/tests/ui/borrowck/issue-93093.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.foo`, which is behind a `&` reference
   --> $DIR/issue-93093.rs:8:9
    |
 LL |         self.foo += 1;
-   |         ^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/issue-93093.stderr
+++ b/tests/ui/borrowck/issue-93093.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.foo`, which is behind a `&` reference
   --> $DIR/issue-93093.rs:8:9
    |
 LL |         self.foo += 1;
-   |         ^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/mutability-errors.stderr
+++ b/tests/ui/borrowck/mutability-errors.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:9:5
    |
 LL |     *x = (1,);
-   |     ^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `x.0`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:10:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:11:5
    |
 LL |     &mut *x;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `x.0` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:12:5
    |
 LL |     &mut x.0;
-   |     ^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/mutability-errors.stderr
+++ b/tests/ui/borrowck/mutability-errors.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:9:5
    |
 LL |     *x = (1,);
-   |     ^^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `x.0`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:10:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:11:5
    |
 LL |     &mut *x;
-   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `x.0` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:12:5
    |
 LL |     &mut x.0;
-   |     ^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*cb` as mutable, as it is behind a `&` reference
   --> $DIR/suggest-as-ref-on-mut-closure.rs:12:26
    |
 LL |     cb.as_ref().map(|cb| cb());
-   |                      --  ^^ `cb` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                      --  ^^ `cb` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |                      |
    |                      consider changing this binding's type to be: `&mut &mut dyn FnMut()`
 

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*cb` as mutable, as it is behind a `&` reference
   --> $DIR/suggest-as-ref-on-mut-closure.rs:12:26
    |
 LL |     cb.as_ref().map(|cb| cb());
-   |                      --  ^^ `cb` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                      --  ^^ `cb` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |                      |
    |                      consider changing this binding's type to be: `&mut &mut dyn FnMut()`
 

--- a/tests/ui/borrowck/suggest-mut-iterator.stderr
+++ b/tests/ui/borrowck/suggest-mut-iterator.stderr
@@ -4,7 +4,7 @@ error[E0596]: cannot borrow `*test` as mutable, as it is behind a `&` reference
 LL |     for test in &tests {
    |                 ------ this iterator yields `&` references
 LL |         test.add(2);
-   |         ^^^^ `test` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `test` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: use a mutable iterator instead
    |

--- a/tests/ui/borrowck/suggest-mut-iterator.stderr
+++ b/tests/ui/borrowck/suggest-mut-iterator.stderr
@@ -4,7 +4,7 @@ error[E0596]: cannot borrow `*test` as mutable, as it is behind a `&` reference
 LL |     for test in &tests {
    |                 ------ this iterator yields `&` references
 LL |         test.add(2);
-   |         ^^^^ `test` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `test` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: use a mutable iterator instead
    |

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` ref
   --> $DIR/mut_ref.rs:12:13
    |
 LL |     let c = || {
-   |             ^^ `ref_mref_x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^ `ref_mref_x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 LL |
 LL |         **ref_mref_x = y;
    |         ------------ mutable borrow occurs due to use of `**ref_mref_x` in closure

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` ref
   --> $DIR/mut_ref.rs:12:13
    |
 LL |     let c = || {
-   |             ^^ `ref_mref_x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^ `ref_mref_x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 LL |
 LL |         **ref_mref_x = y;
    |         ------------ mutable borrow occurs due to use of `**ref_mref_x` in closure

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*self.0` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-109141.rs:6:9
    |
 LL |         self.0.iter_mut()
-   |         ^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*self.0` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-109141.rs:6:9
    |
 LL |         self.0.iter_mut()
-   |         ^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-38147-1.stderr
+++ b/tests/ui/did_you_mean/issue-38147-1.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-38147-1.rs:17:9
    |
 LL |         self.s.push('x');
-   |         ^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-38147-1.stderr
+++ b/tests/ui/did_you_mean/issue-38147-1.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-38147-1.rs:17:9
    |
 LL |         self.s.push('x');
-   |         ^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-38147-4.stderr
+++ b/tests/ui/did_you_mean/issue-38147-4.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*f.s` as mutable, as it is behind a `&` reference
   --> $DIR/issue-38147-4.rs:6:5
    |
 LL |     f.s.push('x');
-   |     ^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-38147-4.stderr
+++ b/tests/ui/did_you_mean/issue-38147-4.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*f.s` as mutable, as it is behind a `&` reference
   --> $DIR/issue-38147-4.rs:6:5
    |
 LL |     f.s.push('x');
-   |     ^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:16:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:20:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:21:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -46,7 +46,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:25:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -57,7 +57,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:26:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -68,7 +68,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:30:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -79,7 +79,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:31:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -90,7 +90,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:35:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -112,7 +112,7 @@ error[E0596]: cannot borrow `w.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:42:13
    |
 LL |     let _ = &mut w.x;
-   |             ^^^^^^^^ `w` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^ `w` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:16:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:20:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:21:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -46,7 +46,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:25:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -57,7 +57,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:26:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -68,7 +68,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:30:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -79,7 +79,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:31:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -90,7 +90,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:35:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -112,7 +112,7 @@ error[E0596]: cannot borrow `w.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:42:13
    |
 LL |     let _ = &mut w.x;
-   |             ^^^^^^^^ `w` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^ `w` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-40823.stderr
+++ b/tests/ui/did_you_mean/issue-40823.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*buf` as mutable, as it is behind a `&` reference
   --> $DIR/issue-40823.rs:3:5
    |
 LL |     buf.iter_mut();
-   |     ^^^ `buf` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `buf` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-40823.stderr
+++ b/tests/ui/did_you_mean/issue-40823.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*buf` as mutable, as it is behind a `&` reference
   --> $DIR/issue-40823.rs:3:5
    |
 LL |     buf.iter_mut();
-   |     ^^^ `buf` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `buf` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/error-codes/E0389.stderr
+++ b/tests/ui/error-codes/E0389.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/E0389.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/error-codes/E0389.stderr
+++ b/tests/ui/error-codes/E0389.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/E0389.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/issues/issue-51515.stderr
+++ b/tests/ui/issues/issue-51515.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:4:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:8:5
    |
 LL |     *bar = 64;
-   |     ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `bar` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/issues/issue-51515.stderr
+++ b/tests/ui/issues/issue-51515.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:4:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:8:5
    |
 LL |     *bar = 64;
-   |     ^^^^^^^^^ `bar` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `bar` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/issues/issue-61623.stderr
+++ b/tests/ui/issues/issue-61623.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x.1` as mutable, as it is behind a `&` reference
   --> $DIR/issue-61623.rs:6:19
    |
 LL |     f2(|| x.0, f1(x.1))
-   |                   ^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/issues/issue-61623.stderr
+++ b/tests/ui/issues/issue-61623.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x.1` as mutable, as it is behind a `&` reference
   --> $DIR/issue-61623.rs:6:19
    |
 LL |     f2(|| x.0, f1(x.1))
-   |                   ^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/let-else/let-else-binding-explicit-mut.stderr
+++ b/tests/ui/let-else/let-else-binding-explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:10:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:14:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:18:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/let-else/let-else-binding-explicit-mut.stderr
+++ b/tests/ui/let-else/let-else-binding-explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:10:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:14:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:18:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/let-else/let-else-binding-immutable.stderr
+++ b/tests/ui/let-else/let-else-binding-immutable.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/let-else-binding-immutable.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/let-else/let-else-binding-immutable.stderr
+++ b/tests/ui/let-else/let-else-binding-immutable.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/let-else-binding-immutable.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/mut/mutable-class-fields-2.stderr
+++ b/tests/ui/mut/mutable-class-fields-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.how_hungry`, which is behind a `&` referenc
   --> $DIR/mutable-class-fields-2.rs:9:5
    |
 LL |     self.how_hungry -= 5;
-   |     ^^^^^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/mut/mutable-class-fields-2.stderr
+++ b/tests/ui/mut/mutable-class-fields-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.how_hungry`, which is behind a `&` referenc
   --> $DIR/mutable-class-fields-2.rs:9:5
    |
 LL |     self.how_hungry -= 5;
-   |     ^^^^^^^^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-47388.stderr
+++ b/tests/ui/nll/issue-47388.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/issue-47388.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-47388.stderr
+++ b/tests/ui/nll/issue-47388.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/issue-47388.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-51244.stderr
+++ b/tests/ui/nll/issue-51244.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     *my_ref = 0;
-   |     ^^^^^^^^^^^ `my_ref` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^ `my_ref` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-51244.stderr
+++ b/tests/ui/nll/issue-51244.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     *my_ref = 0;
-   |     ^^^^^^^^^^^ `my_ref` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^ `my_ref` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-57989.stderr
+++ b/tests/ui/nll/issue-57989.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-57989.rs:5:5
    |
 LL |     *x = 0;
-   |     ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-57989.stderr
+++ b/tests/ui/nll/issue-57989.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-57989.rs:5:5
    |
 LL |     *x = 0;
-   |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -107,7 +107,7 @@ error[E0594]: cannot assign to `*_x0`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:26:5
    |
 LL |     *_x0 = U;
-   |     ^^^^^^^^ `_x0` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x0` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -118,7 +118,7 @@ error[E0594]: cannot assign to `*_x2`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:27:5
    |
 LL |     *_x2 = U;
-   |     ^^^^^^^^ `_x2` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x2` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -107,7 +107,7 @@ error[E0594]: cannot assign to `*_x0`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:26:5
    |
 LL |     *_x0 = U;
-   |     ^^^^^^^^ `_x0` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x0` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -118,7 +118,7 @@ error[E0594]: cannot assign to `*_x2`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:27:5
    |
 LL |     *_x2 = U;
-   |     ^^^^^^^^ `_x2` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x2` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:13:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:19:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:13:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:19:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:7:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:15:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:23:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:7:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:15:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:23:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:65:10
    |
 LL |     &mut x.y
-   |          ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |          ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -45,7 +45,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:92:5
    |
 LL |     x.y = 3;
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -77,7 +77,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:121:5
    |
 LL |     x.y_mut()
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -99,7 +99,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:133:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:65:10
    |
 LL |     &mut x.y
-   |          ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |          ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -45,7 +45,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:92:5
    |
 LL |     x.y = 3;
-   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -77,7 +77,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:121:5
    |
 LL |     x.y_mut()
-   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -99,7 +99,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:133:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |      ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:41:11
    |
 LL |     &mut **x
-   |           ^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |           ^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:53:6
    |
 LL |     **x = 3;
-   |      ^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:41:11
    |
 LL |     &mut **x
-   |           ^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |           ^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:53:6
    |
 LL |     **x = 3;
-   |      ^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:25:5
    |
 LL |     (*f)();
-   |     ^^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `f` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -25,7 +25,7 @@ error[E0596]: cannot borrow `f.f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:34:5
    |
 LL |     f.f.call_mut(())
-   |     ^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:25:5
    |
 LL |     (*f)();
-   |     ^^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -25,7 +25,7 @@ error[E0596]: cannot borrow `f.f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:34:5
    |
 LL |     f.f.call_mut(())
-   |     ^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
+++ b/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-method-from-mut-aliasable.rs:17:5
    |
 LL |     x.h();
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
+++ b/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-method-from-mut-aliasable.rs:17:5
    |
 LL |     x.h();
-   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-fn-in-const-b.stderr
+++ b/tests/ui/span/borrowck-fn-in-const-b.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-fn-in-const-b.rs:7:9
    |
 LL |         x.push(format!("this is broken"));
-   |         ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-fn-in-const-b.stderr
+++ b/tests/ui/span/borrowck-fn-in-const-b.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-fn-in-const-b.rs:7:9
    |
 LL |         x.push(format!("this is broken"));
-   |         ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-object-mutability.stderr
+++ b/tests/ui/span/borrowck-object-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-object-mutability.rs:8:5
    |
 LL |     x.borrowed_mut();
-   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-object-mutability.stderr
+++ b/tests/ui/span/borrowck-object-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-object-mutability.rs:8:5
    |
 LL |     x.borrowed_mut();
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/mut-arg-hint.stderr
+++ b/tests/ui/span/mut-arg-hint.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:3:9
    |
 LL |         a.push_str("bar");
-   |         ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:8:5
    |
 LL |     a.push_str("foo");
-   |     ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `a` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:15:9
    |
 LL |         a.push_str("foo");
-   |         ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/mut-arg-hint.stderr
+++ b/tests/ui/span/mut-arg-hint.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:3:9
    |
 LL |         a.push_str("bar");
-   |         ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:8:5
    |
 LL |     a.push_str("foo");
-   |     ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:15:9
    |
 LL |         a.push_str("foo");
-   |         ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/suggestions/issue-68049-1.stderr
+++ b/tests/ui/suggestions/issue-68049-1.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-1.rs:7:9
    |
 LL |         self.0 += 1;
-   |         ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/issue-68049-1.stderr
+++ b/tests/ui/suggestions/issue-68049-1.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-1.rs:7:9
    |
 LL |         self.0 += 1;
-   |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*input`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:9:7
    |
 LL |       *input = self.0;
-   |       ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
+   |       ^^^^^^^^^^^^^^^ `input` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:17:5
    |
 LL |     self.0 += *input;
-   |     ^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*input`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:9:7
    |
 LL |       *input = self.0;
-   |       ^^^^^^^^^^^^^^^ `input` is an `&' reference, so the data it refers to cannot be written
+   |       ^^^^^^^^^^^^^^^ `input` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:17:5
    |
 LL |     self.0 += *input;
-   |     ^^^^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
@@ -8,7 +8,7 @@ LL |         for mut t in buzz.values() {
    |                      this iterator yields `&` references
 ...
 LL |             t.v += 1;
-   |             ^^^^^^^^ `t` is an `&' reference, so the data it refers to cannot be written
+   |             ^^^^^^^^ `t` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
@@ -8,7 +8,7 @@ LL |         for mut t in buzz.values() {
    |                      this iterator yields `&` references
 ...
 LL |             t.v += 1;
-   |             ^^^^^^^^ `t` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^^ `t` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
@@ -16,6 +16,6 @@ fn main() {
         //~| NOTE this iterator yields `&` references
         v.v += 1;
         //~^ ERROR cannot assign to `v.v`
-        //~| NOTE `v` is an `&' reference
+        //~| NOTE `v` is an `&` reference
     }
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
@@ -16,6 +16,6 @@ fn main() {
         //~| NOTE this iterator yields `&` references
         v.v += 1;
         //~^ ERROR cannot assign to `v.v`
-        //~| NOTE `v` is a `&` reference
+        //~| NOTE `v` is an `&' reference
     }
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
@@ -16,6 +16,6 @@ fn main() {
         //~| NOTE this iterator yields `&` references
         v.v += 1;
         //~^ ERROR cannot assign to `v.v`
-        //~| NOTE `v` is an `&' reference
+        //~| NOTE `v` is an `&` reference
     }
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
@@ -16,6 +16,6 @@ fn main() {
         //~| NOTE this iterator yields `&` references
         v.v += 1;
         //~^ ERROR cannot assign to `v.v`
-        //~| NOTE `v` is a `&` reference
+        //~| NOTE `v` is an `&' reference
     }
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -8,7 +8,7 @@ LL |     for (_k, v) in map.iter() {
    |                    this iterator yields `&` references
 ...
 LL |         v.v += 1;
-   |         ^^^^^^^^ `v` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `v` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -8,7 +8,7 @@ LL |     for (_k, v) in map.iter() {
    |                    this iterator yields `&` references
 ...
 LL |         v.v += 1;
-   |         ^^^^^^^^ `v` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `v` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
@@ -8,7 +8,7 @@ LL |     for mut t in buzz.values() {
    |                  this iterator yields `&` references
 ...
 LL |         t.v += 1;
-   |         ^^^^^^^^ `t` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `t` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
@@ -8,7 +8,7 @@ LL |     for mut t in buzz.values() {
    |                  this iterator yields `&` references
 ...
 LL |         t.v += 1;
-   |         ^^^^^^^^ `t` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `t` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-ref-mut.stderr
+++ b/tests/ui/suggestions/suggest-ref-mut.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:7:9
    |
 LL |         self.0 = 32;
-   |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:15:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:19:9
    |
 LL |         *bar = 32;
-   |         ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^ `bar` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*quo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:23:22
    |
 LL |         ref quo => { *quo = 32; },
-   |                      ^^^^^^^^^ `quo` is a `&` reference, so the data it refers to cannot be written
+   |                      ^^^^^^^^^ `quo` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/suggestions/suggest-ref-mut.stderr
+++ b/tests/ui/suggestions/suggest-ref-mut.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:7:9
    |
 LL |         self.0 = 32;
-   |         ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:15:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:19:9
    |
 LL |         *bar = 32;
-   |         ^^^^^^^^^ `bar` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^ `bar` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*quo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:23:22
    |
 LL |         ref quo => { *quo = 32; },
-   |                      ^^^^^^^^^ `quo` is an `&' reference, so the data it refers to cannot be written
+   |                      ^^^^^^^^^ `quo` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:6:5
    |
 LL |     *t
-   |     ^^ `t` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^ `t` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:10:6
    |
 LL |     {*t}
-   |      ^^ `t` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `t` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:6:5
    |
 LL |     *t
-   |     ^^ `t` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^ `t` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:10:6
    |
 LL |     {*t}
-   |      ^^ `t` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `t` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |


### PR DESCRIPTION
Title: Grammar Fix: Replace "is a &" with "is an &" in Source Code

Description:

A pull request with a minor code change to improve grammatical correctness within the Rust source code. Specifically, I replaced all instances of "is a &" with "is an &" to align with proper grammar.

I've reviewed the affected code thoroughly and ensured that it doesn't introduce any new issues. All existing tests have passed successfully with this change.

Please review the code at your convenience, and let me know if any further adjustments are needed. Your feedback is much appreciated.

Thank you for your contributions to the Rust language!

Best regards,
Aaqid Masoodi