### PR TITLE
rustdoc: Render private fields in tuple struct as `/* private fields */`

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1315,6 +1315,12 @@ fn print_tuple_struct_fields<'a, 'cx: 'a>(
     s: &'a [clean::Item],
 ) -> impl fmt::Display + 'a + Captures<'cx> {
     display_fn(|f| {
+        if s.iter()
+            .all(|field| matches!(*field.kind, clean::StrippedItem(box clean::StructFieldItem(..))))
+        {
+            return f.write_str("/* private fields */");
+        }
+
         for (i, ty) in s.iter().enumerate() {
             if i > 0 {
                 f.write_str(", ")?;
@@ -1936,21 +1942,31 @@ fn render_struct(
         }
         Some(CtorKind::Fn) => {
             w.write_str("(");
-            for (i, field) in fields.iter().enumerate() {
-                if i > 0 {
-                    w.write_str(", ");
-                }
-                match *field.kind {
-                    clean::StrippedItem(box clean::StructFieldItem(..)) => write!(w, "_"),
-                    clean::StructFieldItem(ref ty) => {
-                        write!(
-                            w,
-                            "{}{}",
-                            visibility_print_with_space(field.visibility(tcx), field.item_id, cx),
-                            ty.print(cx),
-                        )
+            if fields.iter().all(|field| {
+                matches!(*field.kind, clean::StrippedItem(box clean::StructFieldItem(..)))
+            }) {
+                write!(w, "/* private fields */");
+            } else {
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        w.write_str(", ");
                     }
-                    _ => unreachable!(),
+                    match *field.kind {
+                        clean::StrippedItem(box clean::StructFieldItem(..)) => write!(w, "_"),
+                        clean::StructFieldItem(ref ty) => {
+                            write!(
+                                w,
+                                "{}{}",
+                                visibility_print_with_space(
+                                    field.visibility(tcx),
+                                    field.item_id,
+                                    cx
+                                ),
+                                ty.print(cx),
+                            )
+                        }
+                        _ => unreachable!(),
+                    }
                 }
             }
             w.write_str(")");

--- a/tests/rustdoc/const-generics/const-generic-defaults.rs
+++ b/tests/rustdoc/const-generics/const-generic-defaults.rs
@@ -1,5 +1,5 @@
 #![crate_name = "foo"]
 
 // @has foo/struct.Foo.html '//pre[@class="rust item-decl"]' \
-//      'pub struct Foo<const M: usize = 10, const N: usize = M, T = i32>(_);'
+//      'pub struct Foo<const M: usize = 10, const N: usize = M, T = i32>('
 pub struct Foo<const M: usize = 10, const N: usize = M, T = i32>(T);

--- a/tests/rustdoc/const-generics/const-generics-docs.rs
+++ b/tests/rustdoc/const-generics/const-generics-docs.rs
@@ -33,7 +33,7 @@ impl<const N: usize> Trait<N> for [u8; N] {}
 // @has foo/struct.Foo.html '//pre[@class="rust item-decl"]' \
 //      'pub struct Foo<const N: usize> where u8: Trait<N>'
 pub struct Foo<const N: usize> where u8: Trait<N>;
-// @has foo/struct.Bar.html '//pre[@class="rust item-decl"]' 'pub struct Bar<T, const N: usize>(_)'
+// @has foo/struct.Bar.html '//pre[@class="rust item-decl"]' 'pub struct Bar<T, const N: usize>('
 pub struct Bar<T, const N: usize>([T; N]);
 
 // @has foo/struct.Foo.html '//*[@id="impl-Foo%3CM%3E"]/h3[@class="code-header"]' 'impl<const M: usize> Foo<M>where u8: Trait<M>'
@@ -92,7 +92,7 @@ macro_rules! define_me {
 }
 
 // @has foo/struct.Foz.html '//pre[@class="rust item-decl"]' \
-//      'pub struct Foz<const N: usize>(_);'
+//      'pub struct Foz<const N: usize>(/* private fields */);'
 define_me!(Foz<N>);
 
 trait Q {

--- a/tests/rustdoc/issue-88600.rs
+++ b/tests/rustdoc/issue-88600.rs
@@ -8,10 +8,10 @@ pub struct S;
 
 // @has issue_88600/enum.FooEnum.html
 pub enum FooEnum {
-    // @has - '//*[@id="variant.HiddenTupleItem"]//h3' 'HiddenTupleItem(_)'
+    // @has - '//*[@id="variant.HiddenTupleItem"]//h3' 'HiddenTupleItem(/* private fields */)'
     // @count - '//*[@id="variant.HiddenTupleItem.field.0"]' 0
     HiddenTupleItem(#[doc(hidden)] H),
-    // @has - '//*[@id="variant.MultipleHidden"]//h3' 'MultipleHidden(_, _)'
+    // @has - '//*[@id="variant.MultipleHidden"]//h3' 'MultipleHidden(/* private fields */)'
     // @count - '//*[@id="variant.MultipleHidden.field.0"]' 0
     // @count - '//*[@id="variant.MultipleHidden.field.1"]' 0
     MultipleHidden(#[doc(hidden)] H, #[doc(hidden)] H),

--- a/tests/rustdoc/private-fields-tuple-struct.rs
+++ b/tests/rustdoc/private-fields-tuple-struct.rs
@@ -1,0 +1,15 @@
+// This test checks the diplay of "/* private fields */" sentence in tuple structs.
+#![crate_name = "foo"]
+
+// @has 'foo/struct.A.html' '//*[@class="rust item-decl"]/code' 'pub struct A(pub u8, _);'
+pub struct A(pub u8, u8);
+// @has 'foo/struct.B.html' '//*[@class="rust item-decl"]/code' 'pub struct B(_, pub u8);'
+pub struct B(u8, pub u8);
+// @has 'foo/struct.C.html' '//*[@class="rust item-decl"]/code' 'pub struct C(_, pub u8, _);'
+pub struct C(u8, pub u8, u8);
+// @has 'foo/struct.D.html' '//*[@class="rust item-decl"]/code' 'pub struct D(pub u8, _, pub u8);'
+pub struct D(pub u8, u8, pub u8);
+// @has 'foo/struct.E.html' '//*[@class="rust item-decl"]/code' 'pub struct E(/* private fields */);'
+pub struct E(u8);
+// @has 'foo/struct.F.html' '//*[@class="rust item-decl"]/code' 'pub struct F(/* private fields */);'
+pub struct F(u8, u8);

--- a/tests/rustdoc/where.SWhere_Simd_item-decl.html
+++ b/tests/rustdoc/where.SWhere_Simd_item-decl.html
@@ -1,3 +1,3 @@
-<pre class="rust item-decl"><code>pub struct Simd&lt;T&gt;(_)
+<pre class="rust item-decl"><code>pub struct Simd&lt;T&gt;(/* private fields */)
 <span class="where">where
     T: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a></span>;</code></pre>

--- a/tests/rustdoc/where.alpha_trait_decl.html
+++ b/tests/rustdoc/where.alpha_trait_decl.html
@@ -1,3 +1,3 @@
-<code>pub struct Alpha&lt;A&gt;(_)
+<code>pub struct Alpha&lt;A&gt;(/* private fields */)
 <span class="where">where
     A: <a class="trait" href="trait.MyTrait.html" title="trait foo::MyTrait">MyTrait</a></span>;</code>

--- a/tests/rustdoc/where.rs
+++ b/tests/rustdoc/where.rs
@@ -4,7 +4,7 @@ use std::io::Lines;
 
 pub trait MyTrait { fn dummy(&self) { } }
 
-// @has foo/struct.Alpha.html '//pre' "pub struct Alpha<A>(_) where A: MyTrait"
+// @has foo/struct.Alpha.html '//pre' "pub struct Alpha<A>(/* private fields */) where A: MyTrait"
 // @snapshot alpha_trait_decl - '//*[@class="rust item-decl"]/code'
 pub struct Alpha<A>(A) where A: MyTrait;
 // @has foo/trait.Bravo.html '//pre' "pub trait Bravo<B>where B: MyTrait"


### PR DESCRIPTION
Reopening of https://github.com/rust-lang/rust/pull/110552. All that was missing was a test for the different cases so I added it into the second commit.

Description from the original PR:

> I've gotten some feedback that the current rustdoc rendering of...
>
> ```
> struct HasPrivateFields(_);
> ```
>
> ...is confusing, and I agree with that feedback, especially compared to the field struct case:
>
> ```
> struct HasPrivateFields { /* private fields */ }
> ```
>
> So this PR makes it so that when all of the fields of a tuple variant are private, just render it with the `/* private fields */` comment. We can't *always* render it like that, for example when there's a mix of private and public fields.

cc @jsha
r? @notriddle 