### PR TITLE
Make create_def a side effect instead of marking the entire query as always red

### DIFF
--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -67,7 +67,8 @@ impl DefPathTable {
             // being used.
             //
             // See the documentation for DefPathHash for more information.
-            panic!(
+            assert_eq!(
+                def_path1, def_path2,
                 "found DefPathHash collision between {def_path1:#?} and {def_path2:#?}. \
                     Compilation cannot continue."
             );
@@ -214,7 +215,7 @@ impl fmt::Display for DisambiguatedDefPathData {
     }
 }
 
-#[derive(Clone, Debug, Encodable, Decodable)]
+#[derive(Clone, Debug, Encodable, Decodable, PartialEq)]
 pub struct DefPath {
     /// The path leading from the crate root to the item.
     pub data: Vec<DisambiguatedDefPathData>,
@@ -391,7 +392,7 @@ impl Definitions {
         parent: LocalDefId,
         data: DefPathData,
         disambiguator: u32,
-    ) -> LocalDefId {
+    ) -> (LocalDefId, DefPathHash) {
         // We can't use `Debug` implementation for `LocalDefId` here, since it tries to acquire a
         // reference to `Definitions` and we're already holding a mutable reference.
         debug!(
@@ -413,7 +414,7 @@ impl Definitions {
         debug!("create_def: after disambiguation, key = {:?}", key);
 
         // Create the definition.
-        LocalDefId { local_def_index: self.table.allocate(key, def_path_hash) }
+        (LocalDefId { local_def_index: self.table.allocate(key, def_path_hash) }, def_path_hash)
     }
 
     #[inline(always)]

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -799,6 +799,7 @@ pub static DEFAULT_QUERY_PROVIDERS: LazyLock<Providers> = LazyLock::new(|| {
     rustc_lint::provide(providers);
     rustc_symbol_mangling::provide(providers);
     rustc_codegen_ssa::provide(providers);
+    crate::callbacks::provide(providers);
     *providers
 });
 

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -1,5 +1,6 @@
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_query_system::ich::StableHashingContext;
+use rustc_query_system::query::DefIdInfo;
 use rustc_session::Session;
 
 use crate::ty::{self, TyCtxt};
@@ -78,6 +79,11 @@ impl<'tcx> DepContext for TyCtxt<'tcx> {
     #[inline(always)]
     fn sess(&self) -> &Session {
         self.sess
+    }
+
+    fn create_def(&self, &DefIdInfo { parent, data, disambiguator: index, hash }: &DefIdInfo) {
+        let (_, h) = self.untracked().definitions.write().create_def(parent, data, index);
+        assert_eq!(hash, h);
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -239,4 +239,7 @@ pub fn provide(providers: &mut Providers) {
     providers.in_scope_traits_map = |tcx, id| {
         tcx.hir_crate(()).owners[id.def_id].as_owner().map(|owner_info| &owner_info.trait_map)
     };
+    providers.create_def_raw = |tcx, (parent, data, disambiguator)| {
+        tcx.untracked().definitions.write().create_def(parent, data, disambiguator)
+    }
 }

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -239,7 +239,4 @@ pub fn provide(providers: &mut Providers) {
     providers.in_scope_traits_map = |tcx, id| {
         tcx.hir_crate(()).owners[id.def_id].as_owner().map(|owner_info| &owner_info.trait_map)
     };
-    providers.create_def_raw = |tcx, (parent, data, disambiguator)| {
-        tcx.untracked().definitions.write().create_def(parent, data, disambiguator)
-    }
 }

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -3,6 +3,7 @@
 use std::ffi::OsStr;
 
 use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalModDefId, ModDefId};
+use rustc_hir::definitions::DefPathData;
 use rustc_hir::hir_id::{HirId, OwnerId};
 use rustc_query_system::dep_graph::DepNodeIndex;
 use rustc_query_system::query::{DefIdCache, DefaultCache, SingleCache, VecCache};
@@ -258,6 +259,14 @@ impl Key for (LocalDefId, DefId) {
 }
 
 impl Key for (LocalDefId, LocalDefId) {
+    type Cache<V> = DefaultCache<Self, V>;
+
+    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+        self.0.default_span(tcx)
+    }
+}
+
+impl Key for (LocalDefId, DefPathData, u32) {
     type Cache<V> = DefaultCache<Self, V>;
 
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2059,6 +2059,7 @@ rustc_queries! {
         desc { |tcx| "computing visibility of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
         feedable
+        cache_on_disk_if { def_id.is_local() }
     }
 
     query inhabited_predicate_adt(key: DefId) -> ty::inhabitedness::InhabitedPredicate<'tcx> {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -159,6 +159,11 @@ rustc_queries! {
         desc { "getting the source span" }
     }
 
+    /// Used to handle incremental replays of [`TyCtxt::create_def`] invocations from tracked queries.
+    query create_def_raw(key: (LocalDefId, rustc_hir::definitions::DefPathData, u32)) -> LocalDefId {
+        desc { "generating a new def id" }
+    }
+
     /// Represents crate as a whole (as distinct from the top-level crate module).
     ///
     /// If you call `tcx.hir_crate(())` we will have to assume that any change

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -41,7 +41,7 @@ use rustc_hir::{self as hir, Attribute, HirId, Node, TraitCandidate};
 use rustc_index::IndexVec;
 use rustc_macros::{HashStable, TyDecodable, TyEncodable};
 use rustc_query_system::cache::WithDepNode;
-use rustc_query_system::dep_graph::DepNodeIndex;
+use rustc_query_system::dep_graph::{DepNodeIndex, TaskDepsRef};
 use rustc_query_system::ich::StableHashingContext;
 use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
 use rustc_session::config::CrateType;
@@ -2001,22 +2001,32 @@ impl<'tcx> TyCtxt<'tcx> {
         disambiguator: &mut DisambiguatorState,
     ) -> TyCtxtFeed<'tcx, LocalDefId> {
         let data = override_def_path_data.unwrap_or_else(|| def_kind.def_path_data(name));
-        // The following call has the side effect of modifying the tables inside `definitions`.
-        // These very tables are relied on by the incr. comp. engine to decode DepNodes and to
-        // decode the on-disk cache.
-        //
-        // Any LocalDefId which is used within queries, either as key or result, either:
-        // - has been created before the construction of the TyCtxt;
-        // - has been created by this call to `create_def`.
-        // As a consequence, this LocalDefId is always re-created before it is needed by the incr.
-        // comp. engine itself.
-        let def_id = self.untracked.definitions.write().create_def(parent, data, disambiguator);
 
-        // This function modifies `self.definitions` using a side-effect.
-        // We need to ensure that these side effects are re-run by the incr. comp. engine.
-        // Depending on the forever-red node will tell the graph that the calling query
-        // needs to be re-evaluated.
-        self.dep_graph.read_index(DepNodeIndex::FOREVER_RED_NODE);
+        let def_id = tls::with_context(|icx| {
+            match icx.task_deps {
+                // Always gets rerun anyway, so nothing to replay
+                TaskDepsRef::EvalAlways |
+                // Top-level queries like the resolver get rerun every time anyway
+                TaskDepsRef::Ignore => {
+                    // The following call has the side effect of modifying the tables inside `definitions`.
+                    // These very tables are relied on by the incr. comp. engine to decode DepNodes and to
+                    // decode the on-disk cache.
+                    //
+                    // Any LocalDefId which is used within queries, either as key or result, either:
+                    // - has been created before the construction of the TyCtxt;
+                    // - has been created by this call to `create_def`.
+                    // As a consequence, this LocalDefId is always re-created before it is needed by the incr.
+                    // comp. engine itself.
+                    self.untracked.definitions.write().create_def(parent, data, disambiguator.next(parent, data))
+                }
+                TaskDepsRef::Forbid => bug!(
+                    "cannot create definition {parent:?} {data:?} without being able to register task dependencies"
+                ),
+                TaskDepsRef::Allow(_) => {
+                    self.create_def_raw((parent, data, disambiguator.next(parent, data)))
+                }
+            }
+        });
 
         let feed = TyCtxtFeed { tcx: self, key: def_id };
         feed.def_kind(def_kind);

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1992,6 +1992,7 @@ impl<'tcx> TyCtxtAt<'tcx> {
 
 impl<'tcx> TyCtxt<'tcx> {
     /// `tcx`-dependent operations performed for every created definition.
+    #[instrument(level = "trace", skip(self))]
     pub fn create_def(
         self,
         parent: LocalDefId,
@@ -2011,13 +2012,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     // The following call has the side effect of modifying the tables inside `definitions`.
                     // These very tables are relied on by the incr. comp. engine to decode DepNodes and to
                     // decode the on-disk cache.
-                    //
-                    // Any LocalDefId which is used within queries, either as key or result, either:
-                    // - has been created before the construction of the TyCtxt;
-                    // - has been created by this call to `create_def`.
-                    // As a consequence, this LocalDefId is always re-created before it is needed by the incr.
-                    // comp. engine itself.
-                    self.untracked.definitions.write().create_def(parent, data, disambiguator.next(parent, data))
+                    self.untracked.definitions.write().create_def(parent, data, disambiguator.next(parent, data)).0
                 }
                 TaskDepsRef::Forbid => bug!(
                     "cannot create definition {parent:?} {data:?} without being able to register task dependencies"

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -871,7 +871,7 @@ macro_rules! define_queries {
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Unit,
                     force_from_dep_node: Some(|tcx, _, prev_index| {
-                        tcx.dep_graph.force_diagnostic_node(QueryCtxt::new(tcx), prev_index);
+                        tcx.dep_graph.force_side_effect_node(QueryCtxt::new(tcx), prev_index);
                         true
                     }),
                     try_load_from_on_disk_cache: None,

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -1,7 +1,6 @@
 use std::assert_matches::assert_matches;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -354,7 +353,6 @@ impl<D: Deps> DepGraphData<D> {
                 node: Some(key),
                 reads: EdgesVec::new(),
                 read_set: Default::default(),
-                phantom_data: PhantomData,
             });
             (with_deps(TaskDepsRef::Allow(&task_deps)), task_deps.into_inner().reads)
         };
@@ -1301,7 +1299,6 @@ pub struct TaskDeps {
     node: Option<DepNode>,
     reads: EdgesVec,
     read_set: FxHashSet<DepNodeIndex>,
-    phantom_data: PhantomData<DepNode>,
 }
 
 impl Default for TaskDeps {
@@ -1311,7 +1308,6 @@ impl Default for TaskDeps {
             node: None,
             reads: EdgesVec::new(),
             read_set: FxHashSet::with_capacity_and_hasher(128, Default::default()),
-            phantom_data: PhantomData,
         }
     }
 }

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -19,6 +19,7 @@ use tracing::instrument;
 
 use self::graph::{MarkFrame, print_markframe_trace};
 use crate::ich::StableHashingContext;
+use crate::query::DefIdInfo;
 
 pub trait DepContext: Copy {
     type Deps: Deps;
@@ -34,6 +35,8 @@ pub trait DepContext: Copy {
 
     /// Access the compiler session.
     fn sess(&self) -> &Session;
+
+    fn create_def(&self, def: &DefIdInfo);
 
     fn dep_kind_info(&self, dep_node: DepKind) -> &DepKindStruct<Self>;
 

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -21,9 +21,10 @@ use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_errors::DiagInner;
 use rustc_hashes::Hash64;
 use rustc_hir::def::DefKind;
+use rustc_hir::def_id::DefPathHash;
 use rustc_macros::{Decodable, Encodable};
 use rustc_span::Span;
-use rustc_span::def_id::DefId;
+use rustc_span::def_id::{DefId, LocalDefId};
 
 pub use self::config::{HashResult, QueryConfig};
 use crate::dep_graph::{DepKind, DepNodeIndex, HasDepContext, SerializedDepNodeIndex};
@@ -147,6 +148,19 @@ pub enum QuerySideEffect {
     /// the query as green, as that query will have the side
     /// effect dep node as a dependency.
     Diagnostic(DiagInner),
+
+    /// A `DefId` that was created during query execution.
+    /// These `DefId`s will be re-created when we mark the query as green.
+    Definition(DefIdInfo),
+}
+
+#[derive(Debug, Clone, Encodable, Decodable, PartialEq)]
+pub struct DefIdInfo {
+    pub parent: LocalDefId,
+    pub data: rustc_hir::definitions::DefPathData,
+    pub hash: DefPathHash,
+    /// Disambiguator
+    pub disambiguator: u32,
 }
 
 pub trait QueryContext: HasDepContext {

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -525,7 +525,7 @@ where
         let dep_node =
             dep_node_opt.get_or_insert_with(|| query.construct_dep_node(*qcx.dep_context(), &key));
 
-        // The diagnostics for this query will be promoted to the current session during
+        // The side_effects for this query will be promoted to the current session during
         // `try_mark_green()`, so we can ignore them here.
         if let Some(ret) = qcx.start_query(job_id, false, || {
             try_load_from_disk_and_cache_in_memory(query, dep_graph_data, qcx, &key, dep_node)

--- a/tests/incremental/rpitit-feeding.rs
+++ b/tests/incremental/rpitit-feeding.rs
@@ -1,0 +1,27 @@
+//@ revisions: cpass cpass2 cpass3
+
+// This test checks that creating a new `DefId` from within a query `A`
+// recreates that `DefId` before reexecuting queries that depend on query `A`.
+// Otherwise we'd end up referring to a `DefId` that doesn't exist.
+// At present this is handled by always marking all queries as red if they create
+// a new `DefId` and thus subsequently rerunning the query.
+
+trait Foo {
+    fn foo() -> impl Sized;
+}
+
+#[cfg(any(cpass, cpass3))]
+impl Foo for String {
+    fn foo() -> i32 {
+        22
+    }
+}
+
+#[cfg(cpass2)]
+impl Foo for String {
+    fn foo() -> u32 {
+        22
+    }
+}
+
+fn main() {}

--- a/tests/run-make/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make/rustc-crates-on-stable/rmake.rs
@@ -8,6 +8,8 @@ fn main() {
     cargo()
         // Ensure `proc-macro2`'s nightly detection is disabled
         .env("RUSTC_STAGE", "0")
+        // Avoid loading stale data from the stage 0 compiler in case that one was incremental
+        .env("CARGO_INCREMENTAL", "0")
         .env("RUSTC", rustc_path())
         // We want to disallow all nightly features to simulate a stable build
         .env("RUSTFLAGS", "-Zallow-features=")


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/115613)*
<!-- homu-ignore:end -->

Before this PR:

* query A creates def id D
* query A is marked as depending on the always-red node, meaning it will always get re-run
* in the next run of rustc: query A is not loaded from the incremental cache, but rerun

After this PR:

* query A creates def id D
* query system registers this a side effect (just like we collect diagnostics to re-emit them without running a query)
* in the next run of rustc: query A is loaded from the incremental cache and its side effect is run (thus re-creating def id D without running query A)

r? @cjgillot 

TODO:

* [ ] need to make feeding queries a side effect, too. At least ones that aren't written to disk.
* [ ] need to re-feed the `def_span` query
* [ ] many more tests