### PR TITLE
Enable lld explicitly for hexagon-unknown-linux-musl

### DIFF
--- a/compiler/rustc_target/src/spec/hexagon_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/hexagon_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Cc, LinkerFlavor, Target};
+use crate::spec::{Cc, LinkerFlavor, Lld, Target};
 
 pub fn target() -> Target {
     let mut base = super::linux_musl_base::opts();
@@ -9,7 +9,8 @@ pub fn target() -> Target {
 
     base.crt_static_default = false;
     base.has_rpath = true;
-    base.linker_flavor = LinkerFlavor::Unix(Cc::Yes);
+    base.linker_flavor = LinkerFlavor::Gnu(Cc::No, Lld::Yes);
+    base.linker = Some("clang".into());
 
     base.c_enum_min_bits = Some(8);
 


### PR DESCRIPTION
Tested with the https://github.com/quic/toolchain_for_hexagon/releases/tag/v17.0.0-rc3 release of the toolchain.