### PR TITLE
Allow library features to be marked internal as well

### DIFF
--- a/compiler/rustc_attr/messages.ftl
+++ b/compiler/rustc_attr/messages.ftl
@@ -34,6 +34,9 @@ attr_incorrect_repr_format_generic =
 attr_incorrect_repr_format_packed_one_or_zero_arg =
     incorrect `repr(packed)` attribute format: `packed` takes exactly one parenthesized argument, or no parentheses at all
 
+attr_internal_no_args =
+    `is_internal` should not have any arguments
+
 attr_invalid_issue_string =
     `issue` must be a non-zero numeric string or "none"
     .must_not_be_zero = `issue` must not be "0", use "none" instead
@@ -87,9 +90,6 @@ attr_rustc_promotable_pairing =
 
 attr_soft_no_args =
     `soft` should not have any arguments
-
-attr_internal_no_args =
-    `is_internal` should not have any arguments
 
 attr_unknown_meta_item =
     unknown meta item '{$item}'

--- a/compiler/rustc_attr/messages.ftl
+++ b/compiler/rustc_attr/messages.ftl
@@ -88,6 +88,9 @@ attr_rustc_promotable_pairing =
 attr_soft_no_args =
     `soft` should not have any arguments
 
+attr_internal_no_args =
+    `is_internal` should not have any arguments
+
 attr_unknown_meta_item =
     unknown meta item '{$item}'
     .label = expected one of {$expected}

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -160,6 +160,8 @@ pub enum StabilityLevel {
         /// Relevant `rust-lang/rust` issue.
         issue: Option<NonZeroU32>,
         is_soft: bool,
+        /// If the feature is internal
+        is_internal: bool,
         /// If part of a feature is stabilized and a new feature is added for the remaining parts,
         /// then the `implied_by` attribute is used to indicate which now-stable feature previously
         /// contained a item.
@@ -461,6 +463,7 @@ fn parse_unstability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabil
     let mut issue = None;
     let mut issue_num = None;
     let mut is_soft = false;
+    let mut is_internal = false;
     let mut implied_by = None;
     for meta in metas {
         let Some(mi) = meta.meta_item() else {
@@ -515,6 +518,12 @@ fn parse_unstability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabil
                 }
                 is_soft = true;
             }
+            sym::is_internal => {
+                if !mi.is_word() {
+                    sess.emit_err(session_diagnostics::InternalNoArgs { span: mi.span });
+                }
+                is_internal = true;
+            }
             sym::implied_by => {
                 if !insert_or_error(mi, &mut implied_by) {
                     return None;
@@ -545,6 +554,7 @@ fn parse_unstability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabil
                 issue: issue_num,
                 is_soft,
                 implied_by,
+                is_internal,
             };
             Some((feature, level))
         }

--- a/compiler/rustc_attr/src/session_diagnostics.rs
+++ b/compiler/rustc_attr/src/session_diagnostics.rs
@@ -387,6 +387,13 @@ pub(crate) struct SoftNoArgs {
 }
 
 #[derive(Diagnostic)]
+#[diag(attr_internal_no_args)]
+pub(crate) struct InternalNoArgs {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(attr_unknown_version_literal)]
 pub(crate) struct UnknownVersionLiteral {
     #[primary_span]

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -534,6 +534,10 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
         self.sess
     }
 
+    pub(crate) fn features(&self) -> &Features {
+        self.features
+    }
+
     pub(crate) fn lint_store(&self) -> &LintStore {
         self.store
     }

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -534,10 +534,6 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
         self.sess
     }
 
-    pub(crate) fn features(&self) -> &Features {
-        self.features
-    }
-
     pub(crate) fn lint_store(&self) -> &LintStore {
         self.store
     }

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -171,6 +171,7 @@ early_lint_methods!(
             SpecialModuleName: SpecialModuleName,
             AnonymousParameters: AnonymousParameters,
             EllipsisInclusiveRangePatterns: EllipsisInclusiveRangePatterns::default(),
+            IncompleteInternalLangFeatures: IncompleteInternalLangFeatures,
             NonCamelCaseTypes: NonCamelCaseTypes,
             DeprecatedAttr: DeprecatedAttr::new(),
             WhileTrue: WhileTrue,
@@ -199,7 +200,7 @@ late_lint_methods!(
             BoxPointers: BoxPointers,
             PathStatements: PathStatements,
             LetUnderscore: LetUnderscore,
-            IncompleteInternalFeatures: IncompleteInternalFeatures,
+            InternalLibFeatures: InternalLibFeatures,
             InvalidReferenceCasting: InvalidReferenceCasting::default(),
             // Depends on referenced function signatures in expressions
             UnusedResults: UnusedResults,

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -176,7 +176,6 @@ early_lint_methods!(
             WhileTrue: WhileTrue,
             NonAsciiIdents: NonAsciiIdents,
             HiddenUnicodeCodepoints: HiddenUnicodeCodepoints,
-            IncompleteInternalFeatures: IncompleteInternalFeatures,
             RedundantSemicolons: RedundantSemicolons,
             UnusedDocComment: UnusedDocComment,
             UnexpectedCfgs: UnexpectedCfgs,
@@ -200,6 +199,7 @@ late_lint_methods!(
             BoxPointers: BoxPointers,
             PathStatements: PathStatements,
             LetUnderscore: LetUnderscore,
+            IncompleteInternalFeatures: IncompleteInternalFeatures,
             InvalidReferenceCasting: InvalidReferenceCasting::default(),
             // Depends on referenced function signatures in expressions
             UnusedResults: UnusedResults,

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -343,7 +343,7 @@ provide! { tcx, def_id, other, cdata,
     module_children => {
         tcx.arena.alloc_from_iter(cdata.get_module_children(def_id.index, tcx.sess))
     }
-    defined_lib_features => { cdata.get_lib_features(tcx) }
+    lib_features => { cdata.get_lib_features(tcx) }
     stability_implications => {
         cdata.get_stability_implications(tcx).iter().copied().collect()
     }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -24,6 +24,7 @@ use rustc_middle::middle::dependency_format::Linkage;
 use rustc_middle::middle::exported_symbols::{
     metadata_symbol_name, ExportedSymbol, SymbolExportInfo,
 };
+use rustc_middle::middle::lib_features::FeatureStability;
 use rustc_middle::mir::interpret;
 use rustc_middle::query::LocalCrate;
 use rustc_middle::query::Providers;
@@ -1871,10 +1872,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         self.lazy_array(deps.iter().map(|(_, dep)| dep))
     }
 
-    fn encode_lib_features(&mut self) -> LazyArray<(Symbol, Option<Symbol>)> {
+    fn encode_lib_features(&mut self) -> LazyArray<(Symbol, FeatureStability)> {
         empty_proc_macro!(self);
         let tcx = self.tcx;
-        let lib_features = tcx.lib_features(());
+        let lib_features = tcx.lib_features(LOCAL_CRATE);
         self.lazy_array(lib_features.to_vec())
     }
 

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -3,6 +3,7 @@ use decoder::Metadata;
 use def_path_hash_map::DefPathHashMapRef;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerFile;
+use rustc_middle::middle::lib_features::FeatureStability;
 use table::TableBuilder;
 
 use rustc_ast as ast;
@@ -264,7 +265,7 @@ pub(crate) struct CrateRoot {
 
     crate_deps: LazyArray<CrateDep>,
     dylib_dependency_formats: LazyArray<Option<LinkagePreference>>,
-    lib_features: LazyArray<(Symbol, Option<Symbol>)>,
+    lib_features: LazyArray<(Symbol, FeatureStability)>,
     stability_implications: LazyArray<(Symbol, Symbol)>,
     lang_items: LazyArray<(DefIndex, LangItem)>,
     lang_items_missing: LazyArray<LangItem>,

--- a/compiler/rustc_middle/src/middle/mod.rs
+++ b/compiler/rustc_middle/src/middle/mod.rs
@@ -7,20 +7,31 @@ pub mod lib_features {
     use rustc_data_structures::fx::FxHashMap;
     use rustc_span::{symbol::Symbol, Span};
 
-    #[derive(HashStable, Debug)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    #[derive(HashStable, TyEncodable, TyDecodable)]
+    pub enum FeatureStability {
+        AcceptedSince(Symbol),
+        Unstable(bool),
+    }
+
+    #[derive(HashStable, Debug, Default)]
     pub struct LibFeatures {
         /// A map from feature to stabilisation version.
         pub stable: FxHashMap<Symbol, (Symbol, Span)>,
-        pub unstable: FxHashMap<Symbol, Span>,
+        pub unstable: FxHashMap<Symbol, (bool, Span)>,
     }
 
     impl LibFeatures {
-        pub fn to_vec(&self) -> Vec<(Symbol, Option<Symbol>)> {
+        pub fn to_vec(&self) -> Vec<(Symbol, FeatureStability)> {
             let mut all_features: Vec<_> = self
                 .stable
                 .iter()
-                .map(|(f, (s, _))| (*f, Some(*s)))
-                .chain(self.unstable.keys().map(|f| (*f, None)))
+                .map(|(f, (s, _))| (*f, FeatureStability::AcceptedSince(*s)))
+                .chain(
+                    self.unstable
+                        .iter()
+                        .map(|(f, (internal, _))| (*f, FeatureStability::Unstable(*internal))),
+                )
                 .collect();
             all_features.sort_unstable_by(|a, b| a.0.as_str().partial_cmp(b.0.as_str()).unwrap());
             all_features

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -440,7 +440,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
         match stability {
             Some(Stability {
-                level: attr::Unstable { reason, issue, is_soft, implied_by },
+                level: attr::Unstable { reason, issue, is_soft, implied_by, is_internal: _ },
                 feature,
                 ..
             }) => {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1744,13 +1744,10 @@ rustc_queries! {
         desc { |tcx| "computing crate imported by `{}`", tcx.def_path_str(def_id) }
     }
 
-    query lib_features(_: ()) -> &'tcx LibFeatures {
-        arena_cache
-        desc { "calculating the lib features map" }
-    }
-    query defined_lib_features(_: CrateNum) -> &'tcx [(Symbol, Option<Symbol>)] {
+    query lib_features(_: CrateNum) -> &'tcx LibFeatures {
         desc { "calculating the lib features defined in a crate" }
         separate_provide_extern
+        arena_cache
     }
     query stability_implications(_: CrateNum) -> &'tcx FxHashMap<Symbol, Symbol> {
         arena_cache

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -59,6 +59,7 @@ trivially_parameterized_over_tcx! {
     crate::middle::codegen_fn_attrs::CodegenFnAttrs,
     crate::middle::debugger_visualizer::DebuggerVisualizerFile,
     crate::middle::exported_symbols::SymbolExportInfo,
+    crate::middle::lib_features::FeatureStability,
     crate::middle::resolve_bound_vars::ObjectLifetimeDefault,
     crate::mir::ConstQualifs,
     ty::AssocItemContainer,

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -849,7 +849,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
     ) {
         let span = path.span;
         if let Some(stability) = &ext.stability {
-            if let StabilityLevel::Unstable { reason, issue, is_soft, implied_by } = stability.level
+            if let StabilityLevel::Unstable { reason, issue, is_soft, implied_by, is_internal: _ } =
+                stability.level
             {
                 let feature = stability.feature;
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -865,6 +865,7 @@ symbols! {
         intra_doc_pointers,
         intrinsics,
         irrefutable_let_patterns,
+        is_internal,
         isa_attribute,
         isize,
         issue,

--- a/tests/ui/lint/auxiliary/lint_stability.rs
+++ b/tests/ui/lint/auxiliary/lint_stability.rs
@@ -186,3 +186,6 @@ macro_rules! macro_test_arg {
 macro_rules! macro_test_arg_nested {
     ($func:ident) => (macro_test_arg!($func()));
 }
+
+#[unstable(feature = "unstable_test_feature_internal", issue = "none", is_internal)]
+pub struct InternalStruct;

--- a/tests/ui/lint/lint-stability-internal.rs
+++ b/tests/ui/lint/lint-stability-internal.rs
@@ -1,0 +1,11 @@
+// aux-build:lint_stability.rs
+
+#![feature(unstable_test_feature_internal)]
+//~^ ERROR the feature `unstable_test_feature_internal` is internal to the compiler or standard library
+#![forbid(internal_features)]
+
+extern crate lint_stability;
+
+fn main() {
+    let _ = lint_stability::InternalStruct;
+}

--- a/tests/ui/lint/lint-stability-internal.stderr
+++ b/tests/ui/lint/lint-stability-internal.stderr
@@ -1,0 +1,15 @@
+error: the feature `unstable_test_feature_internal` is internal to the compiler or standard library
+  --> $DIR/lint-stability-internal.rs:3:12
+   |
+LL | #![feature(unstable_test_feature_internal)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: using it is strongly discouraged
+note: the lint level is defined here
+  --> $DIR/lint-stability-internal.rs:5:11
+   |
+LL | #![forbid(internal_features)]
+   |           ^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
allows `unstable(..., is_internal, ...)` to mark a library feature as internal. Not sure if we should just have a different stability attribute, like `#[internal(...)]` with the same fields as `unstable`.

Part of #115597.

This does no modification to the standard library yet.