### PR TITLE
Explain HRTB + infer limitations of old solver

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -986,6 +986,8 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             }
                         }
 
+                        self.explain_hrtb_projection(&mut err, trait_predicate, obligation.param_env, &obligation.cause);
+
                         // Return early if the trait is Debug or Display and the invocation
                         // originates within a standard library macro, because the output
                         // is otherwise overwhelming and unhelpful (see #85844 for an

--- a/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.current.stderr
+++ b/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.current.stderr
@@ -16,6 +16,14 @@ LL |     build(Bar);
    |     required by a bound introduced by this call
    |
    = help: the trait `for<'a> Send` is not implemented for `impl Future<Output = ()> { <_ as Foo>::bar() }`
+note: this is a known limitation of the trait solver that will be lifted in the future
+  --> $DIR/normalizing-self-auto-trait-issue-109924.rs:23:11
+   |
+LL |     build(Bar);
+   |     ------^^^-
+   |     |     |
+   |     |     the trait solver is unable to infer the generic types that should be inferred from this argument
+   |     add turbofish arguments to this call to specify the types manually, even if it's redundant
 note: required by a bound in `build`
   --> $DIR/normalizing-self-auto-trait-issue-109924.rs:20:39
    |

--- a/tests/ui/generic-associated-types/bugs/issue-88460.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88460.stderr
@@ -7,6 +7,14 @@ LL |     test(Foo);
    |     required by a bound introduced by this call
    |
    = help: the trait `Marker` is implemented for `()`
+note: this is a known limitation of the trait solver that will be lifted in the future
+  --> $DIR/issue-88460.rs:28:10
+   |
+LL |     test(Foo);
+   |     -----^^^-
+   |     |    |
+   |     |    the trait solver is unable to infer the generic types that should be inferred from this argument
+   |     add turbofish arguments to this call to specify the types manually, even if it's redundant
 note: required by a bound in `test`
   --> $DIR/issue-88460.rs:15:27
    |

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.stderr
@@ -8,6 +8,14 @@ LL |         call(f, ());
    |
    = note: expected a closure with arguments `((),)`
               found a closure with arguments `(<_ as ATC<'a>>::Type,)`
+note: this is a known limitation of the trait solver that will be lifted in the future
+  --> $DIR/issue-62529-3.rs:25:14
+   |
+LL |         call(f, ());
+   |         -----^-----
+   |         |    |
+   |         |    the trait solver is unable to infer the generic types that should be inferred from this argument
+   |         add turbofish arguments to this call to specify the types manually, even if it's redundant
 note: required by a bound in `call`
   --> $DIR/issue-62529-3.rs:9:36
    |

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-90950.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-90950.stderr
@@ -7,6 +7,14 @@ LL |     upcast(y)
    |     required by a bound introduced by this call
    |
    = help: the trait `IsCovariant<'a>` is implemented for `std::borrow::Cow<'a, T>`
+note: this is a known limitation of the trait solver that will be lifted in the future
+  --> $DIR/issue-90950.rs:50:12
+   |
+LL |     upcast(y)
+   |     -------^-
+   |     |      |
+   |     |      the trait solver is unable to infer the generic types that should be inferred from this argument
+   |     add turbofish arguments to this call to specify the types manually, even if it's redundant
 note: required by a bound in `upcast`
   --> $DIR/issue-90950.rs:27:42
    |

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution.stderr
@@ -4,6 +4,11 @@ error[E0277]: the trait bound `for<'a> <_ as Trait<'a>>::Out: Copy` is not satis
 LL |     let _: () = weird_bound();
    |                 ^^^^^^^^^^^ the trait `for<'a> Copy` is not implemented for `<_ as Trait<'a>>::Out`
    |
+note: this is a known limitation of the trait solver that will be lifted in the future
+  --> $DIR/norm-before-method-resolution.rs:22:17
+   |
+LL |     let _: () = weird_bound();
+   |                 ^^^^^^^^^^^ try adding turbofish arguments to this expression to specify the types manually, even if it's redundant
 note: required by a bound in `weird_bound`
   --> $DIR/norm-before-method-resolution.rs:18:40
    |


### PR DESCRIPTION
Add a helpful message when we hit the limitation of the old trait solver where we don't properly normalize GATs with infer vars + bound vars, leading to too-eagerly reporting trait errors that would be later satisfied due to inference.