### PR TITLE
changed occurrences of "is a & reference" to "is an & reference" for grammatical correctness.

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -715,7 +715,7 @@ impl<'tcx> BorrowedContentSource<'tcx> {
     pub(super) fn describe_for_immutable_place(&self, tcx: TyCtxt<'_>) -> String {
         match *self {
             BorrowedContentSource::DerefRawPointer => "a `*const` pointer".to_string(),
-            BorrowedContentSource::DerefSharedRef => "a `&` reference".to_string(),
+            BorrowedContentSource::DerefSharedRef => "an `&` reference".to_string(),
             BorrowedContentSource::DerefMutableRef => {
                 bug!("describe_for_immutable_place: DerefMutableRef isn't immutable")
             }

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -468,7 +468,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 );
             }
 
-            // We want to point out when a `&` can be readily replaced
+            // We want to point out when an `&` reference can be readily replaced
             // with an `&mut`.
             //
             // FIXME: can this case be generalized to work for an
@@ -1195,7 +1195,7 @@ fn suggest_ampmut<'tcx>(
     opt_assignment_rhs_span: Option<Span>,
     opt_ty_info: Option<Span>,
 ) -> (bool, Span, String) {
-    // if there is a RHS and it starts with a `&` from it, then check if it is
+    // if there is a RHS and it starts with an `&` reference from it, then check if it is
     // mutable, and if not, put suggest putting `mut ` to make it mutable.
     // we don't have to worry about lifetime annotations here because they are
     // not valid when taking a reference. For example, the following is not valid Rust:

--- a/compiler/rustc_error_codes/src/error_codes/E0389.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0389.md
@@ -14,7 +14,7 @@ struct FancyNum {
 fn main() {
     let mut fancy = FancyNum{ num: 5 };
     let fancy_ref = &(&mut fancy);
-    fancy_ref.num = 6; // error: cannot assign to data in a `&` reference
+    fancy_ref.num = 6; // error: cannot assign to data in an `&` reference
     println!("{}", fancy_ref.num);
 }
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0492.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0492.md
@@ -12,7 +12,7 @@ const B: &'static AtomicUsize = &A;
 ```
 
 A `const` represents a constant value that should never change. If one takes
-a `&` reference to the constant, then one is taking a pointer to some memory
+an `&` reference to the constant, then one is taking a pointer to some memory
 location containing the value. Normally this is perfectly fine: most values
 can't be changed via a shared `&` pointer, but interior mutability would allow
 it. That is, a constant value could be mutated. On the other hand, a `static` is

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -1292,7 +1292,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// ```
     ///
     /// No need to find every potential function which could make a coercion to transform a
-    /// `String` into a `&str` since a `&` would do the trick!
+    /// `String` into a `&str` since an `&` reference would do the trick!
     ///
     /// In addition of this check, it also checks between references mutability state. If the
     /// expected is mutable but the provided isn't, maybe we could just say "Hey, try with
@@ -1486,7 +1486,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 };
 
                 // We have `&T`, check if what was expected was `T`. If so,
-                // we may want to suggest removing a `&`.
+                // we may want to suggest removing an `&` reference.
                 if sm.is_imported(expr.span) {
                     // Go through the spans from which this span was expanded,
                     // and find the one that's pointing inside `sp`.

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -161,7 +161,7 @@ enum ProbeResult {
 
 /// When adjusting a receiver we often want to do one of
 ///
-/// - Add a `&` (or `&mut`), converting the receiver from `T` to `&T` (or `&mut T`)
+/// - Add an `&` reference (or `&mut`), converting the receiver from `T` to `&T` (or `&mut T`)
 /// - If the receiver has type `*mut T`, convert it to `*const T`
 ///
 /// This type tells us which one to do.

--- a/compiler/rustc_middle/src/ty/adjustment.rs
+++ b/compiler/rustc_middle/src/ty/adjustment.rs
@@ -96,7 +96,7 @@ pub enum Adjust<'tcx> {
     /// Dereference once, producing a place.
     Deref(Option<OverloadedDeref<'tcx>>),
 
-    /// Take the address and produce either a `&` or `*` pointer.
+    /// Take the address and produce either an `&` reference or `*` pointer.
     Borrow(AutoBorrow<'tcx>),
 
     Pointer(PointerCoercion),

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -854,7 +854,7 @@ impl<'a> From<&'a CStr> for Cow<'a, CStr> {
 
 #[stable(feature = "cow_from_cstr", since = "1.28.0")]
 impl<'a> From<&'a CString> for Cow<'a, CStr> {
-    /// Converts a `&`[`CString`] into a borrowed [`Cow`] without copying or allocating.
+    /// Converts an `&` reference[`CString`] into a borrowed [`Cow`] without copying or allocating.
     #[inline]
     fn from(s: &'a CString) -> Cow<'a, CStr> {
         Cow::Borrowed(s.as_c_str())

--- a/library/std/src/sys/common/thread_local/mod.rs
+++ b/library/std/src/sys/common/thread_local/mod.rs
@@ -64,7 +64,7 @@ mod lazy {
             //
             // Due to this pattern it's possible for the destructor of the value in
             // `ptr` (e.g., if this is being recursively initialized) to re-access
-            // TLS, in which case there will be a `&` and `&mut` pointer to the same
+            // TLS, in which case there will be an `&` reference and `&mut` pointer to the same
             // value (an aliasing violation). To avoid setting the "I'm running a
             // destructor" flag we just use `mem::replace` which should sequence the
             // operations a little differently and make this safe to call.

--- a/src/tools/clippy/CHANGELOG.md
+++ b/src/tools/clippy/CHANGELOG.md
@@ -2541,7 +2541,7 @@ Released 2021-06-17
 * [`len_without_is_empty`]: Also lint if function signatures of `len` and
   `is_empty` don't match
   [#6980](https://github.com/rust-lang/rust-clippy/pull/6980)
-* [`redundant_pattern_matching`]: Also lint if the pattern is a `&` pattern
+* [`redundant_pattern_matching`]: Also lint if the pattern is an `&' pattern
   [#6991](https://github.com/rust-lang/rust-clippy/pull/6991)
 * [`clone_on_copy`]: Also lint on chained method calls taking `self` by value
   [#7000](https://github.com/rust-lang/rust-clippy/pull/7000)

--- a/src/tools/clippy/CHANGELOG.md
+++ b/src/tools/clippy/CHANGELOG.md
@@ -2541,7 +2541,7 @@ Released 2021-06-17
 * [`len_without_is_empty`]: Also lint if function signatures of `len` and
   `is_empty` don't match
   [#6980](https://github.com/rust-lang/rust-clippy/pull/6980)
-* [`redundant_pattern_matching`]: Also lint if the pattern is an `&' pattern
+* [`redundant_pattern_matching`]: Also lint if the pattern is an `&` pattern
   [#6991](https://github.com/rust-lang/rust-clippy/pull/6991)
 * [`clone_on_copy`]: Also lint on chained method calls taking `self` by value
   [#7000](https://github.com/rust-lang/rust-clippy/pull/7000)

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_none.fixed
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_none.fixed
@@ -25,7 +25,7 @@ fn main() {
     let s1 = String::from("hello world");
     let s2 = String::from("world");
 
-    // caller of `find()` is a `&`static str`
+    // caller of `find()` is an `&'static str`
     let _ = !"hello world".contains("world");
     let _ = !"hello world".contains(&s2);
     let _ = !"hello world".contains(&s2[2..]);

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_none.fixed
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_none.fixed
@@ -25,7 +25,7 @@ fn main() {
     let s1 = String::from("hello world");
     let s2 = String::from("world");
 
-    // caller of `find()` is an `&'static str`
+    // caller of `find()` is an `&`static str`
     let _ = !"hello world".contains("world");
     let _ = !"hello world".contains(&s2);
     let _ = !"hello world".contains(&s2[2..]);

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_none.rs
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_none.rs
@@ -27,7 +27,7 @@ fn main() {
     let s1 = String::from("hello world");
     let s2 = String::from("world");
 
-    // caller of `find()` is a `&`static str`
+    // caller of `find()` is an `&'static str`
     let _ = "hello world".find("world").is_none();
     let _ = "hello world".find(&s2).is_none();
     let _ = "hello world".find(&s2[2..]).is_none();

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_none.rs
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_none.rs
@@ -27,7 +27,7 @@ fn main() {
     let s1 = String::from("hello world");
     let s2 = String::from("world");
 
-    // caller of `find()` is an `&'static str`
+    // caller of `find()` is an `&`static str`
     let _ = "hello world".find("world").is_none();
     let _ = "hello world".find(&s2).is_none();
     let _ = "hello world".find(&s2[2..]).is_none();

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_some.fixed
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_some.fixed
@@ -25,7 +25,7 @@ fn main() {
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
-    // caller of `find()` is a `&`static str`
+    // caller of `find()` is an `&'static str`
     let _ = "hello world".contains("world");
     let _ = "hello world".contains(&s2);
     let _ = "hello world".contains(&s2[2..]);

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_some.fixed
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_some.fixed
@@ -25,7 +25,7 @@ fn main() {
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
-    // caller of `find()` is an `&'static str`
+    // caller of `find()` is an `&`static str`
     let _ = "hello world".contains("world");
     let _ = "hello world".contains(&s2);
     let _ = "hello world".contains(&s2[2..]);

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_some.rs
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_some.rs
@@ -26,7 +26,7 @@ fn main() {
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
-    // caller of `find()` is an `&'static str`
+    // caller of `find()` is an `&`static str`
     let _ = "hello world".find("world").is_some();
     let _ = "hello world".find(&s2).is_some();
     let _ = "hello world".find(&s2[2..]).is_some();

--- a/src/tools/clippy/tests/ui/search_is_some_fixable_some.rs
+++ b/src/tools/clippy/tests/ui/search_is_some_fixable_some.rs
@@ -26,7 +26,7 @@ fn main() {
 
     let s1 = String::from("hello world");
     let s2 = String::from("world");
-    // caller of `find()` is a `&`static str`
+    // caller of `find()` is an `&'static str`
     let _ = "hello world".find("world").is_some();
     let _ = "hello world".find(&s2).is_some();
     let _ = "hello world".find(&s2[2..]).is_some();

--- a/src/tools/miri/src/borrow_tracker/stacked_borrows/mod.rs
+++ b/src/tools/miri/src/borrow_tracker/stacked_borrows/mod.rs
@@ -174,7 +174,7 @@ impl NewPermission {
 /// U2: If the top is `Uniq`, accesses must be through that `Uniq` or remove it.
 /// U3: If an access happens with a `Uniq`, it requires the `Uniq` to be in the stack.
 ///
-/// F1: After creating a `&`, the parts outside `UnsafeCell` have our `SharedReadOnly` on top.
+/// F1: After creating an `&` reference, the parts outside `UnsafeCell` have our `SharedReadOnly` on top.
 /// F2: If a write access happens, it pops the `SharedReadOnly`.  This has three pieces:
 ///     F2a: If a write happens granted by an item below our `SharedReadOnly`, the `SharedReadOnly`
 ///          gets popped.

--- a/src/tools/miri/tests/fail/both_borrows/load_invalid_shr.rs
+++ b/src/tools/miri/tests/fail/both_borrows/load_invalid_shr.rs
@@ -3,7 +3,7 @@
 // Make sure we catch this even without validation
 //@compile-flags: -Zmiri-disable-validation
 
-// Make sure that we cannot load from memory a `&` that got already invalidated.
+// Make sure that we cannot load from memory an `&` reference that got already invalidated.
 fn main() {
     let x = &mut 42;
     let xraw = x as *mut _;

--- a/src/tools/miri/tests/fail/both_borrows/pass_invalid_shr.rs
+++ b/src/tools/miri/tests/fail/both_borrows/pass_invalid_shr.rs
@@ -1,7 +1,7 @@
 //@revisions: stack tree
 //@[tree]compile-flags: -Zmiri-tree-borrows
 
-// Make sure that we cannot pass by argument a `&` that got already invalidated.
+// Make sure that we cannot pass by argument an `&` reference that got already invalidated.
 fn foo(_: &i32) {}
 
 fn main() {

--- a/src/tools/miri/tests/fail/both_borrows/pass_invalid_shr_option.rs
+++ b/src/tools/miri/tests/fail/both_borrows/pass_invalid_shr_option.rs
@@ -1,7 +1,7 @@
 //@revisions: stack tree
 //@[tree]compile-flags: -Zmiri-tree-borrows
 
-// Make sure that we cannot pass by argument a `&` that got already invalidated.
+// Make sure that we cannot pass by argument an `&` reference that got already invalidated.
 fn foo(_: Option<&i32>) {}
 
 fn main() {

--- a/src/tools/miri/tests/fail/both_borrows/pass_invalid_shr_tuple.rs
+++ b/src/tools/miri/tests/fail/both_borrows/pass_invalid_shr_tuple.rs
@@ -1,7 +1,7 @@
 //@revisions: stack tree
 //@[tree]compile-flags: -Zmiri-tree-borrows
 
-// Make sure that we cannot pass by argument a `&` that got already invalidated.
+// Make sure that we cannot pass by argument an `&` reference that got already invalidated.
 fn foo(_: (&i32, &i32)) {}
 
 fn main() {

--- a/src/tools/miri/tests/fail/both_borrows/return_invalid_shr.rs
+++ b/src/tools/miri/tests/fail/both_borrows/return_invalid_shr.rs
@@ -1,7 +1,7 @@
 //@revisions: stack tree
 //@[tree]compile-flags: -Zmiri-tree-borrows
 
-// Make sure that we cannot return a `&` that got already invalidated.
+// Make sure that we cannot return an `&` reference that got already invalidated.
 fn foo(x: &mut (i32, i32)) -> &i32 {
     let xraw = x as *mut (i32, i32);
     let ret = unsafe { &(*xraw).1 };

--- a/src/tools/miri/tests/fail/both_borrows/return_invalid_shr_option.rs
+++ b/src/tools/miri/tests/fail/both_borrows/return_invalid_shr_option.rs
@@ -1,7 +1,7 @@
 //@revisions: stack tree
 //@[tree]compile-flags: -Zmiri-tree-borrows
 
-// Make sure that we cannot return a `&` that got already invalidated, not even in an `Option`.
+// Make sure that we cannot return an `&` reference that got already invalidated, not even in an `Option`.
 fn foo(x: &mut (i32, i32)) -> Option<&i32> {
     let xraw = x as *mut (i32, i32);
     let ret = Some(unsafe { &(*xraw).1 });

--- a/src/tools/miri/tests/fail/both_borrows/return_invalid_shr_tuple.rs
+++ b/src/tools/miri/tests/fail/both_borrows/return_invalid_shr_tuple.rs
@@ -1,7 +1,7 @@
 //@revisions: stack tree
 //@[tree]compile-flags: -Zmiri-tree-borrows
 
-// Make sure that we cannot return a `&` that got already invalidated, not even in a tuple.
+// Make sure that we cannot return an `&` reference that got already invalidated, not even in a tuple.
 fn foo(x: &mut (i32, i32)) -> (&i32,) {
     let xraw = x as *mut (i32, i32);
     let ret = (unsafe { &(*xraw).1 },);

--- a/src/tools/rust-analyzer/crates/hir-def/src/hir.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/hir.rs
@@ -450,7 +450,7 @@ impl Expr {
 #[derive(Clone, PartialEq, Eq, Debug, Copy)]
 pub enum BindingAnnotation {
     /// No binding annotation given: this means that the final binding mode
-    /// will depend on whether we have skipped through a `&` reference
+    /// will depend on whether we have skipped through an `&` reference
     /// when matching. For example, the `x` in `Some(x)` will have binding
     /// mode `None`; if you do `let Some(x) = &Some(22)`, it will
     /// ultimately be inferred to be by-reference.

--- a/src/tools/rust-analyzer/crates/hir-ty/src/infer.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/infer.rs
@@ -322,7 +322,7 @@ pub enum Adjust {
     NeverToAny,
     /// Dereference once, producing a place.
     Deref(Option<OverloadedDeref>),
-    /// Take the address and produce either a `&` or `*` pointer.
+    /// Take the address and produce either an `&` reference or `*` pointer.
     Borrow(AutoBorrow),
     Pointer(PointerCast),
 }

--- a/src/tools/rust-analyzer/crates/hir/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/hir/src/lib.rs
@@ -4615,7 +4615,7 @@ pub enum Adjust {
     NeverToAny,
     /// Dereference once, producing a place.
     Deref(Option<OverloadedDeref>),
-    /// Take the address and produce either a `&` or `*` pointer.
+    /// Take the address and produce either an `&` reference or `*` pointer.
     Borrow(AutoBorrow),
     Pointer(PointerCast),
 }

--- a/tests/ui/array-slice-vec/slice-mut-2.rs
+++ b/tests/ui/array-slice-vec/slice-mut-2.rs
@@ -4,5 +4,5 @@ fn main() {
     let x: &[isize] = &[1, 2, 3, 4, 5];
     // Can't mutably slice an immutable slice
     let slice: &mut [isize] = &mut [0, 1];
-    let _ = &mut x[2..4]; //~ERROR cannot borrow `*x` as mutable, as it is behind a `&` reference
+    let _ = &mut x[2..4]; //~ERROR cannot borrow `*x` as mutable, as it is behind an `&` reference
 }

--- a/tests/ui/array-slice-vec/slice-mut-2.stderr
+++ b/tests/ui/array-slice-vec/slice-mut-2.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/slice-mut-2.rs:7:18
    |
 LL |     let _ = &mut x[2..4];

--- a/tests/ui/array-slice-vec/slice-mut-2.stderr
+++ b/tests/ui/array-slice-vec/slice-mut-2.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/slice-mut-2.rs:7:18
    |
 LL |     let _ = &mut x[2..4];
-   |                  ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/array-slice-vec/slice-mut-2.stderr
+++ b/tests/ui/array-slice-vec/slice-mut-2.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/slice-mut-2.rs:7:18
    |
 LL |     let _ = &mut x[2..4];
-   |                  ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/async-await/dont-print-desugared-async.rs
+++ b/tests/ui/async-await/dont-print-desugared-async.rs
@@ -3,6 +3,6 @@
 // edition:2018
 
 async fn async_fn(&ref mut s: &[i32]) {}
-//~^ ERROR cannot borrow data in a `&` reference as mutable [E0596]
+//~^ ERROR cannot borrow data in an `&` reference as mutable [E0596]
 
 fn main() {}

--- a/tests/ui/async-await/dont-print-desugared-async.stderr
+++ b/tests/ui/async-await/dont-print-desugared-async.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/dont-print-desugared-async.rs:5:20
    |
 LL | async fn async_fn(&ref mut s: &[i32]) {}

--- a/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
+++ b/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrow-raw-address-of-deref-mutability.rs:8:13
    |
 LL |     let q = &raw mut *x;
-   |             ^^^^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
+++ b/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrow-raw-address-of-deref-mutability.rs:8:13
    |
 LL |     let q = &raw mut *x;
-   |             ^^^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
+++ b/tests/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrow-raw-address-of-deref-mutability.rs:8:13
    |
 LL |     let q = &raw mut *x;

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -30,7 +30,7 @@ error[E0596]: cannot borrow `*ref_x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-access-permissions.rs:30:19
    |
 LL |         let _y1 = &mut *ref_x;
-   |                   ^^^^^^^^^^^ `ref_x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^^^^^^^^^ `ref_x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -52,7 +52,7 @@ error[E0596]: cannot borrow `*foo_ref.f` as mutable, as it is behind a `&` refer
   --> $DIR/borrowck-access-permissions.rs:48:18
    |
 LL |         let _y = &mut *foo_ref.f;
-   |                  ^^^^^^^^^^^^^^^ `foo_ref` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^^^^^^^^^^^^^^^ `foo_ref` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -30,7 +30,7 @@ error[E0596]: cannot borrow `*ref_x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-access-permissions.rs:30:19
    |
 LL |         let _y1 = &mut *ref_x;
-   |                   ^^^^^^^^^^^ `ref_x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^^^^^^^^^ `ref_x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -52,7 +52,7 @@ error[E0596]: cannot borrow `*foo_ref.f` as mutable, as it is behind a `&` refer
   --> $DIR/borrowck-access-permissions.rs:48:18
    |
 LL |         let _y = &mut *foo_ref.f;
-   |                  ^^^^^^^^^^^^^^^ `foo_ref` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                  ^^^^^^^^^^^^^^^ `foo_ref` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -26,7 +26,7 @@ help: consider changing this to be mutable
 LL |         let mut box_x = Box::new(1);
    |             +++
 
-error[E0596]: cannot borrow `*ref_x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*ref_x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-access-permissions.rs:30:19
    |
 LL |         let _y1 = &mut *ref_x;
@@ -48,7 +48,7 @@ help: consider changing this to be a mutable pointer
 LL |         let ptr_x : *const _ = &mut x;
    |                                 +++
 
-error[E0596]: cannot borrow `*foo_ref.f` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*foo_ref.f` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-access-permissions.rs:48:18
    |
 LL |         let _y = &mut *foo_ref.f;

--- a/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:9:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:17:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:9:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:17:5
    |
 LL |     *s.pointer += 1;
-   |     ^^^^^^^^^^^^^^^ `s` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^ `s` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
+error[E0594]: cannot assign to `*s.pointer`, which is behind an `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:9:5
    |
 LL |     *s.pointer += 1;
@@ -9,7 +9,7 @@ help: consider changing this to be a mutable reference
 LL | fn a(s: &mut S) {
    |          +++
 
-error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
+error[E0594]: cannot assign to `*s.pointer`, which is behind an `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:17:5
    |
 LL |     *s.pointer += 1;

--- a/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `**t1`, which is behind a `&` reference
+error[E0594]: cannot assign to `**t1`, which is behind an `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:9:5
    |
 LL |     **t1 = 22;
@@ -19,7 +19,7 @@ LL |     let p: &isize = &**t0;
 LL |     **t1 = 22;
    |     --------- mutable borrow later used here
 
-error[E0596]: cannot borrow `**t0` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `**t0` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:19:26
    |
 LL |     let x:  &mut isize = &mut **t0;

--- a/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `**t1`, which is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:9:5
    |
 LL |     **t1 = 22;
-   |     ^^^^^^^^^ `t1` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `t1` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |
@@ -23,7 +23,7 @@ error[E0596]: cannot borrow `**t0` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:19:26
    |
 LL |     let x:  &mut isize = &mut **t0;
-   |                          ^^^^^^^^^ `t0` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                          ^^^^^^^^^ `t0` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `**t1`, which is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:9:5
    |
 LL |     **t1 = 22;
-   |     ^^^^^^^^^ `t1` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `t1` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |
@@ -23,7 +23,7 @@ error[E0596]: cannot borrow `**t0` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:19:26
    |
 LL |     let x:  &mut isize = &mut **t0;
-   |                          ^^^^^^^^^ `t0` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                          ^^^^^^^^^ `t0` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-closures-mut-of-imm.stderr
+++ b/tests/ui/borrowck/borrowck-closures-mut-of-imm.stderr
@@ -1,10 +1,10 @@
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-closures-mut-of-imm.rs:9:25
    |
 LL |     let mut c1 = || set(&mut *x);
    |                         ^^^^^^^ cannot borrow as mutable
 
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-closures-mut-of-imm.rs:11:25
    |
 LL |     let mut c2 = || set(&mut *x);

--- a/tests/ui/borrowck/borrowck-issue-14498.stderr
+++ b/tests/ui/borrowck/borrowck-issue-14498.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `***p`, which is behind a `&` reference
+error[E0594]: cannot assign to `***p`, which is behind an `&` reference
   --> $DIR/borrowck-issue-14498.rs:16:5
    |
 LL |     ***p = 2;

--- a/tests/ui/borrowck/borrowck-issue-14498.stderr
+++ b/tests/ui/borrowck/borrowck-issue-14498.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `***p`, which is behind a `&` reference
   --> $DIR/borrowck-issue-14498.rs:16:5
    |
 LL |     ***p = 2;
-   |     ^^^^^^^^ `p` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `p` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-issue-14498.stderr
+++ b/tests/ui/borrowck/borrowck-issue-14498.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `***p`, which is behind a `&` reference
   --> $DIR/borrowck-issue-14498.rs:16:5
    |
 LL |     ***p = 2;
-   |     ^^^^^^^^ `p` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `p` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
+++ b/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
@@ -102,7 +102,7 @@ LL |     let _foo2 = &mut *foo;
 LL |     use_imm(_bar1);
    |             ----- immutable borrow later used here
 
-error[E0596]: cannot borrow `foo.bar1` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `foo.bar1` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-reborrow-from-mut.rs:88:17
    |
 LL |     let _bar1 = &mut foo.bar1;

--- a/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
+++ b/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
@@ -106,7 +106,7 @@ error[E0596]: cannot borrow `foo.bar1` as mutable, as it is behind a `&` referen
   --> $DIR/borrowck-reborrow-from-mut.rs:88:17
    |
 LL |     let _bar1 = &mut foo.bar1;
-   |                 ^^^^^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
+++ b/tests/ui/borrowck/borrowck-reborrow-from-mut.stderr
@@ -106,7 +106,7 @@ error[E0596]: cannot borrow `foo.bar1` as mutable, as it is behind a `&` referen
   --> $DIR/borrowck-reborrow-from-mut.rs:88:17
    |
 LL |     let _bar1 = &mut foo.bar1;
-   |                 ^^^^^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^^ `foo` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/index-mut-help-with-impl.stderr
+++ b/tests/ui/borrowck/index-mut-help-with-impl.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/index-mut-help-with-impl.rs:9:5
    |
 LL |     Index::index(&v, 1..2).make_ascii_uppercase();

--- a/tests/ui/borrowck/issue-111554.rs
+++ b/tests/ui/borrowck/issue-111554.rs
@@ -9,7 +9,7 @@ impl Foo {
     pub fn baz(&self) {
         || bar(&mut self);
         //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable
-        //~| ERROR cannot borrow data in a `&` reference as mutable
+        //~| ERROR cannot borrow data in an `&` reference as mutable
     }
 
     pub fn qux(mut self) {

--- a/tests/ui/borrowck/issue-111554.stderr
+++ b/tests/ui/borrowck/issue-111554.stderr
@@ -10,7 +10,7 @@ error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
 LL |         || bar(&mut self);
    |                ^^^^^^^^^ cannot borrow as mutable
 
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/issue-111554.rs:10:16
    |
 LL |         || bar(&mut self);

--- a/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
+++ b/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
@@ -5,7 +5,7 @@ LL |     for item in &mut std::iter::empty::<&'static ()>() {
    |                 -------------------------------------- this iterator yields `&` references
 LL |
 LL |         *item = ();
-   |         ^^^^^^^^^^ `item` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^ `item` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
+++ b/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
@@ -5,7 +5,7 @@ LL |     for item in &mut std::iter::empty::<&'static ()>() {
    |                 -------------------------------------- this iterator yields `&` references
 LL |
 LL |         *item = ();
-   |         ^^^^^^^^^^ `item` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^ `item` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
+++ b/tests/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*item`, which is behind a `&` reference
+error[E0594]: cannot assign to `*item`, which is behind an `&` reference
   --> $DIR/issue-69789-iterator-mut-suggestion.rs:7:9
    |
 LL |     for item in &mut std::iter::empty::<&'static ()>() {

--- a/tests/ui/borrowck/issue-82032.stderr
+++ b/tests/ui/borrowck/issue-82032.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*v` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*v` as mutable, as it is behind an `&` reference
   --> $DIR/issue-82032.rs:10:13
    |
 LL |         for v in self.0.values() {

--- a/tests/ui/borrowck/issue-82032.stderr
+++ b/tests/ui/borrowck/issue-82032.stderr
@@ -7,7 +7,7 @@ LL |         for v in self.0.values() {
    |                  |      help: use mutable method: `values_mut()`
    |                  this iterator yields `&` references
 LL |             v.flush();
-   |             ^ `v` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^ `v` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-82032.stderr
+++ b/tests/ui/borrowck/issue-82032.stderr
@@ -7,7 +7,7 @@ LL |         for v in self.0.values() {
    |                  |      help: use mutable method: `values_mut()`
    |                  this iterator yields `&` references
 LL |             v.flush();
-   |             ^ `v` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |             ^ `v` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
@@ -10,7 +10,7 @@ fn main() {
         //~^ NOTE this iterator yields `&` references
         *v -= 1;
         //~^ ERROR cannot assign to `*v`, which is behind a `&` reference
-        //~| NOTE `v` is an `&' reference, so the data it refers to cannot be written
+        //~| NOTE `v` is an `&` reference, so the data it refers to cannot be written
     }
 }
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
@@ -10,7 +10,7 @@ fn main() {
         //~^ NOTE this iterator yields `&` references
         *v -= 1;
         //~^ ERROR cannot assign to `*v`, which is behind a `&` reference
-        //~| NOTE `v` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `v` is an `&' reference, so the data it refers to cannot be written
     }
 }
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
@@ -9,7 +9,7 @@ fn main() {
     for v in Query.iter_mut() {
         //~^ NOTE this iterator yields `&` references
         *v -= 1;
-        //~^ ERROR cannot assign to `*v`, which is behind a `&` reference
+        //~^ ERROR cannot assign to `*v`, which is behind an `&` reference
         //~| NOTE `v` is an `&` reference, so the data it refers to cannot be written
     }
 }

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
@@ -5,7 +5,7 @@ LL |     for v in Query.iter_mut() {
    |              ---------------- this iterator yields `&` references
 LL |
 LL |         *v -= 1;
-   |         ^^^^^^^ `v` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `v` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
@@ -5,7 +5,7 @@ LL |     for v in Query.iter_mut() {
    |              ---------------- this iterator yields `&` references
 LL |
 LL |         *v -= 1;
-   |         ^^^^^^^ `v` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `v` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
+++ b/tests/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*v`, which is behind a `&` reference
+error[E0594]: cannot assign to `*v`, which is behind an `&` reference
   --> $DIR/issue-83309-ice-immut-in-for-loop.rs:11:9
    |
 LL |     for v in Query.iter_mut() {

--- a/tests/ui/borrowck/issue-85765-closure.rs
+++ b/tests/ui/borrowck/issue-85765-closure.rs
@@ -4,28 +4,28 @@ fn main() {
         let rofl: &Vec<Vec<i32>> = &mut test;
         //~^ HELP consider changing this binding's type
         rofl.push(Vec::new());
-        //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
+        //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind an `&` reference
         //~| NOTE `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 
         let mut mutvar = 42;
         let r = &mutvar;
         //~^ HELP consider changing this to be a mutable reference
         *r = 0;
-        //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
+        //~^ ERROR cannot assign to `*r`, which is behind an `&` reference
         //~| NOTE `r` is an `&` reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let x: &usize = &mut{0};
         //~^ HELP consider changing this binding's type
         *x = 1;
-        //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
+        //~^ ERROR cannot assign to `*x`, which is behind an `&` reference
         //~| NOTE `x` is an `&` reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let y: &usize = &mut(0);
         //~^ HELP consider changing this binding's type
         *y = 1;
-        //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
+        //~^ ERROR cannot assign to `*y`, which is behind an `&` reference
         //~| NOTE `y` is an `&` reference, so the data it refers to cannot be written
     };
 }

--- a/tests/ui/borrowck/issue-85765-closure.rs
+++ b/tests/ui/borrowck/issue-85765-closure.rs
@@ -5,27 +5,27 @@ fn main() {
         //~^ HELP consider changing this binding's type
         rofl.push(Vec::new());
         //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-        //~| NOTE `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+        //~| NOTE `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 
         let mut mutvar = 42;
         let r = &mutvar;
         //~^ HELP consider changing this to be a mutable reference
         *r = 0;
         //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-        //~| NOTE `r` is an `&' reference, so the data it refers to cannot be written
+        //~| NOTE `r` is an `&` reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let x: &usize = &mut{0};
         //~^ HELP consider changing this binding's type
         *x = 1;
         //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-        //~| NOTE `x` is an `&' reference, so the data it refers to cannot be written
+        //~| NOTE `x` is an `&` reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let y: &usize = &mut(0);
         //~^ HELP consider changing this binding's type
         *y = 1;
         //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-        //~| NOTE `y` is an `&' reference, so the data it refers to cannot be written
+        //~| NOTE `y` is an `&` reference, so the data it refers to cannot be written
     };
 }

--- a/tests/ui/borrowck/issue-85765-closure.rs
+++ b/tests/ui/borrowck/issue-85765-closure.rs
@@ -5,27 +5,27 @@ fn main() {
         //~^ HELP consider changing this binding's type
         rofl.push(Vec::new());
         //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-        //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+        //~| NOTE `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 
         let mut mutvar = 42;
         let r = &mutvar;
         //~^ HELP consider changing this to be a mutable reference
         *r = 0;
         //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-        //~| NOTE `r` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `r` is an `&' reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let x: &usize = &mut{0};
         //~^ HELP consider changing this binding's type
         *x = 1;
         //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-        //~| NOTE `x` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `x` is an `&' reference, so the data it refers to cannot be written
 
         #[rustfmt::skip]
         let y: &usize = &mut(0);
         //~^ HELP consider changing this binding's type
         *y = 1;
         //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-        //~| NOTE `y` is a `&` reference, so the data it refers to cannot be written
+        //~| NOTE `y` is an `&' reference, so the data it refers to cannot be written
     };
 }

--- a/tests/ui/borrowck/issue-85765-closure.stderr
+++ b/tests/ui/borrowck/issue-85765-closure.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*rofl` as mutable, as it is behind an `&` reference
   --> $DIR/issue-85765-closure.rs:6:9
    |
 LL |         rofl.push(Vec::new());
@@ -9,7 +9,7 @@ help: consider changing this binding's type
 LL |         let rofl: &mut Vec<Vec<i32>> = &mut test;
    |                   ~~~~~~~~~~~~~~~~~~
 
-error[E0594]: cannot assign to `*r`, which is behind a `&` reference
+error[E0594]: cannot assign to `*r`, which is behind an `&` reference
   --> $DIR/issue-85765-closure.rs:13:9
    |
 LL |         *r = 0;
@@ -20,7 +20,7 @@ help: consider changing this to be a mutable reference
 LL |         let r = &mut mutvar;
    |                  +++
 
-error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind an `&` reference
   --> $DIR/issue-85765-closure.rs:20:9
    |
 LL |         *x = 1;
@@ -31,7 +31,7 @@ help: consider changing this binding's type
 LL |         let x: &mut usize = &mut{0};
    |                ~~~~~~~~~~
 
-error[E0594]: cannot assign to `*y`, which is behind a `&` reference
+error[E0594]: cannot assign to `*y`, which is behind an `&` reference
   --> $DIR/issue-85765-closure.rs:27:9
    |
 LL |         *y = 1;

--- a/tests/ui/borrowck/issue-85765-closure.stderr
+++ b/tests/ui/borrowck/issue-85765-closure.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:6:9
    |
 LL |         rofl.push(Vec::new());
-   |         ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:13:9
    |
 LL |         *r = 0;
-   |         ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^ `r` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:20:9
    |
 LL |         *x = 1;
-   |         ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:27:9
    |
 LL |         *y = 1;
-   |         ^^^^^^ `y` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^ `y` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-85765-closure.stderr
+++ b/tests/ui/borrowck/issue-85765-closure.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:6:9
    |
 LL |         rofl.push(Vec::new());
-   |         ^^^^ `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:13:9
    |
 LL |         *r = 0;
-   |         ^^^^^^ `r` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^ `r` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:20:9
    |
 LL |         *x = 1;
-   |         ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:27:9
    |
 LL |         *y = 1;
-   |         ^^^^^^ `y` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^ `y` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-85765.rs
+++ b/tests/ui/borrowck/issue-85765.rs
@@ -3,27 +3,27 @@ fn main() {
     let rofl: &Vec<Vec<i32>> = &mut test;
     //~^ HELP consider changing this binding's type
     rofl.push(Vec::new());
-    //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
+    //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind an `&` reference
     //~| NOTE `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 
     let mut mutvar = 42;
     let r = &mutvar;
     //~^ HELP consider changing this to be a mutable reference
     *r = 0;
-    //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
+    //~^ ERROR cannot assign to `*r`, which is behind an `&` reference
     //~| NOTE `r` is an `&` reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let x: &usize = &mut{0};
     //~^ HELP consider changing this binding's type
     *x = 1;
-    //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
+    //~^ ERROR cannot assign to `*x`, which is behind an `&` reference
     //~| NOTE `x` is an `&` reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let y: &usize = &mut(0);
     //~^ HELP consider changing this binding's type
     *y = 1;
-    //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
+    //~^ ERROR cannot assign to `*y`, which is behind an `&` reference
     //~| NOTE `y` is an `&` reference, so the data it refers to cannot be written
 }

--- a/tests/ui/borrowck/issue-85765.rs
+++ b/tests/ui/borrowck/issue-85765.rs
@@ -4,26 +4,26 @@ fn main() {
     //~^ HELP consider changing this binding's type
     rofl.push(Vec::new());
     //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-    //~| NOTE `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 
     let mut mutvar = 42;
     let r = &mutvar;
     //~^ HELP consider changing this to be a mutable reference
     *r = 0;
     //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-    //~| NOTE `r` is an `&' reference, so the data it refers to cannot be written
+    //~| NOTE `r` is an `&` reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let x: &usize = &mut{0};
     //~^ HELP consider changing this binding's type
     *x = 1;
     //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-    //~| NOTE `x` is an `&' reference, so the data it refers to cannot be written
+    //~| NOTE `x` is an `&` reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let y: &usize = &mut(0);
     //~^ HELP consider changing this binding's type
     *y = 1;
     //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-    //~| NOTE `y` is an `&' reference, so the data it refers to cannot be written
+    //~| NOTE `y` is an `&` reference, so the data it refers to cannot be written
 }

--- a/tests/ui/borrowck/issue-85765.rs
+++ b/tests/ui/borrowck/issue-85765.rs
@@ -4,26 +4,26 @@ fn main() {
     //~^ HELP consider changing this binding's type
     rofl.push(Vec::new());
     //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-    //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 
     let mut mutvar = 42;
     let r = &mutvar;
     //~^ HELP consider changing this to be a mutable reference
     *r = 0;
     //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
-    //~| NOTE `r` is a `&` reference, so the data it refers to cannot be written
+    //~| NOTE `r` is an `&' reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let x: &usize = &mut{0};
     //~^ HELP consider changing this binding's type
     *x = 1;
     //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
-    //~| NOTE `x` is a `&` reference, so the data it refers to cannot be written
+    //~| NOTE `x` is an `&' reference, so the data it refers to cannot be written
 
     #[rustfmt::skip]
     let y: &usize = &mut(0);
     //~^ HELP consider changing this binding's type
     *y = 1;
     //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
-    //~| NOTE `y` is a `&` reference, so the data it refers to cannot be written
+    //~| NOTE `y` is an `&' reference, so the data it refers to cannot be written
 }

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765.rs:5:5
    |
 LL |     rofl.push(Vec::new());
-   |     ^^^^ `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `rofl` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:12:5
    |
 LL |     *r = 0;
-   |     ^^^^^^ `r` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^ `r` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:19:5
    |
 LL |     *x = 1;
-   |     ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:26:5
    |
 LL |     *y = 1;
-   |     ^^^^^^ `y` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^ `y` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*rofl` as mutable, as it is behind an `&` reference
   --> $DIR/issue-85765.rs:5:5
    |
 LL |     rofl.push(Vec::new());
@@ -9,7 +9,7 @@ help: consider changing this binding's type
 LL |     let rofl: &mut Vec<Vec<i32>> = &mut test;
    |               ~~~~~~~~~~~~~~~~~~
 
-error[E0594]: cannot assign to `*r`, which is behind a `&` reference
+error[E0594]: cannot assign to `*r`, which is behind an `&` reference
   --> $DIR/issue-85765.rs:12:5
    |
 LL |     *r = 0;
@@ -20,7 +20,7 @@ help: consider changing this to be a mutable reference
 LL |     let r = &mut mutvar;
    |              +++
 
-error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind an `&` reference
   --> $DIR/issue-85765.rs:19:5
    |
 LL |     *x = 1;
@@ -31,7 +31,7 @@ help: consider changing this binding's type
 LL |     let x: &mut usize = &mut{0};
    |            ~~~~~~~~~~
 
-error[E0594]: cannot assign to `*y`, which is behind a `&` reference
+error[E0594]: cannot assign to `*y`, which is behind an `&` reference
   --> $DIR/issue-85765.rs:26:5
    |
 LL |     *y = 1;

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
   --> $DIR/issue-85765.rs:5:5
    |
 LL |     rofl.push(Vec::new());
-   |     ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `rofl` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this binding's type
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:12:5
    |
 LL |     *r = 0;
-   |     ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `r` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:19:5
    |
 LL |     *x = 1;
-   |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:26:5
    |
 LL |     *y = 1;
-   |     ^^^^^^ `y` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `y` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this binding's type
    |

--- a/tests/ui/borrowck/issue-91206.rs
+++ b/tests/ui/borrowck/issue-91206.rs
@@ -12,5 +12,5 @@ fn main() {
     //~^ HELP consider specifying this binding's type
     inner.clear();
     //~^ ERROR cannot borrow `*inner` as mutable, as it is behind a `&` reference [E0596]
-    //~| NOTE `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `inner` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 }

--- a/tests/ui/borrowck/issue-91206.rs
+++ b/tests/ui/borrowck/issue-91206.rs
@@ -11,6 +11,6 @@ fn main() {
     let inner = client.get_inner_ref();
     //~^ HELP consider specifying this binding's type
     inner.clear();
-    //~^ ERROR cannot borrow `*inner` as mutable, as it is behind a `&` reference [E0596]
+    //~^ ERROR cannot borrow `*inner` as mutable, as it is behind an `&` reference [E0596]
     //~| NOTE `inner` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 }

--- a/tests/ui/borrowck/issue-91206.rs
+++ b/tests/ui/borrowck/issue-91206.rs
@@ -12,5 +12,5 @@ fn main() {
     //~^ HELP consider specifying this binding's type
     inner.clear();
     //~^ ERROR cannot borrow `*inner` as mutable, as it is behind a `&` reference [E0596]
-    //~| NOTE `inner` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+    //~| NOTE `inner` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 }

--- a/tests/ui/borrowck/issue-91206.stderr
+++ b/tests/ui/borrowck/issue-91206.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
   --> $DIR/issue-91206.rs:13:5
    |
 LL |     inner.clear();
-   |     ^^^^^ `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^ `inner` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-91206.stderr
+++ b/tests/ui/borrowck/issue-91206.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
   --> $DIR/issue-91206.rs:13:5
    |
 LL |     inner.clear();
-   |     ^^^^^ `inner` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^ `inner` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-91206.stderr
+++ b/tests/ui/borrowck/issue-91206.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*inner` as mutable, as it is behind an `&` reference
   --> $DIR/issue-91206.rs:13:5
    |
 LL |     inner.clear();

--- a/tests/ui/borrowck/issue-92015.stderr
+++ b/tests/ui/borrowck/issue-92015.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
+error[E0594]: cannot assign to `*foo`, which is behind an `&` reference
   --> $DIR/issue-92015.rs:6:5
    |
 LL |     *foo = 1;

--- a/tests/ui/borrowck/issue-92015.stderr
+++ b/tests/ui/borrowck/issue-92015.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-92015.rs:6:5
    |
 LL |     *foo = 1;
-   |     ^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `foo` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-92015.stderr
+++ b/tests/ui/borrowck/issue-92015.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-92015.rs:6:5
    |
 LL |     *foo = 1;
-   |     ^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/borrowck/issue-93093.rs
+++ b/tests/ui/borrowck/issue-93093.rs
@@ -5,7 +5,7 @@ struct S {
 impl S {
     async fn bar(&self) { //~ HELP consider changing this to be a mutable reference
         //~| SUGGESTION &mut self
-        self.foo += 1; //~ ERROR cannot assign to `self.foo`, which is behind a `&` reference [E0594]
+        self.foo += 1; //~ ERROR cannot assign to `self.foo`, which is behind an `&` reference [E0594]
     }
 }
 

--- a/tests/ui/borrowck/issue-93093.stderr
+++ b/tests/ui/borrowck/issue-93093.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.foo`, which is behind a `&` reference
   --> $DIR/issue-93093.rs:8:9
    |
 LL |         self.foo += 1;
-   |         ^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/issue-93093.stderr
+++ b/tests/ui/borrowck/issue-93093.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.foo`, which is behind a `&` reference
   --> $DIR/issue-93093.rs:8:9
    |
 LL |         self.foo += 1;
-   |         ^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/issue-93093.stderr
+++ b/tests/ui/borrowck/issue-93093.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.foo`, which is behind a `&` reference
+error[E0594]: cannot assign to `self.foo`, which is behind an `&` reference
   --> $DIR/issue-93093.rs:8:9
    |
 LL |         self.foo += 1;

--- a/tests/ui/borrowck/mutability-errors.stderr
+++ b/tests/ui/borrowck/mutability-errors.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:9:5
    |
 LL |     *x = (1,);
-   |     ^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `x.0`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:10:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:11:5
    |
 LL |     &mut *x;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `x.0` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:12:5
    |
 LL |     &mut x.0;
-   |     ^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/mutability-errors.stderr
+++ b/tests/ui/borrowck/mutability-errors.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:9:5
    |
 LL |     *x = (1,);
-   |     ^^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `x.0`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:10:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:11:5
    |
 LL |     &mut *x;
-   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `x.0` as mutable, as it is behind a `&` reference
   --> $DIR/mutability-errors.rs:12:5
    |
 LL |     &mut x.0;
-   |     ^^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/borrowck/mutability-errors.stderr
+++ b/tests/ui/borrowck/mutability-errors.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind an `&` reference
   --> $DIR/mutability-errors.rs:9:5
    |
 LL |     *x = (1,);
@@ -9,7 +9,7 @@ help: consider changing this to be a mutable reference
 LL | fn named_ref(x: &mut (i32,)) {
    |                  +++
 
-error[E0594]: cannot assign to `x.0`, which is behind a `&` reference
+error[E0594]: cannot assign to `x.0`, which is behind an `&` reference
   --> $DIR/mutability-errors.rs:10:5
    |
 LL |     x.0 = 1;
@@ -20,7 +20,7 @@ help: consider changing this to be a mutable reference
 LL | fn named_ref(x: &mut (i32,)) {
    |                  +++
 
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/mutability-errors.rs:11:5
    |
 LL |     &mut *x;
@@ -31,7 +31,7 @@ help: consider changing this to be a mutable reference
 LL | fn named_ref(x: &mut (i32,)) {
    |                  +++
 
-error[E0596]: cannot borrow `x.0` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `x.0` as mutable, as it is behind an `&` reference
   --> $DIR/mutability-errors.rs:12:5
    |
 LL |     &mut x.0;
@@ -42,25 +42,25 @@ help: consider changing this to be a mutable reference
 LL | fn named_ref(x: &mut (i32,)) {
    |                  +++
 
-error[E0594]: cannot assign to data in a `&` reference
+error[E0594]: cannot assign to data in an `&` reference
   --> $DIR/mutability-errors.rs:16:5
    |
 LL |     *f() = (1,);
    |     ^^^^^^^^^^^ cannot assign
 
-error[E0594]: cannot assign to data in a `&` reference
+error[E0594]: cannot assign to data in an `&` reference
   --> $DIR/mutability-errors.rs:17:5
    |
 LL |     f().0 = 1;
    |     ^^^^^^^^^ cannot assign
 
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/mutability-errors.rs:18:5
    |
 LL |     &mut *f();
    |     ^^^^^^^^^ cannot borrow as mutable
 
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/mutability-errors.rs:19:5
    |
 LL |     &mut f().0;

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.rs
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.rs
@@ -10,7 +10,7 @@ fn x(cb: &mut Option<&mut dyn FnMut()>) {
 
 fn x2(cb: &mut Option<&mut dyn FnMut()>) {
     cb.as_ref().map(|cb| cb());
-    //~^ ERROR cannot borrow `*cb` as mutable, as it is behind a `&` reference
+    //~^ ERROR cannot borrow `*cb` as mutable, as it is behind an `&` reference
 }
 
 fn main() {}

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
@@ -10,7 +10,7 @@ LL |     cb.map(|cb| cb());
 note: `Option::<T>::map` takes ownership of the receiver `self`, which moves `*cb`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
-error[E0596]: cannot borrow `*cb` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*cb` as mutable, as it is behind an `&` reference
   --> $DIR/suggest-as-ref-on-mut-closure.rs:12:26
    |
 LL |     cb.as_ref().map(|cb| cb());

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*cb` as mutable, as it is behind a `&` reference
   --> $DIR/suggest-as-ref-on-mut-closure.rs:12:26
    |
 LL |     cb.as_ref().map(|cb| cb());
-   |                      --  ^^ `cb` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                      --  ^^ `cb` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |                      |
    |                      consider changing this binding's type to be: `&mut &mut dyn FnMut()`
 

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*cb` as mutable, as it is behind a `&` reference
   --> $DIR/suggest-as-ref-on-mut-closure.rs:12:26
    |
 LL |     cb.as_ref().map(|cb| cb());
-   |                      --  ^^ `cb` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                      --  ^^ `cb` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |                      |
    |                      consider changing this binding's type to be: `&mut &mut dyn FnMut()`
 

--- a/tests/ui/borrowck/suggest-mut-iterator.fixed
+++ b/tests/ui/borrowck/suggest-mut-iterator.fixed
@@ -19,7 +19,7 @@ fn main() {
         tests.push(Test {a: i});
     }
     for test in &mut tests {
-        test.add(2); //~ ERROR cannot borrow `*test` as mutable, as it is behind a `&` reference
+        test.add(2); //~ ERROR cannot borrow `*test` as mutable, as it is behind an `&` reference
     }
     for test in &mut tests {
         test.add(2);

--- a/tests/ui/borrowck/suggest-mut-iterator.rs
+++ b/tests/ui/borrowck/suggest-mut-iterator.rs
@@ -19,7 +19,7 @@ fn main() {
         tests.push(Test {a: i});
     }
     for test in &tests {
-        test.add(2); //~ ERROR cannot borrow `*test` as mutable, as it is behind a `&` reference
+        test.add(2); //~ ERROR cannot borrow `*test` as mutable, as it is behind an `&` reference
     }
     for test in &mut tests {
         test.add(2);

--- a/tests/ui/borrowck/suggest-mut-iterator.stderr
+++ b/tests/ui/borrowck/suggest-mut-iterator.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*test` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*test` as mutable, as it is behind an `&` reference
   --> $DIR/suggest-mut-iterator.rs:22:9
    |
 LL |     for test in &tests {

--- a/tests/ui/borrowck/suggest-mut-iterator.stderr
+++ b/tests/ui/borrowck/suggest-mut-iterator.stderr
@@ -4,7 +4,7 @@ error[E0596]: cannot borrow `*test` as mutable, as it is behind a `&` reference
 LL |     for test in &tests {
    |                 ------ this iterator yields `&` references
 LL |         test.add(2);
-   |         ^^^^ `test` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `test` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: use a mutable iterator instead
    |

--- a/tests/ui/borrowck/suggest-mut-iterator.stderr
+++ b/tests/ui/borrowck/suggest-mut-iterator.stderr
@@ -4,7 +4,7 @@ error[E0596]: cannot borrow `*test` as mutable, as it is behind a `&` reference
 LL |     for test in &tests {
    |                 ------ this iterator yields `&` references
 LL |         test.add(2);
-   |         ^^^^ `test` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^ `test` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: use a mutable iterator instead
    |

--- a/tests/ui/cleanup-rvalue-scopes.rs
+++ b/tests/ui/cleanup-rvalue-scopes.rs
@@ -91,7 +91,7 @@ pub fn main() {
 
     // In all these cases, we trip over the rules designed to cover
     // the case where we are taking addr of rvalue and storing that
-    // addr into a stack slot, either via `let ref` or via a `&` in
+    // addr into a stack slot, either via `let ref` or via an `&` reference in
     // the initializer.
 
     end_of_block!(_x, AddFlags(1));

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.rs
@@ -11,7 +11,7 @@ fn main() {
     // `x.0` is mutable but we access `x` via `*z.0.0`, which is an immutable reference and
     // therefore can't be mutated.
     let mut c = || {
-    //~^ ERROR: cannot borrow `*z.0.0` as mutable, as it is behind a `&` reference
+    //~^ ERROR: cannot borrow `*z.0.0` as mutable, as it is behind an `&` reference
         z.0.0.0 = format!("X1");
     };
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*z.0.0` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*z.0.0` as mutable, as it is behind an `&` reference
   --> $DIR/cant-mutate-imm-borrow.rs:13:17
    |
 LL |     let mut c = || {

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.rs
@@ -10,7 +10,7 @@ fn imm_mut_ref() {
     let ref_mref_x = &mref_x;
 
     let c = || {
-    //~^ ERROR: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` reference
+    //~^ ERROR: cannot borrow `**ref_mref_x` as mutable, as it is behind an `&` reference
         **ref_mref_x = y;
     };
 
@@ -24,7 +24,7 @@ fn mut_imm_ref() {
     let mref_ref_x = &mut ref_x;
 
     let c = || {
-    //~^ ERROR: cannot borrow `**mref_ref_x` as mutable, as it is behind a `&` reference
+    //~^ ERROR: cannot borrow `**mref_ref_x` as mutable, as it is behind an `&` reference
         **mref_ref_x = y;
     };
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` ref
   --> $DIR/mut_ref.rs:12:13
    |
 LL |     let c = || {
-   |             ^^ `ref_mref_x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^ `ref_mref_x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
 LL |
 LL |         **ref_mref_x = y;
    |         ------------ mutable borrow occurs due to use of `**ref_mref_x` in closure

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` ref
   --> $DIR/mut_ref.rs:12:13
    |
 LL |     let c = || {
-   |             ^^ `ref_mref_x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^ `ref_mref_x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
 LL |
 LL |         **ref_mref_x = y;
    |         ------------ mutable borrow occurs due to use of `**ref_mref_x` in closure

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind an `&` reference
   --> $DIR/mut_ref.rs:12:13
    |
 LL |     let c = || {
@@ -12,7 +12,7 @@ help: consider changing this to be a mutable reference
 LL |     let ref_mref_x = &mut mref_x;
    |                       +++
 
-error[E0596]: cannot borrow `**mref_ref_x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `**mref_ref_x` as mutable, as it is behind an `&` reference
   --> $DIR/mut_ref.rs:26:13
    |
 LL |     let c = || {

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.rs
@@ -3,7 +3,7 @@
 
 impl EntriesBuffer {
     fn a(&self) -> impl Iterator {
-        self.0.iter_mut() //~ ERROR: cannot borrow `*self.0` as mutable, as it is behind a `&` reference
+        self.0.iter_mut() //~ ERROR: cannot borrow `*self.0` as mutable, as it is behind an `&` reference
     }
 }
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*self.0` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-109141.rs:6:9
    |
 LL |         self.0.iter_mut()
-   |         ^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*self.0` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-109141.rs:6:9
    |
 LL |         self.0.iter_mut()
-   |         ^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
@@ -9,7 +9,7 @@ help: you might be missing a const parameter
 LL | struct EntriesBuffer<const HashesEntryLEN: /* Type */>(Box<[[u8; HashesEntryLEN]; 5]>);
    |                     ++++++++++++++++++++++++++++++++++
 
-error[E0596]: cannot borrow `*self.0` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*self.0` as mutable, as it is behind an `&` reference
   --> $DIR/issue-109141.rs:6:9
    |
 LL |         self.0.iter_mut()

--- a/tests/ui/consts/const-mut-refs/issue-76510.32bit.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.32bit.stderr
@@ -13,7 +13,7 @@ LL | const S: &'static mut str = &mut " hello ";
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/issue-76510.rs:5:29
    |
 LL | const S: &'static mut str = &mut " hello ";

--- a/tests/ui/consts/const-mut-refs/issue-76510.64bit.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.64bit.stderr
@@ -13,7 +13,7 @@ LL | const S: &'static mut str = &mut " hello ";
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/issue-76510.rs:5:29
    |
 LL | const S: &'static mut str = &mut " hello ";

--- a/tests/ui/consts/const-mut-refs/issue-76510.rs
+++ b/tests/ui/consts/const-mut-refs/issue-76510.rs
@@ -5,7 +5,7 @@ use std::mem::{transmute, ManuallyDrop};
 const S: &'static mut str = &mut " hello ";
 //~^ ERROR: mutable references are not allowed in the final value of constants
 //~| ERROR: mutation through a reference is not allowed in constants
-//~| ERROR: cannot borrow data in a `&` reference as mutable
+//~| ERROR: cannot borrow data in an `&` reference as mutable
 
 const fn trigger() -> [(); unsafe {
         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));

--- a/tests/ui/did_you_mean/issue-38147-1.rs
+++ b/tests/ui/did_you_mean/issue-38147-1.rs
@@ -14,7 +14,7 @@ struct Foo<'a> {
 
 impl<'a> Foo<'a> {
     fn f(&self) {
-        self.s.push('x'); //~ cannot borrow `*self.s` as mutable, as it is behind a `&` reference
+        self.s.push('x'); //~ cannot borrow `*self.s` as mutable, as it is behind an `&` reference
     }
 }
 

--- a/tests/ui/did_you_mean/issue-38147-1.stderr
+++ b/tests/ui/did_you_mean/issue-38147-1.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-38147-1.rs:17:9
    |
 LL |         self.s.push('x');
-   |         ^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-38147-1.stderr
+++ b/tests/ui/did_you_mean/issue-38147-1.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-38147-1.rs:17:9
    |
 LL |         self.s.push('x');
-   |         ^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-38147-1.stderr
+++ b/tests/ui/did_you_mean/issue-38147-1.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*self.s` as mutable, as it is behind an `&` reference
   --> $DIR/issue-38147-1.rs:17:9
    |
 LL |         self.s.push('x');

--- a/tests/ui/did_you_mean/issue-38147-2.rs
+++ b/tests/ui/did_you_mean/issue-38147-2.rs
@@ -7,10 +7,10 @@ struct Bar<'a> {
 impl<'a> Bar<'a> {
     fn f(&mut self) {
         self.s.push('x');
-        //~^ ERROR cannot borrow `*self.s` as mutable, as it is behind a `&` reference
+        //~^ ERROR cannot borrow `*self.s` as mutable, as it is behind an `&` reference
 
         self.longer_name.push(13);
-        //~^ ERROR cannot borrow `*self.longer_name` as mutable, as it is behind a `&` reference
+        //~^ ERROR cannot borrow `*self.longer_name` as mutable, as it is behind an `&` reference
     }
 }
 

--- a/tests/ui/did_you_mean/issue-38147-2.stderr
+++ b/tests/ui/did_you_mean/issue-38147-2.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*self.s` as mutable, as it is behind an `&` reference
   --> $DIR/issue-38147-2.rs:9:9
    |
 LL |         self.s.push('x');
@@ -9,7 +9,7 @@ help: consider changing this to be mutable
 LL |     s: &'a mut String,
    |            +++
 
-error[E0596]: cannot borrow `*self.longer_name` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*self.longer_name` as mutable, as it is behind an `&` reference
   --> $DIR/issue-38147-2.rs:12:9
    |
 LL |         self.longer_name.push(13);

--- a/tests/ui/did_you_mean/issue-38147-3.rs
+++ b/tests/ui/did_you_mean/issue-38147-3.rs
@@ -5,7 +5,7 @@ struct Qux<'a> {
 impl<'a> Qux<'a> {
     fn f(&self) {
         self.s.push('x');
-        //~^ ERROR cannot borrow `*self.s` as mutable, as it is behind a `&` reference
+        //~^ ERROR cannot borrow `*self.s` as mutable, as it is behind an `&` reference
     }
 }
 

--- a/tests/ui/did_you_mean/issue-38147-3.stderr
+++ b/tests/ui/did_you_mean/issue-38147-3.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*self.s` as mutable, as it is behind an `&` reference
   --> $DIR/issue-38147-3.rs:7:9
    |
 LL |         self.s.push('x');

--- a/tests/ui/did_you_mean/issue-38147-4.rs
+++ b/tests/ui/did_you_mean/issue-38147-4.rs
@@ -3,7 +3,7 @@ struct Foo<'a> {
 }
 
 fn f(x: usize, f: &Foo) {
-    f.s.push('x'); //~ ERROR cannot borrow `*f.s` as mutable, as it is behind a `&` reference
+    f.s.push('x'); //~ ERROR cannot borrow `*f.s` as mutable, as it is behind an `&` reference
 }
 
 fn main() {}

--- a/tests/ui/did_you_mean/issue-38147-4.stderr
+++ b/tests/ui/did_you_mean/issue-38147-4.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*f.s` as mutable, as it is behind a `&` reference
   --> $DIR/issue-38147-4.rs:6:5
    |
 LL |     f.s.push('x');
-   |     ^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-38147-4.stderr
+++ b/tests/ui/did_you_mean/issue-38147-4.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*f.s` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*f.s` as mutable, as it is behind an `&` reference
   --> $DIR/issue-38147-4.rs:6:5
    |
 LL |     f.s.push('x');

--- a/tests/ui/did_you_mean/issue-38147-4.stderr
+++ b/tests/ui/did_you_mean/issue-38147-4.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*f.s` as mutable, as it is behind a `&` reference
   --> $DIR/issue-38147-4.rs:6:5
    |
 LL |     f.s.push('x');
-   |     ^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-39544.rs
+++ b/tests/ui/did_you_mean/issue-39544.rs
@@ -46,5 +46,5 @@ pub fn with_tuple() {
     let mut y = 0;
     let x = (&y,);
     *x.0 = 1;
-    //~^ ERROR cannot assign to `*x.0`, which is behind a `&` reference
+    //~^ ERROR cannot assign to `*x.0`, which is behind an `&` reference
 }

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:16:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:20:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:21:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -46,7 +46,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:25:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -57,7 +57,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:26:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -68,7 +68,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:30:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -79,7 +79,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:31:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -90,7 +90,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:35:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -112,7 +112,7 @@ error[E0596]: cannot borrow `w.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:42:13
    |
 LL |     let _ = &mut w.x;
-   |             ^^^^^^^^ `w` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^ `w` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:16:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:20:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:21:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -46,7 +46,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:25:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -57,7 +57,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:26:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -68,7 +68,7 @@ error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:30:17
    |
 LL |         let _ = &mut self.x;
-   |                 ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -79,7 +79,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:31:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -90,7 +90,7 @@ error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` referenc
   --> $DIR/issue-39544.rs:35:17
    |
 LL |         let _ = &mut other.x;
-   |                 ^^^^^^^^^^^^ `other` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                 ^^^^^^^^^^^^ `other` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -112,7 +112,7 @@ error[E0596]: cannot borrow `w.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:42:13
    |
 LL |     let _ = &mut w.x;
-   |             ^^^^^^^^ `w` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |             ^^^^^^^^ `w` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -9,7 +9,7 @@ help: consider changing this to be mutable
 LL |     let mut z = Z { x: X::Y };
    |         +++
 
-error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `self.x` as mutable, as it is behind an `&` reference
   --> $DIR/issue-39544.rs:16:17
    |
 LL |         let _ = &mut self.x;
@@ -20,7 +20,7 @@ help: consider changing this to be a mutable reference
 LL |     fn foo<'z>(&'z mut self) {
    |                ~~~~~~~~~~~~
 
-error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `self.x` as mutable, as it is behind an `&` reference
   --> $DIR/issue-39544.rs:20:17
    |
 LL |         let _ = &mut self.x;
@@ -31,7 +31,7 @@ help: consider changing this to be a mutable reference
 LL |     fn foo1(&mut self, other: &Z) {
    |             ~~~~~~~~~
 
-error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `other.x` as mutable, as it is behind an `&` reference
   --> $DIR/issue-39544.rs:21:17
    |
 LL |         let _ = &mut other.x;
@@ -42,7 +42,7 @@ help: consider changing this to be a mutable reference
 LL |     fn foo1(&self, other: &mut Z) {
    |                            +++
 
-error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `self.x` as mutable, as it is behind an `&` reference
   --> $DIR/issue-39544.rs:25:17
    |
 LL |         let _ = &mut self.x;
@@ -53,7 +53,7 @@ help: consider changing this to be a mutable reference
 LL |     fn foo2<'a>(&'a mut self, other: &Z) {
    |                 ~~~~~~~~~~~~
 
-error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `other.x` as mutable, as it is behind an `&` reference
   --> $DIR/issue-39544.rs:26:17
    |
 LL |         let _ = &mut other.x;
@@ -64,7 +64,7 @@ help: consider changing this to be a mutable reference
 LL |     fn foo2<'a>(&'a self, other: &mut Z) {
    |                                   +++
 
-error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `self.x` as mutable, as it is behind an `&` reference
   --> $DIR/issue-39544.rs:30:17
    |
 LL |         let _ = &mut self.x;
@@ -75,7 +75,7 @@ help: consider changing this to be a mutable reference
 LL |     fn foo3<'a>(self: &'a mut Self, other: &Z) {
    |                           +++
 
-error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `other.x` as mutable, as it is behind an `&` reference
   --> $DIR/issue-39544.rs:31:17
    |
 LL |         let _ = &mut other.x;
@@ -86,7 +86,7 @@ help: consider changing this to be a mutable reference
 LL |     fn foo3<'a>(self: &'a Self, other: &mut Z) {
    |                                         +++
 
-error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `other.x` as mutable, as it is behind an `&` reference
   --> $DIR/issue-39544.rs:35:17
    |
 LL |         let _ = &mut other.x;
@@ -108,7 +108,7 @@ help: consider changing this to be mutable
 LL | pub fn with_arg(mut z: Z, w: &Z) {
    |                 +++
 
-error[E0596]: cannot borrow `w.x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `w.x` as mutable, as it is behind an `&` reference
   --> $DIR/issue-39544.rs:42:13
    |
 LL |     let _ = &mut w.x;
@@ -119,7 +119,7 @@ help: consider changing this to be a mutable reference
 LL | pub fn with_arg(z: Z, w: &mut Z) {
    |                           +++
 
-error[E0594]: cannot assign to `*x.0`, which is behind a `&` reference
+error[E0594]: cannot assign to `*x.0`, which is behind an `&` reference
   --> $DIR/issue-39544.rs:48:5
    |
 LL |     *x.0 = 1;

--- a/tests/ui/did_you_mean/issue-40823.rs
+++ b/tests/ui/did_you_mean/issue-40823.rs
@@ -1,4 +1,4 @@
 fn main() {
     let mut buf = &[1, 2, 3, 4];
-    buf.iter_mut(); //~ ERROR cannot borrow `*buf` as mutable, as it is behind a `&` reference
+    buf.iter_mut(); //~ ERROR cannot borrow `*buf` as mutable, as it is behind an `&` reference
 }

--- a/tests/ui/did_you_mean/issue-40823.stderr
+++ b/tests/ui/did_you_mean/issue-40823.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*buf` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*buf` as mutable, as it is behind an `&` reference
   --> $DIR/issue-40823.rs:3:5
    |
 LL |     buf.iter_mut();

--- a/tests/ui/did_you_mean/issue-40823.stderr
+++ b/tests/ui/did_you_mean/issue-40823.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*buf` as mutable, as it is behind a `&` reference
   --> $DIR/issue-40823.rs:3:5
    |
 LL |     buf.iter_mut();
-   |     ^^^ `buf` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `buf` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/did_you_mean/issue-40823.stderr
+++ b/tests/ui/did_you_mean/issue-40823.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*buf` as mutable, as it is behind a `&` reference
   --> $DIR/issue-40823.rs:3:5
    |
 LL |     buf.iter_mut();
-   |     ^^^ `buf` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `buf` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/error-codes/E0389.rs
+++ b/tests/ui/error-codes/E0389.rs
@@ -5,6 +5,6 @@ struct FancyNum {
 fn main() {
     let mut fancy = FancyNum{ num: 5 };
     let fancy_ref = &(&mut fancy);
-    fancy_ref.num = 6; //~ ERROR cannot assign to `fancy_ref.num`, which is behind a `&` reference
+    fancy_ref.num = 6; //~ ERROR cannot assign to `fancy_ref.num`, which is behind an `&` reference
     println!("{}", fancy_ref.num);
 }

--- a/tests/ui/error-codes/E0389.stderr
+++ b/tests/ui/error-codes/E0389.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/E0389.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/error-codes/E0389.stderr
+++ b/tests/ui/error-codes/E0389.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
+error[E0594]: cannot assign to `fancy_ref.num`, which is behind an `&` reference
   --> $DIR/E0389.rs:8:5
    |
 LL |     fancy_ref.num = 6;

--- a/tests/ui/error-codes/E0389.stderr
+++ b/tests/ui/error-codes/E0389.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/E0389.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/issues/issue-51515.rs
+++ b/tests/ui/issues/issue-51515.rs
@@ -2,9 +2,9 @@ fn main() {
     let foo = &16;
     //~^ HELP consider changing this to be a mutable reference
     *foo = 32;
-    //~^ ERROR cannot assign to `*foo`, which is behind a `&` reference
+    //~^ ERROR cannot assign to `*foo`, which is behind an `&` reference
     let bar = foo;
     //~^ HELP consider specifying this binding's type
     *bar = 64;
-    //~^ ERROR cannot assign to `*bar`, which is behind a `&` reference
+    //~^ ERROR cannot assign to `*bar`, which is behind an `&` reference
 }

--- a/tests/ui/issues/issue-51515.stderr
+++ b/tests/ui/issues/issue-51515.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
+error[E0594]: cannot assign to `*foo`, which is behind an `&` reference
   --> $DIR/issue-51515.rs:4:5
    |
 LL |     *foo = 32;
@@ -9,7 +9,7 @@ help: consider changing this to be a mutable reference
 LL |     let foo = &mut 16;
    |                +++
 
-error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
+error[E0594]: cannot assign to `*bar`, which is behind an `&` reference
   --> $DIR/issue-51515.rs:8:5
    |
 LL |     *bar = 64;

--- a/tests/ui/issues/issue-51515.stderr
+++ b/tests/ui/issues/issue-51515.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:4:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:8:5
    |
 LL |     *bar = 64;
-   |     ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `bar` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/issues/issue-51515.stderr
+++ b/tests/ui/issues/issue-51515.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:4:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:8:5
    |
 LL |     *bar = 64;
-   |     ^^^^^^^^^ `bar` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `bar` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider specifying this binding's type
    |

--- a/tests/ui/issues/issue-61623.rs
+++ b/tests/ui/issues/issue-61623.rs
@@ -4,7 +4,7 @@ fn f2<P>(_: P, _: ()) {}
 
 fn f3<'a>(x: &'a ((), &'a mut ())) {
     f2(|| x.0, f1(x.1))
-//~^ ERROR cannot borrow `*x.1` as mutable, as it is behind a `&` reference
+//~^ ERROR cannot borrow `*x.1` as mutable, as it is behind an `&` reference
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-61623.stderr
+++ b/tests/ui/issues/issue-61623.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*x.1` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x.1` as mutable, as it is behind an `&` reference
   --> $DIR/issue-61623.rs:6:19
    |
 LL |     f2(|| x.0, f1(x.1))

--- a/tests/ui/issues/issue-61623.stderr
+++ b/tests/ui/issues/issue-61623.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x.1` as mutable, as it is behind a `&` reference
   --> $DIR/issue-61623.rs:6:19
    |
 LL |     f2(|| x.0, f1(x.1))
-   |                   ^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/issues/issue-61623.stderr
+++ b/tests/ui/issues/issue-61623.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x.1` as mutable, as it is behind a `&` reference
   --> $DIR/issue-61623.rs:6:19
    |
 LL |     f2(|| x.0, f1(x.1))
-   |                   ^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |                   ^^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/let-else/let-else-binding-explicit-mut-borrow.rs
+++ b/tests/ui/let-else/let-else-binding-explicit-mut-borrow.rs
@@ -5,7 +5,7 @@
 
 fn main() {
     let Some(n): &mut Option<i32> = &mut &Some(5i32) else {
-        //~^ ERROR cannot borrow data in a `&` reference as mutable
+        //~^ ERROR cannot borrow data in an `&` reference as mutable
         return
     };
     *n += 1;

--- a/tests/ui/let-else/let-else-binding-explicit-mut-borrow.stderr
+++ b/tests/ui/let-else/let-else-binding-explicit-mut-borrow.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/let-else-binding-explicit-mut-borrow.rs:7:37
    |
 LL |     let Some(n): &mut Option<i32> = &mut &Some(5i32) else {

--- a/tests/ui/let-else/let-else-binding-explicit-mut.rs
+++ b/tests/ui/let-else/let-else-binding-explicit-mut.rs
@@ -7,14 +7,14 @@
 
 fn main() {
     let Some(n) = &&Some(5i32) else { return };
-    *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
+    *n += 1; //~ ERROR cannot assign to `*n`, which is behind an `&` reference
     let _ = n;
 
     let Some(n) = &mut &Some(5i32) else { return };
-    *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
+    *n += 1; //~ ERROR cannot assign to `*n`, which is behind an `&` reference
     let _ = n;
 
     let Some(n) = &&mut Some(5i32) else { return };
-    *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
+    *n += 1; //~ ERROR cannot assign to `*n`, which is behind an `&` reference
     let _ = n;
 }

--- a/tests/ui/let-else/let-else-binding-explicit-mut.stderr
+++ b/tests/ui/let-else/let-else-binding-explicit-mut.stderr
@@ -1,16 +1,16 @@
-error[E0594]: cannot assign to `*n`, which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind an `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:10:5
    |
 LL |     *n += 1;
    |     ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*n`, which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind an `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:14:5
    |
 LL |     *n += 1;
    |     ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*n`, which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind an `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:18:5
    |
 LL |     *n += 1;

--- a/tests/ui/let-else/let-else-binding-explicit-mut.stderr
+++ b/tests/ui/let-else/let-else-binding-explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:10:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:14:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:18:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/let-else/let-else-binding-explicit-mut.stderr
+++ b/tests/ui/let-else/let-else-binding-explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:10:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:14:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/let-else-binding-explicit-mut.rs:18:5
    |
 LL |     *n += 1;
-   |     ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/let-else/let-else-binding-immutable.rs
+++ b/tests/ui/let-else/let-else-binding-immutable.rs
@@ -6,5 +6,5 @@ pub fn main() {
     let Some(x) = &Some(3) else {
         panic!();
     };
-    *x += 1; //~ ERROR: cannot assign to `*x`, which is behind a `&` reference
+    *x += 1; //~ ERROR: cannot assign to `*x`, which is behind an `&` reference
 }

--- a/tests/ui/let-else/let-else-binding-immutable.stderr
+++ b/tests/ui/let-else/let-else-binding-immutable.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/let-else-binding-immutable.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/let-else/let-else-binding-immutable.stderr
+++ b/tests/ui/let-else/let-else-binding-immutable.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/let-else-binding-immutable.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/let-else/let-else-binding-immutable.stderr
+++ b/tests/ui/let-else/let-else-binding-immutable.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind an `&` reference
   --> $DIR/let-else-binding-immutable.rs:9:5
    |
 LL |     *x += 1;

--- a/tests/ui/macros/issue-19163.rs
+++ b/tests/ui/macros/issue-19163.rs
@@ -7,5 +7,5 @@ use std::io::Write;
 fn main() {
     let mut v = vec![];
     mywrite!(&v, "Hello world");
-    //~^ ERROR cannot borrow data in a `&` reference as mutable
+    //~^ ERROR cannot borrow data in an `&` reference as mutable
 }

--- a/tests/ui/macros/issue-19163.stderr
+++ b/tests/ui/macros/issue-19163.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/issue-19163.rs:9:14
    |
 LL |     mywrite!(&v, "Hello world");

--- a/tests/ui/mut/mutable-class-fields-2.stderr
+++ b/tests/ui/mut/mutable-class-fields-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.how_hungry`, which is behind a `&` referenc
   --> $DIR/mutable-class-fields-2.rs:9:5
    |
 LL |     self.how_hungry -= 5;
-   |     ^^^^^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/mut/mutable-class-fields-2.stderr
+++ b/tests/ui/mut/mutable-class-fields-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.how_hungry`, which is behind a `&` referenc
   --> $DIR/mutable-class-fields-2.rs:9:5
    |
 LL |     self.how_hungry -= 5;
-   |     ^^^^^^^^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/mut/mutable-class-fields-2.stderr
+++ b/tests/ui/mut/mutable-class-fields-2.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.how_hungry`, which is behind a `&` reference
+error[E0594]: cannot assign to `self.how_hungry`, which is behind an `&` reference
   --> $DIR/mutable-class-fields-2.rs:9:5
    |
 LL |     self.how_hungry -= 5;

--- a/tests/ui/nll/dont-print-desugared.rs
+++ b/tests/ui/nll/dont-print-desugared.rs
@@ -2,7 +2,7 @@
 
 fn for_loop(s: &[i32]) {
     for &ref mut x in s {}
-    //~^ ERROR cannot borrow data in a `&` reference as mutable [E0596]
+    //~^ ERROR cannot borrow data in an `&` reference as mutable [E0596]
 }
 
 struct D<'a>(&'a ());

--- a/tests/ui/nll/dont-print-desugared.stderr
+++ b/tests/ui/nll/dont-print-desugared.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/dont-print-desugared.rs:4:10
    |
 LL |     for &ref mut x in s {}

--- a/tests/ui/nll/issue-47388.stderr
+++ b/tests/ui/nll/issue-47388.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
+error[E0594]: cannot assign to `fancy_ref.num`, which is behind an `&` reference
   --> $DIR/issue-47388.rs:8:5
    |
 LL |     fancy_ref.num = 6;

--- a/tests/ui/nll/issue-47388.stderr
+++ b/tests/ui/nll/issue-47388.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/issue-47388.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-47388.stderr
+++ b/tests/ui/nll/issue-47388.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/issue-47388.rs:8:5
    |
 LL |     fancy_ref.num = 6;
-   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^^ `fancy_ref` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-51191.rs
+++ b/tests/ui/nll/issue-51191.rs
@@ -21,7 +21,7 @@ impl Struct {
     fn immref(&self) {
         (&mut self).bar();
         //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
-        //~^^ ERROR cannot borrow data in a `&` reference as mutable [E0596]
+        //~^^ ERROR cannot borrow data in an `&` reference as mutable [E0596]
     }
 
     fn mtblref(&mut self) {

--- a/tests/ui/nll/issue-51191.stderr
+++ b/tests/ui/nll/issue-51191.stderr
@@ -44,7 +44,7 @@ error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
 
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/issue-51191.rs:22:9
    |
 LL |         (&mut self).bar();

--- a/tests/ui/nll/issue-51244.rs
+++ b/tests/ui/nll/issue-51244.rs
@@ -1,5 +1,5 @@
 fn main() {
     let ref my_ref @ _ = 0;
     *my_ref = 0;
-    //~^ ERROR cannot assign to `*my_ref`, which is behind a `&` reference [E0594]
+    //~^ ERROR cannot assign to `*my_ref`, which is behind an `&` reference [E0594]
 }

--- a/tests/ui/nll/issue-51244.stderr
+++ b/tests/ui/nll/issue-51244.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
+error[E0594]: cannot assign to `*my_ref`, which is behind an `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     *my_ref = 0;

--- a/tests/ui/nll/issue-51244.stderr
+++ b/tests/ui/nll/issue-51244.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     *my_ref = 0;
-   |     ^^^^^^^^^^^ `my_ref` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^ `my_ref` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-51244.stderr
+++ b/tests/ui/nll/issue-51244.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     *my_ref = 0;
-   |     ^^^^^^^^^^^ `my_ref` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^ `my_ref` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-57989.rs
+++ b/tests/ui/nll/issue-57989.rs
@@ -2,7 +2,7 @@
 
 fn f(x: &i32) {
     let g = &x;
-    *x = 0;     //~ ERROR cannot assign to `*x`, which is behind a `&` reference
+    *x = 0;     //~ ERROR cannot assign to `*x`, which is behind an `&` reference
                 //~| ERROR cannot assign to `*x` because it is borrowed
     g;
 }

--- a/tests/ui/nll/issue-57989.stderr
+++ b/tests/ui/nll/issue-57989.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-57989.rs:5:5
    |
 LL |     *x = 0;
-   |     ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-57989.stderr
+++ b/tests/ui/nll/issue-57989.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-57989.rs:5:5
    |
 LL |     *x = 0;
-   |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/nll/issue-57989.stderr
+++ b/tests/ui/nll/issue-57989.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind an `&` reference
   --> $DIR/issue-57989.rs:5:5
    |
 LL |     *x = 0;

--- a/tests/ui/pattern/issue-52240.rs
+++ b/tests/ui/pattern/issue-52240.rs
@@ -7,7 +7,7 @@ enum Foo {
 fn main() {
     let arr = vec!(Foo::Bar(0));
     if let (Some(Foo::Bar(ref mut val)), _) = (&arr.get(0), 0) {
-        //~^ ERROR cannot borrow data in a `&` reference as mutable
+        //~^ ERROR cannot borrow data in an `&` reference as mutable
         *val = 9001;
     }
     match arr[0] {

--- a/tests/ui/pattern/issue-52240.stderr
+++ b/tests/ui/pattern/issue-52240.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow data in a `&` reference as mutable
+error[E0596]: cannot borrow data in an `&` reference as mutable
   --> $DIR/issue-52240.rs:9:27
    |
 LL |     if let (Some(Foo::Bar(ref mut val)), _) = (&arr.get(0), 0) {

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.rs
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.rs
@@ -23,8 +23,8 @@ fn tuple() {
     _x1 = U; //~ ERROR cannot assign twice to immutable variable
     let _x0_hold = &mut tup.0; //~ ERROR cannot borrow `tup.0` as mutable because it is also
     let (ref mut _x0_hold, ..) = tup; //~ ERROR cannot borrow `tup.0` as mutable because it is also
-    *_x0 = U; //~ ERROR cannot assign to `*_x0`, which is behind a `&` reference
-    *_x2 = U; //~ ERROR cannot assign to `*_x2`, which is behind a `&` reference
+    *_x0 = U; //~ ERROR cannot assign to `*_x0`, which is behind an `&` reference
+    *_x2 = U; //~ ERROR cannot assign to `*_x2`, which is behind an `&` reference
     drop(tup.1); //~ ERROR use of moved value: `tup.1`
     let _x1_hold = &tup.1; //~ ERROR borrow of moved value: `tup.1`
     let (.., ref mut _x3) = tup;

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -103,7 +103,7 @@ LL |     let (ref mut _x0_hold, ..) = tup;
 LL |     *_x0 = U;
    |     -------- immutable borrow later used here
 
-error[E0594]: cannot assign to `*_x0`, which is behind a `&` reference
+error[E0594]: cannot assign to `*_x0`, which is behind an `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:26:5
    |
 LL |     *_x0 = U;
@@ -114,7 +114,7 @@ help: consider changing this to be a mutable reference
 LL |     let (ref mut _x0, _x1, ref _x2, ..) = tup;
    |              +++
 
-error[E0594]: cannot assign to `*_x2`, which is behind a `&` reference
+error[E0594]: cannot assign to `*_x2`, which is behind an `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:27:5
    |
 LL |     *_x2 = U;

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -107,7 +107,7 @@ error[E0594]: cannot assign to `*_x0`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:26:5
    |
 LL |     *_x0 = U;
-   |     ^^^^^^^^ `_x0` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x0` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -118,7 +118,7 @@ error[E0594]: cannot assign to `*_x2`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:27:5
    |
 LL |     *_x2 = U;
-   |     ^^^^^^^^ `_x2` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x2` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -107,7 +107,7 @@ error[E0594]: cannot assign to `*_x0`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:26:5
    |
 LL |     *_x0 = U;
-   |     ^^^^^^^^ `_x0` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x0` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -118,7 +118,7 @@ error[E0594]: cannot assign to `*_x2`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:27:5
    |
 LL |     *_x2 = U;
-   |     ^^^^^^^^ `_x2` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^ `_x2` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/regions/regions-lub-ref-ref-rc.rs
+++ b/tests/ui/regions/regions-lub-ref-ref-rc.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 // Test a corner case of LUB coercion. In this case, one arm of the
 // match requires a deref coercion and the other doesn't, and there
-// is an extra `&` on the `rc`. We want to be sure that the lifetime
+// is an extran `&` reference on the `rc`. We want to be sure that the lifetime
 // assigned to this `&rc` value is not `'a` but something smaller.  In
 // other words, the type from `rc` is `&'a Rc<String>` and the type
 // from `&rc` should be `&'x &'a Rc<String>`, where `'x` is something

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.rs
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.rs
@@ -6,17 +6,17 @@ use Wrapper::Wrap;
 
 pub fn main() {
     let Wrap(x) = &Wrap(3);
-    *x += 1; //~ ERROR cannot assign to `*x`, which is behind a `&` reference
+    *x += 1; //~ ERROR cannot assign to `*x`, which is behind an `&` reference
 
 
     if let Some(x) = &Some(3) {
-        *x += 1; //~ ERROR cannot assign to `*x`, which is behind a `&` reference
+        *x += 1; //~ ERROR cannot assign to `*x`, which is behind an `&` reference
     } else {
         panic!();
     }
 
     while let Some(x) = &Some(3) {
-        *x += 1; //~ ERROR cannot assign to `*x`, which is behind a `&` reference
+        *x += 1; //~ ERROR cannot assign to `*x`, which is behind an `&` reference
         break;
     }
 }

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:13:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:19:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:9:5
    |
 LL |     *x += 1;
-   |     ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:13:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:19:9
    |
 LL |         *x += 1;
-   |         ^^^^^^^ `x` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/enum.stderr
@@ -1,16 +1,16 @@
-error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind an `&` reference
   --> $DIR/enum.rs:9:5
    |
 LL |     *x += 1;
    |     ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind an `&` reference
   --> $DIR/enum.rs:13:9
    |
 LL |         *x += 1;
    |         ^^^^^^^ `x` is an `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind an `&` reference
   --> $DIR/enum.rs:19:9
    |
 LL |         *x += 1;

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.rs
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.rs
@@ -4,7 +4,7 @@
 fn main() {
     match &&Some(5i32) {
         Some(n) => {
-            *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
+            *n += 1; //~ ERROR cannot assign to `*n`, which is behind an `&` reference
             let _ = n;
         }
         None => {},
@@ -12,7 +12,7 @@ fn main() {
 
     match &mut &Some(5i32) {
         Some(n) => {
-            *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
+            *n += 1; //~ ERROR cannot assign to `*n`, which is behind an `&` reference
             let _ = n;
         }
         None => {},
@@ -20,7 +20,7 @@ fn main() {
 
     match &&mut Some(5i32) {
         Some(n) => {
-            *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
+            *n += 1; //~ ERROR cannot assign to `*n`, which is behind an `&` reference
             let _ = n;
         }
         None => {},

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -1,16 +1,16 @@
-error[E0594]: cannot assign to `*n`, which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind an `&` reference
   --> $DIR/explicit-mut.rs:7:13
    |
 LL |             *n += 1;
    |             ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*n`, which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind an `&` reference
   --> $DIR/explicit-mut.rs:15:13
    |
 LL |             *n += 1;
    |             ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*n`, which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind an `&` reference
   --> $DIR/explicit-mut.rs:23:13
    |
 LL |             *n += 1;

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:7:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:15:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:23:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -2,19 +2,19 @@ error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:7:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:15:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:23:13
    |
 LL |             *n += 1;
-   |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^ `n` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/reset-mode.rs
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/reset-mode.rs
@@ -1,5 +1,5 @@
 // run-pass
-// Test that we "reset" the mode as we pass through a `&` pattern.
+// Test that we "reset" the mode as we pass through an `&` reference pattern.
 //
 // cc #46688
 

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:65:10
    |
 LL |     &mut x.y
-   |          ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |          ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -45,7 +45,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:92:5
    |
 LL |     x.y = 3;
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -77,7 +77,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:121:5
    |
 LL |     x.y_mut()
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -99,7 +99,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:133:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:65:10
    |
 LL |     &mut x.y
-   |          ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |          ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -45,7 +45,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:92:5
    |
 LL |     x.y = 3;
-   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -77,7 +77,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:121:5
    |
 LL |     x.y_mut()
-   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -99,7 +99,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:133:6
    |
 LL |     *x.y_mut() = 3;
-   |      ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |      ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -9,7 +9,7 @@ help: consider changing this to be mutable
 LL | fn deref_mut_field1(mut x: Own<Point>) {
    |                     +++
 
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:65:10
    |
 LL |     &mut x.y
@@ -41,7 +41,7 @@ help: consider changing this to be mutable
 LL | fn assign_field1<'a>(mut x: Own<Point>) {
    |                      +++
 
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:92:5
    |
 LL |     x.y = 3;
@@ -73,7 +73,7 @@ help: consider changing this to be mutable
 LL | fn deref_mut_method1(mut x: Own<Point>) {
    |                      +++
 
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:121:5
    |
 LL |     x.y_mut()
@@ -95,7 +95,7 @@ help: consider changing this to be mutable
 LL | fn assign_method1<'a>(mut x: Own<Point>) {
    |                       +++
 
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:133:6
    |
 LL |     *x.y_mut() = 3;

--- a/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -9,7 +9,7 @@ help: consider changing this to be mutable
 LL | fn deref_mut1(mut x: Own<isize>) {
    |               +++
 
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:41:11
    |
 LL |     &mut **x
@@ -31,7 +31,7 @@ help: consider changing this to be mutable
 LL | fn assign1<'a>(mut x: Own<isize>) {
    |                +++
 
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:53:6
    |
 LL |     **x = 3;

--- a/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:41:11
    |
 LL |     &mut **x
-   |           ^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |           ^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:53:6
    |
 LL |     **x = 3;
-   |      ^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:41:11
    |
 LL |     &mut **x
-   |           ^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |           ^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:53:6
    |
 LL |     **x = 3;
-   |      ^^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.rs
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.rs
@@ -23,7 +23,7 @@ fn test1() {
 
 fn test2<F>(f: &F) where F: FnMut() {
     (*f)();
-    //~^ ERROR cannot borrow `*f` as mutable, as it is behind a `&` reference
+    //~^ ERROR cannot borrow `*f` as mutable, as it is behind an `&` reference
 }
 
 fn test3<F>(f: &mut F) where F: FnMut() {
@@ -32,7 +32,7 @@ fn test3<F>(f: &mut F) where F: FnMut() {
 
 fn test4(f: &Test) {
     f.f.call_mut(())
-    //~^ ERROR: cannot borrow `f.f` as mutable, as it is behind a `&` reference
+    //~^ ERROR: cannot borrow `f.f` as mutable, as it is behind an `&` reference
 }
 
 fn test5(f: &mut Test) {

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -10,7 +10,7 @@ LL |
 LL |         f((Box::new(|| {})))
    |         - second borrow occurs due to use of `f` in closure
 
-error[E0596]: cannot borrow `*f` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*f` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:25:5
    |
 LL |     (*f)();
@@ -21,7 +21,7 @@ help: consider changing this to be a mutable reference
 LL | fn test2<F>(f: &mut F) where F: FnMut() {
    |                 +++
 
-error[E0596]: cannot borrow `f.f` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `f.f` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:34:5
    |
 LL |     f.f.call_mut(())

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:25:5
    |
 LL |     (*f)();
-   |     ^^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `f` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -25,7 +25,7 @@ error[E0596]: cannot borrow `f.f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:34:5
    |
 LL |     f.f.call_mut(())
-   |     ^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -14,7 +14,7 @@ error[E0596]: cannot borrow `*f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:25:5
    |
 LL |     (*f)();
-   |     ^^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -25,7 +25,7 @@ error[E0596]: cannot borrow `f.f` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:34:5
    |
 LL |     f.f.call_mut(())
-   |     ^^^ `f` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^^ `f` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
+++ b/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-call-method-from-mut-aliasable.rs:17:5
    |
 LL |     x.h();

--- a/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
+++ b/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-method-from-mut-aliasable.rs:17:5
    |
 LL |     x.h();
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
+++ b/tests/ui/span/borrowck-call-method-from-mut-aliasable.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-call-method-from-mut-aliasable.rs:17:5
    |
 LL |     x.h();
-   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-fn-in-const-b.stderr
+++ b/tests/ui/span/borrowck-fn-in-const-b.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-fn-in-const-b.rs:7:9
    |
 LL |         x.push(format!("this is broken"));
-   |         ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-fn-in-const-b.stderr
+++ b/tests/ui/span/borrowck-fn-in-const-b.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-fn-in-const-b.rs:7:9
    |
 LL |         x.push(format!("this is broken"));

--- a/tests/ui/span/borrowck-fn-in-const-b.stderr
+++ b/tests/ui/span/borrowck-fn-in-const-b.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-fn-in-const-b.rs:7:9
    |
 LL |         x.push(format!("this is broken"));
-   |         ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-object-mutability.stderr
+++ b/tests/ui/span/borrowck-object-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-object-mutability.rs:8:5
    |
 LL |     x.borrowed_mut();
-   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/borrowck-object-mutability.stderr
+++ b/tests/ui/span/borrowck-object-mutability.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*x` as mutable, as it is behind an `&` reference
   --> $DIR/borrowck-object-mutability.rs:8:5
    |
 LL |     x.borrowed_mut();

--- a/tests/ui/span/borrowck-object-mutability.stderr
+++ b/tests/ui/span/borrowck-object-mutability.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
   --> $DIR/borrowck-object-mutability.rs:8:5
    |
 LL |     x.borrowed_mut();
-   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `x` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/mut-arg-hint.rs
+++ b/tests/ui/span/mut-arg-hint.rs
@@ -1,18 +1,18 @@
 trait B {
     fn foo(mut a: &String) {
-        a.push_str("bar"); //~ ERROR cannot borrow `*a` as mutable, as it is behind a `&` reference
+        a.push_str("bar"); //~ ERROR cannot borrow `*a` as mutable, as it is behind an `&` reference
     }
 }
 
 pub fn foo<'a>(mut a: &'a String) {
-    a.push_str("foo"); //~ ERROR cannot borrow `*a` as mutable, as it is behind a `&` reference
+    a.push_str("foo"); //~ ERROR cannot borrow `*a` as mutable, as it is behind an `&` reference
 }
 
 struct A {}
 
 impl A {
     pub fn foo(mut a: &String) {
-        a.push_str("foo"); //~ ERROR cannot borrow `*a` as mutable, as it is behind a `&` reference
+        a.push_str("foo"); //~ ERROR cannot borrow `*a` as mutable, as it is behind an `&` reference
     }
 }
 

--- a/tests/ui/span/mut-arg-hint.stderr
+++ b/tests/ui/span/mut-arg-hint.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:3:9
    |
 LL |         a.push_str("bar");
-   |         ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:8:5
    |
 LL |     a.push_str("foo");
-   |     ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `a` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:15:9
    |
 LL |         a.push_str("foo");
-   |         ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/mut-arg-hint.stderr
+++ b/tests/ui/span/mut-arg-hint.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:3:9
    |
 LL |         a.push_str("bar");
-   |         ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:8:5
    |
 LL |     a.push_str("foo");
-   |     ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/mut-arg-hint.rs:15:9
    |
 LL |         a.push_str("foo");
-   |         ^ `a` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |         ^ `a` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/span/mut-arg-hint.stderr
+++ b/tests/ui/span/mut-arg-hint.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*a` as mutable, as it is behind an `&` reference
   --> $DIR/mut-arg-hint.rs:3:9
    |
 LL |         a.push_str("bar");
@@ -9,7 +9,7 @@ help: consider changing this to be a mutable reference
 LL |     fn foo(mut a: &mut String) {
    |                    +++
 
-error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*a` as mutable, as it is behind an `&` reference
   --> $DIR/mut-arg-hint.rs:8:5
    |
 LL |     a.push_str("foo");
@@ -20,7 +20,7 @@ help: consider changing this to be a mutable reference
 LL | pub fn foo<'a>(mut a: &'a mut String) {
    |                           +++
 
-error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `*a` as mutable, as it is behind an `&` reference
   --> $DIR/mut-arg-hint.rs:15:9
    |
 LL |         a.push_str("foo");

--- a/tests/ui/suggestions/issue-68049-1.stderr
+++ b/tests/ui/suggestions/issue-68049-1.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-1.rs:7:9
    |
 LL |         self.0 += 1;
-   |         ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/issue-68049-1.stderr
+++ b/tests/ui/suggestions/issue-68049-1.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
+error[E0594]: cannot assign to `self.0`, which is behind an `&` reference
   --> $DIR/issue-68049-1.rs:7:9
    |
 LL |         self.0 += 1;

--- a/tests/ui/suggestions/issue-68049-1.stderr
+++ b/tests/ui/suggestions/issue-68049-1.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-1.rs:7:9
    |
 LL |         self.0 += 1;
-   |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*input`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:9:7
    |
 LL |       *input = self.0;
-   |       ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
+   |       ^^^^^^^^^^^^^^^ `input` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:17:5
    |
 LL |     self.0 += *input;
-   |     ^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*input`, which is behind a `&` reference
+error[E0594]: cannot assign to `*input`, which is behind an `&` reference
   --> $DIR/issue-68049-2.rs:9:7
    |
 LL |       *input = self.0;
@@ -9,7 +9,7 @@ help: consider changing this to be a mutable reference
 LL |   fn example(&self, input: &mut i32) { // should not suggest here
    |                             +++
 
-error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
+error[E0594]: cannot assign to `self.0`, which is behind an `&` reference
   --> $DIR/issue-68049-2.rs:17:5
    |
 LL |     self.0 += *input;

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `*input`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:9:7
    |
 LL |       *input = self.0;
-   |       ^^^^^^^^^^^^^^^ `input` is an `&' reference, so the data it refers to cannot be written
+   |       ^^^^^^^^^^^^^^^ `input` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:17:5
    |
 LL |     self.0 += *input;
-   |     ^^^^^^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
@@ -8,7 +8,7 @@ LL |         for mut t in buzz.values() {
    |                      this iterator yields `&` references
 ...
 LL |             t.v += 1;
-   |             ^^^^^^^^ `t` is an `&' reference, so the data it refers to cannot be written
+   |             ^^^^^^^^ `t` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
@@ -8,7 +8,7 @@ LL |         for mut t in buzz.values() {
    |                      this iterator yields `&` references
 ...
 LL |             t.v += 1;
-   |             ^^^^^^^^ `t` is a `&` reference, so the data it refers to cannot be written
+   |             ^^^^^^^^ `t` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `t.v`, which is behind a `&` reference
+error[E0594]: cannot assign to `t.v`, which is behind an `&` reference
   --> $DIR/suggest-mut-method-for-loop-closure.rs:15:13
    |
 LL |         for mut t in buzz.values() {

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
@@ -16,6 +16,6 @@ fn main() {
         //~| NOTE this iterator yields `&` references
         v.v += 1;
         //~^ ERROR cannot assign to `v.v`
-        //~| NOTE `v` is an `&' reference
+        //~| NOTE `v` is an `&` reference
     }
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
@@ -16,6 +16,6 @@ fn main() {
         //~| NOTE this iterator yields `&` references
         v.v += 1;
         //~^ ERROR cannot assign to `v.v`
-        //~| NOTE `v` is a `&` reference
+        //~| NOTE `v` is an `&' reference
     }
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
@@ -16,6 +16,6 @@ fn main() {
         //~| NOTE this iterator yields `&` references
         v.v += 1;
         //~^ ERROR cannot assign to `v.v`
-        //~| NOTE `v` is an `&' reference
+        //~| NOTE `v` is an `&` reference
     }
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
@@ -16,6 +16,6 @@ fn main() {
         //~| NOTE this iterator yields `&` references
         v.v += 1;
         //~^ ERROR cannot assign to `v.v`
-        //~| NOTE `v` is a `&` reference
+        //~| NOTE `v` is an `&' reference
     }
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -8,7 +8,7 @@ LL |     for (_k, v) in map.iter() {
    |                    this iterator yields `&` references
 ...
 LL |         v.v += 1;
-   |         ^^^^^^^^ `v` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `v` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `v.v`, which is behind a `&` reference
+error[E0594]: cannot assign to `v.v`, which is behind an `&` reference
   --> $DIR/suggest-mut-method-for-loop-hashmap.rs:17:9
    |
 LL |     for (_k, v) in map.iter() {

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -8,7 +8,7 @@ LL |     for (_k, v) in map.iter() {
    |                    this iterator yields `&` references
 ...
 LL |         v.v += 1;
-   |         ^^^^^^^^ `v` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `v` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `t.v`, which is behind a `&` reference
+error[E0594]: cannot assign to `t.v`, which is behind an `&` reference
   --> $DIR/suggest-mut-method-for-loop.rs:14:9
    |
 LL |     for mut t in buzz.values() {

--- a/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
@@ -8,7 +8,7 @@ LL |     for mut t in buzz.values() {
    |                  this iterator yields `&` references
 ...
 LL |         t.v += 1;
-   |         ^^^^^^^^ `t` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `t` is an `&` reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
@@ -8,7 +8,7 @@ LL |     for mut t in buzz.values() {
    |                  this iterator yields `&` references
 ...
 LL |         t.v += 1;
-   |         ^^^^^^^^ `t` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^ `t` is an `&' reference, so the data it refers to cannot be written
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/suggest-ref-mut.stderr
+++ b/tests/ui/suggestions/suggest-ref-mut.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
+error[E0594]: cannot assign to `self.0`, which is behind an `&` reference
   --> $DIR/suggest-ref-mut.rs:7:9
    |
 LL |         self.0 = 32;
@@ -9,7 +9,7 @@ help: consider changing this to be a mutable reference
 LL |     fn zap(&mut self) {
    |            ~~~~~~~~~
 
-error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
+error[E0594]: cannot assign to `*foo`, which is behind an `&` reference
   --> $DIR/suggest-ref-mut.rs:15:5
    |
 LL |     *foo = 32;
@@ -20,7 +20,7 @@ help: consider changing this to be a mutable reference
 LL |     let ref mut foo = 16;
    |             +++
 
-error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
+error[E0594]: cannot assign to `*bar`, which is behind an `&` reference
   --> $DIR/suggest-ref-mut.rs:19:9
    |
 LL |         *bar = 32;
@@ -31,7 +31,7 @@ help: consider changing this to be a mutable reference
 LL |     if let Some(ref mut bar) = Some(16) {
    |                     +++
 
-error[E0594]: cannot assign to `*quo`, which is behind a `&` reference
+error[E0594]: cannot assign to `*quo`, which is behind an `&` reference
   --> $DIR/suggest-ref-mut.rs:23:22
    |
 LL |         ref quo => { *quo = 32; },

--- a/tests/ui/suggestions/suggest-ref-mut.stderr
+++ b/tests/ui/suggestions/suggest-ref-mut.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:7:9
    |
 LL |         self.0 = 32;
-   |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:15:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:19:9
    |
 LL |         *bar = 32;
-   |         ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^ `bar` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*quo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:23:22
    |
 LL |         ref quo => { *quo = 32; },
-   |                      ^^^^^^^^^ `quo` is a `&` reference, so the data it refers to cannot be written
+   |                      ^^^^^^^^^ `quo` is an `&' reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/suggestions/suggest-ref-mut.stderr
+++ b/tests/ui/suggestions/suggest-ref-mut.stderr
@@ -2,7 +2,7 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:7:9
    |
 LL |         self.0 = 32;
-   |         ^^^^^^^^^^^ `self` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^^^ `self` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:15:5
    |
 LL |     *foo = 32;
-   |     ^^^^^^^^^ `foo` is an `&' reference, so the data it refers to cannot be written
+   |     ^^^^^^^^^ `foo` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -24,7 +24,7 @@ error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:19:9
    |
 LL |         *bar = 32;
-   |         ^^^^^^^^^ `bar` is an `&' reference, so the data it refers to cannot be written
+   |         ^^^^^^^^^ `bar` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |
@@ -35,7 +35,7 @@ error[E0594]: cannot assign to `*quo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:23:22
    |
 LL |         ref quo => { *quo = 32; },
-   |                      ^^^^^^^^^ `quo` is an `&' reference, so the data it refers to cannot be written
+   |                      ^^^^^^^^^ `quo` is an `&` reference, so the data it refers to cannot be written
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:6:5
    |
 LL |     *t
-   |     ^^ `t` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^ `t` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:10:6
    |
 LL |     {*t}
-   |      ^^ `t` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `t` is an `&' reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `**t` as mutable, as it is behind an `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:6:5
    |
 LL |     *t
@@ -9,7 +9,7 @@ help: consider changing this to be a mutable reference
 LL | fn reborrow_mut<'a>(t: &'a mut &'a mut i32) -> &'a mut i32 where &'a mut i32: Copy {
    |                            +++
 
-error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
+error[E0596]: cannot borrow `**t` as mutable, as it is behind an `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:10:6
    |
 LL |     {*t}

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent-copy-reborrow.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:6:5
    |
 LL |     *t
-   |     ^^ `t` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |     ^^ `t` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |
@@ -13,7 +13,7 @@ error[E0596]: cannot borrow `**t` as mutable, as it is behind a `&` reference
   --> $DIR/trivial-bounds-inconsistent-copy-reborrow.rs:10:6
    |
 LL |     {*t}
-   |      ^^ `t` is an `&' reference, so the data it refers to cannot be borrowed as mutable
+   |      ^^ `t` is an `&` reference, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable reference
    |


### PR DESCRIPTION
Hello,

I hope you're doing well. I've created this pull request to address a grammatical correctness issue. In the changes I've made, I replaced occurrences of "is a & reference" with "is an & reference" to align with proper English grammar.

The modification enhances the readability and grammatical accuracy of the code, ensuring that it adheres to established language conventions. This change is consistent with widely-accepted grammatical rules that dictate the use of "an" before words that begin with a vowel sound.

I believe these changes will improve the quality of the codebase and maintain a high standard of linguistic correctness. I kindly request your review and approval of this pull request. If you have any feedback or suggestions for further improvements, please feel free to share them.

Thank you for considering this contribution, and I look forward to your feedback.

Best regards,

Aaqid Masoodi
@aaqidmasoodi