### PR TITLE
Remove "consider specifying this binding's type" when reference differs in mutability

### DIFF
--- a/tests/ui/issue-113767.rs
+++ b/tests/ui/issue-113767.rs
@@ -1,0 +1,8 @@
+fn get() -> &'static Vec<i32> {
+    todo!()
+}
+
+fn main() {
+    let x = get();
+    x.push(1); //~ ERROR cannot borrow `*x` as mutable, as it is behind a `&` reference [E0596]
+}

--- a/tests/ui/issue-113767.stderr
+++ b/tests/ui/issue-113767.stderr
@@ -1,0 +1,9 @@
+error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+  --> $DIR/issue-113767.rs:7:5
+   |
+LL |     x.push(1);
+   |     ^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
This is a draft PR for #113767. It introduces a new test case and a mitigation which seems to work. I am submitting this now to get feedback before refining it further. I am pretty sure I am not covering all cases yet and I need to cleanup the rather insane destructuring haha.

The idea is to check for cases where the original value of a binding is immutable and then avoid suggesting that the type be specified in those cases. As that would not help.

To do this we first find the initial expression's kind HIR ID from the information in [`local.init.kind`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/struct.Local.html), then use a map of HIR IDs to find a `Node`. Finally we determine it's mutability by destructing the `Node` to find it's type information.

I have a few questions:

1. Does this approach seem reasonable to you?
2. There are a lot of cases to cover here, should this be moved to a separate function/utility for determining binding mutability? or is there already something that does this perhaps?

This change causes three existing tests to fail `tests/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs`, `tests/ui/issues/issue-51515.rs` and  `tests/ui/process/nofile-limit.rs`, As far as I can tell the code is working correctly and the test needs to be updated.

We might be able to provide a better suggestion instead of just removing the existing one. Like "consider changing the mutability of the function/value used to initaliase your variable". Formulated more elegantly :sweat_smile: 