### PR TITLE
diagnostics: add test case for trait bounds diagnostic

### DIFF
--- a/tests/ui/trait-bounds/issue-82038.rs
+++ b/tests/ui/trait-bounds/issue-82038.rs
@@ -1,0 +1,9 @@
+// Failed bound `bool: Foo` must not point at the `Self: Clone` line
+
+trait Foo {
+    fn my_method() where Self: Clone;
+}
+
+fn main() {
+    <bool as Foo>::my_method(); //~ERROR [E0277]
+}

--- a/tests/ui/trait-bounds/issue-82038.stderr
+++ b/tests/ui/trait-bounds/issue-82038.stderr
@@ -1,0 +1,9 @@
+error[E0277]: the trait bound `bool: Foo` is not satisfied
+  --> $DIR/issue-82038.rs:8:6
+   |
+LL |     <bool as Foo>::my_method();
+   |      ^^^^ the trait `Foo` is not implemented for `bool`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Closes #82038

It was fixed by https://github.com/rust-lang/rust/pull/89580, a wide-reaching obligation tracking improvement. This commit adds a test case.