### PR TITLE
Add buffering to stdout

### DIFF
--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -529,6 +529,18 @@ impl StdoutWriter {
             StdoutWriter::BufWriter(BufWriter::new(stdout))
         }
     }
+
+    #[allow(dead_code)]
+    /// Creates a new `StdoutWriter` with at least the specified capacity for the internal buffer.
+    ///
+    /// Will check if the output is a terminal and use the appropriate writer.
+    fn with_capacity(capacity: usize, stdout: StdoutRaw) -> StdoutWriter {
+        if stdout.0.is_terminal() {
+            StdoutWriter::LineWriter(LineWriter::with_capacity(capacity, stdout))
+        } else {
+            StdoutWriter::BufWriter(BufWriter::with_capacity(capacity, stdout))
+        }
+    }
 }
 
 impl Write for StdoutWriter {

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -609,8 +609,6 @@ impl Write for StdoutWriter {
 /// [`io::stdout`]: stdout
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Stdout {
-    // FIXME: if this is not line buffered it should also flush-on-panic or some form of
-    //        flush-on-abort.
     inner: &'static ReentrantMutex<RefCell<StdoutWriter>>,
 }
 

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -8,7 +8,9 @@ use crate::io::prelude::*;
 use crate::cell::{Cell, RefCell};
 use crate::fmt;
 use crate::fs::File;
-use crate::io::{self, BorrowedCursor, BufReader, BufWriter, IoSlice, IoSliceMut, LineWriter, Lines};
+use crate::io::{
+    self, BorrowedCursor, BufReader, BufWriter, IoSlice, IoSliceMut, LineWriter, Lines,
+};
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sync::{Arc, Mutex, MutexGuard, OnceLock, ReentrantMutex, ReentrantMutexGuard};
 use crate::sys::stdio;
@@ -1155,7 +1157,18 @@ macro_rules! impl_is_terminal {
     )*}
 }
 
-impl_is_terminal!(File, Stdin, StdinLock<'_>, Stdout, StdoutLock<'_>, Stderr, StderrLock<'_>, stdio::Stdin, stdio::Stdout, stdio::Stderr);
+impl_is_terminal!(
+    File,
+    Stdin,
+    StdinLock<'_>,
+    Stdout,
+    StdoutLock<'_>,
+    Stderr,
+    StderrLock<'_>,
+    stdio::Stdin,
+    stdio::Stdout,
+    stdio::Stderr
+);
 
 #[unstable(
     feature = "print_internals",

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1082,7 +1082,7 @@ macro_rules! impl_is_terminal {
     )*}
 }
 
-impl_is_terminal!(File, Stdin, StdinLock<'_>, Stdout, StdoutLock<'_>, Stderr, StderrLock<'_>);
+impl_is_terminal!(File, Stdin, StdinLock<'_>, Stdout, StdoutLock<'_>, Stderr, StderrLock<'_>, stdio::Stdin, stdio::Stdout, stdio::Stderr);
 
 #[unstable(
     feature = "print_internals",

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -11,6 +11,7 @@ use crate::marker::PhantomData;
 use crate::mem::forget;
 #[cfg(not(any(target_arch = "wasm32", target_env = "sgx", target_os = "hermit")))]
 use crate::sys::cvt;
+use crate::sys::stdio;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 
 /// A borrowed file descriptor.
@@ -433,6 +434,15 @@ impl<'a> AsFd for io::StdinLock<'a> {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
+impl AsFd for stdio::Stdin {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        // SAFETY: user code should not close stdin out from under the standard library
+        unsafe { BorrowedFd::borrow_raw(0) }
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
 impl AsFd for io::Stdout {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -450,6 +460,15 @@ impl<'a> AsFd for io::StdoutLock<'a> {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
+impl AsFd for stdio::Stdout {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        // SAFETY: user code should not close stdout out from under the standard library
+        unsafe { BorrowedFd::borrow_raw(1) }
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
 impl AsFd for io::Stderr {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -459,6 +478,15 @@ impl AsFd for io::Stderr {
 
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl<'a> AsFd for io::StderrLock<'a> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        // SAFETY: user code should not close stderr out from under the standard library
+        unsafe { BorrowedFd::borrow_raw(2) }
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
+impl AsFd for stdio::Stderr {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         // SAFETY: user code should not close stderr out from under the standard library

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -533,6 +533,14 @@ impl<'a> AsHandle for crate::io::StdinLock<'a> {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
+impl AsHandle for crate::sys::stdio::Stdin {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
 impl AsHandle for crate::io::Stdout {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
@@ -549,6 +557,14 @@ impl<'a> AsHandle for crate::io::StdoutLock<'a> {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
+impl AsHandle for crate::sys::stdio::Stdout {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
 impl AsHandle for crate::io::Stderr {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
@@ -558,6 +574,14 @@ impl AsHandle for crate::io::Stderr {
 
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl<'a> AsHandle for crate::io::StderrLock<'a> {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
+impl AsHandle for crate::sys::stdio::Stderr {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -121,6 +121,27 @@ impl AsRawHandle for io::Stderr {
     }
 }
 
+#[stable(feature = "asraw_stdio", since = "1.21.0")]
+impl AsRawHandle for sys::stdio::Stdin {
+    fn as_raw_handle(&self) -> RawHandle {
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_INPUT_HANDLE) as RawHandle })
+    }
+}
+
+#[stable(feature = "asraw_stdio", since = "1.21.0")]
+impl AsRawHandle for sys::stdio::Stdout {
+    fn as_raw_handle(&self) -> RawHandle {
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_OUTPUT_HANDLE) as RawHandle })
+    }
+}
+
+#[stable(feature = "asraw_stdio", since = "1.21.0")]
+impl AsRawHandle for sys::stdio::Stderr {
+    fn as_raw_handle(&self) -> RawHandle {
+        stdio_handle(unsafe { sys::c::GetStdHandle(sys::c::STD_ERROR_HANDLE) as RawHandle })
+    }
+}
+
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawHandle for io::StdinLock<'a> {
     fn as_raw_handle(&self) -> RawHandle {


### PR DESCRIPTION
This PR includes implementing `IsTerminal` for the raw `sys::stdio` structs, so we can check terminal status without constructing an `Stdout` object.

Then `Stdout` switches from wrapping a `LineWriter` to a `StdoutWriter`, which wraps either a `LineWriter` or `BufWriter` depending on whether or not stdout is pointing to a terminal. This means standard output will no longer be line-buffered when outputting to a non-terminal.

We could also make stdout wrap a `dyn Write` instead of the `StdoutWriter` enum, which would make it simpler but I figured we don't want dynamic dispatch for every write to stdout.