### PR TITLE
coverage: Clean up encoding of per-function coverage mapping payloads

### DIFF
--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
@@ -180,7 +180,7 @@ fn write_coverage_mapping<'a>(
     // `file_id` (indexing files referenced by the current function), and construct the
     // function-specific `virtual_file_mapping` from `file_id` to its index in the module's
     // `filenames` array.
-    counter_regions.sort_unstable_by_key(|(_counter, region)| *region);
+    counter_regions.sort_by_key(|(_counter, region)| *region);
     for (counter, region) in counter_regions {
         let CodeRegion { file_name, start_line, start_col, end_line, end_col } = *region;
         let same_file = current_file_name.is_some_and(|p| p == file_name);

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
@@ -55,7 +55,7 @@ pub fn finalize(cx: &CodegenCx<'_, '_>) {
         return;
     }
 
-    let mut mapgen = CoverageMapGenerator::new(tcx);
+    let mut global_file_table = GlobalFileTable::new(tcx);
 
     // Encode coverage mappings and generate function records
     let mut function_data = Vec::new();
@@ -68,7 +68,12 @@ pub fn finalize(cx: &CodegenCx<'_, '_>) {
             function_coverage.get_expressions_and_counter_regions();
 
         let coverage_mapping_buffer = llvm::build_byte_buffer(|coverage_mapping_buffer| {
-            mapgen.write_coverage_mapping(expressions, counter_regions, coverage_mapping_buffer);
+            write_coverage_mapping(
+                &mut global_file_table,
+                expressions,
+                counter_regions,
+                coverage_mapping_buffer,
+            );
         });
 
         if coverage_mapping_buffer.is_empty() {
@@ -87,19 +92,14 @@ pub fn finalize(cx: &CodegenCx<'_, '_>) {
     }
 
     // Encode all filenames referenced by counters/expressions in this module
-    let filenames_buffer = llvm::build_byte_buffer(|filenames_buffer| {
-        coverageinfo::write_filenames_section_to_buffer(
-            mapgen.filenames.iter().map(Symbol::as_str),
-            filenames_buffer,
-        );
-    });
+    let filenames_buffer = global_file_table.into_filenames_buffer();
 
     let filenames_size = filenames_buffer.len();
     let filenames_val = cx.const_bytes(&filenames_buffer);
     let filenames_ref = coverageinfo::hash_bytes(&filenames_buffer);
 
     // Generate the LLVM IR representation of the coverage map and store it in a well-known global
-    let cov_data_val = mapgen.generate_coverage_map(cx, version, filenames_size, filenames_val);
+    let cov_data_val = generate_coverage_map(cx, version, filenames_size, filenames_val);
 
     let covfun_section_name = coverageinfo::covfun_section_name(cx);
     for (mangled_function_name, source_hash, is_used, coverage_mapping_buffer) in function_data {
@@ -118,13 +118,13 @@ pub fn finalize(cx: &CodegenCx<'_, '_>) {
     coverageinfo::save_cov_data_to_mod(cx, cov_data_val);
 }
 
-struct CoverageMapGenerator {
-    filenames: FxIndexSet<Symbol>,
+struct GlobalFileTable {
+    global_file_table: FxIndexSet<Symbol>,
 }
 
-impl CoverageMapGenerator {
+impl GlobalFileTable {
     fn new(tcx: TyCtxt<'_>) -> Self {
-        let mut filenames = FxIndexSet::default();
+        let mut global_file_table = FxIndexSet::default();
         // LLVM Coverage Mapping Format version 6 (zero-based encoded as 5)
         // requires setting the first filename to the compilation directory.
         // Since rustc generates coverage maps with relative paths, the
@@ -133,48 +133,67 @@ impl CoverageMapGenerator {
         let working_dir = Symbol::intern(
             &tcx.sess.opts.working_dir.remapped_path_if_available().to_string_lossy(),
         );
-        filenames.insert(working_dir);
-        Self { filenames }
+        global_file_table.insert(working_dir);
+        Self { global_file_table }
     }
 
-    /// Using the `expressions` and `counter_regions` collected for the current function, generate
-    /// the `mapping_regions` and `virtual_file_mapping`, and capture any new filenames. Then use
-    /// LLVM APIs to encode the `virtual_file_mapping`, `expressions`, and `mapping_regions` into
-    /// the given `coverage_mapping` byte buffer, compliant with the LLVM Coverage Mapping format.
-    fn write_coverage_mapping<'a>(
-        &mut self,
-        expressions: Vec<CounterExpression>,
-        counter_regions: impl Iterator<Item = (Counter, &'a CodeRegion)>,
-        coverage_mapping_buffer: &RustString,
-    ) {
-        let mut counter_regions = counter_regions.collect::<Vec<_>>();
-        if counter_regions.is_empty() {
-            return;
-        }
+    fn global_file_id_for_file_name(&mut self, file_name: Symbol) -> u32 {
+        let (global_file_id, _) = self.global_file_table.insert_full(file_name);
+        global_file_id as u32
+    }
 
-        let mut virtual_file_mapping = Vec::new();
-        let mut mapping_regions = Vec::new();
-        let mut current_file_name = None;
-        let mut current_file_id = 0;
+    fn into_filenames_buffer(self) -> Vec<u8> {
+        // This method takes `self` so that the caller can't accidentally
+        // modify the original file table after encoding it into a buffer.
 
-        // Convert the list of (Counter, CodeRegion) pairs to an array of `CounterMappingRegion`, sorted
-        // by filename and position. Capture any new files to compute the `CounterMappingRegion`s
-        // `file_id` (indexing files referenced by the current function), and construct the
-        // function-specific `virtual_file_mapping` from `file_id` to its index in the module's
-        // `filenames` array.
-        counter_regions.sort_unstable_by_key(|(_counter, region)| *region);
-        for (counter, region) in counter_regions {
-            let CodeRegion { file_name, start_line, start_col, end_line, end_col } = *region;
-            let same_file = current_file_name.is_some_and(|p| p == file_name);
-            if !same_file {
-                if current_file_name.is_some() {
-                    current_file_id += 1;
-                }
-                current_file_name = Some(file_name);
-                debug!("  file_id: {} = '{:?}'", current_file_id, file_name);
-                let (filenames_index, _) = self.filenames.insert_full(file_name);
-                virtual_file_mapping.push(filenames_index as u32);
+        llvm::build_byte_buffer(|buffer| {
+            coverageinfo::write_filenames_section_to_buffer(
+                self.global_file_table.iter().map(Symbol::as_str),
+                buffer,
+            );
+        })
+    }
+}
+
+/// Using the `expressions` and `counter_regions` collected for the current function, generate
+/// the `mapping_regions` and `virtual_file_mapping`, and capture any new filenames. Then use
+/// LLVM APIs to encode the `virtual_file_mapping`, `expressions`, and `mapping_regions` into
+/// the given `coverage_mapping` byte buffer, compliant with the LLVM Coverage Mapping format.
+fn write_coverage_mapping<'a>(
+    global_file_table: &mut GlobalFileTable,
+    expressions: Vec<CounterExpression>,
+    counter_regions: impl Iterator<Item = (Counter, &'a CodeRegion)>,
+    coverage_mapping_buffer: &RustString,
+) {
+    let mut counter_regions = counter_regions.collect::<Vec<_>>();
+    if counter_regions.is_empty() {
+        return;
+    }
+
+    let mut virtual_file_mapping = Vec::new();
+    let mut mapping_regions = Vec::new();
+    let mut current_file_name = None;
+    let mut current_file_id = 0;
+
+    // Convert the list of (Counter, CodeRegion) pairs to an array of `CounterMappingRegion`, sorted
+    // by filename and position. Capture any new files to compute the `CounterMappingRegion`s
+    // `file_id` (indexing files referenced by the current function), and construct the
+    // function-specific `virtual_file_mapping` from `file_id` to its index in the module's
+    // `filenames` array.
+    counter_regions.sort_unstable_by_key(|(_counter, region)| *region);
+    for (counter, region) in counter_regions {
+        let CodeRegion { file_name, start_line, start_col, end_line, end_col } = *region;
+        let same_file = current_file_name.is_some_and(|p| p == file_name);
+        if !same_file {
+            if current_file_name.is_some() {
+                current_file_id += 1;
             }
+            current_file_name = Some(file_name);
+            debug!("  file_id: {} = '{:?}'", current_file_id, file_name);
+            let global_file_id = global_file_table.global_file_id_for_file_name(file_name);
+            virtual_file_mapping.push(global_file_id);
+        }
+        {
             debug!("Adding counter {:?} to map for {:?}", counter, region);
             mapping_regions.push(CounterMappingRegion::code_region(
                 counter,
@@ -185,7 +204,9 @@ impl CoverageMapGenerator {
                 end_col,
             ));
         }
+    }
 
+    {
         // Encode and append the current function's coverage mapping data
         coverageinfo::write_mapping_to_buffer(
             virtual_file_mapping,
@@ -194,33 +215,32 @@ impl CoverageMapGenerator {
             coverage_mapping_buffer,
         );
     }
+}
 
-    /// Construct coverage map header and the array of function records, and combine them into the
-    /// coverage map. Save the coverage map data into the LLVM IR as a static global using a
-    /// specific, well-known section and name.
-    fn generate_coverage_map<'ll>(
-        self,
-        cx: &CodegenCx<'ll, '_>,
-        version: u32,
-        filenames_size: usize,
-        filenames_val: &'ll llvm::Value,
-    ) -> &'ll llvm::Value {
-        debug!("cov map: filenames_size = {}, 0-based version = {}", filenames_size, version);
+/// Construct coverage map header and the array of function records, and combine them into the
+/// coverage map. Save the coverage map data into the LLVM IR as a static global using a
+/// specific, well-known section and name.
+fn generate_coverage_map<'ll>(
+    cx: &CodegenCx<'ll, '_>,
+    version: u32,
+    filenames_size: usize,
+    filenames_val: &'ll llvm::Value,
+) -> &'ll llvm::Value {
+    debug!("cov map: filenames_size = {}, 0-based version = {}", filenames_size, version);
 
-        // Create the coverage data header (Note, fields 0 and 2 are now always zero,
-        // as of `llvm::coverage::CovMapVersion::Version4`.)
-        let zero_was_n_records_val = cx.const_u32(0);
-        let filenames_size_val = cx.const_u32(filenames_size as u32);
-        let zero_was_coverage_size_val = cx.const_u32(0);
-        let version_val = cx.const_u32(version);
-        let cov_data_header_val = cx.const_struct(
-            &[zero_was_n_records_val, filenames_size_val, zero_was_coverage_size_val, version_val],
-            /*packed=*/ false,
-        );
+    // Create the coverage data header (Note, fields 0 and 2 are now always zero,
+    // as of `llvm::coverage::CovMapVersion::Version4`.)
+    let zero_was_n_records_val = cx.const_u32(0);
+    let filenames_size_val = cx.const_u32(filenames_size as u32);
+    let zero_was_coverage_size_val = cx.const_u32(0);
+    let version_val = cx.const_u32(version);
+    let cov_data_header_val = cx.const_struct(
+        &[zero_was_n_records_val, filenames_size_val, zero_was_coverage_size_val, version_val],
+        /*packed=*/ false,
+    );
 
-        // Create the complete LLVM coverage data value to add to the LLVM IR
-        cx.const_struct(&[cov_data_header_val, filenames_val], /*packed=*/ false)
-    }
+    // Create the complete LLVM coverage data value to add to the LLVM IR
+    cx.const_struct(&[cov_data_header_val, filenames_val], /*packed=*/ false)
 }
 
 /// Construct a function record and combine it with the function's coverage mapping data.

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
@@ -171,7 +171,7 @@ fn write_coverage_mapping<'a>(
     }
 
     let mut virtual_file_mapping = Vec::new();
-    let mut mapping_regions = Vec::new();
+    let mut mapping_regions = Vec::with_capacity(counter_regions.len());
     let mut current_file_name = None;
     let mut current_file_id = 0;
 

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(never_type)]
+#![feature(slice_group_by)]
 #![feature(impl_trait_in_assoc_type)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]


### PR DESCRIPTION
This PR contains several small improvements to the code in `rustc_codegen_llvm::coverageinfo::mapgen` that prepares a function's coverage mappings for FFI, and passes them over to LLVM to be encoded into a vector of bytes.

These changes are in preparation for some future changes to the coverage implementation, but they should all stand on their own as worthwhile.

There shouldn't be any changes to the resulting coverage mappings, as verified by the existing `tests/coverage-map` and `tests/run-coverage` suites.

The changes are mostly independent of each other, though they are indirectly affected by the indentation changes made when introducing `GlobalFileTable`.
