### PR TITLE
Improve invalid let expression handling

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -33,7 +33,7 @@ use rustc_macros::HashStable_Generic;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_span::source_map::{respan, Spanned};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{ErrorGuaranteed, Span, DUMMY_SP};
 use std::fmt;
 use std::mem;
 use thin_vec::{thin_vec, ThinVec};
@@ -1426,7 +1426,7 @@ pub enum ExprKind {
     /// of `if` / `while` expressions. (e.g., `if let 0 = x { .. }`).
     ///
     /// `Span` represents the whole `let pat = expr` statement.
-    Let(P<Pat>, P<Expr>, Span),
+    Let(P<Pat>, P<Expr>, Span, Option<ErrorGuaranteed>),
     /// An `if` block, with an optional `else` block.
     ///
     /// `if expr { block } else { expr }`

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1366,7 +1366,7 @@ pub fn noop_visit_expr<T: MutVisitor>(
             vis.visit_ty(ty);
         }
         ExprKind::AddrOf(_, _, ohs) => vis.visit_expr(ohs),
-        ExprKind::Let(pat, scrutinee, _) => {
+        ExprKind::Let(pat, scrutinee, _, _) => {
             vis.visit_pat(pat);
             vis.visit_expr(scrutinee);
         }

--- a/compiler/rustc_ast/src/util/classify.rs
+++ b/compiler/rustc_ast/src/util/classify.rs
@@ -36,7 +36,7 @@ pub fn expr_trailing_brace(mut expr: &ast::Expr) -> Option<&ast::Expr> {
             | AssignOp(_, _, e)
             | Binary(_, _, e)
             | Break(_, Some(e))
-            | Let(_, e, _)
+            | Let(_, e, _, _)
             | Range(_, Some(e), _)
             | Ret(Some(e))
             | Unary(_, e)

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -827,7 +827,7 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
             visitor.visit_expr(subexpression);
             visitor.visit_ty(typ)
         }
-        ExprKind::Let(pat, expr, _) => {
+        ExprKind::Let(pat, expr, _, _) => {
             visitor.visit_pat(pat);
             visitor.visit_expr(expr);
         }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -152,13 +152,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     let ohs = self.lower_expr(ohs);
                     hir::ExprKind::AddrOf(*k, *m, ohs)
                 }
-                ExprKind::Let(pat, scrutinee, span) => {
+                ExprKind::Let(pat, scrutinee, span, is_recovered) => {
                     hir::ExprKind::Let(self.arena.alloc(hir::Let {
                         hir_id: self.next_id(),
                         span: self.lower_span(*span),
                         pat: self.lower_pat(pat),
                         ty: None,
                         init: self.lower_expr(scrutinee),
+                        is_recovered: *is_recovered,
                     }))
                 }
                 ExprKind::If(cond, then, else_opt) => {
@@ -558,13 +559,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_arm(&mut self, arm: &Arm) -> hir::Arm<'hir> {
         let pat = self.lower_pat(&arm.pat);
         let guard = arm.guard.as_ref().map(|cond| {
-            if let ExprKind::Let(pat, scrutinee, span) = &cond.kind {
+            if let ExprKind::Let(pat, scrutinee, span, is_recovered) = &cond.kind {
                 hir::Guard::IfLet(self.arena.alloc(hir::Let {
                     hir_id: self.next_id(),
                     span: self.lower_span(*span),
                     pat: self.lower_pat(pat),
                     ty: None,
                     init: self.lower_expr(scrutinee),
+                    is_recovered: *is_recovered,
                 }))
             } else {
                 hir::Guard::If(self.lower_expr(cond))

--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -117,16 +117,6 @@ ast_passes_forbidden_default =
     `default` is only allowed on items in trait impls
     .label = `default` because of this
 
-ast_passes_forbidden_let =
-    `let` expressions are not supported here
-    .note = only supported directly in conditions of `if` and `while` expressions
-    .not_supported_or = `||` operators are not supported in let chain expressions
-    .not_supported_parentheses = `let`s wrapped in parentheses are not supported in a context with let chains
-
-ast_passes_forbidden_let_stable =
-    expected expression, found statement (`let`)
-    .note = variable declaration using `let` is a statement
-
 ast_passes_forbidden_lifetime_bound =
     lifetime bounds cannot be used in this context
 

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -5,26 +5,7 @@ use rustc_errors::AddToDiagnostic;
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{symbol::Ident, Span, Symbol};
 
-use crate::ast_validation::ForbiddenLetReason;
 use crate::fluent_generated as fluent;
-
-#[derive(Diagnostic)]
-#[diag(ast_passes_forbidden_let)]
-#[note]
-pub struct ForbiddenLet {
-    #[primary_span]
-    pub span: Span,
-    #[subdiagnostic]
-    pub(crate) reason: ForbiddenLetReason,
-}
-
-#[derive(Diagnostic)]
-#[diag(ast_passes_forbidden_let_stable)]
-#[note]
-pub struct ForbiddenLetStable {
-    #[primary_span]
-    pub span: Span,
-}
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_keyword_lifetime)]

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -352,7 +352,7 @@ impl<'a> State<'a> {
                 self.end();
                 self.word(")");
             }
-            ast::ExprKind::Let(pat, scrutinee, _) => {
+            ast::ExprKind::Let(pat, scrutinee, _, _) => {
                 self.print_let(pat, scrutinee);
             }
             ast::ExprKind::If(test, blk, elseopt) => self.print_if(test, blk, elseopt.as_deref()),

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -241,7 +241,7 @@ impl<'cx, 'a> Context<'cx, 'a> {
                 self.manage_cond_expr(prefix);
                 self.manage_cond_expr(suffix);
             }
-            ExprKind::Let(_, local_expr, _) => {
+            ExprKind::Let(_, local_expr, _, _) => {
                 self.manage_cond_expr(local_expr);
             }
             ExprKind::Match(local_expr, _) => {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -19,6 +19,7 @@ use rustc_macros::HashStable_Generic;
 use rustc_span::hygiene::MacroKind;
 use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
+use rustc_span::ErrorGuaranteed;
 use rustc_span::{def_id::LocalDefId, BytePos, Span, DUMMY_SP};
 use rustc_target::asm::InlineAsmRegOrRegClass;
 use rustc_target::spec::abi::Abi;
@@ -1415,6 +1416,9 @@ pub struct Let<'hir> {
     pub pat: &'hir Pat<'hir>,
     pub ty: Option<&'hir Ty<'hir>>,
     pub init: &'hir Expr<'hir>,
+    /// `Some` when this let expressions is not in a syntanctically valid location.
+    /// Used to prevent building MIR in such situations.
+    pub is_recovered: Option<ErrorGuaranteed>,
 }
 
 #[derive(Debug, Clone, Copy, HashStable_Generic)]

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -149,7 +149,7 @@ fn resolve_block<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, blk: &'tcx h
                     // From now on, we continue normally.
                     visitor.cx = prev_cx;
                 }
-                hir::StmtKind::Local(..)=> {
+                hir::StmtKind::Local(..) => {
                     // Each declaration introduces a subscope for bindings
                     // introduced by the declaration; this subscope covers a
                     // suffix of the block. Each subscope in a block has the

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -149,7 +149,7 @@ fn resolve_block<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, blk: &'tcx h
                     // From now on, we continue normally.
                     visitor.cx = prev_cx;
                 }
-                hir::StmtKind::Local(..) | hir::StmtKind::Item(..) => {
+                hir::StmtKind::Local(..)=> {
                     // Each declaration introduces a subscope for bindings
                     // introduced by the declaration; this subscope covers a
                     // suffix of the block. Each subscope in a block has the
@@ -162,6 +162,10 @@ fn resolve_block<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, blk: &'tcx h
                     });
                     visitor.cx.var_parent = visitor.cx.parent;
                     visitor.visit_stmt(statement)
+                }
+                hir::StmtKind::Item(..) => {
+                    // Don't create scopes for items, since they won't be
+                    // lowered to THIR and MIR.
                 }
                 hir::StmtKind::Expr(..) | hir::StmtKind::Semi(..) => visitor.visit_stmt(statement),
             }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1203,7 +1203,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // otherwise check exactly as a let statement
         self.check_decl(let_expr.into());
         // but return a bool, for this is a boolean expression
-        self.tcx.types.bool
+        if let Some(error_guaranteed) = let_expr.is_recovered {
+            self.set_tainted_by_errors(error_guaranteed);
+            Ty::new_error(self.tcx, error_guaranteed)
+        } else {
+            self.tcx.types.bool
+        }
     }
 
     fn check_expr_loop(

--- a/compiler/rustc_hir_typeck/src/gather_locals.rs
+++ b/compiler/rustc_hir_typeck/src/gather_locals.rs
@@ -50,7 +50,7 @@ impl<'a> From<&'a hir::Local<'a>> for Declaration<'a> {
 
 impl<'a> From<&'a hir::Let<'a>> for Declaration<'a> {
     fn from(let_expr: &'a hir::Let<'a>) -> Self {
-        let hir::Let { hir_id, pat, ty, span, init } = *let_expr;
+        let hir::Let { hir_id, pat, ty, span, init, is_recovered: _ } = *let_expr;
         Declaration { hir_id, pat, ty, span, init: Some(init), origin: DeclOrigin::LetExpr }
     }
 }

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -816,8 +816,7 @@ trait UnusedDelimLint {
         let (value, ctx, followed_by_block, left_pos, right_pos, is_kw) = match e.kind {
             // Do not lint `unused_braces` in `if let` expressions.
             If(ref cond, ref block, _)
-                if !matches!(cond.kind, Let(_, _, _))
-                    || Self::LINT_EXPR_IN_PATTERN_MATCHING_CTX =>
+                if !matches!(cond.kind, Let(..)) || Self::LINT_EXPR_IN_PATTERN_MATCHING_CTX =>
             {
                 let left = e.span.lo() + rustc_span::BytePos(2);
                 let right = block.span.lo();
@@ -826,8 +825,7 @@ trait UnusedDelimLint {
 
             // Do not lint `unused_braces` in `while let` expressions.
             While(ref cond, ref block, ..)
-                if !matches!(cond.kind, Let(_, _, _))
-                    || Self::LINT_EXPR_IN_PATTERN_MATCHING_CTX =>
+                if !matches!(cond.kind, Let(..)) || Self::LINT_EXPR_IN_PATTERN_MATCHING_CTX =>
             {
                 let left = e.span.lo() + rustc_span::BytePos(5);
                 let right = block.span.lo();
@@ -1003,7 +1001,7 @@ impl UnusedDelimLint for UnusedParens {
                     self.emit_unused_delims_expr(cx, value, ctx, left_pos, right_pos, is_kw)
                 }
             }
-            ast::ExprKind::Let(_, ref expr, _) => {
+            ast::ExprKind::Let(_, ref expr, _, _) => {
                 self.check_unused_delims_expr(
                     cx,
                     expr,
@@ -1067,7 +1065,7 @@ impl EarlyLintPass for UnusedParens {
         }
 
         match e.kind {
-            ExprKind::Let(ref pat, _, _) | ExprKind::ForLoop(ref pat, ..) => {
+            ExprKind::Let(ref pat, _, _, _) | ExprKind::ForLoop(ref pat, ..) => {
                 self.check_unused_parens_pat(cx, pat, false, false, (true, true));
             }
             // We ignore parens in cases like `if (((let Some(0) = Some(1))))` because we already
@@ -1311,7 +1309,7 @@ impl UnusedDelimLint for UnusedBraces {
                     }
                 }
             }
-            ast::ExprKind::Let(_, ref expr, _) => {
+            ast::ExprKind::Let(_, ref expr, _, _) => {
                 self.check_unused_delims_expr(
                     cx,
                     expr,

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -196,6 +196,7 @@ parse_expected_else_block = expected `{"{"}`, found {$first_tok}
     .suggestion = add an `if` if this is the condition of a chained `else if` statement
 
 parse_expected_expression_found_let = expected expression, found `let` statement
+    .note = only supported directly in conditions of `if` and `while` expressions
     .not_supported_or = `||` operators are not supported in let chain expressions
     .not_supported_parentheses = `let`s wrapped in parentheses are not supported in a context with let chains
 

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -196,6 +196,8 @@ parse_expected_else_block = expected `{"{"}`, found {$first_tok}
     .suggestion = add an `if` if this is the condition of a chained `else if` statement
 
 parse_expected_expression_found_let = expected expression, found `let` statement
+    .not_supported_or = `||` operators are not supported in let chain expressions
+    .not_supported_parentheses = `let`s wrapped in parentheses are not supported in a context with let chains
 
 parse_expected_fn_path_found_fn_keyword = expected identifier, found keyword `fn`
     .suggestion = use `Fn` to refer to the trait

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -10,7 +10,7 @@ use rustc_span::symbol::Ident;
 use rustc_span::{Span, Symbol};
 
 use crate::fluent_generated as fluent;
-use crate::parser::TokenDescription;
+use crate::parser::{ForbiddenLetReason, TokenDescription};
 
 #[derive(Diagnostic)]
 #[diag(parse_maybe_report_ambiguous_plus)]
@@ -395,6 +395,8 @@ pub(crate) struct IfExpressionMissingCondition {
 pub(crate) struct ExpectedExpressionFoundLet {
     #[primary_span]
     pub span: Span,
+    #[subdiagnostic]
+    pub reason: ForbiddenLetReason,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -392,6 +392,7 @@ pub(crate) struct IfExpressionMissingCondition {
 
 #[derive(Diagnostic)]
 #[diag(parse_expected_expression_found_let)]
+#[note]
 pub(crate) struct ExpectedExpressionFoundLet {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2485,9 +2485,6 @@ impl<'a> Parser<'a> {
         }
         let expr = self.parse_expr_assoc_with(1 + prec_let_scrutinee_needs_par(), None.into())?;
         let span = lo.to(expr.span);
-        if is_recovered.is_none() {
-            self.sess.gated_spans.gate(sym::let_chains, span);
-        }
         Ok(self.mk_expr(span, ExprKind::Let(pat, expr, span, is_recovered)))
     }
 
@@ -3460,6 +3457,8 @@ impl MutVisitor for CondChecker<'_> {
                             .sess
                             .emit_err(errors::ExpectedExpressionFoundLet { span, reason }),
                     );
+                } else {
+                    self.parser.sess.gated_spans.gate(sym::let_chains, span);
                 }
             }
             ExprKind::Binary(Spanned { node: BinOpKind::And, .. }, _, _) => {

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -8,6 +8,7 @@ use super::{
 
 use crate::errors;
 use crate::maybe_recover_from_interpolated_ty_qpath;
+use ast::mut_visit::{noop_visit_expr, MutVisitor};
 use ast::{Path, PathSegment};
 use core::mem;
 use rustc_ast::ptr::P;
@@ -27,6 +28,7 @@ use rustc_errors::{
     AddToDiagnostic, Applicability, Diagnostic, DiagnosticBuilder, ErrorGuaranteed, IntoDiagnostic,
     PResult, StashKey,
 };
+use rustc_macros::Subdiagnostic;
 use rustc_session::errors::{report_lit_error, ExprParenthesesNeeded};
 use rustc_session::lint::builtin::BREAK_WITH_LABEL_AND_LOOP;
 use rustc_session::lint::BuiltinLintDiagnostics;
@@ -122,8 +124,8 @@ impl<'a> Parser<'a> {
         self.parse_expr().map(|value| AnonConst { id: DUMMY_NODE_ID, value })
     }
 
-    fn parse_expr_catch_underscore(&mut self) -> PResult<'a, P<Expr>> {
-        match self.parse_expr() {
+    fn parse_expr_catch_underscore(&mut self, restrictions: Restrictions) -> PResult<'a, P<Expr>> {
+        match self.parse_expr_res(restrictions, None) {
             Ok(expr) => Ok(expr),
             Err(mut err) => match self.token.ident() {
                 Some((Ident { name: kw::Underscore, .. }, false))
@@ -141,7 +143,8 @@ impl<'a> Parser<'a> {
 
     /// Parses a sequence of expressions delimited by parentheses.
     fn parse_expr_paren_seq(&mut self) -> PResult<'a, ThinVec<P<Expr>>> {
-        self.parse_paren_comma_seq(|p| p.parse_expr_catch_underscore()).map(|(r, _)| r)
+        self.parse_paren_comma_seq(|p| p.parse_expr_catch_underscore(Restrictions::empty()))
+            .map(|(r, _)| r)
     }
 
     /// Parses an expression, subject to the given restrictions.
@@ -1345,110 +1348,113 @@ impl<'a> Parser<'a> {
         // Outer attributes are already parsed and will be
         // added to the return value after the fact.
 
-        // Note: when adding new syntax here, don't forget to adjust `TokenKind::can_begin_expr()`.
-        let lo = self.token.span;
-        if let token::Literal(_) = self.token.kind {
-            // This match arm is a special-case of the `_` match arm below and
-            // could be removed without changing functionality, but it's faster
-            // to have it here, especially for programs with large constants.
-            self.parse_expr_lit()
-        } else if self.check(&token::OpenDelim(Delimiter::Parenthesis)) {
-            self.parse_expr_tuple_parens()
-        } else if self.check(&token::OpenDelim(Delimiter::Brace)) {
-            self.parse_expr_block(None, lo, BlockCheckMode::Default)
-        } else if self.check(&token::BinOp(token::Or)) || self.check(&token::OrOr) {
-            self.parse_expr_closure().map_err(|mut err| {
-                // If the input is something like `if a { 1 } else { 2 } | if a { 3 } else { 4 }`
-                // then suggest parens around the lhs.
-                if let Some(sp) = self.sess.ambiguous_block_expr_parse.borrow().get(&lo) {
-                    err.subdiagnostic(ExprParenthesesNeeded::surrounding(*sp));
-                }
-                err
-            })
-        } else if self.check(&token::OpenDelim(Delimiter::Bracket)) {
-            self.parse_expr_array_or_repeat(Delimiter::Bracket)
-        } else if self.is_builtin() {
-            self.parse_expr_builtin()
-        } else if self.check_path() {
-            self.parse_expr_path_start()
-        } else if self.check_keyword(kw::Move)
-            || self.check_keyword(kw::Static)
-            || self.check_const_closure()
-        {
-            self.parse_expr_closure()
-        } else if self.eat_keyword(kw::If) {
-            self.parse_expr_if()
-        } else if self.check_keyword(kw::For) {
-            if self.choose_generics_over_qpath(1) {
-                self.parse_expr_closure()
-            } else {
-                assert!(self.eat_keyword(kw::For));
-                self.parse_expr_for(None, self.prev_token.span)
-            }
-        } else if self.eat_keyword(kw::While) {
-            self.parse_expr_while(None, self.prev_token.span)
-        } else if let Some(label) = self.eat_label() {
-            self.parse_expr_labeled(label, true)
-        } else if self.eat_keyword(kw::Loop) {
-            let sp = self.prev_token.span;
-            self.parse_expr_loop(None, self.prev_token.span).map_err(|mut err| {
-                err.span_label(sp, "while parsing this `loop` expression");
-                err
-            })
-        } else if self.eat_keyword(kw::Match) {
-            let match_sp = self.prev_token.span;
-            self.parse_expr_match().map_err(|mut err| {
-                err.span_label(match_sp, "while parsing this `match` expression");
-                err
-            })
-        } else if self.eat_keyword(kw::Unsafe) {
-            let sp = self.prev_token.span;
-            self.parse_expr_block(None, lo, BlockCheckMode::Unsafe(ast::UserProvided)).map_err(
-                |mut err| {
-                    err.span_label(sp, "while parsing this `unsafe` expression");
+        let restrictions = self.restrictions;
+        self.with_res(restrictions - Restrictions::ALLOW_LET, |this| {
+            // Note: when adding new syntax here, don't forget to adjust `TokenKind::can_begin_expr()`.
+            let lo = this.token.span;
+            if let token::Literal(_) = this.token.kind {
+                // This match arm is a special-case of the `_` match arm below and
+                // could be removed without changing functionality, but it's faster
+                // to have it here, especially for programs with large constants.
+                this.parse_expr_lit()
+            } else if this.check(&token::OpenDelim(Delimiter::Parenthesis)) {
+                this.parse_expr_tuple_parens(restrictions)
+            } else if this.check(&token::OpenDelim(Delimiter::Brace)) {
+                this.parse_expr_block(None, lo, BlockCheckMode::Default)
+            } else if this.check(&token::BinOp(token::Or)) || this.check(&token::OrOr) {
+                this.parse_expr_closure().map_err(|mut err| {
+                    // If the input is something like `if a { 1 } else { 2 } | if a { 3 } else { 4 }`
+                    // then suggest parens around the lhs.
+                    if let Some(sp) = this.sess.ambiguous_block_expr_parse.borrow().get(&lo) {
+                        err.subdiagnostic(ExprParenthesesNeeded::surrounding(*sp));
+                    }
                     err
-                },
-            )
-        } else if self.check_inline_const(0) {
-            self.parse_const_block(lo.to(self.token.span), false)
-        } else if self.may_recover() && self.is_do_catch_block() {
-            self.recover_do_catch()
-        } else if self.is_try_block() {
-            self.expect_keyword(kw::Try)?;
-            self.parse_try_block(lo)
-        } else if self.eat_keyword(kw::Return) {
-            self.parse_expr_return()
-        } else if self.eat_keyword(kw::Continue) {
-            self.parse_expr_continue(lo)
-        } else if self.eat_keyword(kw::Break) {
-            self.parse_expr_break()
-        } else if self.eat_keyword(kw::Yield) {
-            self.parse_expr_yield()
-        } else if self.is_do_yeet() {
-            self.parse_expr_yeet()
-        } else if self.eat_keyword(kw::Become) {
-            self.parse_expr_become()
-        } else if self.check_keyword(kw::Let) {
-            self.parse_expr_let()
-        } else if self.eat_keyword(kw::Underscore) {
-            Ok(self.mk_expr(self.prev_token.span, ExprKind::Underscore))
-        } else if self.token.uninterpolated_span().at_least_rust_2018() {
-            // `Span:.at_least_rust_2018()` is somewhat expensive; don't get it repeatedly.
-            if self.check_keyword(kw::Async) {
-                if self.is_async_block() {
-                    // Check for `async {` and `async move {`.
-                    self.parse_async_block()
+                })
+            } else if this.check(&token::OpenDelim(Delimiter::Bracket)) {
+                this.parse_expr_array_or_repeat(Delimiter::Bracket)
+            } else if this.is_builtin() {
+                this.parse_expr_builtin()
+            } else if this.check_path() {
+                this.parse_expr_path_start()
+            } else if this.check_keyword(kw::Move)
+                || this.check_keyword(kw::Static)
+                || this.check_const_closure()
+            {
+                this.parse_expr_closure()
+            } else if this.eat_keyword(kw::If) {
+                this.parse_expr_if()
+            } else if this.check_keyword(kw::For) {
+                if this.choose_generics_over_qpath(1) {
+                    this.parse_expr_closure()
                 } else {
-                    self.parse_expr_closure()
+                    assert!(this.eat_keyword(kw::For));
+                    this.parse_expr_for(None, this.prev_token.span)
                 }
-            } else if self.eat_keyword(kw::Await) {
-                self.recover_incorrect_await_syntax(lo, self.prev_token.span)
+            } else if this.eat_keyword(kw::While) {
+                this.parse_expr_while(None, this.prev_token.span)
+            } else if let Some(label) = this.eat_label() {
+                this.parse_expr_labeled(label, true)
+            } else if this.eat_keyword(kw::Loop) {
+                let sp = this.prev_token.span;
+                this.parse_expr_loop(None, this.prev_token.span).map_err(|mut err| {
+                    err.span_label(sp, "while parsing this `loop` expression");
+                    err
+                })
+            } else if this.eat_keyword(kw::Match) {
+                let match_sp = this.prev_token.span;
+                this.parse_expr_match().map_err(|mut err| {
+                    err.span_label(match_sp, "while parsing this `match` expression");
+                    err
+                })
+            } else if this.eat_keyword(kw::Unsafe) {
+                let sp = this.prev_token.span;
+                this.parse_expr_block(None, lo, BlockCheckMode::Unsafe(ast::UserProvided)).map_err(
+                    |mut err| {
+                        err.span_label(sp, "while parsing this `unsafe` expression");
+                        err
+                    },
+                )
+            } else if this.check_inline_const(0) {
+                this.parse_const_block(lo.to(this.token.span), false)
+            } else if this.may_recover() && this.is_do_catch_block() {
+                this.recover_do_catch()
+            } else if this.is_try_block() {
+                this.expect_keyword(kw::Try)?;
+                this.parse_try_block(lo)
+            } else if this.eat_keyword(kw::Return) {
+                this.parse_expr_return()
+            } else if this.eat_keyword(kw::Continue) {
+                this.parse_expr_continue(lo)
+            } else if this.eat_keyword(kw::Break) {
+                this.parse_expr_break()
+            } else if this.eat_keyword(kw::Yield) {
+                this.parse_expr_yield()
+            } else if this.is_do_yeet() {
+                this.parse_expr_yeet()
+            } else if this.eat_keyword(kw::Become) {
+                this.parse_expr_become()
+            } else if this.check_keyword(kw::Let) {
+                this.parse_expr_let(restrictions)
+            } else if this.eat_keyword(kw::Underscore) {
+                Ok(this.mk_expr(this.prev_token.span, ExprKind::Underscore))
+            } else if this.token.uninterpolated_span().at_least_rust_2018() {
+                // `Span:.at_least_rust_2018()` is somewhat expensive; don't get it repeatedly.
+                if this.check_keyword(kw::Async) {
+                    if this.is_async_block() {
+                        // Check for `async {` and `async move {`.
+                        this.parse_async_block()
+                    } else {
+                        this.parse_expr_closure()
+                    }
+                } else if this.eat_keyword(kw::Await) {
+                    this.recover_incorrect_await_syntax(lo, this.prev_token.span)
+                } else {
+                    this.parse_expr_lit()
+                }
             } else {
-                self.parse_expr_lit()
+                this.parse_expr_lit()
             }
-        } else {
-            self.parse_expr_lit()
-        }
+        })
     }
 
     fn parse_expr_lit(&mut self) -> PResult<'a, P<Expr>> {
@@ -1462,13 +1468,13 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_expr_tuple_parens(&mut self) -> PResult<'a, P<Expr>> {
+    fn parse_expr_tuple_parens(&mut self, restrictions: Restrictions) -> PResult<'a, P<Expr>> {
         let lo = self.token.span;
         self.expect(&token::OpenDelim(Delimiter::Parenthesis))?;
         let (es, trailing_comma) = match self.parse_seq_to_end(
             &token::CloseDelim(Delimiter::Parenthesis),
             SeqSep::trailing_allowed(token::Comma),
-            |p| p.parse_expr_catch_underscore(),
+            |p| p.parse_expr_catch_underscore(restrictions.intersection(Restrictions::ALLOW_LET)),
         ) {
             Ok(x) => x,
             Err(err) => {
@@ -2231,7 +2237,8 @@ impl<'a> Parser<'a> {
         let decl_hi = self.prev_token.span;
         let mut body = match fn_decl.output {
             FnRetTy::Default(_) => {
-                let restrictions = self.restrictions - Restrictions::STMT_EXPR;
+                let restrictions =
+                    self.restrictions - Restrictions::STMT_EXPR - Restrictions::ALLOW_LET;
                 self.parse_expr_res(restrictions, None)?
             }
             _ => {
@@ -2436,10 +2443,12 @@ impl<'a> Parser<'a> {
 
     /// Parses the condition of a `if` or `while` expression.
     fn parse_expr_cond(&mut self) -> PResult<'a, P<Expr>> {
-        let cond =
+        let mut cond =
             self.parse_expr_res(Restrictions::NO_STRUCT_LITERAL | Restrictions::ALLOW_LET, None)?;
 
-        if let ExprKind::Let(..) = cond.kind {
+        CondChecker { parser: self, forbid_let_reason: None }.visit_expr(&mut cond);
+
+        if let ExprKind::Let(_, _, _, None) = cond.kind {
             // Remove the last feature gating of a `let` expression since it's stable.
             self.sess.gated_spans.ungate_last(sym::let_chains, cond.span);
         }
@@ -2448,18 +2457,15 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses a `let $pat = $expr` pseudo-expression.
-    fn parse_expr_let(&mut self) -> PResult<'a, P<Expr>> {
-        // This is a *approximate* heuristic that detects if `let` chains are
-        // being parsed in the right position. It's approximate because it
-        // doesn't deny all invalid `let` expressions, just completely wrong usages.
-        let not_in_chain = !matches!(
-            self.prev_token.kind,
-            TokenKind::AndAnd | TokenKind::Ident(kw::If, _) | TokenKind::Ident(kw::While, _)
-        );
-        if !self.restrictions.contains(Restrictions::ALLOW_LET) || not_in_chain {
-            self.sess.emit_err(errors::ExpectedExpressionFoundLet { span: self.token.span });
-        }
-
+    fn parse_expr_let(&mut self, restrictions: Restrictions) -> PResult<'a, P<Expr>> {
+        let is_recovered = if !restrictions.contains(Restrictions::ALLOW_LET) {
+            Some(self.sess.emit_err(errors::ExpectedExpressionFoundLet {
+                span: self.token.span,
+                reason: ForbiddenLetReason::GenericForbidden,
+            }))
+        } else {
+            None
+        };
         self.bump(); // Eat `let` token
         let lo = self.prev_token.span;
         let pat = self.parse_pat_allow_top_alt(
@@ -2479,8 +2485,10 @@ impl<'a> Parser<'a> {
         }
         let expr = self.parse_expr_assoc_with(1 + prec_let_scrutinee_needs_par(), None.into())?;
         let span = lo.to(expr.span);
-        self.sess.gated_spans.gate(sym::let_chains, span);
-        Ok(self.mk_expr(span, ExprKind::Let(pat, expr, span)))
+        if is_recovered.is_none() {
+            self.sess.gated_spans.gate(sym::let_chains, span);
+        }
+        Ok(self.mk_expr(span, ExprKind::Let(pat, expr, span, is_recovered)))
     }
 
     /// Parses an `else { ... }` expression (`else` token already eaten).
@@ -2829,7 +2837,10 @@ impl<'a> Parser<'a> {
             )?;
             let guard = if this.eat_keyword(kw::If) {
                 let if_span = this.prev_token.span;
-                let cond = this.parse_expr_res(Restrictions::ALLOW_LET, None)?;
+                let mut cond = this.parse_expr_res(Restrictions::ALLOW_LET, None)?;
+
+                CondChecker { parser: this, forbid_let_reason: None }.visit_expr(&mut cond);
+
                 let (has_let_expr, does_not_have_bin_op) = check_let_expr(&cond);
                 if has_let_expr {
                     if does_not_have_bin_op {
@@ -3412,5 +3423,121 @@ impl<'a> Parser<'a> {
             };
             Ok((res, trailing))
         })
+    }
+}
+
+/// Used to forbid `let` expressions in certain syntactic locations.
+#[derive(Clone, Copy, Subdiagnostic)]
+pub(crate) enum ForbiddenLetReason {
+    /// `let` is not valid and the source environment is not important
+    GenericForbidden,
+    /// A let chain with the `||` operator
+    #[note(parse_not_supported_or)]
+    NotSupportedOr(#[primary_span] Span),
+    /// A let chain with invalid parentheses
+    ///
+    /// For example, `let 1 = 1 && (expr && expr)` is allowed
+    /// but `(let 1 = 1 && (let 1 = 1 && (let 1 = 1))) && let a = 1` is not
+    #[note(parse_not_supported_parentheses)]
+    NotSupportedParentheses(#[primary_span] Span),
+}
+
+struct CondChecker<'a> {
+    parser: &'a Parser<'a>,
+    forbid_let_reason: Option<ForbiddenLetReason>,
+}
+
+impl MutVisitor for CondChecker<'_> {
+    fn visit_expr(&mut self, e: &mut P<Expr>) {
+        use ForbiddenLetReason::*;
+
+        let span = e.span;
+        match e.kind {
+            ExprKind::Let(_, _, _, ref mut is_recovered @ None) => {
+                if let Some(reason) = self.forbid_let_reason {
+                    *is_recovered = Some(
+                        self.parser
+                            .sess
+                            .emit_err(errors::ExpectedExpressionFoundLet { span, reason }),
+                    );
+                }
+            }
+            ExprKind::Binary(Spanned { node: BinOpKind::And, .. }, _, _) => {
+                noop_visit_expr(e, self);
+            }
+            ExprKind::Binary(Spanned { node: BinOpKind::Or, span: or_span }, _, _)
+                if let None | Some(NotSupportedOr(_)) = self.forbid_let_reason =>
+            {
+                let forbid_let_reason = self.forbid_let_reason;
+                self.forbid_let_reason = Some(NotSupportedOr(or_span));
+                noop_visit_expr(e, self);
+                self.forbid_let_reason = forbid_let_reason;
+            }
+            ExprKind::Paren(ref inner)
+                if let None | Some(NotSupportedParentheses(_)) = self.forbid_let_reason =>
+            {
+                let forbid_let_reason = self.forbid_let_reason;
+                self.forbid_let_reason = Some(NotSupportedParentheses(inner.span));
+                noop_visit_expr(e, self);
+                self.forbid_let_reason = forbid_let_reason;
+            }
+            ExprKind::Unary(_, _)
+            | ExprKind::Await(_, _)
+            | ExprKind::Assign(_, _, _)
+            | ExprKind::AssignOp(_, _, _)
+            | ExprKind::Range(_, _, _)
+            | ExprKind::Try(_)
+            | ExprKind::AddrOf(_, _, _)
+            | ExprKind::Binary(_, _, _)
+            | ExprKind::Field(_, _)
+            | ExprKind::Index(_, _, _)
+            | ExprKind::Call(_, _)
+            | ExprKind::MethodCall(_)
+            | ExprKind::Tup(_)
+            | ExprKind::Paren(_) => {
+                let forbid_let_reason = self.forbid_let_reason;
+                self.forbid_let_reason = Some(GenericForbidden);
+                noop_visit_expr(e, self);
+                self.forbid_let_reason = forbid_let_reason;
+            }
+            ExprKind::Cast(ref mut op, _)
+            | ExprKind::Type(ref mut op, _) => {
+                let forbid_let_reason = self.forbid_let_reason;
+                self.forbid_let_reason = Some(GenericForbidden);
+                self.visit_expr(op);
+                self.forbid_let_reason = forbid_let_reason;
+            }
+            ExprKind::Let(_, _, _, Some(_))
+            | ExprKind::Array(_)
+            | ExprKind::ConstBlock(_)
+            | ExprKind::Lit(_)
+            | ExprKind::If(_, _, _)
+            | ExprKind::While(_, _, _)
+            | ExprKind::ForLoop(_, _, _, _)
+            | ExprKind::Loop(_, _, _)
+            | ExprKind::Match(_, _)
+            | ExprKind::Closure(_)
+            | ExprKind::Block(_, _)
+            | ExprKind::Async(_, _)
+            | ExprKind::TryBlock(_)
+            | ExprKind::Underscore
+            | ExprKind::Path(_, _)
+            | ExprKind::Break(_, _)
+            | ExprKind::Continue(_)
+            | ExprKind::Ret(_)
+            | ExprKind::InlineAsm(_)
+            | ExprKind::OffsetOf(_, _)
+            | ExprKind::MacCall(_)
+            | ExprKind::Struct(_)
+            | ExprKind::Repeat(_, _)
+            | ExprKind::Yield(_)
+            | ExprKind::Yeet(_)
+            | ExprKind::Become(_)
+            | ExprKind::IncludedBytes(_)
+            | ExprKind::FormatArgs(_)
+            | ExprKind::Err => {
+                // These would forbid any let expressions they contain already.
+            }
+        }
     }
 }

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -13,6 +13,7 @@ mod ty;
 use crate::lexer::UnmatchedDelim;
 pub use attr_wrapper::AttrWrapper;
 pub use diagnostics::AttemptLocalParseRecovery;
+pub(crate) use expr::ForbiddenLetReason;
 pub(crate) use item::FnParseMode;
 pub use pat::{CommaRecoveryMode, RecoverColon, RecoverComma};
 pub use path::PathStyle;

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4176,7 +4176,7 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                 self.resolve_expr(e, Some(&expr));
             }
 
-            ExprKind::Let(ref pat, ref scrutinee, _) => {
+            ExprKind::Let(ref pat, ref scrutinee, _, _) => {
                 self.visit_expr(scrutinee);
                 self.resolve_pattern_top(pat, PatternSource::Let);
             }

--- a/src/tools/clippy/clippy_lints/src/suspicious_operation_groupings.rs
+++ b/src/tools/clippy/clippy_lints/src/suspicious_operation_groupings.rs
@@ -586,7 +586,7 @@ fn ident_difference_expr_with_base_location(
         | (ForLoop(_, _, _, _), ForLoop(_, _, _, _))
         | (While(_, _, _), While(_, _, _))
         | (If(_, _, _), If(_, _, _))
-        | (Let(_, _, _), Let(_, _, _))
+        | (Let(_, _, _, _), Let(_, _, _, _))
         | (Type(_, _), Type(_, _))
         | (Cast(_, _), Cast(_, _))
         | (Lit(_), Lit(_))

--- a/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
+++ b/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
@@ -68,7 +68,7 @@ impl EarlyLintPass for UnnestedOrPatterns {
 
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &ast::Expr) {
         if self.msrv.meets(msrvs::OR_PATTERNS) {
-            if let ast::ExprKind::Let(pat, _, _) = &e.kind {
+            if let ast::ExprKind::Let(pat, _, _, _) = &e.kind {
                 lint_unnested_or_patterns(cx, pat);
             }
         }

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -166,7 +166,7 @@ pub fn eq_expr(l: &Expr, r: &Expr) -> bool {
         (Unary(lo, l), Unary(ro, r)) => mem::discriminant(lo) == mem::discriminant(ro) && eq_expr(l, r),
         (Lit(l), Lit(r)) => l == r,
         (Cast(l, lt), Cast(r, rt)) | (Type(l, lt), Type(r, rt)) => eq_expr(l, r) && eq_ty(lt, rt),
-        (Let(lp, le, _), Let(rp, re, _)) => eq_pat(lp, rp) && eq_expr(le, re),
+        (Let(lp, le, _, _), Let(rp, re, _, _)) => eq_pat(lp, rp) && eq_expr(le, re),
         (If(lc, lt, le), If(rc, rt, re)) => eq_expr(lc, rc) && eq_block(lt, rt) && eq_expr_opt(le, re),
         (While(lc, lt, ll), While(rc, rt, rl)) => eq_label(ll, rl) && eq_expr(lc, rc) && eq_block(lt, rt),
         (ForLoop(lp, li, lt, ll), ForLoop(rp, ri, rt, rl)) => {

--- a/src/tools/rustfmt/src/expr.rs
+++ b/src/tools/rustfmt/src/expr.rs
@@ -664,7 +664,7 @@ struct ControlFlow<'a> {
 
 fn extract_pats_and_cond(expr: &ast::Expr) -> (Option<&ast::Pat>, &ast::Expr) {
     match expr.kind {
-        ast::ExprKind::Let(ref pat, ref cond, _) => (Some(pat), cond),
+        ast::ExprKind::Let(ref pat, ref cond, _, _) => (Some(pat), cond),
         _ => (None, expr),
     }
 }

--- a/tests/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/tests/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -80,14 +80,20 @@ fn iter_exprs(depth: usize, f: &mut dyn FnMut(P<Expr>)) {
                 let seg = PathSegment::from_ident(Ident::from_str("x"));
                 iter_exprs(depth - 1, &mut |e| {
                     g(ExprKind::MethodCall(Box::new(MethodCall {
-                        seg: seg.clone(), receiver: e, args: thin_vec![make_x()], span: DUMMY_SP
-                    }))
-                )});
+                        seg: seg.clone(),
+                        receiver: e,
+                        args: thin_vec![make_x()],
+                        span: DUMMY_SP,
+                    })))
+                });
                 iter_exprs(depth - 1, &mut |e| {
                     g(ExprKind::MethodCall(Box::new(MethodCall {
-                        seg: seg.clone(), receiver: make_x(), args: thin_vec![e], span: DUMMY_SP
-                    }))
-                )});
+                        seg: seg.clone(),
+                        receiver: make_x(),
+                        args: thin_vec![e],
+                        span: DUMMY_SP,
+                    })))
+                });
             }
             2..=7 => {
                 let op = Spanned {
@@ -174,7 +180,7 @@ fn iter_exprs(depth: usize, f: &mut dyn FnMut(P<Expr>)) {
             18 => {
                 let pat =
                     P(Pat { id: DUMMY_NODE_ID, kind: PatKind::Wild, span: DUMMY_SP, tokens: None });
-                iter_exprs(depth - 1, &mut |e| g(ExprKind::Let(pat.clone(), e, DUMMY_SP)))
+                iter_exprs(depth - 1, &mut |e| g(ExprKind::Let(pat.clone(), e, DUMMY_SP, None)))
             }
             _ => panic!("bad counter value in iter_exprs"),
         }

--- a/tests/ui/expr/if/bad-if-let-suggestion.rs
+++ b/tests/ui/expr/if/bad-if-let-suggestion.rs
@@ -4,7 +4,6 @@
 fn a() {
     if let x = 1 && i = 2 {}
     //~^ ERROR cannot find value `i` in this scope
-    //~| ERROR `let` expressions in this position are unstable
     //~| ERROR mismatched types
     //~| ERROR expected expression, found `let` statement
 }

--- a/tests/ui/expr/if/bad-if-let-suggestion.rs
+++ b/tests/ui/expr/if/bad-if-let-suggestion.rs
@@ -6,7 +6,7 @@ fn a() {
     //~^ ERROR cannot find value `i` in this scope
     //~| ERROR `let` expressions in this position are unstable
     //~| ERROR mismatched types
-    //~| ERROR `let` expressions are not supported here
+    //~| ERROR expected expression, found `let` statement
 }
 
 fn b() {

--- a/tests/ui/expr/if/bad-if-let-suggestion.stderr
+++ b/tests/ui/expr/if/bad-if-let-suggestion.stderr
@@ -1,10 +1,8 @@
-error: `let` expressions are not supported here
+error: expected expression, found `let` statement
   --> $DIR/bad-if-let-suggestion.rs:5:8
    |
 LL |     if let x = 1 && i = 2 {}
    |        ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
 
 error[E0425]: cannot find value `i` in this scope
   --> $DIR/bad-if-let-suggestion.rs:5:21

--- a/tests/ui/expr/if/bad-if-let-suggestion.stderr
+++ b/tests/ui/expr/if/bad-if-let-suggestion.stderr
@@ -3,6 +3,8 @@ error: expected expression, found `let` statement
    |
 LL |     if let x = 1 && i = 2 {}
    |        ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error[E0425]: cannot find value `i` in this scope
   --> $DIR/bad-if-let-suggestion.rs:5:21

--- a/tests/ui/expr/if/bad-if-let-suggestion.stderr
+++ b/tests/ui/expr/if/bad-if-let-suggestion.stderr
@@ -11,7 +11,7 @@ LL |     if let x = 1 && i = 2 {}
    |                     ^ not found in this scope
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:13:9
+  --> $DIR/bad-if-let-suggestion.rs:12:9
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -20,7 +20,7 @@ LL |     if (i + j) = i {}
    |         ^ help: a function with a similar name exists: `a`
 
 error[E0425]: cannot find value `j` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:13:13
+  --> $DIR/bad-if-let-suggestion.rs:12:13
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -29,7 +29,7 @@ LL |     if (i + j) = i {}
    |             ^ help: a function with a similar name exists: `a`
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:13:18
+  --> $DIR/bad-if-let-suggestion.rs:12:18
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -38,22 +38,13 @@ LL |     if (i + j) = i {}
    |                  ^ help: a function with a similar name exists: `a`
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:20:8
+  --> $DIR/bad-if-let-suggestion.rs:19:8
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
 ...
 LL |     if x[0] = 1 {}
    |        ^ help: a function with a similar name exists: `a`
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/bad-if-let-suggestion.rs:5:8
-   |
-LL |     if let x = 1 && i = 2 {}
-   |        ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0308]: mismatched types
   --> $DIR/bad-if-let-suggestion.rs:5:8
@@ -66,7 +57,7 @@ help: you might have meant to compare for equality
 LL |     if let x = 1 && i == 2 {}
    |                        +
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0308, E0425, E0658.
+Some errors have detailed explanations: E0308, E0425.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/mir/issue-92893.rs
+++ b/tests/ui/mir/issue-92893.rs
@@ -1,7 +1,5 @@
 struct Bug<A = [(); (let a = (), 1).1]> {
-    //~^ `let` expressions are not supported here
-    //~| `let` expressions in this position are unstable [E0658]
-    //~| expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     a: A
 }
 

--- a/tests/ui/mir/issue-92893.stderr
+++ b/tests/ui/mir/issue-92893.stderr
@@ -3,6 +3,8 @@ error: expected expression, found `let` statement
    |
 LL | struct Bug<A = [(); (let a = (), 1).1]> {
    |                      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: aborting due to previous error
 

--- a/tests/ui/mir/issue-92893.stderr
+++ b/tests/ui/mir/issue-92893.stderr
@@ -4,23 +4,5 @@ error: expected expression, found `let` statement
 LL | struct Bug<A = [(); (let a = (), 1).1]> {
    |                      ^^^
 
-error: `let` expressions are not supported here
-  --> $DIR/issue-92893.rs:1:22
-   |
-LL | struct Bug<A = [(); (let a = (), 1).1]> {
-   |                      ^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
+error: aborting due to previous error
 
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/issue-92893.rs:1:22
-   |
-LL | struct Bug<A = [(); (let a = (), 1).1]> {
-   |                      ^^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error: aborting due to 3 previous errors
-
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
@@ -8,14 +8,12 @@ fn _if_let_guard() {
         //~^ ERROR `if let` guards are experimental
 
         () if (let 0 = 1) => {}
-        //~^ ERROR `let` expressions in this position are unstable
-        //~| ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions are not supported here
+        //~^ ERROR expected expression, found `let` statement
+        //~| ERROR `let` expressions in this position are unstable
 
         () if (((let 0 = 1))) => {}
-        //~^ ERROR `let` expressions in this position are unstable
-        //~| ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions are not supported here
+        //~^ ERROR expected expression, found `let` statement
+        //~| ERROR `let` expressions in this position are unstable
 
         () if true && let 0 = 1 => {}
         //~^ ERROR `if let` guards are experimental
@@ -26,22 +24,18 @@ fn _if_let_guard() {
         //~| ERROR `let` expressions in this position are unstable
 
         () if (let 0 = 1) && true => {}
-        //~^ ERROR `let` expressions in this position are unstable
-        //~| ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions are not supported here
+        //~^ ERROR expected expression, found `let` statement
+        //~| ERROR `let` expressions in this position are unstable
 
         () if true && (let 0 = 1) => {}
-        //~^ ERROR `let` expressions in this position are unstable
-        //~| ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions are not supported here
+        //~^ ERROR expected expression, found `let` statement
+        //~| ERROR `let` expressions in this position are unstable
 
         () if (let 0 = 1) && (let 0 = 1) => {}
-        //~^ ERROR `let` expressions in this position are unstable
+        //~^ ERROR expected expression, found `let` statement
+        //~| ERROR expected expression, found `let` statement
         //~| ERROR `let` expressions in this position are unstable
-        //~| ERROR expected expression, found `let` statement
-        //~| ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions are not supported here
-        //~| ERROR `let` expressions are not supported here
+        //~| ERROR `let` expressions in this position are unstable
 
         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
         //~^ ERROR `if let` guards are experimental
@@ -53,9 +47,6 @@ fn _if_let_guard() {
         //~| ERROR expected expression, found `let` statement
         //~| ERROR expected expression, found `let` statement
         //~| ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions are not supported here
-        //~| ERROR `let` expressions are not supported here
-        //~| ERROR `let` expressions are not supported here
 
 
         () if let Range { start: _, end: _ } = (true..true) && false => {}
@@ -76,13 +67,9 @@ fn _macros() {
         }
     }
     use_expr!((let 0 = 1 && 0 == 0));
-    //~^ ERROR `let` expressions in this position are unstable
-    //~| ERROR expected expression, found `let` statement
-    //~| ERROR `let` expressions are not supported here
+    //~^ ERROR expected expression, found `let` statement
     use_expr!((let 0 = 1));
-    //~^ ERROR `let` expressions in this position are unstable
-    //~| ERROR expected expression, found `let` statement
-    //~| ERROR `let` expressions are not supported here
+    //~^ ERROR expected expression, found `let` statement
     match () {
         #[cfg(FALSE)]
         () if let 0 = 1 => {}

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
@@ -9,11 +9,9 @@ fn _if_let_guard() {
 
         () if (let 0 = 1) => {}
         //~^ ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions in this position are unstable
 
         () if (((let 0 = 1))) => {}
         //~^ ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions in this position are unstable
 
         () if true && let 0 = 1 => {}
         //~^ ERROR `if let` guards are experimental
@@ -25,23 +23,16 @@ fn _if_let_guard() {
 
         () if (let 0 = 1) && true => {}
         //~^ ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions in this position are unstable
 
         () if true && (let 0 = 1) => {}
         //~^ ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions in this position are unstable
 
         () if (let 0 = 1) && (let 0 = 1) => {}
         //~^ ERROR expected expression, found `let` statement
         //~| ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions in this position are unstable
-        //~| ERROR `let` expressions in this position are unstable
 
         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
         //~^ ERROR `if let` guards are experimental
-        //~| ERROR `let` expressions in this position are unstable
-        //~| ERROR `let` expressions in this position are unstable
-        //~| ERROR `let` expressions in this position are unstable
         //~| ERROR `let` expressions in this position are unstable
         //~| ERROR `let` expressions in this position are unstable
         //~| ERROR expected expression, found `let` statement

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
@@ -2,70 +2,124 @@ error: expected expression, found `let` statement
   --> $DIR/feature-gate.rs:10:16
    |
 LL |         () if (let 0 = 1) => {}
-   |                ^^^
+   |                ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/feature-gate.rs:10:16
+   |
+LL |         () if (let 0 = 1) => {}
+   |                ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:15:18
+  --> $DIR/feature-gate.rs:14:18
    |
 LL |         () if (((let 0 = 1))) => {}
-   |                  ^^^
+   |                  ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/feature-gate.rs:14:18
+   |
+LL |         () if (((let 0 = 1))) => {}
+   |                  ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:28:16
+  --> $DIR/feature-gate.rs:26:16
    |
 LL |         () if (let 0 = 1) && true => {}
-   |                ^^^
+   |                ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/feature-gate.rs:26:16
+   |
+LL |         () if (let 0 = 1) && true => {}
+   |                ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:33:24
+  --> $DIR/feature-gate.rs:30:24
    |
 LL |         () if true && (let 0 = 1) => {}
-   |                        ^^^
+   |                        ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/feature-gate.rs:30:24
+   |
+LL |         () if true && (let 0 = 1) => {}
+   |                        ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:38:16
+  --> $DIR/feature-gate.rs:34:16
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
-   |                ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:38:31
+   |                ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/feature-gate.rs:34:16
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
-   |                               ^^^
+   |                ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:46:42
+  --> $DIR/feature-gate.rs:34:31
+   |
+LL |         () if (let 0 = 1) && (let 0 = 1) => {}
+   |                               ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/feature-gate.rs:34:31
+   |
+LL |         () if (let 0 = 1) && (let 0 = 1) => {}
+   |                               ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/feature-gate.rs:40:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                          ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:46:55
+   |                                          ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/feature-gate.rs:40:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                                       ^^^
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:46:68
+  --> $DIR/feature-gate.rs:40:55
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                                                    ^^^
+   |                                                       ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/feature-gate.rs:40:42
+   |
+LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:78:16
+  --> $DIR/feature-gate.rs:40:68
+   |
+LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
+   |                                                                    ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/feature-gate.rs:40:42
+   |
+LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/feature-gate.rs:69:16
    |
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:82:16
+  --> $DIR/feature-gate.rs:71:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^
 
 error: no rules expected the token `let`
-  --> $DIR/feature-gate.rs:92:15
+  --> $DIR/feature-gate.rs:79:15
    |
 LL |     macro_rules! use_expr {
    |     --------------------- when calling this macro
@@ -74,153 +128,10 @@ LL |     use_expr!(let 0 = 1);
    |               ^^^ no rules expected this token in macro call
    |
 note: while trying to match meta-variable `$e:expr`
-  --> $DIR/feature-gate.rs:71:10
+  --> $DIR/feature-gate.rs:62:10
    |
 LL |         ($e:expr) => {
    |          ^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:10:16
-   |
-LL |         () if (let 0 = 1) => {}
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:10:16
-   |
-LL |         () if (let 0 = 1) => {}
-   |                ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:15:18
-   |
-LL |         () if (((let 0 = 1))) => {}
-   |                  ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:15:18
-   |
-LL |         () if (((let 0 = 1))) => {}
-   |                  ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:28:16
-   |
-LL |         () if (let 0 = 1) && true => {}
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:28:16
-   |
-LL |         () if (let 0 = 1) && true => {}
-   |                ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:33:24
-   |
-LL |         () if true && (let 0 = 1) => {}
-   |                        ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:33:24
-   |
-LL |         () if true && (let 0 = 1) => {}
-   |                        ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:38:16
-   |
-LL |         () if (let 0 = 1) && (let 0 = 1) => {}
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:38:16
-   |
-LL |         () if (let 0 = 1) && (let 0 = 1) => {}
-   |                ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:38:31
-   |
-LL |         () if (let 0 = 1) && (let 0 = 1) => {}
-   |                               ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:38:31
-   |
-LL |         () if (let 0 = 1) && (let 0 = 1) => {}
-   |                               ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:46:42
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                          ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:46:42
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:46:55
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                                       ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:46:42
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:46:68
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                                                    ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:46:42
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:78:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:78:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:82:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:82:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
 
 error[E0658]: `if let` guards are experimental
   --> $DIR/feature-gate.rs:7:12
@@ -233,7 +144,7 @@ LL |         () if let 0 = 1 => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:20:12
+  --> $DIR/feature-gate.rs:18:12
    |
 LL |         () if true && let 0 = 1 => {}
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -243,7 +154,7 @@ LL |         () if true && let 0 = 1 => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:24:12
+  --> $DIR/feature-gate.rs:22:12
    |
 LL |         () if let 0 = 1 && true => {}
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -253,7 +164,7 @@ LL |         () if let 0 = 1 && true => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:46:12
+  --> $DIR/feature-gate.rs:40:12
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,7 +174,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:61:12
+  --> $DIR/feature-gate.rs:52:12
    |
 LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -273,7 +184,7 @@ LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:88:12
+  --> $DIR/feature-gate.rs:75:12
    |
 LL |         () if let 0 = 1 => {}
    |            ^^^^^^^^^^^^
@@ -292,7 +203,7 @@ LL |         () if (let 0 = 1) => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:15:18
+  --> $DIR/feature-gate.rs:14:18
    |
 LL |         () if (((let 0 = 1))) => {}
    |                  ^^^^^^^^^
@@ -301,7 +212,7 @@ LL |         () if (((let 0 = 1))) => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:20:23
+  --> $DIR/feature-gate.rs:18:23
    |
 LL |         () if true && let 0 = 1 => {}
    |                       ^^^^^^^^^
@@ -310,7 +221,7 @@ LL |         () if true && let 0 = 1 => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:24:15
+  --> $DIR/feature-gate.rs:22:15
    |
 LL |         () if let 0 = 1 && true => {}
    |               ^^^^^^^^^
@@ -319,7 +230,7 @@ LL |         () if let 0 = 1 && true => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:28:16
+  --> $DIR/feature-gate.rs:26:16
    |
 LL |         () if (let 0 = 1) && true => {}
    |                ^^^^^^^^^
@@ -328,7 +239,7 @@ LL |         () if (let 0 = 1) && true => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:33:24
+  --> $DIR/feature-gate.rs:30:24
    |
 LL |         () if true && (let 0 = 1) => {}
    |                        ^^^^^^^^^
@@ -337,7 +248,7 @@ LL |         () if true && (let 0 = 1) => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:38:16
+  --> $DIR/feature-gate.rs:34:16
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                ^^^^^^^^^
@@ -346,7 +257,7 @@ LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:38:31
+  --> $DIR/feature-gate.rs:34:31
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                               ^^^^^^^^^
@@ -355,7 +266,7 @@ LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:46:15
+  --> $DIR/feature-gate.rs:40:15
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |               ^^^^^^^^^
@@ -364,7 +275,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:46:28
+  --> $DIR/feature-gate.rs:40:28
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                            ^^^^^^^^^
@@ -373,7 +284,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:46:42
+  --> $DIR/feature-gate.rs:40:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^
@@ -382,7 +293,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:46:55
+  --> $DIR/feature-gate.rs:40:55
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                                       ^^^^^^^^^
@@ -391,7 +302,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:46:68
+  --> $DIR/feature-gate.rs:40:68
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                                                    ^^^^^^^^^
@@ -400,7 +311,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:61:15
+  --> $DIR/feature-gate.rs:52:15
    |
 LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -408,24 +319,6 @@ LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:78:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:82:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error: aborting due to 45 previous errors
+error: aborting due to 32 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
@@ -4,6 +4,7 @@ error: expected expression, found `let` statement
 LL |         () if (let 0 = 1) => {}
    |                ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/feature-gate.rs:10:16
    |
@@ -16,6 +17,7 @@ error: expected expression, found `let` statement
 LL |         () if (((let 0 = 1))) => {}
    |                  ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/feature-gate.rs:13:18
    |
@@ -28,6 +30,7 @@ error: expected expression, found `let` statement
 LL |         () if (let 0 = 1) && true => {}
    |                ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/feature-gate.rs:24:16
    |
@@ -40,6 +43,7 @@ error: expected expression, found `let` statement
 LL |         () if true && (let 0 = 1) => {}
    |                        ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/feature-gate.rs:27:24
    |
@@ -52,6 +56,7 @@ error: expected expression, found `let` statement
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/feature-gate.rs:30:16
    |
@@ -64,6 +69,7 @@ error: expected expression, found `let` statement
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                               ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/feature-gate.rs:30:31
    |
@@ -76,6 +82,7 @@ error: expected expression, found `let` statement
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/feature-gate.rs:34:42
    |
@@ -88,6 +95,7 @@ error: expected expression, found `let` statement
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                                       ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/feature-gate.rs:34:42
    |
@@ -100,6 +108,7 @@ error: expected expression, found `let` statement
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                                                    ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/feature-gate.rs:34:42
    |
@@ -111,12 +120,16 @@ error: expected expression, found `let` statement
    |
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/feature-gate.rs:62:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: no rules expected the token `let`
   --> $DIR/feature-gate.rs:70:15

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
@@ -11,115 +11,115 @@ LL |         () if (let 0 = 1) => {}
    |                ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:14:18
+  --> $DIR/feature-gate.rs:13:18
    |
 LL |         () if (((let 0 = 1))) => {}
    |                  ^^^^^^^^^
    |
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:14:18
+  --> $DIR/feature-gate.rs:13:18
    |
 LL |         () if (((let 0 = 1))) => {}
    |                  ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:26:16
+  --> $DIR/feature-gate.rs:24:16
    |
 LL |         () if (let 0 = 1) && true => {}
    |                ^^^^^^^^^
    |
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:26:16
+  --> $DIR/feature-gate.rs:24:16
    |
 LL |         () if (let 0 = 1) && true => {}
    |                ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:30:24
+  --> $DIR/feature-gate.rs:27:24
    |
 LL |         () if true && (let 0 = 1) => {}
    |                        ^^^^^^^^^
    |
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:30:24
+  --> $DIR/feature-gate.rs:27:24
    |
 LL |         () if true && (let 0 = 1) => {}
    |                        ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:34:16
+  --> $DIR/feature-gate.rs:30:16
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                ^^^^^^^^^
    |
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:34:16
+  --> $DIR/feature-gate.rs:30:16
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:34:31
+  --> $DIR/feature-gate.rs:30:31
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                               ^^^^^^^^^
    |
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:34:31
+  --> $DIR/feature-gate.rs:30:31
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                               ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:40:42
+  --> $DIR/feature-gate.rs:34:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^
    |
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:40:42
+  --> $DIR/feature-gate.rs:34:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:40:55
+  --> $DIR/feature-gate.rs:34:55
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                                       ^^^^^^^^^
    |
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:40:42
+  --> $DIR/feature-gate.rs:34:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:40:68
+  --> $DIR/feature-gate.rs:34:68
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                                                    ^^^^^^^^^
    |
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:40:42
+  --> $DIR/feature-gate.rs:34:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:69:16
+  --> $DIR/feature-gate.rs:60:16
    |
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:71:16
+  --> $DIR/feature-gate.rs:62:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^
 
 error: no rules expected the token `let`
-  --> $DIR/feature-gate.rs:79:15
+  --> $DIR/feature-gate.rs:70:15
    |
 LL |     macro_rules! use_expr {
    |     --------------------- when calling this macro
@@ -128,7 +128,7 @@ LL |     use_expr!(let 0 = 1);
    |               ^^^ no rules expected this token in macro call
    |
 note: while trying to match meta-variable `$e:expr`
-  --> $DIR/feature-gate.rs:62:10
+  --> $DIR/feature-gate.rs:53:10
    |
 LL |         ($e:expr) => {
    |          ^^^^^^^
@@ -144,7 +144,7 @@ LL |         () if let 0 = 1 => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:18:12
+  --> $DIR/feature-gate.rs:16:12
    |
 LL |         () if true && let 0 = 1 => {}
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -154,7 +154,7 @@ LL |         () if true && let 0 = 1 => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:22:12
+  --> $DIR/feature-gate.rs:20:12
    |
 LL |         () if let 0 = 1 && true => {}
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -164,7 +164,7 @@ LL |         () if let 0 = 1 && true => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:40:12
+  --> $DIR/feature-gate.rs:34:12
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -174,7 +174,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:52:12
+  --> $DIR/feature-gate.rs:43:12
    |
 LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -184,7 +184,7 @@ LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:75:12
+  --> $DIR/feature-gate.rs:66:12
    |
 LL |         () if let 0 = 1 => {}
    |            ^^^^^^^^^^^^
@@ -194,25 +194,7 @@ LL |         () if let 0 = 1 => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:10:16
-   |
-LL |         () if (let 0 = 1) => {}
-   |                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:14:18
-   |
-LL |         () if (((let 0 = 1))) => {}
-   |                  ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:18:23
+  --> $DIR/feature-gate.rs:16:23
    |
 LL |         () if true && let 0 = 1 => {}
    |                       ^^^^^^^^^
@@ -221,7 +203,7 @@ LL |         () if true && let 0 = 1 => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:22:15
+  --> $DIR/feature-gate.rs:20:15
    |
 LL |         () if let 0 = 1 && true => {}
    |               ^^^^^^^^^
@@ -230,43 +212,7 @@ LL |         () if let 0 = 1 && true => {}
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:26:16
-   |
-LL |         () if (let 0 = 1) && true => {}
-   |                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:30:24
-   |
-LL |         () if true && (let 0 = 1) => {}
-   |                        ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:34:16
-   |
-LL |         () if (let 0 = 1) && (let 0 = 1) => {}
-   |                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:34:31
-   |
-LL |         () if (let 0 = 1) && (let 0 = 1) => {}
-   |                               ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:40:15
+  --> $DIR/feature-gate.rs:34:15
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |               ^^^^^^^^^
@@ -275,7 +221,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:40:28
+  --> $DIR/feature-gate.rs:34:28
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                            ^^^^^^^^^
@@ -284,34 +230,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:40:42
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                          ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:40:55
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                                       ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:40:68
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                                                                    ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:52:15
+  --> $DIR/feature-gate.rs:43:15
    |
 LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -319,6 +238,6 @@ LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
-error: aborting due to 32 previous errors
+error: aborting due to 23 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/macro-expanded.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/macro-expanded.stderr
@@ -7,6 +7,7 @@ LL |     ($e:expr) => { let Some(x) = $e }
 LL |         () if m!(Some(5)) => {}
    |               ----------- in this macro invocation
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/parens.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/parens.rs
@@ -19,9 +19,7 @@ fn main() {
         () if let 0 = 1 => {}
         () if (let 0 = 1) => {}
         //~^ ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions are not supported here
         () if (((let 0 = 1))) => {}
         //~^ ERROR expected expression, found `let` statement
-        //~| ERROR `let` expressions are not supported here
     }
 }

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/parens.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/parens.stderr
@@ -4,6 +4,7 @@ error: expected expression, found `let` statement
 LL |         () if (let 0 = 1) => {}
    |                ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/parens.rs:10:16
    |
@@ -16,6 +17,7 @@ error: expected expression, found `let` statement
 LL |         () if (((let 0 = 1))) => {}
    |                  ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/parens.rs:12:18
    |
@@ -28,6 +30,7 @@ error: expected expression, found `let` statement
 LL |         () if (let 0 = 1) => {}
    |                ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/parens.rs:20:16
    |
@@ -40,6 +43,7 @@ error: expected expression, found `let` statement
 LL |         () if (((let 0 = 1))) => {}
    |                  ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/parens.rs:22:18
    |

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/parens.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/parens.stderr
@@ -2,51 +2,49 @@ error: expected expression, found `let` statement
   --> $DIR/parens.rs:10:16
    |
 LL |         () if (let 0 = 1) => {}
-   |                ^^^
+   |                ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/parens.rs:10:16
+   |
+LL |         () if (let 0 = 1) => {}
+   |                ^^^^^^^^^
 
 error: expected expression, found `let` statement
   --> $DIR/parens.rs:12:18
    |
 LL |         () if (((let 0 = 1))) => {}
-   |                  ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/parens.rs:20:16
+   |                  ^^^^^^^^^
    |
-LL |         () if (let 0 = 1) => {}
-   |                ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/parens.rs:23:18
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/parens.rs:12:18
    |
 LL |         () if (((let 0 = 1))) => {}
-   |                  ^^^
+   |                  ^^^^^^^^^
 
-error: `let` expressions are not supported here
+error: expected expression, found `let` statement
   --> $DIR/parens.rs:20:16
    |
 LL |         () if (let 0 = 1) => {}
    |                ^^^^^^^^^
    |
-   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/parens.rs:20:16
    |
 LL |         () if (let 0 = 1) => {}
    |                ^^^^^^^^^
 
-error: `let` expressions are not supported here
-  --> $DIR/parens.rs:23:18
+error: expected expression, found `let` statement
+  --> $DIR/parens.rs:22:18
    |
 LL |         () if (((let 0 = 1))) => {}
    |                  ^^^^^^^^^
    |
-   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/parens.rs:23:18
+  --> $DIR/parens.rs:22:18
    |
 LL |         () if (((let 0 = 1))) => {}
    |                  ^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.rs
@@ -3,7 +3,7 @@
 fn let_or_guard(x: Result<Option<i32>, ()>) {
     match x {
         Ok(opt) if let Some(4) = opt || false  => {}
-        //~^ ERROR `let` expressions are not supported here
+        //~^ ERROR expected expression, found `let` statement
         _ => {}
     }
 }

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.stderr
@@ -4,6 +4,7 @@ error: expected expression, found `let` statement
 LL |         Ok(opt) if let Some(4) = opt || false  => {}
    |                    ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `||` operators are not supported in let chain expressions
   --> $DIR/ast-validate-guards.rs:5:38
    |

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.stderr
@@ -1,10 +1,9 @@
-error: `let` expressions are not supported here
+error: expected expression, found `let` statement
   --> $DIR/ast-validate-guards.rs:5:20
    |
 LL |         Ok(opt) if let Some(4) = opt || false  => {}
    |                    ^^^^^^^^^^^^^^^^^
    |
-   = note: only supported directly in conditions of `if` and `while` expressions
 note: `||` operators are not supported in let chain expressions
   --> $DIR/ast-validate-guards.rs:5:38
    |

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.rs
@@ -1,0 +1,16 @@
+// Regression test for #104172
+
+const N: usize = {
+    struct U;
+    !let y = 42;
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR `let` expressions are not supported here
+    //~| ERROR `let` expressions in this position are unstable [E0658]
+    3
+};
+
+struct S {
+    x: [(); N]
+}
+
+fn main() {}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.rs
@@ -4,8 +4,6 @@ const N: usize = {
     struct U;
     !let y = 42;
     //~^ ERROR expected expression, found `let` statement
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions in this position are unstable [E0658]
     3
 };
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
@@ -1,0 +1,26 @@
+error: expected expression, found `let` statement
+  --> $DIR/avoid-invalid-mir.rs:5:7
+   |
+LL |     ! let y = 42;
+   |       ^^^
+
+error: `let` expressions are not supported here
+  --> $DIR/avoid-invalid-mir.rs:5:7
+   |
+LL |     ! let y = 42;
+   |       ^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/avoid-invalid-mir.rs:5:7
+   |
+LL |     ! let y = 42;
+   |       ^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
@@ -1,26 +1,8 @@
 error: expected expression, found `let` statement
-  --> $DIR/avoid-invalid-mir.rs:5:7
+  --> $DIR/avoid-invalid-mir.rs:5:6
    |
-LL |     ! let y = 42;
-   |       ^^^
+LL |     !let y = 42;
+   |      ^^^
 
-error: `let` expressions are not supported here
-  --> $DIR/avoid-invalid-mir.rs:5:7
-   |
-LL |     ! let y = 42;
-   |       ^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
+error: aborting due to previous error
 
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/avoid-invalid-mir.rs:5:7
-   |
-LL |     ! let y = 42;
-   |       ^^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error: aborting due to 3 previous errors
-
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
@@ -3,6 +3,8 @@ error: expected expression, found `let` statement
    |
 LL |     !let y = 42;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: aborting due to previous error
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions-without-feature-gate.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions-without-feature-gate.rs
@@ -1,0 +1,340 @@
+// Check that we don't suggest enabling a feature for code that's
+// not accepted even with that feature.
+
+#![allow(irrefutable_let_patterns)]
+
+use std::ops::Range;
+
+fn main() {}
+
+fn _if() {
+    if (let 0 = 1) {}
+    //~^ ERROR expected expression, found `let` statement
+
+    if (((let 0 = 1))) {}
+    //~^ ERROR expected expression, found `let` statement
+
+    if (let 0 = 1) && true {}
+    //~^ ERROR expected expression, found `let` statement
+
+    if true && (let 0 = 1) {}
+    //~^ ERROR expected expression, found `let` statement
+
+    if (let 0 = 1) && (let 0 = 1) {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+
+    if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+}
+
+fn _while() {
+    while (let 0 = 1) {}
+    //~^ ERROR expected expression, found `let` statement
+
+    while (((let 0 = 1))) {}
+    //~^ ERROR expected expression, found `let` statement
+
+    while (let 0 = 1) && true {}
+    //~^ ERROR expected expression, found `let` statement
+
+    while true && (let 0 = 1) {}
+    //~^ ERROR expected expression, found `let` statement
+
+    while (let 0 = 1) && (let 0 = 1) {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+
+    while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+}
+
+fn _macros() {
+    macro_rules! use_expr {
+        ($e:expr) => {
+            if $e {}
+            while $e {}
+        }
+    }
+    use_expr!((let 0 = 1 && 0 == 0));
+    //~^ ERROR expected expression, found `let` statement
+    use_expr!((let 0 = 1));
+    //~^ ERROR expected expression, found `let` statement
+}
+
+fn nested_within_if_expr() {
+    if &let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+
+    if !let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+    if *let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+    if -let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+
+    fn _check_try_binds_tighter() -> Result<(), ()> {
+        if let 0 = 0? {}
+        //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+        Ok(())
+    }
+    if (let 0 = 0)? {}
+    //~^ ERROR expected expression, found `let` statement
+
+    if true || let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+    if (true || let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+    if true && (true || let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+    if true || (true && let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+
+    let mut x = true;
+    if x = let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+
+    if true..(let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+    if ..(let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+    if (let 0 = 0).. {}
+    //~^ ERROR expected expression, found `let` statement
+
+    // Binds as `(let ... = true)..true &&/|| false`.
+    if let Range { start: _, end: _ } = true..true && false {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+    if let Range { start: _, end: _ } = true..true || false {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+
+    // Binds as `(let Range { start: F, end } = F)..(|| true)`.
+    const F: fn() -> bool = || true;
+    if let Range { start: F, end } = F..|| true {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+
+    // Binds as `(let Range { start: true, end } = t)..(&&false)`.
+    let t = &&true;
+    if let Range { start: true, end } = t..&&false {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+
+    if let true = let true = true {}
+    //~^ ERROR expected expression, found `let` statement
+}
+
+fn nested_within_while_expr() {
+    while &let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+
+    while !let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+    while *let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+    while -let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+
+    fn _check_try_binds_tighter() -> Result<(), ()> {
+        while let 0 = 0? {}
+        //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+        Ok(())
+    }
+    while (let 0 = 0)? {}
+    //~^ ERROR expected expression, found `let` statement
+
+    while true || let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+    while (true || let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+    while true && (true || let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+    while true || (true && let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+
+    let mut x = true;
+    while x = let 0 = 0 {}
+    //~^ ERROR expected expression, found `let` statement
+
+    while true..(let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+    while ..(let 0 = 0) {}
+    //~^ ERROR expected expression, found `let` statement
+    while (let 0 = 0).. {}
+    //~^ ERROR expected expression, found `let` statement
+
+    // Binds as `(let ... = true)..true &&/|| false`.
+    while let Range { start: _, end: _ } = true..true && false {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+    while let Range { start: _, end: _ } = true..true || false {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+
+    // Binds as `(let Range { start: F, end } = F)..(|| true)`.
+    const F: fn() -> bool = || true;
+    while let Range { start: F, end } = F..|| true {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+
+    // Binds as `(let Range { start: true, end } = t)..(&&false)`.
+    let t = &&true;
+    while let Range { start: true, end } = t..&&false {}
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR mismatched types
+
+    while let true = let true = true {}
+    //~^ ERROR expected expression, found `let` statement
+}
+
+fn not_error_because_clarified_intent() {
+    if let Range { start: _, end: _ } = (true..true || false) { }
+
+    if let Range { start: _, end: _ } = (true..true && false) { }
+
+    while let Range { start: _, end: _ } = (true..true || false) { }
+
+    while let Range { start: _, end: _ } = (true..true && false) { }
+}
+
+fn outside_if_and_while_expr() {
+    &let 0 = 0;
+    //~^ ERROR expected expression, found `let` statement
+
+    !let 0 = 0;
+    //~^ ERROR expected expression, found `let` statement
+    *let 0 = 0;
+    //~^ ERROR expected expression, found `let` statement
+    -let 0 = 0;
+    //~^ ERROR expected expression, found `let` statement
+    let _ = let _ = 3;
+    //~^ ERROR expected expression, found `let` statement
+
+    fn _check_try_binds_tighter() -> Result<(), ()> {
+        let 0 = 0?;
+        //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+        Ok(())
+    }
+    (let 0 = 0)?;
+    //~^ ERROR expected expression, found `let` statement
+
+    true || let 0 = 0;
+    //~^ ERROR expected expression, found `let` statement
+    (true || let 0 = 0);
+    //~^ ERROR expected expression, found `let` statement
+    true && (true || let 0 = 0);
+    //~^ ERROR expected expression, found `let` statement
+
+    let mut x = true;
+    x = let 0 = 0;
+    //~^ ERROR expected expression, found `let` statement
+
+    true..(let 0 = 0);
+    //~^ ERROR expected expression, found `let` statement
+    ..(let 0 = 0);
+    //~^ ERROR expected expression, found `let` statement
+    (let 0 = 0)..;
+    //~^ ERROR expected expression, found `let` statement
+
+    (let Range { start: _, end: _ } = true..true || false);
+    //~^ ERROR mismatched types
+    //~| ERROR expected expression, found `let` statement
+
+    (let true = let true = true);
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+
+    {
+        #[cfg(FALSE)]
+        let x = true && let y = 1;
+        //~^ ERROR expected expression, found `let` statement
+    }
+
+    #[cfg(FALSE)]
+    {
+        [1, 2, 3][let _ = ()]
+        //~^ ERROR expected expression, found `let` statement
+    }
+
+    // Check function tail position.
+    &let 0 = 0
+    //~^ ERROR expected expression, found `let` statement
+}
+
+// Let's make sure that `let` inside const generic arguments are considered.
+fn inside_const_generic_arguments() {
+    struct A<const B: bool>;
+    impl<const B: bool> A<{B}> { const O: u32 = 5; }
+
+    if let A::<{
+        true && let 1 = 1
+        //~^ ERROR expected expression, found `let` statement
+    }>::O = 5 {}
+
+    while let A::<{
+        true && let 1 = 1
+        //~^ ERROR expected expression, found `let` statement
+    }>::O = 5 {}
+
+    if A::<{
+        true && let 1 = 1
+        //~^ ERROR expected expression, found `let` statement
+    }>::O == 5 {}
+
+    // In the cases above we have `ExprKind::Block` to help us out.
+    // Below however, we would not have a block and so an implementation might go
+    // from visiting expressions to types without banning `let` expressions down the tree.
+    // This tests ensures that we are not caught by surprise should the parser
+    // admit non-IDENT expressions in const generic arguments.
+
+    if A::<
+        true && let 1 = 1
+        //~^ ERROR expressions must be enclosed in braces
+        //~| ERROR expected expression, found `let` statement
+    >::O == 5 {}
+}
+
+fn with_parenthesis() {
+    let opt = Some(Some(1i32));
+
+    if (let Some(a) = opt && true) {
+    //~^ ERROR expected expression, found `let` statement
+    }
+
+    if (let Some(a) = opt) && true {
+    //~^ ERROR expected expression, found `let` statement
+    }
+    if (let Some(a) = opt) && (let Some(b) = a) {
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+    }
+
+    if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+    }
+    if (let Some(a) = opt && (let Some(b) = a)) && true {
+    //~^ ERROR expected expression, found `let` statement
+    //~| ERROR expected expression, found `let` statement
+    }
+    if (let Some(a) = opt && (true)) && true {
+    //~^ ERROR expected expression, found `let` statement
+    }
+
+    #[cfg(FALSE)]
+    let x = (true && let y = 1);
+    //~^ ERROR expected expression, found `let` statement
+
+    #[cfg(FALSE)]
+    {
+        ([1, 2, 3][let _ = ()])
+        //~^ ERROR expected expression, found `let` statement
+    }
+}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions-without-feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions-without-feature-gate.stderr
@@ -1,0 +1,870 @@
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:11:9
+   |
+LL |     if (let 0 = 1) {}
+   |         ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:11:9
+   |
+LL |     if (let 0 = 1) {}
+   |         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:14:11
+   |
+LL |     if (((let 0 = 1))) {}
+   |           ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:14:11
+   |
+LL |     if (((let 0 = 1))) {}
+   |           ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:17:9
+   |
+LL |     if (let 0 = 1) && true {}
+   |         ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:17:9
+   |
+LL |     if (let 0 = 1) && true {}
+   |         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:20:17
+   |
+LL |     if true && (let 0 = 1) {}
+   |                 ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:20:17
+   |
+LL |     if true && (let 0 = 1) {}
+   |                 ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:23:9
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |         ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:23:9
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:23:24
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |                        ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:23:24
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |                        ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:27:9
+   |
+LL |     if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |         ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:27:9
+   |
+LL |     if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:27:22
+   |
+LL |     if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                      ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:27:9
+   |
+LL |     if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:27:35
+   |
+LL |     if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                   ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:27:9
+   |
+LL |     if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:34:12
+   |
+LL |     while (let 0 = 1) {}
+   |            ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:34:12
+   |
+LL |     while (let 0 = 1) {}
+   |            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:37:14
+   |
+LL |     while (((let 0 = 1))) {}
+   |              ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:37:14
+   |
+LL |     while (((let 0 = 1))) {}
+   |              ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:40:12
+   |
+LL |     while (let 0 = 1) && true {}
+   |            ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:40:12
+   |
+LL |     while (let 0 = 1) && true {}
+   |            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:43:20
+   |
+LL |     while true && (let 0 = 1) {}
+   |                    ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:43:20
+   |
+LL |     while true && (let 0 = 1) {}
+   |                    ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:46:12
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |            ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:46:12
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:46:27
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |                           ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:46:27
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |                           ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:50:12
+   |
+LL |     while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |            ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:50:12
+   |
+LL |     while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:50:25
+   |
+LL |     while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                         ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:50:12
+   |
+LL |     while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:50:38
+   |
+LL |     while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                      ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:50:12
+   |
+LL |     while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:70:9
+   |
+LL |     if &let 0 = 0 {}
+   |         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:73:9
+   |
+LL |     if !let 0 = 0 {}
+   |         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:75:9
+   |
+LL |     if *let 0 = 0 {}
+   |         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:77:9
+   |
+LL |     if -let 0 = 0 {}
+   |         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:85:9
+   |
+LL |     if (let 0 = 0)? {}
+   |         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:88:16
+   |
+LL |     if true || let 0 = 0 {}
+   |                ^^^^^^^^^
+   |
+note: `||` operators are not supported in let chain expressions
+  --> $DIR/disallowed-positions-without-feature-gate.rs:88:13
+   |
+LL |     if true || let 0 = 0 {}
+   |             ^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:90:17
+   |
+LL |     if (true || let 0 = 0) {}
+   |                 ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:92:25
+   |
+LL |     if true && (true || let 0 = 0) {}
+   |                         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:94:25
+   |
+LL |     if true || (true && let 0 = 0) {}
+   |                         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:98:12
+   |
+LL |     if x = let 0 = 0 {}
+   |            ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:101:15
+   |
+LL |     if true..(let 0 = 0) {}
+   |               ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:104:11
+   |
+LL |     if ..(let 0 = 0) {}
+   |           ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:106:9
+   |
+LL |     if (let 0 = 0).. {}
+   |         ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:110:8
+   |
+LL |     if let Range { start: _, end: _ } = true..true && false {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:113:8
+   |
+LL |     if let Range { start: _, end: _ } = true..true || false {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:119:8
+   |
+LL |     if let Range { start: F, end } = F..|| true {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:125:8
+   |
+LL |     if let Range { start: true, end } = t..&&false {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:129:19
+   |
+LL |     if let true = let true = true {}
+   |                   ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:134:12
+   |
+LL |     while &let 0 = 0 {}
+   |            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:137:12
+   |
+LL |     while !let 0 = 0 {}
+   |            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:139:12
+   |
+LL |     while *let 0 = 0 {}
+   |            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:141:12
+   |
+LL |     while -let 0 = 0 {}
+   |            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:149:12
+   |
+LL |     while (let 0 = 0)? {}
+   |            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:152:19
+   |
+LL |     while true || let 0 = 0 {}
+   |                   ^^^^^^^^^
+   |
+note: `||` operators are not supported in let chain expressions
+  --> $DIR/disallowed-positions-without-feature-gate.rs:152:16
+   |
+LL |     while true || let 0 = 0 {}
+   |                ^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:154:20
+   |
+LL |     while (true || let 0 = 0) {}
+   |                    ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:156:28
+   |
+LL |     while true && (true || let 0 = 0) {}
+   |                            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:158:28
+   |
+LL |     while true || (true && let 0 = 0) {}
+   |                            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:162:15
+   |
+LL |     while x = let 0 = 0 {}
+   |               ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:165:18
+   |
+LL |     while true..(let 0 = 0) {}
+   |                  ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:168:14
+   |
+LL |     while ..(let 0 = 0) {}
+   |              ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:170:12
+   |
+LL |     while (let 0 = 0).. {}
+   |            ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:174:11
+   |
+LL |     while let Range { start: _, end: _ } = true..true && false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:177:11
+   |
+LL |     while let Range { start: _, end: _ } = true..true || false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:183:11
+   |
+LL |     while let Range { start: F, end } = F..|| true {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:189:11
+   |
+LL |     while let Range { start: true, end } = t..&&false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:193:22
+   |
+LL |     while let true = let true = true {}
+   |                      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:208:6
+   |
+LL |     &let 0 = 0;
+   |      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:211:6
+   |
+LL |     !let 0 = 0;
+   |      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:213:6
+   |
+LL |     *let 0 = 0;
+   |      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:215:6
+   |
+LL |     -let 0 = 0;
+   |      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:217:13
+   |
+LL |     let _ = let _ = 3;
+   |             ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:225:6
+   |
+LL |     (let 0 = 0)?;
+   |      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:228:13
+   |
+LL |     true || let 0 = 0;
+   |             ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:230:14
+   |
+LL |     (true || let 0 = 0);
+   |              ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:232:22
+   |
+LL |     true && (true || let 0 = 0);
+   |                      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:236:9
+   |
+LL |     x = let 0 = 0;
+   |         ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:239:12
+   |
+LL |     true..(let 0 = 0);
+   |            ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:241:8
+   |
+LL |     ..(let 0 = 0);
+   |        ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:243:6
+   |
+LL |     (let 0 = 0)..;
+   |      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:246:6
+   |
+LL |     (let Range { start: _, end: _ } = true..true || false);
+   |      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:250:6
+   |
+LL |     (let true = let true = true);
+   |      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:250:17
+   |
+LL |     (let true = let true = true);
+   |                 ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:256:25
+   |
+LL |         let x = true && let y = 1;
+   |                         ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:262:19
+   |
+LL |         [1, 2, 3][let _ = ()]
+   |                   ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:267:6
+   |
+LL |     &let 0 = 0
+   |      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:277:17
+   |
+LL |         true && let 1 = 1
+   |                 ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:282:17
+   |
+LL |         true && let 1 = 1
+   |                 ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:287:17
+   |
+LL |         true && let 1 = 1
+   |                 ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:298:17
+   |
+LL |         true && let 1 = 1
+   |                 ^^^
+
+error: expressions must be enclosed in braces to be used as const generic arguments
+  --> $DIR/disallowed-positions-without-feature-gate.rs:298:9
+   |
+LL |         true && let 1 = 1
+   |         ^^^^^^^^^^^^^^^^^
+   |
+help: enclose the `const` expression in braces
+   |
+LL |         { true && let 1 = 1 }
+   |         +                   +
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:307:9
+   |
+LL |     if (let Some(a) = opt && true) {
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:307:9
+   |
+LL |     if (let Some(a) = opt && true) {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:311:9
+   |
+LL |     if (let Some(a) = opt) && true {
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:311:9
+   |
+LL |     if (let Some(a) = opt) && true {
+   |         ^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:314:9
+   |
+LL |     if (let Some(a) = opt) && (let Some(b) = a) {
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:314:9
+   |
+LL |     if (let Some(a) = opt) && (let Some(b) = a) {
+   |         ^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:314:32
+   |
+LL |     if (let Some(a) = opt) && (let Some(b) = a) {
+   |                                ^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:314:32
+   |
+LL |     if (let Some(a) = opt) && (let Some(b) = a) {
+   |                                ^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:319:9
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:319:9
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:319:31
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
+   |                               ^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:319:31
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
+   |                               ^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:323:9
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:323:9
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:323:31
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
+   |                               ^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:323:31
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
+   |                               ^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:327:9
+   |
+LL |     if (let Some(a) = opt && (true)) && true {
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions-without-feature-gate.rs:327:9
+   |
+LL |     if (let Some(a) = opt && (true)) && true {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:332:22
+   |
+LL |     let x = (true && let y = 1);
+   |                      ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:337:20
+   |
+LL |         ([1, 2, 3][let _ = ()])
+   |                    ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:63:16
+   |
+LL |     use_expr!((let 0 = 1 && 0 == 0));
+   |                ^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions-without-feature-gate.rs:65:16
+   |
+LL |     use_expr!((let 0 = 1));
+   |                ^^^
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:101:8
+   |
+LL |     if true..(let 0 = 0) {}
+   |        ^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
+   |
+   = note: expected type `bool`
+            found struct `std::ops::Range<bool>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:110:12
+   |
+LL |     if let Range { start: _, end: _ } = true..true && false {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
+   |            |
+   |            expected `bool`, found `Range<_>`
+   |
+   = note: expected type `bool`
+            found struct `std::ops::Range<_>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:113:12
+   |
+LL |     if let Range { start: _, end: _ } = true..true || false {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
+   |            |
+   |            expected `bool`, found `Range<_>`
+   |
+   = note: expected type `bool`
+            found struct `std::ops::Range<_>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:119:12
+   |
+LL |     if let Range { start: F, end } = F..|| true {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `fn() -> bool`
+   |            |
+   |            expected fn pointer, found `Range<_>`
+   |
+   = note: expected fn pointer `fn() -> bool`
+                  found struct `std::ops::Range<_>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:125:12
+   |
+LL |     if let Range { start: true, end } = t..&&false {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `&&bool`
+   |            |
+   |            expected `bool`, found `Range<_>`
+   |
+   = note: expected type `bool`
+            found struct `std::ops::Range<_>`
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/disallowed-positions-without-feature-gate.rs:81:20
+   |
+LL |         if let 0 = 0? {}
+   |                    ^^ the `?` operator cannot be applied to type `{integer}`
+   |
+   = help: the trait `Try` is not implemented for `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:165:11
+   |
+LL |     while true..(let 0 = 0) {}
+   |           ^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
+   |
+   = note: expected type `bool`
+            found struct `std::ops::Range<bool>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:174:15
+   |
+LL |     while let Range { start: _, end: _ } = true..true && false {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
+   |               |
+   |               expected `bool`, found `Range<_>`
+   |
+   = note: expected type `bool`
+            found struct `std::ops::Range<_>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:177:15
+   |
+LL |     while let Range { start: _, end: _ } = true..true || false {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
+   |               |
+   |               expected `bool`, found `Range<_>`
+   |
+   = note: expected type `bool`
+            found struct `std::ops::Range<_>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:183:15
+   |
+LL |     while let Range { start: F, end } = F..|| true {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `fn() -> bool`
+   |               |
+   |               expected fn pointer, found `Range<_>`
+   |
+   = note: expected fn pointer `fn() -> bool`
+                  found struct `std::ops::Range<_>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:189:15
+   |
+LL |     while let Range { start: true, end } = t..&&false {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `&&bool`
+   |               |
+   |               expected `bool`, found `Range<_>`
+   |
+   = note: expected type `bool`
+            found struct `std::ops::Range<_>`
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/disallowed-positions-without-feature-gate.rs:145:23
+   |
+LL |         while let 0 = 0? {}
+   |                       ^^ the `?` operator cannot be applied to type `{integer}`
+   |
+   = help: the trait `Try` is not implemented for `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions-without-feature-gate.rs:246:10
+   |
+LL |     (let Range { start: _, end: _ } = true..true || false);
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
+   |          |
+   |          expected `bool`, found `Range<_>`
+   |
+   = note: expected type `bool`
+            found struct `std::ops::Range<_>`
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/disallowed-positions-without-feature-gate.rs:221:17
+   |
+LL |         let 0 = 0?;
+   |                 ^^ the `?` operator cannot be applied to type `{integer}`
+   |
+   = help: the trait `Try` is not implemented for `{integer}`
+
+error: aborting due to 105 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions-without-feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions-without-feature-gate.stderr
@@ -4,6 +4,7 @@ error: expected expression, found `let` statement
 LL |     if (let 0 = 1) {}
    |         ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:11:9
    |
@@ -16,6 +17,7 @@ error: expected expression, found `let` statement
 LL |     if (((let 0 = 1))) {}
    |           ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:14:11
    |
@@ -28,6 +30,7 @@ error: expected expression, found `let` statement
 LL |     if (let 0 = 1) && true {}
    |         ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:17:9
    |
@@ -40,6 +43,7 @@ error: expected expression, found `let` statement
 LL |     if true && (let 0 = 1) {}
    |                 ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:20:17
    |
@@ -52,6 +56,7 @@ error: expected expression, found `let` statement
 LL |     if (let 0 = 1) && (let 0 = 1) {}
    |         ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:23:9
    |
@@ -64,6 +69,7 @@ error: expected expression, found `let` statement
 LL |     if (let 0 = 1) && (let 0 = 1) {}
    |                        ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:23:24
    |
@@ -76,6 +82,7 @@ error: expected expression, found `let` statement
 LL |     if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |         ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:27:9
    |
@@ -88,6 +95,7 @@ error: expected expression, found `let` statement
 LL |     if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                      ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:27:9
    |
@@ -100,6 +108,7 @@ error: expected expression, found `let` statement
 LL |     if (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                   ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:27:9
    |
@@ -112,6 +121,7 @@ error: expected expression, found `let` statement
 LL |     while (let 0 = 1) {}
    |            ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:34:12
    |
@@ -124,6 +134,7 @@ error: expected expression, found `let` statement
 LL |     while (((let 0 = 1))) {}
    |              ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:37:14
    |
@@ -136,6 +147,7 @@ error: expected expression, found `let` statement
 LL |     while (let 0 = 1) && true {}
    |            ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:40:12
    |
@@ -148,6 +160,7 @@ error: expected expression, found `let` statement
 LL |     while true && (let 0 = 1) {}
    |                    ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:43:20
    |
@@ -160,6 +173,7 @@ error: expected expression, found `let` statement
 LL |     while (let 0 = 1) && (let 0 = 1) {}
    |            ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:46:12
    |
@@ -172,6 +186,7 @@ error: expected expression, found `let` statement
 LL |     while (let 0 = 1) && (let 0 = 1) {}
    |                           ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:46:27
    |
@@ -184,6 +199,7 @@ error: expected expression, found `let` statement
 LL |     while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |            ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:50:12
    |
@@ -196,6 +212,7 @@ error: expected expression, found `let` statement
 LL |     while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                         ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:50:12
    |
@@ -208,6 +225,7 @@ error: expected expression, found `let` statement
 LL |     while (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                      ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:50:12
    |
@@ -219,30 +237,40 @@ error: expected expression, found `let` statement
    |
 LL |     if &let 0 = 0 {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:73:9
    |
 LL |     if !let 0 = 0 {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:75:9
    |
 LL |     if *let 0 = 0 {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:77:9
    |
 LL |     if -let 0 = 0 {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:85:9
    |
 LL |     if (let 0 = 0)? {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:88:16
@@ -250,6 +278,7 @@ error: expected expression, found `let` statement
 LL |     if true || let 0 = 0 {}
    |                ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `||` operators are not supported in let chain expressions
   --> $DIR/disallowed-positions-without-feature-gate.rs:88:13
    |
@@ -261,102 +290,136 @@ error: expected expression, found `let` statement
    |
 LL |     if (true || let 0 = 0) {}
    |                 ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:92:25
    |
 LL |     if true && (true || let 0 = 0) {}
    |                         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:94:25
    |
 LL |     if true || (true && let 0 = 0) {}
    |                         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:98:12
    |
 LL |     if x = let 0 = 0 {}
    |            ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:101:15
    |
 LL |     if true..(let 0 = 0) {}
    |               ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:104:11
    |
 LL |     if ..(let 0 = 0) {}
    |           ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:106:9
    |
 LL |     if (let 0 = 0).. {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:110:8
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:113:8
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:119:8
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:125:8
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:129:19
    |
 LL |     if let true = let true = true {}
    |                   ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:134:12
    |
 LL |     while &let 0 = 0 {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:137:12
    |
 LL |     while !let 0 = 0 {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:139:12
    |
 LL |     while *let 0 = 0 {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:141:12
    |
 LL |     while -let 0 = 0 {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:149:12
    |
 LL |     while (let 0 = 0)? {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:152:19
@@ -364,6 +427,7 @@ error: expected expression, found `let` statement
 LL |     while true || let 0 = 0 {}
    |                   ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `||` operators are not supported in let chain expressions
   --> $DIR/disallowed-positions-without-feature-gate.rs:152:16
    |
@@ -375,210 +439,280 @@ error: expected expression, found `let` statement
    |
 LL |     while (true || let 0 = 0) {}
    |                    ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:156:28
    |
 LL |     while true && (true || let 0 = 0) {}
    |                            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:158:28
    |
 LL |     while true || (true && let 0 = 0) {}
    |                            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:162:15
    |
 LL |     while x = let 0 = 0 {}
    |               ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:165:18
    |
 LL |     while true..(let 0 = 0) {}
    |                  ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:168:14
    |
 LL |     while ..(let 0 = 0) {}
    |              ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:170:12
    |
 LL |     while (let 0 = 0).. {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:174:11
    |
 LL |     while let Range { start: _, end: _ } = true..true && false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:177:11
    |
 LL |     while let Range { start: _, end: _ } = true..true || false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:183:11
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:189:11
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:193:22
    |
 LL |     while let true = let true = true {}
    |                      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:208:6
    |
 LL |     &let 0 = 0;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:211:6
    |
 LL |     !let 0 = 0;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:213:6
    |
 LL |     *let 0 = 0;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:215:6
    |
 LL |     -let 0 = 0;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:217:13
    |
 LL |     let _ = let _ = 3;
    |             ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:225:6
    |
 LL |     (let 0 = 0)?;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:228:13
    |
 LL |     true || let 0 = 0;
    |             ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:230:14
    |
 LL |     (true || let 0 = 0);
    |              ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:232:22
    |
 LL |     true && (true || let 0 = 0);
    |                      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:236:9
    |
 LL |     x = let 0 = 0;
    |         ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:239:12
    |
 LL |     true..(let 0 = 0);
    |            ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:241:8
    |
 LL |     ..(let 0 = 0);
    |        ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:243:6
    |
 LL |     (let 0 = 0)..;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:246:6
    |
 LL |     (let Range { start: _, end: _ } = true..true || false);
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:250:6
    |
 LL |     (let true = let true = true);
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:250:17
    |
 LL |     (let true = let true = true);
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:256:25
    |
 LL |         let x = true && let y = 1;
    |                         ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:262:19
    |
 LL |         [1, 2, 3][let _ = ()]
    |                   ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:267:6
    |
 LL |     &let 0 = 0
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:277:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:282:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:287:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:298:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expressions must be enclosed in braces to be used as const generic arguments
   --> $DIR/disallowed-positions-without-feature-gate.rs:298:9
@@ -597,6 +731,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && true) {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:307:9
    |
@@ -609,6 +744,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt) && true {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:311:9
    |
@@ -621,6 +757,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt) && (let Some(b) = a) {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:314:9
    |
@@ -633,6 +770,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt) && (let Some(b) = a) {
    |                                ^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:314:32
    |
@@ -645,6 +783,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:319:9
    |
@@ -657,6 +796,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
    |                               ^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:319:31
    |
@@ -669,6 +809,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:323:9
    |
@@ -681,6 +822,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
    |                               ^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:323:31
    |
@@ -693,6 +835,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (true)) && true {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions-without-feature-gate.rs:327:9
    |
@@ -704,24 +847,32 @@ error: expected expression, found `let` statement
    |
 LL |     let x = (true && let y = 1);
    |                      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:337:20
    |
 LL |         ([1, 2, 3][let _ = ()])
    |                    ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:63:16
    |
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions-without-feature-gate.rs:65:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions-without-feature-gate.rs:101:8

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.rs
@@ -27,64 +27,46 @@ fn main() {}
 
 fn _if() {
     if (let 0 = 1) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     if (((let 0 = 1))) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     if (let 0 = 1) && true {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     if true && (let 0 = 1) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     if (let 0 = 1) && (let 0 = 1) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
 
     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
 }
 
 fn _while() {
     while (let 0 = 1) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     while (((let 0 = 1))) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     while (let 0 = 1) && true {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     while true && (let 0 = 1) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     while (let 0 = 1) && (let 0 = 1) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
 
     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
 }
@@ -97,32 +79,21 @@ fn _macros() {
         }
     }
     use_expr!((let 0 = 1 && 0 == 0));
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     use_expr!((let 0 = 1));
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 }
 
 fn nested_within_if_expr() {
     if &let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     if !let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     if *let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR type `bool` cannot be dereferenced
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     if -let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR cannot apply unary operator `-` to type `bool`
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     fn _check_try_binds_tighter() -> Result<(), ()> {
         if let 0 = 0? {}
@@ -130,91 +101,63 @@ fn nested_within_if_expr() {
         Ok(())
     }
     if (let 0 = 0)? {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR the `?` operator can only be applied to values that implement `Try`
-    //~| ERROR the `?` operator can only be used in a function that returns `Result`
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     if true || let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     if (true || let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     if true && (true || let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     if true || (true && let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     let mut x = true;
     if x = let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     if true..(let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
     if ..(let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     if (let 0 = 0).. {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     // Binds as `(let ... = true)..true &&/|| false`.
     if let Range { start: _, end: _ } = true..true && false {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
     if let Range { start: _, end: _ } = true..true || false {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
 
     // Binds as `(let Range { start: F, end } = F)..(|| true)`.
     const F: fn() -> bool = || true;
     if let Range { start: F, end } = F..|| true {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR mismatched types
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
 
     // Binds as `(let Range { start: true, end } = t)..(&&false)`.
     let t = &&true;
     if let Range { start: true, end } = t..&&false {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR mismatched types
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
 
     if let true = let true = true {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 }
 
 fn nested_within_while_expr() {
     while &let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     while !let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     while *let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR type `bool` cannot be dereferenced
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     while -let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR cannot apply unary operator `-` to type `bool`
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     fn _check_try_binds_tighter() -> Result<(), ()> {
         while let 0 = 0? {}
@@ -222,72 +165,51 @@ fn nested_within_while_expr() {
         Ok(())
     }
     while (let 0 = 0)? {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR the `?` operator can only be applied to values that implement `Try`
-    //~| ERROR the `?` operator can only be used in a function that returns `Result`
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     while true || let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     while (true || let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     while true && (true || let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     while true || (true && let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     let mut x = true;
     while x = let 0 = 0 {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     while true..(let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
     while ..(let 0 = 0) {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     while (let 0 = 0).. {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     // Binds as `(let ... = true)..true &&/|| false`.
     while let Range { start: _, end: _ } = true..true && false {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
     while let Range { start: _, end: _ } = true..true || false {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
 
     // Binds as `(let Range { start: F, end } = F)..(|| true)`.
     const F: fn() -> bool = || true;
     while let Range { start: F, end } = F..|| true {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR mismatched types
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
 
     // Binds as `(let Range { start: true, end } = t)..(&&false)`.
     let t = &&true;
     while let Range { start: true, end } = t..&&false {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR mismatched types
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR mismatched types
 
     while let true = let true = true {}
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 }
 
 fn not_error_because_clarified_intent() {
@@ -302,20 +224,14 @@ fn not_error_because_clarified_intent() {
 
 fn outside_if_and_while_expr() {
     &let 0 = 0;
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     !let 0 = 0;
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     *let 0 = 0;
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR type `bool` cannot be dereferenced
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     -let 0 = 0;
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR cannot apply unary operator `-` to type `bool`
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     fn _check_try_binds_tighter() -> Result<(), ()> {
         let 0 = 0?;
@@ -323,44 +239,32 @@ fn outside_if_and_while_expr() {
         Ok(())
     }
     (let 0 = 0)?;
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR the `?` operator can only be used in a function that returns `Result`
-    //~| ERROR the `?` operator can only be applied to values that implement `Try`
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     true || let 0 = 0;
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     (true || let 0 = 0);
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     true && (true || let 0 = 0);
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     let mut x = true;
     x = let 0 = 0;
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     true..(let 0 = 0);
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     ..(let 0 = 0);
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     (let 0 = 0)..;
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     (let Range { start: _, end: _ } = true..true || false);
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
+    //~^ ERROR mismatched types
     //~| ERROR expected expression, found `let` statement
 
     (let true = let true = true);
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
 
     {
@@ -377,9 +281,7 @@ fn outside_if_and_while_expr() {
 
     // Check function tail position.
     &let 0 = 0
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 }
 
 // Let's make sure that `let` inside const generic arguments are considered.
@@ -389,20 +291,17 @@ fn inside_const_generic_arguments() {
 
     if let A::<{
         true && let 1 = 1
-        //~^ ERROR `let` expressions are not supported here
-        //~| ERROR expected expression, found `let` statement
+        //~^ ERROR expected expression, found `let` statement
     }>::O = 5 {}
 
     while let A::<{
         true && let 1 = 1
-        //~^ ERROR `let` expressions are not supported here
-        //~| ERROR expected expression, found `let` statement
+        //~^ ERROR expected expression, found `let` statement
     }>::O = 5 {}
 
     if A::<{
         true && let 1 = 1
-        //~^ ERROR `let` expressions are not supported here
-        //~| ERROR expected expression, found `let` statement
+        //~^ ERROR expected expression, found `let` statement
     }>::O == 5 {}
 
     // In the cases above we have `ExprKind::Block` to help us out.
@@ -413,8 +312,7 @@ fn inside_const_generic_arguments() {
 
     if A::<
         true && let 1 = 1
-        //~^ ERROR `let` expressions are not supported here
-        //~| ERROR expressions must be enclosed in braces
+        //~^ ERROR expressions must be enclosed in braces
         //~| ERROR expected expression, found `let` statement
     >::O == 5 {}
 }
@@ -423,38 +321,29 @@ fn with_parenthesis() {
     let opt = Some(Some(1i32));
 
     if (let Some(a) = opt && true) {
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     }
 
     if (let Some(a) = opt) && true {
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     }
     if (let Some(a) = opt) && (let Some(b) = a) {
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
     }
     if let Some(a) = opt && (true && true) {
     }
 
     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
     }
     if (let Some(a) = opt && (let Some(b) = a)) && true {
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     //~| ERROR expected expression, found `let` statement
     }
     if (let Some(a) = opt && (true)) && true {
-    //~^ ERROR `let` expressions are not supported here
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     }
 
     if (true && (true)) && let Some(a) = opt {

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -4,6 +4,7 @@ error: expected expression, found `let` statement
 LL |     if (let 0 = 1) {}
    |         ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:29:9
    |
@@ -16,6 +17,7 @@ error: expected expression, found `let` statement
 LL |     if (((let 0 = 1))) {}
    |           ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:32:11
    |
@@ -28,6 +30,7 @@ error: expected expression, found `let` statement
 LL |     if (let 0 = 1) && true {}
    |         ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:35:9
    |
@@ -40,6 +43,7 @@ error: expected expression, found `let` statement
 LL |     if true && (let 0 = 1) {}
    |                 ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:38:17
    |
@@ -52,6 +56,7 @@ error: expected expression, found `let` statement
 LL |     if (let 0 = 1) && (let 0 = 1) {}
    |         ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:41:9
    |
@@ -64,6 +69,7 @@ error: expected expression, found `let` statement
 LL |     if (let 0 = 1) && (let 0 = 1) {}
    |                        ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:41:24
    |
@@ -76,6 +82,7 @@ error: expected expression, found `let` statement
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                   ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:45:35
    |
@@ -88,6 +95,7 @@ error: expected expression, found `let` statement
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:45:35
    |
@@ -100,6 +108,7 @@ error: expected expression, found `let` statement
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                             ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:45:35
    |
@@ -112,6 +121,7 @@ error: expected expression, found `let` statement
 LL |     while (let 0 = 1) {}
    |            ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:52:12
    |
@@ -124,6 +134,7 @@ error: expected expression, found `let` statement
 LL |     while (((let 0 = 1))) {}
    |              ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:55:14
    |
@@ -136,6 +147,7 @@ error: expected expression, found `let` statement
 LL |     while (let 0 = 1) && true {}
    |            ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:58:12
    |
@@ -148,6 +160,7 @@ error: expected expression, found `let` statement
 LL |     while true && (let 0 = 1) {}
    |                    ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:61:20
    |
@@ -160,6 +173,7 @@ error: expected expression, found `let` statement
 LL |     while (let 0 = 1) && (let 0 = 1) {}
    |            ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:64:12
    |
@@ -172,6 +186,7 @@ error: expected expression, found `let` statement
 LL |     while (let 0 = 1) && (let 0 = 1) {}
    |                           ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:64:27
    |
@@ -184,6 +199,7 @@ error: expected expression, found `let` statement
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                      ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:68:38
    |
@@ -196,6 +212,7 @@ error: expected expression, found `let` statement
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                   ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:68:38
    |
@@ -208,6 +225,7 @@ error: expected expression, found `let` statement
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                                ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:68:38
    |
@@ -219,30 +237,40 @@ error: expected expression, found `let` statement
    |
 LL |     if &let 0 = 0 {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:91:9
    |
 LL |     if !let 0 = 0 {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:93:9
    |
 LL |     if *let 0 = 0 {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:95:9
    |
 LL |     if -let 0 = 0 {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:103:9
    |
 LL |     if (let 0 = 0)? {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:106:16
@@ -250,6 +278,7 @@ error: expected expression, found `let` statement
 LL |     if true || let 0 = 0 {}
    |                ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `||` operators are not supported in let chain expressions
   --> $DIR/disallowed-positions.rs:106:13
    |
@@ -261,102 +290,136 @@ error: expected expression, found `let` statement
    |
 LL |     if (true || let 0 = 0) {}
    |                 ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:110:25
    |
 LL |     if true && (true || let 0 = 0) {}
    |                         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:112:25
    |
 LL |     if true || (true && let 0 = 0) {}
    |                         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:116:12
    |
 LL |     if x = let 0 = 0 {}
    |            ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:119:15
    |
 LL |     if true..(let 0 = 0) {}
    |               ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:122:11
    |
 LL |     if ..(let 0 = 0) {}
    |           ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:124:9
    |
 LL |     if (let 0 = 0).. {}
    |         ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:128:8
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:131:8
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:137:8
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:143:8
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:147:19
    |
 LL |     if let true = let true = true {}
    |                   ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:152:12
    |
 LL |     while &let 0 = 0 {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:155:12
    |
 LL |     while !let 0 = 0 {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:157:12
    |
 LL |     while *let 0 = 0 {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:159:12
    |
 LL |     while -let 0 = 0 {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:167:12
    |
 LL |     while (let 0 = 0)? {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:170:19
@@ -364,6 +427,7 @@ error: expected expression, found `let` statement
 LL |     while true || let 0 = 0 {}
    |                   ^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `||` operators are not supported in let chain expressions
   --> $DIR/disallowed-positions.rs:170:16
    |
@@ -375,204 +439,272 @@ error: expected expression, found `let` statement
    |
 LL |     while (true || let 0 = 0) {}
    |                    ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:174:28
    |
 LL |     while true && (true || let 0 = 0) {}
    |                            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:176:28
    |
 LL |     while true || (true && let 0 = 0) {}
    |                            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:180:15
    |
 LL |     while x = let 0 = 0 {}
    |               ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:183:18
    |
 LL |     while true..(let 0 = 0) {}
    |                  ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:186:14
    |
 LL |     while ..(let 0 = 0) {}
    |              ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:188:12
    |
 LL |     while (let 0 = 0).. {}
    |            ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:192:11
    |
 LL |     while let Range { start: _, end: _ } = true..true && false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:195:11
    |
 LL |     while let Range { start: _, end: _ } = true..true || false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:201:11
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:207:11
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:211:22
    |
 LL |     while let true = let true = true {}
    |                      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:226:6
    |
 LL |     &let 0 = 0;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:229:6
    |
 LL |     !let 0 = 0;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:231:6
    |
 LL |     *let 0 = 0;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:233:6
    |
 LL |     -let 0 = 0;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:241:6
    |
 LL |     (let 0 = 0)?;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:244:13
    |
 LL |     true || let 0 = 0;
    |             ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:246:14
    |
 LL |     (true || let 0 = 0);
    |              ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:248:22
    |
 LL |     true && (true || let 0 = 0);
    |                      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:252:9
    |
 LL |     x = let 0 = 0;
    |         ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:255:12
    |
 LL |     true..(let 0 = 0);
    |            ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:257:8
    |
 LL |     ..(let 0 = 0);
    |        ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:259:6
    |
 LL |     (let 0 = 0)..;
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:262:6
    |
 LL |     (let Range { start: _, end: _ } = true..true || false);
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:266:6
    |
 LL |     (let true = let true = true);
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:266:17
    |
 LL |     (let true = let true = true);
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:272:25
    |
 LL |         let x = true && let y = 1;
    |                         ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:278:19
    |
 LL |         [1, 2, 3][let _ = ()]
    |                   ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:283:6
    |
 LL |     &let 0 = 0
    |      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:293:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:298:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:303:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:314:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expressions must be enclosed in braces to be used as const generic arguments
   --> $DIR/disallowed-positions.rs:314:9
@@ -591,6 +723,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && true) {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:323:9
    |
@@ -603,6 +736,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt) && true {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:327:9
    |
@@ -615,6 +749,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt) && (let Some(b) = a) {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:330:9
    |
@@ -627,6 +762,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt) && (let Some(b) = a) {
    |                                ^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:330:32
    |
@@ -639,6 +775,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:337:9
    |
@@ -651,6 +788,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
    |                               ^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:337:31
    |
@@ -663,6 +801,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:341:9
    |
@@ -675,6 +814,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
    |                               ^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:341:31
    |
@@ -687,6 +827,7 @@ error: expected expression, found `let` statement
 LL |     if (let Some(a) = opt && (true)) && true {
    |         ^^^^^^^^^^^^^^^^^
    |
+   = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
   --> $DIR/disallowed-positions.rs:345:9
    |
@@ -698,24 +839,32 @@ error: expected expression, found `let` statement
    |
 LL |     let x = (true && let y = 1);
    |                      ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:366:20
    |
 LL |         ([1, 2, 3][let _ = ()])
    |                    ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:81:16
    |
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:83:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:119:8

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -2,412 +2,580 @@ error: expected expression, found `let` statement
   --> $DIR/disallowed-positions.rs:29:9
    |
 LL |     if (let 0 = 1) {}
-   |         ^^^
+   |         ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:29:9
+   |
+LL |     if (let 0 = 1) {}
+   |         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:33:11
+  --> $DIR/disallowed-positions.rs:32:11
    |
 LL |     if (((let 0 = 1))) {}
-   |           ^^^
+   |           ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:32:11
+   |
+LL |     if (((let 0 = 1))) {}
+   |           ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:37:9
+  --> $DIR/disallowed-positions.rs:35:9
    |
 LL |     if (let 0 = 1) && true {}
-   |         ^^^
+   |         ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:35:9
+   |
+LL |     if (let 0 = 1) && true {}
+   |         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:41:17
+  --> $DIR/disallowed-positions.rs:38:17
    |
 LL |     if true && (let 0 = 1) {}
-   |                 ^^^
+   |                 ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:38:17
+   |
+LL |     if true && (let 0 = 1) {}
+   |                 ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:45:9
+  --> $DIR/disallowed-positions.rs:41:9
    |
 LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |         ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:45:24
+   |         ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:41:9
    |
 LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |                        ^^^
+   |         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:51:35
+  --> $DIR/disallowed-positions.rs:41:24
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |                        ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:41:24
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |                        ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:45:35
    |
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                   ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:51:48
+   |                                   ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:45:35
    |
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                ^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:51:61
+  --> $DIR/disallowed-positions.rs:45:48
    |
 LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                             ^^^
+   |                                                ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:45:35
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:61:12
+  --> $DIR/disallowed-positions.rs:45:61
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                             ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:45:35
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:52:12
    |
 LL |     while (let 0 = 1) {}
-   |            ^^^
+   |            ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:52:12
+   |
+LL |     while (let 0 = 1) {}
+   |            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:65:14
+  --> $DIR/disallowed-positions.rs:55:14
    |
 LL |     while (((let 0 = 1))) {}
-   |              ^^^
+   |              ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:55:14
+   |
+LL |     while (((let 0 = 1))) {}
+   |              ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:69:12
+  --> $DIR/disallowed-positions.rs:58:12
    |
 LL |     while (let 0 = 1) && true {}
-   |            ^^^
+   |            ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:58:12
+   |
+LL |     while (let 0 = 1) && true {}
+   |            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:73:20
+  --> $DIR/disallowed-positions.rs:61:20
    |
 LL |     while true && (let 0 = 1) {}
-   |                    ^^^
+   |                    ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:61:20
+   |
+LL |     while true && (let 0 = 1) {}
+   |                    ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:77:12
+  --> $DIR/disallowed-positions.rs:64:12
    |
 LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |            ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:77:27
+   |            ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:64:12
    |
 LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |                           ^^^
+   |            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:83:38
+  --> $DIR/disallowed-positions.rs:64:27
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |                           ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:64:27
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |                           ^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:68:38
    |
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                      ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:83:51
+   |                                      ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:68:38
    |
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                   ^^^
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:83:64
+  --> $DIR/disallowed-positions.rs:68:51
    |
 LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                                ^^^
+   |                                                   ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:68:38
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:110:9
+  --> $DIR/disallowed-positions.rs:68:64
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                                ^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:68:38
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:88:9
    |
 LL |     if &let 0 = 0 {}
-   |         ^^^
+   |         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:115:9
+  --> $DIR/disallowed-positions.rs:91:9
    |
 LL |     if !let 0 = 0 {}
-   |         ^^^
+   |         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:118:9
+  --> $DIR/disallowed-positions.rs:93:9
    |
 LL |     if *let 0 = 0 {}
-   |         ^^^
+   |         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:122:9
+  --> $DIR/disallowed-positions.rs:95:9
    |
 LL |     if -let 0 = 0 {}
-   |         ^^^
+   |         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:132:9
+  --> $DIR/disallowed-positions.rs:103:9
    |
 LL |     if (let 0 = 0)? {}
-   |         ^^^
+   |         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:138:16
+  --> $DIR/disallowed-positions.rs:106:16
    |
 LL |     if true || let 0 = 0 {}
-   |                ^^^
+   |                ^^^^^^^^^
+   |
+note: `||` operators are not supported in let chain expressions
+  --> $DIR/disallowed-positions.rs:106:13
+   |
+LL |     if true || let 0 = 0 {}
+   |             ^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:141:17
+  --> $DIR/disallowed-positions.rs:108:17
    |
 LL |     if (true || let 0 = 0) {}
-   |                 ^^^
+   |                 ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:144:25
+  --> $DIR/disallowed-positions.rs:110:25
    |
 LL |     if true && (true || let 0 = 0) {}
-   |                         ^^^
+   |                         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:147:25
+  --> $DIR/disallowed-positions.rs:112:25
    |
 LL |     if true || (true && let 0 = 0) {}
-   |                         ^^^
+   |                         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:152:12
+  --> $DIR/disallowed-positions.rs:116:12
    |
 LL |     if x = let 0 = 0 {}
    |            ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:157:15
+  --> $DIR/disallowed-positions.rs:119:15
    |
 LL |     if true..(let 0 = 0) {}
-   |               ^^^
+   |               ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:161:11
+  --> $DIR/disallowed-positions.rs:122:11
    |
 LL |     if ..(let 0 = 0) {}
-   |           ^^^
+   |           ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:165:9
+  --> $DIR/disallowed-positions.rs:124:9
    |
 LL |     if (let 0 = 0).. {}
-   |         ^^^
+   |         ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:196:19
+  --> $DIR/disallowed-positions.rs:128:8
+   |
+LL |     if let Range { start: _, end: _ } = true..true && false {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:131:8
+   |
+LL |     if let Range { start: _, end: _ } = true..true || false {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:137:8
+   |
+LL |     if let Range { start: F, end } = F..|| true {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:143:8
+   |
+LL |     if let Range { start: true, end } = t..&&false {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:147:19
    |
 LL |     if let true = let true = true {}
    |                   ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:202:12
+  --> $DIR/disallowed-positions.rs:152:12
    |
 LL |     while &let 0 = 0 {}
-   |            ^^^
+   |            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:207:12
+  --> $DIR/disallowed-positions.rs:155:12
    |
 LL |     while !let 0 = 0 {}
-   |            ^^^
+   |            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:210:12
+  --> $DIR/disallowed-positions.rs:157:12
    |
 LL |     while *let 0 = 0 {}
-   |            ^^^
+   |            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:214:12
+  --> $DIR/disallowed-positions.rs:159:12
    |
 LL |     while -let 0 = 0 {}
-   |            ^^^
+   |            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:224:12
+  --> $DIR/disallowed-positions.rs:167:12
    |
 LL |     while (let 0 = 0)? {}
-   |            ^^^
+   |            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:230:19
+  --> $DIR/disallowed-positions.rs:170:19
    |
 LL |     while true || let 0 = 0 {}
-   |                   ^^^
+   |                   ^^^^^^^^^
+   |
+note: `||` operators are not supported in let chain expressions
+  --> $DIR/disallowed-positions.rs:170:16
+   |
+LL |     while true || let 0 = 0 {}
+   |                ^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:233:20
+  --> $DIR/disallowed-positions.rs:172:20
    |
 LL |     while (true || let 0 = 0) {}
-   |                    ^^^
+   |                    ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:236:28
+  --> $DIR/disallowed-positions.rs:174:28
    |
 LL |     while true && (true || let 0 = 0) {}
-   |                            ^^^
+   |                            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:239:28
+  --> $DIR/disallowed-positions.rs:176:28
    |
 LL |     while true || (true && let 0 = 0) {}
-   |                            ^^^
+   |                            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:244:15
+  --> $DIR/disallowed-positions.rs:180:15
    |
 LL |     while x = let 0 = 0 {}
    |               ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:249:18
+  --> $DIR/disallowed-positions.rs:183:18
    |
 LL |     while true..(let 0 = 0) {}
-   |                  ^^^
+   |                  ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:253:14
+  --> $DIR/disallowed-positions.rs:186:14
    |
 LL |     while ..(let 0 = 0) {}
-   |              ^^^
+   |              ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:257:12
+  --> $DIR/disallowed-positions.rs:188:12
    |
 LL |     while (let 0 = 0).. {}
-   |            ^^^
+   |            ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:288:22
+  --> $DIR/disallowed-positions.rs:192:11
+   |
+LL |     while let Range { start: _, end: _ } = true..true && false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:195:11
+   |
+LL |     while let Range { start: _, end: _ } = true..true || false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:201:11
+   |
+LL |     while let Range { start: F, end } = F..|| true {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:207:11
+   |
+LL |     while let Range { start: true, end } = t..&&false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:211:22
    |
 LL |     while let true = let true = true {}
    |                      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:304:6
+  --> $DIR/disallowed-positions.rs:226:6
    |
 LL |     &let 0 = 0;
    |      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:308:6
+  --> $DIR/disallowed-positions.rs:229:6
    |
 LL |     !let 0 = 0;
    |      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:311:6
+  --> $DIR/disallowed-positions.rs:231:6
    |
 LL |     *let 0 = 0;
    |      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:315:6
+  --> $DIR/disallowed-positions.rs:233:6
    |
 LL |     -let 0 = 0;
    |      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:325:6
+  --> $DIR/disallowed-positions.rs:241:6
    |
 LL |     (let 0 = 0)?;
    |      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:331:13
+  --> $DIR/disallowed-positions.rs:244:13
    |
 LL |     true || let 0 = 0;
    |             ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:334:14
+  --> $DIR/disallowed-positions.rs:246:14
    |
 LL |     (true || let 0 = 0);
    |              ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:337:22
+  --> $DIR/disallowed-positions.rs:248:22
    |
 LL |     true && (true || let 0 = 0);
    |                      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:342:9
+  --> $DIR/disallowed-positions.rs:252:9
    |
 LL |     x = let 0 = 0;
    |         ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:346:12
+  --> $DIR/disallowed-positions.rs:255:12
    |
 LL |     true..(let 0 = 0);
    |            ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:349:8
+  --> $DIR/disallowed-positions.rs:257:8
    |
 LL |     ..(let 0 = 0);
    |        ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:352:6
+  --> $DIR/disallowed-positions.rs:259:6
    |
 LL |     (let 0 = 0)..;
    |      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:356:6
+  --> $DIR/disallowed-positions.rs:262:6
    |
 LL |     (let Range { start: _, end: _ } = true..true || false);
    |      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:361:6
+  --> $DIR/disallowed-positions.rs:266:6
    |
 LL |     (let true = let true = true);
    |      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:361:17
+  --> $DIR/disallowed-positions.rs:266:17
    |
 LL |     (let true = let true = true);
    |                 ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:368:25
+  --> $DIR/disallowed-positions.rs:272:25
    |
 LL |         let x = true && let y = 1;
    |                         ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:374:19
+  --> $DIR/disallowed-positions.rs:278:19
    |
 LL |         [1, 2, 3][let _ = ()]
    |                   ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:379:6
+  --> $DIR/disallowed-positions.rs:283:6
    |
 LL |     &let 0 = 0
    |      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:391:17
+  --> $DIR/disallowed-positions.rs:293:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:397:17
+  --> $DIR/disallowed-positions.rs:298:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:403:17
+  --> $DIR/disallowed-positions.rs:303:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:415:17
+  --> $DIR/disallowed-positions.rs:314:17
    |
 LL |         true && let 1 = 1
    |                 ^^^
 
 error: expressions must be enclosed in braces to be used as const generic arguments
-  --> $DIR/disallowed-positions.rs:415:9
+  --> $DIR/disallowed-positions.rs:314:9
    |
 LL |         true && let 1 = 1
    |         ^^^^^^^^^^^^^^^^^
@@ -418,1102 +586,139 @@ LL |         { true && let 1 = 1 }
    |         +                   +
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:425:9
+  --> $DIR/disallowed-positions.rs:323:9
    |
 LL |     if (let Some(a) = opt && true) {
-   |         ^^^
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:323:9
+   |
+LL |     if (let Some(a) = opt && true) {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:430:9
+  --> $DIR/disallowed-positions.rs:327:9
    |
 LL |     if (let Some(a) = opt) && true {
-   |         ^^^
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:327:9
+   |
+LL |     if (let Some(a) = opt) && true {
+   |         ^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:434:9
+  --> $DIR/disallowed-positions.rs:330:9
    |
 LL |     if (let Some(a) = opt) && (let Some(b) = a) {
-   |         ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:434:32
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:330:9
    |
 LL |     if (let Some(a) = opt) && (let Some(b) = a) {
-   |                                ^^^
+   |         ^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:443:9
+  --> $DIR/disallowed-positions.rs:330:32
+   |
+LL |     if (let Some(a) = opt) && (let Some(b) = a) {
+   |                                ^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:330:32
+   |
+LL |     if (let Some(a) = opt) && (let Some(b) = a) {
+   |                                ^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:337:9
    |
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
-   |         ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:443:31
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:337:9
    |
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
-   |                               ^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:449:9
+  --> $DIR/disallowed-positions.rs:337:31
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
+   |                               ^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:337:31
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
+   |                               ^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:341:9
    |
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
-   |         ^^^
-
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:449:31
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:341:9
    |
 LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
-   |                               ^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:455:9
+  --> $DIR/disallowed-positions.rs:341:31
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
+   |                               ^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:341:31
+   |
+LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
+   |                               ^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/disallowed-positions.rs:345:9
    |
 LL |     if (let Some(a) = opt && (true)) && true {
-   |         ^^^
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: `let`s wrapped in parentheses are not supported in a context with let chains
+  --> $DIR/disallowed-positions.rs:345:9
+   |
+LL |     if (let Some(a) = opt && (true)) && true {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:472:22
+  --> $DIR/disallowed-positions.rs:361:22
    |
 LL |     let x = (true && let y = 1);
    |                      ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:477:20
+  --> $DIR/disallowed-positions.rs:366:20
    |
 LL |         ([1, 2, 3][let _ = ()])
    |                    ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:99:16
+  --> $DIR/disallowed-positions.rs:81:16
    |
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:103:16
+  --> $DIR/disallowed-positions.rs:83:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^
 
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:29:9
-   |
-LL |     if (let 0 = 1) {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:29:9
-   |
-LL |     if (let 0 = 1) {}
-   |         ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:33:11
-   |
-LL |     if (((let 0 = 1))) {}
-   |           ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:33:11
-   |
-LL |     if (((let 0 = 1))) {}
-   |           ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:37:9
-   |
-LL |     if (let 0 = 1) && true {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:37:9
-   |
-LL |     if (let 0 = 1) && true {}
-   |         ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:41:17
-   |
-LL |     if true && (let 0 = 1) {}
-   |                 ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:41:17
-   |
-LL |     if true && (let 0 = 1) {}
-   |                 ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:45:9
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:45:9
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |         ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:45:24
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |                        ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:45:24
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |                        ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:51:35
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                   ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:51:35
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:51:48
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:51:35
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:51:61
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                             ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:51:35
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:61:12
-   |
-LL |     while (let 0 = 1) {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:61:12
-   |
-LL |     while (let 0 = 1) {}
-   |            ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:65:14
-   |
-LL |     while (((let 0 = 1))) {}
-   |              ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:65:14
-   |
-LL |     while (((let 0 = 1))) {}
-   |              ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:69:12
-   |
-LL |     while (let 0 = 1) && true {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:69:12
-   |
-LL |     while (let 0 = 1) && true {}
-   |            ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:73:20
-   |
-LL |     while true && (let 0 = 1) {}
-   |                    ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:73:20
-   |
-LL |     while true && (let 0 = 1) {}
-   |                    ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:77:12
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:77:12
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |            ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:77:27
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |                           ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:77:27
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |                           ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:83:38
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:83:38
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:83:51
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                   ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:83:38
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:83:64
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:83:38
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:99:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:99:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:99:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:99:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:103:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:103:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:103:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:103:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:110:9
-   |
-LL |     if &let 0 = 0 {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:115:9
-   |
-LL |     if !let 0 = 0 {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:118:9
-   |
-LL |     if *let 0 = 0 {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:122:9
-   |
-LL |     if -let 0 = 0 {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:132:9
-   |
-LL |     if (let 0 = 0)? {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:132:9
-   |
-LL |     if (let 0 = 0)? {}
-   |         ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:138:16
-   |
-LL |     if true || let 0 = 0 {}
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
-  --> $DIR/disallowed-positions.rs:138:13
-   |
-LL |     if true || let 0 = 0 {}
-   |             ^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:141:17
-   |
-LL |     if (true || let 0 = 0) {}
-   |                 ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
-  --> $DIR/disallowed-positions.rs:141:14
-   |
-LL |     if (true || let 0 = 0) {}
-   |              ^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:144:25
-   |
-LL |     if true && (true || let 0 = 0) {}
-   |                         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
-  --> $DIR/disallowed-positions.rs:144:22
-   |
-LL |     if true && (true || let 0 = 0) {}
-   |                      ^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:147:25
-   |
-LL |     if true || (true && let 0 = 0) {}
-   |                         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:147:17
-   |
-LL |     if true || (true && let 0 = 0) {}
-   |                 ^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:152:12
-   |
-LL |     if x = let 0 = 0 {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:157:15
-   |
-LL |     if true..(let 0 = 0) {}
-   |               ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:157:15
-   |
-LL |     if true..(let 0 = 0) {}
-   |               ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:161:11
-   |
-LL |     if ..(let 0 = 0) {}
-   |           ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:161:11
-   |
-LL |     if ..(let 0 = 0) {}
-   |           ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:165:9
-   |
-LL |     if (let 0 = 0).. {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:165:9
-   |
-LL |     if (let 0 = 0).. {}
-   |         ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:171:8
-   |
-LL |     if let Range { start: _, end: _ } = true..true && false {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:175:8
-   |
-LL |     if let Range { start: _, end: _ } = true..true || false {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:182:8
-   |
-LL |     if let Range { start: F, end } = F..|| true {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:190:8
-   |
-LL |     if let Range { start: true, end } = t..&&false {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:196:19
-   |
-LL |     if let true = let true = true {}
-   |                   ^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:202:12
-   |
-LL |     while &let 0 = 0 {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:207:12
-   |
-LL |     while !let 0 = 0 {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:210:12
-   |
-LL |     while *let 0 = 0 {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:214:12
-   |
-LL |     while -let 0 = 0 {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:224:12
-   |
-LL |     while (let 0 = 0)? {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:224:12
-   |
-LL |     while (let 0 = 0)? {}
-   |            ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:230:19
-   |
-LL |     while true || let 0 = 0 {}
-   |                   ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
-  --> $DIR/disallowed-positions.rs:230:16
-   |
-LL |     while true || let 0 = 0 {}
-   |                ^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:233:20
-   |
-LL |     while (true || let 0 = 0) {}
-   |                    ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
-  --> $DIR/disallowed-positions.rs:233:17
-   |
-LL |     while (true || let 0 = 0) {}
-   |                 ^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:236:28
-   |
-LL |     while true && (true || let 0 = 0) {}
-   |                            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
-  --> $DIR/disallowed-positions.rs:236:25
-   |
-LL |     while true && (true || let 0 = 0) {}
-   |                         ^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:239:28
-   |
-LL |     while true || (true && let 0 = 0) {}
-   |                            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:239:20
-   |
-LL |     while true || (true && let 0 = 0) {}
-   |                    ^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:244:15
-   |
-LL |     while x = let 0 = 0 {}
-   |               ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:249:18
-   |
-LL |     while true..(let 0 = 0) {}
-   |                  ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:249:18
-   |
-LL |     while true..(let 0 = 0) {}
-   |                  ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:253:14
-   |
-LL |     while ..(let 0 = 0) {}
-   |              ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:253:14
-   |
-LL |     while ..(let 0 = 0) {}
-   |              ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:257:12
-   |
-LL |     while (let 0 = 0).. {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:257:12
-   |
-LL |     while (let 0 = 0).. {}
-   |            ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:263:11
-   |
-LL |     while let Range { start: _, end: _ } = true..true && false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:267:11
-   |
-LL |     while let Range { start: _, end: _ } = true..true || false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:274:11
-   |
-LL |     while let Range { start: F, end } = F..|| true {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:282:11
-   |
-LL |     while let Range { start: true, end } = t..&&false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:288:22
-   |
-LL |     while let true = let true = true {}
-   |                      ^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:304:6
-   |
-LL |     &let 0 = 0;
-   |      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:308:6
-   |
-LL |     !let 0 = 0;
-   |      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:311:6
-   |
-LL |     *let 0 = 0;
-   |      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:315:6
-   |
-LL |     -let 0 = 0;
-   |      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:325:6
-   |
-LL |     (let 0 = 0)?;
-   |      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:325:6
-   |
-LL |     (let 0 = 0)?;
-   |      ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:331:13
-   |
-LL |     true || let 0 = 0;
-   |             ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
-  --> $DIR/disallowed-positions.rs:331:10
-   |
-LL |     true || let 0 = 0;
-   |          ^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:334:14
-   |
-LL |     (true || let 0 = 0);
-   |              ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
-  --> $DIR/disallowed-positions.rs:334:11
-   |
-LL |     (true || let 0 = 0);
-   |           ^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:337:22
-   |
-LL |     true && (true || let 0 = 0);
-   |                      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
-  --> $DIR/disallowed-positions.rs:337:19
-   |
-LL |     true && (true || let 0 = 0);
-   |                   ^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:342:9
-   |
-LL |     x = let 0 = 0;
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:346:12
-   |
-LL |     true..(let 0 = 0);
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:346:12
-   |
-LL |     true..(let 0 = 0);
-   |            ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:349:8
-   |
-LL |     ..(let 0 = 0);
-   |        ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:349:8
-   |
-LL |     ..(let 0 = 0);
-   |        ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:352:6
-   |
-LL |     (let 0 = 0)..;
-   |      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:352:6
-   |
-LL |     (let 0 = 0)..;
-   |      ^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:356:6
-   |
-LL |     (let Range { start: _, end: _ } = true..true || false);
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:361:6
-   |
-LL |     (let true = let true = true);
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:361:6
-   |
-LL |     (let true = let true = true);
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:379:6
-   |
-LL |     &let 0 = 0
-   |      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:391:17
-   |
-LL |         true && let 1 = 1
-   |                 ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:397:17
-   |
-LL |         true && let 1 = 1
-   |                 ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:403:17
-   |
-LL |         true && let 1 = 1
-   |                 ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:415:17
-   |
-LL |         true && let 1 = 1
-   |                 ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:425:9
-   |
-LL |     if (let Some(a) = opt && true) {
-   |         ^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:425:9
-   |
-LL |     if (let Some(a) = opt && true) {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:430:9
-   |
-LL |     if (let Some(a) = opt) && true {
-   |         ^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:430:9
-   |
-LL |     if (let Some(a) = opt) && true {
-   |         ^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:434:9
-   |
-LL |     if (let Some(a) = opt) && (let Some(b) = a) {
-   |         ^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:434:9
-   |
-LL |     if (let Some(a) = opt) && (let Some(b) = a) {
-   |         ^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:434:32
-   |
-LL |     if (let Some(a) = opt) && (let Some(b) = a) {
-   |                                ^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:434:32
-   |
-LL |     if (let Some(a) = opt) && (let Some(b) = a) {
-   |                                ^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:443:9
-   |
-LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
-   |         ^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:443:9
-   |
-LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:443:31
-   |
-LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
-   |                               ^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:443:31
-   |
-LL |     if (let Some(a) = opt && (let Some(b) = a)) && b == 1 {
-   |                               ^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:449:9
-   |
-LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
-   |         ^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:449:9
-   |
-LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:449:31
-   |
-LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
-   |                               ^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:449:31
-   |
-LL |     if (let Some(a) = opt && (let Some(b) = a)) && true {
-   |                               ^^^^^^^^^^^^^^^
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:455:9
-   |
-LL |     if (let Some(a) = opt && (true)) && true {
-   |         ^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/disallowed-positions.rs:455:9
-   |
-LL |     if (let Some(a) = opt && (true)) && true {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:110:8
-   |
-LL |     if &let 0 = 0 {}
-   |        ^^^^^^^^^^ expected `bool`, found `&bool`
-   |
-help: consider removing the borrow
-   |
-LL -     if &let 0 = 0 {}
-LL +     if let 0 = 0 {}
-   |
-
-error[E0614]: type `bool` cannot be dereferenced
-  --> $DIR/disallowed-positions.rs:118:8
-   |
-LL |     if *let 0 = 0 {}
-   |        ^^^^^^^^^^
-
-error[E0600]: cannot apply unary operator `-` to type `bool`
-  --> $DIR/disallowed-positions.rs:122:8
-   |
-LL |     if -let 0 = 0 {}
-   |        ^^^^^^^^^^ cannot apply unary operator `-`
-
-error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/disallowed-positions.rs:132:8
-   |
-LL |     if (let 0 = 0)? {}
-   |        ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
-   |
-   = help: the trait `Try` is not implemented for `bool`
-
-error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
-  --> $DIR/disallowed-positions.rs:132:19
-   |
-LL | fn nested_within_if_expr() {
-   | -------------------------- this function should return `Result` or `Option` to accept `?`
-...
-LL |     if (let 0 = 0)? {}
-   |                   ^ cannot use the `?` operator in a function that returns `()`
-   |
-   = help: the trait `FromResidual<_>` is not implemented for `()`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:152:8
-   |
-LL |     if x = let 0 = 0 {}
-   |        ^^^^^^^^^^^^^ expected `bool`, found `()`
-   |
-help: you might have meant to compare for equality
-   |
-LL |     if x == let 0 = 0 {}
-   |           +
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:157:8
+  --> $DIR/disallowed-positions.rs:119:8
    |
 LL |     if true..(let 0 = 0) {}
    |        ^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
@@ -1522,25 +727,7 @@ LL |     if true..(let 0 = 0) {}
             found struct `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:161:8
-   |
-LL |     if ..(let 0 = 0) {}
-   |        ^^^^^^^^^^^^^ expected `bool`, found `RangeTo<bool>`
-   |
-   = note: expected type `bool`
-            found struct `RangeTo<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:165:8
-   |
-LL |     if (let 0 = 0).. {}
-   |        ^^^^^^^^^^^^^ expected `bool`, found `RangeFrom<bool>`
-   |
-   = note: expected type `bool`
-            found struct `RangeFrom<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:171:12
+  --> $DIR/disallowed-positions.rs:128:12
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
@@ -1551,16 +738,7 @@ LL |     if let Range { start: _, end: _ } = true..true && false {}
             found struct `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:171:8
-   |
-LL |     if let Range { start: _, end: _ } = true..true && false {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
-   |
-   = note: expected type `bool`
-            found struct `std::ops::Range<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:175:12
+  --> $DIR/disallowed-positions.rs:131:12
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
@@ -1571,16 +749,7 @@ LL |     if let Range { start: _, end: _ } = true..true || false {}
             found struct `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:175:8
-   |
-LL |     if let Range { start: _, end: _ } = true..true || false {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
-   |
-   = note: expected type `bool`
-            found struct `std::ops::Range<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:182:12
+  --> $DIR/disallowed-positions.rs:137:12
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `fn() -> bool`
@@ -1591,29 +760,7 @@ LL |     if let Range { start: F, end } = F..|| true {}
                   found struct `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:182:41
-   |
-LL |     if let Range { start: F, end } = F..|| true {}
-   |                                         ^^^^^^^ expected `bool`, found closure
-   |
-   = note: expected type `bool`
-           found closure `[closure@$DIR/disallowed-positions.rs:182:41: 182:43]`
-help: use parentheses to call this closure
-   |
-LL |     if let Range { start: F, end } = F..(|| true)() {}
-   |                                         +       +++
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:182:8
-   |
-LL |     if let Range { start: F, end } = F..|| true {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
-   |
-   = note: expected type `bool`
-            found struct `std::ops::Range<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:190:12
+  --> $DIR/disallowed-positions.rs:143:12
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `&&bool`
@@ -1623,29 +770,8 @@ LL |     if let Range { start: true, end } = t..&&false {}
    = note: expected type `bool`
             found struct `std::ops::Range<_>`
 
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:190:44
-   |
-LL |     if let Range { start: true, end } = t..&&false {}
-   |                                            ^^^^^^^ expected `bool`, found `&&bool`
-   |
-help: consider removing the `&&`
-   |
-LL -     if let Range { start: true, end } = t..&&false {}
-LL +     if let Range { start: true, end } = t..false {}
-   |
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:190:8
-   |
-LL |     if let Range { start: true, end } = t..&&false {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
-   |
-   = note: expected type `bool`
-            found struct `std::ops::Range<bool>`
-
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/disallowed-positions.rs:128:20
+  --> $DIR/disallowed-positions.rs:99:20
    |
 LL |         if let 0 = 0? {}
    |                    ^^ the `?` operator cannot be applied to type `{integer}`
@@ -1653,61 +779,7 @@ LL |         if let 0 = 0? {}
    = help: the trait `Try` is not implemented for `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:202:11
-   |
-LL |     while &let 0 = 0 {}
-   |           ^^^^^^^^^^ expected `bool`, found `&bool`
-   |
-help: consider removing the borrow
-   |
-LL -     while &let 0 = 0 {}
-LL +     while let 0 = 0 {}
-   |
-
-error[E0614]: type `bool` cannot be dereferenced
-  --> $DIR/disallowed-positions.rs:210:11
-   |
-LL |     while *let 0 = 0 {}
-   |           ^^^^^^^^^^
-
-error[E0600]: cannot apply unary operator `-` to type `bool`
-  --> $DIR/disallowed-positions.rs:214:11
-   |
-LL |     while -let 0 = 0 {}
-   |           ^^^^^^^^^^ cannot apply unary operator `-`
-
-error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/disallowed-positions.rs:224:11
-   |
-LL |     while (let 0 = 0)? {}
-   |           ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
-   |
-   = help: the trait `Try` is not implemented for `bool`
-
-error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
-  --> $DIR/disallowed-positions.rs:224:22
-   |
-LL | fn nested_within_while_expr() {
-   | ----------------------------- this function should return `Result` or `Option` to accept `?`
-...
-LL |     while (let 0 = 0)? {}
-   |                      ^ cannot use the `?` operator in a function that returns `()`
-   |
-   = help: the trait `FromResidual<_>` is not implemented for `()`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:244:11
-   |
-LL |     while x = let 0 = 0 {}
-   |           ^^^^^^^^^^^^^ expected `bool`, found `()`
-   |
-help: you might have meant to compare for equality
-   |
-LL |     while x == let 0 = 0 {}
-   |              +
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:249:11
+  --> $DIR/disallowed-positions.rs:183:11
    |
 LL |     while true..(let 0 = 0) {}
    |           ^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
@@ -1716,25 +788,7 @@ LL |     while true..(let 0 = 0) {}
             found struct `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:253:11
-   |
-LL |     while ..(let 0 = 0) {}
-   |           ^^^^^^^^^^^^^ expected `bool`, found `RangeTo<bool>`
-   |
-   = note: expected type `bool`
-            found struct `RangeTo<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:257:11
-   |
-LL |     while (let 0 = 0).. {}
-   |           ^^^^^^^^^^^^^ expected `bool`, found `RangeFrom<bool>`
-   |
-   = note: expected type `bool`
-            found struct `RangeFrom<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:263:15
+  --> $DIR/disallowed-positions.rs:192:15
    |
 LL |     while let Range { start: _, end: _ } = true..true && false {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
@@ -1745,16 +799,7 @@ LL |     while let Range { start: _, end: _ } = true..true && false {}
             found struct `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:263:11
-   |
-LL |     while let Range { start: _, end: _ } = true..true && false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
-   |
-   = note: expected type `bool`
-            found struct `std::ops::Range<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:267:15
+  --> $DIR/disallowed-positions.rs:195:15
    |
 LL |     while let Range { start: _, end: _ } = true..true || false {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
@@ -1765,16 +810,7 @@ LL |     while let Range { start: _, end: _ } = true..true || false {}
             found struct `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:267:11
-   |
-LL |     while let Range { start: _, end: _ } = true..true || false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
-   |
-   = note: expected type `bool`
-            found struct `std::ops::Range<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:274:15
+  --> $DIR/disallowed-positions.rs:201:15
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `fn() -> bool`
@@ -1785,29 +821,7 @@ LL |     while let Range { start: F, end } = F..|| true {}
                   found struct `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:274:44
-   |
-LL |     while let Range { start: F, end } = F..|| true {}
-   |                                            ^^^^^^^ expected `bool`, found closure
-   |
-   = note: expected type `bool`
-           found closure `[closure@$DIR/disallowed-positions.rs:274:44: 274:46]`
-help: use parentheses to call this closure
-   |
-LL |     while let Range { start: F, end } = F..(|| true)() {}
-   |                                            +       +++
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:274:11
-   |
-LL |     while let Range { start: F, end } = F..|| true {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
-   |
-   = note: expected type `bool`
-            found struct `std::ops::Range<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:282:15
+  --> $DIR/disallowed-positions.rs:207:15
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `&&bool`
@@ -1817,68 +831,16 @@ LL |     while let Range { start: true, end } = t..&&false {}
    = note: expected type `bool`
             found struct `std::ops::Range<_>`
 
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:282:47
-   |
-LL |     while let Range { start: true, end } = t..&&false {}
-   |                                               ^^^^^^^ expected `bool`, found `&&bool`
-   |
-help: consider removing the `&&`
-   |
-LL -     while let Range { start: true, end } = t..&&false {}
-LL +     while let Range { start: true, end } = t..false {}
-   |
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:282:11
-   |
-LL |     while let Range { start: true, end } = t..&&false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `Range<bool>`
-   |
-   = note: expected type `bool`
-            found struct `std::ops::Range<bool>`
-
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/disallowed-positions.rs:220:23
+  --> $DIR/disallowed-positions.rs:163:23
    |
 LL |         while let 0 = 0? {}
    |                       ^^ the `?` operator cannot be applied to type `{integer}`
    |
    = help: the trait `Try` is not implemented for `{integer}`
 
-error[E0614]: type `bool` cannot be dereferenced
-  --> $DIR/disallowed-positions.rs:311:5
-   |
-LL |     *let 0 = 0;
-   |     ^^^^^^^^^^
-
-error[E0600]: cannot apply unary operator `-` to type `bool`
-  --> $DIR/disallowed-positions.rs:315:5
-   |
-LL |     -let 0 = 0;
-   |     ^^^^^^^^^^ cannot apply unary operator `-`
-
-error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/disallowed-positions.rs:325:5
-   |
-LL |     (let 0 = 0)?;
-   |     ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
-   |
-   = help: the trait `Try` is not implemented for `bool`
-
-error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
-  --> $DIR/disallowed-positions.rs:325:16
-   |
-LL | fn outside_if_and_while_expr() {
-   | ------------------------------ this function should return `Result` or `Option` to accept `?`
-...
-LL |     (let 0 = 0)?;
-   |                ^ cannot use the `?` operator in a function that returns `()`
-   |
-   = help: the trait `FromResidual<_>` is not implemented for `()`
-
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:356:10
+  --> $DIR/disallowed-positions.rs:262:10
    |
 LL |     (let Range { start: _, end: _ } = true..true || false);
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this expression has type `bool`
@@ -1888,24 +850,15 @@ LL |     (let Range { start: _, end: _ } = true..true || false);
    = note: expected type `bool`
             found struct `std::ops::Range<_>`
 
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:379:5
-   |
-LL | fn outside_if_and_while_expr() {
-   |                                - help: try adding a return type: `-> &bool`
-...
-LL |     &let 0 = 0
-   |     ^^^^^^^^^^ expected `()`, found `&bool`
-
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/disallowed-positions.rs:321:17
+  --> $DIR/disallowed-positions.rs:237:17
    |
 LL |         let 0 = 0?;
    |                 ^^ the `?` operator cannot be applied to type `{integer}`
    |
    = help: the trait `Try` is not implemented for `{integer}`
 
-error: aborting due to 215 previous errors
+error: aborting due to 104 previous errors
 
-Some errors have detailed explanations: E0277, E0308, E0600, E0614.
+Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ensure-that-let-else-does-not-interact-with-let-chains.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ensure-that-let-else-does-not-interact-with-let-chains.rs
@@ -14,7 +14,6 @@ fn main() {
     };
     let Some(n) = opt && let another = n else {
     //~^ ERROR a `&&` expression cannot be directly assigned in `let...else`
-    //~| ERROR `let` expressions are not supported here
     //~| ERROR mismatched types
     //~| ERROR mismatched types
     //~| ERROR expected expression, found `let` statement

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ensure-that-let-else-does-not-interact-with-let-chains.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ensure-that-let-else-does-not-interact-with-let-chains.stderr
@@ -27,13 +27,13 @@ LL |     let Some(n) = (opt && let another = n) else {
    |                   +                      +
 
 error: this `if` expression is missing a block after the condition
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:24:5
+  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:23:5
    |
 LL |     if let Some(n) = opt else {
    |     ^^
    |
 help: add a block here
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:24:25
+  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:23:25
    |
 LL |     if let Some(n) = opt else {
    |                         ^
@@ -44,31 +44,31 @@ LL +     let Some(n) = opt else {
    |
 
 error: this `if` expression is missing a block after the condition
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:28:5
+  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:27:5
    |
 LL |     if let Some(n) = opt && n == 1 else {
    |     ^^
    |
 help: add a block here
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:28:35
+  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:27:35
    |
 LL |     if let Some(n) = opt && n == 1 else {
    |                                   ^
 
 error: this `if` expression is missing a block after the condition
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:32:5
+  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:31:5
    |
 LL |     if let Some(n) = opt && let another = n else {
    |     ^^
    |
 help: add a block here
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:32:44
+  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:31:44
    |
 LL |     if let Some(n) = opt && let another = n else {
    |                                            ^
 
 error: expected `{`, found keyword `else`
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:38:33
+  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:37:33
    |
 LL |         while let Some(n) = opt else {
    |         ----- ----------------- ^^^^ expected `{`
@@ -77,7 +77,7 @@ LL |         while let Some(n) = opt else {
    |         while parsing the body of this `while` expression
 
 error: expected `{`, found keyword `else`
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:44:43
+  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:43:43
    |
 LL |         while let Some(n) = opt && n == 1 else {
    |         ----- --------------------------- ^^^^ expected `{`
@@ -86,21 +86,13 @@ LL |         while let Some(n) = opt && n == 1 else {
    |         while parsing the body of this `while` expression
 
 error: expected `{`, found keyword `else`
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:50:52
+  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:49:52
    |
 LL |         while let Some(n) = opt && let another = n else {
    |         ----- ------------------------------------ ^^^^ expected `{`
    |         |     |
    |         |     this `while` condition successfully parsed
    |         while parsing the body of this `while` expression
-
-error: `let` expressions are not supported here
-  --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:15:26
-   |
-LL |     let Some(n) = opt && let another = n else {
-   |                          ^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
 
 error[E0308]: mismatched types
   --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:9:19
@@ -142,6 +134,6 @@ LL |     let Some(n) = opt && let another = n else {
    = note: expected type `bool`
               found enum `Option<_>`
 
-error: aborting due to 14 previous errors
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ensure-that-let-else-does-not-interact-with-let-chains.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ensure-that-let-else-does-not-interact-with-let-chains.stderr
@@ -14,6 +14,8 @@ error: expected expression, found `let` statement
    |
 LL |     let Some(n) = opt && let another = n else {
    |                          ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: a `&&` expression cannot be directly assigned in `let...else`
   --> $DIR/ensure-that-let-else-does-not-interact-with-let-chains.rs:15:19

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.rs
@@ -43,8 +43,7 @@ fn _macros() {
     macro_rules! noop_expr { ($e:expr) => {}; }
 
     noop_expr!((let 0 = 1));
-    //~^ ERROR `let` expressions in this position are unstable [E0658]
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 
     macro_rules! use_expr {
         ($e:expr) => {
@@ -53,8 +52,7 @@ fn _macros() {
         }
     }
     #[cfg(FALSE)] (let 0 = 1);
-    //~^ ERROR `let` expressions in this position are unstable [E0658]
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
     use_expr!(let 0 = 1);
     //~^ ERROR no rules expected the token `let`
 }

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.stderr
@@ -1,5 +1,5 @@
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:55:20
+  --> $DIR/feature-gate.rs:54:20
    |
 LL |     #[cfg(FALSE)] (let 0 = 1);
    |                    ^^^
@@ -11,7 +11,7 @@ LL |     noop_expr!((let 0 = 1));
    |                 ^^^
 
 error: no rules expected the token `let`
-  --> $DIR/feature-gate.rs:58:15
+  --> $DIR/feature-gate.rs:56:15
    |
 LL |     macro_rules! use_expr {
    |     --------------------- when calling this macro
@@ -20,7 +20,7 @@ LL |     use_expr!(let 0 = 1);
    |               ^^^ no rules expected this token in macro call
    |
 note: while trying to match meta-variable `$e:expr`
-  --> $DIR/feature-gate.rs:50:10
+  --> $DIR/feature-gate.rs:49:10
    |
 LL |         ($e:expr) => {
    |          ^^^^^^^
@@ -97,24 +97,6 @@ LL |     while let Range { start: _, end: _ } = (true..true) && false {}
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:55:20
-   |
-LL |     #[cfg(FALSE)] (let 0 = 1);
-   |                    ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:45:17
-   |
-LL |     noop_expr!((let 0 = 1));
-   |                 ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-
-error: aborting due to 13 previous errors
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.stderr
@@ -3,12 +3,16 @@ error: expected expression, found `let` statement
    |
 LL |     #[cfg(FALSE)] (let 0 = 1);
    |                    ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/feature-gate.rs:45:17
    |
 LL |     noop_expr!((let 0 = 1));
    |                 ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: no rules expected the token `let`
   --> $DIR/feature-gate.rs:56:15

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/invalid-let-in-a-valid-let-context.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/invalid-let-in-a-valid-let-context.rs
@@ -13,6 +13,7 @@ fn main() {
         if let Some(elem) = _opt && [1, 2, 3][let _ = &&let Some(x) = Some(42)] = 1 {
         //~^ ERROR expected expression, found `let` statement
         //~| ERROR expected expression, found `let` statement
+        //~| ERROR expected expression, found `let` statement
             true
         }
     }
@@ -31,6 +32,7 @@ fn main() {
     {
         if let Some(elem) = _opt && [1, 2, 3][let _ = ()] = 1 {
         //~^ ERROR expected expression, found `let` statement
+        //~| ERROR expected expression, found `let` statement
             true
         }
     }

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/invalid-let-in-a-valid-let-context.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/invalid-let-in-a-valid-let-context.stderr
@@ -3,48 +3,64 @@ error: expected expression, found `let` statement
    |
 LL |         let _ = &&let Some(x) = Some(42);
    |                   ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/invalid-let-in-a-valid-let-context.rs:13:47
    |
 LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = &&let Some(x) = Some(42)] = 1 {
    |                                               ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/invalid-let-in-a-valid-let-context.rs:13:57
    |
 LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = &&let Some(x) = Some(42)] = 1 {
    |                                                         ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/invalid-let-in-a-valid-let-context.rs:13:12
    |
 LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = &&let Some(x) = Some(42)] = 1 {
    |            ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/invalid-let-in-a-valid-let-context.rs:24:23
    |
 LL |             [1, 2, 3][let _ = ()];
    |                       ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/invalid-let-in-a-valid-let-context.rs:33:47
    |
 LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = ()] = 1 {
    |                                               ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/invalid-let-in-a-valid-let-context.rs:33:12
    |
 LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = ()] = 1 {
    |            ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
   --> $DIR/invalid-let-in-a-valid-let-context.rs:42:21
    |
 LL |             let x = let y = 1;
    |                     ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/invalid-let-in-a-valid-let-context.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/invalid-let-in-a-valid-let-context.stderr
@@ -17,22 +17,34 @@ LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = &&let Some(x) = Some(
    |                                                         ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/invalid-let-in-a-valid-let-context.rs:23:23
+  --> $DIR/invalid-let-in-a-valid-let-context.rs:13:12
+   |
+LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = &&let Some(x) = Some(42)] = 1 {
+   |            ^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/invalid-let-in-a-valid-let-context.rs:24:23
    |
 LL |             [1, 2, 3][let _ = ()];
    |                       ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/invalid-let-in-a-valid-let-context.rs:32:47
+  --> $DIR/invalid-let-in-a-valid-let-context.rs:33:47
    |
 LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = ()] = 1 {
    |                                               ^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/invalid-let-in-a-valid-let-context.rs:40:21
+  --> $DIR/invalid-let-in-a-valid-let-context.rs:33:12
+   |
+LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = ()] = 1 {
+   |            ^^^^^^^^^^^^^^^^^^^^^
+
+error: expected expression, found `let` statement
+  --> $DIR/invalid-let-in-a-valid-let-context.rs:42:21
    |
 LL |             let x = let y = 1;
    |                     ^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
- Move all of the checks for valid let expression positions to parsing. 
- Add a field to ExprKind::Let in AST/HIR to mark whether it's in a valid location.
- Suppress some later errors and MIR construction for invalid let expressions.
- Fix a (drop) scope issue that was also responsible for #104172.

Fixes #104172
Fixes #104868