### PR TITLE
Set default `move_size_limit` to 4kB for `large_assignments` lint on nightly

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -716,6 +716,7 @@ pub fn create_global_ctxt<'tcx>(
 
     sess.time("setup_global_ctxt", || {
         gcx_cell.get_or_init(move || {
+            #[allow(large_assignments)]
             TyCtxt::create_global_ctxt(
                 sess,
                 crate_types,

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -93,6 +93,7 @@ pub struct Queries<'tcx> {
 
 impl<'tcx> Queries<'tcx> {
     pub fn new(compiler: &'tcx Compiler) -> Queries<'tcx> {
+        #[allow(large_assignments)]
         Queries {
             compiler,
             gcx_cell: OnceLock::new(),

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -1,4 +1,4 @@
-#![allow(rustc::bad_opt_access)]
+#![allow(rustc::bad_opt_access, large_assignments)]
 use crate::interface::parse_cfgspecs;
 
 use rustc_data_structures::fx::FxHashSet;

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -126,6 +126,7 @@ pub fn create_session(
     sess.parse_sess.config = cfg;
     sess.parse_sess.check_config = check_cfg;
 
+    #[allow(large_assignments)]
     (sess, codegen_backend)
 }
 

--- a/compiler/rustc_middle/src/middle/limits.rs
+++ b/compiler/rustc_middle/src/middle/limits.rs
@@ -25,7 +25,15 @@ pub fn provide(providers: &mut Providers) {
             tcx.hir().krate_attrs(),
             tcx.sess,
             sym::move_size_limit,
-            tcx.sess.opts.unstable_opts.move_size_limit.unwrap_or(0),
+            // The check is enabled by default in nightly compilers without
+            // needing `#![feature(large_assignments)]` with a limit of 4096
+            // bytes. But if the user wants to use adjust `#![move_size_limit]`,
+            // then `#![feature(large_assignments)]` is needed.
+            tcx.sess.opts.unstable_opts.move_size_limit.unwrap_or(if tcx.sess.is_nightly_build() {
+                4096
+            } else {
+                0
+            }),
         ),
         type_length_limit: get_limit(
             tcx.hir().krate_attrs(),

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -713,6 +713,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let common_lifetimes = CommonLifetimes::new(&interners);
         let common_consts = CommonConsts::new(&interners, &common_types);
 
+        #[allow(large_assignments)]
         GlobalCtxt {
             sess: s,
             crate_types,

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -209,6 +209,7 @@ pub fn query_system<'tcx>(
     on_disk_cache: Option<OnDiskCache<'tcx>>,
     incremental: bool,
 ) -> QuerySystem<'tcx> {
+    #[allow(large_assignments)]
     QuerySystem {
         states: Default::default(),
         arenas: Default::default(),

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1312,7 +1312,7 @@ fn default_emitter(
 }
 
 // JUSTIFICATION: literally session construction
-#[allow(rustc::bad_opt_access)]
+#[allow(rustc::bad_opt_access, large_assignments)]
 pub fn build_session(
     handler: &EarlyErrorHandler,
     sopts: config::Options,

--- a/compiler/rustc_target/src/spec/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/apple/tests.rs
@@ -1,3 +1,5 @@
+#![allow(large_assignments)]
+
 use crate::spec::{
     aarch64_apple_darwin, aarch64_apple_ios_sim, aarch64_apple_watchos_sim, i686_apple_darwin,
     x86_64_apple_darwin, x86_64_apple_ios, x86_64_apple_tvos, x86_64_apple_watchos_sim,

--- a/library/alloc/benches/lib.rs
+++ b/library/alloc/benches/lib.rs
@@ -8,6 +8,7 @@
 #![feature(strict_provenance)]
 #![feature(test)]
 #![deny(fuzzy_provenance_casts)]
+#![allow(large_assignments)]
 
 extern crate test;
 

--- a/library/alloc/benches/vec_deque.rs
+++ b/library/alloc/benches/vec_deque.rs
@@ -1,3 +1,5 @@
+#![allow(large_assignments)]
+
 use core::iter::Iterator;
 use std::{
     collections::{vec_deque, VecDeque},

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -837,6 +837,7 @@ impl<T, A: Allocator> Box<mem::MaybeUninit<T>, A> {
     ///
     /// ```
     /// #![feature(new_uninit)]
+    /// #![allow(large_assignments)]
     ///
     /// let big_box = Box::<[usize; 1024]>::new_uninit();
     ///

--- a/library/core/benches/array.rs
+++ b/library/core/benches/array.rs
@@ -1,3 +1,5 @@
+#![allow(large_assignments)]
+
 use test::black_box;
 use test::Bencher;
 

--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -1,3 +1,5 @@
+#![allow(large_assignments)]
+
 use core::borrow::Borrow;
 use core::iter::*;
 use core::mem;

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -97,6 +97,7 @@ use crate::slice;
 /// unnecessary moves.
 ///
 /// ```
+/// ##![allow(large_assignments)]
 /// use std::mem::MaybeUninit;
 ///
 /// unsafe fn make_vec(out: *mut Vec<i32>) {
@@ -117,6 +118,7 @@ use crate::slice;
 /// `MaybeUninit<T>` can be used to initialize a large array element-by-element:
 ///
 /// ```
+/// ##![allow(large_assignments)]
 /// use std::mem::{self, MaybeUninit};
 ///
 /// let data = {
@@ -145,6 +147,7 @@ use crate::slice;
 /// be found in low-level datastructures.
 ///
 /// ```
+/// ##![allow(large_assignments)]
 /// use std::mem::MaybeUninit;
 ///
 /// // Create an uninitialized array of `MaybeUninit`. The `assume_init` is

--- a/tests/ui/async-await/large_moves.attribute.stderr
+++ b/tests/ui/async-await/large_moves.attribute.stderr
@@ -28,12 +28,60 @@ LL |     let _ = NotBox::new([0; 9999]);
    = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 9999 bytes
-  --> $DIR/large_moves.rs:41:13
+  --> $DIR/large_moves.rs:63:13
    |
 LL |             data,
    |             ^^^^ value moved from here
    |
    = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
-error: aborting due to 4 previous errors
+error: moving 1500 bytes
+  --> $DIR/large_moves.rs:37:13
+   |
+LL |     let _ = NotBox::new([0; 1500]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 2500 bytes
+  --> $DIR/large_moves.rs:41:13
+   |
+LL |     let _ = NotBox::new([0; 2500]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 5000 bytes
+  --> $DIR/large_moves.rs:47:13
+   |
+LL |     let _ = NotBox::new([0; 5000]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 1500 bytes
+  --> $DIR/large_moves.rs:63:13
+   |
+LL |             data,
+   |             ^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 2500 bytes
+  --> $DIR/large_moves.rs:63:13
+   |
+LL |             data,
+   |             ^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 5000 bytes
+  --> $DIR/large_moves.rs:63:13
+   |
+LL |             data,
+   |             ^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/async-await/large_moves.nothing.stderr
+++ b/tests/ui/async-await/large_moves.nothing.stderr
@@ -1,0 +1,55 @@
+error: moving 10024 bytes
+  --> $DIR/large_moves.rs:21:14
+   |
+LL |     let z = (x, 42);
+   |              ^ value moved from here
+   |
+   = note: The current maximum size is 4096, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+note: the lint level is defined here
+  --> $DIR/large_moves.rs:1:9
+   |
+LL | #![deny(large_assignments)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: moving 10024 bytes
+  --> $DIR/large_moves.rs:22:13
+   |
+LL |     let a = z.0;
+   |             ^^^ value moved from here
+   |
+   = note: The current maximum size is 4096, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 9999 bytes
+  --> $DIR/large_moves.rs:27:13
+   |
+LL |     let _ = NotBox::new([0; 9999]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 4096, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 9999 bytes
+  --> $DIR/large_moves.rs:63:13
+   |
+LL |             data,
+   |             ^^^^ value moved from here
+   |
+   = note: The current maximum size is 4096, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 5000 bytes
+  --> $DIR/large_moves.rs:47:13
+   |
+LL |     let _ = NotBox::new([0; 5000]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 4096, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 5000 bytes
+  --> $DIR/large_moves.rs:63:13
+   |
+LL |             data,
+   |             ^^^^ value moved from here
+   |
+   = note: The current maximum size is 4096, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/async-await/large_moves.option.stderr
+++ b/tests/ui/async-await/large_moves.option.stderr
@@ -4,7 +4,7 @@ error: moving 10024 bytes
 LL |     let z = (x, 42);
    |              ^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: The current maximum size is 2000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
   --> $DIR/large_moves.rs:1:9
    |
@@ -17,7 +17,7 @@ error: moving 10024 bytes
 LL |     let a = z.0;
    |             ^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: The current maximum size is 2000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 9999 bytes
   --> $DIR/large_moves.rs:27:13
@@ -25,15 +25,47 @@ error: moving 9999 bytes
 LL |     let _ = NotBox::new([0; 9999]);
    |             ^^^^^^^^^^^^^^^^^^^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: The current maximum size is 2000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 9999 bytes
-  --> $DIR/large_moves.rs:41:13
+  --> $DIR/large_moves.rs:63:13
    |
 LL |             data,
    |             ^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: The current maximum size is 2000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
-error: aborting due to 4 previous errors
+error: moving 2500 bytes
+  --> $DIR/large_moves.rs:41:13
+   |
+LL |     let _ = NotBox::new([0; 2500]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 2000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 5000 bytes
+  --> $DIR/large_moves.rs:47:13
+   |
+LL |     let _ = NotBox::new([0; 5000]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 2000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 2500 bytes
+  --> $DIR/large_moves.rs:63:13
+   |
+LL |             data,
+   |             ^^^^ value moved from here
+   |
+   = note: The current maximum size is 2000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: moving 5000 bytes
+  --> $DIR/large_moves.rs:63:13
+   |
+LL |             data,
+   |             ^^^^ value moved from here
+   |
+   = note: The current maximum size is 2000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/async-await/large_moves.rs
+++ b/tests/ui/async-await/large_moves.rs
@@ -1,10 +1,10 @@
 #![deny(large_assignments)]
-#![feature(large_assignments)]
+#![cfg_attr(attribute, feature(large_assignments))]
 #![cfg_attr(attribute, move_size_limit = "1000")]
 // build-fail
 // only-x86_64
-// revisions: attribute option
-// [option]compile-flags: -Zmove-size-limit=1000
+// revisions: attribute option nothing
+// [option]compile-flags: -Zmove-size-limit=2000
 
 // edition:2018
 // compile-flags: -Zmir-opt-level=0
@@ -25,20 +25,48 @@ fn main() {
     let _ = Box::new([0; 9999]); // OK!
     let _ = Rc::new([0; 9999]); // OK!
     let _ = NotBox::new([0; 9999]); //~ ERROR large_assignments
+    default_limits();
+}
+
+fn default_limits() {
+    // Moving 500 bytes is OK in all revisions
+    let _ = NotBox::new([0; 500]);
+
+    // Moving 1500 bytes should fail only with the `attribute` revision because
+    // its limit is 1000 bytes
+    let _ = NotBox::new([0; 1500]); //[attribute]~ ERROR large_assignments
+
+    // Moving 2500 bytes should fail with both `attribute` and `option` since
+    // their limits are 1000 and 2000 respectively.
+    let _ = NotBox::new([0; 2500]);
+    //[attribute]~^ ERROR large_assignments
+    //[option]~^^ ERROR large_assignments
+
+    // With a nightly compiler the default limit is 4096. So 5000 should fail
+    // for all revisions
+    let _ = NotBox::new([0; 5000]); //~ ERROR large_assignments
 }
 
 async fn thing(y: &[u8]) {
     dbg!(y);
 }
 
-struct NotBox {
-    data: [u8; 9999],
+struct NotBox<const N: usize> {
+    data: [u8; N],
 }
 
-impl NotBox {
-    fn new(data: [u8; 9999]) -> Self {
+impl<const N: usize> NotBox<N> {
+    fn new(data: [u8; N]) -> Self {
+        // FIXME: Each different instantiation of this generic type (with
+        // different N) results in a unique error message. Deduplicate somehow.
         Self {
             data, //~ ERROR large_assignments
+                  //[nothing]~^ ERROR large_assignments
+                  //[option]~| ERROR large_assignments
+                  //[option]~| ERROR large_assignments
+                  //[attribute]~| ERROR large_assignments
+                  //[attribute]~| ERROR large_assignments
+                  //[attribute]~| ERROR large_assignments
         }
     }
 }

--- a/tests/ui/limits/huge-array.rs
+++ b/tests/ui/limits/huge-array.rs
@@ -1,3 +1,4 @@
+#![allow(large_assignments)]
 // build-fail
 
 fn generic<T: Copy>(t: T) {

--- a/tests/ui/limits/huge-array.stderr
+++ b/tests/ui/limits/huge-array.stderr
@@ -1,5 +1,5 @@
 error: values of the type `[[u8; 1518599999]; 1518600000]` are too big for the current architecture
-  --> $DIR/huge-array.rs:4:9
+  --> $DIR/huge-array.rs:5:9
    |
 LL |     let s: [T; 1518600000] = [t; 1518600000];
    |         ^

--- a/tests/ui/print_type_sizes/async.rs
+++ b/tests/ui/print_type_sizes/async.rs
@@ -3,7 +3,7 @@
 // build-pass
 // ignore-pass
 
-#![allow(dropping_copy_types)]
+#![allow(dropping_copy_types, large_assignments)]
 
 async fn wait() {}
 

--- a/tests/ui/print_type_sizes/generator.rs
+++ b/tests/ui/print_type_sizes/generator.rs
@@ -2,6 +2,7 @@
 // build-pass
 // ignore-pass
 
+#![allow(large_assignments)]
 #![feature(generators, generator_trait)]
 
 use std::ops::Generator;

--- a/tests/ui/print_type_sizes/generator.stdout
+++ b/tests/ui/print_type_sizes/generator.stdout
@@ -1,4 +1,4 @@
-print-type-size type: `[generator@$DIR/generator.rs:10:5: 10:14]`: 8193 bytes, alignment: 1 bytes
+print-type-size type: `[generator@$DIR/generator.rs:11:5: 11:14]`: 8193 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 8192 bytes
 print-type-size         upvar `.array`: 8192 bytes

--- a/tests/ui/structs-enums/align-struct.rs
+++ b/tests/ui/structs-enums/align-struct.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(dead_code, unused_allocation)]
+#![allow(dead_code, unused_allocation, large_assignments)]
 
 use std::mem;
 


### PR DESCRIPTION
Only enable it by default in the nightly compiler. The limit can be changed on a per-crate basis with:

    #![feature(large_assignments)]
    #![move_size_limit = "8192"]

or with

    -Zmove-size-limit=8192

Does the _"enable the lint by default with a 4k threshold"_ step in #83518.

Tasks for this PR:
 - [ ] Figure out how to write a test that tests that the stable compiler still has a default move_size_limit of 0. I suspect it is easy once you know the trick, but I haven't been able to figure out the trick yet.
 - [ ] Handle [perf regression](https://github.com/rust-lang/rust/pull/115684#issuecomment-1714504350).

Tasks after this PR:
 - [ ] I found a bug where the lint is duplicated unnecessarily when generic instantiations are involved. See FIXME in the test. We should file an issue about it so we don't forget it. Or at least write a row in the tracking issue.
 - [ ] Improve diagnostics so that `./x test library/alloc` clearly says from where a large move into e.g. `black_box()` is made (when 39a42c3288 is temporarily reverted)

r? @oli-obk who is E-mentor.
