### PR TITLE
Add function that returns span of an item in smir

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -42,6 +42,10 @@ impl<'tcx> Context for Tables<'tcx> {
         self.tcx.def_path_str(self[def_id])
     }
 
+    fn span_of_an_item(&mut self, def_id: stable_mir::DefId) -> stable_mir::ty::Span {
+        self.tcx.def_span(self[def_id]).stable(self)
+    }
+
     fn all_local_items(&mut self) -> stable_mir::CrateItems {
         self.tcx.mir_keys(()).iter().map(|item| self.crate_item(item.to_def_id())).collect()
     }

--- a/compiler/rustc_smir/src/stable_mir/mod.rs
+++ b/compiler/rustc_smir/src/stable_mir/mod.rs
@@ -89,6 +89,10 @@ impl CrateItem {
     pub fn body(&self) -> mir::Body {
         with(|cx| cx.mir_body(self.0))
     }
+
+    pub fn span(&self) -> ty::Span {
+        with(|cx| cx.span_of_an_item(self.0))
+    }
 }
 
 /// Return the function where execution starts if the current
@@ -155,6 +159,9 @@ pub trait Context {
 
     /// Prints the name of given `DefId`
     fn name_of_def_id(&self, def_id: DefId) -> String;
+
+    /// `Span` of an item
+    fn span_of_an_item(&mut self, def_id: DefId) -> Span;
 
     /// Obtain the representation of a type.
     fn ty_kind(&mut self, ty: Ty) -> TyKind;


### PR DESCRIPTION
Addressees https://github.com/rust-lang/project-stable-mir/issues/31

Maybe we should change `Span = Opaque` into something else, and then return `String` with newly added function, I don't think it matters that much though, since we are not storing `Span` anywhere.

r? @oli-obk 