### PR TITLE
Parse unnamed fields and anonymous structs or unions

### DIFF
--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -441,9 +441,6 @@ pub fn walk_ty<'a, V: Visitor<'a>>(visitor: &mut V, typ: &'a Ty) {
         TyKind::Infer | TyKind::ImplicitSelf | TyKind::Err => {}
         TyKind::MacCall(mac) => visitor.visit_mac_call(mac),
         TyKind::Never | TyKind::CVarArgs => {}
-        TyKind::AnonStruct(ref fields, ..) | TyKind::AnonUnion(ref fields, ..) => {
-            walk_list!(visitor, visit_field_def, fields)
-        }
     }
 }
 
@@ -716,7 +713,14 @@ pub fn walk_field_def<'a, V: Visitor<'a>>(visitor: &mut V, field: &'a FieldDef) 
     if let Some(ident) = field.ident {
         visitor.visit_ident(ident);
     }
-    visitor.visit_ty(&field.ty);
+    match &field.ty {
+        FieldTy::Ty(ty) => {
+            visitor.visit_ty(ty);
+        }
+        FieldTy::AnonRecord(anon_record) => {
+            walk_list!(visitor, visit_field_def, &anon_record.fields);
+        }
+    }
     walk_list!(visitor, visit_attribute, &field.attrs);
 }
 

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -35,6 +35,8 @@
 #![doc(rust_logo)]
 #![feature(box_patterns)]
 #![feature(let_chains)]
+#![feature(if_let_guard)]
+#![feature(never_type)]
 #![recursion_limit = "256"]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
@@ -1323,18 +1325,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             TyKind::Err => {
                 hir::TyKind::Err(self.tcx.sess.span_delayed_bug(t.span, "TyKind::Err lowered"))
             }
-            // FIXME(unnamed_fields): IMPLEMENTATION IN PROGRESS
-            #[allow(rustc::untranslatable_diagnostic)]
-            #[allow(rustc::diagnostic_outside_of_impl)]
-            TyKind::AnonStruct(ref _fields) => hir::TyKind::Err(
-                self.tcx.sess.span_err(t.span, "anonymous structs are unimplemented"),
-            ),
-            // FIXME(unnamed_fields): IMPLEMENTATION IN PROGRESS
-            #[allow(rustc::untranslatable_diagnostic)]
-            #[allow(rustc::diagnostic_outside_of_impl)]
-            TyKind::AnonUnion(ref _fields) => hir::TyKind::Err(
-                self.tcx.sess.span_err(t.span, "anonymous unions are unimplemented"),
-            ),
             TyKind::Slice(ty) => hir::TyKind::Slice(self.lower_ty(ty, itctx)),
             TyKind::Ptr(mt) => hir::TyKind::Ptr(self.lower_mt(mt, itctx)),
             TyKind::Ref(region, mt) => {

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -973,14 +973,6 @@ impl<'a> State<'a> {
                 }
                 self.pclose();
             }
-            ast::TyKind::AnonStruct(fields) => {
-                self.head("struct");
-                self.print_record_struct_body(fields, ty.span);
-            }
-            ast::TyKind::AnonUnion(fields) => {
-                self.head("union");
-                self.print_record_struct_body(fields, ty.span);
-            }
             ast::TyKind::Paren(typ) => {
                 self.popen();
                 self.print_type(typ);

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -462,7 +462,15 @@ impl<'a> State<'a> {
                 self.print_visibility(&field.vis);
                 self.print_ident(field.ident.unwrap());
                 self.word_nbsp(":");
-                self.print_type(&field.ty);
+                match &field.ty {
+                    ast::FieldTy::Ty(ty) => {
+                        self.print_type(&ty);
+                    }
+                    ast::FieldTy::AnonRecord(anon_record) => {
+                        self.head(anon_record.kind.name());
+                        self.print_record_struct_body(&anon_record.fields, anon_record.span);
+                    }
+                }
                 self.word(",");
             }
         }
@@ -488,7 +496,7 @@ impl<'a> State<'a> {
                         s.maybe_print_comment(field.span.lo());
                         s.print_outer_attributes(&field.attrs);
                         s.print_visibility(&field.vis);
-                        s.print_type(&field.ty)
+                        s.print_type(field.ty.expect_ty())
                     });
                     self.pclose();
                 }

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -106,7 +106,7 @@ fn cs_clone_simple(
             // This basic redundancy checking only prevents duplication of
             // assertions like `AssertParamIsClone<Foo>` where the type is a
             // simple name. That's enough to get a lot of cases, though.
-            if let Some(name) = field.ty.kind.is_simple_path()
+            if let Some(name) = field.ty.expect_ty().kind.is_simple_path()
                 && !seen_type_names.insert(name)
             {
                 // Already produced an assertion for this type.
@@ -115,7 +115,7 @@ fn cs_clone_simple(
                 super::assert_ty_bounds(
                     cx,
                     &mut stmts,
-                    field.ty.clone(),
+                    field.ty.expect_ty().clone(),
                     field.span,
                     &[sym::clone, sym::AssertParamIsClone],
                 );

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
@@ -73,7 +73,7 @@ fn cs_total_eq_assert(
             // This basic redundancy checking only prevents duplication of
             // assertions like `AssertParamIsEq<Foo>` where the type is a
             // simple name. That's enough to get a lot of cases, though.
-            if let Some(name) = field.ty.kind.is_simple_path()
+            if let Some(name) = field.ty.expect_ty().kind.is_simple_path()
                 && !seen_type_names.insert(name)
             {
                 // Already produced an assertion for this type.
@@ -82,7 +82,7 @@ fn cs_total_eq_assert(
                 super::assert_ty_bounds(
                     cx,
                     &mut stmts,
-                    field.ty.clone(),
+                    field.ty.expect_ty().clone(),
                     field.span,
                     &[sym::cmp, sym::AssertParamIsEq],
                 );

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -808,7 +808,7 @@ impl<'a> TraitDef<'a> {
         is_packed: bool,
     ) -> P<ast::Item> {
         let field_tys: Vec<P<ast::Ty>> =
-            struct_def.fields().iter().map(|field| field.ty.clone()).collect();
+            struct_def.fields().iter().map(|field| field.ty.expect_ty().clone()).collect();
 
         let methods = self
             .methods
@@ -863,7 +863,8 @@ impl<'a> TraitDef<'a> {
         let mut field_tys = Vec::new();
 
         for variant in &enum_def.variants {
-            field_tys.extend(variant.data.fields().iter().map(|field| field.ty.clone()));
+            field_tys
+                .extend(variant.data.fields().iter().map(|field| field.ty.expect_ty().clone()));
         }
 
         let methods = self
@@ -1608,11 +1609,12 @@ impl<'a> TraitDef<'a> {
                             }
                         };
 
-                        let exception = if let TyKind::Slice(ty) = &struct_field.ty.kind &&
+                        let struct_field_ty = struct_field.ty.expect_ty();
+                        let exception = if let TyKind::Slice(ty) = &struct_field_ty.kind &&
                             is_simple_path(ty, sym::u8)
                         {
                             Some("byte")
-                        } else if is_simple_path(&struct_field.ty, sym::str) {
+                        } else if is_simple_path(struct_field_ty, sym::str) {
                             Some("string")
                         } else {
                             None

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -168,7 +168,7 @@ pub fn placeholder(
             id,
             ident: None,
             span,
-            ty: ty(),
+            ty: ty().into(),
             vis,
             is_placeholder: true,
         }]),

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -135,17 +135,6 @@ impl<'a> Parser<'a> {
         )
     }
 
-    /// Parse a type suitable for a field definition.
-    /// The difference from `parse_ty` is that this version
-    /// allows anonymous structs and unions.
-    pub fn parse_ty_for_field_def(&mut self) -> PResult<'a, P<Ty>> {
-        if self.can_begin_anon_struct_or_union() {
-            self.parse_anon_struct_or_union()
-        } else {
-            self.parse_ty()
-        }
-    }
-
     /// Parse a type suitable for a function or function pointer parameter.
     /// The difference from `parse_ty` is that this version allows `...`
     /// (`CVarArgs`) at the top level of the type.
@@ -380,36 +369,6 @@ impl<'a> Parser<'a> {
             ty = self.maybe_recover_from_question_mark(ty);
         }
         if allow_qpath_recovery { self.maybe_recover_from_bad_qpath(ty) } else { Ok(ty) }
-    }
-
-    /// Parse an anonymous struct or union (only for field definitions):
-    /// ```ignore (feature-not-ready)
-    /// #[repr(C)]
-    /// struct Foo {
-    ///     _: struct { // anonymous struct
-    ///         x: u32,
-    ///         y: f64,
-    ///     }
-    ///     _: union { // anonymous union
-    ///         z: u32,
-    ///         w: f64,
-    ///     }
-    /// }
-    /// ```
-    fn parse_anon_struct_or_union(&mut self) -> PResult<'a, P<Ty>> {
-        assert!(self.token.is_keyword(kw::Union) || self.token.is_keyword(kw::Struct));
-        let is_union = self.token.is_keyword(kw::Union);
-
-        let lo = self.token.span;
-        self.bump();
-
-        let (fields, _recovered) =
-            self.parse_record_struct_body(if is_union { "union" } else { "struct" }, lo, false)?;
-        let span = lo.to(self.prev_token.span);
-        self.sess.gated_spans.gate(sym::unnamed_fields, span);
-        // These can be rejected during AST validation in `deny_anon_struct_or_union`.
-        let kind = if is_union { TyKind::AnonUnion(fields) } else { TyKind::AnonStruct(fields) };
-        Ok(self.mk_ty(span, kind))
     }
 
     /// Parses either:
@@ -771,11 +730,6 @@ impl<'a> Parser<'a> {
         }
 
         Ok(bounds)
-    }
-
-    pub(super) fn can_begin_anon_struct_or_union(&mut self) -> bool {
-        (self.token.is_keyword(kw::Struct) || self.token.is_keyword(kw::Union))
-            && self.look_ahead(1, |t| t == &token::OpenDelim(Delimiter::Brace))
     }
 
     /// Can the current token begin a bound?

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -602,8 +602,6 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
                 BareFn,
                 Never,
                 Tup,
-                AnonStruct,
-                AnonUnion,
                 Path,
                 TraitObject,
                 ImplTrait,

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -313,15 +313,16 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
             // The fields are not expanded yet.
             return;
         }
-        let def_ids = vdata.fields().iter().map(|field| self.r.local_def_id(field.id).to_def_id());
+        let def_ids = vdata.all_fields().map(|field| self.r.local_def_id(field.id).to_def_id());
         self.r.field_def_ids.insert(def_id, self.r.tcx.arena.alloc_from_iter(def_ids));
     }
 
     fn insert_field_visibilities_local(&mut self, def_id: DefId, vdata: &ast::VariantData) {
         let field_vis = vdata
-            .fields()
-            .iter()
-            .map(|field| field.vis.span.until(field.ident.map_or(field.ty.span, |i| i.span)))
+            .all_fields()
+            .map(|field| {
+                field.vis.span.until(field.ident.map_or(field.ty.expect_ty().span, |i| i.span))
+            })
             .collect();
         self.r.field_visibility_spans.insert(def_id, field_vis);
     }

--- a/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
@@ -117,7 +117,7 @@ impl EarlyLintPass for ManualNonExhaustiveStruct {
             });
             if let Some(Ok(field)) = iter.next()
                 && iter.next().is_none()
-                && field.ty.kind.is_unit()
+                && field.ty.expect_ty().kind.is_unit()
             {
                 span_lint_and_then(
                     cx,

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -556,7 +556,7 @@ pub fn eq_struct_field(l: &FieldDef, r: &FieldDef) -> bool {
         && over(&l.attrs, &r.attrs, eq_attr)
         && eq_vis(&l.vis, &r.vis)
         && both(&l.ident, &r.ident, |l, r| eq_id(*l, *r))
-        && eq_ty(&l.ty, &r.ty)
+        && eq_ty(l.ty.expect_ty(), r.ty.expect_ty())
 }
 
 pub fn eq_fn_sig(l: &FnSig, r: &FnSig) -> bool {

--- a/src/tools/rustfmt/src/spanned.rs
+++ b/src/tools/rustfmt/src/spanned.rs
@@ -138,7 +138,7 @@ impl Spanned for ast::GenericParam {
 
 impl Spanned for ast::FieldDef {
     fn span(&self) -> Span {
-        span_with_attrs_lo_hi!(self, self.span.lo(), self.ty.span.hi())
+        span_with_attrs_lo_hi!(self, self.span.lo(), self.ty.span().hi())
     }
 }
 

--- a/src/tools/rustfmt/src/types.rs
+++ b/src/tools/rustfmt/src/types.rs
@@ -816,8 +816,6 @@ impl Rewrite for ast::Ty {
             ast::TyKind::Tup(ref items) => {
                 rewrite_tuple(context, items.iter(), self.span, shape, items.len() == 1)
             }
-            ast::TyKind::AnonStruct(_) => Some(context.snippet(self.span).to_owned()),
-            ast::TyKind::AnonUnion(_) => Some(context.snippet(self.span).to_owned()),
             ast::TyKind::Path(ref q_self, ref path) => {
                 rewrite_path(context, PathContext::Type, q_self, path, shape)
             }

--- a/src/tools/rustfmt/tests/target/anonymous-types.rs
+++ b/src/tools/rustfmt/tests/target/anonymous-types.rs
@@ -16,4 +16,16 @@ struct Foo {
     e: f32,
 }
 
+// Test for issue 117942
+struct Foo {
+    _: union  {
+        #[rustfmt::skip]
+    f: String,
+    },
+    #[rustfmt::skip]
+    _: struct {
+    g: i32,
+    },
+}
+
 fn main() {}

--- a/tests/ui/stats/hir-stats.stderr
+++ b/tests/ui/stats/hir-stats.stderr
@@ -15,12 +15,12 @@ ast-stats-1 Arm                       96 ( 1.5%)             2            48
 ast-stats-1 ForeignItem               96 ( 1.5%)             1            96
 ast-stats-1 - Fn                        96 ( 1.5%)             1
 ast-stats-1 FnDecl                   120 ( 1.8%)             5            24
-ast-stats-1 FieldDef                 160 ( 2.5%)             2            80
-ast-stats-1 Stmt                     160 ( 2.5%)             5            32
+ast-stats-1 Stmt                     160 ( 2.4%)             5            32
 ast-stats-1 - Local                     32 ( 0.5%)             1
 ast-stats-1 - MacCall                   32 ( 0.5%)             1
 ast-stats-1 - Expr                      96 ( 1.5%)             3
-ast-stats-1 Param                    160 ( 2.5%)             4            40
+ast-stats-1 Param                    160 ( 2.4%)             4            40
+ast-stats-1 FieldDef                 176 ( 2.7%)             2            88
 ast-stats-1 Block                    192 ( 2.9%)             6            32
 ast-stats-1 Variant                  208 ( 3.2%)             2           104
 ast-stats-1 GenericBound             256 ( 3.9%)             4            64
@@ -28,7 +28,7 @@ ast-stats-1 - Trait                    256 ( 3.9%)             4
 ast-stats-1 AssocItem                352 ( 5.4%)             4            88
 ast-stats-1 - Type                     176 ( 2.7%)             2
 ast-stats-1 - Fn                       176 ( 2.7%)             2
-ast-stats-1 GenericParam             480 ( 7.4%)             5            96
+ast-stats-1 GenericParam             480 ( 7.3%)             5            96
 ast-stats-1 Pat                      504 ( 7.7%)             7            72
 ast-stats-1 - Struct                    72 ( 1.1%)             1
 ast-stats-1 - Wild                      72 ( 1.1%)             1
@@ -45,15 +45,15 @@ ast-stats-1 - Ptr                       64 ( 1.0%)             1
 ast-stats-1 - Ref                       64 ( 1.0%)             1
 ast-stats-1 - ImplicitSelf             128 ( 2.0%)             2
 ast-stats-1 - Path                     640 ( 9.8%)            10
-ast-stats-1 Item                   1_224 (18.8%)             9           136
+ast-stats-1 Item                   1_224 (18.7%)             9           136
 ast-stats-1 - Trait                    136 ( 2.1%)             1
 ast-stats-1 - Enum                     136 ( 2.1%)             1
 ast-stats-1 - ForeignMod               136 ( 2.1%)             1
 ast-stats-1 - Impl                     136 ( 2.1%)             1
 ast-stats-1 - Fn                       272 ( 4.2%)             2
-ast-stats-1 - Use                      408 ( 6.3%)             3
+ast-stats-1 - Use                      408 ( 6.2%)             3
 ast-stats-1 ----------------------------------------------------------------
-ast-stats-1 Total                  6_520
+ast-stats-1 Total                  6_536
 ast-stats-1
 ast-stats-2 POST EXPANSION AST STATS
 ast-stats-2 Name                Accumulated Size         Count     Item Size
@@ -73,12 +73,12 @@ ast-stats-2 FnDecl                   120 ( 1.7%)             5            24
 ast-stats-2 Attribute                128 ( 1.8%)             4            32
 ast-stats-2 - DocComment                32 ( 0.4%)             1
 ast-stats-2 - Normal                    96 ( 1.3%)             3
-ast-stats-2 FieldDef                 160 ( 2.2%)             2            80
 ast-stats-2 Stmt                     160 ( 2.2%)             5            32
 ast-stats-2 - Local                     32 ( 0.4%)             1
 ast-stats-2 - Semi                      32 ( 0.4%)             1
 ast-stats-2 - Expr                      96 ( 1.3%)             3
 ast-stats-2 Param                    160 ( 2.2%)             4            40
+ast-stats-2 FieldDef                 176 ( 2.5%)             2            88
 ast-stats-2 Block                    192 ( 2.7%)             6            32
 ast-stats-2 Variant                  208 ( 2.9%)             2           104
 ast-stats-2 GenericBound             256 ( 3.6%)             4            64
@@ -90,7 +90,7 @@ ast-stats-2 GenericParam             480 ( 6.7%)             5            96
 ast-stats-2 Pat                      504 ( 7.1%)             7            72
 ast-stats-2 - Struct                    72 ( 1.0%)             1
 ast-stats-2 - Wild                      72 ( 1.0%)             1
-ast-stats-2 - Ident                    360 ( 5.1%)             5
+ast-stats-2 - Ident                    360 ( 5.0%)             5
 ast-stats-2 Expr                     648 ( 9.1%)             9            72
 ast-stats-2 - Path                      72 ( 1.0%)             1
 ast-stats-2 - Match                     72 ( 1.0%)             1
@@ -113,7 +113,7 @@ ast-stats-2 - Impl                     136 ( 1.9%)             1
 ast-stats-2 - Fn                       272 ( 3.8%)             2
 ast-stats-2 - Use                      544 ( 7.6%)             4
 ast-stats-2 ----------------------------------------------------------------
-ast-stats-2 Total                  7_120
+ast-stats-2 Total                  7_136
 ast-stats-2
 hir-stats HIR STATS
 hir-stats Name                Accumulated Size         Count     Item Size


### PR DESCRIPTION
This PR implements #49804, and parses the anonymous structs or unions as a special type of field, instead of a general kind of `Ty`.

r? @petrochenkov 