### PR TITLE
Explain revealing of opaque types in layout_of ParamEnv

### DIFF
--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -36,6 +36,9 @@ fn layout_of<'tcx>(
     let (param_env, ty) = query.into_parts();
     debug!(?ty);
 
+    // Optimization: We convert to RevealAll and convert opaque types in the where bounds
+    // to their hidden types. This reduces overall uncached invocations of `layout_of` and
+    // is thus a small performance improvement.
     let param_env = param_env.with_reveal_all_normalized(tcx);
     let unnormalized_ty = ty;
 


### PR DESCRIPTION
r? @compiler-errors 

~~I feel like `layout_of` is doing too many things at once, and I don't really know why. It could allow us to if callers could decide whether to reveal opaque types.~~

Looks like this also exists as a performance optimization. While we could probably figure out a way to do this, all the ones I came up with are fragile as `layout_of` callers now suddenly need to be careful what ParamEnv they pass in.