### PR TITLE
Remove a now-unnecessary check for generators. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ build/
 /src/tools/x/target
 # Created by default with `src/ci/docker/run.sh`
 /obj/
+# Created on ICE during build
+rustc-ice-*.txt
 
 ## Temporary files
 *~

--- a/compiler/rustc_mir_transform/src/reveal_all.rs
+++ b/compiler/rustc_mir_transform/src/reveal_all.rs
@@ -13,11 +13,6 @@ impl<'tcx> MirPass<'tcx> for RevealAll {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        // Do not apply this transformation to generators.
-        if body.generator.is_some() {
-            return;
-        }
-
         let param_env = tcx.param_env_reveal_all_normalized(body.source.def_id());
         RevealAllVisitor { tcx, param_env }.visit_body_preserves_cfg(body);
     }

--- a/src/etc/rust_analyzer_settings.json
+++ b/src/etc/rust_analyzer_settings.json
@@ -16,7 +16,7 @@
         "compiler/rustc_codegen_gcc/Cargo.toml"
     ],
     "rust-analyzer.rustfmt.overrideCommand": [
-        "./build/host/rustfmt/bin/rustfmt",
+        "${workspaceFolder}/build/host/rustfmt/bin/rustfmt",
         "--edition=2021"
     ],
     "rust-analyzer.procMacro.server": "./build/host/stage0/libexec/rust-analyzer-proc-macro-srv",


### PR DESCRIPTION
There should be no cycles from the mir opt pipeline to generators, but not revealing and normalizing in generators may cause us to fix bugs with revealing and normalizing that will then still occur in async code.

r? @cjgillot 

thanks @compiler-errors for the idea