### PR TITLE
Match on elem first while building move paths

### DIFF
--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -208,12 +208,10 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                 }
                 ProjectionElem::Index(_) => match place_ty.kind() {
                     ty::Array(..) => {
-                        if let ProjectionElem::Index(..) = elem {
-                            return Err(MoveError::cannot_move_out_of(
-                                self.loc,
-                                InteriorOfSliceOrArray { ty: place_ty, is_index: true },
-                            ));
-                        }
+                        return Err(MoveError::cannot_move_out_of(
+                            self.loc,
+                            InteriorOfSliceOrArray { ty: place_ty, is_index: true },
+                        ));
                     }
                     ty::Slice(_) => {
                         return Err(MoveError::cannot_move_out_of(

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -127,7 +127,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                     }
                     ty::Adt(adt, _) => {
                         if !adt.is_box() {
-                            bug!("Adt should be a box type");
+                            bug!("Adt should be a box type when Place is deref");
                         }
                     }
                     ty::Bool
@@ -153,7 +153,9 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                     | ty::Bound(_, _)
                     | ty::Infer(_)
                     | ty::Error(_)
-                    | ty::Placeholder(_) => bug!("Place has a wrong type {place_ty:#?}"),
+                    | ty::Placeholder(_) => {
+                        bug!("When Place is Deref it's type shouldn't be {place_ty:#?}")
+                    }
                 },
                 ProjectionElem::Field(_, _) => match place_ty.kind() {
                     ty::Adt(adt, _) if adt.has_dtor(tcx) => {
@@ -190,7 +192,9 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                     | ty::Bound(_, _)
                     | ty::Infer(_)
                     | ty::Error(_)
-                    | ty::Placeholder(_) => bug!("Place has a wrong type {place_ty:#?}"),
+                    | ty::Placeholder(_) => bug!(
+                        "When Place contains ProjectionElem::Field it's type shouldn't be {place_ty:#?}"
+                    ),
                 },
                 ProjectionElem::ConstantIndex { .. } | ProjectionElem::Subslice { .. } => {
                     match place_ty.kind() {


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/pull/115025 @lcnr and I observed "move_paths_for" function matched on the `Ty` instead of `Projection` which seems flawed as it's the `Projection`s that cause the problem not the type.

r? @lcnr 