### PR TITLE
cleanup leftovers of const_err lint

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -372,7 +372,7 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
             };
             let alloc_id = mplace.ptr().provenance.unwrap();
 
-            // Validation failed, report an error. This is always a hard error.
+            // Validation failed, report an error.
             if let Err(error) = validation {
                 let (error, backtrace) = error.into_parts();
                 backtrace.print_backtrace();

--- a/tests/ui/limits/issue-55878.stderr
+++ b/tests/ui/limits/issue-55878.stderr
@@ -1,5 +1,7 @@
-error[E0080]: values of the type `[u8; usize::MAX]` are too big for the current architecture
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   |
+   = note: values of the type `[u8; usize::MAX]` are too big for the current architecture
    |
 note: inside `std::mem::size_of::<[u8; usize::MAX]>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL

--- a/tests/ui/limits/issue-56762.rs
+++ b/tests/ui/limits/issue-56762.rs
@@ -14,8 +14,10 @@ impl TooBigArray {
 }
 
 static MY_TOO_BIG_ARRAY_1: TooBigArray = TooBigArray::new();
-//~^ ERROR values of the type `[u8; 2305843009213693951]` are too big
+//~^ ERROR could not evaluate static initializer
+//~| too big
 static MY_TOO_BIG_ARRAY_2: [u8; HUGE_SIZE] = [0x00; HUGE_SIZE];
-//~^ ERROR values of the type `[u8; 2305843009213693951]` are too big
+//~^ ERROR could not evaluate static initializer
+//~| too big
 
 fn main() { }

--- a/tests/ui/limits/issue-56762.stderr
+++ b/tests/ui/limits/issue-56762.stderr
@@ -1,14 +1,14 @@
-error[E0080]: values of the type `[u8; 2305843009213693951]` are too big for the current architecture
+error[E0080]: could not evaluate static initializer
   --> $DIR/issue-56762.rs:16:1
    |
 LL | static MY_TOO_BIG_ARRAY_1: TooBigArray = TooBigArray::new();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ values of the type `[u8; 2305843009213693951]` are too big for the current architecture
 
-error[E0080]: values of the type `[u8; 2305843009213693951]` are too big for the current architecture
-  --> $DIR/issue-56762.rs:18:1
+error[E0080]: could not evaluate static initializer
+  --> $DIR/issue-56762.rs:19:1
    |
 LL | static MY_TOO_BIG_ARRAY_2: [u8; HUGE_SIZE] = [0x00; HUGE_SIZE];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ values of the type `[u8; 2305843009213693951]` are too big for the current architecture
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Some code / comments seem to not have been updated when const_err was turned into a hard error, so we can do a bit of cleanup here.

r? @oli-obk 