### PR TITLE
Detect cycle errors hidden by opaques during monomorphization

### DIFF
--- a/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.rs
+++ b/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.rs
@@ -1,0 +1,38 @@
+// edition: 2021
+// build-fail
+//~^^ ERROR overflow evaluating the requirement `<A as Second>::{opaque#0} == _`
+
+#![feature(async_fn_in_trait)]
+
+fn main() {
+    let _ = async {
+        A.first().await.second().await;
+    };
+}
+
+pub trait First {
+    type Second: Second;
+    async fn first(self) -> Self::Second;
+}
+
+struct A;
+
+impl First for A {
+    type Second = A;
+    async fn first(self) -> Self::Second {
+        A
+    }
+}
+
+pub trait Second {
+    async fn second(self);
+}
+
+impl<C> Second for C
+where
+    C: First,
+{
+    async fn second(self) {
+        self.first().await.second().await;
+    }
+}

--- a/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.stderr
+++ b/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.stderr
@@ -1,0 +1,5 @@
+error[E0275]: overflow evaluating the requirement `<A as Second>::{opaque#0} == _`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.rs
+++ b/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.rs
@@ -1,0 +1,29 @@
+// edition: 2021
+// build-fail
+//~^^ ERROR overflow evaluating the requirement `<() as Recur>::Recur == _`
+
+#![feature(impl_trait_in_assoc_type)]
+
+use core::future::Future;
+
+trait Recur {
+    type Recur: Future<Output = ()>;
+
+    fn recur(self) -> Self::Recur;
+}
+
+async fn recur(t: impl Recur) {
+    t.recur().await;
+}
+
+impl Recur for () {
+    type Recur = impl Future<Output = ()>;
+
+    fn recur(self) -> Self::Recur {
+        async move { recur(self).await; }
+    }
+}
+
+fn main() {
+    recur(());
+}

--- a/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.stderr
+++ b/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.stderr
@@ -1,0 +1,5 @@
+error[E0275]: overflow evaluating the requirement `<() as Recur>::Recur == _`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.rs
+++ b/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.rs
@@ -1,0 +1,40 @@
+// edition: 2021
+// build-fail
+//~^^ ERROR overflow evaluating the requirement `<() as B>::Assoc == _`
+
+#![feature(rustc_attrs)]
+#![feature(impl_trait_in_assoc_type)]
+
+#[rustc_coinductive]
+trait A {
+    type Assoc;
+
+    fn test() -> Self::Assoc;
+}
+
+#[rustc_coinductive]
+trait B {
+    type Assoc;
+
+    fn test() -> Self::Assoc;
+}
+
+impl<T: A> B for T {
+    type Assoc = impl Sized;
+
+    fn test() -> <Self as B>::Assoc {
+        <T as A>::test()
+    }
+}
+
+fn main() {
+    <() as A>::test();
+}
+
+impl<T: B> A for T {
+    type Assoc = impl Sized;
+
+    fn test() -> <Self as A>::Assoc {
+        <T as B>::test()
+    }
+}

--- a/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.stderr
+++ b/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.stderr
@@ -1,0 +1,5 @@
+error[E0275]: overflow evaluating the requirement `<() as B>::Assoc == _`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Opaque types may reveal to projections, which themselves normalize to opaques. We don't currently normalize when checking that opaques are cyclical, and we may also not know that the opaque is cyclical until monomorphization (see `tests/ui/type-alias-impl-trait/mututally-recursive-overflow.rs`).

Detect cycle errors in `normalize_projection_ty` and report a fatal overflow (in the old solver). Luckily, this is already detected as a fatal overflow in the new solver.

Fixes #112047
