### PR TITLE
rustdoc search: Allow to filter on multiple crates

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -785,14 +785,19 @@ table,
 	border-radius: 4px;
 	outline: none;
 	cursor: pointer;
-	-moz-appearance: none;
-	-webkit-appearance: none;
-	/* Removes default arrow from firefox */
-	text-indent: 0.01px;
 	background-color: var(--main-background-color);
 	color: inherit;
 	line-height: 1.5;
 	font-weight: 500;
+}
+#crate-search-div .popover {
+	font-size: 1rem;
+	display: none;
+	max-width: 50vw;
+	min-width: 100px;
+}
+#crate-search-div .setting-line {
+	margin: 0.6em;
 }
 #crate-search:hover, #crate-search:focus {
 	border-color: var(--crate-search-hover-border);
@@ -823,8 +828,21 @@ so that we can apply CSS-filters to change the arrow color in themes */
 #crate-search-div:hover::after, #crate-search-div:focus-within::after {
 	filter: var(--crate-search-div-hover-filter);
 }
-#crate-search > option {
-	font-size: 1rem;
+.popover button {
+	border-radius: 2px;
+	outline: 0;
+	border: 1px solid var(--main-color);
+	padding: 3px 6px;
+	background: var(--main-background-color);
+	color: var(--main-color);
+}
+.popover button:hover:not(:disabled) {
+	border-color: var(--settings-button-border-focus);
+}
+.popover button:disabled {
+	cursor: initial;
+	color: var(--disabled-element-color);
+	border-color: var(--disabled-element-color);
 }
 .search-input {
 	/* Override Normalize.css: it has a rule that sets
@@ -899,7 +917,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	display: inline;
 }
 
-.popover {
+.popover, .popover-left {
 	position: absolute;
 	top: 100%;
 	right: 0;
@@ -911,9 +929,13 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	color: var(--main-color);
 	--popover-arrow-offset: 11px;
 }
+.popover-left {
+	left: 0;
+	right: initial;
+}
 
 /* This rule is to draw the little arrow connecting the settings menu to the gear icon. */
-.popover::before {
+.popover::before, .popover-left::before {
 	content: '';
 	position: absolute;
 	right: var(--popover-arrow-offset);
@@ -924,7 +946,10 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	transform: rotate(-45deg);
 	top: -5px;
 }
-
+.popover-left::before {
+	left: var(--popover-arrow-offset);
+	right: initial;
+}
 /* use larger max-width for help popover, but not for help.html */
 #help.popover {
 	max-width: 600px;

--- a/src/librustdoc/html/static/css/settings.css
+++ b/src/librustdoc/html/static/css/settings.css
@@ -17,6 +17,9 @@
 
 .setting-radio span, .setting-check span {
 	padding-bottom: 1px;
+	max-width: 100%;
+	overflow-x: hidden;
+	text-overflow: ellipsis;
 }
 
 .setting-radio {
@@ -33,7 +36,6 @@
 }
 
 .setting-check {
-	margin-right: 20px;
 	display: flex;
 	align-items: center;
 	cursor: pointer;
@@ -45,7 +47,7 @@
 }
 .setting-check input:checked {
 	background-color: var(--settings-input-color);
-	border-width: 1px;
+	border-width: 2px;
 	content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">\
 		<path d="M7,25L17,32L33,12" fill="none" stroke="black" stroke-width="5"/>\
 		<path d="M7,23L17,30L33,10" fill="none" stroke="white" stroke-width="5"/></svg>');

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -6,6 +6,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 :root {
 	--main-background-color: #0f1419;
 	--main-color: #c5c5c5;
+	--disabled-element-color: #9b9797;
 	--settings-input-color: #ffb454;
 	--settings-input-border-color: #999;
 	--settings-button-color: #fff;

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -1,6 +1,7 @@
 :root {
 	--main-background-color: #353535;
 	--main-color: #ddd;
+	--disabled-element-color: #9b9797;
 	--settings-input-color: #2196f3;
 	--settings-input-border-color: #999;
 	--settings-button-color: #000;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -1,6 +1,7 @@
 :root {
 	--main-background-color: white;
 	--main-color: black;
+	--disabled-element-color: #9b9797;
 	--settings-input-color: #2196f3;
 	--settings-input-border-color: #717171;
 	--settings-button-color: #000;

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1152,6 +1152,9 @@ href="https://doc.rust-lang.org/${channel}/rustdoc/how-to-read-rustdoc.html\
         onEachLazy(document.querySelectorAll(".search-form .popover"), elem => {
             elem.style.display = "none";
         });
+        onEachLazy(document.querySelectorAll("#crate-search .popover"), elem => {
+            elem.style.display = "none";
+        });
     };
 
     /**


### PR DESCRIPTION
This is something that was discussed some time ago (can't find where though...) so I finally took some time to write a first draft.

## Motivation

As a user of a group of crates with FFI counterpart (like gtk-rs, docs available [here](https://gtk-rs.org/gtk-rs-core/stable/latest/docs/gio/index.html)), I want to not only be able to pick one crate to run the search on but instead pick multiple crates that I want to exclude so that I can exclude results from FFI crates.

Adding this feature allows to decide not only which crate you want to include but also which crates you want to exclude from search results.

Another example is: you're using `bevy` and a lot of additional crates to add more functionalities (like `bevy_egui`) and you want to look at how to get cursor position in both `bevy` and `bevy_egui` without all other crates. This feature allows to do it in one search as well.

## Implementation details

First I tried to use HTML elements to do so (`multiple` attribute on `select` in particular) however I found it really bad as you have to maintain ctrl (or cmd on mac) and click on multiple lines to be able to select more than one element, which isn't great.

So since I couldn't find a native way to do this, I re-used the popover code we already have for the other menus. To prevent reloading every time you check/uncheck a box, I decided to add a "refresh" button instead which is disabled until you pick a different filtering selection.

You can give it a try [here](https://rustdoc.crud.net/imperio/rustdoc-search-multiple-crate-filtering/std/index.html?search=string).

## Unresolved questions

In case there are a lot of crates and you want to only pick one, you'll have to unselect all others, which is quite bad. I had the idea when you checked/unchecked a box to make a small button appear right below it for a few seconds which would allow to do that. Not sure if it's a good idea or not though.

## Remaining to be done

Since this is a draft, this PR isn't complete, here are the missing parts:
 * Set a maximum height on this filter menu and add `overflow-y: auto` to prevent it taking too much height when you have too many crates.
 * Move the `settings.css` content back into `main.css` (I plan to do this in any case as there isn't much point for this file to exist considering it contains very few CSS rules).
 * Add GUI tests
 * Add JS search tests 
 * Make an FCP and write the complete description with screenshots once the UI is defined.

What do you think about it?

cc @jsha 
r? @notriddle 