### PR TITLE
Make AIX known by bootstrap

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -314,9 +314,9 @@ def default_build_triple(verbose):
         return 'x86_64-pc-windows-msvc'
     elif kernel == 'AIX':
         # `uname -m` returns the machine ID rather than machine hardware on AIX,
-        # so we are unable to use cputype to form triple. Since AIX 7.2 and
+        # so we are unable to use cputype to form triple. AIX 7.2 and
         # above supports 32-bit and 64-bit mode simultaneously and `uname -p`
-        # returns `powerpc`. Currently we only supports `powerpc64-ibm-aix` in
+        # returns `powerpc`, however we only supports `powerpc64-ibm-aix` in
         # rust on AIX. For above reasons, kerneltype_mapper and cputype_mapper
         # are not used to infer AIX's triple.
         return 'powerpc64-ibm-aix'

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -317,8 +317,8 @@ def default_build_triple(verbose):
         # so we are unable to use cputype to form triple. Since AIX 7.2 and
         # above supports 32-bit and 64-bit mode simultaneously and `uname -p`
         # returns `powerpc`. Currently we only supports `powerpc64-ibm-aix` in
-        # rust. For above reasons, kerneltype_mapper and cputype_mapper are not
-        # used to infer AIX's triple.
+        # rust on AIX. For above reasons, kerneltype_mapper and cputype_mapper
+        # are not used to infer AIX's triple.
         return 'powerpc64-ibm-aix'
     else:
         err = "unknown OS type: {}".format(kernel)

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -313,6 +313,12 @@ def default_build_triple(verbose):
         # these cases, fall back to using sys.platform.
         return 'x86_64-pc-windows-msvc'
     elif kernel == 'AIX':
+        # `uname -m` returns the machine ID rather than machine hardware on AIX,
+        # so we are unable to use cputype to form triple. Since AIX 7.2 and
+        # above supports 32-bit and 64-bit mode simultaneously and `uname -p`
+        # returns `powerpc`. Currently we only supports `powerpc64-ibm-aix` in
+        # rust. For above reasons, kerneltype_mapper and cputype_mapper are not
+        # used to infer AIX's triple.
         return 'powerpc64-ibm-aix'
     else:
         err = "unknown OS type: {}".format(kernel)

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -312,6 +312,8 @@ def default_build_triple(verbose):
         # non-standard string (e.g. gnuwin32 tools returns `windows32`). In
         # these cases, fall back to using sys.platform.
         return 'x86_64-pc-windows-msvc'
+    elif kernel == 'AIX':
+        return 'powerpc64-ibm-aix'
     else:
         err = "unknown OS type: {}".format(kernel)
         sys.exit(err)


### PR DESCRIPTION
Use `x.py` to build rustc on AIX directly is failing
```
unknown OS type: AIX
Build completed unsuccessfully in 0:00:00
```
If kernel is `AIX`, we should return default triple `powerpc64-ibm-aix` for current rustc.