### PR TITLE
fix: return early when has tainted in mir pass

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -606,6 +606,11 @@ fn inner_optimized_mir(tcx: TyCtxt<'_>, did: LocalDefId) -> Body<'_> {
     let body = tcx.mir_drops_elaborated_and_const_checked(did).steal();
     let mut body = remap_mir_for_const_eval_select(tcx, body, hir::Constness::NotConst);
     debug!("body: {:#?}", body);
+
+    if body.tainted_by_errors.is_some() {
+        return body;
+    }
+
     run_optimization_passes(tcx, &mut body);
 
     body

--- a/tests/ui/unsized/issue-115809.rs
+++ b/tests/ui/unsized/issue-115809.rs
@@ -1,0 +1,13 @@
+// compile-flags: --emit=link -Zmir-opt-level=2 -Zpolymorphize=on
+
+fn foo<T>() {
+    let a: [i32; 0] = [];
+    match [a[..]] {
+        //~^ ERROR cannot move a value of type `[i32]
+        //~| ERROR cannot move out of type `[i32]`, a non-copy slice
+        [[x]] => {}
+        _ => (),
+    }
+}
+
+fn main() {}

--- a/tests/ui/unsized/issue-115809.stderr
+++ b/tests/ui/unsized/issue-115809.stderr
@@ -1,0 +1,19 @@
+error[E0161]: cannot move a value of type `[i32]`
+  --> $DIR/issue-115809.rs:5:12
+   |
+LL |     match [a[..]] {
+   |            ^^^^^ the size of `[i32]` cannot be statically determined
+
+error[E0508]: cannot move out of type `[i32]`, a non-copy slice
+  --> $DIR/issue-115809.rs:5:12
+   |
+LL |     match [a[..]] {
+   |            ^^^^^
+   |            |
+   |            cannot move out of here
+   |            move occurs because value has type `[i32]`, which does not implement the `Copy` trait
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0161, E0508.
+For more information about an error, try `rustc --explain E0161`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/115809

As in #115643, ﻿`run_pass` is skipped if the body has tainted errors.

r? @oli-obk