### PR TITLE
Disabled socketpair for Vita

### DIFF
--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -102,7 +102,7 @@ impl Socket {
         }
     }
 
-    #[cfg(not(target_os = "vxworks"))]
+    #[cfg(not(any(target_os = "vxworks", target_os = "vita")))]
     pub fn new_pair(fam: c_int, ty: c_int) -> io::Result<(Socket, Socket)> {
         unsafe {
             let mut fds = [0, 0];
@@ -133,7 +133,7 @@ impl Socket {
         }
     }
 
-    #[cfg(target_os = "vxworks")]
+    #[cfg(any(target_os = "vxworks", target_os = "vita"))]
     pub fn new_pair(_fam: c_int, _ty: c_int) -> io::Result<(Socket, Socket)> {
         unimplemented!()
     }


### PR DESCRIPTION
There is no `socketpair` syscall in Vita newlib. This is reflected in a rust-lang/libc#3284, in which this method is removed for vita target.

Also, we would need the fixes from the abovementioned PR for sockets in std (previously we had some incorrect constant values),  but that can be done separately when rust-lang/libc#3284 is reviewed, merged, and released.