### PR TITLE
Expose try_destructure_mir_constant_for_diagnostics directly to clippy

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -85,7 +85,7 @@ pub(crate) fn eval_to_valtree<'tcx>(
 }
 
 #[instrument(skip(tcx), level = "debug")]
-pub(crate) fn try_destructure_mir_constant_for_diagnostics<'tcx>(
+pub fn try_destructure_mir_constant_for_diagnostics<'tcx>(
     tcx: TyCtxt<'tcx>,
     val: ConstValue<'tcx>,
     ty: Ty<'tcx>,

--- a/src/ci/docker/host-x86_64/arm-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/arm-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:23.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 COPY scripts/android-base-apt-get.sh /scripts/

--- a/src/ci/docker/host-x86_64/dist-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:23.04
 
 COPY scripts/android-base-apt-get.sh /scripts/
 RUN sh /scripts/android-base-apt-get.sh

--- a/src/ci/docker/host-x86_64/dist-various-1/install-x86_64-redox.sh
+++ b/src/ci/docker/host-x86_64/dist-various-1/install-x86_64-redox.sh
@@ -2,5 +2,5 @@
 
 set -ex
 
-curl https://static.redox-os.org/toolchain/x86_64-unknown-redox/relibc-install.tar.gz | \
+curl https://ci-mirrors.rust-lang.org/rustc/2022-11-27-relibc-install.tar.gz | \
 tar --extract --gzip --directory /usr/local

--- a/src/ci/scripts/setup-environment.sh
+++ b/src/ci/scripts/setup-environment.sh
@@ -10,7 +10,7 @@ source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 # Load extra environment variables
 vars="${EXTRA_VARIABLES-}"
-echo "${vars}" | jq '' >/dev/null  # Validate JSON and exit on errors
+echo "${vars}" | jq '.' >/dev/null  # Validate JSON and exit on errors
 for key in $(echo "${vars}" | jq "keys[]" -r); do
     # On Windows, for whatever reason, $key contains the BOM character in it,
     # and that messes up `jq ".${key}"`. This line strips the BOM from the key.

--- a/src/tools/clippy/clippy_utils/src/consts.rs
+++ b/src/tools/clippy/clippy_utils/src/consts.rs
@@ -724,7 +724,7 @@ fn field_of_struct<'tcx>(
     field: &Ident,
 ) -> Option<mir::ConstantKind<'tcx>> {
     if let mir::ConstantKind::Val(result, ty) = result
-        && let Some(dc) = lcx.tcx.try_destructure_mir_constant_for_diagnostics((result, ty))
+        && let Some(dc) = rustc_const_eval::const_eval::try_destructure_mir_constant_for_diagnostics(lcx.tcx, result, ty)
         && let Some(dc_variant) = dc.variant
         && let Some(variant) = adt_def.variants().get(dc_variant)
         && let Some(field_idx) = variant.fields.iter().position(|el| el.name == field.name)


### PR DESCRIPTION
Otherwise clippy tries to use the query in ways that incremental caching will inevitably cause problems with.

Hopefully gets rid of https://github.com/rust-lang/rust/issues/83085 for good