### PR TITLE
Properly consider binder vars in `HasTypeFlagsVisitor`

### DIFF
--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -34,6 +34,26 @@ impl FlagComputation {
         result.flags
     }
 
+    pub fn bound_var_flags(vars: &ty::List<ty::BoundVariableKind>) -> FlagComputation {
+        let mut computation = FlagComputation::new();
+
+        for bv in vars {
+            match bv {
+                ty::BoundVariableKind::Ty(_) => {
+                    computation.flags |= TypeFlags::HAS_TY_LATE_BOUND;
+                }
+                ty::BoundVariableKind::Region(_) => {
+                    computation.flags |= TypeFlags::HAS_RE_LATE_BOUND;
+                }
+                ty::BoundVariableKind::Const => {
+                    computation.flags |= TypeFlags::HAS_CT_LATE_BOUND;
+                }
+            }
+        }
+
+        computation
+    }
+
     fn add_flags(&mut self, flags: TypeFlags) {
         self.flags = self.flags | flags;
     }
@@ -57,21 +77,7 @@ impl FlagComputation {
     where
         F: FnOnce(&mut Self, T),
     {
-        let mut computation = FlagComputation::new();
-
-        for bv in value.bound_vars() {
-            match bv {
-                ty::BoundVariableKind::Ty(_) => {
-                    computation.flags |= TypeFlags::HAS_TY_LATE_BOUND;
-                }
-                ty::BoundVariableKind::Region(_) => {
-                    computation.flags |= TypeFlags::HAS_RE_LATE_BOUND;
-                }
-                ty::BoundVariableKind::Const => {
-                    computation.flags |= TypeFlags::HAS_CT_LATE_BOUND;
-                }
-            }
-        }
+        let mut computation = FlagComputation::bound_var_flags(value.bound_vars());
 
         f(&mut computation, value.skip_binder());
 

--- a/tests/ui/lifetimes/anonymize-unnamed-bound-vars-in-binders.rs
+++ b/tests/ui/lifetimes/anonymize-unnamed-bound-vars-in-binders.rs
@@ -1,0 +1,27 @@
+// build-pass
+// issue: #115807
+
+trait Chip: for<'a> TraitWithLifetime<'a> + SomeMarker {
+    fn compute(&self);
+}
+
+trait SomeMarker {}
+
+trait TraitWithLifetime<'a>: SomeMarker {}
+
+trait Machine {
+    fn run();
+}
+
+struct BasicMachine;
+
+impl Machine for BasicMachine {
+    fn run() {
+        let chips: [&dyn Chip; 0] = [];
+        let _ = chips.map(|chip| chip.compute());
+    }
+}
+
+fn main() {
+    BasicMachine::run();
+}


### PR DESCRIPTION
Given a PolyTraitRef like `for<'a> Ty: Trait` (where neither `Ty` nor `Trait` mention `'a`), we do *not* return true for `.has_type_flags(TypeFlags::HAS_LATE_BOUND)`, even though binders are supposed to act as if they have late-bound vars even if they don't mention them in their bound value: 31ae3b2bdb9376b749fc1d64b531e86806e03c73. This is because we use `HasTypeFlagsVisitor`, which only computes the type flags for `Ty`, `Const` and `Region` and `Predicates`, and we consequently skip any binders (and setting flags for their vars) that are not contained in one of these types.

This ends up causing a problem, because when we call `TyCtxt::erase_regions` (which both erases regions *and* anonymizes bound vars), we will skip such a PolyTraitRef, not anonymizing it, and therefore not making it structurally equal to other binders. This breaks vtable computations.

This PR computes the flags for all binders we enter in `HasTypeFlagsVisitor` if we're looking for `TypeFlags::HAS_LATE_BOUND` (or `TypeFlags::HAS_{RE,TY,CT}_LATE_BOUND`).

Fixes #115807