### PR TITLE
Ignore `#[doc(hidden)]` functions in clippy doc lints

### DIFF
--- a/src/tools/clippy/clippy_lints/src/doc.rs
+++ b/src/tools/clippy/clippy_lints/src/doc.rs
@@ -479,6 +479,10 @@ fn check_attrs(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, attrs: &[
         Some(("fake".into(), "fake".into()))
     }
 
+    if is_doc_hidden(attrs) {
+        return None;
+    }
+
     let (fragments, _) = attrs_to_doc_fragments(attrs.iter().map(|attr| (attr, None)), true);
     let mut doc = String::new();
     for fragment in &fragments {

--- a/src/tools/clippy/tests/ui/doc_errors.rs
+++ b/src/tools/clippy/tests/ui/doc_errors.rs
@@ -101,6 +101,11 @@ impl Struct1 {
     fn block_comment_leading_asterisks() -> Result<(), ()> {
         unimplemented!();
     }
+
+    #[doc(hidden)]
+    fn doc_hidden() -> Result<(), ()> {
+        unimplemented!();
+    }
 }
 
 pub trait Trait1 {
@@ -111,6 +116,11 @@ pub trait Trait1 {
     /// # Errors
     /// A description of the errors goes here.
     fn trait_method_with_errors_header() -> Result<(), ()>;
+
+    #[doc(hidden)]
+    fn doc_hidden() -> Result<(), ()> {
+        unimplemented!();
+    }
 }
 
 impl Trait1 for Struct1 {
@@ -121,6 +131,11 @@ impl Trait1 for Struct1 {
     fn trait_method_with_errors_header() -> Result<(), ()> {
         unimplemented!();
     }
+}
+
+#[doc(hidden)]
+pub trait DocHidden {
+    fn f() -> Result<(), ()>;
 }
 
 fn main() -> Result<(), ()> {

--- a/src/tools/clippy/tests/ui/doc_errors.stderr
+++ b/src/tools/clippy/tests/ui/doc_errors.stderr
@@ -38,7 +38,7 @@ LL |     pub async fn async_pub_method_missing_errors_header() -> Result<(), ()>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for function returning `Result` missing `# Errors` section
-  --> $DIR/doc_errors.rs:108:5
+  --> $DIR/doc_errors.rs:113:5
    |
 LL |     fn trait_method_missing_errors_header() -> Result<(), ()>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/11501

The implementation before #115689 had a check for unsugared doc comments that also happened to catch `#[doc(hidden)]`, this adds the check back in more explicitly

https://github.com/rust-lang/rust/blob/852bf4e51bf260550cd1a280d2146f1c0641b1e8/src/tools/clippy/clippy_lints/src/doc.rs#L526-L529

r? @flip1995 
