### PR TITLE
Fallback effects even if types also fallback

### DIFF
--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -24,7 +24,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
             self.fulfillment_cx.borrow_mut().pending_obligations()
         );
 
-        let fallback_occured = self.fallback_types() || self.fallback_effects();
+        let fallback_occured = self.fallback_types() | self.fallback_effects();
 
         if !fallback_occured {
             return;

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/fallback.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/fallback.rs
@@ -1,9 +1,16 @@
 // check-pass
 
-#![feature(const_trait_impl, effects)]
+#![feature(effects)]
 
 pub const fn owo() {}
 
 fn main() {
+    // make sure falling back ty/int vars doesn't cause const fallback to be skipped...
+    // See issue: 115791.
+    let _ = 1;
+    if false {
+        let x = panic!();
+    }
+
     let _ = owo;
 }


### PR DESCRIPTION
`||` is short circuiting, so if we do ty/int var fallback, we *don't* do effect fallback 😸 

r? @fee1-dead or @oli-obk 

Fixes #115791
Fixes #115842