### PR TITLE
Make `TyKind::Adt`'s `Debug` impl be more pretty

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -82,6 +82,7 @@ use std::ops::{Bound, Deref};
 impl<'tcx> Interner for TyCtxt<'tcx> {
     type AdtDef = ty::AdtDef<'tcx>;
     type GenericArgsRef = ty::GenericArgsRef<'tcx>;
+    type GenericArg = ty::GenericArg<'tcx>;
     type DefId = DefId;
     type Binder<T> = Binder<'tcx, T>;
     type Ty = Ty<'tcx>;

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -41,7 +41,12 @@ pub trait HashStableContext {}
 
 pub trait Interner: Sized {
     type AdtDef: Clone + Debug + Hash + Ord;
-    type GenericArgsRef: Clone + DebugWithInfcx<Self> + Hash + Ord;
+    type GenericArgsRef: Clone
+        + DebugWithInfcx<Self>
+        + Hash
+        + Ord
+        + IntoIterator<Item = Self::GenericArg>;
+    type GenericArg: Clone + DebugWithInfcx<Self> + Hash + Ord;
     type DefId: Clone + Debug + Hash + Ord;
     type Binder<T>;
     type Ty: Clone + DebugWithInfcx<Self> + Hash + Ord;

--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -517,7 +517,21 @@ impl<I: Interner> DebugWithInfcx<I> for TyKind<I> {
             Int(i) => write!(f, "{i:?}"),
             Uint(u) => write!(f, "{u:?}"),
             Float(float) => write!(f, "{float:?}"),
-            Adt(d, s) => f.debug_tuple_field2_finish("Adt", d, &this.wrap(s)),
+            Adt(d, s) => {
+                write!(f, "{d:?}")?;
+                let mut s = s.clone().into_iter();
+                let first = s.next();
+                match first {
+                    Some(first) => write!(f, "<{:?}", first)?,
+                    None => return Ok(()),
+                };
+
+                for arg in s {
+                    write!(f, ", {:?}", arg)?;
+                }
+
+                write!(f, ">")
+            }
             Foreign(d) => f.debug_tuple_field1_finish("Foreign", d),
             Str => write!(f, "str"),
             Array(t, c) => write!(f, "[{:?}; {:?}]", &this.wrap(t), &this.wrap(c)),

--- a/tests/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.panic-abort.mir
+++ b/tests/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.panic-abort.mir
@@ -2,11 +2,7 @@
 /* generator_layout = GeneratorLayout {
     field_tys: {
         _0: GeneratorSavedTy {
-            ty: Adt(
-                std::string::String,
-                [
-                ],
-            ),
+            ty: std::string::String,
             source_info: SourceInfo {
                 span: $DIR/generator_drop_cleanup.rs:11:13: 11:15 (#0),
                 scope: scope[0],

--- a/tests/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.panic-unwind.mir
+++ b/tests/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.panic-unwind.mir
@@ -2,11 +2,7 @@
 /* generator_layout = GeneratorLayout {
     field_tys: {
         _0: GeneratorSavedTy {
-            ty: Adt(
-                std::string::String,
-                [
-                ],
-            ),
+            ty: std::string::String,
             source_info: SourceInfo {
                 span: $DIR/generator_drop_cleanup.rs:11:13: 11:15 (#0),
                 scope: scope[0],

--- a/tests/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/tests/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -2,11 +2,7 @@
 /* generator_layout = GeneratorLayout {
     field_tys: {
         _0: GeneratorSavedTy {
-            ty: Adt(
-                HasDrop,
-                [
-                ],
-            ),
+            ty: HasDrop,
             source_info: SourceInfo {
                 span: $DIR/generator_tiny.rs:20:13: 20:15 (#0),
                 scope: scope[0],

--- a/tests/ui/thir-print/thir-flat-const-variant.stdout
+++ b/tests/ui/thir-print/thir-flat-const-variant.stdout
@@ -1,11 +1,7 @@
 DefId(0:8 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR1):
 Thir {
     body_type: Const(
-        Adt(
-            Foo,
-            [
-            ],
-        ),
+        Foo,
     ),
     arms: [],
     blocks: [],
@@ -50,11 +46,7 @@ Thir {
                     base: None,
                 },
             ),
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -68,11 +60,7 @@ Thir {
                 ),
                 value: e2,
             },
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -84,11 +72,7 @@ Thir {
                 lint_level: Inherited,
                 value: e3,
             },
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -102,11 +86,7 @@ Thir {
 DefId(0:9 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR2):
 Thir {
     body_type: Const(
-        Adt(
-            Foo,
-            [
-            ],
-        ),
+        Foo,
     ),
     arms: [],
     blocks: [],
@@ -151,11 +131,7 @@ Thir {
                     base: None,
                 },
             ),
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -169,11 +145,7 @@ Thir {
                 ),
                 value: e2,
             },
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -185,11 +157,7 @@ Thir {
                 lint_level: Inherited,
                 value: e3,
             },
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -203,11 +171,7 @@ Thir {
 DefId(0:10 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR3):
 Thir {
     body_type: Const(
-        Adt(
-            Foo,
-            [
-            ],
-        ),
+        Foo,
     ),
     arms: [],
     blocks: [],
@@ -252,11 +216,7 @@ Thir {
                     base: None,
                 },
             ),
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -270,11 +230,7 @@ Thir {
                 ),
                 value: e2,
             },
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -286,11 +242,7 @@ Thir {
                 lint_level: Inherited,
                 value: e3,
             },
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -304,11 +256,7 @@ Thir {
 DefId(0:11 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR4):
 Thir {
     body_type: Const(
-        Adt(
-            Foo,
-            [
-            ],
-        ),
+        Foo,
     ),
     arms: [],
     blocks: [],
@@ -353,11 +301,7 @@ Thir {
                     base: None,
                 },
             ),
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -371,11 +315,7 @@ Thir {
                 ),
                 value: e2,
             },
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),
@@ -387,11 +327,7 @@ Thir {
                 lint_level: Inherited,
                 value: e3,
             },
-            ty: Adt(
-                Foo,
-                [
-                ],
-            ),
+            ty: Foo,
             temp_lifetime: Some(
                 Node(3),
             ),

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -1,13 +1,13 @@
 DefId(0:16 ~ thir_tree_match[fcf8]::has_match):
 params: [
     Param {
-        ty: Adt(Foo, [])
+        ty: Foo
         ty_span: Some($DIR/thir-tree-match.rs:15:19: 15:22 (#0))
         self_kind: None
         hir_id: Some(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).1))
         param: Some( 
             Pat: {
-                ty: Adt(Foo, [])
+                ty: Foo
                 span: $DIR/thir-tree-match.rs:15:14: 15:17 (#0)
                 kind: PatKind {
                     Binding {
@@ -15,7 +15,7 @@ params: [
                         name: "foo"
                         mode: ByValue
                         var: LocalVarId(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).2))
-                        ty: Adt(Foo, [])
+                        ty: Foo
                         is_primary: true
                         subpattern: None
                     }
@@ -73,7 +73,7 @@ body:
                                                                             Match {
                                                                                 scrutinee:
                                                                                     Expr {
-                                                                                        ty: Adt(Foo, [])
+                                                                                        ty: Foo
                                                                                         temp_lifetime: Some(Node(26))
                                                                                         span: $DIR/thir-tree-match.rs:16:11: 16:14 (#0)
                                                                                         kind: 
@@ -82,7 +82,7 @@ body:
                                                                                                 lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).4))
                                                                                                 value:
                                                                                                     Expr {
-                                                                                                        ty: Adt(Foo, [])
+                                                                                                        ty: Foo
                                                                                                         temp_lifetime: Some(Node(26))
                                                                                                         span: $DIR/thir-tree-match.rs:16:11: 16:14 (#0)
                                                                                                         kind: 
@@ -96,7 +96,7 @@ body:
                                                                                     Arm {
                                                                                         pattern: 
                                                                                             Pat: {
-                                                                                                ty: Adt(Foo, [])
+                                                                                                ty: Foo
                                                                                                 span: $DIR/thir-tree-match.rs:17:9: 17:32 (#0)
                                                                                                 kind: PatKind {
                                                                                                     Variant {
@@ -110,7 +110,7 @@ body:
                                                                                                         variant_index: 0
                                                                                                         subpatterns: [
                                                                                                             Pat: {
-                                                                                                                ty: Adt(Bar, [])
+                                                                                                                ty: Bar
                                                                                                                 span: $DIR/thir-tree-match.rs:17:21: 17:31 (#0)
                                                                                                                 kind: PatKind {
                                                                                                                     Variant {
@@ -169,7 +169,7 @@ body:
                                                                                     Arm {
                                                                                         pattern: 
                                                                                             Pat: {
-                                                                                                ty: Adt(Foo, [])
+                                                                                                ty: Foo
                                                                                                 span: $DIR/thir-tree-match.rs:18:9: 18:23 (#0)
                                                                                                 kind: PatKind {
                                                                                                     Variant {
@@ -183,7 +183,7 @@ body:
                                                                                                         variant_index: 0
                                                                                                         subpatterns: [
                                                                                                             Pat: {
-                                                                                                                ty: Adt(Bar, [])
+                                                                                                                ty: Bar
                                                                                                                 span: $DIR/thir-tree-match.rs:18:21: 18:22 (#0)
                                                                                                                 kind: PatKind {
                                                                                                                     Wild
@@ -232,7 +232,7 @@ body:
                                                                                     Arm {
                                                                                         pattern: 
                                                                                             Pat: {
-                                                                                                ty: Adt(Foo, [])
+                                                                                                ty: Foo
                                                                                                 span: $DIR/thir-tree-match.rs:19:9: 19:20 (#0)
                                                                                                 kind: PatKind {
                                                                                                     Variant {


### PR DESCRIPTION
Currently `{:?}` on `Ty` for a `TyKind::Adt` would print as `Adt(Foo, [])`. This PR changes it to be `Foo` when there are no generics or `Foo<T>`/`Foo<T, U>` when there _are_ generics. Example from debug log:
`├─0ms DEBUG rustc_hir_analysis::astconv return=Bar<T/#0, U/#1>`

I should have done this in my initial PR for a prettier TyKind: Debug impl but I thought I would need to be accessing generics_of to figure out where in the "path" the generics would have to go??? but no, adts literally only have a single place the generics can go (on the end). Feel a bit silly about this :)

r? @oli-obk 
