### PR TITLE
Fix duplicated crate keyword in suggested path

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1803,7 +1803,17 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             let mut candidates = self.lookup_import_candidates(ident, TypeNS, parent_scope, is_mod);
             candidates
                 .sort_by_cached_key(|c| (c.path.segments.len(), pprust::path_to_string(&c.path)));
-            if let Some(candidate) = candidates.get(0) {
+            if let Some(candidate) = candidates.get_mut(0) {
+                if path.get(0).map(|s| s.ident.name == kw::Crate).unwrap_or(false)
+                    && candidate
+                        .path
+                        .segments
+                        .get(0)
+                        .map(|s| s.ident.name == kw::Crate)
+                        .unwrap_or(false)
+                {
+                    candidate.path.segments.remove(0);
+                }
                 (
                     String::from("unresolved import"),
                     Some((

--- a/tests/ui/imports/issue-115858-duplicated-crate-diag.rs
+++ b/tests/ui/imports/issue-115858-duplicated-crate-diag.rs
@@ -1,0 +1,20 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/115858>.
+// It ensures that it doesn't suggest paths like `crate::crate::unix`
+
+// edition:2018
+
+#![crate_type = "lib"]
+
+pub mod unix {
+    pub mod linux {
+        pub mod utils {
+            pub fn f() {
+                let x = crate::linux::system::Y;
+                //~^ ERROR unresolved import
+            }
+        }
+        pub mod system {
+            pub const Y: u32 = 0;
+        }
+    }
+}

--- a/tests/ui/imports/issue-115858-duplicated-crate-diag.stderr
+++ b/tests/ui/imports/issue-115858-duplicated-crate-diag.stderr
@@ -1,0 +1,23 @@
+error[E0433]: failed to resolve: unresolved import
+  --> $DIR/issue-115858-duplicated-crate-diag.rs:12:32
+   |
+LL |                 let x = crate::linux::system::Y;
+   |                                ^^^^^ unresolved import
+   |
+help: a similar path exists
+   |
+LL |                 let x = crate::unix::linux::system::Y;
+   |                                ~~~~~~~~~~~
+help: consider importing this module
+   |
+LL +             use crate::unix::linux::system;
+   |
+help: if you import `system`, refer to it directly
+   |
+LL -                 let x = crate::linux::system::Y;
+LL +                 let x = system::Y;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/115858.

This only appears starting the 2018 edition because of [this](https://github.com/rust-lang/rust/blob/8b49731211154fdf7ba9446feb21d31c24210950/compiler/rustc_resolve/src/diagnostics.rs#L1212-L1216).