### PR TITLE
don't globally ignore rustc-ice files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ build/
 \#*
 \#*\#
 .#*
-rustc-ice-*.txt
 
 ## Tags
 tags


### PR DESCRIPTION
Reverts a change that happened in https://github.com/rust-lang/rust/pull/114586 but is unrelated to that PR and wasn't discussed.

ICE files appearing is somewhat of a nuisance, but I'd rather clean them up than have them accumulate in my source folder. @oli-obk if you want to ignore them you can add them to your local `.git/info/exclude`.