### PR TITLE
[beta] backport

### DIFF
--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -830,7 +830,8 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, PatKind> {
         let ident = self.parse_ident()?;
 
-        if !matches!(syntax_loc, Some(PatternLocation::FunctionParameter))
+        if self.may_recover()
+            && !matches!(syntax_loc, Some(PatternLocation::FunctionParameter))
             && self.check_noexpect(&token::Lt)
             && self.look_ahead(1, |t| t.can_begin_type())
         {

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -128,11 +128,14 @@ impl<'r, 'a, 'tcx> EffectiveVisibilitiesVisitor<'r, 'a, 'tcx> {
                 // If the binding is ambiguous, put the root ambiguity binding and all reexports
                 // leading to it into the table. They are used by the `ambiguous_glob_reexports`
                 // lint. For all bindings added to the table this way `is_ambiguity` returns true.
+                let is_ambiguity =
+                    |binding: NameBinding<'a>, warn: bool| binding.ambiguity.is_some() && !warn;
                 let mut parent_id = ParentId::Def(module_id);
+                let mut warn_ambiguity = binding.warn_ambiguity;
                 while let NameBindingKind::Import { binding: nested_binding, .. } = binding.kind {
                     self.update_import(binding, parent_id);
 
-                    if binding.ambiguity.is_some() {
+                    if is_ambiguity(binding, warn_ambiguity) {
                         // Stop at the root ambiguity, further bindings in the chain should not
                         // be reexported because the root ambiguity blocks any access to them.
                         // (Those further bindings are most likely not ambiguities themselves.)
@@ -141,9 +144,9 @@ impl<'r, 'a, 'tcx> EffectiveVisibilitiesVisitor<'r, 'a, 'tcx> {
 
                     parent_id = ParentId::Import(binding);
                     binding = nested_binding;
+                    warn_ambiguity |= nested_binding.warn_ambiguity;
                 }
-
-                if binding.ambiguity.is_none()
+                if !is_ambiguity(binding, warn_ambiguity)
                     && let Some(def_id) = binding.res().opt_def_id().and_then(|id| id.as_local()) {
                     self.update_def(def_id, binding.vis.expect_local(), parent_id);
                 }

--- a/tests/ui/codegen/subtyping-enforces-type-equality.rs
+++ b/tests/ui/codegen/subtyping-enforces-type-equality.rs
@@ -1,0 +1,48 @@
+// ignore-pass
+// build-pass
+// edition:2021
+use std::future::Future;
+use std::pin::Pin;
+
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
+
+fn main() {
+    let _ = wrapper_call(handler);
+}
+
+async fn wrapper_call(handler: impl Handler) {
+    handler.call().await;
+}
+async fn handler() {
+    f(&()).await;
+}
+async fn f<'a>(db: impl Acquire<'a>) {
+    db.acquire().await;
+}
+
+trait Handler {
+    type Future: Future;
+    fn call(self) -> Self::Future;
+}
+
+impl<Fut, F> Handler for F
+where
+    F: Fn() -> Fut,
+    Fut: Future,
+{
+    type Future = Fut;
+    fn call(self) -> Self::Future {
+        loop {}
+    }
+}
+
+trait Acquire<'a> {
+    type Connection;
+    fn acquire(self) -> BoxFuture<Self::Connection>;
+}
+impl<'a> Acquire<'a> for &'a () {
+    type Connection = Self;
+    fn acquire(self) -> BoxFuture<Self> {
+        loop {}
+    }
+}

--- a/tests/ui/codegen/subtyping-enforces-type-equality.stderr
+++ b/tests/ui/codegen/subtyping-enforces-type-equality.stderr
@@ -1,0 +1,1 @@
+WARN rustc_codegen_ssa::mir::locals Unexpected initial operand type. See the issues/114858

--- a/tests/ui/consts/drop-maybe_uninit.rs
+++ b/tests/ui/consts/drop-maybe_uninit.rs
@@ -1,0 +1,17 @@
+// build-pass
+
+pub const fn f<T, const N: usize>(_: [std::mem::MaybeUninit<T>; N]) {}
+
+pub struct Blubb<T>(*const T);
+
+pub const fn g<T, const N: usize>(_: [Blubb<T>; N]) {}
+
+pub struct Blorb<const N: usize>([String; N]);
+
+pub const fn h(_: Blorb<0>) {}
+
+pub struct Wrap(Blorb<0>);
+
+pub const fn i(_: Wrap) {}
+
+fn main() {}

--- a/tests/ui/imports/ambiguous-4.rs
+++ b/tests/ui/imports/ambiguous-4.rs
@@ -1,4 +1,4 @@
-// check-pass
+// build-pass
 // aux-build: ../ambiguous-4-extern.rs
 
 extern crate ambiguous_4_extern;

--- a/tests/ui/parser/issues/issue-115780-pat-lt-bracket-in-macro-call.rs
+++ b/tests/ui/parser/issues/issue-115780-pat-lt-bracket-in-macro-call.rs
@@ -1,0 +1,21 @@
+// Regression test for issue #115780.
+// Ensure that we don't emit a parse error for the token sequence `Ident "<" Ty` in pattern position
+// if we are inside a macro call since it can be valid input for a subsequent macro rule.
+// See also #103534.
+
+// check-pass
+
+macro_rules! mdo {
+    ($p: pat =<< $e: expr ; $( $t: tt )*) => {
+        $e.and_then(|$p| mdo! { $( $t )* })
+    };
+    (ret<$ty: ty> $e: expr;) => { Some::<$ty>($e) };
+}
+
+fn main() {
+    mdo! {
+        x_val =<< Some(0);
+        y_val =<< Some(1);
+        ret<(i32, i32)> (x_val, y_val);
+    };
+}


### PR DESCRIPTION
This PR backports:

- #115785: Only suggest turbofish in patterns if we may recover
- #115527: Don't require `Drop` for `[PhantomData<T>; N]` where `N` and `T` are generic, if `T` requires `Drop`
- #115389: fix(resolve): update def if binding is warning ambiguity
- #115215: Remove assert that checks type equality

r? @Mark-Simulacrum 