### PR TITLE
Move mobile topbar title creation entirely into JS

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -49,10 +49,12 @@ window.currentCrate = getVar("current-crate");
 function setMobileTopbar() {
     // FIXME: It would be nicer to generate this text content directly in HTML,
     // but with the current code it's hard to get the right information in the right place.
-    const mobileLocationTitle = document.querySelector(".mobile-topbar h2");
+    const mobileTopbar = document.querySelector(".mobile-topbar");
     const locationTitle = document.querySelector(".sidebar h2.location");
-    if (mobileLocationTitle && locationTitle) {
-        mobileLocationTitle.innerHTML = locationTitle.innerHTML;
+    if (mobileTopbar && locationTitle) {
+        const mobileTitle = document.createElement("h2");
+        mobileTitle.innerHTML = locationTitle.innerHTML;
+        mobileTopbar.appendChild(mobileTitle);
     }
 }
 

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -84,8 +84,7 @@
             <img class="rust-logo" src="{{static_root_path|safe}}{{files.rust_logo_svg}}" alt="logo"> {# #}
         {% endif %}
         </a> {# #}
-        <h2></h2> {# #}
-    </nav> {# #}
+    </nav>
     {% endif %}
     <nav class="sidebar"> {# #}
         {% if page.css_class != "src" %}


### PR DESCRIPTION
I was looking at potential size improvements and saw that we had an empty `h2` tag for the mobile topbar title that was filled with JS. So at this point, I think it's fine to just completely generate it from JS, like that the w3c HTML validator will emit one less warning.

r? @notriddle 