### PR TITLE
Update to LLVM 17.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/17.0-2023-07-29
+	branch = rustc/17.0-2023-09-19
 	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book

--- a/tests/ui/match/issue-115681.rs
+++ b/tests/ui/match/issue-115681.rs
@@ -1,0 +1,32 @@
+// run-pass
+// compile-flags: -C opt-level=1
+
+// Make sure LLVM does not miscompile this match.
+fn main() {
+    enum Bits {
+        None = 0x00,
+        Low = 0x40,
+        High = 0x80,
+        Both = 0xC0,
+    }
+
+    let value = Box::new(0x40u8);
+    let mut out = Box::new(0u8);
+
+    let bits = match *value {
+        0x00 => Bits::None,
+        0x40 => Bits::Low,
+        0x80 => Bits::High,
+        0xC0 => Bits::Both,
+        _ => return,
+    };
+
+    match bits {
+        Bits::None | Bits::Low => {
+            *out = 1;
+        }
+        _ => (),
+    }
+
+    assert_eq!(*out, 1);
+}


### PR DESCRIPTION
This rebases our LLVM fork to 17.0.0.

Fixes #115681.