### PR TITLE
Split core's PanicInfo and std's PanicInfo

### DIFF
--- a/library/core/src/error.md
+++ b/library/core/src/error.md
@@ -17,8 +17,8 @@ The following are the primary interfaces of the panic system and the
 responsibilities they cover:
 
 * [`panic!`] and [`panic_any`] (Constructing, Propagated automatically)
-* [`PanicHookInfo`] (Reporting)
-* [`set_hook`], [`take_hook`], and [`#[panic_handler]`][panic-handler] (Reporting)
+* [`set_hook`], [`take_hook`], and [`PanicHookInfo`] (Reporting)
+* [`#[panic_handler]`][panic-handler] and [`PanicInfo`] (Reporting in no_std)
 * [`catch_unwind`] and [`resume_unwind`] (Discarding, Propagating)
 
 The following are the primary interfaces of the error system and the
@@ -126,6 +126,7 @@ should be available and executable by the current user".
 
 [`panic_any`]: ../../std/panic/fn.panic_any.html
 [`PanicHookInfo`]: ../../std/panic/struct.PanicHookInfo.html
+[`PanicInfo`]: crate::panic::PanicInfo
 [`catch_unwind`]: ../../std/panic/fn.catch_unwind.html
 [`resume_unwind`]: ../../std/panic/fn.resume_unwind.html
 [`downcast`]: crate::error::Error

--- a/library/core/src/error.md
+++ b/library/core/src/error.md
@@ -17,7 +17,7 @@ The following are the primary interfaces of the panic system and the
 responsibilities they cover:
 
 * [`panic!`] and [`panic_any`] (Constructing, Propagated automatically)
-* [`PanicInfo`] (Reporting)
+* [`PanicHookInfo`] (Reporting)
 * [`set_hook`], [`take_hook`], and [`#[panic_handler]`][panic-handler] (Reporting)
 * [`catch_unwind`] and [`resume_unwind`] (Discarding, Propagating)
 
@@ -125,7 +125,7 @@ expect-as-precondition style error messages remember to focus on the word
 should be available and executable by the current user".
 
 [`panic_any`]: ../../std/panic/fn.panic_any.html
-[`PanicInfo`]: crate::panic::PanicInfo
+[`PanicHookInfo`]: ../../std/panic/struct.PanicHookInfo.html
 [`catch_unwind`]: ../../std/panic/fn.catch_unwind.html
 [`resume_unwind`]: ../../std/panic/fn.resume_unwind.html
 [`downcast`]: crate::error::Error

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -144,7 +144,7 @@ pub macro unreachable_2021 {
 /// use.
 #[unstable(feature = "std_internals", issue = "none")]
 #[doc(hidden)]
-pub unsafe trait PanicPayload {
+pub unsafe trait PanicPayload: crate::fmt::Display {
     /// Take full ownership of the contents.
     /// The return type is actually `Box<dyn Any + Send>`, but we cannot use `Box` in core.
     ///

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -157,4 +157,9 @@ pub unsafe trait PanicPayload: crate::fmt::Display {
 
     /// Just borrow the contents.
     fn get(&mut self) -> &(dyn Any + Send);
+
+    /// Try to borrow the contents as `&str`, if possible without doing any allocations.
+    fn as_str(&mut self) -> Option<&str> {
+        None
+    }
 }

--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -2,9 +2,10 @@ use crate::fmt;
 
 /// A struct containing information about the location of a panic.
 ///
-/// This structure is created by [`PanicInfo::location()`].
+/// This structure is created by [`PanicHookInfo::location()`] and [`PanicInfo::location()`].
 ///
 /// [`PanicInfo::location()`]: crate::panic::PanicInfo::location
+/// [`PanicHookInfo::location()`]: ../../std/panic/struct.PanicHookInfo.html#method.location
 ///
 /// # Examples
 ///

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -24,14 +24,8 @@ pub struct PanicInfo<'a> {
 }
 
 impl<'a> PanicInfo<'a> {
-    #[unstable(
-        feature = "panic_internals",
-        reason = "internal details of the implementation of the `panic!` and related macros",
-        issue = "none"
-    )]
-    #[doc(hidden)]
     #[inline]
-    pub fn internal_constructor(
+    pub(crate) fn new(
         message: fmt::Arguments<'a>,
         location: &'a Location<'a>,
         can_unwind: bool,

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -80,7 +80,7 @@ impl<'a> PanicInfo<'a> {
     ///
     /// [`std::panic::PanicHookInfo`]: ../../std/panic/struct.PanicHookInfo.html
     /// [`std::panic::PanicHookInfo::payload`]: ../../std/panic/struct.PanicHookInfo.html#method.payload
-    #[deprecated(since = "1.74.0", note = "this never returns anything useful")]
+    #[deprecated(since = "1.77.0", note = "this never returns anything useful")]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     #[allow(deprecated, deprecated_in_future)]
     pub fn payload(&self) -> &(dyn crate::any::Any + Send) {

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -5,14 +5,9 @@ use crate::panic::Location;
 ///
 /// A `PanicInfo` structure is passed to the panic handler defined by `#[panic_handler]`.
 ///
-/// There two `PanicInfo` types:
-/// - `core::panic::PanicInfo`, which is used as an argument to a `#[panic_handler]` in `#![no_std]` programs.
-/// - [`std::panic::PanicInfo`], which is used as an argument to a panic hook set by [`std::panic::set_hook`].
+/// For the type used by the panic hook mechanism in `std`, see [`std::panic::PanicHookInfo`].
 ///
-/// This is the first one.
-///
-/// [`std::panic::set_hook`]: ../../std/panic/fn.set_hook.html
-/// [`std::panic::PanicInfo`]: ../../std/panic/struct.PanicInfo.html
+/// [`std::panic::PanicHookInfo`]: ../../std/panic/struct.PanicHookInfo.html
 #[lang = "panic_info"]
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 #[derive(Debug)]
@@ -78,13 +73,13 @@ impl<'a> PanicInfo<'a> {
     /// Returns the payload associated with the panic.
     ///
     /// On `core::panic::PanicInfo`, this method never returns anything useful.
-    /// It only exists because of compatibility with [`std::panic::PanicInfo`],
+    /// It only exists because of compatibility with [`std::panic::PanicHookInfo`],
     /// which used to be the same type.
     ///
-    /// See [`std::panic::PanicInfo::payload`].
+    /// See [`std::panic::PanicHookInfo::payload`].
     ///
-    /// [`std::panic::PanicInfo`]: ../../std/panic/struct.PanicInfo.html
-    /// [`std::panic::PanicInfo::payload`]: ../../std/panic/struct.PanicInfo.html#method.payload
+    /// [`std::panic::PanicHookInfo`]: ../../std/panic/struct.PanicHookInfo.html
+    /// [`std::panic::PanicHookInfo::payload`]: ../../std/panic/struct.PanicHookInfo.html#method.payload
     #[deprecated(since = "1.74.0", note = "this never returns anything useful")]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     #[allow(deprecated, deprecated_in_future)]

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -81,6 +81,24 @@ impl<'a> PanicInfo<'a> {
         Some(&self.location)
     }
 
+    /// Returns the payload associated with the panic.
+    ///
+    /// On `core::panic::PanicInfo`, this method never returns anything useful.
+    /// It only exists because of compatibility with [`std::panic::PanicInfo`],
+    /// which used to be the same type.
+    ///
+    /// See [`std::panic::PanicInfo::payload`].
+    ///
+    /// [`std::panic::PanicInfo`]: ../../std/panic/struct.PanicInfo.html
+    /// [`std::panic::PanicInfo::payload`]: ../../std/panic/struct.PanicInfo.html#method.payload
+    #[deprecated(since = "1.74.0", note = "this never returns anything useful")]
+    #[stable(feature = "panic_hooks", since = "1.10.0")]
+    #[allow(deprecated, deprecated_in_future)]
+    pub fn payload(&self) -> &(dyn crate::any::Any + Send) {
+        struct NoPayload;
+        &NoPayload
+    }
+
     /// Returns whether the panic handler is allowed to unwind the stack from
     /// the point where the panic occurred.
     ///

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -4,6 +4,15 @@ use crate::panic::Location;
 /// A struct providing information about a panic.
 ///
 /// A `PanicInfo` structure is passed to the panic handler defined by `#[panic_handler]`.
+///
+/// There two `PanicInfo` types:
+/// - `core::panic::PanicInfo`, which is used as an argument to a `#[panic_handler]` in `#![no_std]` programs.
+/// - [`std::panic::PanicInfo`], which is used as an argument to a panic hook set by [`std::panic::set_hook`].
+///
+/// This is the first one.
+///
+/// [`std::panic::set_hook`]: ../../std/panic/fn.set_hook.html
+/// [`std::panic::PanicInfo`]: ../../std/panic/struct.PanicInfo.html
 #[lang = "panic_info"]
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 #[derive(Debug)]

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -101,8 +101,12 @@ pub const fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: boo
         }
 
         // PanicInfo with the `can_unwind` flag set to false forces an abort.
-        let pi =
-            PanicInfo::new(fmt, Location::caller(), /* can_unwind */ false, force_no_backtrace);
+        let pi = PanicInfo::new(
+            fmt,
+            Location::caller(),
+            /* can_unwind */ false,
+            force_no_backtrace,
+        );
 
         // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.
         unsafe { panic_impl(&pi) }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -1,11 +1,11 @@
 //! Panic support for core
 //!
-//! In core, panicking is always done with a message, resulting in a core::panic::PanicInfo
-//! containing a fmt::Arguments. In std, however, panicking can be done with panic_any, which throws
-//! a `Box<dyn Any>` containing any type of value. Because of this, std::panic::PanicInfo is a
-//! different type, which contains a &dyn Any instead of a fmt::Arguments.
-//! std's panic handler will convert the fmt::Arguments to a &dyn Any containing either a
-//! &'static str or String containing the formatted message.
+//! In core, panicking is always done with a message, resulting in a `core::panic::PanicInfo`
+//! containing a `fmt::Arguments`. In std, however, panicking can be done with panic_any, which
+//! throws a `Box<dyn Any>` containing any type of value. Because of this,
+//! `std::panic::PanicHookInfo` is a different type, which contains a `&dyn Any` instead of a
+//! `fmt::Arguments`. std's panic handler will convert the `fmt::Arguments` to a `&dyn Any`
+//! containing either a `&'static str` or `String` containing the formatted message.
 //!
 //! The core library cannot define any panic handler, but it can invoke it.
 //! This means that the functions inside of core are allowed to panic, but to be

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -1,7 +1,14 @@
 //! Panic support for core
 //!
-//! The core library cannot define panicking, but it does *declare* panicking. This
-//! means that the functions inside of core are allowed to panic, but to be
+//! In core, panicking is always done with a message, resulting in a core::panic::PanicInfo
+//! containing a fmt::Arguments. In std, however, panicking can be done with panic_any, which throws
+//! a Box<dyn Any> containing any type of value. Because of this, std::panic::PanicInfo is a
+//! different type, which contains a &dyn Any instead of a fmt::Arguments.
+//! std's panic handler will convert the fmt::Arguments to a &dyn Any containing either a
+//! &'static str or String containing the formatted message.
+//!
+//! The core library cannot define any panic handler, but it can invoke it.
+//! This means that the functions inside of core are allowed to panic, but to be
 //! useful an upstream crate must define panicking for core to use. The current
 //! interface for panicking is:
 //!
@@ -9,11 +16,6 @@
 //! fn panic_impl(pi: &core::panic::PanicInfo<'_>) -> !
 //! # { loop {} }
 //! ```
-//!
-//! This definition allows for panicking with any general message, but it does not
-//! allow for failing with a `Box<Any>` value. (`PanicInfo` just contains a `&(dyn Any + Send)`,
-//! for which we fill in a dummy value in `PanicInfo::internal_constructor`.)
-//! The reason for this is that core is not allowed to allocate.
 //!
 //! This module contains a few other panicking functions, but these are just the
 //! necessary lang items for the compiler. All panics are funneled through this

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -63,7 +63,7 @@ pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
         fn panic_impl(pi: &PanicInfo<'_>) -> !;
     }
 
-    let pi = PanicInfo::internal_constructor(
+    let pi = PanicInfo::new(
         fmt,
         Location::caller(),
         /* can_unwind */ true,
@@ -101,12 +101,8 @@ pub const fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: boo
         }
 
         // PanicInfo with the `can_unwind` flag set to false forces an abort.
-        let pi = PanicInfo::internal_constructor(
-            &fmt,
-            Location::caller(),
-            /* can_unwind */ false,
-            force_no_backtrace,
-        );
+        let pi =
+            PanicInfo::new(fmt, Location::caller(), /* can_unwind */ false, force_no_backtrace);
 
         // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.
         unsafe { panic_impl(&pi) }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -2,7 +2,7 @@
 //!
 //! In core, panicking is always done with a message, resulting in a core::panic::PanicInfo
 //! containing a fmt::Arguments. In std, however, panicking can be done with panic_any, which throws
-//! a Box<dyn Any> containing any type of value. Because of this, std::panic::PanicInfo is a
+//! a `Box<dyn Any>` containing any type of value. Because of this, std::panic::PanicInfo is a
 //! different type, which contains a &dyn Any instead of a fmt::Arguments.
 //! std's panic handler will convert the fmt::Arguments to a &dyn Any containing either a
 //! &'static str or String containing the formatted message.

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -62,7 +62,7 @@ pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
     }
 
     let pi = PanicInfo::internal_constructor(
-        Some(&fmt),
+        fmt,
         Location::caller(),
         /* can_unwind */ true,
         /* force_no_backtrace */ false,
@@ -100,7 +100,7 @@ pub const fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: boo
 
         // PanicInfo with the `can_unwind` flag set to false forces an abort.
         let pi = PanicInfo::internal_constructor(
-            Some(&fmt),
+            &fmt,
             Location::caller(),
             /* can_unwind */ false,
             force_no_backtrace,

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -12,7 +12,7 @@ use crate::thread::Result;
 
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 #[deprecated(
-    since = "1.80.0",
+    since = "1.82.0",
     note = "use `PanicHookInfo` instead",
     suggestion = "std::panic::PanicHookInfo"
 )]

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -12,7 +12,7 @@ use crate::thread::Result;
 
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 #[deprecated(
-    since = "1.77.0",
+    since = "1.80.0",
     note = "use `PanicHookInfo` instead",
     suggestion = "std::panic::PanicHookInfo"
 )]

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -73,6 +73,8 @@ impl<'a> PanicHookInfo<'a> {
     /// panic::set_hook(Box::new(|panic_info| {
     ///     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
     ///         println!("panic occurred: {s:?}");
+    ///     } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+    ///         println!("panic occurred: {s:?}");
     ///     } else {
     ///         println!("panic occurred");
     ///     }

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -14,11 +14,9 @@ use crate::thread::Result;
 ///
 /// `PanicInfo` structure is passed to a panic hook set by the [`set_hook`] function.
 ///
-/// [`set_hook`]: ../../std/panic/fn.set_hook.html
-///
 /// There two `PanicInfo` types:
 /// - [`core::panic::PanicInfo`], which is used as an argument to a `#[panic_handler]` in `#![no_std]` programs.
-/// - `std::panic::PanicInfo`, which is used as an argument to a panic hook set by [`std::panic::set_hook`].
+/// - `std::panic::PanicInfo`, which is used as an argument to a panic hook set by [`set_hook`].
 ///
 /// This is the second one.
 ///
@@ -35,6 +33,7 @@ use crate::thread::Result;
 /// ```
 ///
 /// [`core::panic::PanicInfo`]: ../../core/panic/struct.PanicInfo.html
+/// [`set_hook`]: ../../std/panic/fn.set_hook.html
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 #[derive(Debug)]
 pub struct PanicInfo<'a> {

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -4,10 +4,161 @@
 
 use crate::any::Any;
 use crate::collections;
+use crate::fmt;
 use crate::panicking;
 use crate::sync::atomic::{AtomicU8, Ordering};
 use crate::sync::{Condvar, Mutex, RwLock};
 use crate::thread::Result;
+
+/// A struct providing information about a panic.
+///
+/// `PanicInfo` structure is passed to a panic hook set by the [`set_hook`]
+/// function.
+///
+/// [`set_hook`]: ../../std/panic/fn.set_hook.html
+///
+/// # Examples
+///
+/// ```should_panic
+/// use std::panic;
+///
+/// panic::set_hook(Box::new(|panic_info| {
+///     println!("panic occurred: {panic_info}");
+/// }));
+///
+/// panic!("critical system failure");
+/// ```
+#[stable(feature = "panic_hooks", since = "1.10.0")]
+#[derive(Debug)]
+pub struct PanicInfo<'a> {
+    payload: &'a (dyn Any + Send),
+    location: &'a Location<'a>,
+    can_unwind: bool,
+    force_no_backtrace: bool,
+}
+
+impl<'a> PanicInfo<'a> {
+    #[unstable(feature = "panic_internals", issue = "none")]
+    #[doc(hidden)]
+    #[inline]
+    pub fn internal_constructor(
+        location: &'a Location<'a>,
+        can_unwind: bool,
+        force_no_backtrace: bool,
+    ) -> Self {
+        struct NoPayload;
+        PanicInfo { payload: &NoPayload, location, can_unwind, force_no_backtrace }
+    }
+
+    #[unstable(feature = "panic_internals", issue = "none")]
+    #[doc(hidden)]
+    #[inline]
+    pub fn set_payload(&mut self, info: &'a (dyn Any + Send)) {
+        self.payload = info;
+    }
+
+    /// Returns the payload associated with the panic.
+    ///
+    /// This will commonly, but not always, be a `&'static str` or [`String`].
+    ///
+    /// [`String`]: ../../std/string/struct.String.html
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+    ///         println!("panic occurred: {s:?}");
+    ///     } else {
+    ///         println!("panic occurred");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[must_use]
+    #[stable(feature = "panic_hooks", since = "1.10.0")]
+    pub fn payload(&self) -> &(dyn Any + Send) {
+        self.payload
+    }
+
+    /// Returns information about the location from which the panic originated,
+    /// if available.
+    ///
+    /// This method will currently always return [`Some`], but this may change
+    /// in future versions.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(location) = panic_info.location() {
+    ///         println!("panic occurred in file '{}' at line {}",
+    ///             location.file(),
+    ///             location.line(),
+    ///         );
+    ///     } else {
+    ///         println!("panic occurred but can't get location information...");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[must_use]
+    #[stable(feature = "panic_hooks", since = "1.10.0")]
+    pub fn location(&self) -> Option<&Location<'_>> {
+        // NOTE: If this is changed to sometimes return None,
+        // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
+        Some(&self.location)
+    }
+
+    /// Returns whether the panic handler is allowed to unwind the stack from
+    /// the point where the panic occurred.
+    ///
+    /// This is true for most kinds of panics with the exception of panics
+    /// caused by trying to unwind out of a `Drop` implementation or a function
+    /// whose ABI does not support unwinding.
+    ///
+    /// It is safe for a panic handler to unwind even when this function returns
+    /// false, however this will simply cause the panic handler to be called
+    /// again.
+    #[must_use]
+    #[unstable(feature = "panic_can_unwind", issue = "92988")]
+    pub fn can_unwind(&self) -> bool {
+        self.can_unwind
+    }
+
+    #[unstable(
+        feature = "panic_internals",
+        reason = "internal details of the implementation of the `panic!` and related macros",
+        issue = "none"
+    )]
+    #[doc(hidden)]
+    #[inline]
+    pub fn force_no_backtrace(&self) -> bool {
+        self.force_no_backtrace
+    }
+}
+
+#[stable(feature = "panic_hook_display", since = "1.26.0")]
+impl fmt::Display for PanicInfo<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("panicked at ")?;
+        self.location.fmt(formatter)?;
+        if let Some(payload) = self.payload.downcast_ref::<&'static str>() {
+            formatter.write_str(":\n")?;
+            formatter.write_str(payload)?;
+        } else if let Some(payload) = self.payload.downcast_ref::<String>() {
+            formatter.write_str(":\n")?;
+            formatter.write_str(payload)?;
+        }
+        Ok(())
+    }
+}
 
 #[doc(hidden)]
 #[unstable(feature = "edition_panic", issue = "none", reason = "use panic!() instead")]
@@ -43,7 +194,7 @@ pub use crate::panicking::{set_hook, take_hook};
 pub use crate::panicking::update_hook;
 
 #[stable(feature = "panic_hooks", since = "1.10.0")]
-pub use core::panic::{Location, PanicInfo};
+pub use core::panic::Location;
 
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 pub use core::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -10,15 +10,21 @@ use crate::sync::atomic::{AtomicU8, Ordering};
 use crate::sync::{Condvar, Mutex, RwLock};
 use crate::thread::Result;
 
+#[stable(feature = "panic_hooks", since = "1.10.0")]
+#[deprecated(
+    since = "1.77.0",
+    note = "use `PanicHookInfo` instead",
+    suggestion = "std::panic::PanicHookInfo"
+)]
 /// A struct providing information about a panic.
 ///
-/// `PanicInfo` structure is passed to a panic hook set by the [`set_hook`] function.
+/// `PanicInfo` has been renamed to [`PanicHookInfo`] to avoid confusion with
+/// [`core::panic::PanicInfo`].
+pub type PanicInfo<'a> = PanicHookInfo<'a>;
+
+/// A struct providing information about a panic.
 ///
-/// There two `PanicInfo` types:
-/// - [`core::panic::PanicInfo`], which is used as an argument to a `#[panic_handler]` in `#![no_std]` programs.
-/// - `std::panic::PanicInfo`, which is used as an argument to a panic hook set by [`set_hook`].
-///
-/// This is the second one.
+/// `PanicHookInfo` structure is passed to a panic hook set by the [`set_hook`] function.
 ///
 /// # Examples
 ///
@@ -32,18 +38,17 @@ use crate::thread::Result;
 /// panic!("critical system failure");
 /// ```
 ///
-/// [`core::panic::PanicInfo`]: ../../core/panic/struct.PanicInfo.html
 /// [`set_hook`]: ../../std/panic/fn.set_hook.html
-#[stable(feature = "panic_hooks", since = "1.10.0")]
+#[stable(feature = "panic_hook_info", since = "CURRENT_RUSTC_VERSION")]
 #[derive(Debug)]
-pub struct PanicInfo<'a> {
+pub struct PanicHookInfo<'a> {
     payload: &'a (dyn Any + Send),
     location: &'a Location<'a>,
     can_unwind: bool,
     force_no_backtrace: bool,
 }
 
-impl<'a> PanicInfo<'a> {
+impl<'a> PanicHookInfo<'a> {
     #[inline]
     pub(crate) fn new(
         location: &'a Location<'a>,
@@ -51,7 +56,7 @@ impl<'a> PanicInfo<'a> {
         can_unwind: bool,
         force_no_backtrace: bool,
     ) -> Self {
-        PanicInfo { payload, location, can_unwind, force_no_backtrace }
+        PanicHookInfo { payload, location, can_unwind, force_no_backtrace }
     }
 
     /// Returns the payload associated with the panic.
@@ -145,7 +150,7 @@ impl<'a> PanicInfo<'a> {
 }
 
 #[stable(feature = "panic_hook_display", since = "1.26.0")]
-impl fmt::Display for PanicInfo<'_> {
+impl fmt::Display for PanicHookInfo<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("panicked at ")?;
         self.location.fmt(formatter)?;
@@ -204,7 +209,7 @@ pub use core::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
 /// The message can be of any (`Any + Send`) type, not just strings.
 ///
 /// The message is wrapped in a `Box<'static + Any + Send>`, which can be
-/// accessed later using [`PanicInfo::payload`].
+/// accessed later using [`PanicHookInfo::payload`].
 ///
 /// See the [`panic!`] macro for more information about panicking.
 #[stable(feature = "panic_any", since = "1.51.0")]

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -96,6 +96,45 @@ impl<'a> PanicHookInfo<'a> {
         self.payload
     }
 
+    /// Returns the payload associated with the panic, if it is a string.
+    ///
+    /// This returns the payload if it is of type `&'static str` or `String`.
+    ///
+    /// A invocation of the `panic!()` macro in Rust 2021 or later will always result in a
+    /// panic payload where `payload_as_str` returns `Some`.
+    ///
+    /// Only an invocation of [`panic_any`]
+    /// (or, in Rust 2018 and earlier, `panic!(x)` where `x` is something other than a string)
+    /// can result in a panic payload where `payload_as_str` returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```should_panic
+    /// #![feature(panic_payload_as_str)]
+    ///
+    /// std::panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(s) = panic_info.payload_as_str() {
+    ///         println!("panic occurred: {s:?}");
+    ///     } else {
+    ///         println!("panic occurred");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "panic_payload_as_str", issue = "125175")]
+    pub fn payload_as_str(&self) -> Option<&str> {
+        if let Some(s) = self.payload.downcast_ref::<&str>() {
+            Some(s)
+        } else if let Some(s) = self.payload.downcast_ref::<String>() {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
     /// Returns information about the location from which the panic originated,
     /// if available.
     ///

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -12,10 +12,15 @@ use crate::thread::Result;
 
 /// A struct providing information about a panic.
 ///
-/// `PanicInfo` structure is passed to a panic hook set by the [`set_hook`]
-/// function.
+/// `PanicInfo` structure is passed to a panic hook set by the [`set_hook`] function.
 ///
 /// [`set_hook`]: ../../std/panic/fn.set_hook.html
+///
+/// There two `PanicInfo` types:
+/// - [`core::panic::PanicInfo`], which is used as an argument to a `#[panic_handler]` in `#![no_std]` programs.
+/// - `std::panic::PanicInfo`, which is used as an argument to a panic hook set by [`std::panic::set_hook`].
+///
+/// This is the second one.
 ///
 /// # Examples
 ///
@@ -28,6 +33,8 @@ use crate::thread::Result;
 ///
 /// panic!("critical system failure");
 /// ```
+///
+/// [`core::panic::PanicInfo`]: ../../core/panic/struct.PanicInfo.html
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 #[derive(Debug)]
 pub struct PanicInfo<'a> {

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -76,6 +76,7 @@ impl<'a> PanicInfo<'a> {
     /// panic!("Normal panic");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     pub fn payload(&self) -> &(dyn Any + Send) {
         self.payload
@@ -106,6 +107,7 @@ impl<'a> PanicInfo<'a> {
     /// panic!("Normal panic");
     /// ```
     #[must_use]
+    #[inline]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     pub fn location(&self) -> Option<&Location<'_>> {
         // NOTE: If this is changed to sometimes return None,
@@ -124,6 +126,7 @@ impl<'a> PanicInfo<'a> {
     /// false, however this will simply cause the panic handler to be called
     /// again.
     #[must_use]
+    #[inline]
     #[unstable(feature = "panic_can_unwind", issue = "92988")]
     pub fn can_unwind(&self) -> bool {
         self.can_unwind

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -44,23 +44,14 @@ pub struct PanicInfo<'a> {
 }
 
 impl<'a> PanicInfo<'a> {
-    #[unstable(feature = "panic_internals", issue = "none")]
-    #[doc(hidden)]
     #[inline]
-    pub fn internal_constructor(
+    pub(crate) fn new(
         location: &'a Location<'a>,
+        payload: &'a (dyn Any + Send),
         can_unwind: bool,
         force_no_backtrace: bool,
     ) -> Self {
-        struct NoPayload;
-        PanicInfo { payload: &NoPayload, location, can_unwind, force_no_backtrace }
-    }
-
-    #[unstable(feature = "panic_internals", issue = "none")]
-    #[doc(hidden)]
-    #[inline]
-    pub fn set_payload(&mut self, info: &'a (dyn Any + Send)) {
-        self.payload = info;
+        PanicInfo { payload, location, can_unwind, force_no_backtrace }
     }
 
     /// Returns the payload associated with the panic.

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -63,6 +63,13 @@ impl<'a> PanicHookInfo<'a> {
     ///
     /// This will commonly, but not always, be a `&'static str` or [`String`].
     ///
+    /// A invocation of the `panic!()` macro in Rust 2021 or later will always result in a
+    /// panic payload of type `&'static str` or `String`.
+    ///
+    /// Only an invocation of [`panic_any`]
+    /// (or, in Rust 2018 and earlier, `panic!(x)` where `x` is something other than a string)
+    /// can result in a panic payload other than a `&'static str` or `String`.
+    ///
     /// [`String`]: ../../std/string/struct.String.html
     ///
     /// # Examples

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -597,11 +597,7 @@ pub fn begin_panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
         string: Option<String>,
     }
 
-    impl<'a> FormatStringPayload<'a> {
-        fn new(inner: &'a fmt::Arguments<'a>) -> Self {
-            Self { inner, string: None }
-        }
-
+    impl FormatStringPayload<'_> {
         fn fill(&mut self) -> &mut String {
             use crate::fmt::Write;
 
@@ -615,7 +611,7 @@ pub fn begin_panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
         }
     }
 
-    unsafe impl<'a> PanicPayload for FormatStringPayload<'a> {
+    unsafe impl PanicPayload for FormatStringPayload<'_> {
         fn take_box(&mut self) -> *mut (dyn Any + Send) {
             // We do two allocations here, unfortunately. But (a) they're required with the current
             // scheme, and (b) we don't handle panic + OOM properly anyway (see comment in
@@ -654,7 +650,7 @@ pub fn begin_panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
             );
         } else {
             rust_panic_with_hook(
-                &mut FormatStringPayload::new(&msg),
+                &mut FormatStringPayload { inner: &msg, string: None },
                 Some(msg),
                 loc,
                 info.can_unwind(),

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -768,7 +768,9 @@ fn rust_panic_with_hook(
                 // recursive panics. However if the message is just a string, no user-defined
                 // code is involved in printing it, so that is risk-free.
                 let message: &str = payload.as_str().unwrap_or_default();
-                rtprintpanic!("panicked at {location}:\n{message}\nthread panicked while processing panic. aborting.\n");
+                rtprintpanic!(
+                    "panicked at {location}:\n{message}\nthread panicked while processing panic. aborting.\n"
+                );
             }
             panic_count::MustAbort::AlwaysAbort => {
                 // Unfortunately, this does not print a backtrace, because creating

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -58,7 +58,7 @@ use std::{
     env, io,
     io::prelude::Write,
     mem::ManuallyDrop,
-    panic::{self, catch_unwind, AssertUnwindSafe, PanicInfo},
+    panic::{self, catch_unwind, AssertUnwindSafe, PanicHookInfo},
     process::{self, Command, Termination},
     sync::mpsc::{channel, Sender},
     sync::{Arc, Mutex},
@@ -123,7 +123,7 @@ pub fn test_main(args: &[String], tests: Vec<TestDescAndFn>, options: Option<Opt
             // from interleaving with the panic message or appearing after it.
             let builtin_panic_hook = panic::take_hook();
             let hook = Box::new({
-                move |info: &'_ PanicInfo<'_>| {
+                move |info: &'_ PanicHookInfo<'_>| {
                     if !info.can_unwind() {
                         std::mem::forget(std::io::stderr().lock());
                         let mut stdout = ManuallyDrop::new(std::io::stdout().lock());
@@ -726,7 +726,7 @@ fn spawn_test_subprocess(
 
 fn run_test_in_spawned_subprocess(desc: TestDesc, runnable_test: RunnableTest) -> ! {
     let builtin_panic_hook = panic::take_hook();
-    let record_result = Arc::new(move |panic_info: Option<&'_ PanicInfo<'_>>| {
+    let record_result = Arc::new(move |panic_info: Option<&'_ PanicHookInfo<'_>>| {
         let test_result = match panic_info {
             Some(info) => calc_result(&desc, Err(info.payload()), &None, &None),
             None => calc_result(&desc, Ok(()), &None, &None),

--- a/tests/ui/duplicate_entry_error.rs
+++ b/tests/ui/duplicate_entry_error.rs
@@ -5,7 +5,9 @@
 
 #![feature(lang_items)]
 
-use std::panic::PanicInfo;
+extern crate core;
+
+use core::panic::PanicInfo;
 
 #[lang = "panic_impl"]
 fn panic_impl(info: &PanicInfo) -> ! {

--- a/tests/ui/duplicate_entry_error.stderr
+++ b/tests/ui/duplicate_entry_error.stderr
@@ -1,5 +1,5 @@
 error[E0152]: found duplicate lang item `panic_impl`
-  --> $DIR/duplicate_entry_error.rs:11:1
+  --> $DIR/duplicate_entry_error.rs:13:1
    |
 LL | / fn panic_impl(info: &PanicInfo) -> ! {
 LL | |

--- a/tests/ui/panic-handler/panic-handler-std.rs
+++ b/tests/ui/panic-handler/panic-handler-std.rs
@@ -1,8 +1,9 @@
 //@ normalize-stderr-test "loaded from .*libstd-.*.rlib" -> "loaded from SYSROOT/libstd-*.rlib"
 //@ error-pattern: found duplicate lang item `panic_impl`
 
+extern crate core;
 
-use std::panic::PanicInfo;
+use core::panic::PanicInfo;
 
 #[panic_handler]
 fn panic(info: PanicInfo) -> ! {

--- a/tests/ui/panic-handler/panic-handler-std.stderr
+++ b/tests/ui/panic-handler/panic-handler-std.stderr
@@ -1,5 +1,5 @@
 error[E0152]: found duplicate lang item `panic_impl`
-  --> $DIR/panic-handler-std.rs:8:1
+  --> $DIR/panic-handler-std.rs:9:1
    |
 LL | / fn panic(info: PanicInfo) -> ! {
 LL | |     loop {}


### PR DESCRIPTION
`PanicInfo` is used in two ways:

1. As argument to the `#[panic_handler]` in `no_std` context.
2. As argument to the [panic hook](https://doc.rust-lang.org/stable/std/panic/fn.set_hook.html) in `std` context.

In situation 1, the `PanicInfo` always has a *message* (of type `fmt::Arguments`), but never a *payload* (of type `&dyn Any`).

In situation 2, the `PanicInfo` always has a *payload* (which is often a `String`), but not always a *message*.

Having these as the same type is annoying. It means we can't add `.message()` to the first one without also finding a way to properly support it on the second one. (Which is what https://github.com/rust-lang/rust/issues/66745 is blocked on.)

It also means that, because the implementation is in `core`, the implementation cannot make use of the `String` type (which doesn't exist in `core`): https://github.com/rust-lang/rust/blob/0692db1a9082380e027f354912229dfd6af37e78/library/core/src/panic/panic_info.rs#L171-L172

This also means that we cannot easily add a useful method like `PanicInfo::payload_as_str() -> Option<&str>` that works for both `&'static str` and `String` payloads.

I don't see any good reasons for these to be the same type, other than historical reasons.

---

This PR is makes 1 and 2 separate types. To try to avoid breaking existing code and reduce churn, the first one is still named `core::panic::PanicInfo`, and `std::panic::PanicInfo` is a new (deprecated) alias to `PanicHookInfo`. The crater run showed this as a viable option, since people write `core::` when defining a `#[panic_handler]` (because they're in `no_std`) and `std::` when writing a panic hook (since then they're definitely using `std`). On top of that, many definitions of a panic hook don't specify a type at all: they are written as a closure with an inferred argument type.

(Based on some thoughts I was having here: https://github.com/rust-lang/rust/pull/115561#issuecomment-1725830032)

---

For the release notes:

> We have renamed `std::panic::PanicInfo` to `std::panic::PanicHookInfo`. The old name will continue to work as an alias, but will result in a deprecation warning starting in Rust 1.82.0.
>
> `core::panic::PanicInfo` will remain unchanged, however, as this is now a *different type*.
> 
> The reason is that these types have different roles: `std::panic::PanicHookInfo` is the argument to the [panic hook](https://doc.rust-lang.org/stable/std/panic/fn.set_hook.html) in std context (where panics can have an arbitrary *payload*), while `core::panic::PanicInfo` is the argument to the [`#[panic_handler]`](https://doc.rust-lang.org/nomicon/panic-handler.html) in no_std context (where panics always carry a formatted *message*). Separating these types allows us to add more useful methods to these types, such as `std::panic::PanicHookInfo::payload_as_str()` and `core::panic::PanicInfo::message()`.