### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1118,6 +1118,10 @@ where
     fn is_unit(this: TyAndLayout<'tcx>) -> bool {
         matches!(this.ty.kind(), ty::Tuple(list) if list.len() == 0)
     }
+
+    fn is_transparent(this: TyAndLayout<'tcx>) -> bool {
+        matches!(this.ty.kind(), ty::Adt(def, _) if def.repr().transparent())
+    }
 }
 
 /// Calculates whether a function's ABI can unwind or not.

--- a/compiler/rustc_target/src/abi/call/riscv.rs
+++ b/compiler/rustc_target/src/abi/call/riscv.rs
@@ -89,6 +89,17 @@ where
             }
             FieldsShape::Union(_) => {
                 if !arg_layout.is_zst() {
+                    if arg_layout.is_transparent() {
+                        let non_1zst_elem = arg_layout.non_1zst_field(cx).expect("not exactly one non-1-ZST field in non-ZST repr(transparent) union").1;
+                        return should_use_fp_conv_helper(
+                            cx,
+                            &non_1zst_elem,
+                            xlen,
+                            flen,
+                            field1_kind,
+                            field2_kind,
+                        );
+                    }
                     return Err(CannotUseFpConv);
                 }
             }

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -66,6 +66,7 @@ pub trait TyAbiInterface<'a, C>: Sized + std::fmt::Debug {
     fn is_never(this: TyAndLayout<'a, Self>) -> bool;
     fn is_tuple(this: TyAndLayout<'a, Self>) -> bool;
     fn is_unit(this: TyAndLayout<'a, Self>) -> bool;
+    fn is_transparent(this: TyAndLayout<'a, Self>) -> bool;
 }
 
 impl<'a, Ty> TyAndLayout<'a, Ty> {
@@ -134,6 +135,13 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         Ty: TyAbiInterface<'a, C>,
     {
         Ty::is_unit(self)
+    }
+
+    pub fn is_transparent<C>(self) -> bool
+    where
+        Ty: TyAbiInterface<'a, C>,
+    {
+        Ty::is_transparent(self)
     }
 
     pub fn offset_of_subfield<C>(self, cx: &C, indices: impl Iterator<Item = usize>) -> Size

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -957,6 +957,7 @@ impl f32 {
         } else if self == other {
             if self.is_sign_negative() && other.is_sign_positive() { self } else { other }
         } else {
+            // At least one input is NaN. Use `+` to perform NaN propagation and quieting.
             self + other
         }
     }

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -968,6 +968,7 @@ impl f64 {
         } else if self == other {
             if self.is_sign_negative() && other.is_sign_positive() { self } else { other }
         } else {
+            // At least one input is NaN. Use `+` to perform NaN propagation and quieting.
             self + other
         }
     }

--- a/src/bootstrap/job.rs
+++ b/src/bootstrap/job.rs
@@ -134,7 +134,7 @@ pub unsafe fn setup(build: &mut Build) {
     // If this failed, well at least we tried! An example of DuplicateHandle
     // failing in the past has been when the wrong python2 package spawned this
     // build system (e.g., the `python2` package in MSYS instead of
-    // `mingw-w64-x86_64-python2`. Not sure why it failed, but the "failure
+    // `mingw-w64-x86_64-python2`). Not sure why it failed, but the "failure
     // mode" here is that we only clean everything up when the build system
     // dies, not when the python parent does, so not too bad.
     if r.is_err() {

--- a/src/doc/style-guide/src/README.md
+++ b/src/doc/style-guide/src/README.md
@@ -32,6 +32,19 @@ This should not be interpreted as forbidding developers from following a
 non-default style, or forbidding tools from adding any particular configuration
 options.
 
+## Bugs
+
+If the style guide differs from rustfmt, that may represent a bug in rustfmt,
+or a bug in the style guide; either way, please report it to the style team or
+the rustfmt team or both, for investigation and fix.
+
+If implementing a new formatting tool based on the style guide and default Rust
+style, please test it on the corpus of existing Rust code, and avoid causing
+widespread breakage. The implementation and testing of such a tool may surface
+bugs in either the style guide or rustfmt, as well as bugs in the tool itself.
+
+We typically resolve bugs in a fashion that avoids widespread breakage.
+
 ## Formatting conventions
 
 ### Indentation and line width

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -226,13 +226,28 @@ fn test_lang_string_parse() {
         ..Default::default()
     });
     // error
-    t(LangString { original: "{.first.second}".into(), rust: true, ..Default::default() });
+    t(LangString {
+        original: "{.first.second}".into(),
+        rust: true,
+        added_classes: vec!["first.second".into()],
+        ..Default::default()
+    });
     // error
     t(LangString { original: "{class=first=second}".into(), rust: true, ..Default::default() });
     // error
-    t(LangString { original: "{class=first.second}".into(), rust: true, ..Default::default() });
+    t(LangString {
+        original: "{class=first.second}".into(),
+        rust: true,
+        added_classes: vec!["first.second".into()],
+        ..Default::default()
+    });
     // error
-    t(LangString { original: "{class=.first}".into(), rust: true, ..Default::default() });
+    t(LangString {
+        original: "{class=.first}".into(),
+        added_classes: vec![".first".into()],
+        rust: true,
+        ..Default::default()
+    });
     t(LangString {
         original: r#"{class="first"}"#.into(),
         added_classes: vec!["first".into()],

--- a/src/librustdoc/passes/check_custom_code_classes.rs
+++ b/src/librustdoc/passes/check_custom_code_classes.rs
@@ -21,6 +21,10 @@ pub(crate) const CHECK_CUSTOM_CODE_CLASSES: Pass = Pass {
 };
 
 pub(crate) fn check_custom_code_classes(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
+    if cx.tcx.features().custom_code_classes_in_docs {
+        // Nothing to check here if the feature is enabled.
+        return krate;
+    }
     let mut coll = CustomCodeClassLinter { cx };
 
     coll.fold_crate(krate)
@@ -59,7 +63,7 @@ pub(crate) fn look_for_custom_classes<'tcx>(cx: &DocContext<'tcx>, item: &Item) 
     let dox = item.attrs.doc_value();
     find_codes(&dox, &mut tests, ErrorCodes::No, false, None, true, true);
 
-    if !tests.custom_classes_found.is_empty() && !cx.tcx.features().custom_code_classes_in_docs {
+    if !tests.custom_classes_found.is_empty() {
         let span = item.attr_span(cx.tcx);
         let sess = &cx.tcx.sess.parse_sess;
         let mut err = sess

--- a/tests/rustdoc-ui/custom_code_classes_in_docs-warning.rs
+++ b/tests/rustdoc-ui/custom_code_classes_in_docs-warning.rs
@@ -57,25 +57,23 @@ pub fn foo8() {}
 /// ```{class=one=two}
 /// main;
 /// ```
-//~^^^ ERROR unexpected `=`
+//~^^^ ERROR unexpected `=` character
 pub fn foo9() {}
 
 /// ```{.one.two}
 /// main;
 /// ```
-//~^^^ ERROR unexpected `.` character
 pub fn foo10() {}
 
-/// ```{class=.one}
+/// ```{class=(one}
 /// main;
 /// ```
-//~^^^ ERROR unexpected `.` character after `=`
+//~^^^ ERROR unexpected `(` character after `=`
 pub fn foo11() {}
 
 /// ```{class=one.two}
 /// main;
 /// ```
-//~^^^ ERROR unexpected `.` character
 pub fn foo12() {}
 
 /// ```{(comment)}

--- a/tests/rustdoc-ui/custom_code_classes_in_docs-warning.stderr
+++ b/tests/rustdoc-ui/custom_code_classes_in_docs-warning.stderr
@@ -77,37 +77,21 @@ LL | | /// main;
 LL | | /// ```
    | |_______^
 
-error: unexpected `.` character
-  --> $DIR/custom_code_classes_in_docs-warning.rs:63:1
+error: unexpected `(` character after `=`
+  --> $DIR/custom_code_classes_in_docs-warning.rs:68:1
    |
-LL | / /// ```{.one.two}
-LL | | /// main;
-LL | | /// ```
-   | |_______^
-
-error: unexpected `.` character after `=`
-  --> $DIR/custom_code_classes_in_docs-warning.rs:69:1
-   |
-LL | / /// ```{class=.one}
-LL | | /// main;
-LL | | /// ```
-   | |_______^
-
-error: unexpected `.` character
-  --> $DIR/custom_code_classes_in_docs-warning.rs:75:1
-   |
-LL | / /// ```{class=one.two}
+LL | / /// ```{class=(one}
 LL | | /// main;
 LL | | /// ```
    | |_______^
 
 error: unexpected character `(`
-  --> $DIR/custom_code_classes_in_docs-warning.rs:81:1
+  --> $DIR/custom_code_classes_in_docs-warning.rs:79:1
    |
 LL | / /// ```{(comment)}
 LL | | /// main;
 LL | | /// ```
    | |_______^
 
-error: aborting due to 13 previous errors
+error: aborting due to 11 previous errors
 

--- a/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.rs
+++ b/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.rs
@@ -12,7 +12,4 @@ pub struct Bar;
 /// ```ASN.1
 /// int main(void) { return 0; }
 /// ```
-//~^^^ WARNING custom classes in code blocks will change behaviour
-//~| NOTE see issue #79483 <https://github.com/rust-lang/rust/issues/79483>
-//~| HELP add `#![feature(custom_code_classes_in_docs)]` to the crate attributes to enable
 pub struct Bar2;

--- a/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.rs
+++ b/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.rs
@@ -8,3 +8,11 @@
 //~| NOTE see issue #79483 <https://github.com/rust-lang/rust/issues/79483>
 //~| HELP add `#![feature(custom_code_classes_in_docs)]` to the crate attributes to enable
 pub struct Bar;
+
+/// ```ASN.1
+/// int main(void) { return 0; }
+/// ```
+//~^^^ WARNING custom classes in code blocks will change behaviour
+//~| NOTE see issue #79483 <https://github.com/rust-lang/rust/issues/79483>
+//~| HELP add `#![feature(custom_code_classes_in_docs)]` to the crate attributes to enable
+pub struct Bar2;

--- a/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.stderr
+++ b/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.stderr
@@ -10,16 +10,5 @@ LL | | /// ```
    = help: add `#![feature(custom_code_classes_in_docs)]` to the crate attributes to enable
    = note: found these custom classes: class=language-c
 
-warning: custom classes in code blocks will change behaviour
-  --> $DIR/feature-gate-custom_code_classes_in_docs.rs:12:1
-   |
-LL | / /// ```ASN.1
-LL | | /// int main(void) { return 0; }
-LL | | /// ```
-   | |_______^
-   |
-   = note: see issue #79483 <https://github.com/rust-lang/rust/issues/79483> for more information
-   = help: add `#![feature(custom_code_classes_in_docs)]` to the crate attributes to enable
-
-warning: 2 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.stderr
+++ b/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.stderr
@@ -10,5 +10,16 @@ LL | | /// ```
    = help: add `#![feature(custom_code_classes_in_docs)]` to the crate attributes to enable
    = note: found these custom classes: class=language-c
 
-warning: 1 warning emitted
+warning: custom classes in code blocks will change behaviour
+  --> $DIR/feature-gate-custom_code_classes_in_docs.rs:12:1
+   |
+LL | / /// ```ASN.1
+LL | | /// int main(void) { return 0; }
+LL | | /// ```
+   | |_______^
+   |
+   = note: see issue #79483 <https://github.com/rust-lang/rust/issues/79483> for more information
+   = help: add `#![feature(custom_code_classes_in_docs)]` to the crate attributes to enable
+
+warning: 2 warnings emitted
 

--- a/tests/ui/abi/compatibility.rs
+++ b/tests/ui/abi/compatibility.rs
@@ -10,7 +10,6 @@ use std::ptr::NonNull;
 // Hence there are `cfg` throughout this test to disable parts of it on those targets.
 // sparc64: https://github.com/rust-lang/rust/issues/115336
 // mips64: https://github.com/rust-lang/rust/issues/115404
-// riscv64: https://github.com/rust-lang/rust/issues/115481
 // loongarch64: https://github.com/rust-lang/rust/issues/115509
 
 macro_rules! assert_abi_compatible {
@@ -110,7 +109,7 @@ macro_rules! test_transparent {
             test_abi_compatible!(wrap1, $t, Wrapper1<$t>);
             test_abi_compatible!(wrap2, $t, Wrapper2<$t>);
             test_abi_compatible!(wrap3, $t, Wrapper3<$t>);
-            #[cfg(not(any(target_arch = "riscv64", target_arch = "loongarch64")))]
+            #[cfg(not(target_arch = "loongarch64"))]
             test_abi_compatible!(wrap4, $t, WrapperUnion<$t>);
         }
     };

--- a/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.rs
+++ b/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.rs
@@ -1,0 +1,38 @@
+// edition: 2021
+// build-fail
+//~^^ ERROR overflow evaluating the requirement `<A as Second>::{opaque#0} == _`
+
+#![feature(async_fn_in_trait)]
+
+fn main() {
+    let _ = async {
+        A.first().await.second().await;
+    };
+}
+
+pub trait First {
+    type Second: Second;
+    async fn first(self) -> Self::Second;
+}
+
+struct A;
+
+impl First for A {
+    type Second = A;
+    async fn first(self) -> Self::Second {
+        A
+    }
+}
+
+pub trait Second {
+    async fn second(self);
+}
+
+impl<C> Second for C
+where
+    C: First,
+{
+    async fn second(self) {
+        self.first().await.second().await;
+    }
+}

--- a/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.stderr
+++ b/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.stderr
@@ -1,0 +1,5 @@
+error[E0275]: overflow evaluating the requirement `<A as Second>::{opaque#0} == _`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.rs
+++ b/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.rs
@@ -1,0 +1,29 @@
+// edition: 2021
+// build-fail
+//~^^ ERROR overflow evaluating the requirement `<() as Recur>::Recur == _`
+
+#![feature(impl_trait_in_assoc_type)]
+
+use core::future::Future;
+
+trait Recur {
+    type Recur: Future<Output = ()>;
+
+    fn recur(self) -> Self::Recur;
+}
+
+async fn recur(t: impl Recur) {
+    t.recur().await;
+}
+
+impl Recur for () {
+    type Recur = impl Future<Output = ()>;
+
+    fn recur(self) -> Self::Recur {
+        async move { recur(self).await; }
+    }
+}
+
+fn main() {
+    recur(());
+}

--- a/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.stderr
+++ b/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.stderr
@@ -1,0 +1,5 @@
+error[E0275]: overflow evaluating the requirement `<() as Recur>::Recur == _`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.rs
+++ b/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.rs
@@ -1,0 +1,40 @@
+// edition: 2021
+// build-fail
+//~^^ ERROR overflow evaluating the requirement `<() as B>::Assoc == _`
+
+#![feature(rustc_attrs)]
+#![feature(impl_trait_in_assoc_type)]
+
+#[rustc_coinductive]
+trait A {
+    type Assoc;
+
+    fn test() -> Self::Assoc;
+}
+
+#[rustc_coinductive]
+trait B {
+    type Assoc;
+
+    fn test() -> Self::Assoc;
+}
+
+impl<T: A> B for T {
+    type Assoc = impl Sized;
+
+    fn test() -> <Self as B>::Assoc {
+        <T as A>::test()
+    }
+}
+
+fn main() {
+    <() as A>::test();
+}
+
+impl<T: B> A for T {
+    type Assoc = impl Sized;
+
+    fn test() -> <Self as A>::Assoc {
+        <T as B>::test()
+    }
+}

--- a/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.stderr
+++ b/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.stderr
@@ -1,0 +1,5 @@
+error[E0275]: overflow evaluating the requirement `<() as B>::Assoc == _`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Successful merges:

 - #113383 (style-guide: Add section on bugs, and resolving bugs)
 - #115499 (rustc_target/riscv: Fix passing of transparent unions with only one non-ZST member)
 - #115801 (Detect cycle errors hidden by opaques during monomorphization)
 - #115947 (Custom code classes in docs warning)
 - #115957 (fix mismatched symbols)
 - #115958 (explain mysterious addition in float minimum/maximum)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=113383,115499,115801,115947,115957,115958)
<!-- homu-ignore:end -->