### PR TITLE
fix confusing let chain indentation in rustc_resolve

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -991,9 +991,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     if !is_prelude
                     && let Some(max_vis) = max_vis.get()
                     && !max_vis.is_at_least(import.expect_vis(), self.tcx)
-                {
-                    self.lint_buffer.buffer_lint(UNUSED_IMPORTS, id, import.span, fluent::resolve_glob_import_doesnt_reexport);
-                }
+                    {
+                        self.lint_buffer.buffer_lint(UNUSED_IMPORTS, id, import.span, fluent::resolve_glob_import_doesnt_reexport);
+                    }
                     return None;
                 }
                 _ => unreachable!(),


### PR DESCRIPTION
Sorry for opening a PR for such a minor style fix. 
This just felt sufficiently misleading to warrant fixing.