### PR TITLE
Allow anyone to set llvm-fixed-upstream

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -13,7 +13,7 @@ allow-unauthenticated = [
     "WG-*",
     "beta-nominated",
     "const-hack",
-    "llvm-main",
+    "llvm-*",
     "needs-fcp",
     "relnotes",
     "requires-*",


### PR DESCRIPTION
Allow llvm-* to be set by unauthenticated users, which is currently llvm-main and llvm-fixed-upstream.