### PR TITLE
Ensure `build/tmp` exists in `rustdoc_themes::get_themes`

### DIFF
--- a/src/tools/rustdoc-themes/main.rs
+++ b/src/tools/rustdoc-themes/main.rs
@@ -1,5 +1,5 @@
 use std::env::args;
-use std::fs::File;
+use std::fs::{create_dir_all, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 use std::process::{exit, Command};
@@ -14,6 +14,7 @@ fn get_themes<P: AsRef<Path>>(style_path: P) -> Vec<String> {
         std::time::SystemTime::UNIX_EPOCH.elapsed().expect("time is after UNIX epoch").as_millis();
 
     let mut in_theme = None;
+    create_dir_all("build/tmp").expect("failed to create temporary test directory");
     for line in BufReader::new(File::open(style_path).expect("read rustdoc.css failed")).lines() {
         let line = line.expect("read line from rustdoc.css failed");
         let line = line.trim();


### PR DESCRIPTION
This causes failures in ferrocene's CI as `build/tmp` might not exist at this point, causing the following expect to fail here https://github.com/rust-lang/rust/blob/4b91288484569dd59c9a996ae45e08ae9527abc1/src/tools/rustdoc-themes/main.rs#L24