### PR TITLE
RELEASES.md: Add missing patch releases

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -113,6 +113,16 @@ Compatibility Notes
   to a registry.
   [#12291](https://github.com/rust-lang/cargo/pull/12291)
 
+Version 1.71.1 (2023-08-03)
+===========================
+
+- [Fix CVE-2023-38497: Cargo did not respect the umask when extracting dependencies](https://github.com/rust-lang/cargo/security/advisories/GHSA-j3xp-wfr4-hx87)
+- [Fix bash completion for users of Rustup](https://github.com/rust-lang/rust/pull/113579)
+- [Do not show `suspicious_double_ref_op` lint when calling `borrow()`](https://github.com/rust-lang/rust/pull/112517)
+- [Fix ICE: substitute types before checking inlining compatibility](https://github.com/rust-lang/rust/pull/113802)
+- [Fix ICE: don't use `can_eq` in `derive(..)` suggestion for missing method](https://github.com/rust-lang/rust/pull/111516)
+- [Fix building Rust 1.71.0 from the source tarball](https://github.com/rust-lang/rust/issues/113678)
+
 Version 1.71.0 (2023-07-13)
 ==========================
 


### PR DESCRIPTION
This was copy-pasted from the current state of the `stable` branch

see https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/1.2E71.2E1/near/382524871