### PR TITLE
Call panic_display directly in const_panic_fmt.

### DIFF
--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -234,7 +234,7 @@ fn panic_in_cleanup() -> ! {
 #[rustc_const_unstable(feature = "core_panic", issue = "none")]
 pub const fn const_panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
     if let Some(msg) = fmt.as_str() {
-        // The panic_display function is hooked by conost eval.
+        // The panic_display function is hooked by const eval.
         panic_display(&msg);
     } else {
         // SAFETY: This is only evaluated at compile time, which reliably

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -234,7 +234,8 @@ fn panic_in_cleanup() -> ! {
 #[rustc_const_unstable(feature = "core_panic", issue = "none")]
 pub const fn const_panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
     if let Some(msg) = fmt.as_str() {
-        panic_str(msg);
+        // The panic_display function is hooked by conost eval.
+        panic_display(&msg);
     } else {
         // SAFETY: This is only evaluated at compile time, which reliably
         // handles this UB (in case this branch turns out to be reachable


### PR DESCRIPTION
`panic_str` just directly calls `panic_display`. The only reason `panic_str` exists, is for a lint to detect an expansion of `panic_2015!(expr)` (which expands to `panic_str`).

It is `panic_display` that is hooked by const-eval, which is the reason we call it here.

Part of https://github.com/rust-lang/rust/issues/116005

r? @oli-obk