### PR TITLE
Rename BoxMeUp to PanicPayload.

### DIFF
--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -99,7 +99,7 @@ pub macro unreachable_2021 {
 /// use.
 #[unstable(feature = "std_internals", issue = "none")]
 #[doc(hidden)]
-pub unsafe trait BoxMeUp {
+pub unsafe trait PanicPayload {
     /// Take full ownership of the contents.
     /// The return type is actually `Box<dyn Any + Send>`, but we cannot use `Box` in core.
     ///
@@ -107,7 +107,7 @@ pub unsafe trait BoxMeUp {
     /// Calling this method twice, or calling `get` after calling this method, is an error.
     ///
     /// The argument is borrowed because the panic runtime (`__rust_start_panic`) only
-    /// gets a borrowed `dyn BoxMeUp`.
+    /// gets a borrowed `dyn PanicPayload`.
     fn take_box(&mut self) -> *mut (dyn Any + Send);
 
     /// Just borrow the contents.

--- a/library/panic_abort/src/android.rs
+++ b/library/panic_abort/src/android.rs
@@ -1,6 +1,6 @@
 use alloc::string::String;
 use core::mem::transmute;
-use core::panic::BoxMeUp;
+use core::panic::PanicPayload;
 use core::ptr::copy_nonoverlapping;
 
 const ANDROID_SET_ABORT_MESSAGE: &[u8] = b"android_set_abort_message\0";
@@ -15,7 +15,7 @@ type SetAbortMessageType = unsafe extern "C" fn(*const libc::c_char) -> ();
 //
 // Weakly resolve the symbol for android_set_abort_message. This function is only available
 // for API >= 21.
-pub(crate) unsafe fn android_set_abort_message(payload: &mut dyn BoxMeUp) {
+pub(crate) unsafe fn android_set_abort_message(payload: &mut dyn PanicPayload) {
     let func_addr =
         libc::dlsym(libc::RTLD_DEFAULT, ANDROID_SET_ABORT_MESSAGE.as_ptr() as *const libc::c_char)
             as usize;

--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -20,7 +20,7 @@
 mod android;
 
 use core::any::Any;
-use core::panic::BoxMeUp;
+use core::panic::PanicPayload;
 
 #[rustc_std_internal_symbol]
 #[allow(improper_ctypes_definitions)]
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn __rust_panic_cleanup(_: *mut u8) -> *mut (dyn Any + Sen
 
 // "Leak" the payload and shim to the relevant abort on the platform in question.
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_start_panic(_payload: &mut dyn BoxMeUp) -> u32 {
+pub unsafe fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
     // Android has the ability to attach a message as part of the abort.
     #[cfg(target_os = "android")]
     android::android_set_abort_message(_payload);

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -29,7 +29,7 @@
 
 use alloc::boxed::Box;
 use core::any::Any;
-use core::panic::BoxMeUp;
+use core::panic::PanicPayload;
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "emscripten")] {
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any
 // Entry point for raising an exception, just delegates to the platform-specific
 // implementation.
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_start_panic(payload: &mut dyn BoxMeUp) -> u32 {
+pub unsafe fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
     let payload = Box::from_raw(payload.take_box());
 
     imp::panic(payload)


### PR DESCRIPTION
"BoxMeUp" is not very clear. Let's rename that to a description of what it actually represents: a panic payload.

This PR also renames the structs that implement this trait to have more descriptive names.

Part of https://github.com/rust-lang/rust/issues/116005

r? @oli-obk 