### PR TITLE
Fix `ui-fulldeps --stage=1` with `-Zignore-directory-in-diagnostics-source-blocks`

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-15/script.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-15/script.sh
@@ -4,15 +4,18 @@ set -ex
 
 # Only run the stage 1 tests on merges, not on PR CI jobs.
 if [[ -z "${PR_CI_JOB}" ]]; then
-../x.py --stage 1 test --skip src/tools/tidy && \
-           # Run the `mir-opt` tests again but this time for a 32-bit target.
-           # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
-           # both 32-bit and 64-bit outputs updated by the PR author, before
-           # the PR is approved and tested for merging.
-           # It will also detect tests lacking `// EMIT_MIR_FOR_EACH_BIT_WIDTH`,
-           # despite having different output on 32-bit vs 64-bit targets.
-           ../x.py --stage 1 test tests/mir-opt \
-                             --host='' --target=i686-unknown-linux-gnu
+     ../x.py --stage 1 test --skip src/tools/tidy && \
+     # Run the `mir-opt` tests again but this time for a 32-bit target.
+     # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
+     # both 32-bit and 64-bit outputs updated by the PR author, before
+     # the PR is approved and tested for merging.
+     # It will also detect tests lacking `// EMIT_MIR_FOR_EACH_BIT_WIDTH`,
+     # despite having different output on 32-bit vs 64-bit targets.
+     ../x.py --stage 1 test tests/mir-opt \
+          --host='' --target=i686-unknown-linux-gnu && \
+     # Run `ui-fulldeps` in `--stage=1`, which actually uses the stage0
+     # compiler, and is sensitive to the addition of new flags.
+     ../x.py --stage 1 test tests/ui-fulldeps
 fi
 
 # NOTE: intentionally uses all of `x.py`, `x`, and `x.ps1` to make sure they all work on Linux.

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2335,14 +2335,17 @@ impl<'test> TestCx<'test> {
         rustc.arg("-Zsimulate-remapped-rust-src-base=/rustc/FAKE_PREFIX");
         rustc.arg("-Ztranslate-remapped-path-to-local-path=no");
 
-        // Hide Cargo dependency sources from ui tests to make sure the error message doesn't
-        // change depending on whether $CARGO_HOME is remapped or not. If this is not present,
-        // when $CARGO_HOME is remapped the source won't be shown, and when it's not remapped the
-        // source will be shown, causing a blessing hell.
-        rustc.arg("-Z").arg(format!(
-            "ignore-directory-in-diagnostics-source-blocks={}",
-            home::cargo_home().expect("failed to find cargo home").to_str().unwrap()
-        ));
+        // #[cfg(not(bootstrap))]: After beta bump, this should **always** run.
+        if !(self.config.stage_id.starts_with("stage1-") && self.config.suite == "ui-fulldeps") {
+            // Hide Cargo dependency sources from ui tests to make sure the error message doesn't
+            // change depending on whether $CARGO_HOME is remapped or not. If this is not present,
+            // when $CARGO_HOME is remapped the source won't be shown, and when it's not remapped the
+            // source will be shown, causing a blessing hell.
+            rustc.arg("-Z").arg(format!(
+                "ignore-directory-in-diagnostics-source-blocks={}",
+                home::cargo_home().expect("failed to find cargo home").to_str().unwrap()
+            ));
+        }
 
         // Optionally prevent default --sysroot if specified in test compile-flags.
         if !self.props.compile_flags.iter().any(|flag| flag.starts_with("--sysroot"))


### PR DESCRIPTION
Fixes #115977

Also makes sure this doesn't happen again by running `ui-fulldeps --stage=1` in CI