### PR TITLE
const_eval: allow function pointer signatures containing &mut T in const contexts

### DIFF
--- a/tests/ui/consts/const-eval/issue-114994-fail.rs
+++ b/tests/ui/consts/const-eval/issue-114994-fail.rs
@@ -1,0 +1,14 @@
+// This checks that function pointer signatures that are referenced mutably
+// but contain a &mut T parameter still fail in a constant context: see issue #114994.
+//
+// check-fail
+
+const fn use_mut_const_fn(_f: &mut fn(&mut String)) { //~ ERROR mutable references are not allowed in constant functions
+    ()
+}
+
+const fn use_mut_const_tuple_fn(_f: (fn(), &mut u32)) { //~ ERROR mutable references are not allowed in constant functions
+
+}
+
+fn main() {}

--- a/tests/ui/consts/const-eval/issue-114994-fail.stderr
+++ b/tests/ui/consts/const-eval/issue-114994-fail.stderr
@@ -1,0 +1,21 @@
+error[E0658]: mutable references are not allowed in constant functions
+  --> $DIR/issue-114994-fail.rs:6:27
+   |
+LL | const fn use_mut_const_fn(_f: &mut fn(&mut String)) {
+   |                           ^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error[E0658]: mutable references are not allowed in constant functions
+  --> $DIR/issue-114994-fail.rs:10:33
+   |
+LL | const fn use_mut_const_tuple_fn(_f: (fn(), &mut u32)) {
+   |                                 ^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/consts/const-eval/issue-114994.rs
+++ b/tests/ui/consts/const-eval/issue-114994.rs
@@ -1,0 +1,18 @@
+// This checks that function pointer signatures containing &mut T types
+// work in a constant context: see issue #114994.
+//
+// check-pass
+
+const fn use_const_fn(_f: fn(&mut String)) {
+    ()
+}
+
+const fn get_some_fn() -> fn(&mut String) {
+    String::clear
+}
+
+const fn some_const_fn() {
+    let _f: fn(&mut String) = String::clear;
+}
+
+fn main() {}


### PR DESCRIPTION
potentially fixes #114994

We utilize a `TypeVisitor` here in order to more easily handle control flow.
- In the event the typekind the Visitor sees is a function pointer, we skip over it
- However, otherwise we do one of two things:
   - If we find a mutable reference, check it, then continue visiting types
   - If we find any other type, continue visiting types

This means we will check if the function pointer _itself_ is mutable, but not if any of the types _within_ are.