### PR TITLE
Don't pass `-stdlib=libc++` when building C files on macOS

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1146,11 +1146,10 @@ impl Build {
             .filter(|s| !s.starts_with("-O") && !s.starts_with("/O"))
             .collect::<Vec<String>>();
 
-        // If we're compiling on macOS then we add a few unconditional flags
-        // indicating that we want libc++ (more filled out than libstdc++) and
-        // we want to compile for 10.7. This way we can ensure that
+        // If we're compiling C++ on macOS then we add a flag indicating that
+        // we want libc++ (more filled out than libstdc++), ensuring that
         // LLVM/etc are all properly compiled.
-        if target.contains("apple-darwin") {
+        if matches!(c, CLang::Cxx) && target.contains("apple-darwin") {
             base.push("-stdlib=libc++".into());
         }
 


### PR DESCRIPTION
When using *Command Line Tools for Xcode* version 15.0, clang will warn about `argument unused during compilation: '-stdlib=libc++'` if this flag is present when compiling C files only (i.e. no C++ files).

To avoid this warning, we can add the flag only to CXXFLAGS and not to CFLAGS.

---

[Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/clang.20warning.3A.20argument.20unused.20during.20compilation.20.28libc.2B.2B.29)