### PR TITLE
Delete obsolete `--disable-per-crate-search` rustdoc flag

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -503,13 +503,6 @@ fn opts() -> Vec<RustcOptGroup> {
                 "PATH",
             )
         }),
-        unstable("disable-per-crate-search", |o| {
-            o.optflagmulti(
-                "",
-                "disable-per-crate-search",
-                "disables generating the crate selector on the search box",
-            )
-        }),
         unstable("persist-doctests", |o| {
             o.optopt(
                 "",

--- a/tests/run-make/issue-88756-default-output/output-default.stdout
+++ b/tests/run-make/issue-88756-default-output/output-default.stdout
@@ -133,9 +133,6 @@ Options:
                         Path string to force loading static files from in
                         output pages. If not set, uses combinations of '../'
                         to reach the documentation root.
-        --disable-per-crate-search 
-                        disables generating the crate selector on the search
-                        box
         --persist-doctests PATH
                         Directory to persist doctest executables into
         --show-coverage 

--- a/tests/rustdoc/no-crate-filter.rs
+++ b/tests/rustdoc/no-crate-filter.rs
@@ -1,6 +1,0 @@
-#![crate_name = "foo"]
-
-// compile-flags: -Z unstable-options --disable-per-crate-search
-
-// @!has 'foo/struct.Foo.html' '//*[id="crate-search"]' ''
-pub struct Foo;


### PR DESCRIPTION
This unstable flag is unused by rustdoc since https://github.com/rust-lang/rust/pull/92526/commits/ef96d573bff12330080d22f12cad96b818ea5da7.

We should avoid landing this until after https://github.com/rust-lang/docs.rs/pull/2225 is deployed to docs.rs.