### PR TITLE
Allow target specs to use an LLD flavor, and self-contained linking components

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -23,7 +23,7 @@ use rustc_session::utils::NativeLibKind;
 use rustc_session::{filesearch, Session};
 use rustc_span::symbol::Symbol;
 use rustc_target::spec::crt_objects::CrtObjects;
-use rustc_target::spec::LinkSelfContained;
+use rustc_target::spec::LinkSelfContainedDefault;
 use rustc_target::spec::{Cc, LinkOutputKind, LinkerFlavor, Lld, PanicStrategy};
 use rustc_target::spec::{RelocModel, RelroLevel, SanitizerSet, SplitDebuginfo};
 
@@ -1714,9 +1714,9 @@ fn self_contained(sess: &Session, crate_type: CrateType) -> bool {
     }
 
     match sess.target.link_self_contained {
-        LinkSelfContained::True => true,
-        LinkSelfContained::False => false,
-        LinkSelfContained::WithComponents(components) => {
+        LinkSelfContainedDefault::False => false,
+        LinkSelfContainedDefault::True => true,
+        LinkSelfContainedDefault::WithComponents(components) => {
             if components.is_all() {
                 true
             } else if components.is_empty() {
@@ -1733,8 +1733,8 @@ fn self_contained(sess: &Session, crate_type: CrateType) -> bool {
         // FIXME: Find a better heuristic for "native musl toolchain is available",
         // based on host and linker path, for example.
         // (https://github.com/rust-lang/rust/pull/71769#issuecomment-626330237).
-        LinkSelfContained::InferredForMusl => sess.crt_static(Some(crate_type)),
-        LinkSelfContained::InferredForMingw => {
+        LinkSelfContainedDefault::InferredForMusl => sess.crt_static(Some(crate_type)),
+        LinkSelfContainedDefault::InferredForMingw => {
             sess.host == sess.target
                 && sess.target.vendor != "uwp"
                 && detect_self_contained_mingw(&sess)

--- a/compiler/rustc_target/src/spec/crt_objects.rs
+++ b/compiler/rustc_target/src/spec/crt_objects.rs
@@ -40,11 +40,9 @@
 //! but not gcc's. As a result rustc cannot link with C++ static libraries (#36710)
 //! when linking in self-contained mode.
 
-use crate::json::{Json, ToJson};
 use crate::spec::LinkOutputKind;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 pub type CrtObjects = BTreeMap<LinkOutputKind, Vec<Cow<'static, str>>>;
 
@@ -122,40 +120,4 @@ pub(super) fn pre_wasi_self_contained() -> CrtObjects {
 
 pub(super) fn post_wasi_self_contained() -> CrtObjects {
     new(&[])
-}
-
-/// Which logic to use to determine whether to use self-contained linking mode
-/// if `-Clink-self-contained` is not specified explicitly.
-#[derive(Clone, Copy, PartialEq, Hash, Debug)]
-pub enum LinkSelfContainedDefault {
-    False,
-    True,
-    Musl,
-    Mingw,
-}
-
-impl FromStr for LinkSelfContainedDefault {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<LinkSelfContainedDefault, ()> {
-        Ok(match s {
-            "false" => LinkSelfContainedDefault::False,
-            "true" | "wasm" => LinkSelfContainedDefault::True,
-            "musl" => LinkSelfContainedDefault::Musl,
-            "mingw" => LinkSelfContainedDefault::Mingw,
-            _ => return Err(()),
-        })
-    }
-}
-
-impl ToJson for LinkSelfContainedDefault {
-    fn to_json(&self) -> Json {
-        match *self {
-            LinkSelfContainedDefault::False => "false",
-            LinkSelfContainedDefault::True => "true",
-            LinkSelfContainedDefault::Musl => "musl",
-            LinkSelfContainedDefault::Mingw => "mingw",
-        }
-        .to_json()
-    }
 }

--- a/compiler/rustc_target/src/spec/linux_musl_base.rs
+++ b/compiler/rustc_target/src/spec/linux_musl_base.rs
@@ -1,4 +1,5 @@
-use crate::spec::crt_objects::{self, LinkSelfContainedDefault};
+use crate::spec::crt_objects;
+use crate::spec::LinkSelfContained;
 use crate::spec::TargetOptions;
 
 pub fn opts() -> TargetOptions {
@@ -7,7 +8,7 @@ pub fn opts() -> TargetOptions {
     base.env = "musl".into();
     base.pre_link_objects_self_contained = crt_objects::pre_musl_self_contained();
     base.post_link_objects_self_contained = crt_objects::post_musl_self_contained();
-    base.link_self_contained = LinkSelfContainedDefault::Musl;
+    base.link_self_contained = LinkSelfContained::InferredForMusl;
 
     // These targets statically link libc by default
     base.crt_static_default = true;

--- a/compiler/rustc_target/src/spec/linux_musl_base.rs
+++ b/compiler/rustc_target/src/spec/linux_musl_base.rs
@@ -1,6 +1,5 @@
 use crate::spec::crt_objects;
-use crate::spec::LinkSelfContained;
-use crate::spec::TargetOptions;
+use crate::spec::{LinkSelfContainedDefault, TargetOptions};
 
 pub fn opts() -> TargetOptions {
     let mut base = super::linux_base::opts();
@@ -8,7 +7,7 @@ pub fn opts() -> TargetOptions {
     base.env = "musl".into();
     base.pre_link_objects_self_contained = crt_objects::pre_musl_self_contained();
     base.post_link_objects_self_contained = crt_objects::post_musl_self_contained();
-    base.link_self_contained = LinkSelfContained::InferredForMusl;
+    base.link_self_contained = LinkSelfContainedDefault::InferredForMusl;
 
     // These targets statically link libc by default
     base.crt_static_default = true;

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -38,7 +38,7 @@ use crate::abi::call::Conv;
 use crate::abi::{Endian, Integer, Size, TargetDataLayout, TargetDataLayoutErrors};
 use crate::json::{Json, ToJson};
 use crate::spec::abi::{lookup as lookup_abi, Abi};
-use crate::spec::crt_objects::{CrtObjects, LinkSelfContainedDefault};
+use crate::spec::crt_objects::CrtObjects;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_fs_util::try_canonicalize;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -542,7 +542,7 @@ impl ToJson for LinkerFlavorCli {
 /// - explicitly enabling some of the self-contained linking components, e.g. the linker component
 ///   to use `rust-lld`
 #[derive(Clone, Copy, PartialEq, Debug)]
-pub enum LinkSelfContained {
+pub enum LinkSelfContainedDefault {
     /// The target spec explicitly enables self-contained linking.
     True,
 
@@ -560,10 +560,25 @@ pub enum LinkSelfContained {
     WithComponents(LinkSelfContainedComponents),
 }
 
-impl ToJson for LinkSelfContained {
+/// Parses a backwards-compatible `-Clink-self-contained` option string, without components.
+impl FromStr for LinkSelfContainedDefault {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<LinkSelfContainedDefault, ()> {
+        Ok(match s {
+            "false" => LinkSelfContainedDefault::False,
+            "true" | "wasm" => LinkSelfContainedDefault::True,
+            "musl" => LinkSelfContainedDefault::InferredForMusl,
+            "mingw" => LinkSelfContainedDefault::InferredForMingw,
+            _ => return Err(()),
+        })
+    }
+}
+
+impl ToJson for LinkSelfContainedDefault {
     fn to_json(&self) -> Json {
         match *self {
-            LinkSelfContained::WithComponents(components) => {
+            LinkSelfContainedDefault::WithComponents(components) => {
                 // Serialize the components in a json object's `components` field, to prepare for a
                 // future where `crt-objects-fallback` is removed from the json specs and
                 // incorporated as a field here.
@@ -572,29 +587,31 @@ impl ToJson for LinkSelfContained {
                 map.to_json()
             }
 
-            // Stable values backwards-compatible with `LinkSelfContainedDefault`
-            LinkSelfContained::True => "true".to_json(),
-            LinkSelfContained::False => "false".to_json(),
-            LinkSelfContained::InferredForMusl => "musl".to_json(),
-            LinkSelfContained::InferredForMingw => "mingw".to_json(),
+            // Stable backwards-compatible values
+            LinkSelfContainedDefault::True => "true".to_json(),
+            LinkSelfContainedDefault::False => "false".to_json(),
+            LinkSelfContainedDefault::InferredForMusl => "musl".to_json(),
+            LinkSelfContainedDefault::InferredForMingw => "mingw".to_json(),
         }
     }
 }
 
-impl LinkSelfContained {
+impl LinkSelfContainedDefault {
     /// Returns whether the target spec has self-contained linking explicitly disabled. Used to emit
     /// errors if the user then enables it on the CLI.
     pub fn is_disabled(self) -> bool {
-        self == LinkSelfContained::False
+        self == LinkSelfContainedDefault::False
     }
 
     /// Returns whether the target spec explictly requests self-contained linking, i.e. not via
     /// inference.
     pub fn is_linker_enabled(self) -> bool {
         match self {
-            LinkSelfContained::True => true,
-            LinkSelfContained::False => false,
-            LinkSelfContained::WithComponents(c) => c.contains(LinkSelfContainedComponents::LINKER),
+            LinkSelfContainedDefault::True => true,
+            LinkSelfContainedDefault::False => false,
+            LinkSelfContainedDefault::WithComponents(c) => {
+                c.contains(LinkSelfContainedComponents::LINKER)
+            }
             _ => false,
         }
     }
@@ -604,19 +621,8 @@ impl LinkSelfContained {
     /// - the other variants as a backwards-compatible `crt-objects-fallback` string
     fn json_key(self) -> &'static str {
         match self {
-            LinkSelfContained::WithComponents(_) => "link-self-contained",
+            LinkSelfContainedDefault::WithComponents(_) => "link-self-contained",
             _ => "crt-objects-fallback",
-        }
-    }
-}
-
-impl From<LinkSelfContainedDefault> for LinkSelfContained {
-    fn from(value: LinkSelfContainedDefault) -> Self {
-        match value {
-            LinkSelfContainedDefault::True => LinkSelfContained::True,
-            LinkSelfContainedDefault::False => LinkSelfContained::False,
-            LinkSelfContainedDefault::Musl => LinkSelfContained::InferredForMusl,
-            LinkSelfContainedDefault::Mingw => LinkSelfContained::InferredForMingw,
         }
     }
 }
@@ -1888,7 +1894,7 @@ pub struct TargetOptions {
     pub post_link_objects_self_contained: CrtObjects,
     /// Behavior for the self-contained linking mode: inferred for some targets, or explicitly
     /// enabled (in bulk, or with individual components).
-    pub link_self_contained: LinkSelfContained,
+    pub link_self_contained: LinkSelfContainedDefault,
 
     /// Linker arguments that are passed *before* any user-defined libraries.
     pub pre_link_args: LinkArgs,
@@ -2363,7 +2369,7 @@ impl Default for TargetOptions {
             post_link_objects: Default::default(),
             pre_link_objects_self_contained: Default::default(),
             post_link_objects_self_contained: Default::default(),
-            link_self_contained: LinkSelfContained::False,
+            link_self_contained: LinkSelfContainedDefault::False,
             pre_link_args: LinkArgs::new(),
             pre_link_args_json: LinkArgsCli::new(),
             late_link_args: LinkArgs::new(),
@@ -2844,7 +2850,7 @@ impl Target {
                 }
                 Ok::<(), String>(())
             } );
-            ($key_name:ident, LinkSelfContained) => ( {
+            ($key_name:ident, link_self_contained_components) => ( {
                 // Skeleton of what needs to be parsed:
                 //
                 // ```
@@ -2873,18 +2879,18 @@ impl Target {
                                 _ => return Err(format!("not a string: {:?}", s)),
                             };
                         }
-                        base.$key_name = LinkSelfContained::WithComponents(components);
+                        base.$key_name = LinkSelfContainedDefault::WithComponents(components);
                     } else {
                         incorrect_type.push(name)
                     }
                 }
                 Ok::<(), String>(())
             } );
-            ($key_name:ident = $json_name:expr, LinkSelfContainedDefault) => ( {
+            ($key_name:ident = $json_name:expr, link_self_contained_backwards_compatible) => ( {
                 let name = $json_name;
                 obj.remove(name).and_then(|o| o.as_str().and_then(|s| {
                     match s.parse::<LinkSelfContainedDefault>() {
-                        Ok(lsc_default) => base.$key_name = lsc_default.into(),
+                        Ok(lsc_default) => base.$key_name = lsc_default,
                         _ => return Some(Err(format!("'{}' is not a valid `-Clink-self-contained` default. \
                                                       Use 'false', 'true', 'musl' or 'mingw'", s))),
                     }
@@ -3034,9 +3040,12 @@ impl Target {
         key!(pre_link_objects_self_contained = "pre-link-objects-fallback", link_objects);
         key!(post_link_objects_self_contained = "post-link-objects-fallback", link_objects);
         // Deserializes the backwards-compatible variants of `-Clink-self-contained`
-        key!(link_self_contained = "crt-objects-fallback", LinkSelfContainedDefault)?;
+        key!(
+            link_self_contained = "crt-objects-fallback",
+            link_self_contained_backwards_compatible
+        )?;
         // Deserializes the components variant of `-Clink-self-contained`
-        key!(link_self_contained, LinkSelfContained)?;
+        key!(link_self_contained, link_self_contained_components)?;
         key!(pre_link_args_json = "pre-link-args", link_args);
         key!(late_link_args_json = "late-link-args", link_args);
         key!(late_link_args_dynamic_json = "late-link-args-dynamic", link_args);

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -686,6 +686,21 @@ impl LinkSelfContainedComponents {
             LinkSelfContainedComponents::MINGW,
         ]
     }
+
+    /// Returns whether at least a component is enabled.
+    pub fn are_any_components_enabled(self) -> bool {
+        !self.is_empty()
+    }
+
+    /// Returns whether `LinkSelfContainedComponents::LINKER` is enabled.
+    pub fn is_linker_enabled(self) -> bool {
+        self.contains(LinkSelfContainedComponents::LINKER)
+    }
+
+    /// Returns whether `LinkSelfContainedComponents::CRT_OBJECTS` is enabled.
+    pub fn is_crt_objects_enabled(self) -> bool {
+        self.contains(LinkSelfContainedComponents::CRT_OBJECTS)
+    }
 }
 
 impl IntoIterator for LinkSelfContainedComponents {

--- a/compiler/rustc_target/src/spec/tests/tests_impl.rs
+++ b/compiler/rustc_target/src/spec/tests/tests_impl.rs
@@ -97,7 +97,7 @@ impl Target {
             );
         }
 
-        if self.link_self_contained == LinkSelfContainedDefault::False {
+        if self.link_self_contained.is_disabled() {
             assert!(
                 self.pre_link_objects_self_contained.is_empty()
                     && self.post_link_objects_self_contained.is_empty()

--- a/compiler/rustc_target/src/spec/wasm32_wasi.rs
+++ b/compiler/rustc_target/src/spec/wasm32_wasi.rs
@@ -73,7 +73,7 @@
 //! you know what you're getting in to!
 
 use super::crt_objects;
-use super::LinkSelfContained;
+use super::LinkSelfContainedDefault;
 use super::{wasm_base, Cc, LinkerFlavor, Target};
 
 pub fn target() -> Target {
@@ -86,7 +86,7 @@ pub fn target() -> Target {
     options.post_link_objects_self_contained = crt_objects::post_wasi_self_contained();
 
     // FIXME: Figure out cases in which WASM needs to link with a native toolchain.
-    options.link_self_contained = LinkSelfContained::True;
+    options.link_self_contained = LinkSelfContainedDefault::True;
 
     // Right now this is a bit of a workaround but we're currently saying that
     // the target by default has a static crt which we're taking as a signal

--- a/compiler/rustc_target/src/spec/wasm32_wasi.rs
+++ b/compiler/rustc_target/src/spec/wasm32_wasi.rs
@@ -72,7 +72,8 @@
 //! best we can with this target. Don't start relying on too much here unless
 //! you know what you're getting in to!
 
-use super::crt_objects::{self, LinkSelfContainedDefault};
+use super::crt_objects;
+use super::LinkSelfContained;
 use super::{wasm_base, Cc, LinkerFlavor, Target};
 
 pub fn target() -> Target {
@@ -85,7 +86,7 @@ pub fn target() -> Target {
     options.post_link_objects_self_contained = crt_objects::post_wasi_self_contained();
 
     // FIXME: Figure out cases in which WASM needs to link with a native toolchain.
-    options.link_self_contained = LinkSelfContainedDefault::True;
+    options.link_self_contained = LinkSelfContained::True;
 
     // Right now this is a bit of a workaround but we're currently saying that
     // the target by default has a static crt which we're taking as a signal

--- a/compiler/rustc_target/src/spec/wasm32_wasi_preview1_threads.rs
+++ b/compiler/rustc_target/src/spec/wasm32_wasi_preview1_threads.rs
@@ -72,7 +72,8 @@
 //! best we can with this target. Don't start relying on too much here unless
 //! you know what you're getting in to!
 
-use super::crt_objects::{self, LinkSelfContainedDefault};
+use super::crt_objects;
+use super::LinkSelfContained;
 use super::{wasm_base, Cc, LinkerFlavor, Target};
 
 pub fn target() -> Target {
@@ -98,7 +99,7 @@ pub fn target() -> Target {
     options.post_link_objects_self_contained = crt_objects::post_wasi_self_contained();
 
     // FIXME: Figure out cases in which WASM needs to link with a native toolchain.
-    options.link_self_contained = LinkSelfContainedDefault::True;
+    options.link_self_contained = LinkSelfContained::True;
 
     // Right now this is a bit of a workaround but we're currently saying that
     // the target by default has a static crt which we're taking as a signal

--- a/compiler/rustc_target/src/spec/wasm32_wasi_preview1_threads.rs
+++ b/compiler/rustc_target/src/spec/wasm32_wasi_preview1_threads.rs
@@ -72,9 +72,8 @@
 //! best we can with this target. Don't start relying on too much here unless
 //! you know what you're getting in to!
 
-use super::crt_objects;
-use super::LinkSelfContained;
-use super::{wasm_base, Cc, LinkerFlavor, Target};
+use super::{crt_objects, wasm_base};
+use super::{Cc, LinkSelfContainedDefault, LinkerFlavor, Target};
 
 pub fn target() -> Target {
     let mut options = wasm_base::options();
@@ -99,7 +98,7 @@ pub fn target() -> Target {
     options.post_link_objects_self_contained = crt_objects::post_wasi_self_contained();
 
     // FIXME: Figure out cases in which WASM needs to link with a native toolchain.
-    options.link_self_contained = LinkSelfContained::True;
+    options.link_self_contained = LinkSelfContainedDefault::True;
 
     // Right now this is a bit of a workaround but we're currently saying that
     // the target by default has a static crt which we're taking as a signal

--- a/compiler/rustc_target/src/spec/wasm_base.rs
+++ b/compiler/rustc_target/src/spec/wasm_base.rs
@@ -1,5 +1,5 @@
+use super::LinkSelfContainedDefault;
 use super::{cvs, Cc, LinkerFlavor, PanicStrategy, RelocModel, TargetOptions, TlsModel};
-use crate::spec::LinkSelfContained;
 
 pub fn options() -> TargetOptions {
     macro_rules! args {
@@ -100,7 +100,7 @@ pub fn options() -> TargetOptions {
         // rust-lang/rust#104137: cannot blindly remove this without putting in
         // some other way to compensate for lack of `-nostartfiles` in linker
         // invocation.
-        link_self_contained: LinkSelfContained::True,
+        link_self_contained: LinkSelfContainedDefault::True,
 
         // This has no effect in LLVM 8 or prior, but in LLVM 9 and later when
         // PIC code is implemented this has quite a drastic effect if it stays

--- a/compiler/rustc_target/src/spec/wasm_base.rs
+++ b/compiler/rustc_target/src/spec/wasm_base.rs
@@ -1,5 +1,5 @@
-use super::crt_objects::LinkSelfContainedDefault;
 use super::{cvs, Cc, LinkerFlavor, PanicStrategy, RelocModel, TargetOptions, TlsModel};
+use crate::spec::LinkSelfContained;
 
 pub fn options() -> TargetOptions {
     macro_rules! args {
@@ -100,7 +100,7 @@ pub fn options() -> TargetOptions {
         // rust-lang/rust#104137: cannot blindly remove this without putting in
         // some other way to compensate for lack of `-nostartfiles` in linker
         // invocation.
-        link_self_contained: LinkSelfContainedDefault::True,
+        link_self_contained: LinkSelfContained::True,
 
         // This has no effect in LLVM 8 or prior, but in LLVM 9 and later when
         // PIC code is implemented this has quite a drastic effect if it stays

--- a/compiler/rustc_target/src/spec/windows_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/windows_gnu_base.rs
@@ -1,4 +1,5 @@
-use crate::spec::crt_objects::{self, LinkSelfContainedDefault};
+use crate::spec::crt_objects;
+use crate::spec::LinkSelfContained;
 use crate::spec::{cvs, Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions};
 use std::borrow::Cow;
 
@@ -90,7 +91,7 @@ pub fn opts() -> TargetOptions {
         post_link_objects: crt_objects::post_mingw(),
         pre_link_objects_self_contained: crt_objects::pre_mingw_self_contained(),
         post_link_objects_self_contained: crt_objects::post_mingw_self_contained(),
-        link_self_contained: LinkSelfContainedDefault::Mingw,
+        link_self_contained: LinkSelfContained::InferredForMingw,
         late_link_args,
         late_link_args_dynamic,
         late_link_args_static,

--- a/compiler/rustc_target/src/spec/windows_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/windows_gnu_base.rs
@@ -1,5 +1,5 @@
 use crate::spec::crt_objects;
-use crate::spec::LinkSelfContained;
+use crate::spec::LinkSelfContainedDefault;
 use crate::spec::{cvs, Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions};
 use std::borrow::Cow;
 
@@ -91,7 +91,7 @@ pub fn opts() -> TargetOptions {
         post_link_objects: crt_objects::post_mingw(),
         pre_link_objects_self_contained: crt_objects::pre_mingw_self_contained(),
         post_link_objects_self_contained: crt_objects::post_mingw_self_contained(),
-        link_self_contained: LinkSelfContained::InferredForMingw,
+        link_self_contained: LinkSelfContainedDefault::InferredForMingw,
         late_link_args,
         late_link_args_dynamic,
         late_link_args_static,

--- a/tests/run-make/rust-lld-custom-target/Makefile
+++ b/tests/run-make/rust-lld-custom-target/Makefile
@@ -1,0 +1,7 @@
+include ../tools.mk
+
+# needs-rust-lld
+# only-x86_64-unknown-linux-gnu
+all:
+	RUSTC_LOG=rustc_codegen_ssa::back::link=info $(RUSTC) --crate-type cdylib --target custom-target.json -Clink-args=-Wl,-v lib.rs 2> $(TMPDIR)/output.txt
+	$(CGREP) -e "^LLD [0-9]+\.[0-9]+\.[0-9]+" < $(TMPDIR)/output.txt

--- a/tests/run-make/rust-lld-custom-target/custom-target.json
+++ b/tests/run-make/rust-lld-custom-target/custom-target.json
@@ -1,0 +1,57 @@
+{
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "dynamic-linking": true,
+  "env": "gnu",
+  "has-rpath": true,
+  "has-thread-local": true,
+  "link-self-contained": {
+    "components": [
+      "linker"
+    ]
+  },
+  "linker-flavor": "gnu-lld-cc",
+  "llvm-target": "x86_64-unknown-linux-gnu",
+  "max-atomic-width": 64,
+  "os": "linux",
+  "plt-by-default": false,
+  "position-independent-executables": true,
+  "pre-link-args": {
+    "gnu-cc": [
+      "-m64"
+    ],
+    "gnu-lld-cc": [
+      "-m64"
+    ]
+  },
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline-or-call",
+    "min-llvm-version-for-inline": [
+      16,
+      0,
+      0
+    ]
+  },
+  "static-position-independent-executables": true,
+  "supported-sanitizers": [
+    "address",
+    "cfi",
+    "leak",
+    "memory",
+    "thread",
+    "safestack"
+  ],
+  "supported-split-debuginfo": [
+    "packed",
+    "unpacked",
+    "off"
+  ],
+  "supports-xray": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-pointer-width": "64"
+}

--- a/tests/run-make/rust-lld-custom-target/lib.rs
+++ b/tests/run-make/rust-lld-custom-target/lib.rs
@@ -1,0 +1,9 @@
+// Test linking using `cc` with `rust-lld`, using a custom target with features described in MCP 510
+// see https://github.com/rust-lang/compiler-team/issues/510 for more info:
+//
+// Starting from the `x86_64-unknown-linux-gnu` target spec, we add the following options:
+// - a linker-flavor using lld via a C compiler
+// - the self-contained linker component is enabled
+
+#![feature(no_core)]
+#![no_core]


### PR DESCRIPTION
This PR allows:
- target specs to use an LLD linker-flavor: this is needed to switch `x86_64-unknown-linux-gnu` to using LLD, and is currently not possible because the current flavor json serialization fails to roundtrip on the modern linker-flavors. This can e.g. be seen in https://github.com/rust-lang/rust/pull/115622#discussion_r1321312880 which explains where an `Lld::Yes` is ultimately deserialized into an `Lld::No`.
- target specs to declare self-contained linking components: this is needed to switch `x86_64-unknown-linux-gnu` to using `rust-lld`
- adds an end-to-end test of a custom target json simulating `x86_64-unknown-linux-gnu` being switched to using `rust-lld`
- disables codegen backends from participating because they don't support `-Zgcc-ld=lld` which is the basis of mcp510.

r? @petrochenkov: if the approach discussed https://github.com/rust-lang/rust/pull/115622#discussion_r1329403467 and on zulip would work for you: basically, see if we can emit only modern linker flavors in the json specs, but accept both old and new flavors while reading them, to fix the roundtrip issue.

The backwards compatible `LinkSelfContainedDefault` variants are still serialized and deserialized in `crt-objects-fallback`, while the spec equivalent of e.g. `-Clink-self-contained=+linker` is serialized into a different json object (with future-proofing to incorporate `crt-objects-fallback`  in the future).

---

I've been test-driving this in https://github.com/rust-lang/rust/pull/113382 to test actually switching `x86_64-unknown-linux-gnu`  to `rust-lld` (and fix what needs to be fixed in CI, bootstrap, etc), and it seems to work fine.