### PR TITLE
Consider alias bounds when computing liveness in NLL (and opaque captures)

### DIFF
--- a/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
+++ b/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
@@ -1,0 +1,163 @@
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitor};
+
+use std::ops::ControlFlow;
+
+use crate::infer::outlives::test_type_match;
+use crate::infer::region_constraints::VerifyIfEq;
+
+/// Visits free regions in the type that are relevant for liveness computation.
+/// These regions are passed to `OP`.
+///
+/// Specifically, we visit all of the regions of types recursively, except:
+///
+/// 1. If the type is an alias, we look at the outlives bounds in the param-env
+/// and alias's item bounds. If there is a unique outlives bound, then visit
+/// that instead. If there is not a unique but there is a `'static` outlives
+/// bound, then don't visit anything. Otherwise, walk through the opaque's
+/// regions structurally.
+///
+/// 2. If the type is a closure, only walk through the signature of the closure
+/// and the upvars. Similarly, if the type is a generator, walk through the
+/// three "signature" types (yield/resume/return) and its upvars. All generator
+/// interior regions are bound regions, so ther is no need to walk through
+/// that type.
+///
+/// # How does this differ from other region visitors?
+///
+/// We cannot use `push_outlives_components` because regions in closure
+/// signatures are not included in their outlives components. We need to
+/// ensure all regions outlive the given bound so that we don't end up with,
+/// say, `ReVar` appearing in a return type and causing ICEs when other
+/// functions end up with region constraints involving regions from other
+/// functions.
+///
+/// We also cannot use `for_each_free_region` because for closures it includes
+/// the regions parameters from the enclosing item, which we know are always
+/// universal, so we don't particularly care about since they're not relevant
+/// for opaque type captures or computing liveness.
+pub struct FreeRegionsVisitor<'tcx, OP: FnMut(ty::Region<'tcx>)> {
+    pub tcx: TyCtxt<'tcx>,
+    pub param_env: ty::ParamEnv<'tcx>,
+    pub op: OP,
+}
+
+impl<'tcx, OP> TypeVisitor<TyCtxt<'tcx>> for FreeRegionsVisitor<'tcx, OP>
+where
+    OP: FnMut(ty::Region<'tcx>),
+{
+    fn visit_binder<T: TypeVisitable<TyCtxt<'tcx>>>(
+        &mut self,
+        t: &ty::Binder<'tcx, T>,
+    ) -> ControlFlow<Self::BreakTy> {
+        t.super_visit_with(self);
+        ControlFlow::Continue(())
+    }
+
+    fn visit_region(&mut self, r: ty::Region<'tcx>) -> ControlFlow<Self::BreakTy> {
+        match *r {
+            // ignore bound regions, keep visiting
+            ty::ReLateBound(_, _) => ControlFlow::Continue(()),
+            _ => {
+                (self.op)(r);
+                ControlFlow::Continue(())
+            }
+        }
+    }
+
+    fn visit_ty(&mut self, ty: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
+        // We're only interested in types involving regions
+        if !ty.flags().intersects(ty::TypeFlags::HAS_FREE_REGIONS) {
+            return ControlFlow::Continue(());
+        }
+
+        match ty.kind() {
+            ty::Closure(_, ref args) => {
+                // Skip lifetime parameters of the enclosing item(s)
+
+                for upvar in args.as_closure().upvar_tys() {
+                    upvar.visit_with(self);
+                }
+                args.as_closure().sig_as_fn_ptr_ty().visit_with(self);
+            }
+
+            ty::Generator(_, ref args, _) => {
+                // Skip lifetime parameters of the enclosing item(s)
+                // Also skip the witness type, because that has no free regions.
+
+                for upvar in args.as_generator().upvar_tys() {
+                    upvar.visit_with(self);
+                }
+                args.as_generator().return_ty().visit_with(self);
+                args.as_generator().yield_ty().visit_with(self);
+                args.as_generator().resume_ty().visit_with(self);
+            }
+
+            // We can prove that an alias is live two ways:
+            // 1. All the components are live.
+            //
+            // 2. There is a known outlives bound or where-clause, and that
+            //    region is live.
+            //
+            // We search through the item bounds and where clauses for
+            // either `'static` or a unique outlives region, and if one is
+            // found, we just need to prove that that region is still live.
+            // If one is not found, then we continue to walk through the alias.
+            ty::Alias(kind, ty::AliasTy { def_id, args, .. }) => {
+                let tcx = self.tcx;
+                let param_env = self.param_env;
+                let outlives_bounds: Vec<_> = tcx
+                    .item_bounds(def_id)
+                    .iter_instantiated(tcx, args)
+                    .chain(param_env.caller_bounds())
+                    .filter_map(|clause| {
+                        let outlives = clause.as_type_outlives_clause()?;
+                        if let Some(outlives) = outlives.no_bound_vars()
+                            && outlives.0 == ty
+                        {
+                            Some(outlives.1)
+                        } else {
+                            test_type_match::extract_verify_if_eq(
+                                tcx,
+                                param_env,
+                                &outlives.map_bound(|ty::OutlivesPredicate(ty, bound)| {
+                                    VerifyIfEq { ty, bound }
+                                }),
+                                ty,
+                            )
+                        }
+                    })
+                    .collect();
+                // If we find `'static`, then we know the alias doesn't capture *any* regions.
+                // Otherwise, all of the outlives regions should be equal -- if they're not,
+                // we don't really know how to proceed, so we continue recursing through the
+                // alias.
+                if outlives_bounds.contains(&tcx.lifetimes.re_static) {
+                    // no
+                } else if let Some(r) = outlives_bounds.first()
+                    && outlives_bounds[1..].iter().all(|other_r| other_r == r)
+                {
+                    assert!(r.type_flags().intersects(ty::TypeFlags::HAS_FREE_REGIONS));
+                    r.visit_with(self)?;
+                } else {
+                    // Skip lifetime parameters that are not captures.
+                    let variances = match kind {
+                        ty::Opaque => Some(self.tcx.variances_of(*def_id)),
+                        _ => None,
+                    };
+
+                    for (idx, s) in args.iter().enumerate() {
+                        if variances.map(|variances| variances[idx]) != Some(ty::Variance::Bivariant) {
+                            s.visit_with(self)?;
+                        }
+                    }
+                }
+            }
+
+            _ => {
+                ty.super_visit_with(self)?;
+            }
+        }
+
+        ControlFlow::Continue(())
+    }
+}

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -9,6 +9,7 @@ use rustc_middle::ty;
 
 pub mod components;
 pub mod env;
+pub mod for_liveness;
 pub mod obligations;
 pub mod test_type_match;
 pub mod verify;

--- a/tests/ui/borrowck/alias-liveness/gat-static.rs
+++ b/tests/ui/borrowck/alias-liveness/gat-static.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+trait Foo {
+    type Assoc<'a>
+    where
+        Self: 'a;
+
+    fn assoc(&mut self) -> Self::Assoc<'_>;
+}
+
+fn test<T>(mut t: T)
+where
+    T: Foo,
+    for<'a> T::Assoc<'a>: 'static,
+{
+    let a = t.assoc();
+    let b = t.assoc();
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/higher-ranked.rs
+++ b/tests/ui/borrowck/alias-liveness/higher-ranked.rs
@@ -1,0 +1,16 @@
+// check-pass
+
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+trait Outlives<'a>: 'a {}
+impl<'a, T: 'a> Outlives<'a> for T {}
+
+// Test that we treat `for<'a> Opaque: 'a` as `Opaque: 'static`
+fn test<'o>(v: &'o Vec<i32>) -> impl Captures<'o> + for<'a> Outlives<'a> {}
+
+fn statik() -> impl Sized {
+    test(&vec![])
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/opaque-capture.rs
+++ b/tests/ui/borrowck/alias-liveness/opaque-capture.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+fn captures_temp_early<'a>(x: &'a Vec<i32>) -> impl Sized + Captures<'a> + 'static {}
+fn captures_temp_late<'a: 'a>(x: &'a Vec<i32>) -> impl Sized + Captures<'a> + 'static {}
+
+fn test() {
+    let x = captures_temp_early(&vec![]);
+    let y = captures_temp_late(&vec![]);
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/opaque-type-param.rs
+++ b/tests/ui/borrowck/alias-liveness/opaque-type-param.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+trait Trait {}
+impl Trait for () {}
+
+fn foo<'a>(s: &'a str) -> impl Trait + 'static {
+    bar(s)
+}
+
+fn bar<P: AsRef<str>>(s: P) -> impl Trait + 'static {
+    ()
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/rpit-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rpit-static.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+fn foo(x: &i32) -> impl Sized + Captures<'_> + 'static {}
+
+fn main() {
+    let y;
+    {
+        let x = 1;
+        y = foo(&x);
+    }
+}

--- a/tests/ui/borrowck/alias-liveness/rpitit-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rpitit-static.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Foo {
+    fn rpitit(&mut self) -> impl Sized + 'static;
+}
+
+fn test<T: Foo>(mut t: T) {
+    let a = t.rpitit();
+    let b = t.rpitit();
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/rtn-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rtn-static.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+#![feature(return_position_impl_trait_in_trait, return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Foo {
+    fn borrow(&mut self) -> impl Sized + '_;
+}
+
+// Test that the `'_` item bound in `borrow` does not cause us to
+// overlook the `'static` RTN bound.
+fn test<T: Foo<borrow(): 'static>>(mut t: T) {
+    let x = t.borrow();
+    let x = t.borrow();
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/rtn-static.stderr
+++ b/tests/ui/borrowck/alias-liveness/rtn-static.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/rtn-static.rs:3:49
+   |
+LL | #![feature(return_position_impl_trait_in_trait, return_type_notation)]
+   |                                                 ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
# Background

Right now, liveness analysis in NLL is a bit simplistic. It simply walks through all of the regions of a type and marks them as being live at points. This is problematic in the case of aliases, since it requires that we mark **all** of the regions in their args[^1] as live, leading to bugs like #42940.

In reality, we may be able to deduce that fewer regions are allowed to be present in the projected type (or "hidden type" for opaques) via item bounds or where clauses, and therefore ideally, we should be able to soundly require fewer regions to be live in the alias.

For example:
```rust
trait Captures<'a> {}
impl<T> Captures<'_> for T {}

fn capture<'o>(_: &'o mut ()) -> impl Sized + Captures<'o> + 'static {}

fn test_two_mut(mut x: ()) {
    let _f1 = capture(&mut x);
    let _f2 = capture(&mut x);
    //~^ ERROR cannot borrow `x` as mutable more than once at a time
}
```

In the example above, we should be able to deduce from the `'static` bound on `capture`'s opaque that even though `'o` is a captured region, it *can never* show up in the opaque's hidden type, and can soundly be ignored for liveness purposes.

# The Fix

We apply a simple version of RFC 1214's `OutlivesProjectionEnv` and `OutlivesProjectionTraitDef` rules to NLL's `make_all_regions_live` computation.

Specifically, when we encounter an alias type, we:
1. Look for a unique outlives bound in the param-env or item bounds for that alias. If there is more than one unique region, bail, unless any of the outlives bound's regions is `'static`, and in that case, prefer `'static`. If we find such a unique region, we can mark that outlives region as live and skip walking through the args of the opaque.
2. Otherwise, walk through the alias's args recursively, as we do today.

## Additionally: Opaque Hidden Types

A similar bug comes about when walking through the hidden type of an opaque to validate it doesn't capture lifetimes that aren't part of that opaque. For example:

```rust
trait Captures<'a> {}
impl<T> Captures<'_> for T {}

fn a() -> impl Sized + 'static {
    b(&vec![])
}

fn b<'o>(_: &'o Vec<i32>) -> impl Sized + Captures<'o> + 'static {}
```

The hidden type of `a::{opaque}` is inferred to be `b::<'?1>::{opaque}`, where `'?1` is a region local to the body of `a`. However, the `'static` bound on `b`'s opaque should allow us to deduce that the hidden type will never mention that region `'?1`, and we can ignore it (and replace it with `ReErased` in `b`'s opaque's hidden type). Similarly to liveness, we don't currently do anything other than recurse through aliases for their lifetime components.

This PR ends up using the same region visitor as liveness for opaque type region captures.

## Limitations

This approach has some limitations. Specifically, since liveness doesn't use the same type-test logic as outlives bounds do, we can't really try several options when we're faced with a choice.

If we encounter two unique outlives regions in the param-env or bounds, we simply fall back to walking the opaque via its args. I expect this to be mostly mitigated by the special treatment of `'static`, and can be fixed in a forwards-compatible by a more sophisticated analysis in the future.

## Read more

Context: https://github.com/rust-lang/rust/issues/42940#issuecomment-455198309
More context: https://github.com/rust-lang/rust/pull/115822#issuecomment-1731153952

Fixes #42940

[^1]: except for bivariant region args in opaques, which will become less relevant when we move onto edition 2024 capture semantics for opaques.