### PR TITLE
Add note to `is_known_rigid`

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2946,6 +2946,11 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
+    /// Returns `true` when the outermost type cannot be further normalized,
+    /// resolved, or substituted. This includes all primitive types, but also
+    /// things like ADTs and trait objects, sice even if their arguments or
+    /// nested types may be further simplified, the outermost [`TyKind`] or
+    /// type constructor remains the same.
     pub fn is_known_rigid(self) -> bool {
         match self.kind() {
             Bool


### PR DESCRIPTION
Adds a note requested by @RalfJung in https://github.com/rust-lang/rust/pull/114941#discussion_r1329963704

Let me know if there are any other fns that need documentation, I could throw them into this PR too :)