### PR TITLE
[beta] backports

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/17.0-2023-07-29
+	branch = rustc/17.0-2023-09-19
 	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -7,7 +7,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(lazy_cell)]
 #![feature(decl_macro)]
-#![feature(ice_to_disk)]
+#![feature(panic_update_hook)]
 #![feature(let_chains)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
@@ -50,9 +50,9 @@ use std::collections::BTreeMap;
 use std::env;
 use std::ffi::OsString;
 use std::fmt::Write as _;
-use std::fs;
+use std::fs::{self, File};
 use std::io::{self, IsTerminal, Read, Write};
-use std::panic::{self, catch_unwind};
+use std::panic::{self, catch_unwind, PanicInfo};
 use std::path::PathBuf;
 use std::process::{self, Command, Stdio};
 use std::str;
@@ -1363,31 +1363,42 @@ pub fn install_ice_hook(bug_report_url: &'static str, extra_info: fn(&Handler)) 
         std::env::set_var("RUST_BACKTRACE", "full");
     }
 
-    panic::set_hook(Box::new(move |info| {
-        // If the error was caused by a broken pipe then this is not a bug.
-        // Write the error and return immediately. See #98700.
-        #[cfg(windows)]
-        if let Some(msg) = info.payload().downcast_ref::<String>() {
-            if msg.starts_with("failed printing to stdout: ") && msg.ends_with("(os error 232)") {
-                // the error code is already going to be reported when the panic unwinds up the stack
-                let handler = EarlyErrorHandler::new(ErrorOutputType::default());
-                let _ = handler.early_error_no_abort(msg.clone());
-                return;
+    panic::update_hook(Box::new(
+        move |default_hook: &(dyn Fn(&PanicInfo<'_>) + Send + Sync + 'static),
+              info: &PanicInfo<'_>| {
+            // If the error was caused by a broken pipe then this is not a bug.
+            // Write the error and return immediately. See #98700.
+            #[cfg(windows)]
+            if let Some(msg) = info.payload().downcast_ref::<String>() {
+                if msg.starts_with("failed printing to stdout: ") && msg.ends_with("(os error 232)")
+                {
+                    // the error code is already going to be reported when the panic unwinds up the stack
+                    let handler = EarlyErrorHandler::new(ErrorOutputType::default());
+                    let _ = handler.early_error_no_abort(msg.clone());
+                    return;
+                }
+            };
+
+            // Invoke the default handler, which prints the actual panic message and optionally a backtrace
+            // Don't do this for delayed bugs, which already emit their own more useful backtrace.
+            if !info.payload().is::<rustc_errors::DelayedBugPanic>() {
+                default_hook(info);
+                // Separate the output with an empty line
+                eprintln!();
+
+                if let Some(ice_path) = ice_path()
+                    && let Ok(mut out) =
+                        File::options().create(true).append(true).open(&ice_path)
+                {
+                    let _ =
+                        write!(&mut out, "{info}{:#}", std::backtrace::Backtrace::force_capture());
+                }
             }
-        };
 
-        // Invoke the default handler, which prints the actual panic message and optionally a backtrace
-        // Don't do this for delayed bugs, which already emit their own more useful backtrace.
-        if !info.payload().is::<rustc_errors::DelayedBugPanic>() {
-            std::panic_hook_with_disk_dump(info, ice_path().as_deref());
-
-            // Separate the output with an empty line
-            eprintln!();
-        }
-
-        // Print the ICE message
-        report_ice(info, bug_report_url, extra_info);
-    }));
+            // Print the ICE message
+            report_ice(info, bug_report_url, extra_info);
+        },
+    ));
 }
 
 /// Prints the ICE message, including query stack, but without backtrace.

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -613,9 +613,6 @@ pub mod alloc;
 // Private support modules
 mod panicking;
 
-#[unstable(feature = "ice_to_disk", issue = "none")]
-pub use panicking::panic_hook_with_disk_dump;
-
 #[path = "../../backtrace/src/lib.rs"]
 #[allow(dead_code, unused_attributes, fuzzy_provenance_casts)]
 mod backtrace_rs;

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -236,14 +236,6 @@ where
 
 /// The default panic handler.
 fn default_hook(info: &PanicInfo<'_>) {
-    panic_hook_with_disk_dump(info, None)
-}
-
-#[unstable(feature = "ice_to_disk", issue = "none")]
-/// The implementation of the default panic handler.
-///
-/// It can also write the backtrace to a given `path`. This functionality is used only by `rustc`.
-pub fn panic_hook_with_disk_dump(info: &PanicInfo<'_>, path: Option<&crate::path::Path>) {
     // If this is a double panic, make sure that we print a backtrace
     // for this panic. Otherwise only print it if logging is enabled.
     let backtrace = if panic_count::get_count() >= 2 {
@@ -265,7 +257,7 @@ pub fn panic_hook_with_disk_dump(info: &PanicInfo<'_>, path: Option<&crate::path
     let thread = thread_info::current_thread();
     let name = thread.as_ref().and_then(|t| t.name()).unwrap_or("<unnamed>");
 
-    let write = |err: &mut dyn crate::io::Write, backtrace: Option<BacktraceStyle>| {
+    let write = |err: &mut dyn crate::io::Write| {
         let _ = writeln!(err, "thread '{name}' panicked at {location}:\n{msg}");
 
         static FIRST_PANIC: AtomicBool = AtomicBool::new(true);
@@ -279,19 +271,11 @@ pub fn panic_hook_with_disk_dump(info: &PanicInfo<'_>, path: Option<&crate::path
             }
             Some(BacktraceStyle::Off) => {
                 if FIRST_PANIC.swap(false, Ordering::SeqCst) {
-                    if let Some(path) = path {
-                        let _ = writeln!(
-                            err,
-                            "note: a backtrace for this error was stored at `{}`",
-                            path.display(),
-                        );
-                    } else {
-                        let _ = writeln!(
-                            err,
-                            "note: run with `RUST_BACKTRACE=1` environment variable to display a \
+                    let _ = writeln!(
+                        err,
+                        "note: run with `RUST_BACKTRACE=1` environment variable to display a \
                              backtrace"
-                        );
-                    }
+                    );
                 }
             }
             // If backtraces aren't supported, do nothing.
@@ -299,17 +283,11 @@ pub fn panic_hook_with_disk_dump(info: &PanicInfo<'_>, path: Option<&crate::path
         }
     };
 
-    if let Some(path) = path
-        && let Ok(mut out) = crate::fs::File::options().create(true).append(true).open(&path)
-    {
-        write(&mut out, BacktraceStyle::full());
-    }
-
     if let Some(local) = set_output_capture(None) {
-        write(&mut *local.lock().unwrap_or_else(|e| e.into_inner()), backtrace);
+        write(&mut *local.lock().unwrap_or_else(|e| e.into_inner()));
         set_output_capture(Some(local));
     } else if let Some(mut out) = panic_output() {
-        write(&mut out, backtrace);
+        write(&mut out);
     }
 }
 

--- a/library/std/src/sys/wasi/thread.rs
+++ b/library/std/src/sys/wasi/thread.rs
@@ -54,6 +54,13 @@ cfg_if::cfg_if! {
         pub struct Thread {
             id: libc::pthread_t,
         }
+
+        impl Drop for Thread {
+            fn drop(&mut self) {
+                let ret = unsafe { libc::pthread_detach(self.id) };
+                debug_assert_eq!(ret, 0);
+            }
+        }
     } else {
         pub struct Thread(!);
     }
@@ -174,17 +181,6 @@ impl Thread {
                 }
             } else {
                 self.0
-            }
-        }
-    }
-}
-
-cfg_if::cfg_if! {
-    if #[cfg(target_feature = "atomics")] {
-        impl Drop for Thread {
-            fn drop(&mut self) {
-                let ret = unsafe { libc::pthread_detach(self.id) };
-                debug_assert_eq!(ret, 0);
             }
         }
     }

--- a/library/std/src/sys/wasi/thread.rs
+++ b/library/std/src/sys/wasi/thread.rs
@@ -47,6 +47,7 @@ cfg_if::cfg_if! {
                     stack_size: libc::size_t,
                 ) -> ffi::c_int;
                 pub fn pthread_attr_destroy(attr: *mut pthread_attr_t) -> ffi::c_int;
+                pub fn pthread_detach(thread: pthread_t) -> ffi::c_int;
             }
         }
 
@@ -173,6 +174,17 @@ impl Thread {
                 }
             } else {
                 self.0
+            }
+        }
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_feature = "atomics")] {
+        impl Drop for Thread {
+            fn drop(&mut self) {
+                let ret = unsafe { libc::pthread_detach(self.id) };
+                debug_assert_eq!(ret, 0);
             }
         }
     }

--- a/src/ci/docker/host-x86_64/dist-various-2/build-wasi-threads-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-wasi-threads-toolchain.sh
@@ -10,7 +10,7 @@ bin="$PWD/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04/bin"
 git clone https://github.com/WebAssembly/wasi-libc
 
 cd wasi-libc
-git reset --hard 7018e24d8fe248596819d2e884761676f3542a04
+git reset --hard ec4566beae84e54952637f0bf61bee4b4cacc087
 make -j$(nproc) \
     CC="$bin/clang" \
     NM="$bin/llvm-nm" \

--- a/src/ci/docker/host-x86_64/dist-various-2/build-wasi-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-wasi-toolchain.sh
@@ -10,7 +10,7 @@ bin="$PWD/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04/bin"
 git clone https://github.com/WebAssembly/wasi-libc
 
 cd wasi-libc
-git reset --hard 7018e24d8fe248596819d2e884761676f3542a04
+git reset --hard ec4566beae84e54952637f0bf61bee4b4cacc087
 make -j$(nproc) \
     CC="$bin/clang" \
     NM="$bin/llvm-nm" \

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -180,6 +180,7 @@ target | std | notes
 `wasm32-unknown-emscripten` | ✓ | WebAssembly via Emscripten
 `wasm32-unknown-unknown` | ✓ | WebAssembly
 `wasm32-wasi` | ✓ | WebAssembly with WASI
+[`wasm32-wasi-preview1-threads`](platform-support/wasm32-wasi-preview1-threads.md) | ✓ | WebAssembly with WASI Preview 1 and threads
 `x86_64-apple-ios` | ✓ | 64-bit x86 iOS
 [`x86_64-fortanix-unknown-sgx`](platform-support/x86_64-fortanix-unknown-sgx.md) | ✓ | [Fortanix ABI] for 64-bit Intel SGX
 `x86_64-fuchsia` | ✓ | Alias for `x86_64-unknown-fuchsia`
@@ -321,7 +322,6 @@ target | std | host | notes
 `thumbv7a-pc-windows-msvc` | ? |  |
 `thumbv7a-uwp-windows-msvc` | ✓ |  |
 `thumbv7neon-unknown-linux-musleabihf` | ? |  | Thumb2-mode ARMv7-A Linux with NEON, MUSL
-[`wasm32-wasi-preview1-threads`](platform-support/wasm32-wasi-preview1-threads.md) | ✓ | WebAssembly with WASI Preview 1 and threads
 [`wasm64-unknown-unknown`](platform-support/wasm64-unknown-unknown.md) | ? |  | WebAssembly
 `x86_64-apple-ios-macabi` | ✓ |  | Apple Catalyst on x86_64
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ? | | x86 64-bit tvOS

--- a/src/doc/rustc/src/platform-support/wasm32-wasi-preview1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasi-preview1-threads.md
@@ -1,6 +1,6 @@
 # `wasm32-wasi-preview1-threads`
 
-**Tier: 3**
+**Tier: 2**
 
 The `wasm32-wasi-preview1-threads` target is a new and still (as of July 2023) an
 experimental target. This target is an extension to `wasm32-wasi-preview1` target,
@@ -70,12 +70,6 @@ compile `wasm32-wasi-preview1-threads` binaries straight out of the box. You can
 reliably interoperate with C code in this mode (yet).
 
 
-This target is not a stable target. This means that there are not many engines
-which implement the `wasi-threads` feature and if they do they're likely behind a
-flag, for example:
-
-* Wasmtime - `--wasm-features=threads --wasi-modules=experimental-wasi-threads`
-
 Also note that at this time the `wasm32-wasi-preview1-threads` target assumes the
 presence of other merged wasm proposals such as (with their LLVM feature flags):
 
@@ -94,6 +88,17 @@ The target intends to match the corresponding Clang target for its `"C"` ABI.
 > found it's recommended to open an issue either with rust-lang/rust or ideally
 > with LLVM itself.
 
+## Platform requirements
+
+The runtime should support the same set of APIs as any other supported wasi target for interacting with the host environment through the WASI standard. The runtime also should have implemetation of [wasi-threads proposal](https://github.com/WebAssembly/wasi-threads).
+
+This target is not a stable target. This means that there are a few engines
+which implement the `wasi-threads` feature and if they do they're likely behind a
+flag, for example:
+
+* Wasmtime - `--wasm-features=threads --wasi-modules=experimental-wasi-threads`
+* [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) - needs to be built with WAMR_BUILD_LIB_WASI_THREADS=1
+
 ## Building the target
 
 Users need to install or built wasi-sdk since release 20.0
@@ -110,12 +115,16 @@ After that users can build this by adding it to the `target` list in
 
 ## Building Rust programs
 
-Since it is Tier 3, rust doesn't ship pre-compiled artifacts for this target.
+From Rust Nightly 1.71.1 (2023-08-03) on the artifacts are shipped pre-compiled:
 
-Specify `wasi-root` as explained in the previous section and then use the `build-std`
-nightly cargo feature to build the standard library:
-```shell
-cargo +nightly build --target=wasm32-wasi-preview1-threads -Zbuild-std
+```text
+rustup target add wasm32-wasi-preview1-threads --toolchain nightly
+```
+
+Rust programs can be built for that target:
+
+```text
+rustc --target wasm32-wasi-preview1-threads your-code.rs
 ```
 
 ## Cross-compilation

--- a/tests/run-make/dump-ice-to-disk/check.sh
+++ b/tests/run-make/dump-ice-to-disk/check.sh
@@ -22,8 +22,8 @@ rm $TMPDIR/rustc-ice-*.txt
 # Explicitly disabling ICE dump
 export RUSTC_ICE=0
 $RUSTC src/lib.rs -Z treat-err-as-bug=1 1>$TMPDIR/rust-test-disabled.log 2>&1
-should_be_empty_tmp=$(ls -l $TMPDIR/rustc-ice-*.txt | wc -l)
-should_be_empty_dot=$(ls -l ./rustc-ice-*.txt | wc -l)
+should_be_empty_tmp=$(ls -l $TMPDIR/rustc-ice-*.txt 2>/dev/null | wc -l)
+should_be_empty_dot=$(ls -l ./rustc-ice-*.txt 2>/dev/null | wc -l)
 
 echo "#### ICE Dump content:"
 echo $content

--- a/tests/ui/impl-trait/lifetime-ambiguity-regression.rs
+++ b/tests/ui/impl-trait/lifetime-ambiguity-regression.rs
@@ -1,0 +1,13 @@
+//! This test shows a situation where through subtle compiler changes we can
+//! suddenly infer a different lifetime in the hidden type, and thus not meet
+//! the opaque type bounds anymore. In this case `'a` and `'b` are equal, so
+//! picking either is fine, but then we'll fail an identity check of the hidden
+//! type and the expected hidden type.
+
+// check-pass
+
+fn test<'a: 'b, 'b: 'a>() -> impl IntoIterator<Item = (&'a u8, impl Into<(&'b u8, &'a u8)>)> {
+    None::<(_, (_, _))>
+}
+
+fn main() {}

--- a/tests/ui/match/issue-115681.rs
+++ b/tests/ui/match/issue-115681.rs
@@ -1,0 +1,32 @@
+// run-pass
+// compile-flags: -C opt-level=1
+
+// Make sure LLVM does not miscompile this match.
+fn main() {
+    enum Bits {
+        None = 0x00,
+        Low = 0x40,
+        High = 0x80,
+        Both = 0xC0,
+    }
+
+    let value = Box::new(0x40u8);
+    let mut out = Box::new(0u8);
+
+    let bits = match *value {
+        0x00 => Bits::None,
+        0x40 => Bits::Low,
+        0x80 => Bits::High,
+        0xC0 => Bits::Both,
+        _ => return,
+    };
+
+    match bits {
+        Bits::None | Bits::Low => {
+            *out = 1;
+        }
+        _ => (),
+    }
+
+    assert_eq!(*out, 1);
+}

--- a/tests/ui/type-alias-impl-trait/nested-tait-hrtb.rs
+++ b/tests/ui/type-alias-impl-trait/nested-tait-hrtb.rs
@@ -8,7 +8,7 @@ fn without_lt() -> impl for<'a> Trait<'a, Assoc = WithoutLt> {}
 //~^ ERROR captures lifetime that does not appear in bounds
 
 type WithLt<'a> = impl Sized + 'a;
-//~^ ERROR concrete type differs from previous defining opaque type use
+
 fn with_lt() -> impl for<'a> Trait<'a, Assoc = WithLt<'a>> {}
 //~^ ERROR expected generic lifetime parameter, found `'a`
 

--- a/tests/ui/type-alias-impl-trait/nested-tait-hrtb.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-hrtb.stderr
@@ -17,19 +17,7 @@ LL |
 LL | fn with_lt() -> impl for<'a> Trait<'a, Assoc = WithLt<'a>> {}
    |                                                            ^^
 
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/nested-tait-hrtb.rs:10:19
-   |
-LL | type WithLt<'a> = impl Sized + 'a;
-   |                   ^^^^^^^^^^^^^^^ expected `&'a str`, got `{type error}`
-   |
-note: previous use here
-  --> $DIR/nested-tait-hrtb.rs:12:17
-   |
-LL | fn with_lt() -> impl for<'a> Trait<'a, Assoc = WithLt<'a>> {}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0700, E0792.
 For more information about an error, try `rustc --explain E0700`.


### PR DESCRIPTION
-  Fix a pthread_t handle leak #114696 
-  MCP661: Move wasm32-wasi-preview1-threads target to Tier 2 #115345 
-  Don't modify libstd to dump rustc ICEs #115627 
-  Paper over an accidental regression #115844 
-  Update to LLVM 17.0.0 #115959 

r? cuviper