### PR TITLE
Add codegen test to guard against VecDeque optimization regression

### DIFF
--- a/tests/codegen/vecdeque-nonempty-get-no-panic.rs
+++ b/tests/codegen/vecdeque-nonempty-get-no-panic.rs
@@ -1,0 +1,17 @@
+// Guards against regression for optimization discussed in issue #80836
+
+// compile-flags: -O
+// ignore-debug: the debug assertions get in the way
+
+#![crate_type = "lib"]
+
+use std::collections::VecDeque;
+
+// CHECK-LABEL: @front
+// CHECK: ret void
+#[no_mangle]
+pub fn front(v: VecDeque<usize>) {
+    if !v.is_empty() {
+        v.get(0).unwrap();
+    }
+}


### PR DESCRIPTION
Very small PR that adds a codegen test to guard against regression for the `VecDeque` optimization addressed in #80836. Ensures that Rustc optimizes away the panic when unwrapping the result of `.get(0)` because of the `!is_empty()` condition.