### PR TITLE
Make unsized casts illegal

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -725,6 +725,9 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                             },
                             // array-ptr-cast
                             Ptr(mt) => {
+                                if !fcx.type_is_sized_modulo_regions(fcx.param_env, mt.ty) {
+                                    return Err(CastError::IllegalCast);
+                                }
                                 self.check_ref_cast(fcx, TypeAndMut { mutbl, ty: inner_ty }, mt)
                             }
                             _ => Err(CastError::NonScalar),
@@ -735,7 +738,6 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             }
             _ => return Err(CastError::NonScalar),
         };
-
         if let ty::Adt(adt_def, _) = *self.expr_ty.kind() {
             if adt_def.did().krate != LOCAL_CRATE {
                 if adt_def.variants().iter().any(VariantDef::is_field_list_non_exhaustive) {
@@ -743,7 +745,6 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 }
             }
         }
-
         match (t_from, t_cast) {
             // These types have invariants! can't cast into them.
             (_, Int(CEnum) | FnPtr) => Err(CastError::NonScalar),

--- a/tests/ui/cast/unsized-struct-cast.rs
+++ b/tests/ui/cast/unsized-struct-cast.rs
@@ -1,0 +1,6 @@
+pub struct Data([u8]);
+
+fn main(){
+    const _: *const Data = &[] as *const Data;
+    //~^ ERROR: casting `&[_; 0]` as `*const Data` is invalid
+}

--- a/tests/ui/cast/unsized-struct-cast.stderr
+++ b/tests/ui/cast/unsized-struct-cast.stderr
@@ -1,0 +1,9 @@
+error[E0606]: casting `&[_; 0]` as `*const Data` is invalid
+  --> $DIR/unsized-struct-cast.rs:4:28
+   |
+LL |     const _: *const Data = &[] as *const Data;
+   |                            ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0606`.


### PR DESCRIPTION
Weirdly enough this https://github.com/rust-lang/rust/issues/115998 issue seems to exist since Rust 1.0 (couldn't check before that) but it's only recently been noticed. This change makes those casts illegal.

Fixes https://github.com/rust-lang/rust/issues/115998