### PR TITLE
Change `start` to `#[start]` in some diagnosis

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0647.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0647.md
@@ -7,7 +7,7 @@ Erroneous code example:
 
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize where (): Copy {
-    //^ error: start function is not allowed to have a where clause
+    //^ error: `#[start]` function is not allowed to have a where clause
     0
 }
 ```

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -270,20 +270,20 @@ hir_analysis_simd_ffi_highly_experimental = use of SIMD type{$snip} in FFI is hi
 hir_analysis_specialization_trait = implementing `rustc_specialization_trait` traits is unstable
     .help = add `#![feature(min_specialization)]` to the crate attributes to enable
 
-hir_analysis_start_function_parameters = start function is not allowed to have type parameters
-    .label = start function cannot have type parameters
+hir_analysis_start_function_parameters = `#[start]` function is not allowed to have type parameters
+    .label = `#[start]` function cannot have type parameters
 
-hir_analysis_start_function_where = start function is not allowed to have a `where` clause
-    .label = start function cannot have a `where` clause
+hir_analysis_start_function_where = `#[start]` function is not allowed to have a `where` clause
+    .label = `#[start]` function cannot have a `where` clause
 
-hir_analysis_start_not_async = `start` is not allowed to be `async`
-    .label = `start` is not allowed to be `async`
+hir_analysis_start_not_async = `#[start]` function is not allowed to be `async`
+    .label = `#[start]` is not allowed to be `async`
 
-hir_analysis_start_not_target_feature = `start` is not allowed to have `#[target_feature]`
-    .label = `start` is not allowed to have `#[target_feature]`
+hir_analysis_start_not_target_feature = `#[start]` function is not allowed to have `#[target_feature]`
+    .label = `#[start]` function is not allowed to have `#[target_feature]`
 
-hir_analysis_start_not_track_caller = `start` is not allowed to be `#[track_caller]`
-    .label = `start` is not allowed to be `#[track_caller]`
+hir_analysis_start_not_track_caller = `#[start]` function is not allowed to be `#[track_caller]`
+    .label = `#[start]` function is not allowed to be `#[track_caller]`
 
 hir_analysis_static_specialize = cannot specialize on `'static` lifetime
 

--- a/tests/ui/async-await/issue-68523-start.rs
+++ b/tests/ui/async-await/issue-68523-start.rs
@@ -4,6 +4,6 @@
 
 #[start]
 pub async fn start(_: isize, _: *const *const u8) -> isize {
-//~^ ERROR `start` is not allowed to be `async`
+//~^ ERROR `#[start]` function is not allowed to be `async`
     0
 }

--- a/tests/ui/async-await/issue-68523-start.stderr
+++ b/tests/ui/async-await/issue-68523-start.stderr
@@ -1,8 +1,8 @@
-error[E0752]: `start` is not allowed to be `async`
+error[E0752]: `#[start]` function is not allowed to be `async`
   --> $DIR/issue-68523-start.rs:6:1
    |
 LL | pub async fn start(_: isize, _: *const *const u8) -> isize {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `start` is not allowed to be `async`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `#[start]` is not allowed to be `async`
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0132.stderr
+++ b/tests/ui/error-codes/E0132.stderr
@@ -1,8 +1,8 @@
-error[E0132]: start function is not allowed to have type parameters
+error[E0132]: `#[start]` function is not allowed to have type parameters
   --> $DIR/E0132.rs:4:5
    |
 LL | fn f< T >() {}
-   |     ^^^^^ start function cannot have type parameters
+   |     ^^^^^ `#[start]` function cannot have type parameters
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0647.stderr
+++ b/tests/ui/error-codes/E0647.stderr
@@ -1,8 +1,8 @@
-error[E0647]: start function is not allowed to have a `where` clause
+error[E0647]: `#[start]` function is not allowed to have a `where` clause
   --> $DIR/E0647.rs:7:50
    |
 LL | fn start(_: isize, _: *const *const u8) -> isize where (): Copy {
-   |                                                  ^^^^^^^^^^^^^^ start function cannot have a `where` clause
+   |                                                  ^^^^^^^^^^^^^^ `#[start]` function cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-50714-1.stderr
+++ b/tests/ui/issues/issue-50714-1.stderr
@@ -1,8 +1,8 @@
-error[E0647]: start function is not allowed to have a `where` clause
+error[E0647]: `#[start]` function is not allowed to have a `where` clause
   --> $DIR/issue-50714-1.rs:9:50
    |
 LL | fn start(_: isize, _: *const *const u8) -> isize where fn(&()): Eq {
-   |                                                  ^^^^^^^^^^^^^^^^^ start function cannot have a `where` clause
+   |                                                  ^^^^^^^^^^^^^^^^^ `#[start]` function cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-start.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-start.rs
@@ -1,7 +1,7 @@
 #![feature(start)]
 
 #[start]
-#[track_caller] //~ ERROR `start` is not allowed to be `#[track_caller]`
+#[track_caller] //~ ERROR `#[start]` function is not allowed to be `#[track_caller]`
 fn start(_argc: isize, _argv: *const *const u8) -> isize {
     panic!("{}: oh no", std::panic::Location::caller());
 }

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-start.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-start.stderr
@@ -1,10 +1,10 @@
-error: `start` is not allowed to be `#[track_caller]`
+error: `#[start]` function is not allowed to be `#[track_caller]`
   --> $DIR/error-with-start.rs:4:1
    |
 LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 LL | fn start(_argc: isize, _argv: *const *const u8) -> isize {
-   | -------------------------------------------------------- `start` is not allowed to be `#[track_caller]`
+   | -------------------------------------------------------- `#[start]` function is not allowed to be `#[track_caller]`
 
 error: aborting due to previous error
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108645-target-feature-on-start.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108645-target-feature-on-start.rs
@@ -5,5 +5,5 @@
 
 #[start]
 #[target_feature(enable = "avx2")]
-//~^ ERROR `start` is not allowed to have `#[target_feature]`
+//~^ ERROR `#[start]` function is not allowed to have `#[target_feature]`
 fn start(_argc: isize, _argv: *const *const u8) -> isize { 0 }

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108645-target-feature-on-start.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108645-target-feature-on-start.stderr
@@ -1,11 +1,11 @@
-error: `start` is not allowed to have `#[target_feature]`
+error: `#[start]` function is not allowed to have `#[target_feature]`
   --> $DIR/issue-108645-target-feature-on-start.rs:7:1
    |
 LL | #[target_feature(enable = "avx2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | fn start(_argc: isize, _argv: *const *const u8) -> isize { 0 }
-   | -------------------------------------------------------- `start` is not allowed to have `#[target_feature]`
+   | -------------------------------------------------------- `#[start]` function is not allowed to have `#[target_feature]`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
They refer to a function with the `start` attribute, but not necessarily named `start`.