### PR TITLE
Open the FileEncoder file for reading and writing

### DIFF
--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -38,11 +38,16 @@ pub struct FileEncoder {
 
 impl FileEncoder {
     pub fn new<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        // File::create opens the file for writing only. When -Zmeta-stats is enabled, the metadata
+        // encoder rewinds the file to inspect what was written. So we need to always open the file
+        // for reading and writing.
+        let file = File::options().read(true).write(true).create(true).truncate(true).open(path)?;
+
         Ok(FileEncoder {
             buf: vec![0u8; BUF_SIZE].into_boxed_slice().try_into().unwrap(),
             buffered: 0,
             flushed: 0,
-            file: File::create(path)?,
+            file,
             res: Ok(()),
         })
     }

--- a/tests/ui/stats/meta-stats.rs
+++ b/tests/ui/stats/meta-stats.rs
@@ -1,0 +1,7 @@
+// build-pass
+// dont-check-compiler-stderr
+// compile-flags: -Zmeta-stats
+
+#![crate_type = "lib"]
+
+pub fn a() {}


### PR DESCRIPTION
Maybe I just don't know `File` well enough, but the previous comment didn't make it clear enough to me that we can't use `File::create`. This one does.

Fixes https://github.com/rust-lang/rust/issues/116055

r? @WaffleLapkin 