### PR TITLE
Fix debug printing of tuple

### DIFF
--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -564,22 +564,18 @@ impl<I: Interner> DebugWithInfcx<I> for TyKind<I> {
             }
             Never => write!(f, "!"),
             Tuple(t) => {
-                let mut iter = t.clone().into_iter();
-
                 write!(f, "(")?;
-
-                match iter.next() {
-                    None => return write!(f, ")"),
-                    Some(ty) => write!(f, "{:?}", &this.wrap(ty))?,
-                };
-
-                match iter.next() {
-                    None => return write!(f, ",)"),
-                    Some(ty) => write!(f, "{:?})", &this.wrap(ty))?,
+                let mut count = 0;
+                for ty in t.clone() {
+                    if count > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{:?}", &this.wrap(ty))?;
+                    count += 1;
                 }
-
-                for ty in iter {
-                    write!(f, ", {:?}", &this.wrap(ty))?;
+                // unary tuples need a trailing comma
+                if count == 1 {
+                    write!(f, ",")?;
                 }
                 write!(f, ")")
             }


### PR DESCRIPTION
Self-explanatory. Didn't create a UI test, but I guess I could -- not sure where debug output shows up in rustc_attrs to make a sufficient test, tho.