### PR TITLE
Point at cause of expectation of `break` value when possible

### DIFF
--- a/tests/ui/loops/loop-break-value.rs
+++ b/tests/ui/loops/loop-break-value.rs
@@ -95,4 +95,7 @@ fn main() {
         break LOOP;
         //~^ ERROR cannot find value `LOOP` in this scope
     }
+    loop { // point at the return type
+        break 2; //~ ERROR mismatched types
+    }
 }

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -148,12 +148,21 @@ LL |             break 123;
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:16:15
    |
+LL |     let _: i32 = loop {
+   |         -        ---- this loop is expected to be of type `i32`
+   |         |
+   |         expected because of this assignment
 LL |         break "asdf";
    |               ^^^^^^ expected `i32`, found `&str`
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:21:31
    |
+LL |     let _: i32 = 'outer_loop: loop {
+   |         -                     ---- this loop is expected to be of type `i32`
+   |         |
+   |         expected because of this assignment
+LL |         loop {
 LL |             break 'outer_loop "nope";
    |                               ^^^^^^ expected `i32`, found `&str`
 
@@ -187,7 +196,18 @@ LL |         break;
    |         expected integer, found `()`
    |         help: give it a value of the expected type: `break value`
 
-error: aborting due to 17 previous errors; 1 warning emitted
+error[E0308]: mismatched types
+  --> $DIR/loop-break-value.rs:99:15
+   |
+LL | fn main() {
+   |           - expected `()` because of this return type
+...
+LL |     loop { // point at the return type
+   |     ---- this loop is expected to be of type `()`
+LL |         break 2;
+   |               ^ expected `()`, found integer
+
+error: aborting due to 18 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0308, E0425, E0571.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
When encountering a type error within the value of a `break` statement, climb the HIR tree to identify if the expectation comes from an assignment or a return type (if the loop is the tail expression of a `fn`).

Fix #115905.