### PR TITLE
Use placeholders to prevent using inferred RPITIT types to imply their own well-formedness

### DIFF
--- a/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf-via-param.rs
+++ b/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf-via-param.rs
@@ -1,0 +1,26 @@
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Extend {
+    fn extend<'a: 'a>(_: &'a str) -> (impl Sized + 'a, &'static str);
+}
+
+impl Extend for () {
+    fn extend<'a: 'a>(s: &'a str) -> (Option<&'static &'a ()>, &'static str)
+    //~^ ERROR in type `&'static &'a ()`, reference has a longer lifetime than the data it references
+    where
+        'a: 'static,
+    {
+        (None, s)
+    }
+}
+
+// This indirection is not necessary for reproduction,
+// but it makes this test future-proof against #114936.
+fn extend<T: Extend>(s: &str) -> &'static str {
+    <T as Extend>::extend(s).1
+}
+
+fn main() {
+    let use_after_free = extend::<()>(&String::from("temporary"));
+    println!("{}", use_after_free);
+}

--- a/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf-via-param.stderr
+++ b/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf-via-param.stderr
@@ -1,0 +1,16 @@
+error[E0491]: in type `&'static &'a ()`, reference has a longer lifetime than the data it references
+  --> $DIR/rpitit-hidden-types-self-implied-wf-via-param.rs:8:38
+   |
+LL |     fn extend<'a: 'a>(s: &'a str) -> (Option<&'static &'a ()>, &'static str)
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the pointer is valid for the static lifetime
+note: but the referenced data is only valid for the lifetime `'a` as defined here
+  --> $DIR/rpitit-hidden-types-self-implied-wf-via-param.rs:8:15
+   |
+LL |     fn extend<'a: 'a>(s: &'a str) -> (Option<&'static &'a ()>, &'static str)
+   |               ^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0491`.

--- a/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf.rs
+++ b/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf.rs
@@ -1,0 +1,23 @@
+#![feature(return_position_impl_trait_in_trait)]
+
+trait Extend {
+    fn extend(_: &str) -> (impl Sized + '_, &'static str);
+}
+
+impl Extend for () {
+    fn extend(s: &str) -> (Option<&'static &'_ ()>, &'static str) {
+        //~^ ERROR in type `&'static &()`, reference has a longer lifetime than the data it references
+        (None, s)
+    }
+}
+
+// This indirection is not necessary for reproduction,
+// but it makes this test future-proof against #114936.
+fn extend<T: Extend>(s: &str) -> &'static str {
+    <T as Extend>::extend(s).1
+}
+
+fn main() {
+    let use_after_free = extend::<()>(&String::from("temporary"));
+    println!("{}", use_after_free);
+}

--- a/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf.stderr
+++ b/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf.stderr
@@ -1,0 +1,16 @@
+error[E0491]: in type `&'static &()`, reference has a longer lifetime than the data it references
+  --> $DIR/rpitit-hidden-types-self-implied-wf.rs:8:27
+   |
+LL |     fn extend(s: &str) -> (Option<&'static &'_ ()>, &'static str) {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the pointer is valid for the static lifetime
+note: but the referenced data is only valid for the anonymous lifetime defined here
+  --> $DIR/rpitit-hidden-types-self-implied-wf.rs:8:18
+   |
+LL |     fn extend(s: &str) -> (Option<&'static &'_ ()>, &'static str) {
+   |                  ^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0491`.


### PR DESCRIPTION
The issue here is that we use the same signature to do RPITIT inference as we do to compute implied bounds. To fix this, when gathering the assumed wf types for the method, we replace all of the infer vars (that will be eventually used to infer RPITIT types) with type placeholders, which imply nothing about lifetime bounds.

This solution kind of sucks, but I'm not certain there's another feasible way to fix this. If anyone has a better solution, I'd be glad to hear it.

My naive first solution was, instead of using placeholders, to replace the signature with the RPITIT projections that it originally started out with. But turns out that we can't just use the unnormalized signature of the trait method in `implied_outlives_bounds` since we normalize during WF computation -- that would cause a query cycle in `collect_return_position_impl_trait_in_trait_tys`.

idk who to request review...
r? @lcnr or @aliemjay i guess.

Fixes #116060