### PR TITLE
Add Zba, Zbb, and Zbs as target features for riscv64-linux-android

### DIFF
--- a/compiler/rustc_target/src/spec/riscv64_linux_android.rs
+++ b/compiler/rustc_target/src/spec/riscv64_linux_android.rs
@@ -9,7 +9,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             code_model: Some(CodeModel::Medium),
             cpu: "generic-rv64".into(),
-            features: "+m,+a,+f,+d,+c".into(),
+            features: "+m,+a,+f,+d,+c,+Zba,+Zbb,+Zbs".into(),
             llvm_abiname: "lp64d".into(),
             supported_sanitizers: SanitizerSet::ADDRESS,
             max_atomic_width: Some(64),


### PR DESCRIPTION
This pull request adds the Zba, Zbb, and Zbs target features to the `riscv64-linux-android` target specification.  These features have been enabled and tested internally in Android infrastructure.