### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0647.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0647.md
@@ -7,7 +7,7 @@ Erroneous code example:
 
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize where (): Copy {
-    //^ error: start function is not allowed to have a where clause
+    //^ error: `#[start]` function is not allowed to have a where clause
     0
 }
 ```

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -270,20 +270,20 @@ hir_analysis_simd_ffi_highly_experimental = use of SIMD type{$snip} in FFI is hi
 hir_analysis_specialization_trait = implementing `rustc_specialization_trait` traits is unstable
     .help = add `#![feature(min_specialization)]` to the crate attributes to enable
 
-hir_analysis_start_function_parameters = start function is not allowed to have type parameters
-    .label = start function cannot have type parameters
+hir_analysis_start_function_parameters = `#[start]` function is not allowed to have type parameters
+    .label = `#[start]` function cannot have type parameters
 
-hir_analysis_start_function_where = start function is not allowed to have a `where` clause
-    .label = start function cannot have a `where` clause
+hir_analysis_start_function_where = `#[start]` function is not allowed to have a `where` clause
+    .label = `#[start]` function cannot have a `where` clause
 
-hir_analysis_start_not_async = `start` is not allowed to be `async`
-    .label = `start` is not allowed to be `async`
+hir_analysis_start_not_async = `#[start]` function is not allowed to be `async`
+    .label = `#[start]` is not allowed to be `async`
 
-hir_analysis_start_not_target_feature = `start` is not allowed to have `#[target_feature]`
-    .label = `start` is not allowed to have `#[target_feature]`
+hir_analysis_start_not_target_feature = `#[start]` function is not allowed to have `#[target_feature]`
+    .label = `#[start]` function is not allowed to have `#[target_feature]`
 
-hir_analysis_start_not_track_caller = `start` is not allowed to be `#[track_caller]`
-    .label = `start` is not allowed to be `#[track_caller]`
+hir_analysis_start_not_track_caller = `#[start]` function is not allowed to be `#[track_caller]`
+    .label = `#[start]` function is not allowed to be `#[track_caller]`
 
 hir_analysis_static_specialize = cannot specialize on `'static` lifetime
 

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -725,6 +725,9 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                             },
                             // array-ptr-cast
                             Ptr(mt) => {
+                                if !fcx.type_is_sized_modulo_regions(fcx.param_env, mt.ty) {
+                                    return Err(CastError::IllegalCast);
+                                }
                                 self.check_ref_cast(fcx, TypeAndMut { mutbl, ty: inner_ty }, mt)
                             }
                             _ => Err(CastError::NonScalar),
@@ -735,7 +738,6 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             }
             _ => return Err(CastError::NonScalar),
         };
-
         if let ty::Adt(adt_def, _) = *self.expr_ty.kind() {
             if adt_def.did().krate != LOCAL_CRATE {
                 if adt_def.variants().iter().any(VariantDef::is_field_list_non_exhaustive) {
@@ -743,7 +745,6 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 }
             }
         }
-
         match (t_from, t_cast) {
             // These types have invariants! can't cast into them.
             (_, Int(CEnum) | FnPtr) => Err(CastError::NonScalar),

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -664,10 +664,12 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
         );
         self.walk_pat(discr_place, arm.pat, arm.guard.is_some());
 
-        if let Some(hir::Guard::If(e)) = arm.guard {
-            self.consume_expr(e)
-        } else if let Some(hir::Guard::IfLet(ref l)) = arm.guard {
-            self.consume_expr(l.init)
+        match arm.guard {
+            Some(hir::Guard::If(ref e)) => self.consume_expr(e),
+            Some(hir::Guard::IfLet(ref l)) => {
+                self.walk_local(l.init, l.pat, None, |t| t.borrow_expr(l.init, ty::ImmBorrow))
+            }
+            None => {}
         }
 
         self.consume_expr(arm.body);

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -208,12 +208,10 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                 }
                 ProjectionElem::Index(_) => match place_ty.kind() {
                     ty::Array(..) => {
-                        if let ProjectionElem::Index(..) = elem {
-                            return Err(MoveError::cannot_move_out_of(
-                                self.loc,
-                                InteriorOfSliceOrArray { ty: place_ty, is_index: true },
-                            ));
-                        }
+                        return Err(MoveError::cannot_move_out_of(
+                            self.loc,
+                            InteriorOfSliceOrArray { ty: place_ty, is_index: true },
+                        ));
                     }
                     ty::Slice(_) => {
                         return Err(MoveError::cannot_move_out_of(

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -127,7 +127,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                     }
                     ty::Adt(adt, _) => {
                         if !adt.is_box() {
-                            bug!("Adt should be a box type");
+                            bug!("Adt should be a box type when Place is deref");
                         }
                     }
                     ty::Bool
@@ -153,7 +153,9 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                     | ty::Bound(_, _)
                     | ty::Infer(_)
                     | ty::Error(_)
-                    | ty::Placeholder(_) => bug!("Place has a wrong type {place_ty:#?}"),
+                    | ty::Placeholder(_) => {
+                        bug!("When Place is Deref it's type shouldn't be {place_ty:#?}")
+                    }
                 },
                 ProjectionElem::Field(_, _) => match place_ty.kind() {
                     ty::Adt(adt, _) if adt.has_dtor(tcx) => {
@@ -190,7 +192,9 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                     | ty::Bound(_, _)
                     | ty::Infer(_)
                     | ty::Error(_)
-                    | ty::Placeholder(_) => bug!("Place has a wrong type {place_ty:#?}"),
+                    | ty::Placeholder(_) => bug!(
+                        "When Place contains ProjectionElem::Field it's type shouldn't be {place_ty:#?}"
+                    ),
                 },
                 ProjectionElem::ConstantIndex { .. } | ProjectionElem::Subslice { .. } => {
                     match place_ty.kind() {

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -38,11 +38,16 @@ pub struct FileEncoder {
 
 impl FileEncoder {
     pub fn new<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        // File::create opens the file for writing only. When -Zmeta-stats is enabled, the metadata
+        // encoder rewinds the file to inspect what was written. So we need to always open the file
+        // for reading and writing.
+        let file = File::options().read(true).write(true).create(true).truncate(true).open(path)?;
+
         Ok(FileEncoder {
             buf: vec![0u8; BUF_SIZE].into_boxed_slice().try_into().unwrap(),
             buffered: 0,
             flushed: 0,
-            file: File::create(path)?,
+            file,
             res: Ok(()),
         })
     }

--- a/tests/ui/async-await/issue-68523-start.rs
+++ b/tests/ui/async-await/issue-68523-start.rs
@@ -4,6 +4,6 @@
 
 #[start]
 pub async fn start(_: isize, _: *const *const u8) -> isize {
-//~^ ERROR `start` is not allowed to be `async`
+//~^ ERROR `#[start]` function is not allowed to be `async`
     0
 }

--- a/tests/ui/async-await/issue-68523-start.stderr
+++ b/tests/ui/async-await/issue-68523-start.stderr
@@ -1,8 +1,8 @@
-error[E0752]: `start` is not allowed to be `async`
+error[E0752]: `#[start]` function is not allowed to be `async`
   --> $DIR/issue-68523-start.rs:6:1
    |
 LL | pub async fn start(_: isize, _: *const *const u8) -> isize {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `start` is not allowed to be `async`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `#[start]` is not allowed to be `async`
 
 error: aborting due to previous error
 

--- a/tests/ui/cast/unsized-struct-cast.rs
+++ b/tests/ui/cast/unsized-struct-cast.rs
@@ -1,0 +1,6 @@
+pub struct Data([u8]);
+
+fn main(){
+    const _: *const Data = &[] as *const Data;
+    //~^ ERROR: casting `&[_; 0]` as `*const Data` is invalid
+}

--- a/tests/ui/cast/unsized-struct-cast.stderr
+++ b/tests/ui/cast/unsized-struct-cast.stderr
@@ -1,0 +1,9 @@
+error[E0606]: casting `&[_; 0]` as `*const Data` is invalid
+  --> $DIR/unsized-struct-cast.rs:4:28
+   |
+LL |     const _: *const Data = &[] as *const Data;
+   |                            ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0606`.

--- a/tests/ui/closures/2229_closure_analysis/match/if-let-guards-errors.e2018.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/if-let-guards-errors.e2018.stderr
@@ -1,0 +1,33 @@
+error[E0505]: cannot move out of `value` because it is borrowed
+  --> $DIR/if-let-guards-errors.rs:16:13
+   |
+LL |     let f = |x: &E| {
+   |             ------- borrow of `value` occurs here
+LL |         match &x {
+LL |             E::Number(_) if let E::Number(ref mut n) = *value => { }
+   |                                                        ------ borrow occurs due to use in closure
+...
+LL |     let x = value;
+   |             ^^^^^ move out of `value` occurs here
+LL |
+LL |     drop(f);
+   |          - borrow later used here
+
+error[E0382]: use of moved value: `value`
+  --> $DIR/if-let-guards-errors.rs:28:13
+   |
+LL | fn if_let_move(value: Box<E>) {
+   |                ----- move occurs because `value` has type `Box<E>`, which does not implement the `Copy` trait
+LL |     let f = |x: &E| {
+   |             ------- value moved into closure here
+LL |         match &x {
+LL |             E::Number(_) if let E::String(s) = *value => { }
+   |                                                ------ variable moved due to use in closure
+...
+LL |     let x = value;
+   |             ^^^^^ value used here after move
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0382, E0505.
+For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/closures/2229_closure_analysis/match/if-let-guards-errors.e2021.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/if-let-guards-errors.e2021.stderr
@@ -1,0 +1,33 @@
+error[E0505]: cannot move out of `value` because it is borrowed
+  --> $DIR/if-let-guards-errors.rs:16:13
+   |
+LL |     let f = |x: &E| {
+   |             ------- borrow of `*value` occurs here
+LL |         match &x {
+LL |             E::Number(_) if let E::Number(ref mut n) = *value => { }
+   |                                                        ------ borrow occurs due to use in closure
+...
+LL |     let x = value;
+   |             ^^^^^ move out of `value` occurs here
+LL |
+LL |     drop(f);
+   |          - borrow later used here
+
+error[E0382]: use of moved value: `value`
+  --> $DIR/if-let-guards-errors.rs:28:13
+   |
+LL | fn if_let_move(value: Box<E>) {
+   |                ----- move occurs because `value` has type `Box<E>`, which does not implement the `Copy` trait
+LL |     let f = |x: &E| {
+   |             ------- value moved into closure here
+LL |         match &x {
+LL |             E::Number(_) if let E::String(s) = *value => { }
+   |                                                ------ variable moved due to use in closure
+...
+LL |     let x = value;
+   |             ^^^^^ value used here after move
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0382, E0505.
+For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/closures/2229_closure_analysis/match/if-let-guards-errors.rs
+++ b/tests/ui/closures/2229_closure_analysis/match/if-let-guards-errors.rs
@@ -1,0 +1,37 @@
+// Check the if let guards don't force capture by value
+// revisions: e2018 e2021
+//[e2018] edition:2018
+//[e2021] edition:2021
+
+#![feature(if_let_guard)]
+#![allow(irrefutable_let_patterns)]
+
+fn if_let_ref_mut(mut value: Box<E>) {
+    let f = |x: &E| {
+        match &x {
+            E::Number(_) if let E::Number(ref mut n) = *value => { }
+            _ => {}
+        }
+    };
+    let x = value;
+    //~^ ERROR cannot move out of `value` because it is borrowed
+    drop(f);
+}
+
+fn if_let_move(value: Box<E>) {
+    let f = |x: &E| {
+        match &x {
+            E::Number(_) if let E::String(s) = *value => { }
+            _ => {}
+        }
+    };
+    let x = value;
+    //~^ ERROR use of moved value: `value`
+}
+
+enum E {
+    String(String),
+    Number(i32),
+}
+
+fn main() {}

--- a/tests/ui/closures/2229_closure_analysis/match/if-let-guards.rs
+++ b/tests/ui/closures/2229_closure_analysis/match/if-let-guards.rs
@@ -1,0 +1,55 @@
+// Check the if let guards don't force capture by value
+// revisions: e2018 e2021
+// check-pass
+//[e2018] edition:2018
+//[e2021] edition:2021
+
+#![feature(if_let_guard)]
+#![allow(irrefutable_let_patterns)]
+
+fn if_let_underscore(value: Box<E>) {
+    |x: &E| {
+        match &x {
+            E::Number(_) if let _ = *value => { }
+            _ => {}
+        }
+    };
+    let x = value;
+}
+
+fn if_let_copy(value: Box<E>) {
+    |x: &E| {
+        match &x {
+            E::Number(_) if let E::Number(n) = *value => { }
+            _ => {}
+        }
+    };
+    let x = value;
+}
+
+fn if_let_ref(value: Box<E>) {
+    |x: &E| {
+        match &x {
+            E::Number(_) if let E::Number(ref n) = *value => { }
+            _ => {}
+        }
+    };
+    let x = value;
+}
+
+fn if_let_ref_mut(mut value: Box<E>) {
+    |x: &E| {
+        match &x {
+            E::Number(_) if let E::Number(ref mut n) = *value => { }
+            _ => {}
+        }
+    };
+    let x = value;
+}
+
+enum E {
+    String(String),
+    Number(i32),
+}
+
+fn main() {}

--- a/tests/ui/error-codes/E0132.stderr
+++ b/tests/ui/error-codes/E0132.stderr
@@ -1,8 +1,8 @@
-error[E0132]: start function is not allowed to have type parameters
+error[E0132]: `#[start]` function is not allowed to have type parameters
   --> $DIR/E0132.rs:4:5
    |
 LL | fn f< T >() {}
-   |     ^^^^^ start function cannot have type parameters
+   |     ^^^^^ `#[start]` function cannot have type parameters
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0647.stderr
+++ b/tests/ui/error-codes/E0647.stderr
@@ -1,8 +1,8 @@
-error[E0647]: start function is not allowed to have a `where` clause
+error[E0647]: `#[start]` function is not allowed to have a `where` clause
   --> $DIR/E0647.rs:7:50
    |
 LL | fn start(_: isize, _: *const *const u8) -> isize where (): Copy {
-   |                                                  ^^^^^^^^^^^^^^ start function cannot have a `where` clause
+   |                                                  ^^^^^^^^^^^^^^ `#[start]` function cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/tests/ui/issues/issue-50714-1.stderr
+++ b/tests/ui/issues/issue-50714-1.stderr
@@ -1,8 +1,8 @@
-error[E0647]: start function is not allowed to have a `where` clause
+error[E0647]: `#[start]` function is not allowed to have a `where` clause
   --> $DIR/issue-50714-1.rs:9:50
    |
 LL | fn start(_: isize, _: *const *const u8) -> isize where fn(&()): Eq {
-   |                                                  ^^^^^^^^^^^^^^^^^ start function cannot have a `where` clause
+   |                                                  ^^^^^^^^^^^^^^^^^ `#[start]` function cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-start.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-start.rs
@@ -1,7 +1,7 @@
 #![feature(start)]
 
 #[start]
-#[track_caller] //~ ERROR `start` is not allowed to be `#[track_caller]`
+#[track_caller] //~ ERROR `#[start]` function is not allowed to be `#[track_caller]`
 fn start(_argc: isize, _argv: *const *const u8) -> isize {
     panic!("{}: oh no", std::panic::Location::caller());
 }

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-start.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-start.stderr
@@ -1,10 +1,10 @@
-error: `start` is not allowed to be `#[track_caller]`
+error: `#[start]` function is not allowed to be `#[track_caller]`
   --> $DIR/error-with-start.rs:4:1
    |
 LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 LL | fn start(_argc: isize, _argv: *const *const u8) -> isize {
-   | -------------------------------------------------------- `start` is not allowed to be `#[track_caller]`
+   | -------------------------------------------------------- `#[start]` function is not allowed to be `#[track_caller]`
 
 error: aborting due to previous error
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108645-target-feature-on-start.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108645-target-feature-on-start.rs
@@ -5,5 +5,5 @@
 
 #[start]
 #[target_feature(enable = "avx2")]
-//~^ ERROR `start` is not allowed to have `#[target_feature]`
+//~^ ERROR `#[start]` function is not allowed to have `#[target_feature]`
 fn start(_argc: isize, _argv: *const *const u8) -> isize { 0 }

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108645-target-feature-on-start.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108645-target-feature-on-start.stderr
@@ -1,11 +1,11 @@
-error: `start` is not allowed to have `#[target_feature]`
+error: `#[start]` function is not allowed to have `#[target_feature]`
   --> $DIR/issue-108645-target-feature-on-start.rs:7:1
    |
 LL | #[target_feature(enable = "avx2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | fn start(_argc: isize, _argv: *const *const u8) -> isize { 0 }
-   | -------------------------------------------------------- `start` is not allowed to have `#[target_feature]`
+   | -------------------------------------------------------- `#[start]` function is not allowed to have `#[target_feature]`
 
 error: aborting due to previous error
 

--- a/tests/ui/stats/meta-stats.rs
+++ b/tests/ui/stats/meta-stats.rs
@@ -1,0 +1,7 @@
+// build-pass
+// dont-check-compiler-stderr
+// compile-flags: -Zmeta-stats
+
+#![crate_type = "lib"]
+
+pub fn a() {}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -598,7 +598,6 @@ compiler-team = [
 compiler-team-contributors = [
     "@compiler-errors",
     "@jackh726",
-    "@TaKO8Ki",
     "@WaffleLapkin",
     "@b-naber",
 ]
@@ -645,7 +644,6 @@ diagnostics = [
     "@compiler-errors",
     "@davidtwco",
     "@oli-obk",
-    "@TaKO8Ki",
 ]
 parser = [
     "@compiler-errors",


### PR DESCRIPTION
Successful merges:

 - #115770 (Match on elem first while building move paths)
 - #115999 (Capture scrutinee of if let guards correctly)
 - #116056 (Make unsized casts illegal)
 - #116061 (Remove TaKO8Ki from review rotation)
 - #116062 (Change `start` to `#[start]` in some diagnosis)
 - #116067 (Open the FileEncoder file for reading and writing)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115770,115999,116056,116061,116062,116067)
<!-- homu-ignore:end -->