### PR TITLE
Point at more causes of expectation of break value when possible

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -43,7 +43,10 @@ use rustc_infer::traits::query::NoSolution;
 use rustc_infer::traits::ObligationCause;
 use rustc_middle::middle::stability;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AllowTwoPhase};
-use rustc_middle::ty::error::TypeError::FieldMisMatch;
+use rustc_middle::ty::error::{
+    ExpectedFound,
+    TypeError::{FieldMisMatch, Sorts},
+};
 use rustc_middle::ty::GenericArgsRef;
 use rustc_middle::ty::{self, AdtKind, Ty, TypeVisitableExt};
 use rustc_session::errors::ExprParenthesesNeeded;
@@ -664,6 +667,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.suggest_mismatched_types_on_tail(
                                 &mut err, expr, ty, e_ty, target_id,
                             );
+                            let error = Some(Sorts(ExpectedFound { expected: ty, found: e_ty }));
+                            self.annotate_loop_expected_due_to_inference(&mut err, expr, error);
                             if let Some(val) = ty_kind_suggestion(ty) {
                                 let label = destination
                                     .label

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -670,14 +670,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             let error = Some(Sorts(ExpectedFound { expected: ty, found: e_ty }));
                             self.annotate_loop_expected_due_to_inference(&mut err, expr, error);
                             if let Some(val) = ty_kind_suggestion(ty) {
-                                let label = destination
-                                    .label
-                                    .map(|l| format!(" {}", l.ident))
-                                    .unwrap_or_else(String::new);
-                                err.span_suggestion(
-                                    expr.span,
+                                err.span_suggestion_verbose(
+                                    expr.span.shrink_to_hi(),
                                     "give it a value of the expected type",
-                                    format!("break{label} {val}"),
+                                    format!(" {val}"),
                                     Applicability::HasPlaceholders,
                                 );
                             }
@@ -722,7 +718,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // ... except when we try to 'break rust;'.
                 // ICE this expression in particular (see #43162).
                 if let ExprKind::Path(QPath::Resolved(_, path)) = e.kind {
-                    if path.segments.len() == 1 && path.segments[0].ident.name == sym::rust {
+                    if let [segment] = path.segments && segment.ident.name == sym::rust {
                         fatally_break_rust(self.tcx);
                     }
                 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -65,6 +65,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let expr = expr.peel_drop_temps();
         self.suggest_missing_semicolon(err, expr, expected, false);
         let mut pointing_at_return_type = false;
+        if let hir::ExprKind::Break(..) = expr.kind {
+            // `break` type mismatches provide better context for tail `loop` expressions.
+            return false;
+        }
         if let Some((fn_id, fn_decl, can_suggest)) = self.get_fn_decl(blk_id) {
             pointing_at_return_type = self.suggest_missing_return_type(
                 err,

--- a/tests/ui/issues/issue-27042.stderr
+++ b/tests/ui/issues/issue-27042.stderr
@@ -12,10 +12,12 @@ error[E0308]: mismatched types
   --> $DIR/issue-27042.rs:6:16
    |
 LL |         loop { break };
-   |                ^^^^^
-   |                |
-   |                expected `i32`, found `()`
-   |                help: give it a value of the expected type: `break 42`
+   |                ^^^^^ expected `i32`, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |         loop { break 42 };
+   |                      ++
 
 error[E0308]: mismatched types
   --> $DIR/issue-27042.rs:8:9

--- a/tests/ui/loops/loop-break-value.rs
+++ b/tests/ui/loops/loop-break-value.rs
@@ -95,6 +95,30 @@ fn main() {
         break LOOP;
         //~^ ERROR cannot find value `LOOP` in this scope
     }
+
+    let _ = 'a: loop {
+        loop {
+            break; // This doesn't affect the expected break type of the 'a loop
+            loop {
+                loop {
+                    break 'a 1;
+                }
+            }
+        }
+        break; //~ ERROR mismatched types
+    };
+    let _ = 'a: loop {
+        loop {
+            break; // This doesn't affect the expected break type of the 'a loop
+            loop {
+                loop {
+                    break 'a 1;
+                }
+            }
+        }
+        break 'a; //~ ERROR mismatched types
+    };
+
     loop { // point at the return type
         break 2; //~ ERROR mismatched types
     }

--- a/tests/ui/loops/loop-break-value.rs
+++ b/tests/ui/loops/loop-break-value.rs
@@ -107,6 +107,7 @@ fn main() {
         }
         break; //~ ERROR mismatched types
     };
+
     let _ = 'a: loop {
         loop {
             break; // This doesn't affect the expected break type of the 'a loop
@@ -117,6 +118,41 @@ fn main() {
             }
         }
         break 'a; //~ ERROR mismatched types
+    };
+
+    loop {
+        break;
+        let _ = loop {
+            break 2;
+            loop {
+                break;
+            }
+        };
+        break 2; //~ ERROR mismatched types
+    }
+
+    'a: loop {
+        break;
+        let _ = 'a: loop {
+            //~^ WARNING label name `'a` shadows a label name that is already in scope
+            break 2;
+            loop {
+                break 'a; //~ ERROR mismatched types
+            }
+        };
+        break 2; //~ ERROR mismatched types
+    }
+
+    'a: loop {
+        break;
+        let _ = 'a: loop {
+            //~^ WARNING label name `'a` shadows a label name that is already in scope
+            break 'a 2;
+            loop {
+                break 'a; //~ ERROR mismatched types
+            }
+        };
+        break 2; //~ ERROR mismatched types
     };
 
     loop { // point at the return type

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -134,7 +134,10 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:4:31
    |
 LL |     let val: ! = loop { break break; };
-   |                               ^^^^^ expected `!`, found `()`
+   |         ---      ----         ^^^^^ expected `!`, found `()`
+   |         |        |
+   |         |        this loop is expected to be of type `!`
+   |         expected because of this assignment
    |
    = note:   expected type `!`
            found unit type `()`

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -1,3 +1,21 @@
+warning: label name `'a` shadows a label name that is already in scope
+  --> $DIR/loop-break-value.rs:136:17
+   |
+LL |     'a: loop {
+   |     -- first declared here
+LL |         break;
+LL |         let _ = 'a: loop {
+   |                 ^^ label `'a` already in scope
+
+warning: label name `'a` shadows a label name that is already in scope
+  --> $DIR/loop-break-value.rs:148:17
+   |
+LL |     'a: loop {
+   |     -- first declared here
+LL |         break;
+LL |         let _ = 'a: loop {
+   |                 ^^ label `'a` already in scope
+
 error[E0425]: cannot find value `LOOP` in this scope
   --> $DIR/loop-break-value.rs:95:15
    |
@@ -164,12 +182,19 @@ LL |         break "asdf";
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:21:31
    |
+LL |     let _: i32 = 'outer_loop: loop {
+   |         -                     ---- this loop is expected to be of type `i32`
+   |         |
+   |         expected because of this assignment
+LL |         loop {
 LL |             break 'outer_loop "nope";
    |                               ^^^^^^ expected `i32`, found `&str`
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:73:26
    |
+LL |                 break;
+   |                 ----- expected because of this `break`
 LL |                 break 'c 123;
    |                          ^^^ expected `()`, found integer
 
@@ -218,7 +243,7 @@ LL |         break;
    |         help: give it a value of the expected type: `break value`
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:119:9
+  --> $DIR/loop-break-value.rs:120:9
    |
 LL |                     break 'a 1;
    |                     ---------- expected because of this `break`
@@ -230,7 +255,58 @@ LL |         break 'a;
    |         help: give it a value of the expected type: `break 'a value`
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:123:15
+  --> $DIR/loop-break-value.rs:131:15
+   |
+LL |         break;
+   |         ----- expected because of this `break`
+...
+LL |         break 2;
+   |               ^ expected `()`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/loop-break-value.rs:140:17
+   |
+LL |             break 2;
+   |             ------- expected because of this `break`
+LL |             loop {
+LL |                 break 'a;
+   |                 ^^^^^^^^
+   |                 |
+   |                 expected integer, found `()`
+   |                 help: give it a value of the expected type: `break 'a value`
+
+error[E0308]: mismatched types
+  --> $DIR/loop-break-value.rs:143:15
+   |
+LL |         break;
+   |         ----- expected because of this `break`
+...
+LL |         break 2;
+   |               ^ expected `()`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/loop-break-value.rs:152:17
+   |
+LL |             break 'a 2;
+   |             ---------- expected because of this `break`
+LL |             loop {
+LL |                 break 'a;
+   |                 ^^^^^^^^
+   |                 |
+   |                 expected integer, found `()`
+   |                 help: give it a value of the expected type: `break 'a value`
+
+error[E0308]: mismatched types
+  --> $DIR/loop-break-value.rs:155:15
+   |
+LL |         break;
+   |         ----- expected because of this `break`
+...
+LL |         break 2;
+   |               ^ expected `()`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/loop-break-value.rs:159:15
    |
 LL | fn main() {
    |           - expected `()` because of this return type
@@ -240,7 +316,7 @@ LL |     loop { // point at the return type
 LL |         break 2;
    |               ^ expected `()`, found integer
 
-error: aborting due to 20 previous errors; 1 warning emitted
+error: aborting due to 25 previous errors; 3 warnings emitted
 
 Some errors have detailed explanations: E0308, E0425, E0571.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -225,10 +225,12 @@ error[E0308]: mismatched types
 LL |         break 2;
    |         ------- expected because of this `break`
 LL |         break;
-   |         ^^^^^
-   |         |
-   |         expected integer, found `()`
-   |         help: give it a value of the expected type: `break value`
+   |         ^^^^^ expected integer, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |         break value;
+   |               +++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:108:9
@@ -237,10 +239,12 @@ LL |                     break 'a 1;
    |                     ---------- expected because of this `break`
 ...
 LL |         break;
-   |         ^^^^^
-   |         |
-   |         expected integer, found `()`
-   |         help: give it a value of the expected type: `break value`
+   |         ^^^^^ expected integer, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |         break value;
+   |               +++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:120:9
@@ -249,10 +253,12 @@ LL |                     break 'a 1;
    |                     ---------- expected because of this `break`
 ...
 LL |         break 'a;
-   |         ^^^^^^^^
-   |         |
-   |         expected integer, found `()`
-   |         help: give it a value of the expected type: `break 'a value`
+   |         ^^^^^^^^ expected integer, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |         break 'a value;
+   |                  +++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:131:15
@@ -270,10 +276,12 @@ LL |             break 2;
    |             ------- expected because of this `break`
 LL |             loop {
 LL |                 break 'a;
-   |                 ^^^^^^^^
-   |                 |
-   |                 expected integer, found `()`
-   |                 help: give it a value of the expected type: `break 'a value`
+   |                 ^^^^^^^^ expected integer, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |                 break 'a value;
+   |                          +++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:143:15
@@ -291,10 +299,12 @@ LL |             break 'a 2;
    |             ---------- expected because of this `break`
 LL |             loop {
 LL |                 break 'a;
-   |                 ^^^^^^^^
-   |                 |
-   |                 expected integer, found `()`
-   |                 help: give it a value of the expected type: `break 'a value`
+   |                 ^^^^^^^^ expected integer, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |                 break 'a value;
+   |                          +++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:155:15

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -164,11 +164,6 @@ LL |         break "asdf";
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:21:31
    |
-LL |     let _: i32 = 'outer_loop: loop {
-   |         -                     ---- this loop is expected to be of type `i32`
-   |         |
-   |         expected because of this assignment
-LL |         loop {
 LL |             break 'outer_loop "nope";
    |                               ^^^^^^ expected `i32`, found `&str`
 
@@ -202,6 +197,8 @@ LL |         break 2;
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:90:9
    |
+LL |         break 2;
+   |         ------- expected because of this `break`
 LL |         break;
    |         ^^^^^
    |         |
@@ -209,7 +206,31 @@ LL |         break;
    |         help: give it a value of the expected type: `break value`
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:99:15
+  --> $DIR/loop-break-value.rs:108:9
+   |
+LL |                     break 'a 1;
+   |                     ---------- expected because of this `break`
+...
+LL |         break;
+   |         ^^^^^
+   |         |
+   |         expected integer, found `()`
+   |         help: give it a value of the expected type: `break value`
+
+error[E0308]: mismatched types
+  --> $DIR/loop-break-value.rs:119:9
+   |
+LL |                     break 'a 1;
+   |                     ---------- expected because of this `break`
+...
+LL |         break 'a;
+   |         ^^^^^^^^
+   |         |
+   |         expected integer, found `()`
+   |         help: give it a value of the expected type: `break 'a value`
+
+error[E0308]: mismatched types
+  --> $DIR/loop-break-value.rs:123:15
    |
 LL | fn main() {
    |           - expected `()` because of this return type
@@ -219,7 +240,7 @@ LL |     loop { // point at the return type
 LL |         break 2;
    |               ^ expected `()`, found integer
 
-error: aborting due to 18 previous errors; 1 warning emitted
+error: aborting due to 20 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0308, E0425, E0571.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -142,6 +142,9 @@ LL |     let val: ! = loop { break break; };
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:11:19
    |
+LL |             break "asdf";
+   |             ------------ expected because of this `break`
+LL |         } else {
 LL |             break 123;
    |                   ^^^ expected `&str`, found integer
 
@@ -176,7 +179,11 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:80:15
    |
 LL |         break (break, break);
-   |               ^^^^^^^^^^^^^^ expected `()`, found `(!, !)`
+   |               ^-----^^-----^
+   |               ||      |
+   |               ||      expected because of this `break`
+   |               |expected because of this `break`
+   |               expected `()`, found `(!, !)`
    |
    = note: expected unit type `()`
                   found tuple `(!, !)`
@@ -184,6 +191,8 @@ LL |         break (break, break);
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:85:15
    |
+LL |         break;
+   |         ----- expected because of this `break`
 LL |         break 2;
    |               ^ expected `()`, found integer
 

--- a/tests/ui/loops/loop-labeled-break-value.stderr
+++ b/tests/ui/loops/loop-labeled-break-value.stderr
@@ -2,28 +2,34 @@ error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:3:29
    |
 LL |         let _: i32 = loop { break };
-   |                             ^^^^^
-   |                             |
-   |                             expected `i32`, found `()`
-   |                             help: give it a value of the expected type: `break 42`
+   |                             ^^^^^ expected `i32`, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |         let _: i32 = loop { break 42 };
+   |                                   ++
 
 error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:6:37
    |
 LL |         let _: i32 = 'inner: loop { break 'inner };
-   |                                     ^^^^^^^^^^^^
-   |                                     |
-   |                                     expected `i32`, found `()`
-   |                                     help: give it a value of the expected type: `break 'inner 42`
+   |                                     ^^^^^^^^^^^^ expected `i32`, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |         let _: i32 = 'inner: loop { break 'inner 42 };
+   |                                                  ++
 
 error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:9:45
    |
 LL |         let _: i32 = 'inner2: loop { loop { break 'inner2 } };
-   |                                             ^^^^^^^^^^^^^
-   |                                             |
-   |                                             expected `i32`, found `()`
-   |                                             help: give it a value of the expected type: `break 'inner2 42`
+   |                                             ^^^^^^^^^^^^^ expected `i32`, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |         let _: i32 = 'inner2: loop { loop { break 'inner2 42 } };
+   |                                                           ++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/loops/loop-properly-diverging-2.stderr
+++ b/tests/ui/loops/loop-properly-diverging-2.stderr
@@ -2,10 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/loop-properly-diverging-2.rs:2:23
    |
 LL |   let x: i32 = loop { break };
-   |                       ^^^^^
-   |                       |
-   |                       expected `i32`, found `()`
-   |                       help: give it a value of the expected type: `break 42`
+   |                       ^^^^^ expected `i32`, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |   let x: i32 = loop { break 42 };
+   |                             ++
 
 error: aborting due to previous error
 

--- a/tests/ui/never_type/issue-52443.stderr
+++ b/tests/ui/never_type/issue-52443.stderr
@@ -33,10 +33,12 @@ error[E0308]: mismatched types
   --> $DIR/issue-52443.rs:4:17
    |
 LL |     [(); loop { break }];
-   |                 ^^^^^
-   |                 |
-   |                 expected `usize`, found `()`
-   |                 help: give it a value of the expected type: `break 42`
+   |                 ^^^^^ expected `usize`, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |     [(); loop { break 42 }];
+   |                       ++
 
 error[E0015]: cannot convert `RangeFrom<usize>` into an iterator in constants
   --> $DIR/issue-52443.rs:9:21

--- a/tests/ui/type/type-error-break-tail.stderr
+++ b/tests/ui/type/type-error-break-tail.stderr
@@ -2,8 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/type-error-break-tail.rs:3:20
    |
 LL | fn loop_ending() -> i32 {
-   |                     --- expected `i32` because of return type
+   |                     --- expected `i32` because of this return type
 LL |     loop {
+   |     ---- this loop is expected to be of type `i32`
 LL |         if false { break; }
    |                    ^^^^^
    |                    |

--- a/tests/ui/type/type-error-break-tail.stderr
+++ b/tests/ui/type/type-error-break-tail.stderr
@@ -6,10 +6,12 @@ LL | fn loop_ending() -> i32 {
 LL |     loop {
    |     ---- this loop is expected to be of type `i32`
 LL |         if false { break; }
-   |                    ^^^^^
-   |                    |
-   |                    expected `i32`, found `()`
-   |                    help: give it a value of the expected type: `break 42`
+   |                    ^^^^^ expected `i32`, found `()`
+   |
+help: give it a value of the expected type
+   |
+LL |         if false { break 42; }
+   |                          ++
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Follow up to #116071.

r? @compiler-errors 

Disregard the first commit, which is in the other PR.