### PR TITLE
Check that closure/generator's interior/capture types are sized

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -518,8 +518,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.select_obligations_where_possible(|_| {});
 
         let mut generators = self.deferred_generator_interiors.borrow_mut();
-        for (_, body_id, interior, kind) in generators.drain(..) {
-            crate::generator_interior::resolve_interior(self, def_id, body_id, interior, kind);
+        for (generator_def_id, body_id, interior, kind) in generators.drain(..) {
+            crate::generator_interior::resolve_interior(
+                self,
+                def_id,
+                generator_def_id,
+                body_id,
+                interior,
+                kind,
+            );
             self.select_obligations_where_possible(|_| {});
         }
     }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -299,8 +299,10 @@ pub enum ObligationCauseCode<'tcx> {
     SizedYieldType,
     /// Inline asm operand type must be `Sized`.
     InlineAsmSized,
-    /// Captured closure type type must be `Sized`.
+    /// Captured closure type must be `Sized`.
     SizedClosureCapture(LocalDefId),
+    /// Types live across generator yields must be `Sized`.
+    SizedGeneratorInterior(LocalDefId),
     /// `[expr; N]` requires `type_of(expr): Copy`.
     RepeatElementCopy {
         /// If element is a `const fn` we display a help message suggesting to move the

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -299,6 +299,8 @@ pub enum ObligationCauseCode<'tcx> {
     SizedYieldType,
     /// Inline asm operand type must be `Sized`.
     InlineAsmSized,
+    /// Captured closure type type must be `Sized`.
+    SizedClosureCapture(LocalDefId),
     /// `[expr; N]` requires `type_of(expr): Copy`.
     RepeatElementCopy {
         /// If element is a `const fn` we display a help message suggesting to move the

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3018,6 +3018,13 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     err.span_label(span, "this closure captures all values by move");
                 }
             }
+            ObligationCauseCode::SizedGeneratorInterior(generator_def_id) => {
+                let what = match self.tcx.generator_kind(generator_def_id) {
+                    None | Some(hir::GeneratorKind::Gen) => "yield",
+                    Some(hir::GeneratorKind::Async(..)) => "await",
+                };
+                err.note(format!("all values live across `{what}` must have a statically known size"));
+            }
             ObligationCauseCode::ConstPatternStructural => {
                 err.note("constants used for pattern-matching must derive `PartialEq` and `Eq`");
             }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3007,6 +3007,17 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             ObligationCauseCode::InlineAsmSized => {
                 err.note("all inline asm arguments must have a statically known size");
             }
+            ObligationCauseCode::SizedClosureCapture(closure_def_id) => {
+                err.note("all values captured by value by a closure must have a statically known size");
+                let hir::ExprKind::Closure(closure) = self.tcx.hir().get_by_def_id(closure_def_id).expect_expr().kind else {
+                    bug!("expected closure in SizedClosureCapture obligation");
+                };
+                if let hir::CaptureBy::Value = closure.capture_clause
+                    && let Some(span) = closure.fn_arg_span
+                {
+                    err.span_label(span, "this closure captures all values by move");
+                }
+            }
             ObligationCauseCode::ConstPatternStructural => {
                 err.note("constants used for pattern-matching must derive `PartialEq` and `Eq`");
             }

--- a/tests/ui/async-await/awaiting-unsized-param.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/awaiting-unsized-param.drop_tracking_mir.stderr
@@ -1,0 +1,21 @@
+warning: the feature `unsized_locals` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/awaiting-unsized-param.rs:5:31
+   |
+LL | #![feature(unsized_fn_params, unsized_locals)]
+   |                               ^^^^^^^^^^^^^^
+   |
+   = note: see issue #48055 <https://github.com/rust-lang/rust/issues/48055> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: the size for values of type `(dyn Future<Output = T> + Unpin + 'static)` cannot be known at compilation time
+  --> $DIR/awaiting-unsized-param.rs:10:17
+   |
+LL | async fn bug<T>(mut f: dyn Future<Output = T> + Unpin) -> T {
+   |                 ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Future<Output = T> + Unpin + 'static)`
+   = note: all values captured by value by a closure must have a statically known size
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/awaiting-unsized-param.no_drop_tracking.stderr
+++ b/tests/ui/async-await/awaiting-unsized-param.no_drop_tracking.stderr
@@ -1,0 +1,21 @@
+warning: the feature `unsized_locals` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/awaiting-unsized-param.rs:5:31
+   |
+LL | #![feature(unsized_fn_params, unsized_locals)]
+   |                               ^^^^^^^^^^^^^^
+   |
+   = note: see issue #48055 <https://github.com/rust-lang/rust/issues/48055> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: the size for values of type `(dyn Future<Output = T> + Unpin + 'static)` cannot be known at compilation time
+  --> $DIR/awaiting-unsized-param.rs:10:17
+   |
+LL | async fn bug<T>(mut f: dyn Future<Output = T> + Unpin) -> T {
+   |                 ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Future<Output = T> + Unpin + 'static)`
+   = note: all values captured by value by a closure must have a statically known size
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/awaiting-unsized-param.rs
+++ b/tests/ui/async-await/awaiting-unsized-param.rs
@@ -1,0 +1,15 @@
+// edition: 2021
+// revisions: no_drop_tracking drop_tracking_mir
+// [drop_tracking_mir] compile-flags: -Zdrop-tracking-mir
+
+#![feature(unsized_fn_params, unsized_locals)]
+//~^ WARN the feature `unsized_locals` is incomplete
+
+use std::future::Future;
+
+async fn bug<T>(mut f: dyn Future<Output = T> + Unpin) -> T {
+    //~^ ERROR the size for values of type `(dyn Future<Output = T> + Unpin + 'static)` cannot be known at compilation time
+    (&mut f).await
+}
+
+fn main() {}

--- a/tests/ui/async-await/unsized-across-await.drop_tracking_mir.stderr
+++ b/tests/ui/async-await/unsized-across-await.drop_tracking_mir.stderr
@@ -1,0 +1,21 @@
+warning: the feature `unsized_locals` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unsized-across-await.rs:5:12
+   |
+LL | #![feature(unsized_locals)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: see issue #48055 <https://github.com/rust-lang/rust/issues/48055> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: the size for values of type `dyn std::fmt::Display` cannot be known at compilation time
+  --> $DIR/unsized-across-await.rs:11:9
+   |
+LL |     let _x = *x;
+   |         ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn std::fmt::Display`
+   = note: all values live across `await` must have a statically known size
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/unsized-across-await.no_drop_tracking.stderr
+++ b/tests/ui/async-await/unsized-across-await.no_drop_tracking.stderr
@@ -1,0 +1,21 @@
+warning: the feature `unsized_locals` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unsized-across-await.rs:5:12
+   |
+LL | #![feature(unsized_locals)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: see issue #48055 <https://github.com/rust-lang/rust/issues/48055> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: the size for values of type `dyn std::fmt::Display` cannot be known at compilation time
+  --> $DIR/unsized-across-await.rs:11:9
+   |
+LL |     let _x = *x;
+   |         ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn std::fmt::Display`
+   = note: all values live across `await` must have a statically known size
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/unsized-across-await.rs
+++ b/tests/ui/async-await/unsized-across-await.rs
@@ -1,0 +1,18 @@
+// edition: 2021
+// revisions: no_drop_tracking drop_tracking_mir
+// [drop_tracking_mir] compile-flags: -Zdrop-tracking-mir
+
+#![feature(unsized_locals)]
+//~^ WARN the feature `unsized_locals` is incomplete
+
+async fn f() {}
+
+async fn g(x: Box<dyn std::fmt::Display>) {
+    let _x = *x;
+    //~^ ERROR the size for values of type `dyn std::fmt::Display` cannot be known at compilation time
+    f().await;
+}
+
+fn main() {
+    let _a = g(Box::new(5));
+}

--- a/tests/ui/closures/capture-unsized-by-move.rs
+++ b/tests/ui/closures/capture-unsized-by-move.rs
@@ -1,0 +1,10 @@
+// compile-flags: --crate-type=lib
+
+#![feature(unsized_fn_params)]
+
+pub fn f(k: dyn std::fmt::Display) {
+    let k2 = move || {
+        k.to_string();
+        //~^ ERROR the size for values of type `(dyn std::fmt::Display + 'static)` cannot be known at compilation time
+    };
+}

--- a/tests/ui/closures/capture-unsized-by-move.stderr
+++ b/tests/ui/closures/capture-unsized-by-move.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the size for values of type `(dyn std::fmt::Display + 'static)` cannot be known at compilation time
+  --> $DIR/capture-unsized-by-move.rs:7:9
+   |
+LL |     let k2 = move || {
+   |                   -- this closure captures all values by move
+LL |         k.to_string();
+   |         ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn std::fmt::Display + 'static)`
+   = note: all values captured by value by a closure must have a statically known size
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/closures/capture-unsized-by-ref.rs
+++ b/tests/ui/closures/capture-unsized-by-ref.rs
@@ -1,0 +1,10 @@
+// build-pass
+// compile-flags: --crate-type=lib
+
+#![feature(unsized_fn_params)]
+
+pub fn f(k: dyn std::fmt::Display) {
+    let k2 = || {
+        k.to_string();
+    };
+}

--- a/tests/ui/generator/unsized-across-yield.rs
+++ b/tests/ui/generator/unsized-across-yield.rs
@@ -1,0 +1,34 @@
+#![feature(generator_trait)]
+#![feature(generators)]
+#![feature(unsized_locals)]
+//~^ WARN the feature `unsized_locals` is incomplete and may not be safe to use and/or cause compiler crashes
+
+use std::ops::Generator;
+
+fn across() -> impl Generator {
+    move || {
+        let b: [u8] = *(Box::new([]) as Box<[u8]>);
+        //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+
+        yield;
+
+        for elem in b.iter() {}
+    }
+}
+
+fn capture() -> impl Generator {
+    let b: [u8] = *(Box::new([]) as Box<[u8]>);
+    move || {
+        println!("{:?}", &b);
+        //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+
+        yield;
+
+        for elem in b.iter() {}
+    }
+}
+
+fn main() {
+    across();
+    capture();
+}

--- a/tests/ui/generator/unsized-across-yield.stderr
+++ b/tests/ui/generator/unsized-across-yield.stderr
@@ -1,0 +1,32 @@
+warning: the feature `unsized_locals` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unsized-across-yield.rs:3:12
+   |
+LL | #![feature(unsized_locals)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: see issue #48055 <https://github.com/rust-lang/rust/issues/48055> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/unsized-across-yield.rs:10:13
+   |
+LL |         let b: [u8] = *(Box::new([]) as Box<[u8]>);
+   |             ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all values live across `yield` must have a statically known size
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/unsized-across-yield.rs:22:27
+   |
+LL |     move || {
+   |          -- this closure captures all values by move
+LL |         println!("{:?}", &b);
+   |                           ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all values captured by value by a closure must have a statically known size
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
check that closure upvars and generator interiors are sized. this check is only necessary when `unsized_fn_params` or `unsized_locals` is enabled, so only check if those are active.

Fixes #93622
Fixes #61335
Fixes #68543