### PR TITLE
More accurate suggestion for `self.` and `Self::`

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -243,15 +243,20 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                             ));
                             None
                         }
-                        AssocItemKind::Fn(fn_) => Some((
+                        AssocItemKind::Fn(fn_) if fn_.sig.decl.has_self() => Some((
                             sp,
-                            "consider using the associated function",
-                            if fn_.sig.decl.has_self() { "self." } else { "Self::" },
+                            "consider using the method on `Self`",
+                            "self.".to_string(),
+                        )),
+                        AssocItemKind::Fn(_) => Some((
+                            sp,
+                            "consider using the associated function on `Self`",
+                            "Self::".to_string(),
                         )),
                         AssocItemKind::Const(..) => Some((
                             sp,
-                            "consider using the associated constant",
-                            "Self::",
+                            "consider using the associated constant on `Self`",
+                            "Self::".to_string(),
                         )),
                         _ => None
                     }

--- a/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.rs
+++ b/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.rs
@@ -1,0 +1,15 @@
+struct Foo {
+    field: u32,
+}
+
+impl Foo {
+    fn field(&self) -> u32 {
+        self.field
+    }
+
+    fn new() -> Foo {
+        field; //~ ERROR cannot find value `field` in this scope
+        Foo { field } //~ ERROR cannot find value `field` in this scope
+    }
+}
+fn main() {}

--- a/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.stderr
+++ b/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.stderr
@@ -1,0 +1,21 @@
+error[E0425]: cannot find value `field` in this scope
+  --> $DIR/field-and-method-in-self-not-available-in-assoc-fn.rs:11:9
+   |
+LL |     fn field(&self) -> u32 {
+   |        ----- a method by that name is available on `Self` here
+...
+LL |         field;
+   |         ^^^^^ a field by this name exists in `Self`
+
+error[E0425]: cannot find value `field` in this scope
+  --> $DIR/field-and-method-in-self-not-available-in-assoc-fn.rs:12:15
+   |
+LL |     fn field(&self) -> u32 {
+   |        ----- a method by that name is available on `Self` here
+...
+LL |         Foo { field }
+   |               ^^^^^ a field by this name exists in `Self`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/issue-103474.stderr
+++ b/tests/ui/resolve/issue-103474.stderr
@@ -19,7 +19,7 @@ error[E0425]: cannot find function `first` in this scope
 LL |         first()
    |         ^^^^^ not found in this scope
    |
-help: consider using the associated function
+help: consider using the method on `Self`
    |
 LL |         self.first()
    |         +++++

--- a/tests/ui/resolve/issue-2356.stderr
+++ b/tests/ui/resolve/issue-2356.stderr
@@ -73,7 +73,7 @@ error[E0425]: cannot find function `static_method` in this scope
 LL |         static_method();
    |         ^^^^^^^^^^^^^ not found in this scope
    |
-help: consider using the associated function
+help: consider using the associated function on `Self`
    |
 LL |         Self::static_method();
    |         ++++++
@@ -102,7 +102,7 @@ error[E0425]: cannot find function `grow_older` in this scope
 LL |     grow_older();
    |     ^^^^^^^^^^ not found in this scope
    |
-help: consider using the associated function
+help: consider using the associated function on `Self`
    |
 LL |     Self::grow_older();
    |     ++++++

--- a/tests/ui/self/class-missing-self.stderr
+++ b/tests/ui/self/class-missing-self.stderr
@@ -10,7 +10,7 @@ error[E0425]: cannot find function `sleep` in this scope
 LL |       sleep();
    |       ^^^^^ not found in this scope
    |
-help: consider using the associated function
+help: consider using the method on `Self`
    |
 LL |       self.sleep();
    |       +++++

--- a/tests/ui/suggestions/assoc-const-without-self.stderr
+++ b/tests/ui/suggestions/assoc-const-without-self.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `A_CONST` in this scope
 LL |         A_CONST
    |         ^^^^^^^ not found in this scope
    |
-help: consider using the associated constant
+help: consider using the associated constant on `Self`
    |
 LL |         Self::A_CONST
    |         ++++++

--- a/tests/ui/suggestions/assoc_fn_without_self.rs
+++ b/tests/ui/suggestions/assoc_fn_without_self.rs
@@ -17,4 +17,12 @@ impl S {
         bar(); //~ ERROR cannot find function `bar` in this scope
         baz(2, 3); //~ ERROR cannot find function `baz` in this scope
     }
+    fn d(&self) {
+        fn c() {
+            foo(); //~ ERROR cannot find function `foo` in this scope
+        }
+        foo(); //~ ERROR cannot find function `foo` in this scope
+        bar(); //~ ERROR cannot find function `bar` in this scope
+        baz(2, 3); //~ ERROR cannot find function `baz` in this scope
+    }
 }

--- a/tests/ui/suggestions/assoc_fn_without_self.stderr
+++ b/tests/ui/suggestions/assoc_fn_without_self.stderr
@@ -12,6 +12,9 @@ LL |         Self::foo();
 error[E0425]: cannot find function `bar` in this scope
   --> $DIR/assoc_fn_without_self.rs:17:9
    |
+LL |     fn bar(&self) {}
+   |        --- a method by that name is available on `Self` here
+...
 LL |         bar();
    |         ^^^ not found in this scope
 

--- a/tests/ui/suggestions/assoc_fn_without_self.stderr
+++ b/tests/ui/suggestions/assoc_fn_without_self.stderr
@@ -14,11 +14,6 @@ error[E0425]: cannot find function `bar` in this scope
    |
 LL |         bar();
    |         ^^^ not found in this scope
-   |
-help: consider using the associated function
-   |
-LL |         self.bar();
-   |         +++++
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/assoc_fn_without_self.rs:18:9
@@ -37,6 +32,45 @@ error[E0425]: cannot find function `foo` in this scope
 LL |             foo();
    |             ^^^ not found in this scope
 
-error: aborting due to 4 previous errors
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/assoc_fn_without_self.rs:24:9
+   |
+LL |         foo();
+   |         ^^^ not found in this scope
+   |
+help: consider using the associated function
+   |
+LL |         Self::foo();
+   |         ++++++
+
+error[E0425]: cannot find function `bar` in this scope
+  --> $DIR/assoc_fn_without_self.rs:25:9
+   |
+LL |         bar();
+   |         ^^^ not found in this scope
+   |
+help: consider using the associated function
+   |
+LL |         self.bar();
+   |         +++++
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/assoc_fn_without_self.rs:26:9
+   |
+LL |         baz(2, 3);
+   |         ^^^ not found in this scope
+   |
+help: consider using the associated function
+   |
+LL |         Self::baz(2, 3);
+   |         ++++++
+
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/assoc_fn_without_self.rs:22:13
+   |
+LL |             foo();
+   |             ^^^ not found in this scope
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/suggestions/assoc_fn_without_self.stderr
+++ b/tests/ui/suggestions/assoc_fn_without_self.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find function `foo` in this scope
 LL |         foo();
    |         ^^^ not found in this scope
    |
-help: consider using the associated function
+help: consider using the associated function on `Self`
    |
 LL |         Self::foo();
    |         ++++++
@@ -24,7 +24,7 @@ error[E0425]: cannot find function `baz` in this scope
 LL |         baz(2, 3);
    |         ^^^ not found in this scope
    |
-help: consider using the associated function
+help: consider using the associated function on `Self`
    |
 LL |         Self::baz(2, 3);
    |         ++++++
@@ -41,7 +41,7 @@ error[E0425]: cannot find function `foo` in this scope
 LL |         foo();
    |         ^^^ not found in this scope
    |
-help: consider using the associated function
+help: consider using the associated function on `Self`
    |
 LL |         Self::foo();
    |         ++++++
@@ -52,7 +52,7 @@ error[E0425]: cannot find function `bar` in this scope
 LL |         bar();
    |         ^^^ not found in this scope
    |
-help: consider using the associated function
+help: consider using the method on `Self`
    |
 LL |         self.bar();
    |         +++++
@@ -63,7 +63,7 @@ error[E0425]: cannot find function `baz` in this scope
 LL |         baz(2, 3);
    |         ^^^ not found in this scope
    |
-help: consider using the associated function
+help: consider using the associated function on `Self`
    |
 LL |         Self::baz(2, 3);
    |         ++++++


### PR DESCRIPTION
Detect that we can't suggest `self.` in an associated function without `&self` receiver.

Partially address #115992.

r? @compiler-errors 