### PR TITLE
Handle lifetimes correctly in `sym` in inline and global asm

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -283,7 +283,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     hir::ExprKind::Become(sub_expr)
                 }
                 ExprKind::InlineAsm(asm) => {
-                    hir::ExprKind::InlineAsm(self.lower_inline_asm(e.span, asm))
+                    hir::ExprKind::InlineAsm(self.lower_inline_asm(e.span, asm, false))
                 }
                 ExprKind::FormatArgs(fmt) => self.lower_format_args(e.span, fmt),
                 ExprKind::OffsetOf(container, fields) => hir::ExprKind::OffsetOf(

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -311,7 +311,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     .arena
                     .alloc_from_iter(fm.items.iter().map(|x| self.lower_foreign_item_ref(x))),
             },
-            ItemKind::GlobalAsm(asm) => hir::ItemKind::GlobalAsm(self.lower_inline_asm(span, asm)),
+            ItemKind::GlobalAsm(asm) => {
+                hir::ItemKind::GlobalAsm(self.lower_inline_asm(span, asm, true))
+            }
             ItemKind::TyAlias(box TyAlias { generics, where_clauses, ty, .. }) => {
                 // We lower
                 //

--- a/compiler/rustc_codegen_ssa/src/mono_item.rs
+++ b/compiler/rustc_codegen_ssa/src/mono_item.rs
@@ -35,52 +35,55 @@ impl<'a, 'tcx: 'a> MonoItemExt<'a, 'tcx> for MonoItem<'tcx> {
             MonoItem::GlobalAsm(item_id) => {
                 let item = cx.tcx().hir().item(item_id);
                 if let hir::ItemKind::GlobalAsm(ref asm) = item.kind {
-                    let operands: Vec<_> = asm
-                        .operands
-                        .iter()
-                        .map(|(op, op_sp)| match *op {
-                            hir::InlineAsmOperand::Const { ref anon_const } => {
-                                let const_value = cx
-                                    .tcx()
-                                    .const_eval_poly(anon_const.def_id.to_def_id())
-                                    .unwrap_or_else(|_| {
-                                        span_bug!(*op_sp, "asm const cannot be resolved")
-                                    });
-                                let ty = cx
-                                    .tcx()
-                                    .typeck_body(anon_const.body)
-                                    .node_type(anon_const.hir_id);
-                                let string = common::asm_const_to_str(
-                                    cx.tcx(),
-                                    *op_sp,
-                                    const_value,
-                                    cx.layout_of(ty),
-                                );
-                                GlobalAsmOperandRef::Const { string }
-                            }
-                            hir::InlineAsmOperand::SymFn { ref anon_const } => {
-                                let ty = cx
-                                    .tcx()
-                                    .typeck_body(anon_const.body)
-                                    .node_type(anon_const.hir_id);
-                                let instance = match ty.kind() {
-                                    &ty::FnDef(def_id, args) => Instance::new(def_id, args),
-                                    _ => span_bug!(*op_sp, "asm sym is not a function"),
-                                };
+                    let operands: Vec<_> =
+                        asm.operands
+                            .iter()
+                            .map(|(op, op_sp)| match *op {
+                                hir::InlineAsmOperand::Const { ref anon_const } => {
+                                    let const_value = cx
+                                        .tcx()
+                                        .const_eval_poly(anon_const.def_id.to_def_id())
+                                        .unwrap_or_else(|_| {
+                                            span_bug!(*op_sp, "asm const cannot be resolved")
+                                        });
+                                    let ty = cx
+                                        .tcx()
+                                        .typeck_body(anon_const.body)
+                                        .node_type(anon_const.hir_id);
+                                    let string = common::asm_const_to_str(
+                                        cx.tcx(),
+                                        *op_sp,
+                                        const_value,
+                                        cx.layout_of(ty),
+                                    );
+                                    GlobalAsmOperandRef::Const { string }
+                                }
+                                hir::InlineAsmOperand::SymFnInGlobal { ref anon_const } => {
+                                    let fn_ty =
+                                        cx.tcx().type_of(anon_const.def_id).no_bound_vars().expect(
+                                            "`sym` in `global_asm!` should not have generics",
+                                        );
+                                    let instance = match fn_ty.kind() {
+                                        &ty::FnDef(def_id, args) => Instance::new(def_id, args),
+                                        _ => span_bug!(*op_sp, "asm sym is not a function"),
+                                    };
 
-                                GlobalAsmOperandRef::SymFn { instance }
-                            }
-                            hir::InlineAsmOperand::SymStatic { path: _, def_id } => {
-                                GlobalAsmOperandRef::SymStatic { def_id }
-                            }
-                            hir::InlineAsmOperand::In { .. }
-                            | hir::InlineAsmOperand::Out { .. }
-                            | hir::InlineAsmOperand::InOut { .. }
-                            | hir::InlineAsmOperand::SplitInOut { .. } => {
-                                span_bug!(*op_sp, "invalid operand type for global_asm!")
-                            }
-                        })
-                        .collect();
+                                    GlobalAsmOperandRef::SymFn { instance }
+                                }
+                                hir::InlineAsmOperand::SymFnInInline { .. } => {
+                                    bug!("should not encounter `SymFnInInline` in `global_asm!`");
+                                }
+                                hir::InlineAsmOperand::SymStatic { path: _, def_id } => {
+                                    GlobalAsmOperandRef::SymStatic { def_id }
+                                }
+                                hir::InlineAsmOperand::In { .. }
+                                | hir::InlineAsmOperand::Out { .. }
+                                | hir::InlineAsmOperand::InOut { .. }
+                                | hir::InlineAsmOperand::SplitInOut { .. } => {
+                                    span_bug!(*op_sp, "invalid operand type for global_asm!")
+                                }
+                            })
+                            .collect();
 
                     cx.codegen_global_asm(asm.template, &operands, asm.options, asm.line_spans);
                 } else {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2766,8 +2766,11 @@ pub enum InlineAsmOperand<'hir> {
     Const {
         anon_const: AnonConst,
     },
-    SymFn {
+    SymFnInGlobal {
         anon_const: AnonConst,
+    },
+    SymFnInInline {
+        expr: &'hir Expr<'hir>,
     },
     SymStatic {
         path: QPath<'hir>,
@@ -2782,7 +2785,10 @@ impl<'hir> InlineAsmOperand<'hir> {
             | Self::Out { reg, .. }
             | Self::InOut { reg, .. }
             | Self::SplitInOut { reg, .. } => Some(reg),
-            Self::Const { .. } | Self::SymFn { .. } | Self::SymStatic { .. } => None,
+            Self::Const { .. }
+            | Self::SymFnInGlobal { .. }
+            | Self::SymFnInInline { .. }
+            | Self::SymStatic { .. } => None,
         }
     }
 

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1219,7 +1219,12 @@ pub fn walk_inline_asm<'v, V: Visitor<'v>>(visitor: &mut V, asm: &'v InlineAsm<'
                 }
             }
             InlineAsmOperand::Const { anon_const, .. }
-            | InlineAsmOperand::SymFn { anon_const, .. } => visitor.visit_anon_const(anon_const),
+            | InlineAsmOperand::SymFnInGlobal { anon_const, .. } => {
+                visitor.visit_anon_const(anon_const)
+            }
+            InlineAsmOperand::SymFnInInline { expr } => {
+                visitor.visit_expr(expr);
+            }
             InlineAsmOperand::SymStatic { path, .. } => visitor.visit_qpath(path, id, *op_sp),
         }
     }

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -128,7 +128,7 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
                     Node::Expr(&Expr { kind: ExprKind::InlineAsm(asm), .. })
                         if asm.operands.iter().any(|(op, _op_sp)| match op {
                             hir::InlineAsmOperand::Const { anon_const }
-                            | hir::InlineAsmOperand::SymFn { anon_const } => {
+                            | hir::InlineAsmOperand::SymFnInGlobal { anon_const } => {
                                 anon_const.hir_id == hir_id
                             }
                             _ => false,

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -39,7 +39,7 @@ fn anon_const_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
         | Node::Item(&Item { kind: ItemKind::GlobalAsm(asm), .. })
             if asm.operands.iter().any(|(op, _op_sp)| match op {
                 hir::InlineAsmOperand::Const { anon_const }
-                | hir::InlineAsmOperand::SymFn { anon_const } => anon_const.hir_id == hir_id,
+                | hir::InlineAsmOperand::SymFnInGlobal { anon_const } => anon_const.hir_id == hir_id,
                 _ => false,
             }) =>
         {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1309,10 +1309,15 @@ impl<'a> State<'a> {
                     s.space();
                     s.print_anon_const(anon_const);
                 }
-                hir::InlineAsmOperand::SymFn { ref anon_const } => {
+                hir::InlineAsmOperand::SymFnInGlobal { ref anon_const } => {
                     s.word("sym_fn");
                     s.space();
                     s.print_anon_const(anon_const);
+                }
+                hir::InlineAsmOperand::SymFnInInline { ref expr } => {
+                    s.word("sym_fn");
+                    s.space();
+                    s.print_expr(expr);
                 }
                 hir::InlineAsmOperand::SymStatic { ref path, def_id: _ } => {
                     s.word("sym_static");

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3113,10 +3113,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         self.check_expr_asm_operand(out_expr, false);
                     }
                 }
+                hir::InlineAsmOperand::SymFnInInline { expr } => {
+                    self.check_expr(expr);
+                }
                 // `AnonConst`s have their own body and is type-checked separately.
                 // As they don't flow into the type system we don't need them to
                 // be well-formed.
-                hir::InlineAsmOperand::Const { .. } | hir::InlineAsmOperand::SymFn { .. } => {}
+                hir::InlineAsmOperand::Const { .. }
+                | hir::InlineAsmOperand::SymFnInGlobal { .. } => {}
                 hir::InlineAsmOperand::SymStatic { .. } => {}
             }
         }

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -291,7 +291,10 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                         }
                         hir::InlineAsmOperand::Out { expr: None, .. }
                         | hir::InlineAsmOperand::Const { .. }
-                        | hir::InlineAsmOperand::SymFn { .. }
+                        | hir::InlineAsmOperand::SymFnInGlobal { .. }
+                        // `sym`, even in body, operates like a constant,
+                        // so no need to consume or mutate anything here.
+                        | hir::InlineAsmOperand::SymFnInInline { .. }
                         | hir::InlineAsmOperand::SymStatic { .. } => {}
                     }
                 }

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -223,7 +223,9 @@ fn typeck_with_fallback<'tcx>(
                             // Inline assembly constants must be integers.
                             Some(fcx.next_int_var())
                         }
-                        hir::InlineAsmOperand::SymFn { anon_const } if anon_const.hir_id == id => {
+                        hir::InlineAsmOperand::SymFnInGlobal { anon_const }
+                            if anon_const.hir_id == id =>
+                        {
                             Some(fcx.next_ty_var(TypeVariableOrigin {
                                 kind: TypeVariableOriginKind::MiscVariable,
                                 span,

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -566,9 +566,12 @@ pub enum InlineAsmOperand<'tcx> {
         value: mir::Const<'tcx>,
         span: Span,
     },
-    SymFn {
+    SymFnInGlobal {
         value: mir::Const<'tcx>,
         span: Span,
+    },
+    SymFnInInline {
+        expr: ExprId,
     },
     SymStatic {
         def_id: DefId,

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -154,9 +154,12 @@ pub fn walk_expr<'a, 'tcx: 'a, V: Visitor<'a, 'tcx>>(visitor: &mut V, expr: &Exp
                             visitor.visit_expr(&visitor.thir()[*out_expr]);
                         }
                     }
+                    SymFnInInline { expr } => {
+                        visitor.visit_expr(&visitor.thir()[*expr]);
+                    }
                     Out { expr: None, reg: _, late: _ }
                     | Const { value: _, span: _ }
-                    | SymFn { value: _, span: _ }
+                    | SymFnInGlobal { value: _, span: _ }
                     | SymStatic { def_id: _ } => {}
                 }
             }

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -440,13 +440,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 }),
                             }
                         }
-                        thir::InlineAsmOperand::SymFn { value, span } => {
+                        thir::InlineAsmOperand::SymFnInGlobal { value, span } => {
                             mir::InlineAsmOperand::SymFn {
                                 value: Box::new(ConstOperand {
                                     span,
                                     user_ty: None,
                                     const_: value,
                                 }),
+                            }
+                        }
+                        thir::InlineAsmOperand::SymFnInInline { expr } => {
+                            mir::InlineAsmOperand::SymFn {
+                                value: Box::new(this.as_constant(&this.thir[expr])),
                             }
                         }
                         thir::InlineAsmOperand::SymStatic { def_id } => {

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -653,12 +653,15 @@ impl<'tcx> Cx<'tcx> {
 
                             InlineAsmOperand::Const { value, span }
                         }
-                        hir::InlineAsmOperand::SymFn { ref anon_const } => {
+                        hir::InlineAsmOperand::SymFnInGlobal { ref anon_const } => {
                             let value =
                                 mir::Const::from_anon_const(tcx, anon_const.def_id, self.param_env);
                             let span = tcx.def_span(anon_const.def_id);
 
-                            InlineAsmOperand::SymFn { value, span }
+                            InlineAsmOperand::SymFnInGlobal { value, span }
+                        }
+                        hir::InlineAsmOperand::SymFnInInline { expr } => {
+                            InlineAsmOperand::SymFnInInline { expr: self.mirror_expr(expr) }
                         }
                         hir::InlineAsmOperand::SymStatic { path: _, def_id } => {
                             InlineAsmOperand::SymStatic { def_id }

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -897,10 +897,16 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 print_indented!(self, format!("span: {:?}", span), depth_lvl + 1);
                 print_indented!(self, "}", depth_lvl + 1);
             }
-            InlineAsmOperand::SymFn { value, span } => {
-                print_indented!(self, "InlineAsmOperand::SymFn {", depth_lvl);
+            InlineAsmOperand::SymFnInGlobal { value, span } => {
+                print_indented!(self, "InlineAsmOperand::SymFnInGlobal {", depth_lvl);
                 print_indented!(self, format!("value: {:?}", *value), depth_lvl + 1);
                 print_indented!(self, format!("span: {:?}", span), depth_lvl + 1);
+                print_indented!(self, "}", depth_lvl + 1);
+            }
+            InlineAsmOperand::SymFnInInline { expr } => {
+                print_indented!(self, "InlineAsmOperand::SymFnInGlobal {", depth_lvl);
+                print_indented!(self, "expr: ", depth_lvl + 1);
+                self.print_expr(*expr, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);
             }
             InlineAsmOperand::SymStatic { def_id } => {

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -429,10 +429,15 @@ fn collect_items_rec<'tcx>(
                             // are supported. Therefore the value should not
                             // depend on any other items.
                         }
-                        hir::InlineAsmOperand::SymFn { anon_const } => {
-                            let fn_ty =
-                                tcx.typeck_body(anon_const.body).node_type(anon_const.hir_id);
+                        hir::InlineAsmOperand::SymFnInGlobal { anon_const } => {
+                            let fn_ty = tcx
+                                .type_of(anon_const.def_id)
+                                .no_bound_vars()
+                                .expect("`sym` in `global_asm!` should not have generics");
                             visit_fn_use(tcx, fn_ty, false, *op_sp, &mut used_items, &[]);
+                        }
+                        hir::InlineAsmOperand::SymFnInInline { .. } => {
+                            bug!("should not encounter `SymFnInInline` in `global_asm!`");
                         }
                         hir::InlineAsmOperand::SymStatic { path: _, def_id } => {
                             let instance = Instance::mono(tcx, *def_id);

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -1086,7 +1086,8 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                     match op {
                         hir::InlineAsmOperand::In { .. }
                         | hir::InlineAsmOperand::Const { .. }
-                        | hir::InlineAsmOperand::SymFn { .. }
+                        | hir::InlineAsmOperand::SymFnInGlobal { .. }
+                        | hir::InlineAsmOperand::SymFnInInline { .. }
                         | hir::InlineAsmOperand::SymStatic { .. } => {}
                         hir::InlineAsmOperand::Out { expr, .. } => {
                             if let Some(expr) = expr {
@@ -1125,7 +1126,8 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                             succ = self.propagate_through_expr(in_expr, succ);
                         }
                         hir::InlineAsmOperand::Const { .. }
-                        | hir::InlineAsmOperand::SymFn { .. }
+                        | hir::InlineAsmOperand::SymFnInGlobal { .. }
+                        | hir::InlineAsmOperand::SymFnInInline { .. }
                         | hir::InlineAsmOperand::SymStatic { .. } => {}
                     }
                 }

--- a/compiler/rustc_passes/src/naked_functions.rs
+++ b/compiler/rustc_passes/src/naked_functions.rs
@@ -232,8 +232,11 @@ impl<'tcx> CheckInlineAssembly<'tcx> {
             .iter()
             .filter_map(|&(ref op, op_sp)| match op {
                 InlineAsmOperand::Const { .. }
-                | InlineAsmOperand::SymFn { .. }
+                | hir::InlineAsmOperand::SymFnInInline { .. }
                 | InlineAsmOperand::SymStatic { .. } => None,
+                hir::InlineAsmOperand::SymFnInGlobal { .. } => {
+                    bug!("SymFnInGlobal should never be in an inline `asm!`")
+                }
                 InlineAsmOperand::In { .. }
                 | InlineAsmOperand::Out { .. }
                 | InlineAsmOperand::InOut { .. }

--- a/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
@@ -252,9 +252,10 @@ fn never_loop_expr<'tcx>(
                 local_labels,
                 main_loop_id,
             ),
-            InlineAsmOperand::Const { .. } | InlineAsmOperand::SymFn { .. } | InlineAsmOperand::SymStatic { .. } => {
-                NeverLoopResult::Normal
-            },
+            InlineAsmOperand::Const { .. }
+            | InlineAsmOperand::SymFnInGlobal { .. }
+            | InlineAsmOperand::SymFnInInline { .. }
+            | InlineAsmOperand::SymStatic { .. } => NeverLoopResult::Normal,
         })),
         ExprKind::OffsetOf(_, _)
         | ExprKind::Yield(_, _)

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -781,9 +781,12 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                                 self.hash_expr(out_expr);
                             }
                         },
-                        InlineAsmOperand::Const { anon_const } | InlineAsmOperand::SymFn { anon_const } => {
+                        InlineAsmOperand::Const { anon_const } | InlineAsmOperand::SymFnInGlobal { anon_const } => {
                             self.hash_body(anon_const.body);
                         },
+                        InlineAsmOperand::SymFnInInline { expr } => {
+                            self.hash_expr(expr);
+                        }
                         InlineAsmOperand::SymStatic { path, def_id: _ } => self.hash_qpath(path),
                     }
                 }

--- a/tests/ui/asm/global-asm-with-regions-in-sym.rs
+++ b/tests/ui/asm/global-asm-with-regions-in-sym.rs
@@ -1,0 +1,5 @@
+// build-pass
+
+core::arch::global_asm!("/* {} */", sym <&'static ()>::clone);
+
+fn main() {}

--- a/tests/ui/asm/inline-asm-with-regions-in-sym.bad.stderr
+++ b/tests/ui/asm/inline-asm-with-regions-in-sym.bad.stderr
@@ -1,0 +1,14 @@
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/inline-asm-with-regions-in-sym.rs:16:26
+   |
+LL |         asm!("/* {} */", sym dep::<'a, T> );
+   |                          ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | fn test<'a: 'a, T: 'a>() {
+   |                  ++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0309`.

--- a/tests/ui/asm/inline-asm-with-regions-in-sym.rs
+++ b/tests/ui/asm/inline-asm-with-regions-in-sym.rs
@@ -1,0 +1,21 @@
+// revisions: good bad
+//[good] build-pass
+
+use std::arch::asm;
+
+// lifetime requirement, we should check it!!
+#[cfg(bad)]
+fn dep<'a, T: 'a>() {}
+
+// no lifetime requirement
+#[cfg(good)]
+fn dep<'a: 'a, T>() {}
+
+fn test<'a: 'a, T>() {
+    unsafe {
+        asm!("/* {} */", sym dep::<'a, T> );
+        //[bad]~^ ERROR the parameter type `T` may not live long enough
+    }
+}
+
+fn main() {}

--- a/tests/ui/asm/x86_64/type-check-2.rs
+++ b/tests/ui/asm/x86_64/type-check-2.rs
@@ -24,17 +24,6 @@ fn main() {
         asm!("{}", out(reg) v[0]);
         asm!("{}", inout(reg) v[0]);
 
-        // Sym operands must point to a function or static
-
-        const C: i32 = 0;
-        static S: i32 = 0;
-        asm!("{}", sym S);
-        asm!("{}", sym main);
-        asm!("{}", sym C);
-        //~^ ERROR invalid `sym` operand
-        asm!("{}", sym x);
-        //~^ ERROR invalid `sym` operand
-
         // Register operands must be Copy
 
         asm!("{}", in(xmm_reg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
@@ -74,6 +63,25 @@ fn main() {
 
         let u: ! = unreachable!();
         asm!("{}", in(reg) u);
+    }
+}
+
+fn bad_sym() {
+    unsafe {
+        // Sym operands must point to a function or static
+        let x: u64;
+        const C: i32 = 0;
+        static S: i32 = 0;
+        asm!("{}", sym S);
+        asm!("{}", sym main);
+        asm!("{}", sym C);
+        //~^ ERROR invalid `sym` operand
+
+        // N.B. this error is emitted in the resolver, and will taint the
+        // whole typeck body causing other errors to be suppressed. That's
+        // why it's located in a different function.
+        asm!("{}", sym x);
+        //~^ ERROR invalid `sym` operand
     }
 }
 

--- a/tests/ui/asm/x86_64/type-check-2.stderr
+++ b/tests/ui/asm/x86_64/type-check-2.stderr
@@ -1,5 +1,5 @@
 error: invalid `sym` operand
-  --> $DIR/type-check-2.rs:35:24
+  --> $DIR/type-check-2.rs:83:24
    |
 LL |         asm!("{}", sym x);
    |                        ^ is a local variable
@@ -7,31 +7,23 @@ LL |         asm!("{}", sym x);
    = help: `sym` operands must refer to either a function or a static
 
 error: invalid `sym` operand
-  --> $DIR/type-check-2.rs:86:19
+  --> $DIR/type-check-2.rs:94:19
    |
 LL | global_asm!("{}", sym C);
    |                   ^^^^^ is an `i32`
    |
    = help: `sym` operands must refer to either a function or a static
 
-error: invalid `sym` operand
-  --> $DIR/type-check-2.rs:33:20
-   |
-LL |         asm!("{}", sym C);
-   |                    ^^^^^ is an `i32`
-   |
-   = help: `sym` operands must refer to either a function or a static
-
 error: arguments for inline assembly must be copyable
-  --> $DIR/type-check-2.rs:40:32
+  --> $DIR/type-check-2.rs:29:32
    |
 LL |         asm!("{}", in(xmm_reg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `SimdNonCopy` does not implement the Copy trait
 
-error: cannot use value of type `{closure@$DIR/type-check-2.rs:52:28: 52:36}` for inline assembly
-  --> $DIR/type-check-2.rs:52:28
+error: cannot use value of type `{closure@$DIR/type-check-2.rs:41:28: 41:36}` for inline assembly
+  --> $DIR/type-check-2.rs:41:28
    |
 LL |         asm!("{}", in(reg) |x: i32| x);
    |                            ^^^^^^^^^^
@@ -39,7 +31,7 @@ LL |         asm!("{}", in(reg) |x: i32| x);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `Vec<i32>` for inline assembly
-  --> $DIR/type-check-2.rs:54:28
+  --> $DIR/type-check-2.rs:43:28
    |
 LL |         asm!("{}", in(reg) vec![0]);
    |                            ^^^^^^^
@@ -48,7 +40,7 @@ LL |         asm!("{}", in(reg) vec![0]);
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot use value of type `(i32, i32, i32)` for inline assembly
-  --> $DIR/type-check-2.rs:56:28
+  --> $DIR/type-check-2.rs:45:28
    |
 LL |         asm!("{}", in(reg) (1, 2, 3));
    |                            ^^^^^^^^^
@@ -56,7 +48,7 @@ LL |         asm!("{}", in(reg) (1, 2, 3));
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `[i32; 3]` for inline assembly
-  --> $DIR/type-check-2.rs:58:28
+  --> $DIR/type-check-2.rs:47:28
    |
 LL |         asm!("{}", in(reg) [1, 2, 3]);
    |                            ^^^^^^^^^
@@ -64,7 +56,7 @@ LL |         asm!("{}", in(reg) [1, 2, 3]);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `fn() {main}` for inline assembly
-  --> $DIR/type-check-2.rs:66:31
+  --> $DIR/type-check-2.rs:55:31
    |
 LL |         asm!("{}", inout(reg) f);
    |                               ^
@@ -72,12 +64,20 @@ LL |         asm!("{}", inout(reg) f);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `&mut i32` for inline assembly
-  --> $DIR/type-check-2.rs:69:31
+  --> $DIR/type-check-2.rs:58:31
    |
 LL |         asm!("{}", inout(reg) r);
    |                               ^
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
+
+error: invalid `sym` operand
+  --> $DIR/type-check-2.rs:77:20
+   |
+LL |         asm!("{}", sym C);
+   |                    ^^^^^ is an `i32`
+   |
+   = help: `sym` operands must refer to either a function or a static
 
 error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Fixes #111709
Fixes #96304

`sym` in global-asm can never reference regions other than `'static`, so it suffices to fold the constant and replace erased regions with `'static` (see first commit). However, we want to be able to mention both early- and late-bound (and local, e.g. #111709) regions from the function in inline-asm.

This change is a bit invasive, but I'm not really convinced it can be simpler, at least without having to teach `global_asm!` how to be an inference body or something.

This conceptually reverts part of dc345d8bffdd95c65ba537c32a6900b8c19c049d for inline asm, insofar as we return to treating `SymFn` in non-global_asm bodies as a regular HIR exprs.

cc @amanieu who stabilized `sym` in #93333