### PR TITLE
When suggesting `self.x` for `S { x }`, use `S { x: self.x }`

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -215,7 +215,8 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
             }
         } else {
             let mut span_label = None;
-            let item_span = path.last().unwrap().ident.span;
+            let item_ident = path.last().unwrap().ident;
+            let item_span = item_ident.span;
             let (mod_prefix, mod_str, module, suggestion) = if path.len() == 1 {
                 debug!(?self.diagnostic_metadata.current_impl_items);
                 debug!(?self.diagnostic_metadata.current_function);
@@ -231,9 +232,35 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     })
                 {
                     let sp = item_span.shrink_to_lo();
+
+                    // Account for `Foo { field }` when suggesting `self.field` so we result on
+                    // `Foo { field: self.field }`.
+                    let field = match source {
+                        PathSource::Expr(Some(Expr { kind: ExprKind::Struct(expr), .. })) => {
+                            expr.fields.iter().find(|f| f.ident == item_ident)
+                        }
+                        _ => None,
+                    };
+                    let pre = if let Some(field) = field && field.is_shorthand {
+                        format!("{item_ident}: ")
+                    } else {
+                        String::new()
+                    };
+                    // Ensure we provide a structured suggestion for an assoc fn only for
+                    // expressions that are actually a fn call.
+                    let is_call = match field {
+                        Some(ast::ExprField { expr, .. }) => {
+                            matches!(expr.kind, ExprKind::Call(..))
+                        }
+                        _ => matches!(
+                            source,
+                            PathSource::Expr(Some(Expr { kind: ExprKind::Call(..), ..})),
+                        ),
+                    };
+
                     match &item.kind {
                         AssocItemKind::Fn(fn_)
-                        if !sig.decl.has_self() && fn_.sig.decl.has_self() => {
+                        if (!sig.decl.has_self() || !is_call) && fn_.sig.decl.has_self() => {
                             // Ensure that we only suggest `self.` if `self` is available,
                             // you can't call `fn foo(&self)` from `fn bar()` (#115992).
                             // We also want to mention that the method exists.
@@ -243,20 +270,28 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                             ));
                             None
                         }
+                        AssocItemKind::Fn(fn_)
+                        if !fn_.sig.decl.has_self() && !is_call => {
+                            span_label = Some((
+                                item.ident.span,
+                                "an associated function by that name is available on `Self` here",
+                            ));
+                            None
+                        }
                         AssocItemKind::Fn(fn_) if fn_.sig.decl.has_self() => Some((
                             sp,
                             "consider using the method on `Self`",
-                            "self.".to_string(),
+                            format!("{pre}self."),
                         )),
                         AssocItemKind::Fn(_) => Some((
                             sp,
                             "consider using the associated function on `Self`",
-                            "Self::".to_string(),
+                            format!("{pre}Self::"),
                         )),
                         AssocItemKind::Const(..) => Some((
                             sp,
                             "consider using the associated constant on `Self`",
-                            "Self::".to_string(),
+                            format!("{pre}Self::"),
                         )),
                         _ => None
                     }
@@ -621,13 +656,26 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                 self.lookup_assoc_candidate(ident, ns, is_expected, source.is_call())
             {
                 let self_is_available = self.self_value_is_available(path[0].ident.span);
+                // Account for `Foo { field }` when suggesting `self.field` so we result on
+                // `Foo { field: self.field }`.
+                let pre = match source {
+                    PathSource::Expr(Some(Expr { kind: ExprKind::Struct(expr), .. }))
+                        if expr
+                            .fields
+                            .iter()
+                            .any(|f| f.ident == path[0].ident && f.is_shorthand) =>
+                    {
+                        format!("{path_str}: ")
+                    }
+                    _ => String::new(),
+                };
                 match candidate {
                     AssocSuggestion::Field => {
                         if self_is_available {
-                            err.span_suggestion(
-                                span,
+                            err.span_suggestion_verbose(
+                                span.shrink_to_lo(),
                                 "you might have meant to use the available field",
-                                format!("self.{path_str}"),
+                                format!("{pre}self."),
                                 Applicability::MachineApplicable,
                             );
                         } else {
@@ -640,10 +688,10 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                         } else {
                             "you might have meant to refer to the method"
                         };
-                        err.span_suggestion(
-                            span,
+                        err.span_suggestion_verbose(
+                            span.shrink_to_lo(),
                             msg,
-                            format!("self.{path_str}"),
+                            "self.".to_string(),
                             Applicability::MachineApplicable,
                         );
                     }
@@ -651,10 +699,10 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     | AssocSuggestion::AssocFn { .. }
                     | AssocSuggestion::AssocConst
                     | AssocSuggestion::AssocType => {
-                        err.span_suggestion(
-                            span,
+                        err.span_suggestion_verbose(
+                            span.shrink_to_lo(),
                             format!("you might have meant to {}", candidate.action()),
-                            format!("Self::{path_str}"),
+                            "Self::".to_string(),
                             Applicability::MachineApplicable,
                         );
                     }

--- a/tests/ui/resolve/associated-fn-called-as-fn.stderr
+++ b/tests/ui/resolve/associated-fn-called-as-fn.stderr
@@ -2,13 +2,23 @@ error[E0425]: cannot find function `collect_primary` in this scope
   --> $DIR/associated-fn-called-as-fn.rs:6:30
    |
 LL |                 '0'..='9' => collect_primary(&c),
-   |                              ^^^^^^^^^^^^^^^ help: you might have meant to call the associated function: `Self::collect_primary`
+   |                              ^^^^^^^^^^^^^^^
+   |
+help: you might have meant to call the associated function
+   |
+LL |                 '0'..='9' => Self::collect_primary(&c),
+   |                              ++++++
 
 error[E0425]: cannot find function `collect_primary` in this scope
   --> $DIR/associated-fn-called-as-fn.rs:23:30
    |
 LL |                 '0'..='9' => collect_primary(&c),
-   |                              ^^^^^^^^^^^^^^^ help: you might have meant to call the associated function: `Self::collect_primary`
+   |                              ^^^^^^^^^^^^^^^
+   |
+help: you might have meant to call the associated function
+   |
+LL |                 '0'..='9' => Self::collect_primary(&c),
+   |                              ++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.rs
+++ b/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.rs
@@ -11,5 +11,8 @@ impl Foo {
         field; //~ ERROR cannot find value `field` in this scope
         Foo { field } //~ ERROR cannot find value `field` in this scope
     }
+    fn clone(&self) -> Foo {
+        Foo { field } //~ ERROR cannot find value `field` in this scope
+    }
 }
 fn main() {}

--- a/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.stderr
+++ b/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.stderr
@@ -16,6 +16,20 @@ LL |     fn field(&self) -> u32 {
 LL |         Foo { field }
    |               ^^^^^ a field by this name exists in `Self`
 
-error: aborting due to 2 previous errors
+error[E0425]: cannot find value `field` in this scope
+  --> $DIR/field-and-method-in-self-not-available-in-assoc-fn.rs:15:15
+   |
+LL |     fn field(&self) -> u32 {
+   |        ----- a method by that name is available on `Self` here
+...
+LL |         Foo { field }
+   |               ^^^^^
+   |
+help: you might have meant to use the available field
+   |
+LL |         Foo { field: self.field }
+   |               ++++++++++++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.stderr
+++ b/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.stderr
@@ -1,20 +1,26 @@
 error[E0425]: cannot find value `field` in this scope
   --> $DIR/field-and-method-in-self-not-available-in-assoc-fn.rs:11:9
    |
+LL |     field: u32,
+   |     ---------- a field by that name exists in `Self`
+...
 LL |     fn field(&self) -> u32 {
    |        ----- a method by that name is available on `Self` here
 ...
 LL |         field;
-   |         ^^^^^ a field by this name exists in `Self`
+   |         ^^^^^
 
 error[E0425]: cannot find value `field` in this scope
   --> $DIR/field-and-method-in-self-not-available-in-assoc-fn.rs:12:15
    |
+LL |     field: u32,
+   |     ---------- a field by that name exists in `Self`
+...
 LL |     fn field(&self) -> u32 {
    |        ----- a method by that name is available on `Self` here
 ...
 LL |         Foo { field }
-   |               ^^^^^ a field by this name exists in `Self`
+   |               ^^^^^
 
 error[E0425]: cannot find value `field` in this scope
   --> $DIR/field-and-method-in-self-not-available-in-assoc-fn.rs:15:15

--- a/tests/ui/resolve/issue-14254.stderr
+++ b/tests/ui/resolve/issue-14254.stderr
@@ -8,13 +8,23 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/issue-14254.rs:30:9
    |
 LL |         x;
-   |         ^ help: you might have meant to use the available field: `self.x`
+   |         ^
+   |
+help: you might have meant to use the available field
+   |
+LL |         self.x;
+   |         +++++
 
 error[E0425]: cannot find value `y` in this scope
   --> $DIR/issue-14254.rs:32:9
    |
 LL |         y;
-   |         ^ help: you might have meant to use the available field: `self.y`
+   |         ^
+   |
+help: you might have meant to use the available field
+   |
+LL |         self.y;
+   |         +++++
 
 error[E0425]: cannot find value `a` in this scope
   --> $DIR/issue-14254.rs:34:9
@@ -31,7 +41,7 @@ LL |         bah;
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
-   |         ~~~~~~~~~
+   |         ++++++
 
 error[E0425]: cannot find value `b` in this scope
   --> $DIR/issue-14254.rs:38:9
@@ -43,13 +53,23 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/issue-14254.rs:47:9
    |
 LL |         x;
-   |         ^ help: you might have meant to use the available field: `self.x`
+   |         ^
+   |
+help: you might have meant to use the available field
+   |
+LL |         self.x;
+   |         +++++
 
 error[E0425]: cannot find value `y` in this scope
   --> $DIR/issue-14254.rs:49:9
    |
 LL |         y;
-   |         ^ help: you might have meant to use the available field: `self.y`
+   |         ^
+   |
+help: you might have meant to use the available field
+   |
+LL |         self.y;
+   |         +++++
 
 error[E0425]: cannot find value `a` in this scope
   --> $DIR/issue-14254.rs:51:9
@@ -66,7 +86,7 @@ LL |         bah;
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
-   |         ~~~~~~~~~
+   |         ++++++
 
 error[E0425]: cannot find value `b` in this scope
   --> $DIR/issue-14254.rs:55:9
@@ -83,7 +103,7 @@ LL |         bah;
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
-   |         ~~~~~~~~~
+   |         ++++++
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:73:9
@@ -94,7 +114,7 @@ LL |         bah;
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
-   |         ~~~~~~~~~
+   |         ++++++
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:82:9
@@ -105,7 +125,7 @@ LL |         bah;
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
-   |         ~~~~~~~~~
+   |         ++++++
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:91:9
@@ -116,7 +136,7 @@ LL |         bah;
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
-   |         ~~~~~~~~~
+   |         ++++++
 
 error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:100:9
@@ -127,55 +147,95 @@ LL |         bah;
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
-   |         ~~~~~~~~~
+   |         ++++++
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:19:9
    |
 LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
+   |         ^^^
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         +++++
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:28:9
    |
 LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
+   |         ^^^
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         +++++
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:45:9
    |
 LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
+   |         ^^^
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         +++++
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:62:9
    |
 LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
+   |         ^^^
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         +++++
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:71:9
    |
 LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
+   |         ^^^
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         +++++
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:80:9
    |
 LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
+   |         ^^^
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         +++++
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:89:9
    |
 LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
+   |         ^^^
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         +++++
 
 error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:98:9
    |
 LL |         baz();
-   |         ^^^ help: you might have meant to call the method: `self.baz`
+   |         ^^^
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         +++++
 
 error: aborting due to 24 previous errors
 

--- a/tests/ui/resolve/issue-2356.stderr
+++ b/tests/ui/resolve/issue-2356.stderr
@@ -1,8 +1,11 @@
 error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:39:5
    |
+LL |   whiskers: isize,
+   |   --------------- a field by that name exists in `Self`
+...
 LL |     whiskers -= other;
-   |     ^^^^^^^^ a field by this name exists in `Self`
+   |     ^^^^^^^^
 
 error[E0424]: expected value, found module `self`
   --> $DIR/issue-2356.rs:65:8
@@ -31,8 +34,11 @@ LL |     self.whiskers = 0;
 error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:84:5
    |
+LL |   whiskers: isize,
+   |   --------------- a field by that name exists in `Self`
+...
 LL |     whiskers = 4;
-   |     ^^^^^^^^ a field by this name exists in `Self`
+   |     ^^^^^^^^
 
 error[E0424]: expected value, found module `self`
   --> $DIR/issue-2356.rs:92:5

--- a/tests/ui/resolve/issue-2356.stderr
+++ b/tests/ui/resolve/issue-2356.stderr
@@ -21,7 +21,12 @@ error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:79:5
    |
 LL |     whiskers = 0;
-   |     ^^^^^^^^ help: you might have meant to use the available field: `self.whiskers`
+   |     ^^^^^^^^
+   |
+help: you might have meant to use the available field
+   |
+LL |     self.whiskers = 0;
+   |     +++++
 
 error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:84:5
@@ -47,19 +52,34 @@ error[E0425]: cannot find function `clone` in this scope
   --> $DIR/issue-2356.rs:24:5
    |
 LL |     clone();
-   |     ^^^^^ help: you might have meant to call the method: `self.clone`
+   |     ^^^^^
+   |
+help: you might have meant to call the method
+   |
+LL |     self.clone();
+   |     +++++
 
 error[E0425]: cannot find function `default` in this scope
   --> $DIR/issue-2356.rs:31:5
    |
 LL |     default();
-   |     ^^^^^^^ help: you might have meant to call the associated function: `Self::default`
+   |     ^^^^^^^
+   |
+help: you might have meant to call the associated function
+   |
+LL |     Self::default();
+   |     ++++++
 
 error[E0425]: cannot find function `shave` in this scope
   --> $DIR/issue-2356.rs:41:5
    |
 LL |     shave(4);
-   |     ^^^^^ help: you might have meant to call the associated function: `Self::shave`
+   |     ^^^^^
+   |
+help: you might have meant to call the associated function
+   |
+LL |     Self::shave(4);
+   |     ++++++
 
 error[E0425]: cannot find function `purr` in this scope
   --> $DIR/issue-2356.rs:43:5

--- a/tests/ui/resolve/issue-60057.stderr
+++ b/tests/ui/resolve/issue-60057.stderr
@@ -8,7 +8,12 @@ error[E0425]: cannot find value `banana` in this scope
   --> $DIR/issue-60057.rs:14:21
    |
 LL |             banana: banana
-   |                     ^^^^^^ help: you might have meant to use the available field: `self.banana`
+   |                     ^^^^^^
+   |
+help: you might have meant to use the available field
+   |
+LL |             banana: self.banana
+   |                     +++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/issue-60057.stderr
+++ b/tests/ui/resolve/issue-60057.stderr
@@ -1,8 +1,11 @@
 error[E0425]: cannot find value `banana` in this scope
   --> $DIR/issue-60057.rs:8:21
    |
+LL |     banana: u8,
+   |     ---------- a field by that name exists in `Self`
+...
 LL |             banana: banana
-   |                     ^^^^^^ a field by this name exists in `Self`
+   |                     ^^^^^^
 
 error[E0425]: cannot find value `banana` in this scope
   --> $DIR/issue-60057.rs:14:21

--- a/tests/ui/resolve/resolve-assoc-suggestions.stderr
+++ b/tests/ui/resolve/resolve-assoc-suggestions.stderr
@@ -14,13 +14,23 @@ error[E0425]: cannot find value `field` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:20:9
    |
 LL |         field;
-   |         ^^^^^ help: you might have meant to use the available field: `self.field`
+   |         ^^^^^
+   |
+help: you might have meant to use the available field
+   |
+LL |         self.field;
+   |         +++++
 
 error[E0412]: cannot find type `Type` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:23:16
    |
 LL |         let _: Type;
-   |                ^^^^ help: you might have meant to use the associated type: `Self::Type`
+   |                ^^^^
+   |
+help: you might have meant to use the associated type
+   |
+LL |         let _: Self::Type;
+   |                ++++++
 
 error[E0531]: cannot find tuple struct or tuple variant `Type` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:25:13
@@ -50,7 +60,12 @@ error[E0425]: cannot find value `method` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:34:9
    |
 LL |         method;
-   |         ^^^^^^ help: you might have meant to refer to the method: `self.method`
+   |         ^^^^^^
+   |
+help: you might have meant to refer to the method
+   |
+LL |         self.method;
+   |         +++++
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/resolve/resolve-speculative-adjustment.stderr
+++ b/tests/ui/resolve/resolve-speculative-adjustment.stderr
@@ -8,13 +8,23 @@ error[E0425]: cannot find value `field` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:23:9
    |
 LL |         field;
-   |         ^^^^^ help: you might have meant to use the available field: `self.field`
+   |         ^^^^^
+   |
+help: you might have meant to use the available field
+   |
+LL |         self.field;
+   |         +++++
 
 error[E0425]: cannot find function `method` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:25:9
    |
 LL |         method();
-   |         ^^^^^^ help: you might have meant to call the method: `self.method`
+   |         ^^^^^^
+   |
+help: you might have meant to call the method
+   |
+LL |         self.method();
+   |         +++++
 
 error[E0425]: cannot find function `method` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:19:13

--- a/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -25,7 +25,7 @@ LL |         println!("{config}");
 help: you might have meant to use the available field
    |
 LL |         println!("{self.config}");
-   |                    ~~~~~~~~~~~
+   |                    +++++
 help: a local variable with a similar name exists
    |
 LL |         println!("{cofig}");
@@ -43,7 +43,7 @@ LL | fn ba() {}
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
-   |         ~~~~~~~~~
+   |         ++++++
 help: a function with a similar name exists
    |
 LL |         ba;
@@ -61,7 +61,7 @@ LL | const BARR: u32 = 3;
 help: you might have meant to use the associated `const`
    |
 LL |         Self::BAR;
-   |         ~~~~~~~~~
+   |         ++++++
 help: a constant with a similar name exists
    |
 LL |         BARR;
@@ -79,7 +79,7 @@ LL | type Bar = String;
 help: you might have meant to use the associated type
    |
 LL |         let foo: Self::Baz = "".to_string();
-   |                  ~~~~~~~~~
+   |                  ++++++
 help: a type alias with a similar name exists
    |
 LL |         let foo: Bar = "".to_string();
@@ -97,7 +97,7 @@ LL | fn ba() {}
 help: you might have meant to call the method
    |
 LL |         self.baz();
-   |         ~~~~~~~~
+   |         +++++
 help: a function with a similar name exists
    |
 LL |         ba();

--- a/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -1,20 +1,20 @@
 error[E0425]: cannot find value `config` in this scope
   --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:7:16
    |
+LL |     config: String,
+   |     -------------- a field by that name exists in `Self`
+...
 LL |         Self { config }
-   |                ^^^^^^
-   |                |
-   |                a field by this name exists in `Self`
-   |                help: a local variable with a similar name exists: `cofig`
+   |                ^^^^^^ help: a local variable with a similar name exists: `cofig`
 
 error[E0425]: cannot find value `config` in this scope
   --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:11:20
    |
+LL |     config: String,
+   |     -------------- a field by that name exists in `Self`
+...
 LL |         println!("{config}");
-   |                    ^^^^^^
-   |                    |
-   |                    a field by this name exists in `Self`
-   |                    help: a local variable with a similar name exists: `cofig`
+   |                    ^^^^^^ help: a local variable with a similar name exists: `cofig`
 
 error[E0425]: cannot find value `config` in this scope
   --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:15:20

--- a/tests/ui/resolve/unresolved_static_type_field.stderr
+++ b/tests/ui/resolve/unresolved_static_type_field.stderr
@@ -1,8 +1,11 @@
 error[E0425]: cannot find value `cx` in this scope
   --> $DIR/unresolved_static_type_field.rs:9:11
    |
+LL |     cx: bool,
+   |     -------- a field by that name exists in `Self`
+...
 LL |         f(cx);
-   |           ^^ a field by this name exists in `Self`
+   |           ^^
 
 error: aborting due to previous error
 

--- a/tests/ui/self/class-missing-self.stderr
+++ b/tests/ui/self/class-missing-self.stderr
@@ -2,7 +2,12 @@ error[E0425]: cannot find value `meows` in this scope
   --> $DIR/class-missing-self.rs:9:7
    |
 LL |       meows += 1;
-   |       ^^^^^ help: you might have meant to use the available field: `self.meows`
+   |       ^^^^^
+   |
+help: you might have meant to use the available field
+   |
+LL |       self.meows += 1;
+   |       +++++
 
 error[E0425]: cannot find function `sleep` in this scope
   --> $DIR/class-missing-self.rs:10:7

--- a/tests/ui/suggestions/assoc-type-in-method-return.stderr
+++ b/tests/ui/suggestions/assoc-type-in-method-return.stderr
@@ -2,7 +2,12 @@ error[E0412]: cannot find type `Bla` in this scope
   --> $DIR/assoc-type-in-method-return.rs:3:25
    |
 LL |     fn to_bla(&self) -> Bla;
-   |                         ^^^ help: you might have meant to use the associated type: `Self::Bla`
+   |                         ^^^
+   |
+help: you might have meant to use the associated type
+   |
+LL |     fn to_bla(&self) -> Self::Bla;
+   |                         ++++++
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fix #115992.

r? @compiler-errors 

Follow up to #116086.