### PR TITLE
test: reproduce the issue with the cstr parsing inside a the proc macro

### DIFF
--- a/tests/ui/rfcs/rfc-3348-c-string-literals/auxiliary/wrong_parsing.rs
+++ b/tests/ui/rfcs/rfc-3348-c-string-literals/auxiliary/wrong_parsing.rs
@@ -1,0 +1,17 @@
+// force-host
+// no-prefer-dynamic
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::{TokenStream, TokenTree};
+
+#[proc_macro]
+pub fn repro(input: TokenStream) -> TokenStream {
+    for token in input {
+        if let TokenTree::Literal(literal) = token {
+            assert!(format!("{}", literal).contains(&"c\""), "panic on: `{}`", literal);
+        }
+    }
+    TokenStream::new()
+}

--- a/tests/ui/rfcs/rfc-3348-c-string-literals/edition-issue-112820-spans.rs
+++ b/tests/ui/rfcs/rfc-3348-c-string-literals/edition-issue-112820-spans.rs
@@ -1,0 +1,14 @@
+// edition: 2021
+// known-bug: #112820
+//
+// aux-build: count.rs
+#![feature(c_str_literals)]
+
+// aux-build: wrong_parsing.rs
+extern crate wrong_parsing;
+
+const _: () = {
+    wrong_parsing::repro!(c"cstr");
+};
+
+fn main() {}

--- a/tests/ui/rfcs/rfc-3348-c-string-literals/edition-issue-112820-spans.stderr
+++ b/tests/ui/rfcs/rfc-3348-c-string-literals/edition-issue-112820-spans.stderr
@@ -1,0 +1,10 @@
+error: proc macro panicked
+  --> $DIR/edition-issue-112820-spans.rs:11:5
+   |
+LL |     wrong_parsing::repro!(c"cstr");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: message: panic on: `cstr`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
While I am working on trying to patch https://github.com/rust-lang/rust/issues/112820

I think it is useful to have a test for this case as known-bug