### PR TITLE
[TEST] Optimize hash map operations in the query system

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -524,7 +524,8 @@ macro_rules! define_feedable {
                             &value,
                             hash_result!([$($modifiers)*]),
                         );
-                        cache.complete(key, erased, dep_node_index);
+                        let key_hash = rustc_data_structures::sharded::make_hash(&key);
+                        cache.complete(key, key_hash, erased, dep_node_index);
                     }
                 }
             }


### PR DESCRIPTION
This is a variant of https://github.com/rust-lang/rust/pull/115747 without using the `hashbrown` crate to see if that change the bootstrap impact.

r? @cjgillot 