### PR TITLE
Migrate GUI colors test to original CSS color format

### DIFF
--- a/tests/rustdoc-gui/default-settings.goml
+++ b/tests/rustdoc-gui/default-settings.goml
@@ -5,4 +5,4 @@
 go-to: "file://" + |DOC_PATH| + "/settings/index.html"
 // Wait a bit to be sure the default theme is applied.
 // If the theme isn't applied, the command will time out.
-wait-for-css: ("body", {"background-color": "rgb(15, 20, 25)"})
+wait-for-css: ("body", {"background-color": "#0f1419"})


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/111459.

And with this one I'm finally done with this migration.

r? @notriddle