### PR TITLE
Pass `-jN` from Make to `BOOTSTRAP_ARGS`

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -6,6 +6,13 @@ Q := @
 BOOTSTRAP_ARGS :=
 endif
 
+# Pass `-jN` to the bootstrap if it is specified.
+ifdef MAKEFLAGS
+  ifneq (,$(findstring -j, $(MAKEFLAGS)))
+    BOOTSTRAP_ARGS += $(filter -j%, $(MAKEFLAGS))
+  endif
+endif
+
 BOOTSTRAP := $(CFG_PYTHON) $(CFG_SRC_DIR)src/bootstrap/bootstrap.py
 
 all:


### PR DESCRIPTION
Enables the same functionality as `x -jN` in Make by passing the `-jN` arg from Make to the `BOOTSTRAP_ARGS` if it is specified.