### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -758,7 +758,9 @@ impl Map {
             self.value_count += 1;
         }
 
-        if let Some(ref_ty) = ty.builtin_deref(true) && let ty::Slice(..) = ref_ty.ty.kind() {
+        if let ty::Ref(_, ref_ty, _) | ty::RawPtr(ty::TypeAndMut { ty: ref_ty, .. }) = ty.kind()
+            && let ty::Slice(..) = ref_ty.kind()
+        {
             assert!(self.places[place].value_index.is_none(), "slices are not scalars");
 
             // Prepend new child to the linked list.

--- a/compiler/rustc_target/src/spec/riscv64_linux_android.rs
+++ b/compiler/rustc_target/src/spec/riscv64_linux_android.rs
@@ -9,7 +9,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             code_model: Some(CodeModel::Medium),
             cpu: "generic-rv64".into(),
-            features: "+m,+a,+f,+d,+c".into(),
+            features: "+m,+a,+f,+d,+c,+Zba,+Zbb,+Zbs".into(),
             llvm_abiname: "lp64d".into(),
             supported_sanitizers: SanitizerSet::ADDRESS,
             max_atomic_width: Some(64),

--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -564,22 +564,18 @@ impl<I: Interner> DebugWithInfcx<I> for TyKind<I> {
             }
             Never => write!(f, "!"),
             Tuple(t) => {
-                let mut iter = t.clone().into_iter();
-
                 write!(f, "(")?;
-
-                match iter.next() {
-                    None => return write!(f, ")"),
-                    Some(ty) => write!(f, "{:?}", &this.wrap(ty))?,
-                };
-
-                match iter.next() {
-                    None => return write!(f, ",)"),
-                    Some(ty) => write!(f, "{:?})", &this.wrap(ty))?,
+                let mut count = 0;
+                for ty in t.clone() {
+                    if count > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{:?}", &this.wrap(ty))?;
+                    count += 1;
                 }
-
-                for ty in iter {
-                    write!(f, ", {:?}", &this.wrap(ty))?;
+                // unary tuples need a trailing comma
+                if count == 1 {
+                    write!(f, ",")?;
                 }
                 write!(f, ")")
             }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1307,6 +1307,10 @@ macro_rules! uint_impl {
         /// This function exists, so that all operations
         /// are accounted for in the wrapping operations.
         ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is 0.
+        ///
         /// # Examples
         ///
         /// Basic usage:

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1259,6 +1259,10 @@ macro_rules! uint_impl {
         /// This function exists, so that all operations
         /// are accounted for in the wrapping operations.
         ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is 0.
+        ///
         /// # Examples
         ///
         /// Basic usage:
@@ -1283,6 +1287,10 @@ macro_rules! uint_impl {
         /// Since, for the positive integers, all common
         /// definitions of division are equal, this
         /// is exactly equal to `self.wrapping_div(rhs)`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is 0.
         ///
         /// # Examples
         ///
@@ -1336,6 +1344,10 @@ macro_rules! uint_impl {
         /// Since, for the positive integers, all common
         /// definitions of division are equal, this
         /// is exactly equal to `self.wrapping_rem(rhs)`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is 0.
         ///
         /// # Examples
         ///

--- a/tests/assembly/closure-inherit-target-feature.rs
+++ b/tests/assembly/closure-inherit-target-feature.rs
@@ -1,0 +1,58 @@
+// only-x86_64
+// assembly-output: emit-asm
+// make sure the feature is not enabled at compile-time
+// compile-flags: -C target-feature=-sse4.1 -C llvm-args=-x86-asm-syntax=intel
+
+#![feature(target_feature_11)]
+#![crate_type = "rlib"]
+
+use std::arch::x86_64::{__m128, _mm_blend_ps};
+
+#[no_mangle]
+pub unsafe fn sse41_blend_nofeature(x: __m128, y: __m128) -> __m128 {
+    let f = {
+        // check that _mm_blend_ps is not being inlined into the closure
+        // CHECK-LABEL: {{sse41_blend_nofeature.*closure.*:}}
+        // CHECK-NOT: blendps
+        // CHECK: {{call .*_mm_blend_ps.*}}
+        // CHECK-NOT: blendps
+        // CHECK: ret
+        #[inline(never)] |x, y| _mm_blend_ps(x, y, 0b0101)
+    };
+    f(x, y)
+}
+
+#[target_feature(enable = "sse4.1")]
+pub fn sse41_blend_noinline(x: __m128, y: __m128) -> __m128 {
+    let f = {
+        // check that _mm_blend_ps is being inlined into the closure
+        // CHECK-LABEL: {{sse41_blend_noinline.*closure.*:}}
+        // CHECK-NOT: _mm_blend_ps
+        // CHECK: blendps
+        // CHECK-NOT: _mm_blend_ps
+        // CHECK: ret
+        #[inline(never)] |x, y| unsafe {
+            _mm_blend_ps(x, y, 0b0101)
+        }
+    };
+    f(x, y)
+}
+
+#[no_mangle]
+#[target_feature(enable = "sse4.1")]
+pub fn sse41_blend_doinline(x: __m128, y: __m128) -> __m128 {
+    // check that the closure and _mm_blend_ps are being inlined into the function
+    // CHECK-LABEL: sse41_blend_doinline:
+    // CHECK-NOT: {{sse41_blend_doinline.*closure.*}}
+    // CHECK-NOT: _mm_blend_ps
+    // CHECK: blendps
+    // CHECK-NOT: {{sse41_blend_doinline.*closure.*}}
+    // CHECK-NOT: _mm_blend_ps
+    // CHECK: ret
+    let f = {
+        #[inline] |x, y| unsafe {
+            _mm_blend_ps(x, y, 0b0101)
+        }
+    };
+    f(x, y)
+}

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.ConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.ConstProp.32bit.panic-abort.diff
@@ -1,0 +1,119 @@
+- // MIR for `main` before ConstProp
++ // MIR for `main` after ConstProp
+  
+  fn main() -> () {
+      let mut _0: ();
+      let _1: A;
+      let mut _2: std::boxed::Box<[bool]>;
+      scope 1 {
+          debug a => _1;
+      }
+      scope 2 (inlined <Box<[bool]> as Default>::default) {
+          let _3: std::ptr::Unique<[bool]>;
+          let mut _4: std::ptr::Unique<[bool; 0]>;
+          scope 3 {
+              debug ptr => _3;
+          }
+          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+              let mut _5: std::ptr::NonNull<[bool; 0]>;
+              scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
+                  let mut _7: usize;
+                  scope 6 {
+                      let _6: *mut [bool; 0];
+                      scope 7 {
+                          debug ptr => _6;
+                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                              debug ptr => _6;
+                              let mut _8: *const [bool; 0];
+                              scope 12 {
+                                  scope 13 (inlined NonNull::<T>::new_unchecked::runtime::<[bool; 0]>) {
+                                      debug ptr => _6;
+                                      scope 14 (inlined ptr::mut_ptr::<impl *mut [bool; 0]>::is_null) {
+                                          debug self => _6;
+                                          let mut _9: *mut u8;
+                                          scope 15 {
+                                              scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
+                                                  debug ptr => _9;
+                                                  scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
+                                                      debug self => _9;
+                                                      scope 18 {
+                                                          scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
+                                                              debug self => _9;
+                                                          }
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                      scope 8 (inlined align_of::<[bool; 0]>) {
+                      }
+                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
+                          debug addr => _7;
+                          scope 10 {
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+-         _7 = AlignOf([bool; 0]);
+-         _6 = _7 as *mut [bool; 0] (Transmute);
++         _7 = const 1_usize;
++         _6 = const {0x1 as *mut [bool; 0]};
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+-         _8 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
+-         _5 = NonNull::<[bool; 0]> { pointer: _8 };
++         _8 = const {0x1 as *const [bool; 0]};
++         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_6);
+-         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
++         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+-         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize));
++         _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc7, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+-         _2 = Box::<[bool]>(_3, const std::alloc::Global);
++         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc10, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+-         _1 = A { foo: move _2 };
++         _1 = A { foo: const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc11, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) };
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
++ }
++ 
++ alloc11 (size: 8, align: 4) {
++     01 00 00 00 00 00 00 00                         │ ........
++ }
++ 
++ alloc10 (size: 8, align: 4) {
++     01 00 00 00 00 00 00 00                         │ ........
++ }
++ 
++ alloc7 (size: 8, align: 4) {
++     01 00 00 00 00 00 00 00                         │ ........
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.ConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.ConstProp.32bit.panic-unwind.diff
@@ -1,0 +1,123 @@
+- // MIR for `main` before ConstProp
++ // MIR for `main` after ConstProp
+  
+  fn main() -> () {
+      let mut _0: ();
+      let _1: A;
+      let mut _2: std::boxed::Box<[bool]>;
+      scope 1 {
+          debug a => _1;
+      }
+      scope 2 (inlined <Box<[bool]> as Default>::default) {
+          let _3: std::ptr::Unique<[bool]>;
+          let mut _4: std::ptr::Unique<[bool; 0]>;
+          scope 3 {
+              debug ptr => _3;
+          }
+          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+              let mut _5: std::ptr::NonNull<[bool; 0]>;
+              scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
+                  let mut _7: usize;
+                  scope 6 {
+                      let _6: *mut [bool; 0];
+                      scope 7 {
+                          debug ptr => _6;
+                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                              debug ptr => _6;
+                              let mut _8: *const [bool; 0];
+                              scope 12 {
+                                  scope 13 (inlined NonNull::<T>::new_unchecked::runtime::<[bool; 0]>) {
+                                      debug ptr => _6;
+                                      scope 14 (inlined ptr::mut_ptr::<impl *mut [bool; 0]>::is_null) {
+                                          debug self => _6;
+                                          let mut _9: *mut u8;
+                                          scope 15 {
+                                              scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
+                                                  debug ptr => _9;
+                                                  scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
+                                                      debug self => _9;
+                                                      scope 18 {
+                                                          scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
+                                                              debug self => _9;
+                                                          }
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                      scope 8 (inlined align_of::<[bool; 0]>) {
+                      }
+                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
+                          debug addr => _7;
+                          scope 10 {
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+-         _7 = AlignOf([bool; 0]);
+-         _6 = _7 as *mut [bool; 0] (Transmute);
++         _7 = const 1_usize;
++         _6 = const {0x1 as *mut [bool; 0]};
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+-         _8 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
+-         _5 = NonNull::<[bool; 0]> { pointer: _8 };
++         _8 = const {0x1 as *const [bool; 0]};
++         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_6);
+-         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
++         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+-         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize));
++         _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc7, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+-         _2 = Box::<[bool]>(_3, const std::alloc::Global);
++         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc10, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+-         _1 = A { foo: move _2 };
++         _1 = A { foo: const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc11, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) };
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind: bb2];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  
+      bb2 (cleanup): {
+          resume;
+      }
++ }
++ 
++ alloc11 (size: 8, align: 4) {
++     01 00 00 00 00 00 00 00                         │ ........
++ }
++ 
++ alloc10 (size: 8, align: 4) {
++     01 00 00 00 00 00 00 00                         │ ........
++ }
++ 
++ alloc7 (size: 8, align: 4) {
++     01 00 00 00 00 00 00 00                         │ ........
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.ConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.ConstProp.64bit.panic-abort.diff
@@ -1,0 +1,119 @@
+- // MIR for `main` before ConstProp
++ // MIR for `main` after ConstProp
+  
+  fn main() -> () {
+      let mut _0: ();
+      let _1: A;
+      let mut _2: std::boxed::Box<[bool]>;
+      scope 1 {
+          debug a => _1;
+      }
+      scope 2 (inlined <Box<[bool]> as Default>::default) {
+          let _3: std::ptr::Unique<[bool]>;
+          let mut _4: std::ptr::Unique<[bool; 0]>;
+          scope 3 {
+              debug ptr => _3;
+          }
+          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+              let mut _5: std::ptr::NonNull<[bool; 0]>;
+              scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
+                  let mut _7: usize;
+                  scope 6 {
+                      let _6: *mut [bool; 0];
+                      scope 7 {
+                          debug ptr => _6;
+                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                              debug ptr => _6;
+                              let mut _8: *const [bool; 0];
+                              scope 12 {
+                                  scope 13 (inlined NonNull::<T>::new_unchecked::runtime::<[bool; 0]>) {
+                                      debug ptr => _6;
+                                      scope 14 (inlined ptr::mut_ptr::<impl *mut [bool; 0]>::is_null) {
+                                          debug self => _6;
+                                          let mut _9: *mut u8;
+                                          scope 15 {
+                                              scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
+                                                  debug ptr => _9;
+                                                  scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
+                                                      debug self => _9;
+                                                      scope 18 {
+                                                          scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
+                                                              debug self => _9;
+                                                          }
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                      scope 8 (inlined align_of::<[bool; 0]>) {
+                      }
+                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
+                          debug addr => _7;
+                          scope 10 {
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+-         _7 = AlignOf([bool; 0]);
+-         _6 = _7 as *mut [bool; 0] (Transmute);
++         _7 = const 1_usize;
++         _6 = const {0x1 as *mut [bool; 0]};
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+-         _8 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
+-         _5 = NonNull::<[bool; 0]> { pointer: _8 };
++         _8 = const {0x1 as *const [bool; 0]};
++         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_6);
+-         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
++         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+-         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize));
++         _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc7, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+-         _2 = Box::<[bool]>(_3, const std::alloc::Global);
++         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc10, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+-         _1 = A { foo: move _2 };
++         _1 = A { foo: const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc11, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) };
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
++ }
++ 
++ alloc11 (size: 16, align: 8) {
++     01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
++ }
++ 
++ alloc10 (size: 16, align: 8) {
++     01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
++ }
++ 
++ alloc7 (size: 16, align: 8) {
++     01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.ConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.ConstProp.64bit.panic-unwind.diff
@@ -1,0 +1,123 @@
+- // MIR for `main` before ConstProp
++ // MIR for `main` after ConstProp
+  
+  fn main() -> () {
+      let mut _0: ();
+      let _1: A;
+      let mut _2: std::boxed::Box<[bool]>;
+      scope 1 {
+          debug a => _1;
+      }
+      scope 2 (inlined <Box<[bool]> as Default>::default) {
+          let _3: std::ptr::Unique<[bool]>;
+          let mut _4: std::ptr::Unique<[bool; 0]>;
+          scope 3 {
+              debug ptr => _3;
+          }
+          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+              let mut _5: std::ptr::NonNull<[bool; 0]>;
+              scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
+                  let mut _7: usize;
+                  scope 6 {
+                      let _6: *mut [bool; 0];
+                      scope 7 {
+                          debug ptr => _6;
+                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                              debug ptr => _6;
+                              let mut _8: *const [bool; 0];
+                              scope 12 {
+                                  scope 13 (inlined NonNull::<T>::new_unchecked::runtime::<[bool; 0]>) {
+                                      debug ptr => _6;
+                                      scope 14 (inlined ptr::mut_ptr::<impl *mut [bool; 0]>::is_null) {
+                                          debug self => _6;
+                                          let mut _9: *mut u8;
+                                          scope 15 {
+                                              scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
+                                                  debug ptr => _9;
+                                                  scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
+                                                      debug self => _9;
+                                                      scope 18 {
+                                                          scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
+                                                              debug self => _9;
+                                                          }
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                      scope 8 (inlined align_of::<[bool; 0]>) {
+                      }
+                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
+                          debug addr => _7;
+                          scope 10 {
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+-         _7 = AlignOf([bool; 0]);
+-         _6 = _7 as *mut [bool; 0] (Transmute);
++         _7 = const 1_usize;
++         _6 = const {0x1 as *mut [bool; 0]};
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+-         _8 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
+-         _5 = NonNull::<[bool; 0]> { pointer: _8 };
++         _8 = const {0x1 as *const [bool; 0]};
++         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_6);
+-         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
++         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+-         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize));
++         _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc7, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+-         _2 = Box::<[bool]>(_3, const std::alloc::Global);
++         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc10, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+-         _1 = A { foo: move _2 };
++         _1 = A { foo: const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc11, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) };
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind: bb2];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  
+      bb2 (cleanup): {
+          resume;
+      }
++ }
++ 
++ alloc11 (size: 16, align: 8) {
++     01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
++ }
++ 
++ alloc10 (size: 16, align: 8) {
++     01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
++ }
++ 
++ alloc7 (size: 16, align: 8) {
++     01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -1,0 +1,111 @@
+- // MIR for `main` before DataflowConstProp
++ // MIR for `main` after DataflowConstProp
+  
+  fn main() -> () {
+      let mut _0: ();
+      let _1: A;
+      let mut _2: std::boxed::Box<[bool]>;
+      scope 1 {
+          debug a => _1;
+      }
+      scope 2 (inlined <Box<[bool]> as Default>::default) {
+          let _3: std::ptr::Unique<[bool]>;
+          let mut _4: std::ptr::Unique<[bool; 0]>;
+          scope 3 {
+              debug ptr => _3;
+          }
+          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+              let mut _5: std::ptr::NonNull<[bool; 0]>;
+              scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
+                  let mut _7: usize;
+                  scope 6 {
+                      let _6: *mut [bool; 0];
+                      scope 7 {
+                          debug ptr => _6;
+                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                              debug ptr => _6;
+                              let mut _8: *const [bool; 0];
+                              scope 12 {
+                                  scope 13 (inlined NonNull::<T>::new_unchecked::runtime::<[bool; 0]>) {
+                                      debug ptr => _6;
+                                      scope 14 (inlined ptr::mut_ptr::<impl *mut [bool; 0]>::is_null) {
+                                          debug self => _6;
+                                          let mut _9: *mut u8;
+                                          scope 15 {
+                                              scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
+                                                  debug ptr => _9;
+                                                  scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
+                                                      debug self => _9;
+                                                      scope 18 {
+                                                          scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
+                                                              debug self => _9;
+                                                          }
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                      scope 8 (inlined align_of::<[bool; 0]>) {
+                      }
+                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
+                          debug addr => _7;
+                          scope 10 {
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+          _7 = const 1_usize;
+          _6 = const {0x1 as *mut [bool; 0]};
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+          _8 = const {0x1 as *const [bool; 0]};
+          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_6);
+          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc7, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc10, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+          _1 = A { foo: const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc11, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) };
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  }
+  
+  alloc11 (size: 8, align: 4) {
+      01 00 00 00 00 00 00 00                         │ ........
+  }
+  
+  alloc10 (size: 8, align: 4) {
+      01 00 00 00 00 00 00 00                         │ ........
+  }
+  
+  alloc7 (size: 8, align: 4) {
+      01 00 00 00 00 00 00 00                         │ ........
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -1,0 +1,115 @@
+- // MIR for `main` before DataflowConstProp
++ // MIR for `main` after DataflowConstProp
+  
+  fn main() -> () {
+      let mut _0: ();
+      let _1: A;
+      let mut _2: std::boxed::Box<[bool]>;
+      scope 1 {
+          debug a => _1;
+      }
+      scope 2 (inlined <Box<[bool]> as Default>::default) {
+          let _3: std::ptr::Unique<[bool]>;
+          let mut _4: std::ptr::Unique<[bool; 0]>;
+          scope 3 {
+              debug ptr => _3;
+          }
+          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+              let mut _5: std::ptr::NonNull<[bool; 0]>;
+              scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
+                  let mut _7: usize;
+                  scope 6 {
+                      let _6: *mut [bool; 0];
+                      scope 7 {
+                          debug ptr => _6;
+                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                              debug ptr => _6;
+                              let mut _8: *const [bool; 0];
+                              scope 12 {
+                                  scope 13 (inlined NonNull::<T>::new_unchecked::runtime::<[bool; 0]>) {
+                                      debug ptr => _6;
+                                      scope 14 (inlined ptr::mut_ptr::<impl *mut [bool; 0]>::is_null) {
+                                          debug self => _6;
+                                          let mut _9: *mut u8;
+                                          scope 15 {
+                                              scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
+                                                  debug ptr => _9;
+                                                  scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
+                                                      debug self => _9;
+                                                      scope 18 {
+                                                          scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
+                                                              debug self => _9;
+                                                          }
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                      scope 8 (inlined align_of::<[bool; 0]>) {
+                      }
+                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
+                          debug addr => _7;
+                          scope 10 {
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+          _7 = const 1_usize;
+          _6 = const {0x1 as *mut [bool; 0]};
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+          _8 = const {0x1 as *const [bool; 0]};
+          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_6);
+          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc7, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc10, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+          _1 = A { foo: const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc11, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) };
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind: bb2];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  
+      bb2 (cleanup): {
+          resume;
+      }
+  }
+  
+  alloc11 (size: 8, align: 4) {
+      01 00 00 00 00 00 00 00                         │ ........
+  }
+  
+  alloc10 (size: 8, align: 4) {
+      01 00 00 00 00 00 00 00                         │ ........
+  }
+  
+  alloc7 (size: 8, align: 4) {
+      01 00 00 00 00 00 00 00                         │ ........
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -1,0 +1,111 @@
+- // MIR for `main` before DataflowConstProp
++ // MIR for `main` after DataflowConstProp
+  
+  fn main() -> () {
+      let mut _0: ();
+      let _1: A;
+      let mut _2: std::boxed::Box<[bool]>;
+      scope 1 {
+          debug a => _1;
+      }
+      scope 2 (inlined <Box<[bool]> as Default>::default) {
+          let _3: std::ptr::Unique<[bool]>;
+          let mut _4: std::ptr::Unique<[bool; 0]>;
+          scope 3 {
+              debug ptr => _3;
+          }
+          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+              let mut _5: std::ptr::NonNull<[bool; 0]>;
+              scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
+                  let mut _7: usize;
+                  scope 6 {
+                      let _6: *mut [bool; 0];
+                      scope 7 {
+                          debug ptr => _6;
+                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                              debug ptr => _6;
+                              let mut _8: *const [bool; 0];
+                              scope 12 {
+                                  scope 13 (inlined NonNull::<T>::new_unchecked::runtime::<[bool; 0]>) {
+                                      debug ptr => _6;
+                                      scope 14 (inlined ptr::mut_ptr::<impl *mut [bool; 0]>::is_null) {
+                                          debug self => _6;
+                                          let mut _9: *mut u8;
+                                          scope 15 {
+                                              scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
+                                                  debug ptr => _9;
+                                                  scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
+                                                      debug self => _9;
+                                                      scope 18 {
+                                                          scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
+                                                              debug self => _9;
+                                                          }
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                      scope 8 (inlined align_of::<[bool; 0]>) {
+                      }
+                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
+                          debug addr => _7;
+                          scope 10 {
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+          _7 = const 1_usize;
+          _6 = const {0x1 as *mut [bool; 0]};
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+          _8 = const {0x1 as *const [bool; 0]};
+          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_6);
+          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc7, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc10, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+          _1 = A { foo: const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc11, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) };
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  }
+  
+  alloc11 (size: 16, align: 8) {
+      01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+  }
+  
+  alloc10 (size: 16, align: 8) {
+      01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+  }
+  
+  alloc7 (size: 16, align: 8) {
+      01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -1,0 +1,115 @@
+- // MIR for `main` before DataflowConstProp
++ // MIR for `main` after DataflowConstProp
+  
+  fn main() -> () {
+      let mut _0: ();
+      let _1: A;
+      let mut _2: std::boxed::Box<[bool]>;
+      scope 1 {
+          debug a => _1;
+      }
+      scope 2 (inlined <Box<[bool]> as Default>::default) {
+          let _3: std::ptr::Unique<[bool]>;
+          let mut _4: std::ptr::Unique<[bool; 0]>;
+          scope 3 {
+              debug ptr => _3;
+          }
+          scope 4 (inlined Unique::<[bool; 0]>::dangling) {
+              let mut _5: std::ptr::NonNull<[bool; 0]>;
+              scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
+                  let mut _7: usize;
+                  scope 6 {
+                      let _6: *mut [bool; 0];
+                      scope 7 {
+                          debug ptr => _6;
+                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                              debug ptr => _6;
+                              let mut _8: *const [bool; 0];
+                              scope 12 {
+                                  scope 13 (inlined NonNull::<T>::new_unchecked::runtime::<[bool; 0]>) {
+                                      debug ptr => _6;
+                                      scope 14 (inlined ptr::mut_ptr::<impl *mut [bool; 0]>::is_null) {
+                                          debug self => _6;
+                                          let mut _9: *mut u8;
+                                          scope 15 {
+                                              scope 16 (inlined ptr::mut_ptr::<impl *mut T>::is_null::runtime_impl) {
+                                                  debug ptr => _9;
+                                                  scope 17 (inlined ptr::mut_ptr::<impl *mut u8>::addr) {
+                                                      debug self => _9;
+                                                      scope 18 {
+                                                          scope 19 (inlined ptr::mut_ptr::<impl *mut u8>::cast::<()>) {
+                                                              debug self => _9;
+                                                          }
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                      scope 8 (inlined align_of::<[bool; 0]>) {
+                      }
+                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
+                          debug addr => _7;
+                          scope 10 {
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+          _7 = const 1_usize;
+          _6 = const {0x1 as *mut [bool; 0]};
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+          _8 = const {0x1 as *const [bool; 0]};
+          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_6);
+          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc7, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc10, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+          _1 = A { foo: const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: alloc11, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) };
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind: bb2];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  
+      bb2 (cleanup): {
+          resume;
+      }
+  }
+  
+  alloc11 (size: 16, align: 8) {
+      01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+  }
+  
+  alloc10 (size: 16, align: 8) {
+      01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+  }
+  
+  alloc7 (size: 16, align: 8) {
+      01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -1,0 +1,16 @@
+// unit-test: DataflowConstProp
+// compile-flags: -Zmir-enable-passes=+ConstProp,+Inline
+// EMIT_MIR_FOR_EACH_BIT_WIDTH
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+
+struct A {
+    foo: Box<[bool]>,
+}
+
+// EMIT_MIR default_boxed_slice.main.ConstProp.diff
+// EMIT_MIR default_boxed_slice.main.DataflowConstProp.diff
+fn main() {
+    // ConstProp will create a constant of type `Box<[bool]>`.
+    // Verify that `DataflowConstProp` does not ICE trying to dereference it directly.
+    let a: A = A { foo: Box::default() };
+}

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -1,5 +1,6 @@
 // unit-test: DataflowConstProp
 // compile-flags: -Zmir-enable-passes=+ConstProp,+Inline
+// ignore-debug assertions change the output MIR
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 


### PR DESCRIPTION
Successful merges:

 - #115794 (Do not create a DerefLen place for `Box<[T]>`.)
 - #116069 (Fix debug printing of tuple)
 - #116075 (Document panics on unsigned wrapping_div/rem calls (#116063))
 - #116076 (Add Zba, Zbb, and Zbs as target features for riscv64-linux-android)
 - #116078 (Add assembly test to make sure that inlining works as expected when closures inherit target features)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115794,116069,116075,116076,116078)
<!-- homu-ignore:end -->