### PR TITLE
detect dyn-unsized arguments before they cause ICEs

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -250,9 +250,12 @@ pub(crate) fn verify_func(
 }
 
 fn codegen_fn_body(fx: &mut FunctionCx<'_, '_, '_>, start_block: Block) {
-    if let Err(err) =
-        fx.mir.post_mono_checks(fx.tcx, ty::ParamEnv::reveal_all(), |c| Ok(fx.monomorphize(c)))
-    {
+    if let Err(err) = fx.mir.post_mono_checks(
+        fx.tcx,
+        ty::ParamEnv::reveal_all(),
+        |c| Ok(fx.monomorphize(c)),
+        |ty| Ok(fx.monomorphize(ty)),
+    ) {
         err.emit_err(fx.tcx);
         fx.bcx.append_block_params_for_function_params(fx.block_map[START_BLOCK]);
         fx.bcx.switch_to_block(fx.block_map[START_BLOCK]);

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -212,9 +212,12 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     fx.per_local_var_debug_info = fx.compute_per_local_var_debug_info(&mut start_bx);
 
     // Rust post-monomorphization checks; we later rely on them.
-    if let Err(err) =
-        mir.post_mono_checks(cx.tcx(), ty::ParamEnv::reveal_all(), |c| Ok(fx.monomorphize(c)))
-    {
+    if let Err(err) = mir.post_mono_checks(
+        cx.tcx(),
+        ty::ParamEnv::reveal_all(),
+        |c| Ok(fx.monomorphize(c)),
+        |ty| Ok(fx.monomorphize(ty)),
+    ) {
         err.emit_err(cx.tcx());
         // This IR shouldn't ever be emitted, but let's try to guard against any of this code
         // ever running.

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -752,9 +752,12 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         if M::POST_MONO_CHECKS {
             // `ctfe_query` does some error message decoration that we want to be in effect here.
             self.ctfe_query(None, |tcx| {
-                body.post_mono_checks(*tcx, self.param_env, |c| {
-                    self.subst_from_current_frame_and_normalize_erasing_regions(c)
-                })
+                body.post_mono_checks(
+                    *tcx,
+                    self.param_env,
+                    |c| self.subst_from_current_frame_and_normalize_erasing_regions(c),
+                    |ty| self.subst_from_current_frame_and_normalize_erasing_regions(ty),
+                )
             })?;
         }
 

--- a/compiler/rustc_middle/messages.ftl
+++ b/compiler/rustc_middle/messages.ftl
@@ -52,6 +52,20 @@ middle_drop_check_overflow =
     overflow while adding drop-check rules for {$ty}
     .note = overflowed on {$overflow_ty}
 
+middle_dyn_unsized_local =
+    {$is_arg ->
+        [true] function argument
+        *[other] local variable
+    } does not have a dynamically computable size
+    .note = `{$ty}` contains an `extern type`, which is not allowed in {$is_arg ->
+        [true] function arguments
+        *[other] local variables
+    }
+
+middle_dyn_unsized_param =
+    function parameter does not have a dynamically computable size
+    .note = `{$ty}` contains an `extern type`, which is not allowed in function parameters
+
 middle_erroneous_constant = erroneous constant encountered
 
 middle_layout_references_error =

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -54,6 +54,25 @@ pub struct LimitInvalid<'a> {
 }
 
 #[derive(Diagnostic)]
+#[diag(middle_dyn_unsized_local)]
+#[note]
+pub struct DynUnsizedLocal<'tcx> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'tcx>,
+    pub is_arg: bool,
+}
+
+#[derive(Diagnostic)]
+#[diag(middle_dyn_unsized_param)]
+#[note]
+pub struct DynUnsizedParam<'tcx> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'tcx>,
+}
+
+#[derive(Diagnostic)]
 #[diag(middle_recursion_limit_reached)]
 #[help]
 pub struct RecursionLimitReached<'tcx> {

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -666,9 +666,9 @@ pub enum TerminatorKind<'tcx> {
         /// The function that’s being called.
         func: Operand<'tcx>,
         /// Arguments the function is called with.
-        /// These are owned by the callee, which is free to modify them.
-        /// This allows the memory occupied by "by-value" arguments to be
-        /// reused across function calls without duplicating the contents.
+        /// Any `Move` operands in this list are owned by the callee, which is free to modify them.
+        /// This allows the memory occupied by "by-value" arguments to be reused across function
+        /// calls without duplicating the contents.
         args: Vec<Operand<'tcx>>,
         /// Where the returned value will be written
         destination: Place<'tcx>,

--- a/src/tools/miri/tests/fail/unsized-extern-type-arg.rs
+++ b/src/tools/miri/tests/fail/unsized-extern-type-arg.rs
@@ -1,0 +1,17 @@
+#![feature(extern_types)]
+#![feature(unsized_fn_params)]
+
+extern {
+    pub type E;
+}
+
+fn test(_e: E) {}
+
+pub fn calltest(e: Box<E>) {
+    test(*e) //~ERROR: does not have a dynamically computable size
+}
+
+fn main() {
+    let b = Box::new(0u32);
+    calltest(unsafe { std::mem::transmute(b)} );
+}

--- a/src/tools/miri/tests/fail/unsized-extern-type-arg.stderr
+++ b/src/tools/miri/tests/fail/unsized-extern-type-arg.stderr
@@ -1,0 +1,10 @@
+error: function parameter does not have a dynamically computable size
+  --> $DIR/unsized-extern-type-arg.rs:LL:CC
+   |
+LL |     test(*e)
+   |     ^^^^^^^^
+   |
+   = note: `E` contains an `extern type`, which is not allowed in function parameters
+
+error: aborting due to previous error
+

--- a/tests/ui/unsized-locals/extern-type.rs
+++ b/tests/ui/unsized-locals/extern-type.rs
@@ -1,0 +1,14 @@
+// build-fail
+#![feature(extern_types)]
+#![feature(unsized_fn_params)]
+#![crate_type = "lib"]
+
+extern {
+    pub type E;
+}
+
+fn test(e: E) {} //~ERROR: does not have a dynamically computable size
+
+pub fn calltest(e: Box<E>) {
+    test(*e) //~ERROR: does not have a dynamically computable size
+}

--- a/tests/ui/unsized-locals/extern-type.stderr
+++ b/tests/ui/unsized-locals/extern-type.stderr
@@ -1,0 +1,18 @@
+error: function argument does not have a dynamically computable size
+  --> $DIR/extern-type.rs:10:9
+   |
+LL | fn test(e: E) {}
+   |         ^
+   |
+   = note: `E` contains an `extern type`, which is not allowed in function arguments
+
+error: function parameter does not have a dynamically computable size
+  --> $DIR/extern-type.rs:13:5
+   |
+LL |     test(*e)
+   |     ^^^^^^^^
+   |
+   = note: `E` contains an `extern type`, which is not allowed in function parameters
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
"Fixes" https://github.com/rust-lang/rust/issues/115709 in a crude way, with a post-mono check. This is entirely caused by us not having a trait to express "type can have its size determined at runtime".