### PR TITLE
Properly print cstr literals in `proc_macro::Literal::to_string`

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1411,7 +1411,15 @@ impl Literal {
                 let hashes = get_hashes_str(n);
                 f(&["br", hashes, "\"", symbol, "\"", hashes, suffix])
             }
-            _ => f(&[symbol, suffix]),
+            bridge::LitKind::CStr => f(&["c\"", symbol, "\"", suffix]),
+            bridge::LitKind::CStrRaw(n) => {
+                let hashes = get_hashes_str(n);
+                f(&["cr", hashes, "\"", symbol, "\"", hashes, suffix])
+            }
+
+            bridge::LitKind::Integer | bridge::LitKind::Float | bridge::LitKind::Err => {
+                f(&[symbol, suffix])
+            }
         })
     }
 }

--- a/tests/ui/proc-macro/auxiliary/print-tokens.rs
+++ b/tests/ui/proc-macro/auxiliary/print-tokens.rs
@@ -1,0 +1,16 @@
+// force-host
+// no-prefer-dynamic
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::{TokenStream, TokenTree};
+
+#[proc_macro]
+pub fn print_tokens(input: TokenStream) -> TokenStream {
+    println!("{:#?}", input);
+    for token in input {
+        println!("{token}");
+    }
+    TokenStream::new()
+}

--- a/tests/ui/proc-macro/literal-to-string.rs
+++ b/tests/ui/proc-macro/literal-to-string.rs
@@ -1,0 +1,26 @@
+// check-pass
+// edition: 2021
+#![feature(c_str_literals)]
+
+// aux-build: print-tokens.rs
+extern crate print_tokens;
+
+fn main() {
+    print_tokens::print_tokens! {
+        1
+        17u8
+        42.
+        3.14f32
+        b'a'
+        b'\xFF'
+        'c'
+        '\x32'
+        "\"str\""
+        r#""raw" str"#
+        r###"very ##"raw"## str"###
+        b"\"byte\" str"
+        br#""raw" "byte" str"#
+        c"\"c\" str"
+        cr#""raw" "c" str"#
+    }
+}

--- a/tests/ui/proc-macro/literal-to-string.stdout
+++ b/tests/ui/proc-macro/literal-to-string.stdout
@@ -1,0 +1,107 @@
+TokenStream [
+    Literal {
+        kind: Integer,
+        symbol: "1",
+        suffix: None,
+        span: #0 bytes(172..173),
+    },
+    Literal {
+        kind: Integer,
+        symbol: "17",
+        suffix: Some("u8"),
+        span: #0 bytes(182..186),
+    },
+    Literal {
+        kind: Float,
+        symbol: "42.",
+        suffix: None,
+        span: #0 bytes(195..198),
+    },
+    Literal {
+        kind: Float,
+        symbol: "3.14",
+        suffix: Some("f32"),
+        span: #0 bytes(207..214),
+    },
+    Literal {
+        kind: Byte,
+        symbol: "a",
+        suffix: None,
+        span: #0 bytes(223..227),
+    },
+    Literal {
+        kind: Byte,
+        symbol: "\xFF",
+        suffix: None,
+        span: #0 bytes(236..243),
+    },
+    Literal {
+        kind: Char,
+        symbol: "c",
+        suffix: None,
+        span: #0 bytes(252..255),
+    },
+    Literal {
+        kind: Char,
+        symbol: "\x32",
+        suffix: None,
+        span: #0 bytes(264..270),
+    },
+    Literal {
+        kind: Str,
+        symbol: "\\"str\\"",
+        suffix: None,
+        span: #0 bytes(279..288),
+    },
+    Literal {
+        kind: StrRaw(1),
+        symbol: "\"raw\" str",
+        suffix: None,
+        span: #0 bytes(297..311),
+    },
+    Literal {
+        kind: StrRaw(3),
+        symbol: "very ##\"raw\"## str",
+        suffix: None,
+        span: #0 bytes(320..347),
+    },
+    Literal {
+        kind: ByteStr,
+        symbol: "\\"byte\\" str",
+        suffix: None,
+        span: #0 bytes(356..371),
+    },
+    Literal {
+        kind: ByteStrRaw(1),
+        symbol: "\"raw\" \"byte\" str",
+        suffix: None,
+        span: #0 bytes(380..402),
+    },
+    Literal {
+        kind: CStr,
+        symbol: "\\"c\\" str",
+        suffix: None,
+        span: #0 bytes(411..423),
+    },
+    Literal {
+        kind: CStrRaw(1),
+        symbol: "\"raw\" \"c\" str",
+        suffix: None,
+        span: #0 bytes(432..451),
+    },
+]
+1
+17u8
+42.
+3.14f32
+b'a'
+b'\xFF'
+'c'
+'\x32'
+"\"str\""
+r#""raw" str"#
+r###"very ##"raw"## str"###
+b"\"byte\" str"
+br#""raw" "byte" str"#
+c"\"c\" str"
+cr#""raw" "c" str"#


### PR DESCRIPTION
Previously we printed the contents of the string, rather than the actual string literal (e.g. `the c string` instead of `c"the c string"`).

Fixes #112820
cc #105723