### PR TITLE
[rustdoc] Show enum discriminant if it is a C-like variant

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2091,9 +2091,8 @@ impl Discriminant {
     pub(crate) fn expr(&self, tcx: TyCtxt<'_>) -> Option<String> {
         self.expr.map(|body| rendered_const(tcx, body))
     }
-    /// Will always be a machine readable number, without underscores or suffixes.
-    pub(crate) fn value(&self, tcx: TyCtxt<'_>) -> String {
-        print_evaluated_const(tcx, self.value, false).unwrap()
+    pub(crate) fn value(&self, tcx: TyCtxt<'_>, with_underscores: bool) -> String {
+        print_evaluated_const(tcx, self.value, with_underscores, false).unwrap()
     }
 }
 
@@ -2348,7 +2347,7 @@ impl ConstantKind {
         match *self {
             ConstantKind::TyConst { .. } | ConstantKind::Anonymous { .. } => None,
             ConstantKind::Extern { def_id } | ConstantKind::Local { def_id, .. } => {
-                print_evaluated_const(tcx, def_id, true)
+                print_evaluated_const(tcx, def_id, true, true)
             }
         }
     }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -275,7 +275,8 @@ pub(crate) fn print_const(cx: &DocContext<'_>, n: ty::Const<'_>) -> String {
 pub(crate) fn print_evaluated_const(
     tcx: TyCtxt<'_>,
     def_id: DefId,
-    underscores_and_type: bool,
+    with_underscores: bool,
+    with_type: bool,
 ) -> Option<String> {
     tcx.const_eval_poly(def_id).ok().and_then(|val| {
         let ty = tcx.type_of(def_id).instantiate_identity();
@@ -284,7 +285,7 @@ pub(crate) fn print_evaluated_const(
             (mir::ConstValue::Scalar(_), &ty::Adt(_, _)) => None,
             (mir::ConstValue::Scalar(_), _) => {
                 let const_ = mir::Const::from_value(val, ty);
-                Some(print_const_with_custom_print_scalar(tcx, const_, underscores_and_type))
+                Some(print_const_with_custom_print_scalar(tcx, const_, with_underscores, with_type))
             }
             _ => None,
         }
@@ -320,14 +321,25 @@ fn format_integer_with_underscore_sep(num: &str) -> String {
 fn print_const_with_custom_print_scalar<'tcx>(
     tcx: TyCtxt<'tcx>,
     ct: mir::Const<'tcx>,
-    underscores_and_type: bool,
+    with_underscores: bool,
+    with_type: bool,
 ) -> String {
     // Use a slightly different format for integer types which always shows the actual value.
     // For all other types, fallback to the original `pretty_print_const`.
     match (ct, ct.ty().kind()) {
         (mir::Const::Val(mir::ConstValue::Scalar(int), _), ty::Uint(ui)) => {
-            if underscores_and_type {
-                format!("{}{}", format_integer_with_underscore_sep(&int.to_string()), ui.name_str())
+            if with_underscores {
+                if with_type {
+                    format!(
+                        "{}{}",
+                        format_integer_with_underscore_sep(&int.to_string()),
+                        ui.name_str()
+                    )
+                } else {
+                    format_integer_with_underscore_sep(&int.to_string())
+                }
+            } else if with_type {
+                format!("{}{}", int.to_string(), ui.name_str())
             } else {
                 int.to_string()
             }
@@ -337,12 +349,18 @@ fn print_const_with_custom_print_scalar<'tcx>(
             let size = tcx.layout_of(ty::ParamEnv::empty().and(ty)).unwrap().size;
             let data = int.assert_bits(size);
             let sign_extended_data = size.sign_extend(data) as i128;
-            if underscores_and_type {
-                format!(
-                    "{}{}",
-                    format_integer_with_underscore_sep(&sign_extended_data.to_string()),
-                    i.name_str()
-                )
+            if with_underscores {
+                if with_type {
+                    format!(
+                        "{}{}",
+                        format_integer_with_underscore_sep(&sign_extended_data.to_string()),
+                        i.name_str()
+                    )
+                } else {
+                    format_integer_with_underscore_sep(&sign_extended_data.to_string())
+                }
+            } else if with_type {
+                format!("{}{}", sign_extended_data.to_string(), i.name_str())
             } else {
                 sign_extended_data.to_string()
             }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -328,42 +328,30 @@ fn print_const_with_custom_print_scalar<'tcx>(
     // For all other types, fallback to the original `pretty_print_const`.
     match (ct, ct.ty().kind()) {
         (mir::Const::Val(mir::ConstValue::Scalar(int), _), ty::Uint(ui)) => {
-            if with_underscores {
-                if with_type {
-                    format!(
-                        "{}{}",
-                        format_integer_with_underscore_sep(&int.to_string()),
-                        ui.name_str()
-                    )
-                } else {
-                    format_integer_with_underscore_sep(&int.to_string())
-                }
-            } else if with_type {
-                format!("{}{}", int.to_string(), ui.name_str())
+            let mut output = if with_underscores {
+                format_integer_with_underscore_sep(&int.to_string())
             } else {
                 int.to_string()
+            };
+            if with_type {
+                output += ui.name_str();
             }
+            output
         }
         (mir::Const::Val(mir::ConstValue::Scalar(int), _), ty::Int(i)) => {
             let ty = ct.ty();
             let size = tcx.layout_of(ty::ParamEnv::empty().and(ty)).unwrap().size;
             let data = int.assert_bits(size);
             let sign_extended_data = size.sign_extend(data) as i128;
-            if with_underscores {
-                if with_type {
-                    format!(
-                        "{}{}",
-                        format_integer_with_underscore_sep(&sign_extended_data.to_string()),
-                        i.name_str()
-                    )
-                } else {
-                    format_integer_with_underscore_sep(&sign_extended_data.to_string())
-                }
-            } else if with_type {
-                format!("{}{}", sign_extended_data.to_string(), i.name_str())
+            let mut output = if with_underscores {
+                format_integer_with_underscore_sep(&sign_extended_data.to_string())
             } else {
                 sign_extended_data.to_string()
+            };
+            if with_type {
+                output += i.name_str();
             }
+            output
         }
         _ => ct.to_string(),
     }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -745,7 +745,7 @@ impl FromWithTcx<clean::Discriminant> for Discriminant {
             // `rustc_middle` types, not `rustc_hir`, but because JSON never inlines
             // the expr is always some.
             expr: disr.expr(tcx).unwrap(),
-            value: disr.value(tcx),
+            value: disr.value(tcx, false),
         }
     }
 }

--- a/tests/rustdoc/auxiliary/enum-variant.rs
+++ b/tests/rustdoc/auxiliary/enum-variant.rs
@@ -1,0 +1,24 @@
+#![crate_name = "bar"]
+
+pub enum E {
+    A = 12,
+    B,
+    C = 1245,
+}
+
+pub enum F {
+    A,
+    B,
+}
+
+#[repr(u32)]
+pub enum G {
+    A = 12,
+    B,
+    C(u32),
+}
+
+pub enum H {
+    A,
+    C(u32),
+}

--- a/tests/rustdoc/enum-variant-value.rs
+++ b/tests/rustdoc/enum-variant-value.rs
@@ -1,0 +1,15 @@
+// This test ensures that the variant value is displayed with underscores but without
+// a type name at the end.
+
+#![crate_name = "foo"]
+
+// @has 'foo/enum.B.html'
+// @has - '//*[@class="rust item-decl"]/code' 'A = 12,'
+// @has - '//*[@class="rust item-decl"]/code' 'C = 1_245,'
+// @matches - '//*[@id="variant.A"]/h3' '^A = 12$'
+// @matches - '//*[@id="variant.C"]/h3' '^C = 1_245$'
+pub enum B {
+    A = 12,
+    B,
+    C = 1245,
+}

--- a/tests/rustdoc/enum-variant-value.rs
+++ b/tests/rustdoc/enum-variant-value.rs
@@ -1,7 +1,11 @@
 // This test ensures that the variant value is displayed with underscores but without
 // a type name at the end.
 
+// aux-build:enum-variant.rs
+
 #![crate_name = "foo"]
+
+extern crate bar;
 
 // In this case, since all variants are C-like variants and at least one of them
 // has its value set, we display values for all of them.
@@ -60,3 +64,35 @@ pub enum D {
     A,
     C(u32),
 }
+
+// @has 'foo/enum.E.html'
+// @has - '//*[@class="rust item-decl"]/code' 'A = 12,'
+// @has - '//*[@class="rust item-decl"]/code' 'B = 13,'
+// @has - '//*[@class="rust item-decl"]/code' 'C = 1_245,'
+// @matches - '//*[@id="variant.A"]/h3' '^A = 12$'
+// @matches - '//*[@id="variant.B"]/h3' '^B = 13$'
+// @matches - '//*[@id="variant.C"]/h3' '^C = 1_245$'
+pub use bar::E;
+
+// @has 'foo/enum.F.html'
+// @has - '//*[@class="rust item-decl"]/code' 'A,'
+// @has - '//*[@class="rust item-decl"]/code' 'B,'
+// @matches - '//*[@id="variant.A"]/h3' '^A$'
+// @matches - '//*[@id="variant.B"]/h3' '^B$'
+pub use bar::F;
+
+// @has 'foo/enum.G.html'
+// @has - '//*[@class="rust item-decl"]/code' 'A = 12,'
+// @has - '//*[@class="rust item-decl"]/code' 'B,'
+// @has - '//*[@class="rust item-decl"]/code' 'C(u32),'
+// @matches - '//*[@id="variant.A"]/h3' '^A = 12$'
+// @matches - '//*[@id="variant.B"]/h3' '^B$'
+// @has - '//*[@id="variant.C"]/h3' 'C(u32)'
+pub use bar::G;
+
+// @has 'foo/enum.H.html'
+// @has - '//*[@class="rust item-decl"]/code' 'A,'
+// @has - '//*[@class="rust item-decl"]/code' 'C(u32),'
+// @matches - '//*[@id="variant.A"]/h3' '^A$'
+// @has - '//*[@id="variant.C"]/h3' 'C(u32)'
+pub use bar::H;

--- a/tests/rustdoc/enum-variant-value.rs
+++ b/tests/rustdoc/enum-variant-value.rs
@@ -3,13 +3,60 @@
 
 #![crate_name = "foo"]
 
-// @has 'foo/enum.B.html'
+// In this case, since all variants are C-like variants and at least one of them
+// has its value set, we display values for all of them.
+
+// @has 'foo/enum.A.html'
 // @has - '//*[@class="rust item-decl"]/code' 'A = 12,'
+// @has - '//*[@class="rust item-decl"]/code' 'B = 13,'
 // @has - '//*[@class="rust item-decl"]/code' 'C = 1_245,'
 // @matches - '//*[@id="variant.A"]/h3' '^A = 12$'
+// @matches - '//*[@id="variant.B"]/h3' '^B = 13$'
 // @matches - '//*[@id="variant.C"]/h3' '^C = 1_245$'
-pub enum B {
+pub enum A {
     A = 12,
     B,
     C = 1245,
+}
+
+// In this case, all variants are C-like variants but none of them has its value set.
+// Therefore we don't display values.
+
+// @has 'foo/enum.B.html'
+// @has - '//*[@class="rust item-decl"]/code' 'A,'
+// @has - '//*[@class="rust item-decl"]/code' 'B,'
+// @matches - '//*[@id="variant.A"]/h3' '^A$'
+// @matches - '//*[@id="variant.B"]/h3' '^B$'
+pub enum B {
+    A,
+    B,
+}
+
+// In this case, not all variants are C-like variants so we don't display values.
+
+// @has 'foo/enum.C.html'
+// @has - '//*[@class="rust item-decl"]/code' 'A = 12,'
+// @has - '//*[@class="rust item-decl"]/code' 'B,'
+// @has - '//*[@class="rust item-decl"]/code' 'C(u32),'
+// @matches - '//*[@id="variant.A"]/h3' '^A = 12$'
+// @matches - '//*[@id="variant.B"]/h3' '^B$'
+// @has - '//*[@id="variant.C"]/h3' 'C(u32)'
+#[repr(u32)]
+pub enum C {
+    A = 12,
+    B,
+    C(u32),
+}
+
+// In this case, not all variants are C-like variants and no C-like variant has its
+// value set, so we don't display values.
+
+// @has 'foo/enum.D.html'
+// @has - '//*[@class="rust item-decl"]/code' 'A,'
+// @has - '//*[@class="rust item-decl"]/code' 'C(u32),'
+// @matches - '//*[@id="variant.A"]/h3' '^A$'
+// @has - '//*[@id="variant.C"]/h3' 'C(u32)'
+pub enum D {
+    A,
+    C(u32),
 }

--- a/tests/rustdoc/enum-variant-value.rs
+++ b/tests/rustdoc/enum-variant-value.rs
@@ -96,3 +96,22 @@ pub use bar::G;
 // @matches - '//*[@id="variant.A"]/h3' '^A$'
 // @has - '//*[@id="variant.C"]/h3' 'C(u32)'
 pub use bar::H;
+
+// Testing more complex cases.
+pub const X: isize = 2;
+// @has 'foo/enum.I.html'
+// @has - '//*[@class="rust item-decl"]/code' 'A = 2,'
+// @has - '//*[@class="rust item-decl"]/code' 'B = 4,'
+// @has - '//*[@class="rust item-decl"]/code' 'C = 9,'
+// @has - '//*[@class="rust item-decl"]/code' 'D = -1,'
+// @matches - '//*[@id="variant.A"]/h3' '^A = 2$'
+// @matches - '//*[@id="variant.B"]/h3' '^B = 4$'
+// @matches - '//*[@id="variant.C"]/h3' '^C = 9$'
+// @matches - '//*[@id="variant.D"]/h3' '^D = -1$'
+#[repr(isize)]
+pub enum I {
+    A = X,
+    B = X * 2,
+    C = Self::B as isize + X + 3,
+    D = -1,
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/101337.

We currently display values for associated constant items in traits:

![image](https://github.com/rust-lang/rust/assets/3050060/03e566ec-c670-47b4-8ca2-b982baa7a0f4)

And we also display constant values like [here](file:///home/imperio/rust/rust/build/x86_64-unknown-linux-gnu/doc/std/f32/consts/constant.E.html).

I think that for coherency, we should display values of C-like enum variants.

With this change, it looks like this:

![image](https://github.com/rust-lang/rust/assets/3050060/b53fbbe0-bdb1-4289-8537-f2dd4988e9ac)

As for the display of the constant value itself, I used what we already have to keep coherency.

We display the C-like variants value in the following scenario:
 1. It is a C-like variant with a value set => all the time
 2. It is a C-like variant without a value set: All other variants are C-like variants and at least one them has its value set.

Here is the result in code:

```rust
// Ax and Bx value will be displayed. 
enum A {
    Ax = 12,
    Bx,
}

// Ax and Bx value will not be displayed
enum B {
    Ax,
    Bx,
}

// Bx value will not be displayed
enum C {
    Ax(u32),
    Bx,
}

// Bx value will not be displayed, Cx value will be displayed.
#[repr(u32)]
enum D {
    Ax(u32),
    Bx,
    Cx = 12,
}
```

r? @notriddle 