### PR TITLE
Monomorphize OpaqueCast

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/value_and_place.rs
+++ b/compiler/rustc_codegen_cranelift/src/value_and_place.rs
@@ -679,7 +679,7 @@ impl<'tcx> CPlace<'tcx> {
         fx: &mut FunctionCx<'_, '_, 'tcx>,
         ty: Ty<'tcx>,
     ) -> CPlace<'tcx> {
-        CPlace { inner: self.inner, layout: fx.layout_of(ty) }
+        CPlace { inner: self.inner, layout: fx.layout_of(fx.monomorphize(ty)) }
     }
 
     pub(crate) fn place_field(

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -463,7 +463,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 mir::ProjectionElem::Field(ref field, _) => {
                     cg_base.project_field(bx, field.index())
                 }
-                mir::ProjectionElem::OpaqueCast(ty) => cg_base.project_type(bx, ty),
+                mir::ProjectionElem::OpaqueCast(ty) => {
+                    cg_base.project_type(bx, self.monomorphize(ty))
+                }
                 mir::ProjectionElem::Index(index) => {
                     let index = &mir::Operand::Copy(mir::Place::from(index));
                     let index = self.codegen_operand(bx, index);

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -316,7 +316,10 @@ where
     {
         use rustc_middle::mir::ProjectionElem::*;
         Ok(match proj_elem {
-            OpaqueCast(ty) => base.transmute(self.layout_of(ty)?, self)?,
+            OpaqueCast(ty) => base.transmute(
+                self.layout_of(self.subst_from_current_frame_and_normalize_erasing_regions(ty)?)?,
+                self,
+            )?,
             Field(field, _) => self.project_field(base, field.index())?,
             Downcast(_, variant) => self.project_downcast(base, variant)?,
             Deref => self.deref_pointer(&base.to_op(self)?)?.into(),

--- a/tests/ui/type-alias-impl-trait/cross_inference_pattern_bug.rs
+++ b/tests/ui/type-alias-impl-trait/cross_inference_pattern_bug.rs
@@ -1,5 +1,5 @@
 // compile-flags: --edition=2021
-// check-pass
+// build-pass
 #![feature(type_alias_impl_trait)]
 
 fn main() {

--- a/tests/ui/type-alias-impl-trait/opaque-cast-monormophize-2.rs
+++ b/tests/ui/type-alias-impl-trait/opaque-cast-monormophize-2.rs
@@ -1,0 +1,13 @@
+// build-pass
+
+#![feature(type_alias_impl_trait)]
+const fn foo<T: Copy>(x: T) {
+    type Opaque<T: Copy> = impl Copy;
+    let foo: Opaque<T> = (x, 2u32);
+    let (a, b): (T, u32) = foo;
+}
+
+fn main() {
+    const CONST: () = foo::<u32>(42u32);
+    CONST
+}

--- a/tests/ui/type-alias-impl-trait/opaque-cast-monormophize.rs
+++ b/tests/ui/type-alias-impl-trait/opaque-cast-monormophize.rs
@@ -1,0 +1,13 @@
+// build-pass
+
+#![feature(type_alias_impl_trait)]
+
+fn foo<T: Copy>(x: T) {
+    type Opaque<T: Copy> = impl Copy;
+    let foo: &Opaque<T> = &(x, 2u32);
+    let (a, b): (T, u32) = *foo;
+}
+
+fn main() {
+    foo::<u32>(1);
+}


### PR DESCRIPTION
In previous attempt, https://github.com/rust-lang/rust/pull/116140 we thought `OpaqueCast` was unused during few places, but we were wrong, in reality we didn't have any test that could test it, so in this pr attempt is to correct the behavior of few `OpaqueCast`s in rustc.

r? @lcnr 