### PR TITLE
Fix whitespace in rustdoc type_layout.html

### DIFF
--- a/src/librustdoc/html/templates/type_layout.html
+++ b/src/librustdoc/html/templates/type_layout.html
@@ -9,12 +9,12 @@
             <strong>Note:</strong> Most layout information is <strong>completely {#+ #}
                 unstable</strong> and may even differ between compilations. {#+ #}
             The only exception is types with certain <code>repr(...)</code> {#+ #}
-            attributes. Please see the Rust Reference’s {#+ #}
+            attributes. Please see the Rust Reference's {#+ #}
             <a href="https://doc.rust-lang.org/reference/type-layout.html">“Type Layout”</a> {#+ #}
             chapter for details on type layout guarantees. {# #}
         </p> {# #}
     </div> {# #}
-    <p><strong>Size:</strong> {{ type_layout_size|safe }}</p> {# #}
+    <p><strong>Size:</strong> {{+ type_layout_size|safe }}</p> {# #}
     {% if !variants.is_empty() %}
     <p> {# #}
         <strong>Size for each variant:</strong> {# #}


### PR DESCRIPTION
`Size: <size>` was missing a space after the colon:

![image](https://github.com/rust-lang/rust/assets/57450786/c5a672f3-a28a-4b56-91e7-a4e6ffc8106e)
