### PR TITLE
Document that Instant may or may not include system-suspend time

### DIFF
--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -58,6 +58,8 @@ pub use core::time::TryFromFloatSecsError;
 /// some seconds may be longer than others). An instant may jump forwards or
 /// experience time dilation (slow down or speed up), but it will never go
 /// backwards.
+/// As part of this non-guarantee it is also not specified whether system suspends count as
+/// elapsed time or not. The behavior varies across platforms and rust versions.
 ///
 /// Instants are opaque types that can only be compared to one another. There is
 /// no method to get "the number of seconds" from an instant. Instead, it only


### PR DESCRIPTION
Since people are still occasionally surprised by this let's make it more explicit. This doesn't add any new guarantees, only documents the status quo.

Related issues: #87906 #79462