### PR TITLE
add missing feature gate for rustc_safe_intrinsic

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -537,7 +537,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         allow_internal_unsafe, Normal, template!(Word), WarnFollowing,
         "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
-    ungated!(rustc_safe_intrinsic, Normal, template!(Word), DuplicatesOk),
     rustc_attr!(rustc_allowed_through_unstable_modules, Normal, template!(Word), WarnFollowing,
     "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
     through unstable paths"),
@@ -738,6 +737,12 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_host, AttributeType::Normal, template!(Word), ErrorFollowing,
         "#[rustc_host] annotates const generic parameters as the `host` effect param, \
         and it is only intended for internal use and as a desugaring."
+    ),
+
+    rustc_attr!(
+        rustc_safe_intrinsic, AttributeType::Normal, template!(Word), ErrorFollowing,
+        "#[rustc_safe_intrinsics] declares intrinsics that are safe to use, tying it to the internal \
+        intrinsic mechanisms."
     ),
 
     BuiltinAttribute {


### PR DESCRIPTION
https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/Removal.20of.20.60auto.20trait.60.20syntax/near/393075179

We don't seem to have feature gate tests for those usually.

This was added as `ungated` in https://github.com/rust-lang/rust/pull/100719/files#diff-09c366d3ad3ec9a42125253b610ca83cad6b156aa2a723f6c7e83eddef7b1e8fR502, probably because the author looked at the surrounding attributes, which are ungated because they are gated specially behind the `staged_api` feature.

I don't think we need to crater this, the attribute is entirely useless without the `intrinsics` feature, which is already unstable..