### PR TITLE
Don't include destruction scopes in THIR

### DIFF
--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -349,10 +349,6 @@ impl ScopeTree {
         }
     }
 
-    pub fn opt_destruction_scope(&self, n: hir::ItemLocalId) -> Option<Scope> {
-        self.destruction_scopes.get(&n).cloned()
-    }
-
     pub fn record_var_scope(&mut self, var: hir::ItemLocalId, lifetime: Scope) {
         debug!("record_var_scope(sub={:?}, sup={:?})", var, lifetime);
         assert!(var != lifetime.item_local_id());

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -134,7 +134,6 @@ pub struct Block {
     /// This does *not* include labels on loops, e.g. `'label: loop {}`.
     pub targeted_by_break: bool,
     pub region_scope: region::Scope,
-    pub opt_destruction_scope: Option<region::Scope>,
     /// The span of the block, including the opening braces,
     /// the label, and the `unsafe` keyword, if present.
     pub span: Span,
@@ -193,7 +192,6 @@ pub enum BlockSafety {
 #[derive(Clone, Debug, HashStable)]
 pub struct Stmt<'tcx> {
     pub kind: StmtKind<'tcx>,
-    pub opt_destruction_scope: Option<region::Scope>,
 }
 
 #[derive(Clone, Debug, HashStable)]
@@ -1224,12 +1222,12 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
 mod size_asserts {
     use super::*;
     // tidy-alphabetical-start
-    static_assert_size!(Block, 56);
+    static_assert_size!(Block, 48);
     static_assert_size!(Expr<'_>, 64);
     static_assert_size!(ExprKind<'_>, 40);
     static_assert_size!(Pat<'_>, 64);
     static_assert_size!(PatKind<'_>, 48);
-    static_assert_size!(Stmt<'_>, 56);
+    static_assert_size!(Stmt<'_>, 48);
     static_assert_size!(StmtKind<'_>, 48);
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -13,32 +13,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         ast_block: BlockId,
         source_info: SourceInfo,
     ) -> BlockAnd<()> {
-        let Block {
-            region_scope,
-            opt_destruction_scope,
-            span,
-            ref stmts,
-            expr,
-            targeted_by_break,
-            safety_mode,
-        } = self.thir[ast_block];
+        let Block { region_scope, span, ref stmts, expr, targeted_by_break, safety_mode } =
+            self.thir[ast_block];
         let expr = expr.map(|expr| &self.thir[expr]);
-        self.in_opt_scope(opt_destruction_scope.map(|de| (de, source_info)), move |this| {
-            this.in_scope((region_scope, source_info), LintLevel::Inherited, move |this| {
-                if targeted_by_break {
-                    this.in_breakable_scope(None, destination, span, |this| {
-                        Some(this.ast_block_stmts(
-                            destination,
-                            block,
-                            span,
-                            stmts,
-                            expr,
-                            safety_mode,
-                            region_scope,
-                        ))
-                    })
-                } else {
-                    this.ast_block_stmts(
+        self.in_scope((region_scope, source_info), LintLevel::Inherited, move |this| {
+            if targeted_by_break {
+                this.in_breakable_scope(None, destination, span, |this| {
+                    Some(this.ast_block_stmts(
                         destination,
                         block,
                         span,
@@ -46,9 +27,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         expr,
                         safety_mode,
                         region_scope,
-                    )
-                }
-            })
+                    ))
+                })
+            } else {
+                this.ast_block_stmts(
+                    destination,
+                    block,
+                    span,
+                    stmts,
+                    expr,
+                    safety_mode,
+                    region_scope,
+                )
+            }
         })
     }
 
@@ -92,20 +83,15 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         let source_info = this.source_info(span);
         for stmt in stmts {
-            let Stmt { ref kind, opt_destruction_scope } = this.thir[*stmt];
+            let Stmt { ref kind } = this.thir[*stmt];
             match kind {
                 StmtKind::Expr { scope, expr } => {
                     this.block_context.push(BlockFrame::Statement { ignores_expr_result: true });
+                    let si = (*scope, source_info);
                     unpack!(
-                        block = this.in_opt_scope(
-                            opt_destruction_scope.map(|de| (de, source_info)),
-                            |this| {
-                                let si = (*scope, source_info);
-                                this.in_scope(si, LintLevel::Inherited, |this| {
-                                    this.stmt_expr(block, &this.thir[*expr], Some(*scope))
-                                })
-                            }
-                        )
+                        block = this.in_scope(si, LintLevel::Inherited, |this| {
+                            this.stmt_expr(block, &this.thir[*expr], Some(*scope))
+                        })
                     );
                 }
                 StmtKind::Let {
@@ -221,43 +207,38 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     let init = &this.thir[*initializer];
                     let initializer_span = init.span;
+                    let scope = (*init_scope, source_info);
                     let failure = unpack!(
-                        block = this.in_opt_scope(
-                            opt_destruction_scope.map(|de| (de, source_info)),
-                            |this| {
-                                let scope = (*init_scope, source_info);
-                                this.in_scope(scope, *lint_level, |this| {
-                                    this.declare_bindings(
-                                        visibility_scope,
-                                        remainder_span,
-                                        pattern,
-                                        None,
-                                        Some((Some(&destination), initializer_span)),
-                                    );
-                                    this.visit_primary_bindings(
-                                        pattern,
-                                        UserTypeProjections::none(),
-                                        &mut |this, _, _, _, node, span, _, _| {
-                                            this.storage_live_binding(
-                                                block,
-                                                node,
-                                                span,
-                                                OutsideGuard,
-                                                true,
-                                            );
-                                        },
-                                    );
-                                    this.ast_let_else(
+                        block = this.in_scope(scope, *lint_level, |this| {
+                            this.declare_bindings(
+                                visibility_scope,
+                                remainder_span,
+                                pattern,
+                                None,
+                                Some((Some(&destination), initializer_span)),
+                            );
+                            this.visit_primary_bindings(
+                                pattern,
+                                UserTypeProjections::none(),
+                                &mut |this, _, _, _, node, span, _, _| {
+                                    this.storage_live_binding(
                                         block,
-                                        init,
-                                        initializer_span,
-                                        *else_block,
-                                        &last_remainder_scope,
-                                        pattern,
-                                    )
-                                })
-                            }
-                        )
+                                        node,
+                                        span,
+                                        OutsideGuard,
+                                        true,
+                                    );
+                                },
+                            );
+                            this.ast_let_else(
+                                block,
+                                init,
+                                initializer_span,
+                                *else_block,
+                                &last_remainder_scope,
+                                pattern,
+                            )
+                        })
                     );
                     this.cfg.goto(failure, source_info, failure_entry);
 
@@ -298,25 +279,20 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     if let Some(init) = initializer {
                         let init = &this.thir[*init];
                         let initializer_span = init.span;
+                        let scope = (*init_scope, source_info);
 
                         unpack!(
-                            block = this.in_opt_scope(
-                                opt_destruction_scope.map(|de| (de, source_info)),
-                                |this| {
-                                    let scope = (*init_scope, source_info);
-                                    this.in_scope(scope, *lint_level, |this| {
-                                        this.declare_bindings(
-                                            visibility_scope,
-                                            remainder_span,
-                                            pattern,
-                                            None,
-                                            Some((None, initializer_span)),
-                                        );
-                                        this.expr_into_pattern(block, pattern, init)
-                                        // irrefutable pattern
-                                    })
-                                },
-                            )
+                            block = this.in_scope(scope, *lint_level, |this| {
+                                this.declare_bindings(
+                                    visibility_scope,
+                                    remainder_span,
+                                    pattern,
+                                    None,
+                                    Some((None, initializer_span)),
+                                );
+                                this.expr_into_pattern(block, &pattern, init)
+                                // irrefutable pattern
+                            })
                         )
                     } else {
                         let scope = (*init_scope, source_info);

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -537,27 +537,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         (then_block, else_block)
     }
 
-    pub(crate) fn in_opt_scope<F, R>(
-        &mut self,
-        opt_scope: Option<(region::Scope, SourceInfo)>,
-        f: F,
-    ) -> BlockAnd<R>
-    where
-        F: FnOnce(&mut Builder<'a, 'tcx>) -> BlockAnd<R>,
-    {
-        debug!("in_opt_scope(opt_scope={:?})", opt_scope);
-        if let Some(region_scope) = opt_scope {
-            self.push_scope(region_scope);
-        }
-        let mut block;
-        let rv = unpack!(block = f(self));
-        if let Some(region_scope) = opt_scope {
-            unpack!(block = self.pop_scope(region_scope, block));
-        }
-        debug!("in_scope: exiting opt_scope={:?} block={:?}", opt_scope, block);
-        block.and(rv)
-    }
-
     /// Convenience wrapper that pushes a scope and then executes `f`
     /// to build its contents, popping the scope afterwards.
     #[instrument(skip(self, f), level = "debug")]

--- a/compiler/rustc_mir_build/src/thir/cx/block.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/block.rs
@@ -13,15 +13,12 @@ impl<'tcx> Cx<'tcx> {
         // We have to eagerly lower the "spine" of the statements
         // in order to get the lexical scoping correctly.
         let stmts = self.mirror_stmts(block.hir_id.local_id, block.stmts);
-        let opt_destruction_scope =
-            self.region_scope_tree.opt_destruction_scope(block.hir_id.local_id);
         let block = Block {
             targeted_by_break: block.targeted_by_break,
             region_scope: region::Scope {
                 id: block.hir_id.local_id,
                 data: region::ScopeData::Node,
             },
-            opt_destruction_scope,
             span: block.span,
             stmts,
             expr: block.expr.map(|expr| self.mirror_expr(expr)),
@@ -49,7 +46,6 @@ impl<'tcx> Cx<'tcx> {
             .enumerate()
             .filter_map(|(index, stmt)| {
                 let hir_id = stmt.hir_id;
-                let opt_dxn_ext = self.region_scope_tree.opt_destruction_scope(hir_id.local_id);
                 match stmt.kind {
                     hir::StmtKind::Expr(expr) | hir::StmtKind::Semi(expr) => {
                         let stmt = Stmt {
@@ -60,7 +56,6 @@ impl<'tcx> Cx<'tcx> {
                                 },
                                 expr: self.mirror_expr(expr),
                             },
-                            opt_destruction_scope: opt_dxn_ext,
                         };
                         Some(self.thir.stmts.push(stmt))
                     }
@@ -122,7 +117,6 @@ impl<'tcx> Cx<'tcx> {
                                 lint_level: LintLevel::Explicit(local.hir_id),
                                 span,
                             },
-                            opt_destruction_scope: opt_dxn_ext,
                         };
                         Some(self.thir.stmts.push(stmt))
                     }

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -54,7 +54,7 @@ impl<'tcx> Cx<'tcx> {
 
         trace!(?expr.ty, "after adjustments");
 
-        // Next, wrap this up in the expr's scope.
+        // Finally, wrap this up in the expr's scope.
         expr = Expr {
             temp_lifetime: expr.temp_lifetime,
             ty: expr.ty,
@@ -65,22 +65,6 @@ impl<'tcx> Cx<'tcx> {
                 lint_level: LintLevel::Explicit(hir_expr.hir_id),
             },
         };
-
-        // Finally, create a destruction scope, if any.
-        if let Some(region_scope) =
-            self.region_scope_tree.opt_destruction_scope(hir_expr.hir_id.local_id)
-        {
-            expr = Expr {
-                temp_lifetime: expr.temp_lifetime,
-                ty: expr.ty,
-                span: hir_expr.span,
-                kind: ExprKind::Scope {
-                    region_scope,
-                    value: self.thir.exprs.push(expr),
-                    lint_level: LintLevel::Inherited,
-                },
-            };
-        }
 
         // OK, all done!
         self.thir.exprs.push(expr)

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -91,23 +91,11 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
     }
 
     fn print_block(&mut self, block_id: BlockId, depth_lvl: usize) {
-        let Block {
-            targeted_by_break,
-            opt_destruction_scope,
-            span,
-            region_scope,
-            stmts,
-            expr,
-            safety_mode,
-        } = &self.thir.blocks[block_id];
+        let Block { targeted_by_break, span, region_scope, stmts, expr, safety_mode } =
+            &self.thir.blocks[block_id];
 
         print_indented!(self, "Block {", depth_lvl);
         print_indented!(self, format!("targeted_by_break: {}", targeted_by_break), depth_lvl + 1);
-        print_indented!(
-            self,
-            format!("opt_destruction_scope: {:?}", opt_destruction_scope),
-            depth_lvl + 1
-        );
         print_indented!(self, format!("span: {:?}", span), depth_lvl + 1);
         print_indented!(self, format!("region_scope: {:?}", region_scope), depth_lvl + 1);
         print_indented!(self, format!("safety_mode: {:?}", safety_mode), depth_lvl + 1);
@@ -133,14 +121,9 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
     }
 
     fn print_stmt(&mut self, stmt_id: StmtId, depth_lvl: usize) {
-        let Stmt { kind, opt_destruction_scope } = &self.thir.stmts[stmt_id];
+        let Stmt { kind } = &self.thir.stmts[stmt_id];
 
         print_indented!(self, "Stmt {", depth_lvl);
-        print_indented!(
-            self,
-            format!("opt_destruction_scope: {:?}", opt_destruction_scope),
-            depth_lvl + 1
-        );
 
         match kind {
             StmtKind::Expr { scope, expr } => {

--- a/tests/ui/thir-print/thir-flat-const-variant.stdout
+++ b/tests/ui/thir-print/thir-flat-const-variant.stdout
@@ -66,18 +66,6 @@ Thir {
             ),
             span: $DIR/thir-flat-const-variant.rs:12:23: 12:35 (#0),
         },
-        Expr {
-            kind: Scope {
-                region_scope: Destruction(3),
-                lint_level: Inherited,
-                value: e3,
-            },
-            ty: Foo,
-            temp_lifetime: Some(
-                Node(3),
-            ),
-            span: $DIR/thir-flat-const-variant.rs:12:23: 12:35 (#0),
-        },
     ],
     stmts: [],
     params: [],
@@ -144,18 +132,6 @@ Thir {
                     HirId(DefId(0:9 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR2).3),
                 ),
                 value: e2,
-            },
-            ty: Foo,
-            temp_lifetime: Some(
-                Node(3),
-            ),
-            span: $DIR/thir-flat-const-variant.rs:13:23: 13:36 (#0),
-        },
-        Expr {
-            kind: Scope {
-                region_scope: Destruction(3),
-                lint_level: Inherited,
-                value: e3,
             },
             ty: Foo,
             temp_lifetime: Some(
@@ -236,18 +212,6 @@ Thir {
             ),
             span: $DIR/thir-flat-const-variant.rs:14:24: 14:36 (#0),
         },
-        Expr {
-            kind: Scope {
-                region_scope: Destruction(3),
-                lint_level: Inherited,
-                value: e3,
-            },
-            ty: Foo,
-            temp_lifetime: Some(
-                Node(3),
-            ),
-            span: $DIR/thir-flat-const-variant.rs:14:24: 14:36 (#0),
-        },
     ],
     stmts: [],
     params: [],
@@ -321,18 +285,6 @@ Thir {
             ),
             span: $DIR/thir-flat-const-variant.rs:15:24: 15:37 (#0),
         },
-        Expr {
-            kind: Scope {
-                region_scope: Destruction(3),
-                lint_level: Inherited,
-                value: e3,
-            },
-            ty: Foo,
-            temp_lifetime: Some(
-                Node(3),
-            ),
-            span: $DIR/thir-flat-const-variant.rs:15:24: 15:37 (#0),
-        },
     ],
     stmts: [],
     params: [],
@@ -348,7 +300,6 @@ Thir {
         Block {
             targeted_by_break: false,
             region_scope: Node(1),
-            opt_destruction_scope: None,
             span: $DIR/thir-flat-const-variant.rs:18:11: 18:13 (#0),
             stmts: [],
             expr: None,
@@ -373,18 +324,6 @@ Thir {
                     HirId(DefId(0:12 ~ thir_flat_const_variant[1f54]::main).2),
                 ),
                 value: e0,
-            },
-            ty: (),
-            temp_lifetime: Some(
-                Node(2),
-            ),
-            span: $DIR/thir-flat-const-variant.rs:18:11: 18:13 (#0),
-        },
-        Expr {
-            kind: Scope {
-                region_scope: Destruction(2),
-                lint_level: Inherited,
-                value: e1,
             },
             ty: (),
             temp_lifetime: Some(

--- a/tests/ui/thir-print/thir-flat.stdout
+++ b/tests/ui/thir-print/thir-flat.stdout
@@ -8,7 +8,6 @@ Thir {
         Block {
             targeted_by_break: false,
             region_scope: Node(1),
-            opt_destruction_scope: None,
             span: $DIR/thir-flat.rs:4:15: 4:17 (#0),
             stmts: [],
             expr: None,
@@ -33,18 +32,6 @@ Thir {
                     HirId(DefId(0:3 ~ thir_flat[7b97]::main).2),
                 ),
                 value: e0,
-            },
-            ty: (),
-            temp_lifetime: Some(
-                Node(2),
-            ),
-            span: $DIR/thir-flat.rs:4:15: 4:17 (#0),
-        },
-        Expr {
-            kind: Scope {
-                region_scope: Destruction(2),
-                lint_level: Inherited,
-                value: e1,
             },
             ty: (),
             temp_lifetime: Some(

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -31,262 +31,217 @@ body:
         span: $DIR/thir-tree-match.rs:15:32: 21:2 (#0)
         kind: 
             Scope {
-                region_scope: Destruction(26)
-                lint_level: Inherited
+                region_scope: Node(26)
+                lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).26))
                 value:
                     Expr {
                         ty: bool
                         temp_lifetime: Some(Node(26))
                         span: $DIR/thir-tree-match.rs:15:32: 21:2 (#0)
                         kind: 
-                            Scope {
-                                region_scope: Node(26)
-                                lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).26))
-                                value:
+                            Block {
+                                targeted_by_break: false
+                                span: $DIR/thir-tree-match.rs:15:32: 21:2 (#0)
+                                region_scope: Node(25)
+                                safety_mode: Safe
+                                stmts: []
+                                expr:
                                     Expr {
                                         ty: bool
                                         temp_lifetime: Some(Node(26))
-                                        span: $DIR/thir-tree-match.rs:15:32: 21:2 (#0)
+                                        span: $DIR/thir-tree-match.rs:16:5: 20:6 (#0)
                                         kind: 
-                                            Block {
-                                                targeted_by_break: false
-                                                opt_destruction_scope: None
-                                                span: $DIR/thir-tree-match.rs:15:32: 21:2 (#0)
-                                                region_scope: Node(25)
-                                                safety_mode: Safe
-                                                stmts: []
-                                                expr:
+                                            Scope {
+                                                region_scope: Node(3)
+                                                lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).3))
+                                                value:
                                                     Expr {
                                                         ty: bool
                                                         temp_lifetime: Some(Node(26))
                                                         span: $DIR/thir-tree-match.rs:16:5: 20:6 (#0)
                                                         kind: 
-                                                            Scope {
-                                                                region_scope: Node(3)
-                                                                lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).3))
-                                                                value:
+                                                            Match {
+                                                                scrutinee:
                                                                     Expr {
-                                                                        ty: bool
+                                                                        ty: Foo
                                                                         temp_lifetime: Some(Node(26))
-                                                                        span: $DIR/thir-tree-match.rs:16:5: 20:6 (#0)
+                                                                        span: $DIR/thir-tree-match.rs:16:11: 16:14 (#0)
                                                                         kind: 
-                                                                            Match {
-                                                                                scrutinee:
+                                                                            Scope {
+                                                                                region_scope: Node(4)
+                                                                                lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).4))
+                                                                                value:
                                                                                     Expr {
                                                                                         ty: Foo
                                                                                         temp_lifetime: Some(Node(26))
                                                                                         span: $DIR/thir-tree-match.rs:16:11: 16:14 (#0)
                                                                                         kind: 
-                                                                                            Scope {
-                                                                                                region_scope: Node(4)
-                                                                                                lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).4))
-                                                                                                value:
-                                                                                                    Expr {
-                                                                                                        ty: Foo
-                                                                                                        temp_lifetime: Some(Node(26))
-                                                                                                        span: $DIR/thir-tree-match.rs:16:11: 16:14 (#0)
-                                                                                                        kind: 
-                                                                                                            VarRef {
-                                                                                                                id: LocalVarId(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).2))
-                                                                                                            }
-                                                                                                    }
+                                                                                            VarRef {
+                                                                                                id: LocalVarId(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).2))
                                                                                             }
                                                                                     }
-                                                                                arms: [
-                                                                                    Arm {
-                                                                                        pattern: 
+                                                                            }
+                                                                    }
+                                                                arms: [
+                                                                    Arm {
+                                                                        pattern: 
+                                                                            Pat: {
+                                                                                ty: Foo
+                                                                                span: $DIR/thir-tree-match.rs:17:9: 17:32 (#0)
+                                                                                kind: PatKind {
+                                                                                    Variant {
+                                                                                        adt_def: 
+                                                                                            AdtDef {
+                                                                                                did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
+                                                                                                variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])) }], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], flags: NO_VARIANT_FLAGS }]
+                                                                                                flags: IS_ENUM
+                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: (empty), field_shuffle_seed: 3477539199540094892 }
+                                                                                        args: []
+                                                                                        variant_index: 0
+                                                                                        subpatterns: [
                                                                                             Pat: {
-                                                                                                ty: Foo
-                                                                                                span: $DIR/thir-tree-match.rs:17:9: 17:32 (#0)
+                                                                                                ty: Bar
+                                                                                                span: $DIR/thir-tree-match.rs:17:21: 17:31 (#0)
                                                                                                 kind: PatKind {
                                                                                                     Variant {
                                                                                                         adt_def: 
                                                                                                             AdtDef {
-                                                                                                                did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
-                                                                                                                variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])) }], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], flags: NO_VARIANT_FLAGS }]
+                                                                                                                did: DefId(0:3 ~ thir_tree_match[fcf8]::Bar)
+                                                                                                                variants: [VariantDef { def_id: DefId(0:4 ~ thir_tree_match[fcf8]::Bar::First), ctor: Some((Const, DefId(0:5 ~ thir_tree_match[fcf8]::Bar::First::{constructor#0}))), name: "First", discr: Relative(0), fields: [], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:6 ~ thir_tree_match[fcf8]::Bar::Second), ctor: Some((Const, DefId(0:7 ~ thir_tree_match[fcf8]::Bar::Second::{constructor#0}))), name: "Second", discr: Relative(1), fields: [], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:8 ~ thir_tree_match[fcf8]::Bar::Third), ctor: Some((Const, DefId(0:9 ~ thir_tree_match[fcf8]::Bar::Third::{constructor#0}))), name: "Third", discr: Relative(2), fields: [], flags: NO_VARIANT_FLAGS }]
                                                                                                                 flags: IS_ENUM
-                                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: (empty), field_shuffle_seed: 3477539199540094892 }
+                                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: (empty), field_shuffle_seed: 10333377570083945360 }
                                                                                                         args: []
                                                                                                         variant_index: 0
-                                                                                                        subpatterns: [
-                                                                                                            Pat: {
-                                                                                                                ty: Bar
-                                                                                                                span: $DIR/thir-tree-match.rs:17:21: 17:31 (#0)
-                                                                                                                kind: PatKind {
-                                                                                                                    Variant {
-                                                                                                                        adt_def: 
-                                                                                                                            AdtDef {
-                                                                                                                                did: DefId(0:3 ~ thir_tree_match[fcf8]::Bar)
-                                                                                                                                variants: [VariantDef { def_id: DefId(0:4 ~ thir_tree_match[fcf8]::Bar::First), ctor: Some((Const, DefId(0:5 ~ thir_tree_match[fcf8]::Bar::First::{constructor#0}))), name: "First", discr: Relative(0), fields: [], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:6 ~ thir_tree_match[fcf8]::Bar::Second), ctor: Some((Const, DefId(0:7 ~ thir_tree_match[fcf8]::Bar::Second::{constructor#0}))), name: "Second", discr: Relative(1), fields: [], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:8 ~ thir_tree_match[fcf8]::Bar::Third), ctor: Some((Const, DefId(0:9 ~ thir_tree_match[fcf8]::Bar::Third::{constructor#0}))), name: "Third", discr: Relative(2), fields: [], flags: NO_VARIANT_FLAGS }]
-                                                                                                                                flags: IS_ENUM
-                                                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: (empty), field_shuffle_seed: 10333377570083945360 }
-                                                                                                                        args: []
-                                                                                                                        variant_index: 0
-                                                                                                                        subpatterns: []
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            }
-                                                                                                        ]
+                                                                                                        subpatterns: []
                                                                                                     }
                                                                                                 }
                                                                                             }
-                                                                                        guard: None
-                                                                                        body: 
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        guard: None
+                                                                        body: 
+                                                                            Expr {
+                                                                                ty: bool
+                                                                                temp_lifetime: Some(Node(13))
+                                                                                span: $DIR/thir-tree-match.rs:17:36: 17:40 (#0)
+                                                                                kind: 
+                                                                                    Scope {
+                                                                                        region_scope: Node(13)
+                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).13))
+                                                                                        value:
                                                                                             Expr {
                                                                                                 ty: bool
                                                                                                 temp_lifetime: Some(Node(13))
                                                                                                 span: $DIR/thir-tree-match.rs:17:36: 17:40 (#0)
                                                                                                 kind: 
-                                                                                                    Scope {
-                                                                                                        region_scope: Destruction(13)
-                                                                                                        lint_level: Inherited
-                                                                                                        value:
-                                                                                                            Expr {
-                                                                                                                ty: bool
-                                                                                                                temp_lifetime: Some(Node(13))
-                                                                                                                span: $DIR/thir-tree-match.rs:17:36: 17:40 (#0)
-                                                                                                                kind: 
-                                                                                                                    Scope {
-                                                                                                                        region_scope: Node(13)
-                                                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).13))
-                                                                                                                        value:
-                                                                                                                            Expr {
-                                                                                                                                ty: bool
-                                                                                                                                temp_lifetime: Some(Node(13))
-                                                                                                                                span: $DIR/thir-tree-match.rs:17:36: 17:40 (#0)
-                                                                                                                                kind: 
-                                                                                                                                    Literal( lit: Spanned { node: Bool(true), span: $DIR/thir-tree-match.rs:17:36: 17:40 (#0) }, neg: false)
+                                                                                                    Literal( lit: Spanned { node: Bool(true), span: $DIR/thir-tree-match.rs:17:36: 17:40 (#0) }, neg: false)
 
-                                                                                                                            }
-                                                                                                                    }
-                                                                                                            }
-                                                                                                    }
                                                                                             }
-                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).12))
-                                                                                        scope: Node(12)
-                                                                                        span: $DIR/thir-tree-match.rs:17:9: 17:40 (#0)
                                                                                     }
-                                                                                    Arm {
-                                                                                        pattern: 
+                                                                            }
+                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).12))
+                                                                        scope: Node(12)
+                                                                        span: $DIR/thir-tree-match.rs:17:9: 17:40 (#0)
+                                                                    }
+                                                                    Arm {
+                                                                        pattern: 
+                                                                            Pat: {
+                                                                                ty: Foo
+                                                                                span: $DIR/thir-tree-match.rs:18:9: 18:23 (#0)
+                                                                                kind: PatKind {
+                                                                                    Variant {
+                                                                                        adt_def: 
+                                                                                            AdtDef {
+                                                                                                did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
+                                                                                                variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])) }], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], flags: NO_VARIANT_FLAGS }]
+                                                                                                flags: IS_ENUM
+                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: (empty), field_shuffle_seed: 3477539199540094892 }
+                                                                                        args: []
+                                                                                        variant_index: 0
+                                                                                        subpatterns: [
                                                                                             Pat: {
-                                                                                                ty: Foo
-                                                                                                span: $DIR/thir-tree-match.rs:18:9: 18:23 (#0)
+                                                                                                ty: Bar
+                                                                                                span: $DIR/thir-tree-match.rs:18:21: 18:22 (#0)
                                                                                                 kind: PatKind {
-                                                                                                    Variant {
-                                                                                                        adt_def: 
-                                                                                                            AdtDef {
-                                                                                                                did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
-                                                                                                                variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])) }], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], flags: NO_VARIANT_FLAGS }]
-                                                                                                                flags: IS_ENUM
-                                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: (empty), field_shuffle_seed: 3477539199540094892 }
-                                                                                                        args: []
-                                                                                                        variant_index: 0
-                                                                                                        subpatterns: [
-                                                                                                            Pat: {
-                                                                                                                ty: Bar
-                                                                                                                span: $DIR/thir-tree-match.rs:18:21: 18:22 (#0)
-                                                                                                                kind: PatKind {
-                                                                                                                    Wild
-                                                                                                                }
-                                                                                                            }
-                                                                                                        ]
-                                                                                                    }
+                                                                                                    Wild
                                                                                                 }
                                                                                             }
-                                                                                        guard: None
-                                                                                        body: 
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        guard: None
+                                                                        body: 
+                                                                            Expr {
+                                                                                ty: bool
+                                                                                temp_lifetime: Some(Node(19))
+                                                                                span: $DIR/thir-tree-match.rs:18:27: 18:32 (#0)
+                                                                                kind: 
+                                                                                    Scope {
+                                                                                        region_scope: Node(19)
+                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).19))
+                                                                                        value:
                                                                                             Expr {
                                                                                                 ty: bool
                                                                                                 temp_lifetime: Some(Node(19))
                                                                                                 span: $DIR/thir-tree-match.rs:18:27: 18:32 (#0)
                                                                                                 kind: 
-                                                                                                    Scope {
-                                                                                                        region_scope: Destruction(19)
-                                                                                                        lint_level: Inherited
-                                                                                                        value:
-                                                                                                            Expr {
-                                                                                                                ty: bool
-                                                                                                                temp_lifetime: Some(Node(19))
-                                                                                                                span: $DIR/thir-tree-match.rs:18:27: 18:32 (#0)
-                                                                                                                kind: 
-                                                                                                                    Scope {
-                                                                                                                        region_scope: Node(19)
-                                                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).19))
-                                                                                                                        value:
-                                                                                                                            Expr {
-                                                                                                                                ty: bool
-                                                                                                                                temp_lifetime: Some(Node(19))
-                                                                                                                                span: $DIR/thir-tree-match.rs:18:27: 18:32 (#0)
-                                                                                                                                kind: 
-                                                                                                                                    Literal( lit: Spanned { node: Bool(false), span: $DIR/thir-tree-match.rs:18:27: 18:32 (#0) }, neg: false)
+                                                                                                    Literal( lit: Spanned { node: Bool(false), span: $DIR/thir-tree-match.rs:18:27: 18:32 (#0) }, neg: false)
 
-                                                                                                                            }
-                                                                                                                    }
-                                                                                                            }
-                                                                                                    }
                                                                                             }
-                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).18))
-                                                                                        scope: Node(18)
-                                                                                        span: $DIR/thir-tree-match.rs:18:9: 18:32 (#0)
                                                                                     }
-                                                                                    Arm {
-                                                                                        pattern: 
-                                                                                            Pat: {
-                                                                                                ty: Foo
-                                                                                                span: $DIR/thir-tree-match.rs:19:9: 19:20 (#0)
-                                                                                                kind: PatKind {
-                                                                                                    Variant {
-                                                                                                        adt_def: 
-                                                                                                            AdtDef {
-                                                                                                                did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
-                                                                                                                variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])) }], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], flags: NO_VARIANT_FLAGS }]
-                                                                                                                flags: IS_ENUM
-                                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: (empty), field_shuffle_seed: 3477539199540094892 }
-                                                                                                        args: []
-                                                                                                        variant_index: 1
-                                                                                                        subpatterns: []
-                                                                                                    }
-                                                                                                }
-                                                                                            }
-                                                                                        guard: None
-                                                                                        body: 
+                                                                            }
+                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).18))
+                                                                        scope: Node(18)
+                                                                        span: $DIR/thir-tree-match.rs:18:9: 18:32 (#0)
+                                                                    }
+                                                                    Arm {
+                                                                        pattern: 
+                                                                            Pat: {
+                                                                                ty: Foo
+                                                                                span: $DIR/thir-tree-match.rs:19:9: 19:20 (#0)
+                                                                                kind: PatKind {
+                                                                                    Variant {
+                                                                                        adt_def: 
+                                                                                            AdtDef {
+                                                                                                did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
+                                                                                                variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])) }], flags: NO_VARIANT_FLAGS }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], flags: NO_VARIANT_FLAGS }]
+                                                                                                flags: IS_ENUM
+                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: (empty), field_shuffle_seed: 3477539199540094892 }
+                                                                                        args: []
+                                                                                        variant_index: 1
+                                                                                        subpatterns: []
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        guard: None
+                                                                        body: 
+                                                                            Expr {
+                                                                                ty: bool
+                                                                                temp_lifetime: Some(Node(24))
+                                                                                span: $DIR/thir-tree-match.rs:19:24: 19:28 (#0)
+                                                                                kind: 
+                                                                                    Scope {
+                                                                                        region_scope: Node(24)
+                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).24))
+                                                                                        value:
                                                                                             Expr {
                                                                                                 ty: bool
                                                                                                 temp_lifetime: Some(Node(24))
                                                                                                 span: $DIR/thir-tree-match.rs:19:24: 19:28 (#0)
                                                                                                 kind: 
-                                                                                                    Scope {
-                                                                                                        region_scope: Destruction(24)
-                                                                                                        lint_level: Inherited
-                                                                                                        value:
-                                                                                                            Expr {
-                                                                                                                ty: bool
-                                                                                                                temp_lifetime: Some(Node(24))
-                                                                                                                span: $DIR/thir-tree-match.rs:19:24: 19:28 (#0)
-                                                                                                                kind: 
-                                                                                                                    Scope {
-                                                                                                                        region_scope: Node(24)
-                                                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).24))
-                                                                                                                        value:
-                                                                                                                            Expr {
-                                                                                                                                ty: bool
-                                                                                                                                temp_lifetime: Some(Node(24))
-                                                                                                                                span: $DIR/thir-tree-match.rs:19:24: 19:28 (#0)
-                                                                                                                                kind: 
-                                                                                                                                    Literal( lit: Spanned { node: Bool(true), span: $DIR/thir-tree-match.rs:19:24: 19:28 (#0) }, neg: false)
+                                                                                                    Literal( lit: Spanned { node: Bool(true), span: $DIR/thir-tree-match.rs:19:24: 19:28 (#0) }, neg: false)
 
-                                                                                                                            }
-                                                                                                                    }
-                                                                                                            }
-                                                                                                    }
                                                                                             }
-                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).23))
-                                                                                        scope: Node(23)
-                                                                                        span: $DIR/thir-tree-match.rs:19:9: 19:28 (#0)
                                                                                     }
-                                                                                ]
                                                                             }
+                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).23))
+                                                                        scope: Node(23)
+                                                                        span: $DIR/thir-tree-match.rs:19:9: 19:28 (#0)
                                                                     }
+                                                                ]
                                                             }
                                                     }
                                             }
@@ -307,33 +262,21 @@ body:
         span: $DIR/thir-tree-match.rs:23:11: 23:13 (#0)
         kind: 
             Scope {
-                region_scope: Destruction(2)
-                lint_level: Inherited
+                region_scope: Node(2)
+                lint_level: Explicit(HirId(DefId(0:17 ~ thir_tree_match[fcf8]::main).2))
                 value:
                     Expr {
                         ty: ()
                         temp_lifetime: Some(Node(2))
                         span: $DIR/thir-tree-match.rs:23:11: 23:13 (#0)
                         kind: 
-                            Scope {
-                                region_scope: Node(2)
-                                lint_level: Explicit(HirId(DefId(0:17 ~ thir_tree_match[fcf8]::main).2))
-                                value:
-                                    Expr {
-                                        ty: ()
-                                        temp_lifetime: Some(Node(2))
-                                        span: $DIR/thir-tree-match.rs:23:11: 23:13 (#0)
-                                        kind: 
-                                            Block {
-                                                targeted_by_break: false
-                                                opt_destruction_scope: None
-                                                span: $DIR/thir-tree-match.rs:23:11: 23:13 (#0)
-                                                region_scope: Node(1)
-                                                safety_mode: Safe
-                                                stmts: []
-                                                expr: []
-                                            }
-                                    }
+                            Block {
+                                targeted_by_break: false
+                                span: $DIR/thir-tree-match.rs:23:11: 23:13 (#0)
+                                region_scope: Node(1)
+                                safety_mode: Safe
+                                stmts: []
+                                expr: []
                             }
                     }
             }

--- a/tests/ui/thir-print/thir-tree.stdout
+++ b/tests/ui/thir-print/thir-tree.stdout
@@ -8,33 +8,21 @@ body:
         span: $DIR/thir-tree.rs:4:15: 4:17 (#0)
         kind: 
             Scope {
-                region_scope: Destruction(2)
-                lint_level: Inherited
+                region_scope: Node(2)
+                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree[7aaa]::main).2))
                 value:
                     Expr {
                         ty: ()
                         temp_lifetime: Some(Node(2))
                         span: $DIR/thir-tree.rs:4:15: 4:17 (#0)
                         kind: 
-                            Scope {
-                                region_scope: Node(2)
-                                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree[7aaa]::main).2))
-                                value:
-                                    Expr {
-                                        ty: ()
-                                        temp_lifetime: Some(Node(2))
-                                        span: $DIR/thir-tree.rs:4:15: 4:17 (#0)
-                                        kind: 
-                                            Block {
-                                                targeted_by_break: false
-                                                opt_destruction_scope: None
-                                                span: $DIR/thir-tree.rs:4:15: 4:17 (#0)
-                                                region_scope: Node(1)
-                                                safety_mode: Safe
-                                                stmts: []
-                                                expr: []
-                                            }
-                                    }
+                            Block {
+                                targeted_by_break: false
+                                span: $DIR/thir-tree.rs:4:15: 4:17 (#0)
+                                region_scope: Node(1)
+                                safety_mode: Safe
+                                stmts: []
+                                expr: []
                             }
                     }
             }


### PR DESCRIPTION
They are not used by anyone, and add memory/performance overhead.