### PR TITLE
Broaden the consequences of recursive TLS initialization

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -29,9 +29,9 @@ use crate::fmt;
 /// within a thread, and values that implement [`Drop`] get destructed when a
 /// thread exits. Some caveats apply, which are explained below.
 ///
-/// A `LocalKey`'s initializer cannot recursively depend on itself, and using
-/// a `LocalKey` in this way will cause the initializer to infinitely recurse
-/// on the first call to `with`.
+/// A `LocalKey`'s initializer cannot recursively depend on itself. Using a
+/// `LocalKey` in this way may cause panics, aborts or infinite recursion on
+/// the first call to `with`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This PR updates the documentation of `LocalKey` to clearly disallow the behaviour described in [this comment](https://github.com/rust-lang/rust/issues/110897#issuecomment-1525738849). This allows using `OnceCell` for the lazy initialization of TLS variables, which panics on reentrant initialization instead of updating the value like TLS variables currently do.

@rustbot label +T-libs-api
r? @m-ou-se 