### PR TITLE
New atomic reference counting algorithm

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -989,7 +989,7 @@ impl<T, A: Allocator> Arc<T, A> {
                     .compare_exchange(ONE_STRONG_WITH_WEAK, STRONG_DROPPED, Acquire, Relaxed)
                     .is_ok() =>
             {
-                // The strong count was one, without any weak pointers.
+                // The strong count was one, potentially with weak pointers.
                 let mut this = mem::ManuallyDrop::new(this);
                 let value = unsafe { ptr::read(Self::get_mut_unchecked(&mut this)) };
                 let alloc = unsafe { ptr::read(&this.alloc) };

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2174,7 +2174,7 @@ impl<T: Clone, A: Allocator + Clone> Arc<T, A> {
                 // Weak pointers can no longer upgrade at this point, though.
                 if this.inner().weak.load(Relaxed) == ONE_WEAK {
                     // No Weak pointers exist.
-                    this.inner().strong.store(ONE_STRONG_WITH_WEAK, Release); // Restore the strong count for this Arc.
+                    this.inner().strong.store(ONE_STRONG, Release); // Restore the strong count for this Arc.
                 } else {
                     // Weak pointers exist.
                     // So we can just steal the data, but need a new allocation.

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2172,7 +2172,7 @@ impl<T: Clone, A: Allocator + Clone> Arc<T, A> {
             {
                 // This is the only Arc, but other Weak pointers might exist.
                 // Weak pointers can no longer upgrade at this point, though.
-                if this.inner().weak.load(Relaxed) == ONE_WEAK {
+                if this.inner().weak.compare_exchange(ONE_WEAK, NO_WEAK, Relaxed, Relaxed).is_ok() {
                     // No Weak pointers exist.
                     this.inner().strong.store(ONE_STRONG, Release); // Restore the strong count for this Arc.
                 } else {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2190,7 +2190,7 @@ impl<T: Clone, A: Allocator + Clone> Arc<T, A> {
                 }
             }
             _ => {
-                // Another Arcs exist, so we must clone.
+                // Other Arcs might exist, so we must clone.
                 // Pre-allocate memory to allow writing the cloned value directly.
                 let mut arc = Self::new_uninit_in(this.alloc.clone());
                 unsafe {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -939,6 +939,7 @@ impl<T, A: Allocator> Arc<T, A> {
             ))
         }
     }
+
     /// Returns the inner value, if the `Arc` has exactly one strong reference.
     ///
     /// Otherwise, an [`Err`] is returned with the same `Arc` that was

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2358,7 +2358,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
                 if self
                     .inner()
                     .weak
-                    .compare_exchange(NO_STRONG_WITH_WEAK, STRONG_DROPPED, Acquire, Relaxed)
+                    .compare_exchange(ONE_WEAK, WEAK_LOCKED, Acquire, Relaxed)
                     .is_ok() =>
             {
                 // This was the only Arc when we looked at the strong pointer,

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -168,7 +168,16 @@ class StdRcProvider:
         self.ptr = unwrap_unique_or_non_null(valobj["ptr"])
         self.value = self.ptr["data" if is_atomic else "value"]
         self.strong = self.ptr["strong"]["v" if is_atomic else "value"]["value"]
-        self.weak = self.ptr["weak"]["v" if is_atomic else "value"]["value"] - 1
+        self.weak = self.ptr["weak"]["v" if is_atomic else "value"]["value"]
+        if is_atomic:
+            if self.weak % 2 == 1:
+                self.weak = 0
+            elif self.weak > 0:
+                self.weak >>= 1
+                self.weak -= 1
+            self.strong >>= 2
+        else:
+            self.weak -= 1
 
     def to_string(self):
         if self.is_atomic:

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -610,6 +610,8 @@ class StdRcSyntheticProvider:
 
         self.value_builder = ValueBuilder(valobj)
 
+        self.is_atomic = is_atomic
+
         self.update()
 
     def num_children(self):
@@ -641,7 +643,16 @@ class StdRcSyntheticProvider:
     def update(self):
         # type: () -> None
         self.strong_count = self.strong.GetValueAsUnsigned()
-        self.weak_count = self.weak.GetValueAsUnsigned() - 1
+        self.weak_count = self.weak.GetValueAsUnsigned()
+        if self.is_atomic:
+            if self.weak_count % 2 == 1:
+                self.weak_count = 0
+            elif self.weak_count > 0:
+                self.weak_count >>= 1
+                self.weak_count -= 1
+            self.strong_count >>= 2
+        else:
+            self.weak_count -= 1
 
     def has_children(self):
         # type: () -> bool


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/116173)*
<!-- homu-ignore:end -->

This implements a new 'wait-free' atomic reference counting algorithm based on the paper [Wait-Free Weak Reference Counting](https://www.microsoft.com/en-us/research/uploads/prod/2023/04/preprint-644bdf17da97d.pdf) by @mjp41, @sylvanc and @bensimner.

The paper contains a way to implement atomic reference counting *wait free*, for five operations:
1. Release weak (= Weak::drop)
2. Release strong (= Arc::drop)
3. Acquire weak (= Weak::clone and Arc::downgrade)
4. Acquire strong (= Arc::clone)
5. Acquire strong from weak (= Weak::upgrade)

`Weak::upgrade` must increase the strong count if it is nonzero. Unfortunately, processors do not have native 'increment if nonzero' instructions. Therefore, it is usually implemented with a CAS loop to increment the strong count only if it is not zero.

The paper shows a way to avoid this CAS loop to make it wait-free. By reserving the least significant bit in the strong counter (by shifting the counter one bit to the left), we can use that extra bit to indicate the final 'dropped' state in which the strong counter is permanently zero. Then `Weak::upgrade` can be implemented as a `fetch_add(2)`, which leaves the 'permanently zero' bit untouched.

This however does mean that Arc::drop must now do an additional operation. Not only must it decrement the strong counter, it must also use a CAS operation to set the 'permanently zero' bit if the counter is zero.

The paper also shows an optimized version of the algorithm in which an additional bit in the strong counter is reserved to indicate whether there have ever been any weak pointers. When this bit is not set, some steps can be skipped.

However, the algorithm from the paper is unfortunately not something we can directly use in for Rust's standard `Arc` and `Weak`, because we have more operations:

1. Weak::drop
2. Arc::drop
3. Weak::clone
4. Arc::clone
5. Weak::upgrade
7. Arc::downgrade
8. Arc::get_mut
9. Arc::try_unwrap
10. Arc::into_inner

Specifically `Arc::get_mut` requires locking the weak counter to temporarily block `Arc::downgrade` from completing. We cannot implement `Arc::downgrade` as just `Weak::clone`.

Our `Arc::downgrade` implementation is implemented as a CAS loop to increment the weak counter if it doesn't hold the special 'locked' (usize::MAX) value, similar to how Weak::upgrade uses a CAS loop (which is what the paper solves).

I have extended the algorithm by also reserving the lowest bit in the weak counter to represent the 'weak counter locked' state. That way, `Arc::downgrade` can be implemented as a `fetch_add(2)` rather than a CAS loop. It will still have to spin in case of a concurrent call to `Arc::get_mut`, but in absence of `Arc::get_mut`, this makes Arc and Weak wait-free.

The paper shows some promising benchmarking results. I have not benchmarked this change yet.