### PR TITLE
Add "integer square root" method to integer primitive types

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -178,6 +178,7 @@
 #![feature(ip)]
 #![feature(ip_bits)]
 #![feature(is_ascii_octdigit)]
+#![feature(isqrt)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(ptr_alignment_type)]
 #![feature(ptr_metadata)]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -915,26 +915,10 @@ macro_rules! int_impl {
         #[inline]
         pub const fn checked_isqrt(self) -> Option<Self> {
             if self < 0 {
-                return None;
-            } else if self < 2 {
-                return Some(self);
+                None
+            } else {
+                Some((self as $UnsignedT).isqrt() as Self)
             }
-
-            let mut x: Self = self;
-            let mut c: Self = 0;
-            let mut d: Self = 1 << (self.ilog2() & !1);
-
-            while (d != 0) {
-                if x >= c + d {
-                    x -= c + d;
-                    c = (c >> 1) + d;
-                } else {
-                    c >>= 1;
-                }
-                d >>= 2;
-            }
-
-            return Some(c);
         }
 
         /// Saturating integer addition. Computes `self + rhs`, saturating at the numeric
@@ -2118,27 +2102,15 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         pub const fn isqrt(self) -> Self {
-            if self < 0 {
-                panic!("argument of integer square root must be non-negative")
-            } else if self < 2 {
-                return self;
+            // I would like to implement it as
+            // ```
+            // self.checked_isqrt().expect("argument of integer square root must be non-negative")
+            // ```
+            // but `expect` is not yet stable as a `const fn`.
+            match self.checked_isqrt() {
+                Some(sqrt) => sqrt,
+                None => panic!("argument of integer square root must be non-negative"),
             }
-
-            let mut x: Self = self;
-            let mut c: Self = 0;
-            let mut d: Self = 1 << (self.ilog2() & !1);
-
-            while (d != 0) {
-                if x >= c + d {
-                    x -= c + d;
-                    c = (c >> 1) + d;
-                } else {
-                    c >>= 1;
-                }
-                d >>= 2;
-            }
-
-            return c;
         }
 
         /// Calculates the quotient of Euclidean division of `self` by `rhs`.

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -906,10 +906,11 @@ macro_rules! int_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(isqrt)]
         #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".checked_isqrt(), Some(3));")]
         /// ```
-        #[stable(feature = "isqrt", since = "1.73.0")]
-        #[rustc_const_stable(feature = "isqrt", since = "1.73.0")]
+        #[unstable(feature = "isqrt", issue = "none")]
+        #[rustc_const_unstable(feature = "isqrt", issue = "none")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
@@ -2094,10 +2095,11 @@ macro_rules! int_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(isqrt)]
         #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".isqrt(), 3);")]
         /// ```
-        #[stable(feature = "isqrt", since = "1.73.0")]
-        #[rustc_const_stable(feature = "isqrt", since = "1.73.0")]
+        #[unstable(feature = "isqrt", issue = "none")]
+        #[rustc_const_unstable(feature = "isqrt", issue = "none")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -898,6 +898,45 @@ macro_rules! int_impl {
             acc.checked_mul(base)
         }
 
+        /// Returns the square root of the number, rounded down.
+        ///
+        /// Returns `None` if `self` is negative.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".checked_isqrt(), Some(3));")]
+        /// ```
+        #[stable(feature = "isqrt", since = "1.73.0")]
+        #[rustc_const_stable(feature = "isqrt", since = "1.73.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn checked_isqrt(self) -> Option<Self> {
+            if self < 0 {
+                return None;
+            } else if self < 2 {
+                return Some(self);
+            }
+
+            let mut x: Self = self;
+            let mut c: Self = 0;
+            let mut d: Self = 1 << (self.ilog2() & !1);
+
+            while (d != 0) {
+                if x >= c + d {
+                    x -= c + d;
+                    c = (c >> 1) + d;
+                } else {
+                    c >>= 1;
+                }
+                d >>= 2;
+            }
+
+            return Some(c);
+        }
+
         /// Saturating integer addition. Computes `self + rhs`, saturating at the numeric
         /// bounds instead of overflowing.
         ///
@@ -2059,6 +2098,47 @@ macro_rules! int_impl {
             // squaring the base afterwards is not necessary and may cause a
             // needless overflow.
             acc * base
+        }
+
+        /// Returns the square root of the number, rounded down.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `self` is negative.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".isqrt(), 3);")]
+        /// ```
+        #[stable(feature = "isqrt", since = "1.73.0")]
+        #[rustc_const_stable(feature = "isqrt", since = "1.73.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn isqrt(self) -> Self {
+            if self < 0 {
+                panic!("argument of integer square root must be non-negative")
+            } else if self < 2 {
+                return self;
+            }
+
+            let mut x: Self = self;
+            let mut c: Self = 0;
+            let mut d: Self = 1 << (self.ilog2() & !1);
+
+            while (d != 0) {
+                if x >= c + d {
+                    x -= c + d;
+                    c = (c >> 1) + d;
+                } else {
+                    c >>= 1;
+                }
+                d >>= 2;
+            }
+
+            return c;
         }
 
         /// Calculates the quotient of Euclidean division of `self` by `rhs`.

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -909,8 +909,8 @@ macro_rules! int_impl {
         /// #![feature(isqrt)]
         #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".checked_isqrt(), Some(3));")]
         /// ```
-        #[unstable(feature = "isqrt", issue = "none")]
-        #[rustc_const_unstable(feature = "isqrt", issue = "none")]
+        #[unstable(feature = "isqrt", issue = "116226")]
+        #[rustc_const_unstable(feature = "isqrt", issue = "116226")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
@@ -2098,8 +2098,8 @@ macro_rules! int_impl {
         /// #![feature(isqrt)]
         #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".isqrt(), 3);")]
         /// ```
-        #[unstable(feature = "isqrt", issue = "none")]
-        #[rustc_const_unstable(feature = "isqrt", issue = "none")]
+        #[unstable(feature = "isqrt", issue = "116226")]
+        #[rustc_const_unstable(feature = "isqrt", issue = "116226")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2011,7 +2011,7 @@ macro_rules! uint_impl {
                 d >>= 2;
             }
 
-            return c;
+            c
         }
 
         /// Performs Euclidean division.

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1988,8 +1988,8 @@ macro_rules! uint_impl {
         /// #![feature(isqrt)]
         #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".isqrt(), 3);")]
         /// ```
-        #[unstable(feature = "isqrt", issue = "none")]
-        #[rustc_const_unstable(feature = "isqrt", issue = "none")]
+        #[unstable(feature = "isqrt", issue = "116226")]
+        #[rustc_const_unstable(feature = "isqrt", issue = "116226")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1985,10 +1985,11 @@ macro_rules! uint_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(isqrt)]
         #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".isqrt(), 3);")]
         /// ```
-        #[stable(feature = "isqrt", since = "1.73.0")]
-        #[rustc_const_stable(feature = "isqrt", since = "1.73.0")]
+        #[unstable(feature = "isqrt", issue = "none")]
+        #[rustc_const_unstable(feature = "isqrt", issue = "none")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1998,21 +1998,26 @@ macro_rules! uint_impl {
                 return self;
             }
 
-            let mut x = self;
-            let mut c = 0;
-            let mut d = 1 << (self.ilog2() & !1);
+            // The algorithm is based on the one presented in
+            // <https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Binary_numeral_system_(base_2)>
+            // which cites as source the following C code:
+            // <https://web.archive.org/web/20120306040058/http://medialab.freaknet.org/martin/src/sqrt/sqrt.c>.
 
-            while d != 0 {
-                if x >= c + d {
-                    x -= c + d;
-                    c = (c >> 1) + d;
+            let mut op = self;
+            let mut res = 0;
+            let mut one = 1 << (self.ilog2() & !1);
+
+            while one != 0 {
+                if op >= res + one {
+                    op -= res + one;
+                    res = (res >> 1) + one;
                 } else {
-                    c >>= 1;
+                    res >>= 1;
                 }
-                d >>= 2;
+                one >>= 2;
             }
 
-            c
+            res
         }
 
         /// Performs Euclidean division.

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1997,11 +1997,11 @@ macro_rules! uint_impl {
                 return self;
             }
 
-            let mut x: Self = self;
-            let mut c: Self = 0;
-            let mut d: Self = 1 << (self.ilog2() & !1);
+            let mut x = self;
+            let mut c = 0;
+            let mut d = 1 << (self.ilog2() & !1);
 
-            while (d != 0) {
+            while d != 0 {
                 if x >= c + d {
                     x -= c + d;
                     c = (c >> 1) + d;

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1979,6 +1979,41 @@ macro_rules! uint_impl {
             acc * base
         }
 
+        /// Returns the square root of the number, rounded down.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(10", stringify!($SelfT), ".isqrt(), 3);")]
+        /// ```
+        #[stable(feature = "isqrt", since = "1.73.0")]
+        #[rustc_const_stable(feature = "isqrt", since = "1.73.0")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn isqrt(self) -> Self {
+            if self < 2 {
+                return self;
+            }
+
+            let mut x: Self = self;
+            let mut c: Self = 0;
+            let mut d: Self = 1 << (self.ilog2() & !1);
+
+            while (d != 0) {
+                if x >= c + d {
+                    x -= c + d;
+                    c = (c >> 1) + d;
+                } else {
+                    c >>= 1;
+                }
+                d >>= 2;
+            }
+
+            return c;
+        }
+
         /// Performs Euclidean division.
         ///
         /// Since, for the positive integers, all common

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2017,6 +2017,13 @@ macro_rules! uint_impl {
                 one >>= 2;
             }
 
+            // SAFETY: the result is positive and fits in an integer with half as many bits.
+            // Inform the optimizer about it.
+            unsafe {
+                intrinsics::assume(0 < res);
+                intrinsics::assume(res < 1 << (Self::BITS / 2));
+            }
+
             res
         }
 

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -56,6 +56,7 @@
 #![feature(min_specialization)]
 #![feature(numfmt)]
 #![feature(num_midpoint)]
+#![feature(isqrt)]
 #![feature(step_trait)]
 #![feature(str_internals)]
 #![feature(std_internals)]

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -299,6 +299,23 @@ macro_rules! int_module {
                 assert_eq!((2 as $T).isqrt(), 1 as $T);
                 assert_eq!((99 as $T).isqrt(), 9 as $T);
                 assert_eq!((100 as $T).isqrt(), 10 as $T);
+
+                let n_max: $T = (1024 * 1024).min($T::MAX as u128) as $T;
+                for n in 0..=n_max {
+                    let isqrt: $T = n.isqrt();
+
+                    assert!(isqrt.pow(2) <= n);
+                    let (square, overflow) = (isqrt + 1).overflowing_pow(2);
+                    assert!(overflow || square > n);
+                }
+
+                for n in ($T::MAX - 127)..=$T::MAX {
+                    let isqrt: $T = n.isqrt();
+
+                    assert!(isqrt.pow(2) <= n);
+                    let (square, overflow) = (isqrt + 1).overflowing_pow(2);
+                    assert!(overflow || square > n);
+                }
             }
 
             #[test]

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -291,6 +291,17 @@ macro_rules! int_module {
             }
 
             #[test]
+            fn test_isqrt() {
+                assert_eq!($T::MIN.checked_isqrt(), None);
+                assert_eq!((-1 as $T).checked_isqrt(), None);
+                assert_eq!((0 as $T).isqrt(), 0 as $T);
+                assert_eq!((1 as $T).isqrt(), 1 as $T);
+                assert_eq!((2 as $T).isqrt(), 1 as $T);
+                assert_eq!((99 as $T).isqrt(), 9 as $T);
+                assert_eq!((100 as $T).isqrt(), 10 as $T);
+            }
+
+            #[test]
             fn test_div_floor() {
                 let a: $T = 8;
                 let b = 3;

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -299,7 +299,11 @@ macro_rules! int_module {
                 assert_eq!((2 as $T).isqrt(), 1 as $T);
                 assert_eq!((99 as $T).isqrt(), 9 as $T);
                 assert_eq!((100 as $T).isqrt(), 10 as $T);
+            }
 
+            #[cfg(not(miri))] // Miri is too slow
+            #[test]
+            fn test_lots_of_isqrt() {
                 let n_max: $T = (1024 * 1024).min($T::MAX as u128) as $T;
                 for n in 0..=n_max {
                     let isqrt: $T = n.isqrt();

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -214,7 +214,11 @@ macro_rules! uint_module {
                 assert_eq!((99 as $T).isqrt(), 9 as $T);
                 assert_eq!((100 as $T).isqrt(), 10 as $T);
                 assert_eq!($T::MAX.isqrt(), (1 << ($T::BITS / 2)) - 1);
+            }
 
+            #[cfg(not(miri))] // Miri is too slow
+            #[test]
+            fn test_lots_of_isqrt() {
                 let n_max: $T = (1024 * 1024).min($T::MAX as u128) as $T;
                 for n in 0..=n_max {
                     let isqrt: $T = n.isqrt();

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -214,6 +214,21 @@ macro_rules! uint_module {
                 assert_eq!((99 as $T).isqrt(), 9 as $T);
                 assert_eq!((100 as $T).isqrt(), 10 as $T);
                 assert_eq!($T::MAX.isqrt(), (1 << ($T::BITS / 2)) - 1);
+
+                let n_max: $T = (1024 * 1024).min($T::MAX as u128) as $T;
+                for n in 0..=n_max {
+                    let isqrt: $T = n.isqrt();
+
+                    assert!(isqrt.pow(2) <= n);
+                    assert!(isqrt + 1 == (1 as $T) << ($T::BITS / 2) || (isqrt + 1).pow(2) > n);
+                }
+
+                for n in ($T::MAX - 255)..=$T::MAX {
+                    let isqrt: $T = n.isqrt();
+
+                    assert!(isqrt.pow(2) <= n);
+                    assert!(isqrt + 1 == (1 as $T) << ($T::BITS / 2) || (isqrt + 1).pow(2) > n);
+                }
             }
 
             #[test]

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -207,6 +207,16 @@ macro_rules! uint_module {
             }
 
             #[test]
+            fn test_isqrt() {
+                assert_eq!((0 as $T).isqrt(), 0 as $T);
+                assert_eq!((1 as $T).isqrt(), 1 as $T);
+                assert_eq!((2 as $T).isqrt(), 1 as $T);
+                assert_eq!((99 as $T).isqrt(), 9 as $T);
+                assert_eq!((100 as $T).isqrt(), 10 as $T);
+                assert_eq!($T::MAX.isqrt(), (1 << ($T::BITS / 2)) - 1);
+            }
+
+            #[test]
             fn test_div_floor() {
                 assert_eq!((8 as $T).div_floor(3), 2);
             }


### PR DESCRIPTION
For every suffix `N` among `8`, `16`, `32`, `64`, `128` and `size`, this PR adds the methods

```rust
const fn uN::isqrt() -> uN;
const fn iN::isqrt() -> iN;
const fn iN::checked_isqrt() -> Option<iN>;
```

to compute the [integer square root](https://en.wikipedia.org/wiki/Integer_square_root), addressing issue #89273.

The implementation is based on the [base 2 digit-by-digit algorithm](https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Binary_numeral_system_(base_2)) on Wikipedia, which after some benchmarking has proved to be faster than both binary search and Heron's/Newton's method. I haven't had the time to understand and port [this code](http://atoms.alife.co.uk/sqrt/SquareRoot.java) based on lookup tables instead, but I'm not sure whether it's worth complicating such a function this much for relatively little benefit.