### PR TITLE
WIP: bootstrap: remove use-lld

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -625,15 +625,6 @@ changelog-seen = 2
 # rustc to execute.
 #lld = false
 
-# Indicates whether LLD will be used to link Rust crates during bootstrap on
-# supported platforms. The LLD from the bootstrap distribution will be used
-# and not the LLD compiled during the bootstrap.
-#
-# LLD will not be used if we're cross linking.
-#
-# Explicitly setting the linker for a target will override this option when targeting MSVC.
-#use-lld = false
-
 # Indicates whether some LLVM tools, like llvm-objdump, will be made available in the
 # sysroot.
 #llvm-tools = false

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -115,9 +115,6 @@ fn main() {
         if let Ok(host_linker) = env::var("RUSTC_HOST_LINKER") {
             cmd.arg(format!("-Clinker={host_linker}"));
         }
-        if env::var_os("RUSTC_HOST_FUSE_LD_LLD").is_some() {
-            cmd.arg("-Clink-args=-fuse-ld=lld");
-        }
 
         if let Ok(s) = env::var("RUSTC_HOST_CRT_STATIC") {
             if s == "true" {

--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -53,10 +53,6 @@ fn main() {
         arg.push(&linker);
         cmd.arg(arg);
     }
-    if let Ok(no_threads) = env::var("RUSTDOC_LLD_NO_THREADS") {
-        cmd.arg("-Clink-arg=-fuse-ld=lld");
-        cmd.arg(format!("-Clink-arg=-Wl,{no_threads}"));
-    }
     // Cargo doesn't pass RUSTDOCFLAGS to proc_macros:
     // https://github.com/rust-lang/cargo/issues/4423
     // Thus, if we are on stage 0, we explicitly set `--cfg=bootstrap`.

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1174,9 +1174,6 @@ impl<'a> Builder<'a> {
         if let Some(linker) = self.linker(compiler.host) {
             cmd.env("RUSTDOC_LINKER", linker);
         }
-        if self.is_fuse_ld_lld(compiler.host) {
-            cmd.env("RUSTDOC_FUSE_LD_LLD", "1");
-        }
         cmd
     }
 
@@ -1657,21 +1654,11 @@ impl<'a> Builder<'a> {
         if let Some(host_linker) = self.linker(compiler.host) {
             cargo.env("RUSTC_HOST_LINKER", host_linker);
         }
-        if self.is_fuse_ld_lld(compiler.host) {
-            cargo.env("RUSTC_HOST_FUSE_LD_LLD", "1");
-            cargo.env("RUSTDOC_FUSE_LD_LLD", "1");
-        }
 
         if let Some(target_linker) = self.linker(target) {
             let target = crate::envify(&target.triple);
             cargo.env(&format!("CARGO_TARGET_{target}_LINKER"), target_linker);
         }
-        if self.is_fuse_ld_lld(target) {
-            rustflags.arg("-Clink-args=-fuse-ld=lld");
-        }
-        self.lld_flags(target).for_each(|flag| {
-            rustdocflags.arg(&flag);
-        });
 
         if !(["build", "check", "clippy", "fix", "rustc"].contains(&cmd)) && want_rustdoc {
             cargo.env("RUSTDOC_LIBDIR", self.rustc_libdir(compiler));

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -822,9 +822,9 @@ impl Step for Rustc {
         // is already on by default in MSVC optimized builds, which is interpreted as --icf=all:
         // https://github.com/llvm/llvm-project/blob/3329cec2f79185bafd678f310fafadba2a8c76d2/lld/COFF/Driver.cpp#L1746
         // https://github.com/rust-lang/rust/blob/f22819bcce4abaff7d1246a56eec493418f9f4ee/compiler/rustc_codegen_ssa/src/back/linker.rs#L827
-        if builder.config.use_lld && !compiler.host.contains("msvc") {
-            cargo.rustflag("-Clink-args=-Wl,--icf=all");
-        }
+        // if builder.config.use_lld && !compiler.host.contains("msvc") {
+        //     cargo.rustflag("-Clink-args=-Wl,--icf=all");
+        // }
 
         let is_collecting = if let Some(path) = &builder.config.rust_profile_generate {
             if compiler.stage == 1 {

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -193,7 +193,6 @@ pub struct Config {
     pub llvm_from_ci: bool,
     pub llvm_build_config: HashMap<String, String>,
 
-    pub use_lld: bool,
     pub lld_enabled: bool,
     pub llvm_tools_enabled: bool,
 
@@ -989,7 +988,6 @@ define_config! {
         save_toolstates: Option<String> = "save-toolstates",
         codegen_backends: Option<Vec<String>> = "codegen-backends",
         lld: Option<bool> = "lld",
-        use_lld: Option<bool> = "use-lld",
         llvm_tools: Option<bool> = "llvm-tools",
         deny_warnings: Option<bool> = "deny-warnings",
         backtrace_on_ice: Option<bool> = "backtrace-on-ice",
@@ -1407,7 +1405,6 @@ impl Config {
             if let Some(true) = rust.incremental {
                 config.incremental = true;
             }
-            set(&mut config.use_lld, rust.use_lld);
             set(&mut config.lld_enabled, rust.lld);
             set(&mut config.llvm_tools_enabled, rust.llvm_tools);
             config.rustc_parallel = rust.parallel_compiler.unwrap_or(false);

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -856,12 +856,6 @@ impl Step for RustdocTheme {
         if let Some(linker) = builder.linker(self.compiler.host) {
             cmd.env("RUSTDOC_LINKER", linker);
         }
-        if builder.is_fuse_ld_lld(self.compiler.host) {
-            cmd.env(
-                "RUSTDOC_LLD_NO_THREADS",
-                util::lld_flag_no_threads(self.compiler.host.contains("windows")),
-            );
-        }
         builder.run_delaying_failure(&mut cmd);
     }
 }
@@ -1637,14 +1631,12 @@ note: if you're sure you want to do this, please open an issue as to why. In the
 
         let mut hostflags = flags.clone();
         hostflags.push(format!("-Lnative={}", builder.test_helpers_out(compiler.host).display()));
-        hostflags.extend(builder.lld_flags(compiler.host));
         for flag in hostflags {
             cmd.arg("--host-rustcflags").arg(flag);
         }
 
         let mut targetflags = flags;
         targetflags.push(format!("-Lnative={}", builder.test_helpers_out(target).display()));
-        targetflags.extend(builder.lld_flags(target));
         for flag in targetflags {
             cmd.arg("--target-rustcflags").arg(flag);
         }

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -14,7 +14,6 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::builder::Builder;
 use crate::config::{Config, TargetSelection};
-use crate::OnceCell;
 
 /// A helper macro to `unwrap` a result except also print out details like:
 ///
@@ -477,19 +476,6 @@ pub fn get_clang_cl_resource_dir(clang_cl_path: &str) -> PathBuf {
     // `$LLVM_DISTRO_ROOT/lib/clang/$LLVM_VERSION/lib/windows`.
     let clang_rt_dir = clang_rt_builtins.parent().expect("The clang lib folder should exist");
     clang_rt_dir.to_path_buf()
-}
-
-pub fn lld_flag_no_threads(is_windows: bool) -> &'static str {
-    static LLD_NO_THREADS: OnceCell<(&'static str, &'static str)> = OnceCell::new();
-    let (windows, other) = LLD_NO_THREADS.get_or_init(|| {
-        let out = output(Command::new("lld").arg("-flavor").arg("ld").arg("--version"));
-        let newer = match (out.find(char::is_numeric), out.find('.')) {
-            (Some(b), Some(e)) => out.as_str()[b..e].parse::<i32>().ok().unwrap_or(14) > 10,
-            _ => true,
-        };
-        if newer { ("/threads:1", "--threads=1") } else { ("/no-threads", "--no-threads") }
-    });
-    if is_windows { windows } else { other }
 }
 
 pub fn dir_is_empty(dir: &Path) -> bool {

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -83,7 +83,6 @@ ENV RUST_CONFIGURE_ARGS \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
       --set rust.jemalloc \
-      --set rust.use-lld=true \
       --set rust.lto=thin
 
 ENV SCRIPT python3 ../x.py build --set rust.debug=true opt-dist && \


### PR DESCRIPTION
Removes the `use-lld` flag, which doesn't seem very useful - it's only used on one place in our CI explicitly, and setting of `lld` is far from being as simple as a boolean option. I think that we should just use lld based on the target specs or other inferred LLD usage. Opening a PR to see what CI has to say about it.