### PR TITLE
Add context to `let: Ty = loop { break };`

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -545,6 +545,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Climb the HIR tree to see if the current `Expr` is part of a `break;` statement.
             let Some(
                 hir::Node::Stmt(hir::Stmt { kind: hir::StmtKind::Semi(&ref p), .. })
+                | hir::Node::Block(hir::Block { expr: Some(&ref p), .. })
                 | hir::Node::Expr(&ref p),
             ) = self.tcx.hir().find(parent_id)
             else {

--- a/tests/ui/issues/issue-27042.stderr
+++ b/tests/ui/issues/issue-27042.stderr
@@ -11,8 +11,13 @@ LL | |         while true { break }; // but here we cite the whole loop
 error[E0308]: mismatched types
   --> $DIR/issue-27042.rs:6:16
    |
+LL |     let _: i32 =
+   |         - expected because of this assignment
+LL |         'a: // in this case, the citation is just the `break`:
 LL |         loop { break };
-   |                ^^^^^ expected `i32`, found `()`
+   |         ----   ^^^^^ expected `i32`, found `()`
+   |         |
+   |         this loop is expected to be of type `i32`
    |
 help: give it a value of the expected type
    |

--- a/tests/ui/loops/loop-labeled-break-value.stderr
+++ b/tests/ui/loops/loop-labeled-break-value.stderr
@@ -2,7 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:3:29
    |
 LL |         let _: i32 = loop { break };
-   |                             ^^^^^ expected `i32`, found `()`
+   |             -        ----   ^^^^^ expected `i32`, found `()`
+   |             |        |
+   |             |        this loop is expected to be of type `i32`
+   |             expected because of this assignment
    |
 help: give it a value of the expected type
    |
@@ -13,7 +16,10 @@ error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:6:37
    |
 LL |         let _: i32 = 'inner: loop { break 'inner };
-   |                                     ^^^^^^^^^^^^ expected `i32`, found `()`
+   |             -                ----   ^^^^^^^^^^^^ expected `i32`, found `()`
+   |             |                |
+   |             |                this loop is expected to be of type `i32`
+   |             expected because of this assignment
    |
 help: give it a value of the expected type
    |
@@ -24,7 +30,10 @@ error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:9:45
    |
 LL |         let _: i32 = 'inner2: loop { loop { break 'inner2 } };
-   |                                             ^^^^^^^^^^^^^ expected `i32`, found `()`
+   |             -                 ----          ^^^^^^^^^^^^^ expected `i32`, found `()`
+   |             |                 |
+   |             |                 this loop is expected to be of type `i32`
+   |             expected because of this assignment
    |
 help: give it a value of the expected type
    |

--- a/tests/ui/loops/loop-properly-diverging-2.stderr
+++ b/tests/ui/loops/loop-properly-diverging-2.stderr
@@ -2,7 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/loop-properly-diverging-2.rs:2:23
    |
 LL |   let x: i32 = loop { break };
-   |                       ^^^^^ expected `i32`, found `()`
+   |       -        ----   ^^^^^ expected `i32`, found `()`
+   |       |        |
+   |       |        this loop is expected to be of type `i32`
+   |       expected because of this assignment
    |
 help: give it a value of the expected type
    |


### PR DESCRIPTION
We weren't accounting for the case where `break` was immediately within the `loop` block.