### PR TITLE
bootstrap: do not invoke global `lld` binary

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1275,7 +1275,8 @@ impl Build {
                 options[0] = Some("-Clink-arg=-fuse-ld=lld".to_string());
             }
 
-            let no_threads = util::lld_flag_no_threads(target.contains("windows"));
+            let no_threads =
+                util::lld_flag_no_threads(&self.initial_lld, target.contains("windows"));
             options[1] = Some(format!("-Clink-arg=-Wl,{no_threads}"));
         }
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -859,7 +859,10 @@ impl Step for RustdocTheme {
         if builder.is_fuse_ld_lld(self.compiler.host) {
             cmd.env(
                 "RUSTDOC_LLD_NO_THREADS",
-                util::lld_flag_no_threads(self.compiler.host.contains("windows")),
+                util::lld_flag_no_threads(
+                    &builder.initial_lld,
+                    self.compiler.host.contains("windows"),
+                ),
             );
         }
         builder.run_delaying_failure(&mut cmd);

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -479,10 +479,11 @@ pub fn get_clang_cl_resource_dir(clang_cl_path: &str) -> PathBuf {
     clang_rt_dir.to_path_buf()
 }
 
-pub fn lld_flag_no_threads(is_windows: bool) -> &'static str {
+/// Find out which thread flags should be passed to LLD.
+pub fn lld_flag_no_threads(lld: &Path, is_windows: bool) -> &'static str {
     static LLD_NO_THREADS: OnceCell<(&'static str, &'static str)> = OnceCell::new();
     let (windows, other) = LLD_NO_THREADS.get_or_init(|| {
-        let out = output(Command::new("lld").arg("-flavor").arg("ld").arg("--version"));
+        let out = output(Command::new(lld).arg("-flavor").arg("ld").arg("--version"));
         let newer = match (out.find(char::is_numeric), out.find('.')) {
             (Some(b), Some(e)) => out.as_str()[b..e].parse::<i32>().ok().unwrap_or(14) > 10,
             _ => true,


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/102101 has introduced a check for passing some thread flags to `lld`. However, it was invoking a (globally available) binary called `lld`, which I'm pretty sure we never want to do in bootstrap. If you enable `use-lld` and don't have a `lld` binary available, this will crash the build.

This PR fixes that by invoking the `lld` coming from the snapshot compiler instead.