### PR TITLE
Fix `noop_method_call` detection

### DIFF
--- a/compiler/rustc_lint/src/noop_method_call.rs
+++ b/compiler/rustc_lint/src/noop_method_call.rs
@@ -98,6 +98,12 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
         let Ok(Some(i)) = ty::Instance::resolve(cx.tcx, cx.param_env, did, args) else { return };
         // (Re)check that it implements the noop diagnostic.
         let Some(name) = cx.tcx.get_diagnostic_name(i.def_id()) else { return };
+        if !matches!(
+            name,
+            sym::noop_method_borrow | sym::noop_method_clone | sym::noop_method_deref
+        ) {
+            return;
+        }
 
         let receiver_ty = cx.typeck_results().expr_ty(receiver);
         let expr_ty = cx.typeck_results().expr_ty_adjusted(expr);

--- a/tests/ui/lint/noop-method-call.fixed
+++ b/tests/ui/lint/noop-method-call.fixed
@@ -1,6 +1,7 @@
 // check-pass
 // run-rustfix
 
+#![feature(rustc_attrs)]
 #![allow(unused)]
 
 use std::borrow::Borrow;
@@ -48,4 +49,16 @@ fn generic<T>(non_clone_type: &PlainType<T>) {
 fn non_generic(non_clone_type: &PlainType<u32>) {
     non_clone_type;
     //~^ WARN call to `.clone()` on a reference in this situation does nothing
+}
+
+struct DiagnosticClone;
+impl Clone for DiagnosticClone {
+    #[rustc_diagnostic_item = "other_clone"]
+    fn clone(&self) -> Self {
+        DiagnosticClone
+    }
+}
+
+fn with_other_diagnostic_item(x: DiagnosticClone) {
+    x.clone();
 }

--- a/tests/ui/lint/noop-method-call.rs
+++ b/tests/ui/lint/noop-method-call.rs
@@ -1,6 +1,7 @@
 // check-pass
 // run-rustfix
 
+#![feature(rustc_attrs)]
 #![allow(unused)]
 
 use std::borrow::Borrow;
@@ -48,4 +49,16 @@ fn generic<T>(non_clone_type: &PlainType<T>) {
 fn non_generic(non_clone_type: &PlainType<u32>) {
     non_clone_type.clone();
     //~^ WARN call to `.clone()` on a reference in this situation does nothing
+}
+
+struct DiagnosticClone;
+impl Clone for DiagnosticClone {
+    #[rustc_diagnostic_item = "other_clone"]
+    fn clone(&self) -> Self {
+        DiagnosticClone
+    }
+}
+
+fn with_other_diagnostic_item(x: DiagnosticClone) {
+    x.clone();
 }

--- a/tests/ui/lint/noop-method-call.stderr
+++ b/tests/ui/lint/noop-method-call.stderr
@@ -1,5 +1,5 @@
 warning: call to `.clone()` on a reference in this situation does nothing
-  --> $DIR/noop-method-call.rs:15:25
+  --> $DIR/noop-method-call.rs:16:25
    |
 LL |     let _ = &mut encoded.clone();
    |                         ^^^^^^^^ help: remove this redundant call
@@ -8,7 +8,7 @@ LL |     let _ = &mut encoded.clone();
    = note: `#[warn(noop_method_call)]` on by default
 
 warning: call to `.clone()` on a reference in this situation does nothing
-  --> $DIR/noop-method-call.rs:17:21
+  --> $DIR/noop-method-call.rs:18:21
    |
 LL |     let _ = &encoded.clone();
    |                     ^^^^^^^^ help: remove this redundant call
@@ -16,7 +16,7 @@ LL |     let _ = &encoded.clone();
    = note: the type `[u8]` does not implement `Clone`, so calling `clone` on `&[u8]` copies the reference, which does not do anything and can be removed
 
 warning: call to `.clone()` on a reference in this situation does nothing
-  --> $DIR/noop-method-call.rs:23:71
+  --> $DIR/noop-method-call.rs:24:71
    |
 LL |     let non_clone_type_ref_clone: &PlainType<u32> = non_clone_type_ref.clone();
    |                                                                       ^^^^^^^^ help: remove this redundant call
@@ -24,7 +24,7 @@ LL |     let non_clone_type_ref_clone: &PlainType<u32> = non_clone_type_ref.clon
    = note: the type `PlainType<u32>` does not implement `Clone`, so calling `clone` on `&PlainType<u32>` copies the reference, which does not do anything and can be removed
 
 warning: call to `.deref()` on a reference in this situation does nothing
-  --> $DIR/noop-method-call.rs:31:63
+  --> $DIR/noop-method-call.rs:32:63
    |
 LL |     let non_deref_type_deref: &PlainType<u32> = non_deref_type.deref();
    |                                                               ^^^^^^^^ help: remove this redundant call
@@ -32,7 +32,7 @@ LL |     let non_deref_type_deref: &PlainType<u32> = non_deref_type.deref();
    = note: the type `PlainType<u32>` does not implement `Deref`, so calling `deref` on `&PlainType<u32>` copies the reference, which does not do anything and can be removed
 
 warning: call to `.borrow()` on a reference in this situation does nothing
-  --> $DIR/noop-method-call.rs:35:66
+  --> $DIR/noop-method-call.rs:36:66
    |
 LL |     let non_borrow_type_borrow: &PlainType<u32> = non_borrow_type.borrow();
    |                                                                  ^^^^^^^^^ help: remove this redundant call
@@ -40,7 +40,7 @@ LL |     let non_borrow_type_borrow: &PlainType<u32> = non_borrow_type.borrow();
    = note: the type `PlainType<u32>` does not implement `Borrow`, so calling `borrow` on `&PlainType<u32>` copies the reference, which does not do anything and can be removed
 
 warning: call to `.clone()` on a reference in this situation does nothing
-  --> $DIR/noop-method-call.rs:44:19
+  --> $DIR/noop-method-call.rs:45:19
    |
 LL |     non_clone_type.clone();
    |                   ^^^^^^^^ help: remove this redundant call
@@ -48,7 +48,7 @@ LL |     non_clone_type.clone();
    = note: the type `PlainType<T>` does not implement `Clone`, so calling `clone` on `&PlainType<T>` copies the reference, which does not do anything and can be removed
 
 warning: call to `.clone()` on a reference in this situation does nothing
-  --> $DIR/noop-method-call.rs:49:19
+  --> $DIR/noop-method-call.rs:50:19
    |
 LL |     non_clone_type.clone();
    |                   ^^^^^^^^ help: remove this redundant call


### PR DESCRIPTION
This needs to be merged before #116198 can compile. The error occurs before the compiler is built so this needs to be a separate PR.