### PR TITLE
rustdoc: while -> if

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1083,7 +1083,7 @@ impl<'a, 'tcx> TagIterator<'a, 'tcx> {
     }
 
     fn parse_in_attribute_block(&mut self) -> Option<LangStringToken<'a>> {
-        while let Some((pos, c)) = self.inner.next() {
+        if let Some((pos, c)) = self.inner.next() {
             if c == '}' {
                 self.is_in_attribute_block = false;
                 return self.next();


### PR DESCRIPTION
we will always return once we step inside the while-loop thus `if` is sufficient here