### PR TITLE
Ensure that `~const` trait bounds on associated functions are in const traits or impls

### DIFF
--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/const-bound-on-not-const-associated-fn.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/const-bound-on-not-const-associated-fn.rs
@@ -1,0 +1,28 @@
+#![feature(const_trait_impl, effects)]
+
+#[const_trait]
+trait MyTrait {
+    fn do_something(&self);
+}
+
+trait OtherTrait {
+    fn do_something_else() where Self: ~const MyTrait;
+    //~^ ERROR `~const` is not allowed here
+}
+
+struct MyStruct<T>(T);
+
+impl const MyTrait for u32 {
+    fn do_something(&self) {}
+}
+
+impl<T> MyStruct<T> {
+    pub fn foo(&self) where T: ~const MyTrait {
+        //~^ ERROR `~const` is not allowed here
+        self.0.do_something();
+    }
+}
+
+fn main() {
+    MyStruct(0u32).foo();
+}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/const-bound-on-not-const-associated-fn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/const-bound-on-not-const-associated-fn.stderr
@@ -1,0 +1,26 @@
+error: `~const` is not allowed here
+  --> $DIR/const-bound-on-not-const-associated-fn.rs:9:40
+   |
+LL |     fn do_something_else() where Self: ~const MyTrait;
+   |                                        ^^^^^^^^^^^^^^
+   |
+note: this function is not `const`, so it cannot have `~const` trait bounds
+  --> $DIR/const-bound-on-not-const-associated-fn.rs:9:8
+   |
+LL |     fn do_something_else() where Self: ~const MyTrait;
+   |        ^^^^^^^^^^^^^^^^^
+
+error: `~const` is not allowed here
+  --> $DIR/const-bound-on-not-const-associated-fn.rs:20:32
+   |
+LL |     pub fn foo(&self) where T: ~const MyTrait {
+   |                                ^^^^^^^^^^^^^^
+   |
+note: this function is not `const`, so it cannot have `~const` trait bounds
+  --> $DIR/const-bound-on-not-const-associated-fn.rs:20:12
+   |
+LL |     pub fn foo(&self) where T: ~const MyTrait {
+   |            ^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-and-const-params.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-and-const-params.rs
@@ -7,7 +7,8 @@ struct Foo<const N: usize>;
 
 impl<const N: usize> Foo<N> {
     fn add<A: ~const Add42>(self) -> Foo<{ A::add(N) }> {
-        //~^ ERROR mismatched types
+        //~^ ERROR `~const` is not allowed here
+        //~| ERROR mismatched types
         Foo
     }
 }
@@ -30,7 +31,7 @@ fn bar<A: ~const Add42, const N: usize>(_: Foo<N>) -> Foo<{ A::add(N) }> {
 }
 
 fn main() {
-   let foo = Foo::<0>;
-   let foo = bar::<(), _>(foo);
-   let _foo = bar::<(), _>(foo);
+    let foo = Foo::<0>;
+    let foo = bar::<(), _>(foo);
+    let _foo = bar::<(), _>(foo);
 }

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-and-const-params.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-and-const-params.stderr
@@ -1,17 +1,29 @@
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-and-const-params.rs:26:11
+  --> $DIR/tilde-const-and-const-params.rs:9:15
+   |
+LL |     fn add<A: ~const Add42>(self) -> Foo<{ A::add(N) }> {
+   |               ^^^^^^^^^^^^
+   |
+note: this function is not `const`, so it cannot have `~const` trait bounds
+  --> $DIR/tilde-const-and-const-params.rs:9:8
+   |
+LL |     fn add<A: ~const Add42>(self) -> Foo<{ A::add(N) }> {
+   |        ^^^
+
+error: `~const` is not allowed here
+  --> $DIR/tilde-const-and-const-params.rs:27:11
    |
 LL | fn bar<A: ~const Add42, const N: usize>(_: Foo<N>) -> Foo<{ A::add(N) }> {
    |           ^^^^^^^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-and-const-params.rs:26:4
+  --> $DIR/tilde-const-and-const-params.rs:27:4
    |
 LL | fn bar<A: ~const Add42, const N: usize>(_: Foo<N>) -> Foo<{ A::add(N) }> {
    |    ^^^
 
 error[E0308]: mismatched types
-  --> $DIR/tilde-const-and-const-params.rs:26:61
+  --> $DIR/tilde-const-and-const-params.rs:27:61
    |
 LL | fn bar<A: ~const Add42, const N: usize>(_: Foo<N>) -> Foo<{ A::add(N) }> {
    |                                                             ^^^^^^^^^ expected `false`, found `true`
@@ -28,6 +40,6 @@ LL |     fn add<A: ~const Add42>(self) -> Foo<{ A::add(N) }> {
    = note: expected constant `false`
               found constant `true`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-where-clause.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-where-clause.rs
@@ -6,7 +6,9 @@ trait Bar {}
 trait Foo {
     fn a();
     fn b() where Self: ~const Bar;
+    //~^ ERROR `~const` is not allowed here
     fn c<T: ~const Bar>();
+    //~^ ERROR `~const` is not allowed here
 }
 
 fn test1<T: Foo>() {

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-where-clause.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-where-clause.stderr
@@ -1,5 +1,29 @@
+error: `~const` is not allowed here
+  --> $DIR/trait-where-clause.rs:8:24
+   |
+LL |     fn b() where Self: ~const Bar;
+   |                        ^^^^^^^^^^
+   |
+note: this function is not `const`, so it cannot have `~const` trait bounds
+  --> $DIR/trait-where-clause.rs:8:8
+   |
+LL |     fn b() where Self: ~const Bar;
+   |        ^
+
+error: `~const` is not allowed here
+  --> $DIR/trait-where-clause.rs:10:13
+   |
+LL |     fn c<T: ~const Bar>();
+   |             ^^^^^^^^^^
+   |
+note: this function is not `const`, so it cannot have `~const` trait bounds
+  --> $DIR/trait-where-clause.rs:10:8
+   |
+LL |     fn c<T: ~const Bar>();
+   |        ^
+
 error[E0277]: the trait bound `T: Bar` is not satisfied
-  --> $DIR/trait-where-clause.rs:14:5
+  --> $DIR/trait-where-clause.rs:16:5
    |
 LL |     T::b();
    |     ^ the trait `Bar` is not implemented for `T`
@@ -15,13 +39,13 @@ LL | fn test1<T: Foo + Bar>() {
    |                 +++++
 
 error[E0277]: the trait bound `T: Bar` is not satisfied
-  --> $DIR/trait-where-clause.rs:16:12
+  --> $DIR/trait-where-clause.rs:18:12
    |
 LL |     T::c::<T>();
    |            ^ the trait `Bar` is not implemented for `T`
    |
 note: required by a bound in `Foo::c`
-  --> $DIR/trait-where-clause.rs:9:13
+  --> $DIR/trait-where-clause.rs:10:13
    |
 LL |     fn c<T: ~const Bar>();
    |             ^^^^^^^^^^ required by this bound in `Foo::c`
@@ -30,6 +54,6 @@ help: consider further restricting this bound
 LL | fn test1<T: Foo + Bar>() {
    |                 +++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Zulip discussion: https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/topic/How.20to.2Fshould.20I.20try.20to.20pinpoint.20ICEs.20related.20to.20effects.3F