### PR TITLE
core/slice: Fix inconsistency between docs for `rotate_left` and `rotate_right`

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3410,7 +3410,7 @@ impl<T> [T] {
     /// assert_eq!(a, ['e', 'f', 'a', 'b', 'c', 'd']);
     /// ```
     ///
-    /// Rotate a subslice:
+    /// Rotating a subslice:
     ///
     /// ```
     /// let mut a = ['a', 'b', 'c', 'd', 'e', 'f'];


### PR DESCRIPTION
A minor fix for documentation inconsistency as shown below:
## Before:
![2023_09_28_0k3_Kleki](https://github.com/rust-lang/rust/assets/83179501/569a49d3-0d72-49ac-92a2-ef5e1d94130b)
## After:
![image](https://github.com/rust-lang/rust/assets/83179501/afd0c8d7-6fb7-4878-801b-b47c8fe23c7d)
Docs url: https://doc.rust-lang.org/stable/core/primitive.slice.html#method.rotate_left