### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -245,7 +245,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             let Trait(PolyTraitRef { trait_ref, span: trait_span, .. }, _) = bound else { return; };
             diag.span_note(
                 *trait_span,
-                format!("due to current limitations in the borrow checker, this implies a `'static` lifetime")
+                "due to current limitations in the borrow checker, this implies a `'static` lifetime"
             );
             let Some(generics_fn) = hir.get_generics(self.body.source.def_id().expect_local()) else { return; };
             let Def(_, trait_res_defid) = trait_ref.path.res else { return; };
@@ -277,7 +277,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         if suggestions.len() > 0 {
             suggestions.dedup();
             diag.multipart_suggestion_verbose(
-                format!("consider restricting the type parameter to the `'static` lifetime"),
+                "consider restricting the type parameter to the `'static` lifetime",
                 suggestions,
                 Applicability::MaybeIncorrect,
             );

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -181,7 +181,7 @@ pub fn unsized_info<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                 old_info
             }
         }
-        (_, &ty::Dynamic(ref data, _, _)) => meth::get_vtable(cx, source, data.principal()),
+        (_, ty::Dynamic(data, _, _)) => meth::get_vtable(cx, source, data.principal()),
         _ => bug!("unsized_info: invalid unsizing {:?} -> {:?}", source, target),
     }
 }

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1374,7 +1374,7 @@ fn impl_trait_ref(
                 // make astconv happy.
                 let mut path_segments = ast_trait_ref.path.segments.to_vec();
                 let last_segment = path_segments.len() - 1;
-                let mut args = path_segments[last_segment].args().clone();
+                let mut args = *path_segments[last_segment].args();
                 let last_arg = args.args.len() - 1;
                 assert!(matches!(args.args[last_arg], hir::GenericArg::Const(anon_const) if tcx.has_attr(anon_const.value.def_id, sym::rustc_host)));
                 args.args = &args.args[..args.args.len() - 1];

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -644,7 +644,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             if self.can_eq(self.param_env, ty, expected) {
                                 err.span_label(
                                     ex.span,
-                                    format!("expected because of this `break`"),
+                                    "expected because of this `break`",
                                 );
                                 exit = true;
                             }

--- a/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
@@ -621,7 +621,7 @@ fn foo(&self) -> Self::T { String::new() }
                         {
                             diag.span_label(
                                 item.span,
-                                format!("associated type is `default` and may be overridden"),
+                                "associated type is `default` and may be overridden",
                             );
                             return true;
                         }

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -1146,10 +1146,10 @@ fn post_fmt_projection(projection: &[PlaceElem<'_>], fmt: &mut Formatter<'_>) ->
             ProjectionElem::ConstantIndex { offset, min_length, from_end: true } => {
                 write!(fmt, "[-{offset:?} of {min_length:?}]")?;
             }
-            ProjectionElem::Subslice { from, to, from_end: true } if to == 0 => {
+            ProjectionElem::Subslice { from, to: 0, from_end: true } => {
                 write!(fmt, "[{from:?}:]")?;
             }
-            ProjectionElem::Subslice { from, to, from_end: true } if from == 0 => {
+            ProjectionElem::Subslice { from: 0, to, from_end: true } => {
                 write!(fmt, "[:-{to:?}]")?;
             }
             ProjectionElem::Subslice { from, to, from_end: true } => {

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -740,9 +740,7 @@ fn non_exhaustive_match<'p, 'tcx>(
                         ));
                 }
             } else if ty == cx.tcx.types.str_ {
-                err.note(format!(
-                    "`&str` cannot be matched exhaustively, so a wildcard `_` is necessary",
-                ));
+                err.note("`&str` cannot be matched exhaustively, so a wildcard `_` is necessary");
             } else if cx.is_foreign_non_exhaustive_enum(ty) {
                 err.note(format!("`{ty}` is marked as non-exhaustive, so a wildcard `_` is necessary to match exhaustively"));
             }

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -763,7 +763,7 @@ pub(super) fn filtered_statement_span(statement: &Statement<'_>) -> Option<Span>
         // and `_1` is the `Place` for `somenum`.
         //
         // If and when the Issue is resolved, remove this special case match pattern:
-        StatementKind::FakeRead(box (cause, _)) if cause == FakeReadCause::ForGuardBinding => None,
+        StatementKind::FakeRead(box (FakeReadCause::ForGuardBinding, _)) => None,
 
         // Retain spans from all other statements
         StatementKind::FakeRead(box (_, _)) // Not including `ForGuardBinding`

--- a/compiler/rustc_mir_transform/src/large_enums.rs
+++ b/compiler/rustc_mir_transform/src/large_enums.rs
@@ -54,11 +54,8 @@ impl EnumSizeOpt {
         let layout = tcx.layout_of(param_env.and(ty)).ok()?;
         let variants = match &layout.variants {
             Variants::Single { .. } => return None,
-            Variants::Multiple { tag_encoding, .. }
-                if matches!(tag_encoding, TagEncoding::Niche { .. }) =>
-            {
-                return None;
-            }
+            Variants::Multiple { tag_encoding: TagEncoding::Niche { .. }, .. } => return None,
+
             Variants::Multiple { variants, .. } if variants.len() <= 1 => return None,
             Variants::Multiple { variants, .. } => variants,
         };

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -509,7 +509,7 @@ parse_maybe_fn_typo_with_impl = you might have meant to write `impl` instead of 
 
 parse_maybe_recover_from_bad_qpath_stage_2 =
     missing angle brackets in associated item path
-    .suggestion = try: `{$ty}`
+    .suggestion = types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
 
 parse_maybe_recover_from_bad_type_plus =
     expected a path on the left-hand side of `+`, not `{$ty}`

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -59,9 +59,18 @@ pub(crate) enum BadTypePlusSub {
 #[diag(parse_maybe_recover_from_bad_qpath_stage_2)]
 pub(crate) struct BadQPathStage2 {
     #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
     pub span: Span,
-    pub ty: String,
+    #[subdiagnostic]
+    pub wrap: WrapType,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_suggestion, applicability = "machine-applicable")]
+pub(crate) struct WrapType {
+    #[suggestion_part(code = "<")]
+    pub lo: Span,
+    #[suggestion_part(code = ">")]
+    pub hi: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -16,7 +16,7 @@ use crate::errors::{
     StructLiteralBodyWithoutPath, StructLiteralBodyWithoutPathSugg, StructLiteralNeedingParens,
     StructLiteralNeedingParensSugg, SuggAddMissingLetStmt, SuggEscapeIdentifier, SuggRemoveComma,
     TernaryOperator, UnexpectedConstInGenericParam, UnexpectedConstParamDeclaration,
-    UnexpectedConstParamDeclarationSugg, UnmatchedAngleBrackets, UseEqInstead,
+    UnexpectedConstParamDeclarationSugg, UnmatchedAngleBrackets, UseEqInstead, WrapType,
 };
 
 use crate::fluent_generated as fluent;
@@ -1589,10 +1589,9 @@ impl<'a> Parser<'a> {
         self.parse_path_segments(&mut path.segments, T::PATH_STYLE, None)?;
         path.span = ty_span.to(self.prev_token.span);
 
-        let ty_str = self.span_to_snippet(ty_span).unwrap_or_else(|_| pprust::ty_to_string(&ty));
         self.sess.emit_err(BadQPathStage2 {
-            span: path.span,
-            ty: format!("<{}>::{}", ty_str, pprust::path_to_string(&path)),
+            span: ty_span,
+            wrap: WrapType { lo: ty_span.shrink_to_lo(), hi: ty_span.shrink_to_hi() },
         });
 
         let path_span = ty_span.shrink_to_hi(); // Use an empty path since `position == 0`.

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -186,7 +186,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                 fallback_label: format!("not a {expected}"),
                 span,
                 span_label: match res {
-                    Res::Def(kind, def_id) if kind == DefKind::TyParam => {
+                    Res::Def(DefKind::TyParam, def_id) => {
                         Some((self.r.def_span(def_id), "found this type parameter"))
                     }
                     _ => None,

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1753,7 +1753,7 @@ impl SourceFile {
         // is recorded.
         let diff = match self.normalized_pos.binary_search_by(|np| np.pos.cmp(&pos)) {
             Ok(i) => self.normalized_pos[i].diff,
-            Err(i) if i == 0 => 0,
+            Err(0) => 0,
             Err(i) => self.normalized_pos[i - 1].diff,
         };
 
@@ -1775,7 +1775,7 @@ impl SourceFile {
             .binary_search_by(|np| (np.pos.0 + np.diff).cmp(&(self.start_pos.0 + offset)))
         {
             Ok(i) => self.normalized_pos[i].diff,
-            Err(i) if i == 0 => 0,
+            Err(0) => 0,
             Err(i) => self.normalized_pos[i - 1].diff,
         };
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -3211,7 +3211,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
         let name = match self.tcx.opaque_type_origin(def_id.expect_local()) {
             hir::OpaqueTyOrigin::FnReturn(_) | hir::OpaqueTyOrigin::AsyncFn(_) => {
-                format!("opaque type")
+                "opaque type".to_string()
             }
             hir::OpaqueTyOrigin::TyAlias { .. } => {
                 format!("`{}`", self.tcx.def_path_debug_str(def_id))

--- a/compiler/stable_mir/src/fold.rs
+++ b/compiler/stable_mir/src/fold.rs
@@ -81,7 +81,7 @@ impl Foldable for UnevaluatedConst {
 
 impl Foldable for ConstDef {
     fn super_fold<V: Folder>(&self, _folder: &mut V) -> ControlFlow<V::Break, Self> {
-        ControlFlow::Continue(self.clone())
+        ControlFlow::Continue(*self)
     }
 }
 
@@ -96,7 +96,7 @@ impl<T: Foldable> Foldable for Option<T> {
 
 impl Foldable for Promoted {
     fn super_fold<V: Folder>(&self, _folder: &mut V) -> ControlFlow<V::Break, Self> {
-        ControlFlow::Continue(self.clone())
+        ControlFlow::Continue(*self)
     }
 }
 

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -281,9 +281,9 @@ pub macro PartialEq($item:item) {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Eq"]
 pub trait Eq: PartialEq<Self> {
-    // this method is used solely by #[deriving] to assert
-    // that every component of a type implements #[deriving]
-    // itself, the current deriving infrastructure means doing this
+    // this method is used solely by #[derive(Eq)] to assert
+    // that every component of a type implements `Eq`
+    // itself. The current deriving infrastructure means doing this
     // assertion without using a method on this trait is nearly
     // impossible.
     //

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -112,9 +112,9 @@ pub trait Write {
     ///
     /// # Errors
     ///
-    /// This function will return an instance of [`Error`] on error.
+    /// This function will return an instance of [`std::fmt::Error`] on error.
     ///
-    /// The purpose of std::fmt::Error is to abort the formatting operation when the underlying
+    /// The purpose of that error is to abort the formatting operation when the underlying
     /// destination encounters some error preventing it from accepting more text; it should
     /// generally be propagated rather than handled, at least when implementing formatting traits.
     ///

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -112,7 +112,7 @@ pub trait Write {
     ///
     /// # Errors
     ///
-    /// This function will return an instance of [`std::fmt::Error`] on error.
+    /// This function will return an instance of [`std::fmt::Error`][Error] on error.
     ///
     /// The purpose of that error is to abort the formatting operation when the underlying
     /// destination encounters some error preventing it from accepting more text; it should

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -12,9 +12,9 @@
 //! use std::process::Command;
 //!
 //! let output = Command::new("echo")
-//!                      .arg("Hello world")
-//!                      .output()
-//!                      .expect("Failed to execute command");
+//!     .arg("Hello world")
+//!     .output()
+//!     .expect("Failed to execute command");
 //!
 //! assert_eq!(b"Hello world\n", output.stdout.as_slice());
 //! ```
@@ -154,12 +154,11 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 /// use std::process::Command;
 ///
 /// let mut child = Command::new("/bin/cat")
-///                         .arg("file.txt")
-///                         .spawn()
-///                         .expect("failed to execute child");
+///     .arg("file.txt")
+///     .spawn()
+///     .expect("failed to execute child");
 ///
-/// let ecode = child.wait()
-///                  .expect("failed to wait on child");
+/// let ecode = child.wait().expect("failed to wait on child");
 ///
 /// assert!(ecode.success());
 /// ```
@@ -481,15 +480,15 @@ impl fmt::Debug for ChildStderr {
 ///
 /// let output = if cfg!(target_os = "windows") {
 ///     Command::new("cmd")
-///             .args(["/C", "echo hello"])
-///             .output()
-///             .expect("failed to execute process")
+///         .args(["/C", "echo hello"])
+///         .output()
+///         .expect("failed to execute process")
 /// } else {
 ///     Command::new("sh")
-///             .arg("-c")
-///             .arg("echo hello")
-///             .output()
-///             .expect("failed to execute process")
+///         .arg("-c")
+///         .arg("echo hello")
+///         .output()
+///         .expect("failed to execute process")
 /// };
 ///
 /// let hello = output.stdout;
@@ -502,8 +501,7 @@ impl fmt::Debug for ChildStderr {
 /// use std::process::Command;
 ///
 /// let mut echo_hello = Command::new("sh");
-/// echo_hello.arg("-c")
-///           .arg("echo hello");
+/// echo_hello.arg("-c").arg("echo hello");
 /// let hello_1 = echo_hello.output().expect("failed to execute process");
 /// let hello_2 = echo_hello.output().expect("failed to execute process");
 /// ```
@@ -576,8 +574,8 @@ impl Command {
     /// use std::process::Command;
     ///
     /// Command::new("sh")
-    ///         .spawn()
-    ///         .expect("sh command failed to start");
+    ///     .spawn()
+    ///     .expect("sh command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn new<S: AsRef<OsStr>>(program: S) -> Command {
@@ -620,10 +618,10 @@ impl Command {
     /// use std::process::Command;
     ///
     /// Command::new("ls")
-    ///         .arg("-l")
-    ///         .arg("-a")
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .arg("-l")
+    ///     .arg("-a")
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Command {
@@ -650,9 +648,9 @@ impl Command {
     /// use std::process::Command;
     ///
     /// Command::new("ls")
-    ///         .args(["-l", "-a"])
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .args(["-l", "-a"])
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn args<I, S>(&mut self, args: I) -> &mut Command
@@ -688,9 +686,9 @@ impl Command {
     /// use std::process::Command;
     ///
     /// Command::new("ls")
-    ///         .env("PATH", "/bin")
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .env("PATH", "/bin")
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Command
@@ -731,12 +729,12 @@ impl Command {
     ///     ).collect();
     ///
     /// Command::new("printenv")
-    ///         .stdin(Stdio::null())
-    ///         .stdout(Stdio::inherit())
-    ///         .env_clear()
-    ///         .envs(&filtered_env)
-    ///         .spawn()
-    ///         .expect("printenv failed to start");
+    ///     .stdin(Stdio::null())
+    ///     .stdout(Stdio::inherit())
+    ///     .env_clear()
+    ///     .envs(&filtered_env)
+    ///     .spawn()
+    ///     .expect("printenv failed to start");
     /// ```
     #[stable(feature = "command_envs", since = "1.19.0")]
     pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Command
@@ -772,9 +770,9 @@ impl Command {
     /// use std::process::Command;
     ///
     /// Command::new("ls")
-    ///         .env_remove("PATH")
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .env_remove("PATH")
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Command {
@@ -802,9 +800,9 @@ impl Command {
     /// use std::process::Command;
     ///
     /// Command::new("ls")
-    ///         .env_clear()
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .env_clear()
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn env_clear(&mut self) -> &mut Command {
@@ -830,9 +828,9 @@ impl Command {
     /// use std::process::Command;
     ///
     /// Command::new("ls")
-    ///         .current_dir("/bin")
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .current_dir("/bin")
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     ///
     /// [`canonicalize`]: crate::fs::canonicalize
@@ -861,9 +859,9 @@ impl Command {
     /// use std::process::{Command, Stdio};
     ///
     /// Command::new("ls")
-    ///         .stdin(Stdio::null())
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .stdin(Stdio::null())
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn stdin<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Command {
@@ -890,9 +888,9 @@ impl Command {
     /// use std::process::{Command, Stdio};
     ///
     /// Command::new("ls")
-    ///         .stdout(Stdio::null())
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .stdout(Stdio::null())
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn stdout<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Command {
@@ -919,9 +917,9 @@ impl Command {
     /// use std::process::{Command, Stdio};
     ///
     /// Command::new("ls")
-    ///         .stderr(Stdio::null())
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .stderr(Stdio::null())
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Command {
@@ -941,8 +939,8 @@ impl Command {
     /// use std::process::Command;
     ///
     /// Command::new("ls")
-    ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///     .spawn()
+    ///     .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn spawn(&mut self) -> io::Result<Child> {
@@ -963,9 +961,9 @@ impl Command {
     /// use std::process::Command;
     /// use std::io::{self, Write};
     /// let output = Command::new("/bin/cat")
-    ///                      .arg("file.txt")
-    ///                      .output()
-    ///                      .expect("failed to execute process");
+    ///     .arg("file.txt")
+    ///     .output()
+    ///     .expect("failed to execute process");
     ///
     /// println!("status: {}", output.status);
     /// io::stdout().write_all(&output.stdout).unwrap();
@@ -990,9 +988,9 @@ impl Command {
     /// use std::process::Command;
     ///
     /// let status = Command::new("/bin/cat")
-    ///                      .arg("file.txt")
-    ///                      .status()
-    ///                      .expect("failed to execute process");
+    ///     .arg("file.txt")
+    ///     .status()
+    ///     .expect("failed to execute process");
     ///
     /// println!("process finished with: {status}");
     ///
@@ -1558,9 +1556,9 @@ impl ExitStatus {
     /// use std::process::Command;
     ///
     /// let status = Command::new("ls")
-    ///                      .arg("/dev/nonexistent")
-    ///                      .status()
-    ///                      .expect("ls could not be executed");
+    ///     .arg("/dev/nonexistent")
+    ///     .status()
+    ///     .expect("ls could not be executed");
     ///
     /// println!("ls: {status}");
     /// status.exit_ok().expect_err("/dev/nonexistent could be listed!");
@@ -1580,9 +1578,9 @@ impl ExitStatus {
     /// use std::process::Command;
     ///
     /// let status = Command::new("mkdir")
-    ///                      .arg("projects")
-    ///                      .status()
-    ///                      .expect("failed to execute mkdir");
+    ///     .arg("projects")
+    ///     .status()
+    ///     .expect("failed to execute mkdir");
     ///
     /// if status.success() {
     ///     println!("'projects/' directory created");
@@ -1613,13 +1611,13 @@ impl ExitStatus {
     /// use std::process::Command;
     ///
     /// let status = Command::new("mkdir")
-    ///                      .arg("projects")
-    ///                      .status()
-    ///                      .expect("failed to execute mkdir");
+    ///     .arg("projects")
+    ///     .status()
+    ///     .expect("failed to execute mkdir");
     ///
     /// match status.code() {
     ///     Some(code) => println!("Exited with status code: {code}"),
-    ///     None       => println!("Process terminated by signal")
+    ///     None => println!("Process terminated by signal")
     /// }
     /// ```
     #[must_use]

--- a/src/doc/unstable-book/src/compiler-flags/link-native-libraries.md
+++ b/src/doc/unstable-book/src/compiler-flags/link-native-libraries.md
@@ -1,0 +1,8 @@
+# `link-native-libraries`
+
+This option allows ignoring libraries specified in `#[link]` attributes instead of passing them to the linker.
+This can be useful in build systems that manage native libraries themselves and pass them manually,
+e.g. with `-Clink-arg`.
+
+- `yes` - Pass native libraries to the linker. Default.
+- `no` - Don't pass native libraries to the linker.

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -681,7 +681,7 @@ pub(crate) fn make_test(
             if s.contains(crate_name) {
                 // rustdoc implicitly inserts an `extern crate` item for the own crate
                 // which may be unused, so we need to allow the lint.
-                prog.push_str(&format!("#[allow(unused_extern_crates)]\n"));
+                prog.push_str("#[allow(unused_extern_crates)]\n");
 
                 prog.push_str(&format!("extern crate r#{crate_name};\n"));
                 line_offset += 1;

--- a/tests/ui/did_you_mean/bad-assoc-expr.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-expr.stderr
@@ -2,60 +2,104 @@ error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-expr.rs:3:5
    |
 LL |     [i32; 4]::clone(&a);
-   |     ^^^^^^^^^^^^^^^ help: try: `<[i32; 4]>::clone`
+   |     ^^^^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     <[i32; 4]>::clone(&a);
+   |     +        +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-expr.rs:6:5
    |
 LL |     [i32]::as_ref(&a);
-   |     ^^^^^^^^^^^^^ help: try: `<[i32]>::as_ref`
+   |     ^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     <[i32]>::as_ref(&a);
+   |     +     +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-expr.rs:9:5
    |
 LL |     (u8)::clone(&0);
-   |     ^^^^^^^^^^^ help: try: `<(u8)>::clone`
+   |     ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     <(u8)>::clone(&0);
+   |     +    +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-expr.rs:12:5
    |
 LL |     (u8, u8)::clone(&(0, 0));
-   |     ^^^^^^^^^^^^^^^ help: try: `<(u8, u8)>::clone`
+   |     ^^^^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     <(u8, u8)>::clone(&(0, 0));
+   |     +        +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-expr.rs:15:6
    |
 LL |     &(u8)::clone(&0);
-   |      ^^^^^^^^^^^ help: try: `<(u8)>::clone`
+   |      ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     &<(u8)>::clone(&0);
+   |      +    +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-expr.rs:18:10
    |
 LL |     10 + (u8)::clone(&0);
-   |          ^^^^^^^^^^^ help: try: `<(u8)>::clone`
+   |          ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     10 + <(u8)>::clone(&0);
+   |          +    +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-expr.rs:32:13
    |
 LL |     let _ = ty!()::clone(&0);
-   |             ^^^^^^^^^^^^ help: try: `<ty!()>::clone`
+   |             ^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     let _ = <ty!()>::clone(&0);
+   |             +     +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-expr.rs:34:5
    |
 LL |     ty!()::clone(&0);
-   |     ^^^^^^^^^^^^ help: try: `<ty!()>::clone`
+   |     ^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     <ty!()>::clone(&0);
+   |     +     +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-expr.rs:23:19
    |
 LL |     ($ty: ty) => ($ty::clone(&0))
-   |                   ^^^^^^^^^^ help: try: `<$ty>::clone`
+   |                   ^^^
 ...
 LL |     expr!(u8);
    |     --------- in this macro invocation
    |
    = note: this error originates in the macro `expr` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     ($ty: ty) => (<$ty>::clone(&0))
+   |                   +   +
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/did_you_mean/bad-assoc-pat.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-pat.stderr
@@ -2,42 +2,71 @@ error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-pat.rs:3:9
    |
 LL |         [u8]::AssocItem => {}
-   |         ^^^^^^^^^^^^^^^ help: try: `<[u8]>::AssocItem`
+   |         ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |         <[u8]>::AssocItem => {}
+   |         +    +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-pat.rs:6:9
    |
 LL |         (u8, u8)::AssocItem => {}
-   |         ^^^^^^^^^^^^^^^^^^^ help: try: `<(u8, u8)>::AssocItem`
+   |         ^^^^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |         <(u8, u8)>::AssocItem => {}
+   |         +        +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-pat.rs:9:9
    |
 LL |         _::AssocItem => {}
-   |         ^^^^^^^^^^^^ help: try: `<_>::AssocItem`
+   |         ^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |         <_>::AssocItem => {}
+   |         + +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-pat.rs:14:10
    |
 LL |         &(u8,)::AssocItem => {}
-   |          ^^^^^^^^^^^^^^^^ help: try: `<(u8,)>::AssocItem`
+   |          ^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |         &<(u8,)>::AssocItem => {}
+   |          +     +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-pat.rs:32:9
    |
 LL |         ty!()::AssocItem => {}
-   |         ^^^^^^^^^^^^^^^^ help: try: `<ty!()>::AssocItem`
+   |         ^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |         <ty!()>::AssocItem => {}
+   |         +     +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-pat.rs:21:19
    |
 LL |     ($ty: ty) => ($ty::AssocItem)
-   |                   ^^^^^^^^^^^^^^ help: try: `<$ty>::AssocItem`
+   |                   ^^^
 ...
 LL |         pat!(u8) => {}
    |         -------- in this macro invocation
    |
    = note: this error originates in the macro `pat` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     ($ty: ty) => (<$ty>::AssocItem)
+   |                   +   +
 
 error[E0599]: no associated item named `AssocItem` found for slice `[u8]` in the current scope
   --> $DIR/bad-assoc-pat.rs:3:15

--- a/tests/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.stderr
@@ -2,60 +2,104 @@ error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:1:10
    |
 LL | type A = [u8; 4]::AssocTy;
-   |          ^^^^^^^^^^^^^^^^ help: try: `<[u8; 4]>::AssocTy`
+   |          ^^^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type A = <[u8; 4]>::AssocTy;
+   |          +       +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:5:10
    |
 LL | type B = [u8]::AssocTy;
-   |          ^^^^^^^^^^^^^ help: try: `<[u8]>::AssocTy`
+   |          ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type B = <[u8]>::AssocTy;
+   |          +    +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:9:10
    |
 LL | type C = (u8)::AssocTy;
-   |          ^^^^^^^^^^^^^ help: try: `<(u8)>::AssocTy`
+   |          ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type C = <(u8)>::AssocTy;
+   |          +    +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:13:10
    |
 LL | type D = (u8, u8)::AssocTy;
-   |          ^^^^^^^^^^^^^^^^^ help: try: `<(u8, u8)>::AssocTy`
+   |          ^^^^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type D = <(u8, u8)>::AssocTy;
+   |          +        +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:17:10
    |
 LL | type E = _::AssocTy;
-   |          ^^^^^^^^^^ help: try: `<_>::AssocTy`
+   |          ^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type E = <_>::AssocTy;
+   |          + +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:21:19
    |
 LL | type F = &'static (u8)::AssocTy;
-   |                   ^^^^^^^^^^^^^ help: try: `<(u8)>::AssocTy`
+   |                   ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type F = &'static <(u8)>::AssocTy;
+   |                   +    +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:27:10
    |
 LL | type G = dyn 'static + (Send)::AssocTy;
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `<dyn 'static + (Send)>::AssocTy`
+   |          ^^^^^^^^^^^^^^^^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type G = <dyn 'static + (Send)>::AssocTy;
+   |          +                    +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:46:10
    |
 LL | type I = ty!()::AssocTy;
-   |          ^^^^^^^^^^^^^^ help: try: `<ty!()>::AssocTy`
+   |          ^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type I = <ty!()>::AssocTy;
+   |          +     +
 
 error: missing angle brackets in associated item path
   --> $DIR/bad-assoc-ty.rs:39:19
    |
 LL |     ($ty: ty) => ($ty::AssocTy);
-   |                   ^^^^^^^^^^^^ help: try: `<$ty>::AssocTy`
+   |                   ^^^
 ...
 LL | type J = ty!(u8);
    |          ------- in this macro invocation
    |
    = note: this error originates in the macro `ty` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     ($ty: ty) => (<$ty>::AssocTy);
+   |                   +   +
 
 error[E0223]: ambiguous associated type
   --> $DIR/bad-assoc-ty.rs:1:10

--- a/tests/ui/parser/issues/issue-89388.stderr
+++ b/tests/ui/parser/issues/issue-89388.stderr
@@ -2,7 +2,12 @@ error: missing angle brackets in associated item path
   --> $DIR/issue-89388.rs:5:24
    |
 LL |     let _ = option.map([_]::to_vec);
-   |                        ^^^^^^^^^^^ help: try: `<[_]>::to_vec`
+   |                        ^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     let _ = option.map(<[_]>::to_vec);
+   |                        +   +
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #112959 (Change the wording in `std::fmt::Write::write_str`)
 - #115535 (format doc-comment code examples in std::process)
 - #115888 (fix a comment about assert_receiver_is_total_eq)
 - #116211 (more clippy complextity fixes )
 - #116213 (Document -Zlink-native-libraries)
 - #116215 (Tweak wording of missing angle backets in qualified path)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112959,115535,115888,116211,116213,116215)
<!-- homu-ignore:end -->