### PR TITLE
resolve: skip underscore character during candidate lookup

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1169,6 +1169,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     return;
                 }
 
+                if ident.name == kw::Underscore {
+                    return;
+                }
+
                 let child_accessible =
                     accessible && this.is_accessible_from(name_binding.vis, parent_scope.module);
 

--- a/tests/ui/resolve/issue-116164.rs
+++ b/tests/ui/resolve/issue-116164.rs
@@ -1,0 +1,19 @@
+#![allow(unused_imports)]
+
+mod inner {
+    pub enum Example {
+        ExOne,
+    }
+}
+
+mod reexports {
+    pub use crate::inner::Example as _;
+}
+
+use crate::reexports::*;
+//~^ SUGGESTION: use inner::Example::ExOne
+
+fn main() {
+    ExOne;
+    //~^ ERROR: cannot find value `ExOne` in this scope
+}

--- a/tests/ui/resolve/issue-116164.stderr
+++ b/tests/ui/resolve/issue-116164.stderr
@@ -1,0 +1,14 @@
+error[E0425]: cannot find value `ExOne` in this scope
+  --> $DIR/issue-116164.rs:17:5
+   |
+LL |     ExOne;
+   |     ^^^^^ not found in this scope
+   |
+help: consider importing this unit variant
+   |
+LL + use inner::Example::ExOne;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes #116164

In use statement, an underscore is merely a placeholder symbol and does not bind to any name. Therefore, it can be safely ignored.