### PR TITLE
Clippy backport: Move needless_raw_string_hashes to pedantic

### DIFF
--- a/src/tools/clippy/clippy_lints/src/raw_strings.rs
+++ b/src/tools/clippy/clippy_lints/src/raw_strings.rs
@@ -50,7 +50,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.72.0"]
     pub NEEDLESS_RAW_STRING_HASHES,
-    style,
+    pedantic,
     "suggests reducing the number of hashes around a raw string literal"
 }
 impl_lint_pass!(RawStrings => [NEEDLESS_RAW_STRINGS, NEEDLESS_RAW_STRING_HASHES]);


### PR DESCRIPTION
Really small backport this time. Context: https://github.com/rust-lang/rust-clippy/pull/11415#issuecomment-1739880932

I'd rather get this in 1.74 than waiting another release cycle.

r? @Manishearth 

cc @Mark-Simulacrum This should be merged before beta is branched tomorrow.