### PR TITLE
On type error of closure call argument, point at earlier calls that affected inference

### DIFF
--- a/tests/ui/unboxed-closures/unboxed-closures-type-mismatch.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-type-mismatch.rs
@@ -1,7 +1,35 @@
 use std::ops::FnMut;
 
-pub fn main() {
+fn main() {
     let mut f = |x: isize, y: isize| -> isize { x + y };
-    let z = f(1_usize, 2);    //~ ERROR mismatched types
+    let z = f(1_usize, 2); //~ ERROR mismatched types
     println!("{}", z);
+    let mut g = |x, y| { x + y };
+    let y = g(1_i32, 2);
+    let z = g(1_usize, 2); //~ ERROR mismatched types
+    println!("{}", z);
+}
+
+trait T {
+    fn bar(&self) {
+        let identity = |x| x;
+        identity(1u8);
+        identity(1u16); //~ ERROR mismatched types
+        let identity = |x| x;
+        identity(&1u8);
+        identity(&1u16); //~ ERROR mismatched types
+    }
+}
+
+struct S;
+
+impl T  for S {
+    fn bar(&self) {
+        let identity = |x| x;
+        identity(1u8);
+        identity(1u16); //~ ERROR mismatched types
+        let identity = |x| x;
+        identity(&1u8);
+        identity(&1u16); //~ ERROR mismatched types
+    }
 }

--- a/tests/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
@@ -16,6 +16,127 @@ help: change the type of the numeric literal from `usize` to `isize`
 LL |     let z = f(1_isize, 2);
    |                 ~~~~~
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:9:15
+   |
+LL |     let z = g(1_usize, 2);
+   |             - ^^^^^^^ expected `i32`, found `usize`
+   |             |
+   |             arguments to this function are incorrect
+   |
+note: expected because the closure was earlier called with an argument of type `i32`
+  --> $DIR/unboxed-closures-type-mismatch.rs:8:15
+   |
+LL |     let y = g(1_i32, 2);
+   |             - ^^^^^ expected because this argument is of type `i32`
+   |             |
+   |             in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:7:18
+   |
+LL |     let mut g = |x, y| { x + y };
+   |                  ^
+help: change the type of the numeric literal from `usize` to `i32`
+   |
+LL |     let z = g(1_i32, 2);
+   |                 ~~~
+
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:17:18
+   |
+LL |         identity(1u16);
+   |         -------- ^^^^ expected `u8`, found `u16`
+   |         |
+   |         arguments to this function are incorrect
+   |
+note: expected because the closure was earlier called with an argument of type `u8`
+  --> $DIR/unboxed-closures-type-mismatch.rs:16:18
+   |
+LL |         identity(1u8);
+   |         -------- ^^^ expected because this argument is of type `u8`
+   |         |
+   |         in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:15:25
+   |
+LL |         let identity = |x| x;
+   |                         ^
+help: change the type of the numeric literal from `u16` to `u8`
+   |
+LL |         identity(1u8);
+   |                   ~~
+
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:20:18
+   |
+LL |         identity(&1u16);
+   |         -------- ^^^^^ expected `&u8`, found `&u16`
+   |         |
+   |         arguments to this function are incorrect
+   |
+   = note: expected reference `&u8`
+              found reference `&u16`
+note: expected because the closure was earlier called with an argument of type `&u8`
+  --> $DIR/unboxed-closures-type-mismatch.rs:19:18
+   |
+LL |         identity(&1u8);
+   |         -------- ^^^^ expected because this argument is of type `&u8`
+   |         |
+   |         in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:18:25
+   |
+LL |         let identity = |x| x;
+   |                         ^
+
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:30:18
+   |
+LL |         identity(1u16);
+   |         -------- ^^^^ expected `u8`, found `u16`
+   |         |
+   |         arguments to this function are incorrect
+   |
+note: expected because the closure was earlier called with an argument of type `u8`
+  --> $DIR/unboxed-closures-type-mismatch.rs:29:18
+   |
+LL |         identity(1u8);
+   |         -------- ^^^ expected because this argument is of type `u8`
+   |         |
+   |         in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:28:25
+   |
+LL |         let identity = |x| x;
+   |                         ^
+help: change the type of the numeric literal from `u16` to `u8`
+   |
+LL |         identity(1u8);
+   |                   ~~
+
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:33:18
+   |
+LL |         identity(&1u16);
+   |         -------- ^^^^^ expected `&u8`, found `&u16`
+   |         |
+   |         arguments to this function are incorrect
+   |
+   = note: expected reference `&u8`
+              found reference `&u16`
+note: expected because the closure was earlier called with an argument of type `&u8`
+  --> $DIR/unboxed-closures-type-mismatch.rs:32:18
+   |
+LL |         identity(&1u8);
+   |         -------- ^^^^ expected because this argument is of type `&u8`
+   |         |
+   |         in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:31:25
+   |
+LL |         let identity = |x| x;
+   |                         ^
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Mitigate part of  https://github.com/rust-lang/rust/issues/71209.

When we encounter a type error on a specific argument of a closure call argument, where the closure's definition doesn't have a type specified, look for other calls of the closure to try and find the specific call that cased that argument to be inferred of the expected type.

```
error[E0308]: mismatched types
  --> $DIR/unboxed-closures-type-mismatch.rs:30:18
   |
LL |         identity(1u16);
   |         -------- ^^^^ expected `u8`, found `u16`
   |         |
   |         arguments to this function are incorrect
   |
note: expected because the closure was earlier called with an argument of type `u8`
  --> $DIR/unboxed-closures-type-mismatch.rs:29:18
   |
LL |         identity(1u8);
   |         -------- ^^^ expected because this argument is of type `u8`
   |         |
   |         in this closure call
note: closure parameter defined here
  --> $DIR/unboxed-closures-type-mismatch.rs:28:25
   |
LL |         let identity = |x| x;
   |                         ^
help: change the type of the numeric literal from `u16` to `u8`
   |
LL |         identity(1u8);
   |                   ~~
```