### PR TITLE
Make `adt_const_params` feature suggestion consistent with other features and improve when it is emitted

### DIFF
--- a/tests/ui/const-generics/adt_const_params/suggest_feature_only_when_possible.rs
+++ b/tests/ui/const-generics/adt_const_params/suggest_feature_only_when_possible.rs
@@ -1,0 +1,44 @@
+// Test that when adt_const_params is not enabled, we suggest adding the feature only when
+// it would be possible for the type to be used as a const generic or when it's likely
+// possible for the user to fix their type to be used.
+
+// Can never be used as const generics.
+fn uwu_0<const N: &'static mut ()>() {}
+//~^ ERROR: forbidden as the type of a const generic
+
+// Needs the feature but can be used, so suggest adding the feature.
+fn owo_0<const N: &'static u32>() {}
+//~^ ERROR: forbidden as the type of a const generic
+//~^^ HELP: add `#![feature(adt_const_params)]`
+
+// Can only be used in const generics with changes.
+struct Meow {
+    meow: u8,
+}
+
+fn meow_0<const N: Meow>() {}
+//~^ ERROR: forbidden as the type of a const generic
+//~^^ HELP: add `#![feature(adt_const_params)]`
+fn meow_1<const N: &'static Meow>() {}
+//~^ ERROR: forbidden as the type of a const generic
+//~^^ HELP: add `#![feature(adt_const_params)]`
+fn meow_2<const N: [Meow; 100]>() {}
+//~^ ERROR: forbidden as the type of a const generic
+//~^^ HELP: add `#![feature(adt_const_params)]`
+fn meow_3<const N: (Meow, u8)>() {}
+//~^ ERROR: forbidden as the type of a const generic
+//~^^ HELP: add `#![feature(adt_const_params)]`
+
+// This is suboptimal that it thinks it can be used
+// but better to suggest the feature to the user.
+fn meow_4<const N: (Meow, String)>() {}
+//~^ ERROR: forbidden as the type of a const generic
+//~^^ HELP: add `#![feature(adt_const_params)]`
+
+// Non-local ADT that does not impl `ConstParamTy`
+fn nya_0<const N: String>() {}
+//~^ ERROR: forbidden as the type of a const generic
+fn nya_1<const N: Vec<u32>>() {}
+//~^ ERROR: forbidden as the type of a const generic
+
+fn main() {}

--- a/tests/ui/const-generics/adt_const_params/suggest_feature_only_when_possible.stderr
+++ b/tests/ui/const-generics/adt_const_params/suggest_feature_only_when_possible.stderr
@@ -1,0 +1,80 @@
+error: `&'static mut ()` is forbidden as the type of a const generic parameter
+  --> $DIR/suggest_feature_only_when_possible.rs:6:19
+   |
+LL | fn uwu_0<const N: &'static mut ()>() {}
+   |                   ^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+
+error: `&'static u32` is forbidden as the type of a const generic parameter
+  --> $DIR/suggest_feature_only_when_possible.rs:10:19
+   |
+LL | fn owo_0<const N: &'static u32>() {}
+   |                   ^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
+error: `Meow` is forbidden as the type of a const generic parameter
+  --> $DIR/suggest_feature_only_when_possible.rs:19:20
+   |
+LL | fn meow_0<const N: Meow>() {}
+   |                    ^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
+error: `&'static Meow` is forbidden as the type of a const generic parameter
+  --> $DIR/suggest_feature_only_when_possible.rs:22:20
+   |
+LL | fn meow_1<const N: &'static Meow>() {}
+   |                    ^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
+error: `[Meow; 100]` is forbidden as the type of a const generic parameter
+  --> $DIR/suggest_feature_only_when_possible.rs:25:20
+   |
+LL | fn meow_2<const N: [Meow; 100]>() {}
+   |                    ^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
+error: `(Meow, u8)` is forbidden as the type of a const generic parameter
+  --> $DIR/suggest_feature_only_when_possible.rs:28:20
+   |
+LL | fn meow_3<const N: (Meow, u8)>() {}
+   |                    ^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
+error: `(Meow, String)` is forbidden as the type of a const generic parameter
+  --> $DIR/suggest_feature_only_when_possible.rs:34:20
+   |
+LL | fn meow_4<const N: (Meow, String)>() {}
+   |                    ^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
+error: `String` is forbidden as the type of a const generic parameter
+  --> $DIR/suggest_feature_only_when_possible.rs:39:19
+   |
+LL | fn nya_0<const N: String>() {}
+   |                   ^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+
+error: `Vec<u32>` is forbidden as the type of a const generic parameter
+  --> $DIR/suggest_feature_only_when_possible.rs:41:19
+   |
+LL | fn nya_1<const N: Vec<u32>>() {}
+   |                   ^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/const-generics/const-param-elided-lifetime.min.stderr
+++ b/tests/ui/const-generics/const-param-elided-lifetime.min.stderr
@@ -35,7 +35,7 @@ LL | struct A<const N: &u8>;
    |                   ^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `&u8` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-elided-lifetime.rs:14:15
@@ -44,7 +44,7 @@ LL | impl<const N: &u8> A<N> {
    |               ^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `&u8` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-elided-lifetime.rs:22:15
@@ -53,7 +53,7 @@ LL | impl<const N: &u8> B for A<N> {}
    |               ^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `&u8` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-elided-lifetime.rs:26:17
@@ -62,7 +62,7 @@ LL | fn bar<const N: &u8>() {}
    |                 ^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `&u8` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-elided-lifetime.rs:17:21
@@ -71,7 +71,7 @@ LL |     fn foo<const M: &u8>(&self) {}
    |                     ^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
@@ -21,7 +21,7 @@ LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    |                                               ^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `[u8; N]` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-type-depends-on-const-param.rs:15:35
@@ -30,7 +30,7 @@ LL | pub struct SelfDependent<const N: [u8; N]>;
    |                                   ^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/float-generic.simple.stderr
+++ b/tests/ui/const-generics/float-generic.simple.stderr
@@ -5,7 +5,6 @@ LL | fn foo<const F: f32>() {}
    |                 ^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/fn-const-param-call.min.stderr
+++ b/tests/ui/const-generics/fn-const-param-call.min.stderr
@@ -3,12 +3,16 @@ error: using function pointers as const generic parameters is forbidden
    |
 LL | struct Wrapper<const F: fn() -> u32>;
    |                         ^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/fn-const-param-call.rs:13:15
    |
 LL | impl<const F: fn() -> u32> Wrapper<F> {
    |               ^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/fn-const-param-infer.min.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.min.stderr
@@ -3,6 +3,8 @@ error: using function pointers as const generic parameters is forbidden
    |
 LL | struct Checked<const F: fn(usize) -> bool>;
    |                         ^^^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
@@ -23,7 +23,7 @@ LL | struct B<const CFG: Config> {
    |                     ^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
+++ b/tests/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
@@ -14,7 +14,7 @@ LL | trait Trait<const S: &'static str> {}
    |                      ^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-56445-1.min.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-1.min.stderr
@@ -13,7 +13,7 @@ LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
    |                         ^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-62878.min.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.min.stderr
@@ -13,7 +13,7 @@ LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                 ^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-63322-forbid-dyn.min.stderr
+++ b/tests/ui/const-generics/issues/issue-63322-forbid-dyn.min.stderr
@@ -5,7 +5,7 @@ LL | fn test<const T: &'static dyn A>() {
    |                  ^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/issues/issue-68615-adt.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68615-adt.min.stderr
@@ -5,7 +5,7 @@ LL | struct Const<const V: [usize; 0]> {}
    |                       ^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/issues/issue-68615-array.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68615-array.min.stderr
@@ -5,7 +5,7 @@ LL | struct Foo<const V: [usize; 0] > {}
    |                     ^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/issues/issue-71169.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71169.min.stderr
@@ -13,7 +13,7 @@ LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
    |                                      ^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-71381.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.min.stderr
@@ -19,12 +19,16 @@ error: using function pointers as const generic parameters is forbidden
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71381.rs:23:19
    |
 LL |         const FN: unsafe extern "C" fn(Args),
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/issues/issue-71382.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71382.min.stderr
@@ -3,6 +3,8 @@ error: using function pointers as const generic parameters is forbidden
    |
 LL |     fn test<const FN: fn()>(&self) {
    |                       ^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/issues/issue-71611.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71611.min.stderr
@@ -11,6 +11,8 @@ error: using function pointers as const generic parameters is forbidden
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                     ^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-72352.min.stderr
+++ b/tests/ui/const-generics/issues/issue-72352.min.stderr
@@ -3,6 +3,8 @@ error: using function pointers as const generic parameters is forbidden
    |
 LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const i8) -> usize {
    |                                          ^^^^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/issues/issue-73491.min.stderr
+++ b/tests/ui/const-generics/issues/issue-73491.min.stderr
@@ -5,7 +5,7 @@ LL | fn hoge<const IN: [u32; LEN]>() {}
    |                   ^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/issues/issue-73727-static-reference-array-const-param.min.stderr
+++ b/tests/ui/const-generics/issues/issue-73727-static-reference-array-const-param.min.stderr
@@ -5,7 +5,7 @@ LL | fn a<const X: &'static [u32]>() {}
    |               ^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/issues/issue-74101.min.stderr
+++ b/tests/ui/const-generics/issues/issue-74101.min.stderr
@@ -5,7 +5,7 @@ LL | fn test<const N: [u8; 1 + 2]>() {}
    |                  ^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `[u8; 1 + 2]` is forbidden as the type of a const generic parameter
   --> $DIR/issue-74101.rs:9:21
@@ -14,7 +14,7 @@ LL | struct Foo<const N: [u8; 1 + 2]>;
    |                     ^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-74255.min.stderr
+++ b/tests/ui/const-generics/issues/issue-74255.min.stderr
@@ -5,7 +5,7 @@ LL |     fn ice_struct_fn<const I: IceEnum>() {}
    |                               ^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/issues/issue-74950.min.stderr
+++ b/tests/ui/const-generics/issues/issue-74950.min.stderr
@@ -5,7 +5,7 @@ LL | struct Outer<const I: Inner>;
    |                       ^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `Inner` is forbidden as the type of a const generic parameter
   --> $DIR/issue-74950.rs:20:23
@@ -14,7 +14,7 @@ LL | struct Outer<const I: Inner>;
    |                       ^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `Inner` is forbidden as the type of a const generic parameter
   --> $DIR/issue-74950.rs:20:23
@@ -23,7 +23,7 @@ LL | struct Outer<const I: Inner>;
    |                       ^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `Inner` is forbidden as the type of a const generic parameter
   --> $DIR/issue-74950.rs:20:23
@@ -32,7 +32,7 @@ LL | struct Outer<const I: Inner>;
    |                       ^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `Inner` is forbidden as the type of a const generic parameter
   --> $DIR/issue-74950.rs:20:23
@@ -41,7 +41,7 @@ LL | struct Outer<const I: Inner>;
    |                       ^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/const-generics/issues/issue-75047.min.stderr
+++ b/tests/ui/const-generics/issues/issue-75047.min.stderr
@@ -5,7 +5,7 @@ LL | struct Foo<const N: [u8; Bar::<u32>::value()]>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/lifetime-in-const-param.stderr
+++ b/tests/ui/const-generics/lifetime-in-const-param.stderr
@@ -11,7 +11,7 @@ LL | struct S<'a, const N: S2>(&'a ());
    |                       ^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/complex-types.stderr
+++ b/tests/ui/const-generics/min_const_generics/complex-types.stderr
@@ -5,7 +5,7 @@ LL | struct Foo<const N: [u8; 0]>;
    |                     ^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `()` is forbidden as the type of a const generic parameter
   --> $DIR/complex-types.rs:6:21
@@ -14,7 +14,7 @@ LL | struct Bar<const N: ()>;
    |                     ^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `No` is forbidden as the type of a const generic parameter
   --> $DIR/complex-types.rs:11:21
@@ -23,7 +23,7 @@ LL | struct Fez<const N: No>;
    |                     ^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `&'static u8` is forbidden as the type of a const generic parameter
   --> $DIR/complex-types.rs:14:21
@@ -32,7 +32,7 @@ LL | struct Faz<const N: &'static u8>;
    |                     ^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `!` is forbidden as the type of a const generic parameter
   --> $DIR/complex-types.rs:17:21
@@ -41,7 +41,6 @@ LL | struct Fiz<const N: !>;
    |                     ^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
 
 error: `()` is forbidden as the type of a const generic parameter
   --> $DIR/complex-types.rs:20:19
@@ -50,7 +49,7 @@ LL | enum Goo<const N: ()> { A, B }
    |                   ^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `()` is forbidden as the type of a const generic parameter
   --> $DIR/complex-types.rs:23:20
@@ -59,7 +58,7 @@ LL | union Boo<const N: ()> { a: () }
    |                    ^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/const-generics/nested-type.min.stderr
+++ b/tests/ui/const-generics/nested-type.min.stderr
@@ -30,7 +30,7 @@ LL | | }]>;
    | |__^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/projection-as-arg-const.stderr
+++ b/tests/ui/const-generics/projection-as-arg-const.stderr
@@ -5,7 +5,6 @@ LL | pub fn foo<const X: <i32 as Identity>::Identity>() {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/raw-ptr-const-param-deref.min.stderr
+++ b/tests/ui/const-generics/raw-ptr-const-param-deref.min.stderr
@@ -3,12 +3,16 @@ error: using raw pointers as const generic parameters is forbidden
    |
 LL | struct Const<const P: *const u32>;
    |                       ^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: using raw pointers as const generic parameters is forbidden
   --> $DIR/raw-ptr-const-param-deref.rs:11:15
    |
 LL | impl<const P: *const u32> Const<P> {
    |               ^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/raw-ptr-const-param.min.stderr
+++ b/tests/ui/const-generics/raw-ptr-const-param.min.stderr
@@ -3,6 +3,8 @@ error: using raw pointers as const generic parameters is forbidden
    |
 LL | struct Const<const P: *const u32>;
    |                       ^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/slice-const-param-mismatch.min.stderr
+++ b/tests/ui/const-generics/slice-const-param-mismatch.min.stderr
@@ -5,7 +5,7 @@ LL | struct ConstString<const T: &'static str>;
    |                             ^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `&'static [u8]` is forbidden as the type of a const generic parameter
   --> $DIR/slice-const-param-mismatch.rs:9:28
@@ -14,7 +14,7 @@ LL | struct ConstBytes<const T: &'static [u8]>;
    |                            ^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/std/const-generics-range.min.stderr
+++ b/tests/ui/const-generics/std/const-generics-range.min.stderr
@@ -5,7 +5,7 @@ LL | struct _Range<const R: std::ops::Range<usize>>;
    |                        ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `RangeFrom<usize>` is forbidden as the type of a const generic parameter
   --> $DIR/const-generics-range.rs:13:28
@@ -14,7 +14,7 @@ LL | struct _RangeFrom<const R: std::ops::RangeFrom<usize>>;
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `RangeFull` is forbidden as the type of a const generic parameter
   --> $DIR/const-generics-range.rs:18:28
@@ -23,7 +23,7 @@ LL | struct _RangeFull<const R: std::ops::RangeFull>;
    |                            ^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `RangeInclusive<usize>` is forbidden as the type of a const generic parameter
   --> $DIR/const-generics-range.rs:24:33
@@ -32,7 +32,7 @@ LL | struct _RangeInclusive<const R: std::ops::RangeInclusive<usize>>;
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `RangeTo<usize>` is forbidden as the type of a const generic parameter
   --> $DIR/const-generics-range.rs:29:26
@@ -41,7 +41,7 @@ LL | struct _RangeTo<const R: std::ops::RangeTo<usize>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `RangeToInclusive<usize>` is forbidden as the type of a const generic parameter
   --> $DIR/const-generics-range.rs:34:35
@@ -50,7 +50,7 @@ LL | struct _RangeToInclusive<const R: std::ops::RangeToInclusive<usize>>;
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/const-generics/transmute-const-param-static-reference.min.stderr
+++ b/tests/ui/const-generics/transmute-const-param-static-reference.min.stderr
@@ -5,7 +5,7 @@ LL | struct Const<const P: &'static ()>;
    |                       ^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to previous error
 

--- a/tests/ui/const-generics/type-dependent/issue-71348.min.stderr
+++ b/tests/ui/const-generics/type-dependent/issue-71348.min.stderr
@@ -5,7 +5,7 @@ LL | trait Get<'a, const N: &'static str> {
    |                        ^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `&'static str` is forbidden as the type of a const generic parameter
   --> $DIR/issue-71348.rs:18:25
@@ -14,7 +14,7 @@ LL |     fn ask<'a, const N: &'static str>(&'a self) -> &'a <Self as Get<N>>::Ta
    |                         ^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/type-dependent/issue-71382.stderr
+++ b/tests/ui/const-generics/type-dependent/issue-71382.stderr
@@ -3,6 +3,8 @@ error: using function pointers as const generic parameters is forbidden
    |
 LL |     fn test<const FN: fn() -> u8>(&self) -> u8 {
    |                       ^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
 
 error: aborting due to previous error
 

--- a/tests/ui/feature-gates/feature-gate-adt_const_params.stderr
+++ b/tests/ui/feature-gates/feature-gate-adt_const_params.stderr
@@ -5,7 +5,7 @@ LL | struct Foo<const NAME: &'static str>;
    |                        ^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to previous error
 

--- a/tests/ui/generic-const-items/elided-lifetimes.stderr
+++ b/tests/ui/generic-const-items/elided-lifetimes.stderr
@@ -28,7 +28,7 @@ LL | const I<const S: &str>: &str = "";
    |                  ^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -56,7 +56,7 @@ LL | fn d<const C: S>() {}
    |               ^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: `&dyn for<'a> Foo<'a>` is forbidden as the type of a const generic parameter
   --> $DIR/unusual-rib-combinations.rs:29:21
@@ -65,7 +65,7 @@ LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
-   = help: more complex types are supported with `#![feature(adt_const_params)]`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
 error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Makes the suggestion to add `adt_const_params` formatted like every other feature gate (notably this makes it such that the playground recognizes it). Additionally improves the situations in which that help is emitted so that it's only emitted when the type would be valid or the type *could* be valid (using a slightly incorrect heuristic that favors suggesting the feature over not) instead of, for example, implying that adding the feature would allow the use of `String`.

Also adds the "the only supported types are integers, `bool` and `char`" note to the errors on fn and raw pointers.

r? @compiler-errors 