### PR TITLE
More fixes for running the test suite on a bare metal target

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -580,6 +580,8 @@ pub struct TargetCfg {
     pub(crate) sanitizers: Vec<Sanitizer>,
     #[serde(rename = "supports-xray", default)]
     pub(crate) xray: bool,
+    #[serde(default = "default_reloc_model")]
+    pub(crate) relocation_model: String,
 }
 
 impl TargetCfg {
@@ -590,6 +592,10 @@ impl TargetCfg {
 
 fn default_os() -> String {
     "none".into()
+}
+
+fn default_reloc_model() -> String {
+    "pic".into()
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Default, serde::Deserialize)]

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -134,6 +134,11 @@ pub(super) fn handle_needs(
             condition: config.target_cfg().dynamic_linking,
             ignore_reason: "ignored on targets without dynamic linking",
         },
+        Need {
+            name: "needs-relocation-model-pic",
+            condition: config.target_cfg().relocation_model == "pic",
+            ignore_reason: "ignored on targets without PIC relocation model",
+        },
     ];
 
     let (name, comment) = match ln.split_once([':', ' ']) {

--- a/tests/incremental/change_crate_dep_kind.rs
+++ b/tests/incremental/change_crate_dep_kind.rs
@@ -5,6 +5,7 @@
 // needs-unwind
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph -Cpanic=unwind
+// needs-unwind
 // build-pass (FIXME(62277): could be check-pass?)
 
 #![feature(panic_unwind)]

--- a/tests/ui/abi/relocation_model_pic.rs
+++ b/tests/ui/abi/relocation_model_pic.rs
@@ -1,7 +1,6 @@
 // run-pass
 // compile-flags: -C relocation-model=pic
-// ignore-emscripten no pic
-// ignore-wasm
+// needs-relocation-model-pic
 
 #![feature(cfg_relocation_model)]
 

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.rs
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.rs
@@ -2,6 +2,7 @@
 // run-fail
 // check-run-results
 // exec-env:RUST_BACKTRACE=1
+// needs-unwind
 // ignore-android FIXME #17520
 // ignore-wasm no panic support
 // ignore-openbsd no support for libbacktrace without filename

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/short-ice-remove-middle-frames-2.rs:56:5:
+thread 'main' panicked at $DIR/short-ice-remove-middle-frames-2.rs:57:5:
 debug!!!
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/short-ice-remove-middle-frames.rs
+++ b/tests/ui/panics/short-ice-remove-middle-frames.rs
@@ -2,6 +2,7 @@
 // run-fail
 // check-run-results
 // exec-env:RUST_BACKTRACE=1
+// needs-unwind
 // ignore-android FIXME #17520
 // ignore-wasm no panic support
 // ignore-openbsd no support for libbacktrace without filename

--- a/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/short-ice-remove-middle-frames.rs:52:5:
+thread 'main' panicked at $DIR/short-ice-remove-middle-frames.rs:53:5:
 debug!!!
 stack backtrace:
    0: std::panicking::begin_panic


### PR DESCRIPTION
This PR adds more fixes needed to run the test suite on bare metal targets (in this case, without unwinding and with static relocations). There is no CI job exercising tests without unwinds, but I can confirm this worked in Ferrocene's CI.