### PR TITLE
Errorrecovery.rs

### DIFF
--- a/Errorrecovery.rs
+++ b/Errorrecovery.rs
@@ -1,0 +1,13 @@
+macro_rules! define {
+    (struct $name:ident) => {
+        struct $name {}
+    };
+}
+
+define! {
+    struct Hello
+}
+
+fn main() {
+    let _hello_instance = Hello {};
+}


### PR DESCRIPTION
added code for Error recovery after errors during macro expansion is usually futile #116180

In this code, I added {} after Hello to create a struct instance using struct literal syntax. This should resolve the error, and your code will compile successfully.

thanks & regards 
Police Akshith Reddy