### PR TITLE
Only trigger `refining_impl_trait` lint on reachable traits

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -23,8 +23,12 @@ pub(super) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
     if !tcx.impl_method_has_trait_impl_trait_tys(impl_m.def_id) {
         return;
     }
-    // crate-private traits don't have any library guarantees, there's no need to do this check.
-    if !tcx.visibility(trait_m.container_id(tcx)).is_public() {
+    // unreachable traits don't have any library guarantees, there's no need to do this check.
+    if trait_m
+        .container_id(tcx)
+        .as_local()
+        .is_some_and(|trait_def_id| !tcx.effective_visibilities(()).is_reachable(trait_def_id))
+    {
         return;
     }
 

--- a/tests/ui/async-await/in-trait/missing-feature-flag.stderr
+++ b/tests/ui/async-await/in-trait/missing-feature-flag.stderr
@@ -7,6 +7,12 @@ LL |     async fn foo(_: T) -> &'static str;
 LL | impl<T> MyTrait<T> for MyStruct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
 
+error[E0308]: mismatched types
+  --> $DIR/missing-feature-flag.rs:16:42
+   |
+LL |     async fn foo(_: i32) -> &'static str {}
+   |                                          ^^ expected `&str`, found `()`
+
 error[E0520]: `foo` specializes an item from a parent `impl`, but that item is not marked `default`
   --> $DIR/missing-feature-flag.rs:16:5
    |
@@ -17,12 +23,6 @@ LL |     async fn foo(_: i32) -> &'static str {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot specialize default item `foo`
    |
    = note: to specialize, `foo` in the parent `impl` must be marked `default`
-
-error[E0308]: mismatched types
-  --> $DIR/missing-feature-flag.rs:16:42
-   |
-LL |     async fn foo(_: i32) -> &'static str {}
-   |                                          ^^ expected `&str`, found `()`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/in-trait/refine.rs
+++ b/tests/ui/impl-trait/in-trait/refine.rs
@@ -45,4 +45,15 @@ impl Late for D {
     //~^ ERROR impl method signature does not match trait method signature
 }
 
+mod unreachable {
+    pub trait UnreachablePub {
+        fn bar() -> impl Sized;
+    }
+
+    struct E;
+    impl UnreachablePub for E {
+        fn bar() {}
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Public but unreachable traits don't matter 😸 

r? @tmandry