### PR TITLE
make soft_unstable show up in future breakage reports

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2457,7 +2457,7 @@ declare_lint! {
     Deny,
     "a feature gate that doesn't break dependent crates",
     @future_incompatible = FutureIncompatibleInfo {
-        reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
+        reason: FutureIncompatibilityReason::FutureReleaseErrorReportInDeps,
         reference: "issue #64266 <https://github.com/rust-lang/rust/issues/64266>",
     };
 }

--- a/tests/ui/feature-gates/bench.stderr
+++ b/tests/ui/feature-gates/bench.stderr
@@ -19,3 +19,25 @@ LL | use bench as _;
 
 error: aborting due to 2 previous errors
 
+Future incompatibility report: Future breakage diagnostic:
+error: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable
+  --> $DIR/bench.rs:3:3
+   |
+LL | #[bench]
+   |   ^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+   = note: `#[deny(soft_unstable)]` on by default
+
+Future breakage diagnostic:
+error: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable
+  --> $DIR/bench.rs:7:5
+   |
+LL | use bench as _;
+   |     ^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+   = note: `#[deny(soft_unstable)]` on by default
+

--- a/tests/ui/lint/expansion-time.stderr
+++ b/tests/ui/lint/expansion-time.stderr
@@ -54,3 +54,18 @@ LL | #[warn(incomplete_include)]
 
 warning: 4 warnings emitted
 
+Future incompatibility report: Future breakage diagnostic:
+warning: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable
+  --> $DIR/expansion-time.rs:14:7
+   |
+LL |     #[bench]
+   |       ^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+note: the lint level is defined here
+  --> $DIR/expansion-time.rs:12:8
+   |
+LL | #[warn(soft_unstable)]
+   |        ^^^^^^^^^^^^^
+

--- a/tests/ui/proc-macro/inner-attr-non-inline-mod.stderr
+++ b/tests/ui/proc-macro/inner-attr-non-inline-mod.stderr
@@ -38,3 +38,14 @@ LL | #![rustfmt::skip]
 error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0658`.
+Future incompatibility report: Future breakage diagnostic:
+error: custom inner attributes are unstable
+  --> $DIR/module_with_attrs.rs:3:4
+   |
+LL | #![rustfmt::skip]
+   |    ^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+   = note: `#[deny(soft_unstable)]` on by default
+

--- a/tests/ui/proc-macro/proc-macro-gates.stderr
+++ b/tests/ui/proc-macro/proc-macro-gates.stderr
@@ -89,3 +89,14 @@ LL |     #![test]
 error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0658`.
+Future incompatibility report: Future breakage diagnostic:
+error: inner macro attributes are unstable
+  --> $DIR/proc-macro-gates.rs:49:8
+   |
+LL |     #![test]
+   |        ^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+   = note: `#[deny(soft_unstable)]` on by default
+


### PR DESCRIPTION
If we want to break these in the future, let's warn users of affected crates.