### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_hir_typeck/src/mem_categorization.rs
+++ b/compiler/rustc_hir_typeck/src/mem_categorization.rs
@@ -464,7 +464,7 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
         // Opaque types can't have field projections, but we can instead convert
         // the current place in-place (heh) to the hidden type, and then apply all
         // follow up projections on that.
-        if node_ty != place_ty && place_ty.has_opaque_types() {
+        if node_ty != place_ty && matches!(place_ty.kind(), ty::Alias(ty::Opaque, ..)) {
             projections.push(Projection { kind: ProjectionKind::OpaqueCast, ty: node_ty });
         }
         projections.push(Projection { kind, ty });

--- a/tests/ui/impl-trait/opaque-cast-field-access-in-future.rs
+++ b/tests/ui/impl-trait/opaque-cast-field-access-in-future.rs
@@ -1,0 +1,27 @@
+// edition: 2021
+
+use std::future::Future;
+
+async fn bop() {
+    fold(run(), |mut foo| async move {
+        &mut foo.bar;
+    })
+}
+
+fn fold<Fut, F, U>(_: Foo<U>, f: F)
+where
+    F: FnMut(Foo<U>) -> Fut,
+{
+    loop {}
+}
+
+struct Foo<F> {
+    bar: Vec<F>,
+}
+
+fn run() -> Foo<impl Future<Output = ()>> {
+    //~^ ERROR type annotations needed
+    loop {}
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/opaque-cast-field-access-in-future.stderr
+++ b/tests/ui/impl-trait/opaque-cast-field-access-in-future.stderr
@@ -1,0 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/opaque-cast-field-access-in-future.rs:22:17
+   |
+LL | fn run() -> Foo<impl Future<Output = ()>> {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
- Only prevent field projections into opaque types, not types containing opaque types #116156
- Update LLVM submodule #116227

r? cuviper