### PR TITLE
Cleanup number handling in match exhaustiveness

### DIFF
--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -288,7 +288,16 @@ impl<'tcx> Const<'tcx> {
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> Option<ScalarInt> {
-        self.try_eval_scalar(tcx, param_env)?.try_to_int().ok()
+        match self {
+            // If the constant is already evaluated, we shortcut here.
+            Const::Ty(c) if let ty::ConstKind::Value(valtree) = c.kind() => {
+                valtree.try_to_scalar_int()
+            },
+            // This is a more general form of the previous case.
+            _ => {
+                self.try_eval_scalar(tcx, param_env)?.try_to_int().ok()
+            },
+        }
     }
 
     #[inline]

--- a/tests/ui/pattern/usefulness/floats.rs
+++ b/tests/ui/pattern/usefulness/floats.rs
@@ -1,19 +1,45 @@
+#![feature(exclusive_range_pattern)]
 #![allow(illegal_floating_point_literal_pattern)]
 #![deny(unreachable_patterns)]
 
 fn main() {
     match 0.0 {
-      0.0..=1.0 => {}
-      _ => {} // ok
+        0.0..=1.0 => {}
+        _ => {} // ok
     }
 
-    match 0.0 { //~ ERROR non-exhaustive patterns
-      0.0..=1.0 => {}
+    match 0.0 {
+        //~^ ERROR non-exhaustive patterns
+        0.0..=1.0 => {}
     }
 
     match 1.0f64 {
-      0.01f64 ..= 6.5f64 => {}
-      0.02f64 => {} //~ ERROR unreachable pattern
-      _ => {}
+        0.01f64..=6.5f64 => {}
+        0.005f64 => {}
+        0.01f64 => {} //~ ERROR unreachable pattern
+        0.02f64 => {} //~ ERROR unreachable pattern
+        6.5f64 => {}  //~ ERROR unreachable pattern
+        6.6f64 => {}
+        1.0f64..=4.0f64 => {} //~ ERROR unreachable pattern
+        5.0f64..=7.0f64 => {}
+        _ => {}
+    };
+    match 1.0f64 {
+        0.01f64..6.5f64 => {}
+        6.5f64 => {} // this is reachable
+        _ => {}
+    };
+
+    match 1.0f32 {
+        0.01f32..=6.5f32 => {}
+        0.01f32 => {} //~ ERROR unreachable pattern
+        0.02f32 => {} //~ ERROR unreachable pattern
+        6.5f32 => {}  //~ ERROR unreachable pattern
+        _ => {}
+    };
+    match 1.0f32 {
+        0.01f32..6.5f32 => {}
+        6.5f32 => {} // this is reachable
+        _ => {}
     };
 }

--- a/tests/ui/pattern/usefulness/floats.stderr
+++ b/tests/ui/pattern/usefulness/floats.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/floats.rs:10:11
+  --> $DIR/floats.rs:11:11
    |
 LL |     match 0.0 {
    |           ^^^ pattern `_` not covered
@@ -7,22 +7,58 @@ LL |     match 0.0 {
    = note: the matched value is of type `f64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~       0.0..=1.0 => {},
-LL +       _ => todo!()
+LL ~         0.0..=1.0 => {},
+LL +         _ => todo!()
    |
 
 error: unreachable pattern
-  --> $DIR/floats.rs:16:7
+  --> $DIR/floats.rs:19:9
    |
-LL |       0.02f64 => {}
-   |       ^^^^^^^
+LL |         0.01f64 => {}
+   |         ^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/floats.rs:2:9
+  --> $DIR/floats.rs:3:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: unreachable pattern
+  --> $DIR/floats.rs:20:9
+   |
+LL |         0.02f64 => {}
+   |         ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:21:9
+   |
+LL |         6.5f64 => {}
+   |         ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:23:9
+   |
+LL |         1.0f64..=4.0f64 => {}
+   |         ^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:35:9
+   |
+LL |         0.01f32 => {}
+   |         ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:36:9
+   |
+LL |         0.02f32 => {}
+   |         ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:37:9
+   |
+LL |         6.5f32 => {}
+   |         ^^^^^^
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
Doing a little bit of cleanup; handling number constants was somewhat messy. In particular, this:

- evals float consts once instead of repetitively
- reduces `Constructor` from 88 bytes to 56 (`mir::Const` is big!)

The `fast_try_eval_bits` function was mostly constructed from inlining existing code but I don't fully understand it; I don't follow how consts work and are evaluated very well.