### PR TITLE
More accurately point to where default return type should go

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1189,7 +1189,7 @@ fn report_trait_method_mismatch<'tcx>(
                     let ap = Applicability::MachineApplicable;
                     match sig.decl.output {
                         hir::FnRetTy::DefaultReturn(sp) => {
-                            let sugg = format!("-> {} ", trait_sig.output());
+                            let sugg = format!(" -> {}", trait_sig.output());
                             diag.span_suggestion_verbose(sp, msg, sugg, ap);
                         }
                         hir::FnRetTy::Return(hir_ty) => {

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -113,7 +113,11 @@ pub(super) fn check_fn<'a, 'tcx>(
 
     fcx.typeck_results.borrow_mut().liberated_fn_sigs_mut().insert(fn_id, fn_sig);
 
-    fcx.require_type_is_sized(declared_ret_ty, decl.output.span(), traits::SizedReturnType);
+    let return_or_body_span = match decl.output {
+        hir::FnRetTy::DefaultReturn(_) => body.value.span,
+        hir::FnRetTy::Return(ty) => ty.span,
+    };
+    fcx.require_type_is_sized(declared_ret_ty, return_or_body_span, traits::SizedReturnType);
     fcx.check_return_expr(&body.value, false);
 
     // We insert the deferred_generator_interiors entry after visiting the body.

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -110,7 +110,7 @@ pub struct AddressOfTemporaryTaken {
 pub enum AddReturnTypeSuggestion {
     #[suggestion(
         hir_typeck_add_return_type_add,
-        code = "-> {found} ",
+        code = " -> {found}",
         applicability = "machine-applicable"
     )]
     Add {
@@ -120,7 +120,7 @@ pub enum AddReturnTypeSuggestion {
     },
     #[suggestion(
         hir_typeck_add_return_type_missing_here,
-        code = "-> _ ",
+        code = " -> _",
         applicability = "has-placeholders"
     )]
     MissingHere {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -782,8 +782,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
             hir::FnRetTy::Return(hir_ty) => {
-                let span = hir_ty.span;
-
                 if let hir::TyKind::OpaqueDef(item_id, ..) = hir_ty.kind
                     && let hir::Node::Item(hir::Item {
                         kind: hir::ItemKind::OpaqueTy(op_ty),
@@ -799,28 +797,28 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     debug!(?found);
                     if found.is_suggestable(self.tcx, false) {
                         if term.span.is_empty() {
-                            err.subdiagnostic(errors::AddReturnTypeSuggestion::Add { span, found: found.to_string() });
+                            err.subdiagnostic(errors::AddReturnTypeSuggestion::Add { span: term.span, found: found.to_string() });
                             return true;
                         } else {
-                            err.subdiagnostic(errors::ExpectedReturnTypeLabel::Other { span, expected });
+                            err.subdiagnostic(errors::ExpectedReturnTypeLabel::Other { span: term.span, expected });
                         }
                     }
-                }
-
-                // Only point to return type if the expected type is the return type, as if they
-                // are not, the expectation must have been caused by something else.
-                debug!("return type {:?}", hir_ty);
-                let ty = self.astconv().ast_ty_to_ty(hir_ty);
-                debug!("return type {:?}", ty);
-                debug!("expected type {:?}", expected);
-                let bound_vars = self.tcx.late_bound_vars(hir_ty.hir_id.owner.into());
-                let ty = Binder::bind_with_vars(ty, bound_vars);
-                let ty = self.normalize(span, ty);
-                let ty = self.tcx.erase_late_bound_regions(ty);
-                if self.can_coerce(expected, ty) {
-                    err.subdiagnostic(errors::ExpectedReturnTypeLabel::Other { span, expected });
-                    self.try_suggest_return_impl_trait(err, expected, ty, fn_id);
-                    return true;
+                } else {
+                    // Only point to return type if the expected type is the return type, as if they
+                    // are not, the expectation must have been caused by something else.
+                    debug!("return type {:?}", hir_ty);
+                    let ty = self.astconv().ast_ty_to_ty(hir_ty);
+                    debug!("return type {:?}", ty);
+                    debug!("expected type {:?}", expected);
+                    let bound_vars = self.tcx.late_bound_vars(hir_ty.hir_id.owner.into());
+                    let ty = Binder::bind_with_vars(ty, bound_vars);
+                    let ty = self.normalize(hir_ty.span, ty);
+                    let ty = self.tcx.erase_late_bound_regions(ty);
+                    if self.can_coerce(expected, ty) {
+                        err.subdiagnostic(errors::ExpectedReturnTypeLabel::Other { span: hir_ty.span, expected });
+                        self.try_suggest_return_impl_trait(err, expected, ty, fn_id);
+                        return true;
+                    }
                 }
             }
             _ => {}

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -194,13 +194,13 @@ impl<'a> SourceKindMultiSuggestion<'a> {
         data: &'a FnRetTy<'a>,
         should_wrap_expr: Option<Span>,
     ) -> Self {
-        let (arrow, post) = match data {
-            FnRetTy::DefaultReturn(_) => ("-> ", " "),
-            _ => ("", ""),
+        let arrow = match data {
+            FnRetTy::DefaultReturn(_) => " -> ",
+            _ => "",
         };
         let (start_span, start_span_code, end_span) = match should_wrap_expr {
-            Some(end_span) => (data.span(), format!("{arrow}{ty_info}{post}{{ "), Some(end_span)),
-            None => (data.span(), format!("{arrow}{ty_info}{post}"), None),
+            Some(end_span) => (data.span(), format!("{arrow}{ty_info} {{"), Some(end_span)),
+            None => (data.span(), format!("{arrow}{ty_info}"), None),
         };
         Self::ClosureReturn { start_span, start_span_code, end_span }
     }

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -247,7 +247,7 @@ impl<'a> Parser<'a> {
             )?;
             FnRetTy::Ty(ty)
         } else {
-            FnRetTy::Default(self.token.span.shrink_to_lo())
+            FnRetTy::Default(self.prev_token.span.shrink_to_hi())
         })
     }
 

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_literal_unwrap.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_literal_unwrap.rs
@@ -102,14 +102,10 @@ pub(super) fn check(
             ]),
             ("None", "unwrap_or_else", _) => match args[0].kind {
                 hir::ExprKind::Closure(hir::Closure {
-                    fn_decl:
-                        hir::FnDecl {
-                            output: hir::FnRetTy::DefaultReturn(span) | hir::FnRetTy::Return(hir::Ty { span, .. }),
-                            ..
-                        },
+                    body,
                     ..
                 }) => Some(vec![
-                    (expr.span.with_hi(span.hi()), String::new()),
+                    (expr.span.with_hi(cx.tcx.hir().body(*body).value.span.lo()), String::new()),
                     (expr.span.with_lo(args[0].span.hi()), String::new()),
                 ]),
                 _ => None,

--- a/src/tools/clippy/tests/ui-toml/too_many_arguments/too_many_arguments.stderr
+++ b/src/tools/clippy/tests/ui-toml/too_many_arguments/too_many_arguments.stderr
@@ -2,7 +2,7 @@ error: this function has too many arguments (11/10)
   --> $DIR/too_many_arguments.rs:4:1
    |
 LL | fn too_many(p1: u8, p2: u8, p3: u8, p4: u8, p5: u8, p6: u8, p7: u8, p8: u8, p9: u8, p10: u8, p11: u8) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::too-many-arguments` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::too_many_arguments)]`

--- a/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
@@ -12,10 +12,10 @@ LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: &[u8]| x }]> {
    |                                                +
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/ice-6251.rs:4:53
+  --> $DIR/ice-6251.rs:4:54
    |
 LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: [u8]| x }]> {
-   |                                                     ^ doesn't have a size known at compile-time
+   |                                                      ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: the return type of a function must have a statically known size

--- a/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
@@ -12,10 +12,10 @@ LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: &[u8]| x }]> {
    |                                                +
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/ice-6251.rs:4:54
+  --> $DIR/ice-6251.rs:4:53
    |
 LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: [u8]| x }]> {
-   |                                                      ^ doesn't have a size known at compile-time
+   |                                                     ^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = note: the return type of a function must have a statically known size

--- a/src/tools/clippy/tests/ui/functions.stderr
+++ b/src/tools/clippy/tests/ui/functions.stderr
@@ -2,7 +2,7 @@ error: this function has too many arguments (8/7)
   --> $DIR/functions.rs:8:1
    |
 LL | fn bad(_one: u32, _two: u32, _three: &str, _four: bool, _five: f32, _six: f32, _seven: bool, _eight: ()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::too-many-arguments` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::too_many_arguments)]`
@@ -17,7 +17,7 @@ LL | |     two: u32,
 ...  |
 LL | |     eight: ()
 LL | | ) {
-   | |__^
+   | |_^
 
 error: this function has too many arguments (8/7)
   --> $DIR/functions.rs:48:5
@@ -29,7 +29,7 @@ error: this function has too many arguments (8/7)
   --> $DIR/functions.rs:58:5
    |
 LL |     fn bad_method(_one: u32, _two: u32, _three: &str, _four: bool, _five: f32, _six: f32, _seven: bool, _eight: ()) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> $DIR/functions.rs:68:34

--- a/src/tools/clippy/tests/ui/must_use_unit.stderr
+++ b/src/tools/clippy/tests/ui/must_use_unit.stderr
@@ -4,7 +4,7 @@ error: this unit-returning function has a `#[must_use]` attribute
 LL | #[must_use]
    | ----------- help: remove the attribute
 LL | pub fn must_use_default() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::must-use-unit` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::must_use_unit)]`
@@ -23,7 +23,7 @@ error: this unit-returning function has a `#[must_use]` attribute
 LL | #[must_use = "With note"]
    | ------------------------- help: remove the attribute
 LL | pub fn must_use_with_note() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/clippy/tests/ui/unnecessary_literal_unwrap.fixed
+++ b/src/tools/clippy/tests/ui/unnecessary_literal_unwrap.fixed
@@ -23,7 +23,7 @@ fn unwrap_option_none() {
     let _val: u16 = 234;
     let _val: u16 = 234;
     let _val: u16 = { 234 };
-    let _val: u16 =  { 234 };
+    let _val: u16 = { 234 };
 
     panic!();
     panic!("this always happens");
@@ -31,7 +31,7 @@ fn unwrap_option_none() {
     234;
     234;
     { 234 };
-     { 234 };
+    { 234 };
 }
 
 fn unwrap_result_ok() {

--- a/src/tools/clippy/tests/ui/unnecessary_literal_unwrap.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_literal_unwrap.stderr
@@ -116,7 +116,7 @@ LL |     let _val: u16 = None.unwrap_or_else(|| -> u16 { 234 });
 help: remove the `None` and `unwrap_or_else()`
    |
 LL -     let _val: u16 = None.unwrap_or_else(|| -> u16 { 234 });
-LL +     let _val: u16 =  { 234 };
+LL +     let _val: u16 = { 234 };
    |
 
 error: used `unwrap()` on `None` value
@@ -187,7 +187,7 @@ LL |     None::<u16>.unwrap_or_else(|| -> u16 { 234 });
 help: remove the `None` and `unwrap_or_else()`
    |
 LL -     None::<u16>.unwrap_or_else(|| -> u16 { 234 });
-LL +      { 234 };
+LL +     { 234 };
    |
 
 error: used `unwrap()` on `Ok` value

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -2599,7 +2599,8 @@ fn rewrite_fn_base(
     if where_clause_str.is_empty() {
         if let ast::FnRetTy::Default(ret_span) = fd.output {
             match recover_missing_comment_in_span(
-                mk_sp(params_span.hi(), ret_span.hi()),
+                // from after the closing paren to right before block or semicolon
+                mk_sp(ret_span.lo(), span.hi()),
                 shape,
                 context,
                 last_line_width(&result),

--- a/tests/ui/associated-type-bounds/issue-71443-1.stderr
+++ b/tests/ui/associated-type-bounds/issue-71443-1.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-71443-1.rs:6:5
    |
 LL | fn hello<F: for<'a> Iterator<Item: 'a>>() {
-   |                                           - help: try adding a return type: `-> Incorrect`
+   |                                          - help: try adding a return type: `-> Incorrect`
 LL |     Incorrect
    |     ^^^^^^^^^ expected `()`, found `Incorrect`
 

--- a/tests/ui/block-result/block-must-not-have-result-res.stderr
+++ b/tests/ui/block-result/block-must-not-have-result-res.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/block-must-not-have-result-res.rs:5:9
    |
 LL |     fn drop(&mut self) {
-   |                        - expected `()` because of default return type
+   |                       - expected `()` because of default return type
 LL |         true
    |         ^^^^ expected `()`, found `bool`
 

--- a/tests/ui/block-result/issue-20862.stderr
+++ b/tests/ui/block-result/issue-20862.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-20862.rs:2:5
    |
 LL | fn foo(x: i32) {
-   |                - help: a return type might be missing here: `-> _`
+   |               - help: a return type might be missing here: `-> _`
 LL |     |y| x + y
    |     ^^^^^^^^^ expected `()`, found closure
    |

--- a/tests/ui/block-result/issue-22645.stderr
+++ b/tests/ui/block-result/issue-22645.stderr
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-22645.rs:15:3
    |
 LL | fn main() {
-   |           - expected `()` because of default return type
+   |          - expected `()` because of default return type
 LL |   let b = Bob + 3.5;
 LL |   b + 3
    |   ^^^^^ expected `()`, found `Bob`

--- a/tests/ui/block-result/issue-5500.stderr
+++ b/tests/ui/block-result/issue-5500.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-5500.rs:2:5
    |
 LL | fn main() {
-   |           - expected `()` because of default return type
+   |          - expected `()` because of default return type
 LL |     &panic!()
    |     ^^^^^^^^^ expected `()`, found `&_`
    |

--- a/tests/ui/closures/add_semicolon_non_block_closure.stderr
+++ b/tests/ui/closures/add_semicolon_non_block_closure.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/add_semicolon_non_block_closure.rs:8:12
    |
 LL | fn main() {
-   |           - expected `()` because of default return type
+   |          - expected `()` because of default return type
 LL |     foo(|| bar())
    |            ^^^^^ expected `()`, found `i32`
    |

--- a/tests/ui/closures/binder/implicit-return.stderr
+++ b/tests/ui/closures/binder/implicit-return.stderr
@@ -1,8 +1,8 @@
 error: implicit types in closure signatures are forbidden when `for<...>` is present
-  --> $DIR/implicit-return.rs:4:34
+  --> $DIR/implicit-return.rs:4:33
    |
 LL |     let _f = for<'a> |_: &'a ()| {};
-   |              -------             ^
+   |              -------            ^
    |              |
    |              `for<...>` is here
 

--- a/tests/ui/closures/binder/implicit-stuff.stderr
+++ b/tests/ui/closures/binder/implicit-stuff.stderr
@@ -41,10 +41,10 @@ LL |     let _ = for<'a> |x: &'a ()| -> &() { x };
    |                                    ^ explicit lifetime name needed here
 
 error: implicit types in closure signatures are forbidden when `for<...>` is present
-  --> $DIR/implicit-stuff.rs:5:22
+  --> $DIR/implicit-stuff.rs:5:21
    |
 LL |     let _ = for<> || {};
-   |             -----    ^
+   |             -----   ^
    |             |
    |             `for<...>` is here
 

--- a/tests/ui/codemap_tests/tab.stderr
+++ b/tests/ui/codemap_tests/tab.stderr
@@ -8,7 +8,7 @@ error[E0308]: mismatched types
   --> $DIR/tab.rs:8:2
    |
 LL | fn foo() {
-   |          - help: try adding a return type: `-> &'static str`
+   |         - help: try adding a return type: `-> &'static str`
 LL |     "bar            boo"
    |     ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `&str`
 

--- a/tests/ui/compare-method/bad-self-type.stderr
+++ b/tests/ui/compare-method/bad-self-type.stderr
@@ -28,10 +28,10 @@ LL |     fn foo(self);
               found signature `fn(Box<MyFuture>)`
 
 error[E0053]: method `bar` has an incompatible type for trait
-  --> $DIR/bad-self-type.rs:24:18
+  --> $DIR/bad-self-type.rs:24:17
    |
 LL |     fn bar(self) {}
-   |                  ^ expected `Option<()>`, found `()`
+   |                 ^ expected `Option<()>`, found `()`
    |
 note: type in trait
   --> $DIR/bad-self-type.rs:18:21

--- a/tests/ui/impl-trait/in-trait/refine.stderr
+++ b/tests/ui/impl-trait/in-trait/refine.stderr
@@ -30,8 +30,8 @@ LL |     fn bar() {}
    = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
 help: replace the return type so that it matches the trait
    |
-LL |     fn bar() -> impl Sized {}
-   |              +++++++++++++
+LL |     fn bar()-> impl Sized  {}
+   |             +++++++++++++
 
 error: impl trait in impl method signature does not match trait method signature
   --> $DIR/refine.rs:22:17

--- a/tests/ui/issues/issue-66667-function-cmp-cycle.stderr
+++ b/tests/ui/issues/issue-66667-function-cmp-cycle.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-66667-function-cmp-cycle.rs:2:5
    |
 LL | fn first() {
-   |            - help: try adding a return type: `-> bool`
+   |           - help: try adding a return type: `-> bool`
 LL |     second == 1
    |     ^^^^^^^^^^^ expected `()`, found `bool`
 
@@ -44,7 +44,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-66667-function-cmp-cycle.rs:8:5
    |
 LL | fn second() {
-   |             - help: try adding a return type: `-> bool`
+   |            - help: try adding a return type: `-> bool`
 LL |     first == 1
    |     ^^^^^^^^^^ expected `()`, found `bool`
 
@@ -69,7 +69,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-66667-function-cmp-cycle.rs:14:5
    |
 LL | fn bar() {
-   |          - help: try adding a return type: `-> bool`
+   |         - help: try adding a return type: `-> bool`
 LL |     bar == 1
    |     ^^^^^^^^ expected `()`, found `bool`
 

--- a/tests/ui/lang-items/start_lang_item_args.missing_ret.stderr
+++ b/tests/ui/lang-items/start_lang_item_args.missing_ret.stderr
@@ -1,8 +1,8 @@
 error[E0308]: lang item `start` function has wrong type
-  --> $DIR/start_lang_item_args.rs:29:84
+  --> $DIR/start_lang_item_args.rs:29:83
    |
 LL | fn start<T>(_main: fn() -> T, _argc: isize, _argv: *const *const u8, _sigpipe: u8) {}
-   |                                                                                    ^ expected `isize`, found `()`
+   |                                                                                   ^ expected `isize`, found `()`
    |
    = note: expected signature `fn(fn() -> _, _, _, _) -> isize`
               found signature `fn(fn() -> _, _, _, _)`

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -319,7 +319,7 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:159:15
    |
 LL | fn main() {
-   |           - expected `()` because of this return type
+   |          - expected `()` because of this return type
 ...
 LL |     loop { // point at the return type
    |     ---- this loop is expected to be of type `()`

--- a/tests/ui/mismatched_types/issue-19109.stderr
+++ b/tests/ui/mismatched_types/issue-19109.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-19109.rs:4:5
    |
 LL | fn function(t: &mut dyn Trait) {
-   |                                - help: try adding a return type: `-> *mut dyn Trait`
+   |                               - help: try adding a return type: `-> *mut dyn Trait`
 LL |     t as *mut dyn Trait
    |     ^^^^^^^^^^^^^^^^^^^ expected `()`, found `*mut dyn Trait`
    |

--- a/tests/ui/offset-of/offset-of-output-type.stderr
+++ b/tests/ui/offset-of/offset-of-output-type.stderr
@@ -42,7 +42,7 @@ error[E0308]: mismatched types
   --> $DIR/offset-of-output-type.rs:19:5
    |
 LL | fn main() {
-   |           - expected `()` because of default return type
+   |          - expected `()` because of default return type
 ...
 LL |     offset_of!(S, v)
    |     ^^^^^^^^^^^^^^^^ expected `()`, found `usize`

--- a/tests/ui/parser/recover-quantified-closure.stderr
+++ b/tests/ui/parser/recover-quantified-closure.stderr
@@ -25,10 +25,10 @@ LL |     for <Foo>::Bar in x {}
    = help: consider removing `for<...>`
 
 error: implicit types in closure signatures are forbidden when `for<...>` is present
-  --> $DIR/recover-quantified-closure.rs:2:25
+  --> $DIR/recover-quantified-closure.rs:2:24
    |
 LL |     for<'a> |x: &'a u8| *x + 1;
-   |     -------             ^
+   |     -------            ^
    |     |
    |     `for<...>` is here
 

--- a/tests/ui/proc-macro/issue-37788.stderr
+++ b/tests/ui/proc-macro/issue-37788.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-37788.rs:8:5
    |
 LL | fn main() {
-   |           - expected `()` because of default return type
+   |          - expected `()` because of default return type
 LL |     // Test that constructing the `visible_parent_map` (in `cstore_impl.rs`) does not ICE.
 LL |     std::cell::Cell::new(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^- help: consider using a semicolon here: `;`

--- a/tests/ui/proc-macro/resolved-located-at.stderr
+++ b/tests/ui/proc-macro/resolved-located-at.stderr
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
   --> $DIR/resolved-located-at.rs:7:27
    |
 LL | fn main() {
-   |           - expected `()` because of default return type
+   |          - expected `()` because of default return type
 LL |     resolve_located_at!(a b)
    |                           ^ expected `()`, found `S`
    |

--- a/tests/ui/proc-macro/span-preservation.stderr
+++ b/tests/ui/proc-macro/span-preservation.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:39:5
    |
 LL | extern "C" fn bar() {
-   |                     - help: try adding a return type: `-> i32`
+   |                    - help: try adding a return type: `-> i32`
 LL |     0
    |     ^ expected `()`, found integer
 
@@ -46,7 +46,7 @@ error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:44:5
    |
 LL | extern "C" fn baz() {
-   |                     - help: try adding a return type: `-> i32`
+   |                    - help: try adding a return type: `-> i32`
 LL |     0
    |     ^ expected `()`, found integer
 
@@ -54,7 +54,7 @@ error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:49:5
    |
 LL | extern "Rust" fn rust_abi() {
-   |                             - help: try adding a return type: `-> i32`
+   |                            - help: try adding a return type: `-> i32`
 LL |     0
    |     ^ expected `()`, found integer
 
@@ -62,7 +62,7 @@ error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:54:5
    |
 LL | extern "\x43" fn c_abi_escaped() {
-   |                                  - help: try adding a return type: `-> i32`
+   |                                 - help: try adding a return type: `-> i32`
 LL |     0
    |     ^ expected `()`, found integer
 

--- a/tests/ui/return/return-struct.stderr
+++ b/tests/ui/return/return-struct.stderr
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
   --> $DIR/return-struct.rs:15:5
    |
 LL | fn bar() {
-   |          - help: try adding a return type: `-> Age`
+   |         - help: try adding a return type: `-> Age`
 LL |     let mut age = 29;
 LL |     Age::Years(age, 55)
    |     ^^^^^^^^^^^^^^^^^^^ expected `()`, found `Age`
@@ -26,7 +26,7 @@ error[E0308]: mismatched types
   --> $DIR/return-struct.rs:20:5
    |
 LL | fn baz() {
-   |          - help: try adding a return type: `-> S`
+   |         - help: try adding a return type: `-> S`
 LL |     S
    |     ^ expected `()`, found `S`
 

--- a/tests/ui/suggestions/issue-83892.stderr
+++ b/tests/ui/suggestions/issue-83892.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-83892.rs:9:15
    |
 LL | fn main() {
-   |           - expected `()` because of default return type
+   |          - expected `()` because of default return type
 LL |     match () {
 LL |         () => func()
    |               ^^^^^^ expected `()`, found `u8`

--- a/tests/ui/suggestions/return-closures.stderr
+++ b/tests/ui/suggestions/return-closures.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/return-closures.rs:3:5
    |
 LL | fn foo() {
-   |          - help: try adding a return type: `-> impl for<'a> Fn(&'a i32) -> i32`
+   |         - help: try adding a return type: `-> impl for<'a> Fn(&'a i32) -> i32`
 LL |
 LL |     |x: &i32| 1i32
    |     ^^^^^^^^^^^^^^ expected `()`, found closure
@@ -14,7 +14,7 @@ error[E0308]: mismatched types
   --> $DIR/return-closures.rs:9:5
    |
 LL | fn bar(i: impl Sized) {
-   |                       - help: a return type might be missing here: `-> _`
+   |                      - help: a return type might be missing here: `-> _`
 LL |
 LL |     || i
    |     ^^^^ expected `()`, found closure

--- a/tests/ui/suggestions/suggest-ret-on-async-w-late.fixed
+++ b/tests/ui/suggestions/suggest-ret-on-async-w-late.fixed
@@ -6,7 +6,7 @@
 // Make sure we don't ICE when suggesting a return type
 // for an async fn that has late-bound vars...
 
-async fn ice(_: &i32) {
+async fn ice(_: &i32) -> bool {
     true
     //~^ ERROR mismatched types
 }

--- a/tests/ui/suggestions/suggest-ret-on-async-w-late.stderr
+++ b/tests/ui/suggestions/suggest-ret-on-async-w-late.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/suggest-ret-on-async-w-late.rs:7:5
+  --> $DIR/suggest-ret-on-async-w-late.rs:10:5
    |
 LL | async fn ice(_: &i32) {
-   | --------------------- help: try adding a return type: `-> bool`
+   |                      - help: try adding a return type: `-> bool`
 LL |     true
    |     ^^^^ expected `()`, found `bool`
 

--- a/tests/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.stderr
+++ b/tests/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-57673-ice-on-deref-of-boxed-trait.rs:5:5
    |
 LL | fn ice(x: Box<dyn Iterator<Item=()>>) {
-   |                                       - help: try adding a return type: `-> (dyn Iterator<Item = ()> + 'static)`
+   |                                      - help: try adding a return type: `-> (dyn Iterator<Item = ()> + 'static)`
 LL |     *x
    |     ^^ expected `()`, found `dyn Iterator`
    |

--- a/tests/ui/typeck/issue-90027-async-fn-return-suggestion.stderr
+++ b/tests/ui/typeck/issue-90027-async-fn-return-suggestion.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-90027-async-fn-return-suggestion.rs:4:5
    |
 LL | async fn hello() {
-   | ---------------- help: try adding a return type: `-> i32`
+   |                 - help: try adding a return type: `-> i32`
 LL |     0
    |     ^ expected `()`, found integer
 
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-90027-async-fn-return-suggestion.rs:9:5
    |
 LL | async fn world() -> () {
-   | ---------------------- expected `()` because of return type
+   |                     -- expected `()` because of return type
 LL |     0
    |     ^ expected `()`, found integer
 

--- a/tests/ui/typeck/issue-91267.stderr
+++ b/tests/ui/typeck/issue-91267.stderr
@@ -14,7 +14,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-91267.rs:4:5
    |
 LL | fn main() {
-   |           - expected `()` because of default return type
+   |          - expected `()` because of default return type
 LL |     type_ascribe!(0, u8<e<5>=e>)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `u8`
 


### PR DESCRIPTION
When getting the "default return type" span, instead of pointing to the low span of the next token, point to the high span of the previous token. This:

1. Makes forming return type suggestions more uniform, since we expect them all in the same place.
2. Arguably makes labels easier to understand, since we're pointing to where the implicit `-> ()` would've gone, rather than the starting brace or the semicolon.

r? @estebank