### PR TITLE
Fix the wrong suggestion to add a format literal `"{}"` directly where a proc macro is invoked.

### DIFF
--- a/tests/ui/fmt/auxiliary/format_in_declarative_macro.rs
+++ b/tests/ui/fmt/auxiliary/format_in_declarative_macro.rs
@@ -1,0 +1,10 @@
+#![crate_type = "lib"]
+
+#[macro_export]
+macro_rules! external_decl {
+    () => {
+        fn external_decl_fn(test: impl ::std::fmt::Display) {
+            println!(test);
+        }
+    };
+}

--- a/tests/ui/fmt/auxiliary/format_in_macro.rs
+++ b/tests/ui/fmt/auxiliary/format_in_macro.rs
@@ -1,0 +1,29 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(derive)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    r#"fn derive_fn(text: impl ::std::fmt::Display) {
+    println!(text);
+}"#.parse().unwrap()
+}
+
+#[proc_macro]
+pub fn function(input: TokenStream) -> TokenStream {
+    r#"fn function_fn(text: impl ::std::fmt::Display) {
+    println!(text);
+}"#.parse().unwrap()
+}
+
+#[proc_macro_attribute]
+pub fn attribute(input: TokenStream, attribute: TokenStream) -> TokenStream {
+    r#"fn attribute_fn(text: impl ::std::fmt::Display) {
+    println!(text);
+}"#.parse().unwrap()
+}

--- a/tests/ui/fmt/format_in_declarative_macro.rs
+++ b/tests/ui/fmt/format_in_declarative_macro.rs
@@ -1,0 +1,18 @@
+// aux-build:format_in_declarative_macro.rs
+
+extern crate format_in_declarative_macro;
+macro_rules! by_example {
+    () => {
+        fn by_example_fn(test: impl ::std::fmt::Display) {
+            println!(test);
+            //~^ERROR format argument must be a string literal
+            //~|HELP you might be missing a string literal to format with
+        }
+    };
+}
+
+by_example!();
+format_in_declarative_macro::external_decl!();
+//~^ERROR format argument must be a string literal
+//~|HELP you might be missing a string literal to format with
+fn main() {}

--- a/tests/ui/fmt/format_in_declarative_macro.stderr
+++ b/tests/ui/fmt/format_in_declarative_macro.stderr
@@ -1,0 +1,30 @@
+error: format argument must be a string literal
+  --> $DIR/format_in_declarative_macro.rs:7:22
+   |
+LL |             println!(test);
+   |                      ^^^^
+...
+LL | by_example!();
+   | ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `by_example` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might be missing a string literal to format with
+   |
+LL |             println!("{}", test);
+   |                      +++++
+
+error: format argument must be a string literal
+  --> $DIR/format_in_declarative_macro.rs:15:1
+   |
+LL | format_in_declarative_macro::external_decl!();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `format_in_declarative_macro::external_decl` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might be missing a string literal to format with
+  --> $DIR/auxiliary/format_in_declarative_macro.rs:7:22
+   |
+LL |             println!("{}", test);
+   |                      +++++
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/fmt/format_in_macro.rs
+++ b/tests/ui/fmt/format_in_macro.rs
@@ -1,0 +1,24 @@
+// aux-build:format_in_macro.rs
+extern crate format_in_macro;
+#[derive(format_in_macro::derive)]
+pub struct Foo;
+//~^^ERROR format argument must be a string literal
+
+format_in_macro::function!();
+//~^ERROR format argument must be a string literal
+
+#[format_in_macro::attribute]
+const UNIT:() = ();
+//~^^ERROR format argument must be a string literal
+
+macro_rules! indirect {
+    () => {
+        format_in_macro::function!();
+        //~^ERROR format argument must be a string literal
+    }
+}
+fn new_scope() {
+    indirect!();
+}
+
+fn main() {}

--- a/tests/ui/fmt/format_in_macro.stderr
+++ b/tests/ui/fmt/format_in_macro.stderr
@@ -1,0 +1,53 @@
+error: format argument must be a string literal
+  --> $DIR/format_in_macro.rs:3:10
+   |
+LL | #[derive(format_in_macro::derive)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `format_in_macro::derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might be missing a string literal to format with
+   |
+LL | #[derive("{}", format_in_macro::derive)]
+   |          +++++
+
+error: format argument must be a string literal
+  --> $DIR/format_in_macro.rs:7:1
+   |
+LL | format_in_macro::function!();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `format_in_macro::function` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might be missing a string literal to format with
+   |
+LL | "{}", format_in_macro::function!();
+   | +++++
+
+error: format argument must be a string literal
+  --> $DIR/format_in_macro.rs:10:1
+   |
+LL | #[format_in_macro::attribute]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `format_in_macro::attribute` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might be missing a string literal to format with
+   |
+LL | "{}", #[format_in_macro::attribute]
+   | +++++
+
+error: format argument must be a string literal
+  --> $DIR/format_in_macro.rs:16:9
+   |
+LL |         format_in_macro::function!();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     indirect!();
+   |     ----------- in this macro invocation
+   |
+   = note: this error originates in the macro `format_in_macro::function` which comes from the expansion of the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might be missing a string literal to format with
+   |
+LL |         "{}", format_in_macro::function!();
+   |         +++++
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes #116190