### PR TITLE
Remove eval_always from check_private_in_public.

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1391,7 +1391,6 @@ rustc_queries! {
         desc { "checking effective visibilities" }
     }
     query check_private_in_public(_: ()) {
-        eval_always
         desc { "checking for private elements in public interfaces" }
     }
 


### PR DESCRIPTION
This PR attempts to avoid re-computing `check_private_in_public` query. First by marking the query as non-`eval_always`, and by reducing the amount of accesses to HIR as much as possible.

Latest perf https://github.com/rust-lang/rust/pull/116316#issuecomment-3094672105 shows that we manage it. The cost is extra dep-graph bookkeeping.