### PR TITLE
Add track_caller attribute to Result::unwrap_or_else

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1422,6 +1422,7 @@ impl<T, E> Result<T, E> {
     /// assert_eq!(Err("foo").unwrap_or_else(count), 3);
     /// ```
     #[inline]
+    #[track_caller]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap_or_else<F: FnOnce(E) -> T>(self, op: F) -> T {
         match self {


### PR DESCRIPTION
Fixes issue where panics in unwrap_or_else callbacks marked with the `track_caller` attribute appear as errors in core.