### PR TITLE
Fix default stack size in stdlib docs

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -125,7 +125,7 @@
 //! ## Stack size
 //!
 //! The default stack size is platform-dependent and subject to change.
-//! Currently, it is 2 MiB on all Tier-1 platforms.
+//! Currently, it is 8 MiB on all Tier-1 platforms.
 //!
 //! There are two ways to manually specify the stack size for spawned threads:
 //!


### PR DESCRIPTION
It was changed from 2 MiB to 8 MiB three years ago (https://github.com/rust-lang/rust/pull/55617). The size is now 8 MiB (https://github.com/rust-lang/rust/blob/8ed1d4a02ddd840a1efaca4e5e66881cbec5b0b3/compiler/rustc_interface/src/util.rs#L134).