### PR TITLE
update some comments around swap()

### DIFF
--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -996,7 +996,7 @@ pub type AssertMessage<'tcx> = AssertKind<Operand<'tcx>>;
 ///
 /// [UCG#319]: https://github.com/rust-lang/unsafe-code-guidelines/issues/319
 ///
-/// Rust currently requires that every place obey those two rules. This is checked by MIRI and taken
+/// Rust currently requires that every place obey those two rules. This is checked by Miri and taken
 /// advantage of by codegen (via `gep inbounds`). That is possibly subject to change.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, HashStable, TypeFoldable, TypeVisitable)]
 pub struct Place<'tcx> {

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -728,10 +728,6 @@ pub const fn swap<T>(x: &mut T, y: &mut T) {
     // reinterpretation of values as (chunkable) byte arrays, and the loop in the
     // block optimization in `swap_slice` is hard to rewrite back
     // into the (unoptimized) direct swapping implementation, so we disable it.
-    // FIXME(eddyb) the block optimization also prevents MIR optimizations from
-    // understanding `mem::replace`, `Option::take`, etc. - a better overall
-    // solution might be to make `ptr::swap_nonoverlapping` into an intrinsic, which
-    // a backend can choose to implement using the block optimization, or not.
     #[cfg(not(any(target_arch = "spirv")))]
     {
         // For types that are larger multiples of their alignment, the simple way
@@ -768,11 +764,14 @@ pub(crate) const fn swap_simple<T>(x: &mut T, y: &mut T) {
     // And LLVM actually optimizes it to 3×memcpy if called with
     // a type larger than it's willing to keep in a register.
     // Having typed reads and writes in MIR here is also good as
-    // it lets MIRI and CTFE understand them better, including things
+    // it lets Miri and CTFE understand them better, including things
     // like enforcing type validity for them.
     // Importantly, read+copy_nonoverlapping+write introduces confusing
     // asymmetry to the behaviour where one value went through read+write
     // whereas the other was copied over by the intrinsic (see #94371).
+    // Furthermore, using only read+write here benefits limited backends
+    // such as SPIR-V that work on an underlying *typed* view of memory,
+    // and thus have trouble with Rust's untyped memory operations.
 
     // SAFETY: exclusive references are always valid to read/write,
     // including being aligned, and nothing here panics so it's drop-safe.

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -663,7 +663,7 @@ fn array_mixed_equality_nans() {
 
 #[test]
 fn array_into_iter_fold() {
-    // Strings to help MIRI catch if we double-free or something
+    // Strings to help Miri catch if we double-free or something
     let a = ["Aa".to_string(), "Bb".to_string(), "Cc".to_string()];
     let mut s = "s".to_string();
     a.into_iter().for_each(|b| s += &b);
@@ -679,7 +679,7 @@ fn array_into_iter_fold() {
 
 #[test]
 fn array_into_iter_rfold() {
-    // Strings to help MIRI catch if we double-free or something
+    // Strings to help Miri catch if we double-free or something
     let a = ["Aa".to_string(), "Bb".to_string(), "Cc".to_string()];
     let mut s = "s".to_string();
     a.into_iter().rev().for_each(|b| s += &b);

--- a/tests/ui/consts/const-eval/nrvo.rs
+++ b/tests/ui/consts/const-eval/nrvo.rs
@@ -1,7 +1,8 @@
 // run-pass
 
 // When the NRVO is applied, the return place (`_0`) gets treated like a normal local. For example,
-// its address may be taken and it may be written to indirectly. Ensure that MIRI can handle this.
+// its address may be taken and it may be written to indirectly. Ensure that the const-eval
+// interpreter can handle this.
 
 #![feature(const_mut_refs)]
 


### PR DESCRIPTION
Based on @eddyb's comment [here](https://github.com/rust-lang/unsafe-code-guidelines/issues/461#issuecomment-1742156410).

And then I noticed the wrong capitalization for Miri and fixed it in some other places as well.