### PR TITLE
Make `DroplessArena::alloc_from_iter` like `TypedArena::alloc_from_iter`.

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -164,23 +164,6 @@ where
     }
 }
 
-impl<T, const N: usize> IterExt<T> for std::array::IntoIter<T, N> {
-    #[inline]
-    fn alloc_from_iter(self, arena: &TypedArena<T>) -> &mut [T] {
-        let len = self.len();
-        if len == 0 {
-            return &mut [];
-        }
-        // Move the content to the arena by copying and then forgetting it.
-        let start_ptr = arena.alloc_raw_slice(len);
-        unsafe {
-            self.as_slice().as_ptr().copy_to_nonoverlapping(start_ptr, len);
-            mem::forget(self);
-            slice::from_raw_parts_mut(start_ptr, len)
-        }
-    }
-}
-
 impl<T> IterExt<T> for Vec<T> {
     #[inline]
     fn alloc_from_iter(mut self, arena: &TypedArena<T>) -> &mut [T] {

--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -136,8 +136,8 @@ pub(super) fn explicit_item_bounds(
             };
             let args = GenericArgs::identity_for_item(tcx, def_id);
             let item_ty = Ty::new_opaque(tcx, def_id.to_def_id(), args);
-            tcx.arena.alloc_slice(
-                &opaque_type_bounds(tcx, def_id, bounds, item_ty, *span)
+            tcx.arena.alloc_from_iter(
+                opaque_type_bounds(tcx, def_id, bounds, item_ty, *span)
                     .to_vec()
                     .fold_with(&mut AssocTyToOpaque { tcx, fn_def_id: fn_def_id.to_def_id() }),
             )

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -469,7 +469,7 @@ pub(super) fn explicit_predicates_of<'tcx>(
         } else {
             ty::GenericPredicates {
                 parent: predicates_and_bounds.parent,
-                predicates: tcx.arena.alloc_slice(&predicates),
+                predicates: tcx.arena.alloc_from_iter(predicates),
             }
         }
     } else {

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -506,7 +506,7 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
         has_alloc_error_handler: |tcx, LocalCrate| CStore::from_tcx(tcx).has_alloc_error_handler(),
         postorder_cnums: |tcx, ()| {
             tcx.arena
-                .alloc_slice(&CStore::from_tcx(tcx).crate_dependencies_in_postorder(LOCAL_CRATE))
+                .alloc_from_iter(CStore::from_tcx(tcx).crate_dependencies_in_postorder(LOCAL_CRATE))
         },
         crates: |tcx, ()| {
             // The list of loaded crates is now frozen in query cache,

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2282,7 +2282,7 @@ pub fn provide(providers: &mut Providers) {
 
             // Bring everything into deterministic order.
             traits.sort_by_cached_key(|&def_id| tcx.def_path_hash(def_id));
-            tcx.arena.alloc_slice(&traits)
+            tcx.arena.alloc_from_iter(traits)
         },
         trait_impls_in_crate: |tcx, LocalCrate| {
             let mut trait_impls = Vec::new();
@@ -2296,7 +2296,7 @@ pub fn provide(providers: &mut Providers) {
 
             // Bring everything into deterministic order.
             trait_impls.sort_by_cached_key(|&def_id| tcx.def_path_hash(def_id));
-            tcx.arena.alloc_slice(&trait_impls)
+            tcx.arena.alloc_from_iter(trait_impls)
         },
 
         ..*providers

--- a/compiler/rustc_middle/src/ty/trait_def.rs
+++ b/compiler/rustc_middle/src/ty/trait_def.rs
@@ -269,5 +269,5 @@ pub(super) fn incoherent_impls_provider(tcx: TyCtxt<'_>, simp: SimplifiedType) -
 
     debug!(?impls);
 
-    tcx.arena.alloc_slice(&impls)
+    tcx.arena.alloc_from_iter(impls)
 }

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -171,5 +171,5 @@ pub(crate) fn mir_inliner_callees<'tcx>(
             calls.insert(call);
         }
     }
-    tcx.arena.alloc_from_iter(calls.iter().copied())
+    tcx.arena.alloc_from_iter(calls)
 }

--- a/compiler/rustc_ty_utils/src/implied_bounds.rs
+++ b/compiler/rustc_ty_utils/src/implied_bounds.rs
@@ -37,7 +37,7 @@ fn assumed_wf_types<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx [(Ty<'
                 liberated_sig.inputs_and_output,
                 fn_sig_spans(tcx, def_id),
             ));
-            tcx.arena.alloc_slice(&assumed_wf_types)
+            tcx.arena.alloc_from_iter(assumed_wf_types)
         }
         DefKind::Impl { .. } => {
             // Trait arguments and the self type for trait impls or only the self type for


### PR DESCRIPTION
Although they do similar things, they are currently implemented differently.

r? @ghost