### PR TITLE
Normalize opaques before defining them in the new solver

### DIFF
--- a/tests/ui/impl-trait/issues/issue-83919.current.stderr
+++ b/tests/ui/impl-trait/issues/issue-83919.current.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `{integer}` is not a future
-  --> $DIR/issue-83919.rs:21:26
+  --> $DIR/issue-83919.rs:23:26
    |
 LL |     fn get_fut(&self) -> Self::Fut {
    |                          ^^^^^^^^^ `{integer}` is not a future

--- a/tests/ui/impl-trait/issues/issue-83919.next.stderr
+++ b/tests/ui/impl-trait/issues/issue-83919.next.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-83919.rs:25:9
+   |
+LL |       fn get_fut(&self) -> Self::Fut {
+   |                            --------- expected `<Implementor as Foo>::Fut` because of return type
+LL |
+LL | /         async move {
+LL | |
+LL | |             42
+LL | |             // 42 does not impl Future and rustc does actually point out the error,
+LL | |             // but rustc used to panic.
+LL | |             // Putting a valid Future here always worked fine.
+LL | |         }
+   | |_________^ types differ
+   |
+   = note: expected associated type `<Implementor as Foo>::Fut`
+                found `async` block `{async block@$DIR/issue-83919.rs:25:9: 31:10}`
+   = help: consider constraining the associated type `<Implementor as Foo>::Fut` to `{async block@$DIR/issue-83919.rs:25:9: 31:10}` or calling a method that returns `<Implementor as Foo>::Fut`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/issues/issue-83919.rs
+++ b/tests/ui/impl-trait/issues/issue-83919.rs
@@ -1,6 +1,8 @@
-#![feature(impl_trait_in_assoc_type)]
-
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 // edition:2021
+
+#![feature(impl_trait_in_assoc_type)]
 
 use std::future::Future;
 
@@ -19,8 +21,9 @@ impl Foo for Implementor {
     type Fut = impl Future<Output = Self::Fut2>;
 
     fn get_fut(&self) -> Self::Fut {
-        //~^ ERROR `{integer}` is not a future
+        //[current]~^ ERROR `{integer}` is not a future
         async move {
+            //[next]~^ ERROR mismatched types
             42
             // 42 does not impl Future and rustc does actually point out the error,
             // but rustc used to panic.

--- a/tests/ui/impl-trait/recursive-generator.current.stderr
+++ b/tests/ui/impl-trait/recursive-generator.current.stderr
@@ -1,5 +1,5 @@
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-generator.rs:5:13
+  --> $DIR/recursive-generator.rs:8:13
    |
 LL | fn foo() -> impl Generator<Yield = (), Return = ()> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ recursive opaque type

--- a/tests/ui/impl-trait/recursive-generator.next.stderr
+++ b/tests/ui/impl-trait/recursive-generator.next.stderr
@@ -1,0 +1,12 @@
+error[E0720]: cannot resolve opaque type
+  --> $DIR/recursive-generator.rs:8:13
+   |
+LL | fn foo() -> impl Generator<Yield = (), Return = ()> {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ recursive opaque type
+...
+LL |         let mut gen = Box::pin(foo());
+   |             ------- generator captures itself here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0720`.

--- a/tests/ui/impl-trait/recursive-generator.rs
+++ b/tests/ui/impl-trait/recursive-generator.rs
@@ -1,3 +1,6 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+
 #![feature(generators, generator_trait)]
 
 use std::ops::{Generator, GeneratorState};

--- a/tests/ui/impl-trait/two_tait_defining_each_other.current.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other.current.stderr
@@ -1,16 +1,16 @@
 error: opaque type's hidden type cannot be another opaque type from the same scope
-  --> $DIR/two_tait_defining_each_other.rs:12:5
+  --> $DIR/two_tait_defining_each_other.rs:16:5
    |
 LL |     x // A's hidden type is `Bar`, because all the hidden types of `B` are compared with each other
    |     ^ one of the two opaque types used here has to be outside its defining scope
    |
 note: opaque type whose hidden type is being assigned
-  --> $DIR/two_tait_defining_each_other.rs:4:10
+  --> $DIR/two_tait_defining_each_other.rs:8:10
    |
 LL | type B = impl Foo;
    |          ^^^^^^^^
 note: opaque type being used as hidden type
-  --> $DIR/two_tait_defining_each_other.rs:3:10
+  --> $DIR/two_tait_defining_each_other.rs:7:10
    |
 LL | type A = impl Foo;
    |          ^^^^^^^^

--- a/tests/ui/impl-trait/two_tait_defining_each_other.rs
+++ b/tests/ui/impl-trait/two_tait_defining_each_other.rs
@@ -1,3 +1,7 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+//[next] check-pass
+
 #![feature(type_alias_impl_trait)]
 
 type A = impl Foo;
@@ -10,7 +14,7 @@ fn muh(x: A) -> B {
         return Bar; // B's hidden type is Bar
     }
     x // A's hidden type is `Bar`, because all the hidden types of `B` are compared with each other
-    //~^ ERROR opaque type's hidden type cannot be another opaque type
+    //[current]~^ ERROR opaque type's hidden type cannot be another opaque type
 }
 
 struct Bar;

--- a/tests/ui/impl-trait/two_tait_defining_each_other3.current.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other3.current.stderr
@@ -1,16 +1,16 @@
 error: opaque type's hidden type cannot be another opaque type from the same scope
-  --> $DIR/two_tait_defining_each_other3.rs:10:16
+  --> $DIR/two_tait_defining_each_other3.rs:14:16
    |
 LL |         return x;  // B's hidden type is A (opaquely)
    |                ^ one of the two opaque types used here has to be outside its defining scope
    |
 note: opaque type whose hidden type is being assigned
-  --> $DIR/two_tait_defining_each_other3.rs:4:10
+  --> $DIR/two_tait_defining_each_other3.rs:8:10
    |
 LL | type B = impl Foo;
    |          ^^^^^^^^
 note: opaque type being used as hidden type
-  --> $DIR/two_tait_defining_each_other3.rs:3:10
+  --> $DIR/two_tait_defining_each_other3.rs:7:10
    |
 LL | type A = impl Foo;
    |          ^^^^^^^^

--- a/tests/ui/impl-trait/two_tait_defining_each_other3.rs
+++ b/tests/ui/impl-trait/two_tait_defining_each_other3.rs
@@ -1,3 +1,7 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+//[next] check-pass
+
 #![feature(type_alias_impl_trait)]
 
 type A = impl Foo;
@@ -8,7 +12,7 @@ trait Foo {}
 fn muh(x: A) -> B {
     if false {
         return x;  // B's hidden type is A (opaquely)
-        //~^ ERROR opaque type's hidden type cannot be another opaque type
+        //[current]~^ ERROR opaque type's hidden type cannot be another opaque type
     }
     Bar // A's hidden type is `Bar`, because all the return types are compared with each other
 }

--- a/tests/ui/traits/new-solver/opaque-hidden-ty-is-rigid-projection.rs
+++ b/tests/ui/traits/new-solver/opaque-hidden-ty-is-rigid-projection.rs
@@ -1,0 +1,8 @@
+// known-bug: unknown
+// compile-flags: -Ztrait-solver=next
+
+fn test<T: Iterator>(x: T::Item) -> impl Sized {
+    x
+}
+
+fn main() {}

--- a/tests/ui/traits/new-solver/opaque-hidden-ty-is-rigid-projection.stderr
+++ b/tests/ui/traits/new-solver/opaque-hidden-ty-is-rigid-projection.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/opaque-hidden-ty-is-rigid-projection.rs:5:5
+   |
+LL | fn test<T: Iterator>(x: T::Item) -> impl Sized {
+   |                                     ----------
+   |                                     |
+   |                                     the expected opaque type
+   |                                     expected `impl Sized` because of return type
+LL |     x
+   |     ^ types differ
+   |
+   = note:  expected opaque type `impl Sized`
+           found associated type `<T as Iterator>::Item`
+help: consider constraining the associated type `<T as Iterator>::Item` to `impl Sized`
+   |
+LL | fn test<T: Iterator<Item = impl Sized>>(x: T::Item) -> impl Sized {
+   |                    +++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/assoc-type-const.rs
+++ b/tests/ui/type-alias-impl-trait/assoc-type-const.rs
@@ -1,6 +1,9 @@
 // Tests that we properly detect defining usages when using
 // const generics in an associated opaque type
+
 // check-pass
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 
 #![feature(impl_trait_in_assoc_type)]
 

--- a/tests/ui/type-alias-impl-trait/assoc-type-lifetime.rs
+++ b/tests/ui/type-alias-impl-trait/assoc-type-lifetime.rs
@@ -1,6 +1,9 @@
 // Tests that we still detect defining usages when
 // lifetimes are used in an associated opaque type
+
 // check-pass
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 
 #![feature(impl_trait_in_assoc_type)]
 

--- a/tests/ui/type-alias-impl-trait/issue-78450.rs
+++ b/tests/ui/type-alias-impl-trait/issue-78450.rs
@@ -1,4 +1,6 @@
 // check-pass
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
 
 #![feature(impl_trait_in_assoc_type)]
 

--- a/tests/ui/type-alias-impl-trait/wf-in-associated-type.fail.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-in-associated-type.fail.stderr
@@ -1,5 +1,5 @@
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/wf-in-associated-type.rs:36:23
+  --> $DIR/wf-in-associated-type.rs:38:23
    |
 LL |     impl<'a, T> Trait<'a, T> for () {
    |          -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
@@ -12,7 +12,7 @@ LL |     impl<'a, T: 'a> Trait<'a, T> for () {
    |               ++++
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/wf-in-associated-type.rs:36:23
+  --> $DIR/wf-in-associated-type.rs:38:23
    |
 LL |     impl<'a, T> Trait<'a, T> for () {
    |          -- the parameter type `T` must be valid for the lifetime `'a` as defined here...

--- a/tests/ui/type-alias-impl-trait/wf-in-associated-type.rs
+++ b/tests/ui/type-alias-impl-trait/wf-in-associated-type.rs
@@ -1,14 +1,16 @@
 // WF check for impl Trait in associated type position.
 //
-// revisions: pass fail
+// revisions: pass pass_next fail
 // [pass] check-pass
+// [pass_next] compile-flags: -Ztrait-solver=next
+// [pass_next] check-pass
 // [fail] check-fail
 
 #![feature(impl_trait_in_assoc_type)]
 
 // The hidden type here (`&'a T`) requires proving `T: 'a`.
 // We know it holds because of implied bounds from the impl header.
-#[cfg(pass)]
+#[cfg(any(pass, pass_next))]
 mod pass {
     trait Trait<Req> {
         type Opaque1;


### PR DESCRIPTION
We normalize the hidden type of an opaque before defining it to ensure that we don't:
1. Infer a hidden type that is normalizes to the opaque directly
2. Infer a hidden type that normalizes to an infer var, which can then be set to the opaque

Tests are a combination of things that went from ICE -> (expected) fail, and fail -> pass.

r? lcnr