### PR TITLE
Create the previous dep graph index on a background thread

### DIFF
--- a/compiler/rustc_data_structures/src/marker.rs
+++ b/compiler/rustc_data_structures/src/marker.rs
@@ -71,6 +71,7 @@ macro_rules! impl_dyn_send {
 }
 
 impl_dyn_send!(
+    [std::thread::JoinHandle<T> where T]
     [std::sync::atomic::AtomicPtr<T> where T]
     [std::sync::Mutex<T> where T: ?Sized+ DynSend]
     [std::sync::mpsc::Sender<T> where T: DynSend]
@@ -154,6 +155,7 @@ macro_rules! impl_dyn_sync {
 }
 
 impl_dyn_sync!(
+    [std::thread::JoinHandle<T> where T]
     [std::sync::atomic::AtomicPtr<T> where T]
     [std::sync::OnceLock<T> where T: DynSend + DynSync]
     [std::sync::Mutex<T> where T: ?Sized + DynSend]

--- a/compiler/rustc_incremental/src/persist/save.rs
+++ b/compiler/rustc_incremental/src/persist/save.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::sync::join;
 use rustc_middle::dep_graph::{
-    DepGraph, SerializedDepGraph, WorkProduct, WorkProductId, WorkProductMap,
+    DepGraph, DepsType, SerializedDepGraph, WorkProduct, WorkProductId, WorkProductMap,
 };
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::Encodable as RustcEncodable;
@@ -144,7 +144,7 @@ fn encode_query_cache(tcx: TyCtxt<'_>, encoder: FileEncoder) -> FileEncodeResult
 /// and moves it to the permanent dep-graph path
 pub(crate) fn build_dep_graph(
     sess: &Session,
-    prev_graph: Arc<SerializedDepGraph>,
+    prev_graph: Arc<SerializedDepGraph<DepsType>>,
     prev_work_products: WorkProductMap,
 ) -> Option<DepGraph> {
     if sess.opts.incremental.is_none() {

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -91,7 +91,7 @@ pub(crate) struct DepGraphData<D: Deps> {
 
     /// The dep-graph from the previous compilation session. It contains all
     /// nodes and edges as well as all fingerprints of nodes that have them.
-    previous: Arc<SerializedDepGraph>,
+    previous: Arc<SerializedDepGraph<D>>,
 
     colors: DepNodeColorMap,
 
@@ -121,7 +121,7 @@ where
 impl<D: Deps> DepGraph<D> {
     pub fn new(
         session: &Session,
-        prev_graph: Arc<SerializedDepGraph>,
+        prev_graph: Arc<SerializedDepGraph<D>>,
         prev_work_products: WorkProductMap,
         encoder: FileEncoder,
     ) -> DepGraph<D> {
@@ -1192,7 +1192,7 @@ impl<D: Deps> CurrentDepGraph<D> {
         session: &Session,
         prev_graph_node_count: usize,
         encoder: FileEncoder,
-        previous: Arc<SerializedDepGraph>,
+        previous: Arc<SerializedDepGraph<D>>,
     ) -> Self {
         let mut stable_hasher = StableHasher::new();
         previous.session_count().hash(&mut stable_hasher);
@@ -1281,7 +1281,7 @@ impl<D: Deps> CurrentDepGraph<D> {
     #[inline]
     fn debug_assert_not_in_new_nodes(
         &self,
-        prev_graph: &SerializedDepGraph,
+        prev_graph: &SerializedDepGraph<D>,
         prev_index: SerializedDepNodeIndex,
     ) {
         if let Some(ref nodes_in_current_session) = self.nodes_in_current_session {

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use graph::DepGraphData;
 pub use graph::{DepGraph, DepNodeIndex, TaskDepsRef, WorkProduct, WorkProductMap, hash_result};
 pub use query::DepGraphQuery;
 use rustc_data_structures::profiling::SelfProfilerRef;
-use rustc_data_structures::sync::DynSync;
+use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_session::Session;
 pub use serialized::{SerializedDepGraph, SerializedDepNodeIndex};
 use tracing::instrument;
@@ -92,7 +92,7 @@ pub trait DepContext: Copy {
     fn with_reduced_queries<T>(self, _: impl FnOnce() -> T) -> T;
 }
 
-pub trait Deps: DynSync {
+pub trait Deps: DynSend + DynSync + Send + Sync + 'static {
     /// Execute the operation with provided dependencies.
     fn with_deps<OP, R>(deps: TaskDepsRef<'_>, op: OP) -> R
     where


### PR DESCRIPTION
This changes `SerializedDepGraph.index` to be computed on-demand per dep kind. This means we can immediately start using queries without waiting for the entire index to be constructed. Additionally a background thread is started which computes the entire index, effectively off-loading most of the index construction to the background thread.

<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th><td align="right">Memory</td><td align="right">Memory</td><td align="right">%</th></tr><tr><td>🟣 <b>clap</b>:check:unchanged</td><td align="right">0.4259s</td><td align="right">0.4225s</td><td align="right"> -0.79%</td><td align="right">89.65 MiB</td><td align="right">90.08 MiB</td><td align="right"> 0.48%</td></tr><tr><td>🟣 <b>hyper</b>:check:unchanged</td><td align="right">0.1425s</td><td align="right">0.1417s</td><td align="right"> -0.53%</td><td align="right">47.85 MiB</td><td align="right">47.91 MiB</td><td align="right"> 0.13%</td></tr><tr><td>🟣 <b>regex</b>:check:unchanged</td><td align="right">0.3188s</td><td align="right">0.3157s</td><td align="right"> -0.97%</td><td align="right">71.09 MiB</td><td align="right">71.58 MiB</td><td align="right"> 0.69%</td></tr><tr><td>🟣 <b>syn</b>:check:unchanged</td><td align="right">0.5895s</td><td align="right">0.5813s</td><td align="right">💚  -1.38%</td><td align="right">101.68 MiB</td><td align="right">102.15 MiB</td><td align="right"> 0.47%</td></tr><tr><td>🟣 <b>syntex_syntax</b>:check:unchanged</td><td align="right">1.4392s</td><td align="right">1.4361s</td><td align="right"> -0.22%</td><td align="right">200.62 MiB</td><td align="right">201.68 MiB</td><td align="right"> 0.53%</td></tr><tr><td>Total</td><td align="right">2.9158s</td><td align="right">2.8974s</td><td align="right"> -0.63%</td><td align="right">510.89 MiB</td><td align="right">513.40 MiB</td><td align="right"> 0.49%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">0.9922s</td><td align="right"> -0.78%</td><td align="right">1 byte</td><td align="right">1.00 bytes</td><td align="right"> 0.46%</td></tr></table>

<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th><td align="right">Memory</td><td align="right">Memory</td><td align="right">%</th></tr><tr><td>🟠 <b>clap</b>:debug:unchanged</td><td align="right">1.0753s</td><td align="right">1.0684s</td><td align="right"> -0.64%</td><td align="right">142.80 MiB</td><td align="right">142.72 MiB</td><td align="right"> -0.05%</td></tr><tr><td>🟠 <b>hyper</b>:debug:unchanged</td><td align="right">0.2857s</td><td align="right">0.2847s</td><td align="right"> -0.35%</td><td align="right">63.06 MiB</td><td align="right">63.15 MiB</td><td align="right"> 0.13%</td></tr><tr><td>🟠 <b>regex</b>:debug:unchanged</td><td align="right">0.7703s</td><td align="right">0.7633s</td><td align="right"> -0.90%</td><td align="right">108.76 MiB</td><td align="right">109.03 MiB</td><td align="right"> 0.25%</td></tr><tr><td>🟠 <b>syn</b>:debug:unchanged</td><td align="right">1.0596s</td><td align="right">1.0531s</td><td align="right"> -0.62%</td><td align="right">142.08 MiB</td><td align="right">142.18 MiB</td><td align="right"> 0.07%</td></tr><tr><td>🟠 <b>syntex_syntax</b>:debug:unchanged</td><td align="right">2.7530s</td><td align="right">2.7274s</td><td align="right"> -0.93%</td><td align="right">308.92 MiB</td><td align="right">308.63 MiB</td><td align="right"> -0.09%</td></tr><tr><td>Total</td><td align="right">5.9438s</td><td align="right">5.8969s</td><td align="right"> -0.79%</td><td align="right">765.62 MiB</td><td align="right">765.71 MiB</td><td align="right"> 0.01%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">0.9931s</td><td align="right"> -0.69%</td><td align="right">1 byte</td><td align="right">1.00 bytes</td><td align="right"> 0.06%</td></tr></table>

r? @cjgillot 