### PR TITLE
Normalize opaque alias type

### DIFF
--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -687,7 +687,14 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
 
                 let kind = match parent_ty.ty.kind() {
                     &ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) => {
-                        self.tcx.type_of(def_id).instantiate(self.tcx, args).kind()
+                        let ty = self.tcx.type_of(def_id).instantiate(self.tcx, args);
+                        // If the type we get is opaque, we want to normalize it.
+                        if ty.is_impl_trait() {
+                            let inner_ty = self.tcx.expand_opaque_types(ty).kind();
+                            inner_ty
+                        } else {
+                            ty.kind()
+                        }
                     }
                     kind => kind,
                 };

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -690,7 +690,8 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                         let ty = self.tcx.type_of(def_id).instantiate(self.tcx, args);
                         // If the type we get is opaque, we want to normalize it.
                         if ty.is_impl_trait() {
-                            let inner_ty = self.tcx.expand_opaque_types(ty).kind();
+                            let inner_ty =
+                                self.tcx.normalize_erasing_regions(self.param_env, ty).kind();
                             inner_ty
                         } else {
                             ty.kind()

--- a/tests/ui/type-alias-impl-trait/normalize-alias-type.rs
+++ b/tests/ui/type-alias-impl-trait/normalize-alias-type.rs
@@ -1,0 +1,32 @@
+// check-pass
+// compile-flags: -Z mir-opt-level=3
+#![feature(type_alias_impl_trait)]
+#![crate_type = "lib"]
+pub trait Tr {
+    fn get(&self) -> u32;
+}
+
+impl Tr for (u32,) {
+    #[inline]
+    fn get(&self) -> u32 { self.0 }
+}
+
+pub fn tr1() -> impl Tr {
+    (32,)
+}
+
+pub fn tr2() -> impl Tr {
+    struct Inner {
+        x: X,
+    }
+    type X = impl Tr;
+    impl Tr for Inner {
+        fn get(&self) -> u32 {
+            self.x.get()
+        }
+    }
+
+    Inner {
+        x: tr1(),
+    }
+}

--- a/tests/ui/type-alias-impl-trait/tait-normalize.rs
+++ b/tests/ui/type-alias-impl-trait/tait-normalize.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+fn enum_upvar() {
+    type T = impl Copy;
+    let foo: T = Some((1u32, 2u32));
+    let x = move || match foo {
+        None => (),
+        Some((a, b)) => (),
+    };
+}
+
+fn main(){}


### PR DESCRIPTION
In cases like https://github.com/rust-lang/rust/issues/116332, we might end up with `Alias(Opaque)`, which causes match to ICE, this fixes that by normalizing opaque value we get.

Fixes #116332
Fixes https://github.com/rust-lang/rust/issues/116265
Fixes https://github.com/rust-lang/rust/issues/116383

r? @oli-obk 