### PR TITLE
non_lifetime_binders: fix ICE in lint opaque-hidden-inferred-bound

### DIFF
--- a/tests/ui/traits/non_lifetime_binders/on-rpit.rs
+++ b/tests/ui/traits/non_lifetime_binders/on-rpit.rs
@@ -1,0 +1,16 @@
+// check-pass
+
+#![feature(non_lifetime_binders)]
+//~^ WARN the feature `non_lifetime_binders` is incomplete
+
+trait Trait<T: ?Sized> {}
+
+impl<T: ?Sized> Trait<T> for i32 {}
+
+fn produce() -> impl for<T> Trait<T> {
+    16
+}
+
+fn main() {
+    let _ = produce();
+}

--- a/tests/ui/traits/non_lifetime_binders/on-rpit.stderr
+++ b/tests/ui/traits/non_lifetime_binders/on-rpit.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/on-rpit.rs:3:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Opaque types like `impl for<T> Trait<T>` would previously lead to an ICE.

r? @compiler-errors