### PR TITLE
Rename MaybeUninit::write_slice

### DIFF
--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -289,7 +289,7 @@ impl<'a> BorrowedCursor<'a> {
 
         // SAFETY: we do not de-initialize any of the elements of the slice
         unsafe {
-            MaybeUninit::write_slice(&mut self.as_mut()[..buf.len()], buf);
+            MaybeUninit::copy_from_slice(&mut self.as_mut()[..buf.len()], buf);
         }
 
         // SAFETY: We just added the entire contents of buf to the filled section.

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1019,7 +1019,7 @@ impl<T> MaybeUninit<T> {
 
     /// Copies the elements from `src` to `this`, returning a mutable reference to the now initialized contents of `this`.
     ///
-    /// If `T` does not implement `Copy`, use [`write_slice_cloned`]
+    /// If `T` does not implement `Copy`, use [`clone_from_slice`]
     ///
     /// This is similar to [`slice::copy_from_slice`].
     ///
@@ -1036,7 +1036,7 @@ impl<T> MaybeUninit<T> {
     /// let mut dst = [MaybeUninit::uninit(); 32];
     /// let src = [0; 32];
     ///
-    /// let init = MaybeUninit::write_slice(&mut dst, &src);
+    /// let init = MaybeUninit::copy_from_slice(&mut dst, &src);
     ///
     /// assert_eq!(init, src);
     /// ```
@@ -1048,7 +1048,7 @@ impl<T> MaybeUninit<T> {
     /// let mut vec = Vec::with_capacity(32);
     /// let src = [0; 16];
     ///
-    /// MaybeUninit::write_slice(&mut vec.spare_capacity_mut()[..src.len()], &src);
+    /// MaybeUninit::copy_from_slice(&mut vec.spare_capacity_mut()[..src.len()], &src);
     ///
     /// // SAFETY: we have just copied all the elements of len into the spare capacity
     /// // the first src.len() elements of the vec are valid now.
@@ -1059,9 +1059,9 @@ impl<T> MaybeUninit<T> {
     /// assert_eq!(vec, src);
     /// ```
     ///
-    /// [`write_slice_cloned`]: MaybeUninit::write_slice_cloned
+    /// [`clone_from_slice`]: MaybeUninit::clone_from_slice
     #[unstable(feature = "maybe_uninit_write_slice", issue = "79995")]
-    pub fn write_slice<'a>(this: &'a mut [MaybeUninit<T>], src: &[T]) -> &'a mut [T]
+    pub fn copy_from_slice<'a>(this: &'a mut [MaybeUninit<T>], src: &[T]) -> &'a mut [T]
     where
         T: Copy,
     {
@@ -1077,7 +1077,7 @@ impl<T> MaybeUninit<T> {
     /// Clones the elements from `src` to `this`, returning a mutable reference to the now initialized contents of `this`.
     /// Any already initialized elements will not be dropped.
     ///
-    /// If `T` implements `Copy`, use [`write_slice`]
+    /// If `T` implements `Copy`, use [`copy_from_slice`]
     ///
     /// This is similar to [`slice::clone_from_slice`] but does not drop existing elements.
     ///
@@ -1096,7 +1096,7 @@ impl<T> MaybeUninit<T> {
     /// let mut dst = [MaybeUninit::uninit(), MaybeUninit::uninit(), MaybeUninit::uninit(), MaybeUninit::uninit(), MaybeUninit::uninit()];
     /// let src = ["wibbly".to_string(), "wobbly".to_string(), "timey".to_string(), "wimey".to_string(), "stuff".to_string()];
     ///
-    /// let init = MaybeUninit::write_slice_cloned(&mut dst, &src);
+    /// let init = MaybeUninit::clone_from_slice(&mut dst, &src);
     ///
     /// assert_eq!(init, src);
     /// ```
@@ -1108,7 +1108,7 @@ impl<T> MaybeUninit<T> {
     /// let mut vec = Vec::with_capacity(32);
     /// let src = ["rust", "is", "a", "pretty", "cool", "language"];
     ///
-    /// MaybeUninit::write_slice_cloned(&mut vec.spare_capacity_mut()[..src.len()], &src);
+    /// MaybeUninit::clone_from_slice(&mut vec.spare_capacity_mut()[..src.len()], &src);
     ///
     /// // SAFETY: we have just cloned all the elements of len into the spare capacity
     /// // the first src.len() elements of the vec are valid now.
@@ -1119,9 +1119,9 @@ impl<T> MaybeUninit<T> {
     /// assert_eq!(vec, src);
     /// ```
     ///
-    /// [`write_slice`]: MaybeUninit::write_slice
+    /// [`copy_from_slice`]: MaybeUninit::copy_from_slice
     #[unstable(feature = "maybe_uninit_write_slice", issue = "79995")]
-    pub fn write_slice_cloned<'a>(this: &'a mut [MaybeUninit<T>], src: &[T]) -> &'a mut [T]
+    pub fn clone_from_slice<'a>(this: &'a mut [MaybeUninit<T>], src: &[T]) -> &'a mut [T]
     where
         T: Clone,
     {
@@ -1264,7 +1264,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// let mut uninit = [MaybeUninit::<u16>::uninit(), MaybeUninit::<u16>::uninit()];
     /// let uninit_bytes = MaybeUninit::slice_as_bytes_mut(&mut uninit);
-    /// MaybeUninit::write_slice(uninit_bytes, &[0x12, 0x34, 0x56, 0x78]);
+    /// MaybeUninit::copy_from_slice(uninit_bytes, &[0x12, 0x34, 0x56, 0x78]);
     /// let vals = unsafe { MaybeUninit::slice_assume_init_ref(&uninit) };
     /// if cfg!(target_endian = "little") {
     ///     assert_eq!(vals, &[0x3412u16, 0x7856u16]);

--- a/library/core/src/net/display_buffer.rs
+++ b/library/core/src/net/display_buffer.rs
@@ -30,7 +30,7 @@ impl<const SIZE: usize> fmt::Write for DisplayBuffer<SIZE> {
         let bytes = s.as_bytes();
 
         if let Some(buf) = self.buf.get_mut(self.len..(self.len + bytes.len())) {
-            MaybeUninit::write_slice(buf, bytes);
+            MaybeUninit::copy_from_slice(buf, bytes);
             self.len += bytes.len();
             Ok(())
         } else {

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -205,7 +205,7 @@ fn uninit_write_slice() {
     let mut dst = [MaybeUninit::new(255); 64];
     let src = [0; 64];
 
-    assert_eq!(MaybeUninit::write_slice(&mut dst, &src), &src);
+    assert_eq!(MaybeUninit::copy_from_slice(&mut dst, &src), &src);
 }
 
 #[test]
@@ -214,7 +214,7 @@ fn uninit_write_slice_panic_lt() {
     let mut dst = [MaybeUninit::uninit(); 64];
     let src = [0; 32];
 
-    MaybeUninit::write_slice(&mut dst, &src);
+    MaybeUninit::copy_from_slice(&mut dst, &src);
 }
 
 #[test]
@@ -223,7 +223,7 @@ fn uninit_write_slice_panic_gt() {
     let mut dst = [MaybeUninit::uninit(); 64];
     let src = [0; 128];
 
-    MaybeUninit::write_slice(&mut dst, &src);
+    MaybeUninit::copy_from_slice(&mut dst, &src);
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn uninit_clone_from_slice() {
     let mut dst = [MaybeUninit::new(255); 64];
     let src = [0; 64];
 
-    assert_eq!(MaybeUninit::write_slice_cloned(&mut dst, &src), &src);
+    assert_eq!(MaybeUninit::clone_from_slice(&mut dst, &src), &src);
 }
 
 #[test]
@@ -240,7 +240,7 @@ fn uninit_write_slice_cloned_panic_lt() {
     let mut dst = [MaybeUninit::uninit(); 64];
     let src = [0; 32];
 
-    MaybeUninit::write_slice_cloned(&mut dst, &src);
+    MaybeUninit::clone_from_slice(&mut dst, &src);
 }
 
 #[test]
@@ -249,7 +249,7 @@ fn uninit_write_slice_cloned_panic_gt() {
     let mut dst = [MaybeUninit::uninit(); 64];
     let src = [0; 128];
 
-    MaybeUninit::write_slice_cloned(&mut dst, &src);
+    MaybeUninit::clone_from_slice(&mut dst, &src);
 }
 
 #[test]
@@ -290,7 +290,7 @@ fn uninit_write_slice_cloned_mid_panic() {
     ];
 
     let err = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        MaybeUninit::write_slice_cloned(&mut dst, &src);
+        MaybeUninit::clone_from_slice(&mut dst, &src);
     }));
 
     drop(src);
@@ -322,7 +322,7 @@ fn uninit_write_slice_cloned_no_drop() {
     let mut dst = [MaybeUninit::uninit()];
     let src = [Bomb];
 
-    MaybeUninit::write_slice_cloned(&mut dst, &src);
+    MaybeUninit::clone_from_slice(&mut dst, &src);
 
     forget(src);
 }

--- a/library/proc_macro/src/bridge/arena.rs
+++ b/library/proc_macro/src/bridge/arena.rs
@@ -104,7 +104,7 @@ impl Arena {
 
     pub(crate) fn alloc_str<'a>(&'a self, string: &str) -> &'a mut str {
         let alloc = self.alloc_raw(string.len());
-        let bytes = MaybeUninit::write_slice(alloc, string.as_bytes());
+        let bytes = MaybeUninit::copy_from_slice(alloc, string.as_bytes());
 
         // SAFETY: we convert from `&str` to `&[u8]`, clone it into the arena,
         // and immediately convert the clone back to `&str`.


### PR DESCRIPTION
A step to push #79995 forward.

https://github.com/rust-lang/libs-team/issues/122 also suggested to make them inherent methods, but they can't be — they'd conflict with slice's regular methods.

