### PR TITLE
Add missing inline attributes to Duration trait impls

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -910,6 +910,7 @@ impl Duration {
 impl Add for Duration {
     type Output = Duration;
 
+    #[inline]
     fn add(self, rhs: Duration) -> Duration {
         self.checked_add(rhs).expect("overflow when adding durations")
     }
@@ -917,6 +918,7 @@ impl Add for Duration {
 
 #[stable(feature = "time_augmented_assignment", since = "1.9.0")]
 impl AddAssign for Duration {
+    #[inline]
     fn add_assign(&mut self, rhs: Duration) {
         *self = *self + rhs;
     }
@@ -926,6 +928,7 @@ impl AddAssign for Duration {
 impl Sub for Duration {
     type Output = Duration;
 
+    #[inline]
     fn sub(self, rhs: Duration) -> Duration {
         self.checked_sub(rhs).expect("overflow when subtracting durations")
     }
@@ -933,6 +936,7 @@ impl Sub for Duration {
 
 #[stable(feature = "time_augmented_assignment", since = "1.9.0")]
 impl SubAssign for Duration {
+    #[inline]
     fn sub_assign(&mut self, rhs: Duration) {
         *self = *self - rhs;
     }
@@ -942,6 +946,7 @@ impl SubAssign for Duration {
 impl Mul<u32> for Duration {
     type Output = Duration;
 
+    #[inline]
     fn mul(self, rhs: u32) -> Duration {
         self.checked_mul(rhs).expect("overflow when multiplying duration by scalar")
     }
@@ -951,6 +956,7 @@ impl Mul<u32> for Duration {
 impl Mul<Duration> for u32 {
     type Output = Duration;
 
+    #[inline]
     fn mul(self, rhs: Duration) -> Duration {
         rhs * self
     }
@@ -958,6 +964,7 @@ impl Mul<Duration> for u32 {
 
 #[stable(feature = "time_augmented_assignment", since = "1.9.0")]
 impl MulAssign<u32> for Duration {
+    #[inline]
     fn mul_assign(&mut self, rhs: u32) {
         *self = *self * rhs;
     }
@@ -967,6 +974,7 @@ impl MulAssign<u32> for Duration {
 impl Div<u32> for Duration {
     type Output = Duration;
 
+    #[inline]
     fn div(self, rhs: u32) -> Duration {
         self.checked_div(rhs).expect("divide by zero error when dividing duration by scalar")
     }
@@ -974,6 +982,7 @@ impl Div<u32> for Duration {
 
 #[stable(feature = "time_augmented_assignment", since = "1.9.0")]
 impl DivAssign<u32> for Duration {
+    #[inline]
     fn div_assign(&mut self, rhs: u32) {
         *self = *self / rhs;
     }


### PR DESCRIPTION
Currently `Duration::checked_add` is marked `#[inline]` but it's trait relative `Add::add` is not.
Leading to a case where:
```rust
pub fn foo() -> Duration {
    Duration::from_secs(10) + Duration::from_millis(6)
}

pub fn bar() -> Duration {
    Duration::from_secs(10).checked_add(Duration::from_millis(6)).expect("overflow when adding durations")
}
```
compiles to:
```asm

playground::foo:
	movl	$10, %edi
	xorl	%esi, %esi
	xorl	%edx, %edx
	movl	$6000000, %ecx
	jmpq	*<core::time::Duration as core::ops::arith::Add>::add@GOTPCREL(%rip)

playground::bar:
	movl	$10, %eax
	movl	$6000000, %edx
	retq
```
(The same happens for all arithmetic operation)