### PR TITLE
Allow any `const` expression blocks in `thread_local!`

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -152,7 +152,10 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 /// ```
 /// use std::cell::Cell;
 /// thread_local! {
-///     pub static FOO: Cell<u32> = const { Cell::new(1) };
+///     pub static FOO: Cell<u32> = const {
+///         let value = 1;
+///         Cell::new(value)
+///     };
 /// }
 ///
 /// FOO.with(|foo| assert_eq!(foo.get(), 1));
@@ -170,12 +173,12 @@ macro_rules! thread_local {
     // empty (base case for the recursion)
     () => {};
 
-    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const { $init:expr }; $($rest:tt)*) => (
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const $init:block; $($rest:tt)*) => (
         $crate::thread::local_impl::thread_local_inner!($(#[$attr])* $vis $name, $t, const $init);
         $crate::thread_local!($($rest)*);
     );
 
-    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const { $init:expr }) => (
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const $init:block) => (
         $crate::thread::local_impl::thread_local_inner!($(#[$attr])* $vis $name, $t, const $init);
     );
 


### PR DESCRIPTION
Previously only a single expression could be allowed within the `const` block. This change allows for statements to precede the final expression, similarly to [real inline `const` expressions](https://github.com/rust-lang/rust/issues/76001).

This works by taking `$init` as a `block` in `thread_local!` and passing it to `thread_local_inner!`, where it is accepted as an `expr`.