### PR TITLE
Emit feature gate *warning* for `auto` traits pre-expansion

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -603,6 +603,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
         "exclusive range pattern syntax is experimental"
     );
     gate_all_legacy_dont_use!(try_blocks, "`try` blocks are unstable");
+    gate_all_legacy_dont_use!(auto_traits, "`auto` traits are unstable");
 
     visit::walk_crate(&mut visitor, krate);
 }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -813,7 +813,12 @@ impl<'a> Parser<'a> {
     fn parse_item_trait(&mut self, attrs: &mut AttrVec, lo: Span) -> PResult<'a, ItemInfo> {
         let unsafety = self.parse_unsafety(Case::Sensitive);
         // Parse optional `auto` prefix.
-        let is_auto = if self.eat_keyword(kw::Auto) { IsAuto::Yes } else { IsAuto::No };
+        let is_auto = if self.eat_keyword(kw::Auto) {
+            self.sess.gated_spans.gate(sym::auto_traits, self.prev_token.span);
+            IsAuto::Yes
+        } else {
+            IsAuto::No
+        };
 
         self.expect_keyword(kw::Trait)?;
         let ident = self.parse_ident()?;

--- a/tests/ui/auto-traits/pre-cfg.rs
+++ b/tests/ui/auto-traits/pre-cfg.rs
@@ -1,0 +1,8 @@
+// check-pass
+
+#[cfg(FALSE)]
+auto trait Foo {}
+//~^ WARN `auto` traits are unstable
+//~| WARN unstable syntax can change at any point in the future, causing a hard error!
+
+fn main() {}

--- a/tests/ui/auto-traits/pre-cfg.stderr
+++ b/tests/ui/auto-traits/pre-cfg.stderr
@@ -1,0 +1,13 @@
+warning: `auto` traits are unstable
+  --> $DIR/pre-cfg.rs:4:1
+   |
+LL | auto trait Foo {}
+   | ^^^^
+   |
+   = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
+   = help: add `#![feature(auto_traits)]` to the crate attributes to enable
+   = warning: unstable syntax can change at any point in the future, causing a hard error!
+   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+
+warning: 1 warning emitted
+

--- a/tests/ui/macros/stringify.rs
+++ b/tests/ui/macros/stringify.rs
@@ -3,6 +3,7 @@
 // compile-flags: --test
 
 #![feature(async_closure)]
+#![feature(auto_traits)]
 #![feature(box_patterns)]
 #![feature(const_trait_impl)]
 #![feature(decl_macro)]


### PR DESCRIPTION
Auto traits were introduced before we were more careful about not stabilizing new syntax pre-expansion.

This is a more conservative step in the general direction we want to go in https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/Removal.20of.20.60auto.20trait.60.20syntax.

Fixes #116121