### PR TITLE
Detect object safety errors when assoc type is missing

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -404,7 +404,7 @@ hir_analysis_unused_associated_type_bounds =
     .suggestion = remove this bound
 
 hir_analysis_value_of_associated_struct_already_specified =
-    the value of the associated type `{$item_name}` (from trait `{$def_path}`) is already specified
+    the value of the associated type `{$item_name}` in trait `{$def_path}` is already specified
     .label = re-bound here
     .previous_bound_label = `{$item_name}` bound here first
 

--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -585,9 +585,10 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
         }
 
-        let names = names
+        let mut names = names
             .into_iter()
-            .map(|(trait_, assocs)| {
+            .map(|(trait_, mut assocs)| {
+                assocs.sort();
                 format!(
                     "{} in `{trait_}`",
                     match &assocs[..] {
@@ -600,8 +601,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     }
                 )
             })
-            .collect::<Vec<String>>()
-            .join(", ");
+            .collect::<Vec<String>>();
+        names.sort();
+        let names = names.join(", ");
 
         trait_bound_spans.sort();
         let mut err = struct_span_err!(

--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -3,6 +3,7 @@ use crate::errors::{
     AssocTypeBindingNotAllowed, ManualImplementation, MissingTypeParams,
     ParenthesizedFnTraitExpansion,
 };
+use crate::traits::error_reporting::report_object_safety_error;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{pluralize, struct_span_err, Applicability, Diagnostic, ErrorGuaranteed};
 use rustc_hir as hir;
@@ -13,6 +14,7 @@ use rustc_session::parse::feature_err;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::symbol::{sym, Ident};
 use rustc_span::{Span, Symbol, DUMMY_SP};
+use rustc_trait_selection::traits::object_safety_violations_for_assoc_item;
 
 use std::collections::BTreeSet;
 
@@ -520,23 +522,32 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 (span, def_ids.into_iter().map(|did| tcx.associated_item(did)).collect())
             })
             .collect();
-        let mut names = vec![];
+        let mut names: FxHashMap<String, Vec<Symbol>> = Default::default();
+        let mut names_len = 0;
 
         // Account for things like `dyn Foo + 'a`, like in tests `issue-22434.rs` and
         // `issue-22560.rs`.
         let mut trait_bound_spans: Vec<Span> = vec![];
+        let mut object_safety_violations = false;
         for (span, items) in &associated_types {
             if !items.is_empty() {
                 trait_bound_spans.push(*span);
             }
             for assoc_item in items {
                 let trait_def_id = assoc_item.container_id(tcx);
-                names.push(format!(
-                    "`{}` (from trait `{}`)",
-                    assoc_item.name,
-                    tcx.def_path_str(trait_def_id),
-                ));
+                names.entry(tcx.def_path_str(trait_def_id)).or_default().push(assoc_item.name);
+                names_len += 1;
+
+                let violations =
+                    object_safety_violations_for_assoc_item(tcx, trait_def_id, *assoc_item);
+                if !violations.is_empty() {
+                    report_object_safety_error(tcx, *span, trait_def_id, &violations).emit();
+                    object_safety_violations = true;
+                }
             }
+        }
+        if object_safety_violations {
+            return;
         }
         if let ([], [bound]) = (&potential_assoc_types[..], &trait_bounds) {
             match bound.trait_ref.path.segments {
@@ -573,15 +584,33 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 _ => {}
             }
         }
-        names.sort();
+
+        let names = names
+            .into_iter()
+            .map(|(trait_, assocs)| {
+                format!(
+                    "{} in `{trait_}`",
+                    match &assocs[..] {
+                        [] => String::new(),
+                        [only] => format!("`{only}`"),
+                        [assocs @ .., last] => format!(
+                            "{} and `{last}`",
+                            assocs.iter().map(|a| format!("`{a}`")).collect::<Vec<_>>().join(", ")
+                        ),
+                    }
+                )
+            })
+            .collect::<Vec<String>>()
+            .join(", ");
+
         trait_bound_spans.sort();
         let mut err = struct_span_err!(
             tcx.sess,
             trait_bound_spans,
             E0191,
             "the value of the associated type{} {} must be specified",
-            pluralize!(names.len()),
-            names.join(", "),
+            pluralize!(names_len),
+            names,
         );
         let mut suggestions = vec![];
         let mut types_count = 0;

--- a/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
@@ -380,7 +380,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             span,
                             E0228,
                             "the lifetime bound for this object type cannot be deduced \
-                         from context; please supply an explicit bound"
+                             from context; please supply an explicit bound"
                         );
                         let e = if borrowed {
                             // We will have already emitted an error E0106 complaining about a

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -47,7 +47,7 @@ pub use self::engine::{ObligationCtxt, TraitEngineExt};
 pub use self::fulfill::{FulfillmentContext, PendingPredicateObligation};
 pub use self::object_safety::astconv_object_safety_violations;
 pub use self::object_safety::is_vtable_safe_method;
-pub use self::object_safety::MethodViolationCode;
+pub use self::object_safety::object_safety_violations_for_assoc_item;
 pub use self::object_safety::ObjectSafetyViolation;
 pub use self::project::NormalizeExt;
 pub use self::project::{normalize_inherent_projection, normalize_projection_type};

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -360,7 +360,7 @@ fn generics_require_sized_self(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 
 /// Returns `Some(_)` if this item makes the containing trait not object safe.
 #[instrument(level = "debug", skip(tcx), ret)]
-fn object_safety_violations_for_assoc_item(
+pub fn object_safety_violations_for_assoc_item(
     tcx: TyCtxt<'_>,
     trait_def_id: DefId,
     item: ty::AssocItem,

--- a/tests/ui/associated-type-bounds/duplicate.rs
+++ b/tests/ui/associated-type-bounds/duplicate.rs
@@ -5,258 +5,258 @@ use std::iter;
 use std::mem::ManuallyDrop;
 
 struct SI1<T: Iterator<Item: Copy, Item: Send>> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     f: T,
 }
 struct SI2<T: Iterator<Item: Copy, Item: Copy>> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     f: T,
 }
 struct SI3<T: Iterator<Item: 'static, Item: 'static>> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     f: T,
 }
 struct SW1<T>
 where
     T: Iterator<Item: Copy, Item: Send>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
     f: T,
 }
 struct SW2<T>
 where
     T: Iterator<Item: Copy, Item: Copy>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
     f: T,
 }
 struct SW3<T>
 where
     T: Iterator<Item: 'static, Item: 'static>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
     f: T,
 }
 
 enum EI1<T: Iterator<Item: Copy, Item: Send>> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     V(T),
 }
 enum EI2<T: Iterator<Item: Copy, Item: Copy>> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     V(T),
 }
 enum EI3<T: Iterator<Item: 'static, Item: 'static>> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     V(T),
 }
 enum EW1<T>
 where
     T: Iterator<Item: Copy, Item: Send>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
     V(T),
 }
 enum EW2<T>
 where
     T: Iterator<Item: Copy, Item: Copy>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
     V(T),
 }
 enum EW3<T>
 where
     T: Iterator<Item: 'static, Item: 'static>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
     V(T),
 }
 
 union UI1<T: Iterator<Item: Copy, Item: Send>> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     f: ManuallyDrop<T>,
 }
 union UI2<T: Iterator<Item: Copy, Item: Copy>> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     f: ManuallyDrop<T>,
 }
 union UI3<T: Iterator<Item: 'static, Item: 'static>> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     f: ManuallyDrop<T>,
 }
 union UW1<T>
 where
     T: Iterator<Item: Copy, Item: Send>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
     f: ManuallyDrop<T>,
 }
 union UW2<T>
 where
     T: Iterator<Item: Copy, Item: Copy>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
     f: ManuallyDrop<T>,
 }
 union UW3<T>
 where
     T: Iterator<Item: 'static, Item: 'static>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
     f: ManuallyDrop<T>,
 }
 
 fn FI1<T: Iterator<Item: Copy, Item: Send>>() {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 fn FI2<T: Iterator<Item: Copy, Item: Copy>>() {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 fn FI3<T: Iterator<Item: 'static, Item: 'static>>() {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 fn FW1<T>()
 where
     T: Iterator<Item: Copy, Item: Send>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 fn FW2<T>()
 where
     T: Iterator<Item: Copy, Item: Copy>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 fn FW3<T>()
 where
     T: Iterator<Item: 'static, Item: 'static>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 
 fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
 }
 fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
 }
 fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
 }
 fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 
 type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type TAW1<T>
 where
     T: Iterator<Item: Copy, Item: Send>,
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 = T;
 type TAW2<T>
 where
     T: Iterator<Item: Copy, Item: Copy>,
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 = T;
 type TAW3<T>
 where
     T: Iterator<Item: 'static, Item: 'static>,
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 = T;
 
 type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 
 trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRS1: Iterator<Item: Copy, Item: Send> {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRS2: Iterator<Item: Copy, Item: Copy> {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRS3: Iterator<Item: 'static, Item: 'static> {}
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
-//~| ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRW1<T>
 where
     T: Iterator<Item: Copy, Item: Send>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRW2<T>
 where
     T: Iterator<Item: Copy, Item: Copy>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRW3<T>
 where
     T: Iterator<Item: 'static, Item: 'static>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRSW1
 where
     Self: Iterator<Item: Copy, Item: Send>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
-    //~| ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRSW2
 where
     Self: Iterator<Item: Copy, Item: Copy>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
-    //~| ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRSW3
 where
     Self: Iterator<Item: 'static, Item: 'static>,
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
-    //~| ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRA1 {
     type A: Iterator<Item: Copy, Item: Send>;
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 }
 trait TRA2 {
     type A: Iterator<Item: Copy, Item: Copy>;
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 }
 trait TRA3 {
     type A: Iterator<Item: 'static, Item: 'static>;
-    //~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+    //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 }
 
 type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
-//~^ ERROR the value of the associated type `Item` (from trait `Iterator`) is already specified [E0719]
+//~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/duplicate.stderr
+++ b/tests/ui/associated-type-bounds/duplicate.stderr
@@ -1,4 +1,4 @@
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:7:36
    |
 LL | struct SI1<T: Iterator<Item: Copy, Item: Send>> {
@@ -6,7 +6,7 @@ LL | struct SI1<T: Iterator<Item: Copy, Item: Send>> {
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:11:36
    |
 LL | struct SI2<T: Iterator<Item: Copy, Item: Copy>> {
@@ -14,7 +14,7 @@ LL | struct SI2<T: Iterator<Item: Copy, Item: Copy>> {
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:15:39
    |
 LL | struct SI3<T: Iterator<Item: 'static, Item: 'static>> {
@@ -22,7 +22,7 @@ LL | struct SI3<T: Iterator<Item: 'static, Item: 'static>> {
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:21:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
@@ -30,7 +30,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:28:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
@@ -38,7 +38,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:35:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
@@ -46,7 +46,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:41:34
    |
 LL | enum EI1<T: Iterator<Item: Copy, Item: Send>> {
@@ -54,7 +54,7 @@ LL | enum EI1<T: Iterator<Item: Copy, Item: Send>> {
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:45:34
    |
 LL | enum EI2<T: Iterator<Item: Copy, Item: Copy>> {
@@ -62,7 +62,7 @@ LL | enum EI2<T: Iterator<Item: Copy, Item: Copy>> {
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:49:37
    |
 LL | enum EI3<T: Iterator<Item: 'static, Item: 'static>> {
@@ -70,7 +70,7 @@ LL | enum EI3<T: Iterator<Item: 'static, Item: 'static>> {
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:55:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
@@ -78,7 +78,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:62:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
@@ -86,7 +86,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:69:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
@@ -94,7 +94,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:75:35
    |
 LL | union UI1<T: Iterator<Item: Copy, Item: Send>> {
@@ -102,7 +102,7 @@ LL | union UI1<T: Iterator<Item: Copy, Item: Send>> {
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:79:35
    |
 LL | union UI2<T: Iterator<Item: Copy, Item: Copy>> {
@@ -110,7 +110,7 @@ LL | union UI2<T: Iterator<Item: Copy, Item: Copy>> {
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:83:38
    |
 LL | union UI3<T: Iterator<Item: 'static, Item: 'static>> {
@@ -118,7 +118,7 @@ LL | union UI3<T: Iterator<Item: 'static, Item: 'static>> {
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:89:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
@@ -126,7 +126,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:96:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
@@ -134,7 +134,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:103:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
@@ -142,7 +142,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:109:32
    |
 LL | fn FI1<T: Iterator<Item: Copy, Item: Send>>() {}
@@ -150,7 +150,7 @@ LL | fn FI1<T: Iterator<Item: Copy, Item: Send>>() {}
    |                    |
    |                    `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:111:32
    |
 LL | fn FI2<T: Iterator<Item: Copy, Item: Copy>>() {}
@@ -158,7 +158,7 @@ LL | fn FI2<T: Iterator<Item: Copy, Item: Copy>>() {}
    |                    |
    |                    `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:113:35
    |
 LL | fn FI3<T: Iterator<Item: 'static, Item: 'static>>() {}
@@ -166,7 +166,7 @@ LL | fn FI3<T: Iterator<Item: 'static, Item: 'static>>() {}
    |                    |
    |                    `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:117:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
@@ -174,7 +174,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:123:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
@@ -182,7 +182,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:129:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
@@ -190,7 +190,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:134:42
    |
 LL | fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
@@ -198,7 +198,7 @@ LL | fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
    |                              |
    |                              `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:138:42
    |
 LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
@@ -206,7 +206,7 @@ LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
    |                              |
    |                              `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:142:45
    |
 LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
@@ -214,7 +214,7 @@ LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
    |                              |
    |                              `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:146:40
    |
 LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
@@ -222,7 +222,7 @@ LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:148:40
    |
 LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
@@ -230,7 +230,7 @@ LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:150:43
    |
 LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
@@ -238,7 +238,7 @@ LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:153:35
    |
 LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
@@ -246,7 +246,7 @@ LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:155:35
    |
 LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
@@ -254,7 +254,7 @@ LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:157:38
    |
 LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
@@ -262,7 +262,7 @@ LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
    |                       |
    |                       `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:161:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
@@ -270,7 +270,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:166:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
@@ -278,7 +278,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:171:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
@@ -286,7 +286,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:175:36
    |
 LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
@@ -294,7 +294,7 @@ LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:177:36
    |
 LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
@@ -302,7 +302,7 @@ LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:179:39
    |
 LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
@@ -310,7 +310,7 @@ LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:181:40
    |
 LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
@@ -318,7 +318,7 @@ LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:183:40
    |
 LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
@@ -326,7 +326,7 @@ LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:185:43
    |
 LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
@@ -334,7 +334,7 @@ LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:188:36
    |
 LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
@@ -342,7 +342,7 @@ LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:190:36
    |
 LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
@@ -350,7 +350,7 @@ LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:192:39
    |
 LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
@@ -358,7 +358,7 @@ LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
    |                        |
    |                        `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:194:34
    |
 LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
@@ -366,7 +366,7 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:194:34
    |
 LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
@@ -376,7 +376,7 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:197:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
@@ -384,7 +384,7 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:197:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
@@ -394,7 +394,7 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:200:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
@@ -402,7 +402,7 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:200:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
@@ -412,7 +412,7 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:205:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
@@ -420,7 +420,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:211:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
@@ -428,7 +428,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:217:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
@@ -436,7 +436,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 |
    |                 `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:223:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Send>,
@@ -444,7 +444,7 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    |
    |                    `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:223:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Send>,
@@ -454,7 +454,7 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:230:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Copy>,
@@ -462,7 +462,7 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    |
    |                    `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:230:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Copy>,
@@ -472,7 +472,7 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:237:35
    |
 LL |     Self: Iterator<Item: 'static, Item: 'static>,
@@ -480,7 +480,7 @@ LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    |
    |                    `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:237:35
    |
 LL |     Self: Iterator<Item: 'static, Item: 'static>,
@@ -490,7 +490,7 @@ LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:255:40
    |
 LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
@@ -498,7 +498,7 @@ LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:257:44
    |
 LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
@@ -506,7 +506,7 @@ LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
    |                                |
    |                                `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:259:43
    |
 LL | type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
@@ -514,7 +514,7 @@ LL | type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
    |                            |
    |                            `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:243:34
    |
 LL |     type A: Iterator<Item: Copy, Item: Send>;
@@ -522,7 +522,7 @@ LL |     type A: Iterator<Item: Copy, Item: Send>;
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:247:34
    |
 LL |     type A: Iterator<Item: Copy, Item: Copy>;
@@ -530,7 +530,7 @@ LL |     type A: Iterator<Item: Copy, Item: Copy>;
    |                      |
    |                      `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:251:37
    |
 LL |     type A: Iterator<Item: 'static, Item: 'static>;

--- a/tests/ui/associated-type-bounds/overlaping-bound-suggestion.stderr
+++ b/tests/ui/associated-type-bounds/overlaping-bound-suggestion.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated types `Item`, `IntoIter`, `Item` and `IntoIter` in `IntoIterator` must be specified
+error[E0191]: the value of the associated types `Item`, `Item`, `IntoIter` and `IntoIter` in `IntoIterator` must be specified
   --> $DIR/overlaping-bound-suggestion.rs:7:13
    |
 LL |     inner: <IntoIterator<Item: IntoIterator<Item: >>::IntoIterator as Item>::Core,

--- a/tests/ui/associated-type-bounds/overlaping-bound-suggestion.stderr
+++ b/tests/ui/associated-type-bounds/overlaping-bound-suggestion.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated types `IntoIter` (from trait `IntoIterator`), `IntoIter` (from trait `IntoIterator`), `Item` (from trait `IntoIterator`), `Item` (from trait `IntoIterator`) must be specified
+error[E0191]: the value of the associated types `Item`, `IntoIter`, `Item` and `IntoIter` in `IntoIterator` must be specified
   --> $DIR/overlaping-bound-suggestion.rs:7:13
    |
 LL |     inner: <IntoIterator<Item: IntoIterator<Item: >>::IntoIterator as Item>::Core,

--- a/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
+++ b/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
@@ -45,7 +45,7 @@ LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
                    T: Vehicle::Color = COLOR,
                    T: Box::Color = COLOR
 
-error[E0191]: the value of the associated types `Color` in `Vehicle`, `Color` in `Box` must be specified
+error[E0191]: the value of the associated types `Color` in `Box`, `Color` in `Vehicle` must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
    |
 LL |     type Color;
@@ -80,7 +80,7 @@ help: use fully-qualified syntax to disambiguate
 LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
    |                             ~~~~~~~~~~~~
 
-error[E0191]: the value of the associated types `Color` in `Vehicle`, `Color` in `Box` must be specified
+error[E0191]: the value of the associated types `Color` in `Box`, `Color` in `Vehicle` must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32
    |
 LL |     type Color;

--- a/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
+++ b/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
@@ -45,7 +45,7 @@ LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
                    T: Vehicle::Color = COLOR,
                    T: Box::Color = COLOR
 
-error[E0191]: the value of the associated types `Color` (from trait `Box`), `Color` (from trait `Vehicle`) must be specified
+error[E0191]: the value of the associated types `Color` in `Vehicle`, `Color` in `Box` must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
    |
 LL |     type Color;
@@ -80,7 +80,7 @@ help: use fully-qualified syntax to disambiguate
 LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
    |                             ~~~~~~~~~~~~
 
-error[E0191]: the value of the associated types `Color` (from trait `Box`), `Color` (from trait `Vehicle`) must be specified
+error[E0191]: the value of the associated types `Color` in `Vehicle`, `Color` in `Box` must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32
    |
 LL |     type Color;

--- a/tests/ui/associated-types/associated-types-incomplete-object.rs
+++ b/tests/ui/associated-types/associated-types-incomplete-object.rs
@@ -21,11 +21,11 @@ pub fn main() {
     let a = &42isize as &dyn Foo<A=usize, B=char>;
 
     let b = &42isize as &dyn Foo<A=usize>;
-    //~^ ERROR the value of the associated type `B` (from trait `Foo`) must be specified
+    //~^ ERROR the value of the associated type `B` in `Foo` must be specified
 
     let c = &42isize as &dyn Foo<B=char>;
-    //~^ ERROR the value of the associated type `A` (from trait `Foo`) must be specified
+    //~^ ERROR the value of the associated type `A` in `Foo` must be specified
 
     let d = &42isize as &dyn Foo;
-    //~^ ERROR the value of the associated types `A` (from trait `Foo`), `B` (from trait
+    //~^ ERROR the value of the associated types `A` and `B` in `Foo`
 }

--- a/tests/ui/associated-types/associated-types-incomplete-object.stderr
+++ b/tests/ui/associated-types/associated-types-incomplete-object.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `B` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated type `B` in `Foo` must be specified
   --> $DIR/associated-types-incomplete-object.rs:23:30
    |
 LL |     type B;
@@ -7,7 +7,7 @@ LL |     type B;
 LL |     let b = &42isize as &dyn Foo<A=usize>;
    |                              ^^^^^^^^^^^^ help: specify the associated type: `Foo<A=usize, B = Type>`
 
-error[E0191]: the value of the associated type `A` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated type `A` in `Foo` must be specified
   --> $DIR/associated-types-incomplete-object.rs:26:30
    |
 LL |     type A;
@@ -16,7 +16,7 @@ LL |     type A;
 LL |     let c = &42isize as &dyn Foo<B=char>;
    |                              ^^^^^^^^^^^ help: specify the associated type: `Foo<B=char, A = Type>`
 
-error[E0191]: the value of the associated types `A` (from trait `Foo`), `B` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated types `A` and `B` in `Foo` must be specified
   --> $DIR/associated-types-incomplete-object.rs:29:30
    |
 LL |     type A;

--- a/tests/ui/associated-types/issue-22560.stderr
+++ b/tests/ui/associated-types/issue-22560.stderr
@@ -9,7 +9,7 @@ LL | type Test = dyn Add + Sub;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add + Sub {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `Output` (from trait `Add`), `Output` (from trait `Sub`) must be specified
+error[E0191]: the value of the associated types `Output` in `Sub`, `Output` in `Add` must be specified
   --> $DIR/issue-22560.rs:9:17
    |
 LL |     type Output;

--- a/tests/ui/associated-types/issue-22560.stderr
+++ b/tests/ui/associated-types/issue-22560.stderr
@@ -9,7 +9,7 @@ LL | type Test = dyn Add + Sub;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add + Sub {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `Output` in `Sub`, `Output` in `Add` must be specified
+error[E0191]: the value of the associated types `Output` in `Add`, `Output` in `Sub` must be specified
   --> $DIR/issue-22560.rs:9:17
    |
 LL |     type Output;

--- a/tests/ui/associated-types/issue-23595-1.stderr
+++ b/tests/ui/associated-types/issue-23595-1.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated types `ChildKey` (from trait `Hierarchy`), `Children` (from trait `Hierarchy`), `Value` (from trait `Hierarchy`) must be specified
+error[E0191]: the value of the associated types `Value`, `ChildKey` and `Children` in `Hierarchy` must be specified
   --> $DIR/issue-23595-1.rs:8:58
    |
 LL |     type Value;

--- a/tests/ui/associated-types/missing-associated-types.stderr
+++ b/tests/ui/associated-types/missing-associated-types.stderr
@@ -9,7 +9,7 @@ LL | type Foo<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs>;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `A` in `Y`, `Output` in `Sub`, `Output` in `Mul`, `Output` in `Add` must be specified
+error[E0191]: the value of the associated types `A` in `Y`, `Output` in `Add`, `Output` in `Mul`, `Output` in `Sub` must be specified
   --> $DIR/missing-associated-types.rs:12:21
    |
 LL |     type A;
@@ -38,7 +38,7 @@ LL | type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `Output` and `Output` in `Div`, `Output` in `Add`, `Output` in `Sub`, `Output` in `Mul`, `A` and `B` in `Z` must be specified
+error[E0191]: the value of the associated types `A` and `B` in `Z`, `Output` and `Output` in `Div`, `Output` in `Add`, `Output` in `Mul`, `Output` in `Sub` must be specified
   --> $DIR/missing-associated-types.rs:15:21
    |
 LL |     type A;
@@ -74,7 +74,7 @@ LL | type Baz<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Y<Rhs>;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + Y<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `Output` in `Sub`, `A` in `Y`, `Output` in `Add` must be specified
+error[E0191]: the value of the associated types `A` in `Y`, `Output` in `Add`, `Output` in `Sub` must be specified
   --> $DIR/missing-associated-types.rs:18:21
    |
 LL |     type A;
@@ -102,7 +102,7 @@ LL | type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + Fine<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `Output` in `Sub`, `Output` in `Add` must be specified
+error[E0191]: the value of the associated types `Output` in `Add`, `Output` in `Sub` must be specified
   --> $DIR/missing-associated-types.rs:21:21
    |
 LL | type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;

--- a/tests/ui/associated-types/missing-associated-types.stderr
+++ b/tests/ui/associated-types/missing-associated-types.stderr
@@ -9,7 +9,7 @@ LL | type Foo<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs>;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `A` (from trait `Y`), `Output` (from trait `Add`), `Output` (from trait `Mul`), `Output` (from trait `Sub`) must be specified
+error[E0191]: the value of the associated types `A` in `Y`, `Output` in `Sub`, `Output` in `Mul`, `Output` in `Add` must be specified
   --> $DIR/missing-associated-types.rs:12:21
    |
 LL |     type A;
@@ -38,7 +38,7 @@ LL | type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `A` (from trait `Z`), `B` (from trait `Z`), `Output` (from trait `Add`), `Output` (from trait `Div`), `Output` (from trait `Div`), `Output` (from trait `Mul`), `Output` (from trait `Sub`) must be specified
+error[E0191]: the value of the associated types `Output` and `Output` in `Div`, `Output` in `Add`, `Output` in `Sub`, `Output` in `Mul`, `A` and `B` in `Z` must be specified
   --> $DIR/missing-associated-types.rs:15:21
    |
 LL |     type A;
@@ -74,7 +74,7 @@ LL | type Baz<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Y<Rhs>;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + Y<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `A` (from trait `Y`), `Output` (from trait `Add`), `Output` (from trait `Sub`) must be specified
+error[E0191]: the value of the associated types `Output` in `Sub`, `A` in `Y`, `Output` in `Add` must be specified
   --> $DIR/missing-associated-types.rs:18:21
    |
 LL |     type A;
@@ -102,7 +102,7 @@ LL | type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + Fine<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0191]: the value of the associated types `Output` (from trait `Add`), `Output` (from trait `Sub`) must be specified
+error[E0191]: the value of the associated types `Output` in `Sub`, `Output` in `Add` must be specified
   --> $DIR/missing-associated-types.rs:21:21
    |
 LL | type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
@@ -115,7 +115,7 @@ help: specify the associated types
 LL | type Bat<Rhs> = dyn Add<Rhs, Output = Type> + Sub<Rhs, Output = Type> + Fine<Rhs>;
    |                     ~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~
 
-error[E0191]: the value of the associated types `Output` (from trait `Div`), `Output` (from trait `Mul`) must be specified
+error[E0191]: the value of the associated types `Output` in `Div`, `Output` in `Mul` must be specified
   --> $DIR/missing-associated-types.rs:24:21
    |
 LL | type Bal<Rhs> = dyn X<Rhs>;

--- a/tests/ui/error-codes/E0191.stderr
+++ b/tests/ui/error-codes/E0191.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `Bar` (from trait `Trait`) must be specified
+error[E0191]: the value of the associated type `Bar` in `Trait` must be specified
   --> $DIR/E0191.rs:5:16
    |
 LL |     type Bar;

--- a/tests/ui/error-codes/E0220.stderr
+++ b/tests/ui/error-codes/E0220.stderr
@@ -4,7 +4,7 @@ error[E0220]: associated type `F` not found for `Trait`
 LL | type Foo = dyn Trait<F=i32>;
    |                      ^ help: `Trait` has the following associated type: `Bar`
 
-error[E0191]: the value of the associated type `Bar` (from trait `Trait`) must be specified
+error[E0191]: the value of the associated type `Bar` in `Trait` must be specified
   --> $DIR/E0220.rs:5:16
    |
 LL |     type Bar;

--- a/tests/ui/error-codes/E0719.stderr
+++ b/tests/ui/error-codes/E0719.stderr
@@ -1,4 +1,4 @@
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/E0719.rs:1:33
    |
 LL | trait Foo: Iterator<Item = i32, Item = i32> {}
@@ -6,7 +6,7 @@ LL | trait Foo: Iterator<Item = i32, Item = i32> {}
    |                     |
    |                     `Item` bound here first
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/E0719.rs:1:33
    |
 LL | trait Foo: Iterator<Item = i32, Item = i32> {}
@@ -16,7 +16,7 @@ LL | trait Foo: Iterator<Item = i32, Item = i32> {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/E0719.rs:7:42
    |
 LL | fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {

--- a/tests/ui/issues/issue-19482.rs
+++ b/tests/ui/issues/issue-19482.rs
@@ -8,6 +8,6 @@ trait Foo {
 }
 
 fn bar(x: &dyn Foo) {}
-//~^ ERROR the associated type `A` (from trait `Foo`) must be specified
+//~^ ERROR the associated type `A` in `Foo` must be specified
 
 pub fn main() {}

--- a/tests/ui/issues/issue-19482.stderr
+++ b/tests/ui/issues/issue-19482.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `A` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated type `A` in `Foo` must be specified
   --> $DIR/issue-19482.rs:10:16
    |
 LL |     type A;

--- a/tests/ui/issues/issue-21950.stderr
+++ b/tests/ui/issues/issue-21950.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `Output` (from trait `Add`) must be specified
+error[E0191]: the value of the associated type `Output` in `Add` must be specified
   --> $DIR/issue-21950.rs:10:25
    |
 LL |     type Output;

--- a/tests/ui/issues/issue-22434.rs
+++ b/tests/ui/issues/issue-22434.rs
@@ -3,6 +3,6 @@ pub trait Foo {
 }
 
 type I<'a> = &'a (dyn Foo + 'a);
-//~^ ERROR the value of the associated type `A` (from trait `Foo`) must be specified
+//~^ ERROR the value of the associated type `A` in `Foo` must be specified
 
 fn main() {}

--- a/tests/ui/issues/issue-22434.stderr
+++ b/tests/ui/issues/issue-22434.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `A` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated type `A` in `Foo` must be specified
   --> $DIR/issue-22434.rs:5:23
    |
 LL |     type A;

--- a/tests/ui/issues/issue-23024.rs
+++ b/tests/ui/issues/issue-23024.rs
@@ -8,5 +8,5 @@ fn main()
     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
     //~^ ERROR the precise format of `Fn`-family traits'
     //~| ERROR missing generics for trait `Fn`
-    //~| ERROR the value of the associated type `Output` (from trait `FnOnce`)
+    //~| ERROR the value of the associated type `Output` in `FnOnce`
 }

--- a/tests/ui/issues/issue-23024.stderr
+++ b/tests/ui/issues/issue-23024.stderr
@@ -18,7 +18,7 @@ help: add missing generic argument
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn<Args>)(3));
    |                                         ++++++
 
-error[E0191]: the value of the associated type `Output` (from trait `FnOnce`) must be specified
+error[E0191]: the value of the associated type `Output` in `FnOnce` must be specified
   --> $DIR/issue-23024.rs:8:39
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));

--- a/tests/ui/issues/issue-28344.stderr
+++ b/tests/ui/issues/issue-28344.stderr
@@ -12,7 +12,7 @@ help: use `dyn`
 LL |     let x: u8 = <dyn BitXor>::bitor(0 as u8, 0 as u8);
    |                 ++++       +
 
-error[E0191]: the value of the associated type `Output` (from trait `BitXor`) must be specified
+error[E0191]: the value of the associated type `Output` in `BitXor` must be specified
   --> $DIR/issue-28344.rs:4:17
    |
 LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
@@ -40,7 +40,7 @@ help: use `dyn`
 LL |     let g = <dyn BitXor>::bitor;
    |             ++++       +
 
-error[E0191]: the value of the associated type `Output` (from trait `BitXor`) must be specified
+error[E0191]: the value of the associated type `Output` in `BitXor` must be specified
   --> $DIR/issue-28344.rs:10:13
    |
 LL |     let g = BitXor::bitor;

--- a/tests/ui/object-safety/assoc_type_bounds.rs
+++ b/tests/ui/object-safety/assoc_type_bounds.rs
@@ -7,7 +7,7 @@ trait Foo<T> {
 trait Cake {}
 impl Cake for () {}
 
-fn foo(_: &dyn Foo<()>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
-fn bar(_: &dyn Foo<i32>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+fn foo(_: &dyn Foo<()>) {} //~ ERROR: the value of the associated type `Bar` in `Foo` must be specified
+fn bar(_: &dyn Foo<i32>) {} //~ ERROR: the value of the associated type `Bar` in `Foo` must be specified
 
 fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated type `Bar` in `Foo` must be specified
   --> $DIR/assoc_type_bounds.rs:10:16
    |
 LL |     type Bar
@@ -7,7 +7,7 @@ LL |     type Bar
 LL | fn foo(_: &dyn Foo<()>) {}
    |                ^^^^^^^ help: specify the associated type: `Foo<(), Bar = Type>`
 
-error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated type `Bar` in `Foo` must be specified
   --> $DIR/assoc_type_bounds.rs:11:16
    |
 LL |     type Bar

--- a/tests/ui/object-safety/assoc_type_bounds2.rs
+++ b/tests/ui/object-safety/assoc_type_bounds2.rs
@@ -7,7 +7,7 @@ trait Foo<T> {
 trait Cake {}
 impl Cake for () {}
 
-fn foo(_: &dyn Foo<()>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
-fn bar(_: &dyn Foo<i32>) {} //~ ERROR: the value of the associated type `Bar` (from trait `Foo`) must be specified
+fn foo(_: &dyn Foo<()>) {} //~ ERROR: the value of the associated type `Bar` in `Foo` must be specified
+fn bar(_: &dyn Foo<i32>) {} //~ ERROR: the value of the associated type `Bar` in `Foo` must be specified
 
 fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds2.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds2.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated type `Bar` in `Foo` must be specified
   --> $DIR/assoc_type_bounds2.rs:10:16
    |
 LL |     type Bar
@@ -7,7 +7,7 @@ LL |     type Bar
 LL | fn foo(_: &dyn Foo<()>) {}
    |                ^^^^^^^ help: specify the associated type: `Foo<(), Bar = Type>`
 
-error[E0191]: the value of the associated type `Bar` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated type `Bar` in `Foo` must be specified
   --> $DIR/assoc_type_bounds2.rs:11:16
    |
 LL |     type Bar

--- a/tests/ui/object-safety/assoc_type_bounds_sized_others.rs
+++ b/tests/ui/object-safety/assoc_type_bounds_sized_others.rs
@@ -10,7 +10,7 @@ trait Foo {
 }
 
 fn foo(_: &dyn Foo) {}
-//~^ ERROR the value of the associated type `Bop` (from trait `Foo`) must be specified
+//~^ ERROR the value of the associated type `Bop` in `Foo` must be specified
 
 trait Bar {
     type Bop;
@@ -20,6 +20,6 @@ trait Bar {
 }
 
 fn bar(_: &dyn Bar) {}
-//~^ ERROR the value of the associated type `Bop` (from trait `Bar`) must be specified
+//~^ ERROR the value of the associated type `Bop` in `Bar` must be specified
 
 fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds_sized_others.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_sized_others.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `Bop` (from trait `Foo`) must be specified
+error[E0191]: the value of the associated type `Bop` in `Foo` must be specified
   --> $DIR/assoc_type_bounds_sized_others.rs:12:16
    |
 LL |     type Bop;
@@ -7,7 +7,7 @@ LL |     type Bop;
 LL | fn foo(_: &dyn Foo) {}
    |                ^^^ help: specify the associated type: `Foo<Bop = Type>`
 
-error[E0191]: the value of the associated type `Bop` (from trait `Bar`) must be specified
+error[E0191]: the value of the associated type `Bop` in `Bar` must be specified
   --> $DIR/assoc_type_bounds_sized_others.rs:22:16
    |
 LL |     type Bop;

--- a/tests/ui/suggestions/trait-hidden-method.stderr
+++ b/tests/ui/suggestions/trait-hidden-method.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+error[E0191]: the value of the associated type `Item` in `Iterator` must be specified
   --> $DIR/trait-hidden-method.rs:6:33
    |
 LL |     Box::new(1..=10) as Box<dyn Iterator>

--- a/tests/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
+++ b/tests/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
@@ -14,7 +14,7 @@ help: replace the generic bounds with the associated types
 LL |     i: Box<dyn T<usize, usize, A = usize, C = usize, B=usize>>,
    |                                +++        +++
 
-error[E0191]: the value of the associated types `A` (from trait `T`), `C` (from trait `T`) must be specified
+error[E0191]: the value of the associated types `A` and `C` in `T` must be specified
   --> $DIR/use-type-argument-instead-of-assoc-type.rs:7:16
    |
 LL |     type A;

--- a/tests/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
+++ b/tests/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
@@ -14,7 +14,7 @@ help: replace the generic bounds with the associated types
 LL |     i: Box<dyn T<usize, usize, A = usize, C = usize, B=usize>>,
    |                                +++        +++
 
-error[E0191]: the value of the associated types `A` and `C` in `T` must be specified
+error[E0191]: the value of the associated types `C` and `A` in `T` must be specified
   --> $DIR/use-type-argument-instead-of-assoc-type.rs:7:16
    |
 LL |     type A;

--- a/tests/ui/traits/alias/object-fail.stderr
+++ b/tests/ui/traits/alias/object-fail.stderr
@@ -9,7 +9,7 @@ note: for a trait to be "object safe" it needs to allow building a vtable to all
    |
    = note: the trait cannot be made into an object because it uses `Self` as a type parameter
 
-error[E0191]: the value of the associated type `Item` (from trait `Iterator`) must be specified
+error[E0191]: the value of the associated type `Item` in `Iterator` must be specified
   --> $DIR/object-fail.rs:9:17
    |
 LL |     let _: &dyn IteratorAlias = &vec![123].into_iter();

--- a/tests/ui/traits/object/object-unsafe-missing-assoc-type.rs
+++ b/tests/ui/traits/object/object-unsafe-missing-assoc-type.rs
@@ -1,0 +1,7 @@
+trait Foo {
+    type Bar<T>;
+}
+
+fn bar(x: &dyn Foo) {} //~ ERROR the trait `Foo` cannot be made into an object
+
+fn main() {}

--- a/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
+++ b/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
@@ -1,0 +1,18 @@
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:16
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |                ^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/object/with-self-in-projection-output-bad.rs
+++ b/tests/ui/traits/object/with-self-in-projection-output-bad.rs
@@ -43,8 +43,8 @@ impl NormalizableHelper for u32
 
 fn main() {
     let _x: Box<dyn Helper<Target=i32>> = Box::new(2u32);
-    //~^ ERROR the value of the associated type `Output` (from trait `Base`) must be specified
+    //~^ ERROR the value of the associated type `Output` in `Base` must be specified
 
     let _y: Box<dyn NormalizableHelper<Target=i32>> = Box::new(2u32);
-    //~^ ERROR the value of the associated type `Output` (from trait `Base`) must be specified
+    //~^ ERROR the value of the associated type `Output` in `Base` must be specified
 }

--- a/tests/ui/traits/object/with-self-in-projection-output-bad.stderr
+++ b/tests/ui/traits/object/with-self-in-projection-output-bad.stderr
@@ -1,4 +1,4 @@
-error[E0191]: the value of the associated type `Output` (from trait `Base`) must be specified
+error[E0191]: the value of the associated type `Output` in `Base` must be specified
   --> $DIR/with-self-in-projection-output-bad.rs:45:21
    |
 LL |     type Output;
@@ -7,7 +7,7 @@ LL |     type Output;
 LL |     let _x: Box<dyn Helper<Target=i32>> = Box::new(2u32);
    |                     ^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Helper<Target=i32, Output = Type>`
 
-error[E0191]: the value of the associated type `Output` (from trait `Base`) must be specified
+error[E0191]: the value of the associated type `Output` in `Base` must be specified
   --> $DIR/with-self-in-projection-output-bad.rs:48:21
    |
 LL |     type Output;


### PR DESCRIPTION
When an associated type with GATs isn't specified in a `dyn Trait`, emit an object safety error instead of only complaining about the missing associated type, as it will lead the user down a path of three different errors before letting them know that what they were trying to do is impossible to begin with.

Fix #103155.