### PR TITLE
Bump host compiler on x64 dist Linux to LLVM 17.0.2

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-17.0.0-rc3
+LLVM=llvmorg-17.0.2
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
17.0.0-rc3 had a bunch of miscompilations, and it's probably better in general not to use a RC version of LLVM long term on CI.