### PR TITLE
Remove is global hack

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1752,30 +1752,9 @@ impl<'tcx> ParamEnv<'tcx> {
         Self::new(List::empty(), self.reveal())
     }
 
-    /// Creates a suitable environment in which to perform trait
-    /// queries on the given value. When type-checking, this is simply
-    /// the pair of the environment plus value. But when reveal is set to
-    /// All, then if `value` does not reference any type parameters, we will
-    /// pair it with the empty environment. This improves caching and is generally
-    /// invisible.
-    ///
-    /// N.B., we preserve the environment when type-checking because it
-    /// is possible for the user to have wacky where-clauses like
-    /// `where Box<u32>: Copy`, which are clearly never
-    /// satisfiable. We generally want to behave as if they were true,
-    /// although the surrounding function is never reachable.
+    /// Creates a pair of param-env and value for use in queries.
     pub fn and<T: TypeVisitable<TyCtxt<'tcx>>>(self, value: T) -> ParamEnvAnd<'tcx, T> {
-        match self.reveal() {
-            Reveal::UserFacing => ParamEnvAnd { param_env: self, value },
-
-            Reveal::All => {
-                if value.is_global() {
-                    ParamEnvAnd { param_env: self.without_caller_bounds(), value }
-                } else {
-                    ParamEnvAnd { param_env: self, value }
-                }
-            }
-        }
+        ParamEnvAnd { param_env: self, value }
     }
 }
 

--- a/tests/ui/traits/associated_type_bound/impl-is-shadowed.rs
+++ b/tests/ui/traits/associated_type_bound/impl-is-shadowed.rs
@@ -1,0 +1,21 @@
+// check-pass
+trait Bar<'a> {
+    type Assoc: 'static;
+}
+
+impl<'a> Bar<'a> for () {
+    type Assoc = ();
+}
+
+struct ImplsStatic<CG: Bar<'static>> {
+    d: &'static <CG as Bar<'static>>::Assoc,
+}
+
+fn caller(b: ImplsStatic<()>)
+where
+    for<'a> (): Bar<'a>
+{
+    let _: &<() as Bar<'static>>::Assoc = b.d;
+}
+
+fn main() {}


### PR DESCRIPTION
In attempt to fix https://github.com/rust-lang/rust/issues/114057 we found several issues with how compiler computes layouts, this change removes `is_global` from `and` to stop impl from being shadowed.

In depth conversation can be read here https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/topic/Getting.20different.20types.20from.20almost.20same.20inputs

This is a fix candidate opened for performance run.

r? @lcnr 