### PR TITLE
discard invalid spans in external blocks

### DIFF
--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1676,7 +1676,7 @@ pub(crate) struct ExternItemCannotBeConst {
     #[primary_span]
     pub ident_span: Span,
     #[suggestion(code = "static ", applicability = "machine-applicable")]
-    pub const_span: Span,
+    pub const_span: Option<Span>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1143,9 +1143,11 @@ impl<'a> Parser<'a> {
                     Ok(kind) => kind,
                     Err(kind) => match kind {
                         ItemKind::Const(box ConstItem { ty, expr, .. }) => {
+                            let const_span = Some(span.with_hi(ident.span.lo()))
+                                .filter(|span| span.can_be_used_for_suggestions());
                             self.sess.emit_err(errors::ExternItemCannotBeConst {
                                 ident_span: ident.span,
-                                const_span: span.with_hi(ident.span.lo()),
+                                const_span,
                             });
                             ForeignItemKind::Static(ty, Mutability::Not, expr)
                         }

--- a/tests/ui/extern/issue-116203.rs
+++ b/tests/ui/extern/issue-116203.rs
@@ -1,0 +1,21 @@
+extern "C" {
+    thread_local! {
+      static FOO: u32 = 0;
+      //~^ error: extern items cannot be `const`
+      //~| error: incorrect `static` inside `extern` block
+    }
+}
+
+macro_rules! hello {
+    ($name:ident) => {
+        const $name: () = ();
+    };
+}
+
+extern "C" {
+    hello! { yes }
+    //~^ error: extern items cannot be `const`
+    //~| error: incorrect `static` inside `extern` block
+}
+
+fn main() {}

--- a/tests/ui/extern/issue-116203.stderr
+++ b/tests/ui/extern/issue-116203.stderr
@@ -1,0 +1,46 @@
+error: extern items cannot be `const`
+  --> $DIR/issue-116203.rs:3:14
+   |
+LL |       static FOO: u32 = 0;
+   |              ^^^
+   |
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: extern items cannot be `const`
+  --> $DIR/issue-116203.rs:16:14
+   |
+LL |     hello! { yes }
+   |              ^^^
+   |
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: incorrect `static` inside `extern` block
+  --> $DIR/issue-116203.rs:3:14
+   |
+LL |   extern "C" {
+   |   ---------- `extern` blocks define existing foreign statics and statics inside of them cannot have a body
+LL | /     thread_local! {
+LL | |       static FOO: u32 = 0;
+   | |              ^^^ cannot have a body
+LL | |
+LL | |
+LL | |     }
+   | |_____- the invalid body
+   |
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: incorrect `static` inside `extern` block
+  --> $DIR/issue-116203.rs:16:14
+   |
+LL |         const $name: () = ();
+   |                           -- the invalid body
+...
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign statics and statics inside of them cannot have a body
+LL |     hello! { yes }
+   |              ^^^ cannot have a body
+   |
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes #116203

This PR has discarded the invalid `﻿const_span`, thereby making the format more neat.

r? @Nilstrieb