### PR TITLE
Add a note to duplicate diagnostics

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1376,16 +1376,16 @@ impl HandlerInner {
                 self.emitted_diagnostic_codes.insert(code.clone());
             }
 
-            let already_emitted = |this: &mut Self| {
+            let already_emitted = {
                 let mut hasher = StableHasher::new();
                 diagnostic.hash(&mut hasher);
                 let diagnostic_hash = hasher.finish();
-                !this.emitted_diagnostics.insert(diagnostic_hash)
+                !self.emitted_diagnostics.insert(diagnostic_hash)
             };
 
             // Only emit the diagnostic if we've been asked to deduplicate or
             // haven't already emitted an equivalent diagnostic.
-            if !(self.flags.deduplicate_diagnostics && already_emitted(self)) {
+            if !(self.flags.deduplicate_diagnostics && already_emitted) {
                 debug!(?diagnostic);
                 debug!(?self.emitted_diagnostics);
                 let already_emitted_sub = |sub: &mut SubDiagnostic| {
@@ -1401,6 +1401,11 @@ impl HandlerInner {
                 };
 
                 diagnostic.children.extract_if(already_emitted_sub).for_each(|_| {});
+                if already_emitted {
+                    diagnostic.note(
+                        "duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`",
+                    );
+                }
 
                 self.emitter.emit_diagnostic(diagnostic);
                 if diagnostic.is_error() {

--- a/tests/rustdoc-ui/custom_code_classes_in_docs-warning3.stderr
+++ b/tests/rustdoc-ui/custom_code_classes_in_docs-warning3.stderr
@@ -28,6 +28,8 @@ LL | |
 LL | | /// main;
 LL | | /// ```
    | |_______^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/rustdoc-ui/intra-doc/broken-link-in-unused-doc-string.stderr
+++ b/tests/rustdoc-ui/intra-doc/broken-link-in-unused-doc-string.stderr
@@ -22,6 +22,7 @@ LL | /// [1]
    |      ^ no item named `1` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/rustdoc-ui/issues/issue-105742.stderr
+++ b/tests/rustdoc-ui/issues/issue-105742.stderr
@@ -169,6 +169,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     <Self as SVec>::Item<'a>,
@@ -185,6 +186,7 @@ note: associated type defined here, with 1 generic parameter: `T`
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
 LL |     <Self as SVec>::Item<T>,
@@ -201,6 +203,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     Output = <Index<<Self as SVec>::Item<'a>,
@@ -217,6 +220,7 @@ note: associated type defined here, with 1 generic parameter: `T`
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
 LL |     Output = <Index<<Self as SVec>::Item<T>,
@@ -233,6 +237,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     Output = <Self as SVec>::Item<'a>> as SVec>::Item,
@@ -249,6 +254,7 @@ note: associated type defined here, with 1 generic parameter: `T`
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
 LL |     Output = <Self as SVec>::Item<T>> as SVec>::Item,
@@ -265,6 +271,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<'a>,
@@ -281,6 +288,7 @@ note: associated type defined here, with 1 generic parameter: `T`
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
@@ -327,6 +335,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     <Self as SVec>::Item<'a>,
@@ -343,6 +352,7 @@ note: associated type defined here, with 1 generic parameter: `T`
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
 LL |     <Self as SVec>::Item<T>,
@@ -359,6 +369,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     Output = <Index<<Self as SVec>::Item<'a>,
@@ -375,6 +386,7 @@ note: associated type defined here, with 1 generic parameter: `T`
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
 LL |     Output = <Index<<Self as SVec>::Item<T>,
@@ -391,6 +403,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     Output = <Self as SVec>::Item<'a>> as SVec>::Item,
@@ -407,6 +420,7 @@ note: associated type defined here, with 1 generic parameter: `T`
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
 LL |     Output = <Self as SVec>::Item<T>> as SVec>::Item,
@@ -423,6 +437,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<'a>,
@@ -439,6 +454,7 @@ note: associated type defined here, with 1 generic parameter: `T`
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,

--- a/tests/rustdoc-ui/lints/feature-gate-rustdoc_missing_doc_code_examples.rs
+++ b/tests/rustdoc-ui/lints/feature-gate-rustdoc_missing_doc_code_examples.rs
@@ -1,12 +1,7 @@
+// compile-flags: -Zdeduplicate-diagnostics=yes
 #![deny(unknown_lints)]
 //~^ NOTE defined here
 #![allow(rustdoc::missing_doc_code_examples)]
 //~^ ERROR unknown lint
-//~| ERROR unknown lint
-//~| ERROR unknown lint
 //~| NOTE lint is unstable
-//~| NOTE lint is unstable
-//~| NOTE lint is unstable
-//~| NOTE see issue
-//~| NOTE see issue
 //~| NOTE see issue

--- a/tests/rustdoc-ui/lints/feature-gate-rustdoc_missing_doc_code_examples.stderr
+++ b/tests/rustdoc-ui/lints/feature-gate-rustdoc_missing_doc_code_examples.stderr
@@ -1,5 +1,5 @@
 error: unknown lint: `rustdoc::missing_doc_code_examples`
-  --> $DIR/feature-gate-rustdoc_missing_doc_code_examples.rs:3:1
+  --> $DIR/feature-gate-rustdoc_missing_doc_code_examples.rs:4:1
    |
 LL | #![allow(rustdoc::missing_doc_code_examples)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,30 +8,10 @@ LL | #![allow(rustdoc::missing_doc_code_examples)]
    = note: see issue #101730 <https://github.com/rust-lang/rust/issues/101730> for more information
    = help: add `#![feature(rustdoc_missing_doc_code_examples)]` to the crate attributes to enable
 note: the lint level is defined here
-  --> $DIR/feature-gate-rustdoc_missing_doc_code_examples.rs:1:9
+  --> $DIR/feature-gate-rustdoc_missing_doc_code_examples.rs:2:9
    |
 LL | #![deny(unknown_lints)]
    |         ^^^^^^^^^^^^^
 
-error: unknown lint: `rustdoc::missing_doc_code_examples`
-  --> $DIR/feature-gate-rustdoc_missing_doc_code_examples.rs:3:1
-   |
-LL | #![allow(rustdoc::missing_doc_code_examples)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: the `rustdoc::missing_doc_code_examples` lint is unstable
-   = note: see issue #101730 <https://github.com/rust-lang/rust/issues/101730> for more information
-   = help: add `#![feature(rustdoc_missing_doc_code_examples)]` to the crate attributes to enable
-
-error: unknown lint: `rustdoc::missing_doc_code_examples`
-  --> $DIR/feature-gate-rustdoc_missing_doc_code_examples.rs:3:1
-   |
-LL | #![allow(rustdoc::missing_doc_code_examples)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: the `rustdoc::missing_doc_code_examples` lint is unstable
-   = note: see issue #101730 <https://github.com/rust-lang/rust/issues/101730> for more information
-   = help: add `#![feature(rustdoc_missing_doc_code_examples)]` to the crate attributes to enable
-
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 

--- a/tests/rustdoc-ui/unescaped_backticks.stderr
+++ b/tests/rustdoc-ui/unescaped_backticks.stderr
@@ -302,6 +302,7 @@ LL | |     /// level changes.
    = help: if you meant to use a literal backtick, escape it
             change: or `None` if it isn't.
            to this: or `None\` if it isn't.
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unescaped backtick
   --> $DIR/unescaped_backticks.rs:323:5
@@ -321,6 +322,7 @@ LL | |     /// level changes.
    = help: if you meant to use a literal backtick, escape it
             change: `on_event` should be called.
            to this: `on_event\` should be called.
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unescaped backtick
   --> $DIR/unescaped_backticks.rs:323:5
@@ -340,6 +342,7 @@ LL | |     /// level changes.
    = help: if you meant to use a literal backtick, escape it
             change: [`rebuild_interest_cache`][rebuild] is called after the value of the max
            to this: [`rebuild_interest_cache\`][rebuild] is called after the value of the max
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unescaped backtick
   --> $DIR/unescaped_backticks.rs:349:56

--- a/tests/ui-fulldeps/plugin/lint-plugin-forbid-attrs.stderr
+++ b/tests/ui-fulldeps/plugin/lint-plugin-forbid-attrs.stderr
@@ -27,6 +27,8 @@ LL | #![forbid(test_lint)]
 ...
 LL | #[allow(test_lint)]
    |         ^^^^^^^^^ overruled by previous forbid
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
   --> $DIR/lint-plugin-forbid-attrs.rs:5:1

--- a/tests/ui-fulldeps/plugin/lint-plugin-forbid-cmdline.stderr
+++ b/tests/ui-fulldeps/plugin/lint-plugin-forbid-cmdline.stderr
@@ -21,6 +21,7 @@ LL | #[allow(test_lint)]
    |         ^^^^^^^^^ overruled by previous forbid
    |
    = note: `forbid` lint level was set on command line
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
   --> $DIR/lint-plugin-forbid-cmdline.rs:6:1

--- a/tests/ui-fulldeps/plugin/lint-tool-cmdline-allow.stderr
+++ b/tests/ui-fulldeps/plugin/lint-tool-cmdline-allow.stderr
@@ -8,6 +8,7 @@ warning: lint name `test_lint` is deprecated and may not have an effect in the f
    |
    = help: change it to clippy::test_lint
    = note: requested on the command line with `-A test_lint`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: item is named 'lintme'
   --> $DIR/lint-tool-cmdline-allow.rs:9:1
@@ -29,6 +30,7 @@ warning: lint name `test_lint` is deprecated and may not have an effect in the f
    |
    = help: change it to clippy::test_lint
    = note: requested on the command line with `-A test_lint`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 5 warnings emitted
 

--- a/tests/ui-fulldeps/plugin/lint-tool-test.stderr
+++ b/tests/ui-fulldeps/plugin/lint-tool-test.stderr
@@ -23,12 +23,16 @@ warning: lint name `test_lint` is deprecated and may not have an effect in the f
    |
 LL | #![cfg_attr(foo, warn(test_lint))]
    |                       ^^^^^^^^^ help: change it to: `clippy::test_lint`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: lint name `clippy_group` is deprecated and may not have an effect in the future.
   --> $DIR/lint-tool-test.rs:13:9
    |
 LL | #![deny(clippy_group)]
    |         ^^^^^^^^^^^^ help: change it to: `clippy::group`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: item is named 'lintme'
   --> $DIR/lint-tool-test.rs:18:1
@@ -56,6 +60,8 @@ warning: lint name `test_group` is deprecated and may not have an effect in the 
    |
 LL | #[allow(test_group)]
    |         ^^^^^^^^^^ help: change it to: `clippy::test_group`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `this_lint_does_not_exist`
   --> $DIR/lint-tool-test.rs:33:8
@@ -78,18 +84,24 @@ warning: lint name `test_lint` is deprecated and may not have an effect in the f
    |
 LL | #![cfg_attr(foo, warn(test_lint))]
    |                       ^^^^^^^^^ help: change it to: `clippy::test_lint`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: lint name `clippy_group` is deprecated and may not have an effect in the future.
   --> $DIR/lint-tool-test.rs:13:9
    |
 LL | #![deny(clippy_group)]
    |         ^^^^^^^^^^^^ help: change it to: `clippy::group`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: lint name `test_group` is deprecated and may not have an effect in the future.
   --> $DIR/lint-tool-test.rs:29:9
    |
 LL | #[allow(test_group)]
    |         ^^^^^^^^^^ help: change it to: `clippy::test_group`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors; 11 warnings emitted
 

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -414,6 +414,8 @@ error: `#[lint(...)]` is not a valid attribute
    |
 LL | #[lint(no_crate_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:601:1

--- a/tests/ui/allocator/not-an-allocator.stderr
+++ b/tests/ui/allocator/not-an-allocator.stderr
@@ -18,6 +18,7 @@ LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
@@ -29,6 +30,7 @@ LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
@@ -40,6 +42,7 @@ LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors

--- a/tests/ui/associated-consts/defaults-not-assumed-fail.stderr
+++ b/tests/ui/associated-consts/defaults-not-assumed-fail.stderr
@@ -24,6 +24,7 @@ note: erroneous constant encountered
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/tests/ui/associated-inherent-types/issue-109789.stderr
+++ b/tests/ui/associated-inherent-types/issue-109789.stderr
@@ -15,6 +15,7 @@ LL | fn bar(_: Foo<for<'a> fn(&'a ())>::Assoc) {}
    |
    = note: expected struct `Foo<fn(&'static ())>`
               found struct `Foo<for<'a> fn(&'a ())>`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-type-bounds/duplicate.stderr
+++ b/tests/ui/associated-type-bounds/duplicate.stderr
@@ -373,6 +373,8 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
    |                      |
    |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
   --> $DIR/duplicate.rs:197:34
@@ -389,6 +391,8 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
    |                      |
    |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
   --> $DIR/duplicate.rs:200:37
@@ -405,6 +409,8 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
    |                      |
    |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
   --> $DIR/duplicate.rs:205:29
@@ -445,6 +451,8 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    ----------  ^^^^^^^^^^ re-bound here
    |                    |
    |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
   --> $DIR/duplicate.rs:230:32
@@ -461,6 +469,8 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    ----------  ^^^^^^^^^^ re-bound here
    |                    |
    |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
   --> $DIR/duplicate.rs:237:35
@@ -477,6 +487,8 @@ LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    -------------  ^^^^^^^^^^^^^ re-bound here
    |                    |
    |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
   --> $DIR/duplicate.rs:255:40

--- a/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
@@ -45,6 +45,7 @@ LL | trait Z<'a, T: ?Sized>
 ...
 LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
    |                                   ^^^^^ required by this bound in `Z`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/async-await/drop-tracking-unresolved-typeck-results.stderr
+++ b/tests/ui/async-await/drop-tracking-unresolved-typeck-results.stderr
@@ -23,6 +23,7 @@ LL | |     });
    |
    = note: `fn(&'0 ()) -> std::future::Ready<&'0 ()> {std::future::ready::<&'0 ()>}` must implement `FnOnce<(&'1 (),)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `FnOnce<(&(),)>`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.stderr
@@ -44,6 +44,7 @@ note: the lifetime requirement is introduced here
    |
 LL |     F: Future + Send + 'static,
    |                 ^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
+++ b/tests/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
@@ -53,6 +53,7 @@ note: ...does not necessarily outlive the lifetime `'c` as defined here
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |                        ^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0195]: lifetime parameters or bounds on method `wrong_bound2` do not match the trait declaration
   --> $DIR/regions-bound-missing-bound-in-impl.rs:42:20

--- a/tests/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
+++ b/tests/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
@@ -25,6 +25,7 @@ LL | #![cfg_attr(foo, crate_type="bin")]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `crate_name` within an `#![cfg_attr] attribute is deprecated`
   --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:9:18
@@ -34,6 +35,7 @@ LL | #![cfg_attr(foo, crate_name="bar")]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -74,6 +74,7 @@ LL |         #[cfg(feature = $expr)]
 LL | generate_s10!(concat!("nonexistent"));
    | ------------------------------------- in this macro invocation
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the macro `generate_s10` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 11 previous errors

--- a/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
+++ b/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
@@ -39,6 +39,7 @@ note: associated constant defined here
    |
 LL |     const MODE: Mode;
    |     ^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/issues/issue-74950.min.stderr
+++ b/tests/ui/const-generics/issues/issue-74950.min.stderr
@@ -15,6 +15,7 @@ LL | struct Outer<const I: Inner>;
    |
    = note: the only supported types are integers, `bool` and `char`
    = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `Inner` is forbidden as the type of a const generic parameter
   --> $DIR/issue-74950.rs:20:23
@@ -24,6 +25,7 @@ LL | struct Outer<const I: Inner>;
    |
    = note: the only supported types are integers, `bool` and `char`
    = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `Inner` is forbidden as the type of a const generic parameter
   --> $DIR/issue-74950.rs:20:23
@@ -33,6 +35,7 @@ LL | struct Outer<const I: Inner>;
    |
    = note: the only supported types are integers, `bool` and `char`
    = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `Inner` is forbidden as the type of a const generic parameter
   --> $DIR/issue-74950.rs:20:23
@@ -42,6 +45,7 @@ LL | struct Outer<const I: Inner>;
    |
    = note: the only supported types are integers, `bool` and `char`
    = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/consts/const-err-late.stderr
+++ b/tests/ui/consts/const-err-late.stderr
@@ -27,6 +27,8 @@ note: erroneous constant encountered
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    |                ^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/issue-44578.stderr
+++ b/tests/ui/consts/const-eval/issue-44578.stderr
@@ -24,6 +24,7 @@ note: erroneous constant encountered
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -17,6 +17,8 @@ note: erroneous constant encountered
    |
 LL |     let _ = PrintName::VOID;
    |             ^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to previous error
 

--- a/tests/ui/consts/const-eval/stable-metric/ctfe-simple-loop.warn.stderr
+++ b/tests/ui/consts/const-eval/stable-metric/ctfe-simple-loop.warn.stderr
@@ -40,6 +40,7 @@ help: the constant being evaluated
    |
 LL | const Y: u32 = simple_loop(35);
    | ^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: constant evaluation is taking a long time
   --> $DIR/ctfe-simple-loop.rs:9:5

--- a/tests/ui/consts/const-eval/union-const-eval-field.rs
+++ b/tests/ui/consts/const-eval/union-const-eval-field.rs
@@ -1,5 +1,3 @@
-// only-x86_64
-
 type Field1 = i32;
 type Field2 = f32;
 type Field3 = i64;

--- a/tests/ui/consts/const-eval/union-const-eval-field.stderr
+++ b/tests/ui/consts/const-eval/union-const-eval-field.stderr
@@ -1,20 +1,22 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/union-const-eval-field.rs:28:37
+  --> $DIR/union-const-eval-field.rs:26:37
    |
 LL |     const FIELD3: Field3 = unsafe { UNION.field3 };
    |                                     ^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 note: erroneous constant encountered
-  --> $DIR/union-const-eval-field.rs:31:5
+  --> $DIR/union-const-eval-field.rs:29:5
    |
 LL |     FIELD3
    |     ^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/union-const-eval-field.rs:31:5
+  --> $DIR/union-const-eval-field.rs:29:5
    |
 LL |     FIELD3
    |     ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to previous error
 

--- a/tests/ui/consts/const_in_pattern/reject_non_structural.rs
+++ b/tests/ui/consts/const_in_pattern/reject_non_structural.rs
@@ -1,3 +1,5 @@
+// compile-flags: -Zdeduplicate-diagnostics=yes
+
 // This test of structural match checking enumerates the different kinds of
 // const definitions, collecting cases where the const pattern is rejected.
 //
@@ -76,9 +78,6 @@ fn main() {
     const REPEAT: [OND; 2] = [Some(NoDerive); 2];
     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
     //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
-    //~| NOTE the traits must be derived
-    //~| NOTE StructuralEq.html for details
-    //~| ERROR must be annotated with `#[derive(PartialEq, Eq)]`
     //~| NOTE the traits must be derived
     //~| NOTE StructuralEq.html for details
 

--- a/tests/ui/consts/const_in_pattern/reject_non_structural.stderr
+++ b/tests/ui/consts/const_in_pattern/reject_non_structural.stderr
@@ -1,5 +1,5 @@
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:40:36
+  --> $DIR/reject_non_structural.rs:42:36
    |
 LL |     match Derive::Some(NoDerive) { ENUM => dbg!(ENUM), _ => panic!("whoops"), };
    |                                    ^^^^
@@ -8,7 +8,7 @@ LL |     match Derive::Some(NoDerive) { ENUM => dbg!(ENUM), _ => panic!("whoops"
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:46:28
+  --> $DIR/reject_non_structural.rs:48:28
    |
 LL |     match Some(NoDerive) { FIELD => dbg!(FIELD), _ => panic!("whoops"), };
    |                            ^^^^^
@@ -17,7 +17,7 @@ LL |     match Some(NoDerive) { FIELD => dbg!(FIELD), _ => panic!("whoops"), };
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:53:27
+  --> $DIR/reject_non_structural.rs:55:27
    |
 LL |     match Some(NoDerive) {INDIRECT => dbg!(INDIRECT), _ => panic!("whoops"), };
    |                           ^^^^^^^^
@@ -26,7 +26,7 @@ LL |     match Some(NoDerive) {INDIRECT => dbg!(INDIRECT), _ => panic!("whoops")
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:59:36
+  --> $DIR/reject_non_structural.rs:61:36
    |
 LL |     match (None, Some(NoDerive)) { TUPLE => dbg!(TUPLE), _ => panic!("whoops"), };
    |                                    ^^^^^
@@ -35,7 +35,7 @@ LL |     match (None, Some(NoDerive)) { TUPLE => dbg!(TUPLE), _ => panic!("whoop
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:65:28
+  --> $DIR/reject_non_structural.rs:67:28
    |
 LL |     match Some(NoDerive) { TYPE_ASCRIPTION => dbg!(TYPE_ASCRIPTION), _ => panic!("whoops"), };
    |                            ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     match Some(NoDerive) { TYPE_ASCRIPTION => dbg!(TYPE_ASCRIPTION), _ => p
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:71:36
+  --> $DIR/reject_non_structural.rs:73:36
    |
 LL |     match [None, Some(NoDerive)] { ARRAY => dbg!(ARRAY), _ => panic!("whoops"), };
    |                                    ^^^^^
@@ -53,7 +53,7 @@ LL |     match [None, Some(NoDerive)] { ARRAY => dbg!(ARRAY), _ => panic!("whoop
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:77:33
+  --> $DIR/reject_non_structural.rs:79:33
    |
 LL |     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
    |                                 ^^^^^^
@@ -62,16 +62,7 @@ LL |     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:77:33
-   |
-LL |     match [Some(NoDerive); 2] { REPEAT => dbg!(REPEAT), _ => panic!("whoops"), };
-   |                                 ^^^^^^
-   |
-   = note: the traits must be derived, manual `impl`s are not sufficient
-   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
-
-error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:87:28
+  --> $DIR/reject_non_structural.rs:86:28
    |
 LL |     match Some(NoDerive) { NoDerive::ASSOC => dbg!(NoDerive::ASSOC), _ => panic!("whoops"), };
    |                            ^^^^^^^^^^^^^^^
@@ -80,7 +71,7 @@ LL |     match Some(NoDerive) { NoDerive::ASSOC => dbg!(NoDerive::ASSOC), _ => p
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 error: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:93:28
+  --> $DIR/reject_non_structural.rs:92:28
    |
 LL |     match Some(NoDerive) { BLOCK => dbg!(BLOCK), _ => panic!("whoops"), };
    |                            ^^^^^
@@ -89,7 +80,7 @@ LL |     match Some(NoDerive) { BLOCK => dbg!(BLOCK), _ => panic!("whoops"), };
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 
 warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/reject_non_structural.rs:99:29
+  --> $DIR/reject_non_structural.rs:98:29
    |
 LL |     match &Some(NoDerive) { ADDR_OF => dbg!(ADDR_OF), _ => panic!("whoops"), };
    |                             ^^^^^^^
@@ -99,10 +90,10 @@ LL |     match &Some(NoDerive) { ADDR_OF => dbg!(ADDR_OF), _ => panic!("whoops")
    = note: the traits must be derived, manual `impl`s are not sufficient
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
 note: the lint level is defined here
-  --> $DIR/reject_non_structural.rs:12:9
+  --> $DIR/reject_non_structural.rs:14:9
    |
 LL | #![warn(indirect_structural_match)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 10 previous errors; 1 warning emitted
+error: aborting due to 9 previous errors; 1 warning emitted
 

--- a/tests/ui/consts/enum-discr-type-err.stderr
+++ b/tests/ui/consts/enum-discr-type-err.stderr
@@ -24,6 +24,7 @@ LL | |     B = T,
 LL | | }
    | |_- in this macro invocation
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -21,6 +21,8 @@ error: ~const can only be applied to `#[const_trait]` traits
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |               ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: ~const can only be applied to `#[const_trait]` traits
   --> $DIR/fn_trait_refs.rs:22:15
@@ -33,6 +35,8 @@ error: ~const can only be applied to `#[const_trait]` traits
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |               ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: ~const can only be applied to `#[const_trait]` traits
   --> $DIR/fn_trait_refs.rs:29:15
@@ -45,6 +49,8 @@ error: ~const can only be applied to `#[const_trait]` traits
    |
 LL |     T: ~const FnOnce<()>,
    |               ^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: ~const can only be applied to `#[const_trait]` traits
   --> $DIR/fn_trait_refs.rs:36:15
@@ -57,6 +63,8 @@ error: ~const can only be applied to `#[const_trait]` traits
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |               ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: ~const can only be applied to `#[const_trait]` traits
   --> $DIR/fn_trait_refs.rs:50:15
@@ -69,6 +77,8 @@ error: ~const can only be applied to `#[const_trait]` traits
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |               ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/consts/invalid-union.32bit.stderr
+++ b/tests/ui/consts/invalid-union.32bit.stderr
@@ -20,6 +20,8 @@ note: erroneous constant encountered
    |
 LL |     let _: &'static _ = &C;
    |                         ^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to previous error
 

--- a/tests/ui/consts/invalid-union.64bit.stderr
+++ b/tests/ui/consts/invalid-union.64bit.stderr
@@ -20,6 +20,8 @@ note: erroneous constant encountered
    |
 LL |     let _: &'static _ = &C;
    |                         ^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to previous error
 

--- a/tests/ui/consts/issue-102117.stderr
+++ b/tests/ui/consts/issue-102117.stderr
@@ -15,6 +15,7 @@ error[E0310]: the parameter type `T` may not live long enough
 LL |                 type_id: TypeId::of::<T>(),
    |                          ^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider adding an explicit lifetime bound...
    |
 LL |     pub fn new<T: 'static>() -> &'static Self {

--- a/tests/ui/consts/issue-17718-const-bad-values.stderr
+++ b/tests/ui/consts/issue-17718-const-bad-values.stderr
@@ -19,6 +19,7 @@ LL | const C2: &'static mut usize = unsafe { &mut S };
    |                                              ^
    |
    = help: consider extracting the value of the `static` to a `const`, and referring to that
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -24,6 +24,8 @@ note: erroneous constant encountered
    |
 LL |     let y = <String as Bar<Vec<u32>, String>>::F;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/miri_unleashed/assoc_const_2.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const_2.stderr
@@ -15,6 +15,8 @@ note: erroneous constant encountered
    |
 LL |     let y = <String as Bar<String>>::F;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to previous error
 

--- a/tests/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/tests/ui/consts/uninhabited-const-issue-61744.stderr
@@ -656,6 +656,8 @@ note: erroneous constant encountered
    |
 LL |     dbg!(i32::CONSTANT);
    |          ^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to previous error
 

--- a/tests/ui/crate-loading/invalid-rlib.rs
+++ b/tests/ui/crate-loading/invalid-rlib.rs
@@ -8,3 +8,4 @@ use ::foo; //~ ERROR invalid metadata files for crate `foo`
 //~| NOTE failed to mmap file
 //~^^ ERROR invalid metadata files for crate `foo`
 //~| NOTE failed to mmap file
+//~| NOTE duplicate diagnostic

--- a/tests/ui/crate-loading/invalid-rlib.stderr
+++ b/tests/ui/crate-loading/invalid-rlib.stderr
@@ -13,6 +13,7 @@ LL | use ::foo;
    |       ^^^
    |
    = note: failed to mmap file 'auxiliary/libfoo.rlib'
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/deduplicate-diagnostics.duplicate.stderr
+++ b/tests/ui/deduplicate-diagnostics.duplicate.stderr
@@ -15,12 +15,16 @@ error: cannot find derive macro `Unresolved` in this scope
    |
 LL | #[derive(Unresolved)]
    |          ^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0452]: malformed lint attribute input
   --> $DIR/deduplicate-diagnostics.rs:8:8
    |
 LL | #[deny("literal")]
    |        ^^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/derives/deriving-bounds.stderr
+++ b/tests/ui/derives/deriving-bounds.stderr
@@ -21,6 +21,7 @@ note: unsafe traits like `Sync` should be implemented explicitly
    |
 LL | #[derive(Sync)]
    |          ^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot find derive macro `Send` in this scope
   --> $DIR/deriving-bounds.rs:1:10
@@ -45,6 +46,7 @@ note: unsafe traits like `Send` should be implemented explicitly
    |
 LL | #[derive(Send)]
    |          ^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/derives/deriving-meta-unknown-trait.stderr
+++ b/tests/ui/derives/deriving-meta-unknown-trait.stderr
@@ -15,6 +15,8 @@ LL | #[derive(Eqr)]
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: similarly named derive macro `Eq` defined here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/derives/deriving-primitive.stderr
+++ b/tests/ui/derives/deriving-primitive.stderr
@@ -9,6 +9,8 @@ error: cannot find derive macro `FromPrimitive` in this scope
    |
 LL | #[derive(FromPrimitive)]
    |          ^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
@@ -35,6 +35,8 @@ warning: malformed `on_unimplemented` attribute
    |
 LL | #[diagnostic::on_unimplemented(unsupported = "foo")]
    |                                ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:31:14
@@ -60,6 +62,8 @@ warning: malformed `on_unimplemented` attribute
    |
 LL | #[diagnostic::on_unimplemented(message = "Boom", unsupported = "Bar")]
    |                                                  ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: Boom
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:33:14
@@ -85,6 +89,8 @@ warning: malformed `on_unimplemented` attribute
    |
 LL | #[diagnostic::on_unimplemented(message = "Boom", on(_Self = "i32", message = "whatever"))]
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: Boom
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:35:15

--- a/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -50,6 +50,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
@@ -63,6 +64,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
@@ -76,6 +78,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
@@ -89,6 +92,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {

--- a/tests/ui/error-codes/E0452.stderr
+++ b/tests/ui/error-codes/E0452.stderr
@@ -9,18 +9,24 @@ error[E0452]: malformed lint attribute input
    |
 LL | #![allow(foo = "")]
    |          ^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0452]: malformed lint attribute input
   --> $DIR/E0452.rs:1:10
    |
 LL | #![allow(foo = "")]
    |          ^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0452]: malformed lint attribute input
   --> $DIR/E0452.rs:1:10
    |
 LL | #![allow(foo = "")]
    |          ^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/error-codes/E0453.stderr
+++ b/tests/ui/error-codes/E0453.stderr
@@ -15,6 +15,8 @@ LL | #![forbid(non_snake_case)]
 LL |
 LL | #[allow(non_snake_case)]
    |         ^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0602.stderr
+++ b/tests/ui/error-codes/E0602.stderr
@@ -6,10 +6,12 @@ warning[E0602]: unknown lint: `bogus`
 warning[E0602]: unknown lint: `bogus`
    |
    = note: requested on the command line with `-D bogus`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning[E0602]: unknown lint: `bogus`
    |
    = note: requested on the command line with `-D bogus`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/error-codes/E0719.stderr
+++ b/tests/ui/error-codes/E0719.stderr
@@ -13,6 +13,8 @@ LL | trait Foo: Iterator<Item = i32, Item = i32> {}
    |                     ----------  ^^^^^^^^^^ re-bound here
    |                     |
    |                     `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` (from trait `Iterator`) is already specified
   --> $DIR/E0719.rs:7:42

--- a/tests/ui/error-codes/E0789.stderr
+++ b/tests/ui/error-codes/E0789.stderr
@@ -9,6 +9,8 @@ error[E0789]: `rustc_allowed_through_unstable_modules` attribute must be paired 
    |
 LL | struct Foo;
    | ^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-lint-reasons.stderr
+++ b/tests/ui/feature-gates/feature-gate-lint-reasons.stderr
@@ -15,6 +15,7 @@ LL | #![warn(nonstandard_style, reason = "the standard should be respected")]
    |
    = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
    = help: add `#![feature(lint_reasons)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-multiple_supertrait_upcastable.stderr
+++ b/tests/ui/feature-gates/feature-gate-multiple_supertrait_upcastable.stderr
@@ -25,6 +25,7 @@ LL | #![deny(multiple_supertrait_upcastable)]
    |
    = note: the `multiple_supertrait_upcastable` lint is unstable
    = help: add `#![feature(multiple_supertrait_upcastable)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `multiple_supertrait_upcastable`
   --> $DIR/feature-gate-multiple_supertrait_upcastable.rs:7:1
@@ -34,6 +35,7 @@ LL | #![warn(multiple_supertrait_upcastable)]
    |
    = note: the `multiple_supertrait_upcastable` lint is unstable
    = help: add `#![feature(multiple_supertrait_upcastable)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `multiple_supertrait_upcastable`
   --> $DIR/feature-gate-multiple_supertrait_upcastable.rs:3:1
@@ -43,6 +45,7 @@ LL | #![deny(multiple_supertrait_upcastable)]
    |
    = note: the `multiple_supertrait_upcastable` lint is unstable
    = help: add `#![feature(multiple_supertrait_upcastable)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `multiple_supertrait_upcastable`
   --> $DIR/feature-gate-multiple_supertrait_upcastable.rs:7:1
@@ -52,6 +55,7 @@ LL | #![warn(multiple_supertrait_upcastable)]
    |
    = note: the `multiple_supertrait_upcastable` lint is unstable
    = help: add `#![feature(multiple_supertrait_upcastable)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 6 warnings emitted
 

--- a/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
+++ b/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
@@ -38,6 +38,7 @@ LL |     #[allow(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:29:9
@@ -58,6 +59,7 @@ LL | #![deny(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:6:1
@@ -68,6 +70,7 @@ LL | #![allow(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:15:5
@@ -78,6 +81,7 @@ LL |     #[allow(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:15:5
@@ -88,6 +92,7 @@ LL |     #[allow(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:29:9
@@ -98,6 +103,7 @@ LL |         #[warn(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0004]: non-exhaustive patterns: `Foo::C` not covered
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:20:11

--- a/tests/ui/feature-gates/feature-gate-strict_provenance.stderr
+++ b/tests/ui/feature-gates/feature-gate-strict_provenance.stderr
@@ -28,6 +28,7 @@ LL | #![deny(fuzzy_provenance_casts)]
    = note: the `fuzzy_provenance_casts` lint is unstable
    = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
    = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `lossy_provenance_casts`
   --> $DIR/feature-gate-strict_provenance.rs:7:1
@@ -38,6 +39,7 @@ LL | #![deny(lossy_provenance_casts)]
    = note: the `lossy_provenance_casts` lint is unstable
    = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
    = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `fuzzy_provenance_casts`
   --> $DIR/feature-gate-strict_provenance.rs:3:1
@@ -48,6 +50,7 @@ LL | #![deny(fuzzy_provenance_casts)]
    = note: the `fuzzy_provenance_casts` lint is unstable
    = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
    = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `lossy_provenance_casts`
   --> $DIR/feature-gate-strict_provenance.rs:7:1
@@ -58,6 +61,7 @@ LL | #![deny(lossy_provenance_casts)]
    = note: the `lossy_provenance_casts` lint is unstable
    = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
    = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 6 warnings emitted
 

--- a/tests/ui/feature-gates/feature-gate-test_unstable_lint.stderr
+++ b/tests/ui/feature-gates/feature-gate-test_unstable_lint.stderr
@@ -16,6 +16,7 @@ LL | #![allow(test_unstable_lint)]
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `#![feature(test_unstable_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `test_unstable_lint`
   --> $DIR/feature-gate-test_unstable_lint.rs:4:1
@@ -25,6 +26,7 @@ LL | #![allow(test_unstable_lint)]
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `#![feature(test_unstable_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/feature-gates/feature-gate-type_privacy_lints.stderr
+++ b/tests/ui/feature-gates/feature-gate-type_privacy_lints.stderr
@@ -18,6 +18,7 @@ LL | #![warn(unnameable_types)]
    = note: the `unnameable_types` lint is unstable
    = note: see issue #48054 <https://github.com/rust-lang/rust/issues/48054> for more information
    = help: add `#![feature(type_privacy_lints)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `unnameable_types`
   --> $DIR/feature-gate-type_privacy_lints.rs:3:1
@@ -28,6 +29,7 @@ LL | #![warn(unnameable_types)]
    = note: the `unnameable_types` lint is unstable
    = note: see issue #48054 <https://github.com/rust-lang/rust/issues/48054> for more information
    = help: add `#![feature(type_privacy_lints)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-derive-2.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-derive-2.stderr
@@ -9,6 +9,8 @@ error: cannot find derive macro `x3300` in this scope
    |
 LL |     #[derive(x3300)]
    |              ^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot find derive macro `x3300` in this scope
   --> $DIR/issue-43106-gating-of-derive-2.rs:9:14
@@ -21,6 +23,8 @@ error: cannot find derive macro `x3300` in this scope
    |
 LL |     #[derive(x3300)]
    |              ^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot find derive macro `x3300` in this scope
   --> $DIR/issue-43106-gating-of-derive-2.rs:4:14
@@ -33,6 +37,8 @@ error: cannot find derive macro `x3300` in this scope
    |
 LL |     #[derive(x3300)]
    |              ^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
@@ -25,6 +25,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |   type Y<'a>;
    |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |   fn foo<'a, T1: X<Y<'a> = T1>>(t : T1) -> T1::Y<'a> {

--- a/tests/ui/generic-associated-types/issue-91139.stderr
+++ b/tests/ui/generic-associated-types/issue-91139.stderr
@@ -9,6 +9,8 @@ error: `T` does not live long enough
    |
 LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/higher-ranked/subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.stderr
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.stderr
@@ -24,6 +24,7 @@ LL | | for<'a>    fn(Inv<'a>, Inv<'a>)) }
    |
    = note: expected enum `Option<for<'a, 'b> fn(Inv<'a>, Inv<'b>)>`
               found enum `Option<for<'a> fn(Inv<'a>, Inv<'a>)>`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-conflate-regions.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-conflate-regions.stderr
@@ -15,6 +15,7 @@ LL | fn b() { want_foo2::<SomeStruct>(); }
    |
    = note: `SomeStruct` must implement `Foo<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `Foo<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
+++ b/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
@@ -20,6 +20,7 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {
@@ -33,6 +34,7 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {

--- a/tests/ui/impl-trait/issue-55872-2.stderr
+++ b/tests/ui/impl-trait/issue-55872-2.stderr
@@ -9,6 +9,8 @@ error: type parameter `T` is part of concrete type but not used in parameter lis
    |
 LL |         async {}
    |         ^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/imports/ambiguous-9.stderr
+++ b/tests/ui/imports/ambiguous-9.stderr
@@ -60,6 +60,7 @@ note: `date_range` could also refer to the function imported here
 LL | use prelude::*;
    |     ^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 4 warnings emitted
 

--- a/tests/ui/imports/issue-55457.stderr
+++ b/tests/ui/imports/issue-55457.stderr
@@ -38,6 +38,7 @@ LL | #[derive(NonExistent)]
    |          ^^^^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot determine resolution for the derive macro `NonExistent`
   --> $DIR/issue-55457.rs:5:10
@@ -46,6 +47,7 @@ LL | #[derive(NonExistent)]
    |          ^^^^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/issues/issue-33571.stderr
+++ b/tests/ui/issues/issue-33571.stderr
@@ -21,6 +21,7 @@ note: unsafe traits like `Sync` should be implemented explicitly
    |
 LL |          Sync,
    |          ^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-40000.stderr
+++ b/tests/ui/issues/issue-40000.stderr
@@ -15,6 +15,7 @@ LL |     foo(bar);
    |
    = note: expected trait object `dyn for<'a> Fn(&'a i32)`
               found trait object `dyn Fn(&i32)`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-46101.stderr
+++ b/tests/ui/issues/issue-46101.stderr
@@ -9,6 +9,8 @@ error[E0433]: failed to resolve: partially resolved path in a derive macro
    |
 LL | #[derive(Foo::Anything)]
    |          ^^^^^^^^^^^^^ partially resolved path in a derive macro
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-53251.stderr
+++ b/tests/ui/issues/issue-53251.stderr
@@ -32,6 +32,7 @@ note: associated function defined here, with 0 generic parameters
    |
 LL |     fn f() {}
    |        ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/lifetimes/issue-105675.stderr
+++ b/tests/ui/lifetimes/issue-105675.stderr
@@ -81,6 +81,7 @@ note: the lifetime requirement is introduced here
    |
 LL | fn thing(x: impl FnOnce(&u32, &u32, u32)) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider specifying the type of the closure parameters
    |
 LL |     let f = |x: &_, y: &_, z: u32| ();

--- a/tests/ui/limits/issue-55878.stderr
+++ b/tests/ui/limits/issue-55878.stderr
@@ -25,6 +25,7 @@ note: erroneous constant encountered
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/tests/ui/lint/cli-unknown-force-warn.stderr
+++ b/tests/ui/lint/cli-unknown-force-warn.stderr
@@ -6,10 +6,12 @@ warning[E0602]: unknown lint: `foo_qux`
 warning[E0602]: unknown lint: `foo_qux`
    |
    = note: requested on the command line with `--force-warn foo_qux`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning[E0602]: unknown lint: `foo_qux`
    |
    = note: requested on the command line with `--force-warn foo_qux`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/lint/command-line-register-unknown-lint-tool.stderr
+++ b/tests/ui/lint/command-line-register-unknown-lint-tool.stderr
@@ -5,6 +5,7 @@ error[E0602]: unknown lint tool: `unknown_tool`
 error[E0602]: unknown lint tool: `unknown_tool`
    |
    = note: requested on the command line with `-A unknown_tool::foo`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/crate_level_only_lint.stderr
+++ b/tests/ui/lint/crate_level_only_lint.stderr
@@ -27,36 +27,48 @@ error: allow(uncommon_codepoints) is ignored unless specified at crate level
    |
 LL | #![allow(uncommon_codepoints)]
    |          ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(uncommon_codepoints) is ignored unless specified at crate level
   --> $DIR/crate_level_only_lint.rs:9:9
    |
 LL | #[allow(uncommon_codepoints)]
    |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(uncommon_codepoints) is ignored unless specified at crate level
   --> $DIR/crate_level_only_lint.rs:17:9
    |
 LL | #[allow(uncommon_codepoints)]
    |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(uncommon_codepoints) is ignored unless specified at crate level
   --> $DIR/crate_level_only_lint.rs:4:10
    |
 LL | #![allow(uncommon_codepoints)]
    |          ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(uncommon_codepoints) is ignored unless specified at crate level
   --> $DIR/crate_level_only_lint.rs:9:9
    |
 LL | #[allow(uncommon_codepoints)]
    |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(uncommon_codepoints) is ignored unless specified at crate level
   --> $DIR/crate_level_only_lint.rs:17:9
    |
 LL | #[allow(uncommon_codepoints)]
    |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/lint/forbid-group-group-2.stderr
+++ b/tests/ui/lint/forbid-group-group-2.stderr
@@ -26,6 +26,7 @@ LL | #[allow(nonstandard_style)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(nonstandard_style) incompatible with previous forbid
   --> $DIR/forbid-group-group-2.rs:7:9
@@ -38,6 +39,7 @@ LL | #[allow(nonstandard_style)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(nonstandard_style) incompatible with previous forbid
   --> $DIR/forbid-group-group-2.rs:7:9
@@ -50,6 +52,7 @@ LL | #[allow(nonstandard_style)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(nonstandard_style) incompatible with previous forbid
   --> $DIR/forbid-group-group-2.rs:7:9
@@ -62,6 +65,7 @@ LL | #[allow(nonstandard_style)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(nonstandard_style) incompatible with previous forbid
   --> $DIR/forbid-group-group-2.rs:7:9
@@ -74,6 +78,7 @@ LL | #[allow(nonstandard_style)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(nonstandard_style) incompatible with previous forbid
   --> $DIR/forbid-group-group-2.rs:7:9
@@ -86,6 +91,7 @@ LL | #[allow(nonstandard_style)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(nonstandard_style) incompatible with previous forbid
   --> $DIR/forbid-group-group-2.rs:7:9
@@ -98,6 +104,7 @@ LL | #[allow(nonstandard_style)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: allow(nonstandard_style) incompatible with previous forbid
   --> $DIR/forbid-group-group-2.rs:7:9
@@ -110,6 +117,7 @@ LL | #[allow(nonstandard_style)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/lint/forbid-group-member.stderr
+++ b/tests/ui/lint/forbid-group-member.stderr
@@ -22,6 +22,7 @@ LL | #[allow(unused_variables)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: allow(unused_variables) incompatible with previous forbid
   --> $DIR/forbid-group-member.rs:8:9
@@ -34,6 +35,7 @@ LL | #[allow(unused_variables)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/lint/forbid-member-group.stderr
+++ b/tests/ui/lint/forbid-member-group.stderr
@@ -15,6 +15,8 @@ LL | #![forbid(unused_variables)]
 LL |
 LL | #[allow(unused)]
    |         ^^^^^^ overruled by previous forbid
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -20,6 +20,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
@@ -33,6 +34,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/tests/ui/lint/force-warn/cap-lints-allow.stderr
@@ -20,6 +20,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
@@ -33,6 +34,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -21,6 +21,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
@@ -34,6 +35,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -21,6 +21,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
@@ -34,6 +35,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -21,6 +21,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
@@ -34,6 +35,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/force-warn/warnings-lint-group.stderr
+++ b/tests/ui/lint/force-warn/warnings-lint-group.stderr
@@ -1,6 +1,8 @@
 error[E0602]: `warnings` lint group is not supported with ´--force-warn´
 
 error[E0602]: `warnings` lint group is not supported with ´--force-warn´
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/issue-80988.stderr
+++ b/tests/ui/lint/issue-80988.stderr
@@ -22,6 +22,7 @@ LL | #[deny(warnings)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: deny(warnings) incompatible with previous forbid
   --> $DIR/issue-80988.rs:7:8
@@ -34,6 +35,7 @@ LL | #[deny(warnings)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/lint/lint-forbid-attr.stderr
+++ b/tests/ui/lint/lint-forbid-attr.stderr
@@ -15,6 +15,8 @@ LL | #![forbid(deprecated)]
 LL |
 LL | #[allow(deprecated)]
    |         ^^^^^^^^^^ overruled by previous forbid
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/lint-forbid-cmdline.stderr
+++ b/tests/ui/lint/lint-forbid-cmdline.stderr
@@ -13,6 +13,7 @@ LL | #[allow(deprecated)]
    |         ^^^^^^^^^^ overruled by previous forbid
    |
    = note: `forbid` lint level was set on command line
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/lint-malformed.stderr
+++ b/tests/ui/lint/lint-malformed.stderr
@@ -9,6 +9,8 @@ error[E0452]: malformed lint attribute input
    |
 LL | #![allow(bar = "baz")]
    |          ^^^^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: malformed `deny` attribute input
   --> $DIR/lint-malformed.rs:1:1
@@ -21,12 +23,16 @@ error[E0452]: malformed lint attribute input
    |
 LL | #![allow(bar = "baz")]
    |          ^^^^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0452]: malformed lint attribute input
   --> $DIR/lint-malformed.rs:2:10
    |
 LL | #![allow(bar = "baz")]
    |          ^^^^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/lint/lint-removed-cmdline-deny.stderr
+++ b/tests/ui/lint/lint-removed-cmdline-deny.stderr
@@ -6,10 +6,12 @@ error: lint `raw_pointer_derive` has been removed: using derive with raw pointer
 error: lint `raw_pointer_derive` has been removed: using derive with raw pointers is ok
    |
    = note: requested on the command line with `-D raw_pointer_derive`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: lint `raw_pointer_derive` has been removed: using derive with raw pointers is ok
    |
    = note: requested on the command line with `-D raw_pointer_derive`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unused variable: `unused`
   --> $DIR/lint-removed-cmdline-deny.rs:13:17

--- a/tests/ui/lint/lint-removed-cmdline.stderr
+++ b/tests/ui/lint/lint-removed-cmdline.stderr
@@ -6,10 +6,12 @@ warning: lint `raw_pointer_derive` has been removed: using derive with raw point
 warning: lint `raw_pointer_derive` has been removed: using derive with raw pointers is ok
    |
    = note: requested on the command line with `-D raw_pointer_derive`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: lint `raw_pointer_derive` has been removed: using derive with raw pointers is ok
    |
    = note: requested on the command line with `-D raw_pointer_derive`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unused variable: `unused`
   --> $DIR/lint-removed-cmdline.rs:13:17

--- a/tests/ui/lint/lint-renamed-cmdline-deny.stderr
+++ b/tests/ui/lint/lint-renamed-cmdline-deny.stderr
@@ -8,11 +8,13 @@ error: lint `bare_trait_object` has been renamed to `bare_trait_objects`
    |
    = help: use the new name `bare_trait_objects`
    = note: requested on the command line with `-D bare_trait_object`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: lint `bare_trait_object` has been renamed to `bare_trait_objects`
    |
    = help: use the new name `bare_trait_objects`
    = note: requested on the command line with `-D bare_trait_object`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unused variable: `unused`
   --> $DIR/lint-renamed-cmdline-deny.rs:10:17

--- a/tests/ui/lint/lint-renamed-cmdline.stderr
+++ b/tests/ui/lint/lint-renamed-cmdline.stderr
@@ -8,11 +8,13 @@ warning: lint `bare_trait_object` has been renamed to `bare_trait_objects`
    |
    = help: use the new name `bare_trait_objects`
    = note: requested on the command line with `-D bare_trait_object`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: lint `bare_trait_object` has been renamed to `bare_trait_objects`
    |
    = help: use the new name `bare_trait_objects`
    = note: requested on the command line with `-D bare_trait_object`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unused variable: `unused`
   --> $DIR/lint-renamed-cmdline.rs:9:17

--- a/tests/ui/lint/lint-stability-deprecated.stderr
+++ b/tests/ui/lint/lint-stability-deprecated.stderr
@@ -639,18 +639,24 @@ warning: use of deprecated associated type `lint_stability::TraitWithAssociatedT
    |
 LL |         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
    |                                                ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
   --> $DIR/lint-stability-deprecated.rs:102:13
    |
 LL |             TypeDeprecated = u16,
    |             ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
   --> $DIR/lint-stability-deprecated.rs:102:13
    |
 LL |             TypeDeprecated = u16,
    |             ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 108 warnings emitted
 

--- a/tests/ui/lint/lint-unexported-no-mangle.stderr
+++ b/tests/ui/lint/lint-unexported-no-mangle.stderr
@@ -10,18 +10,22 @@ warning: lint `private_no_mangle_statics` has been removed: no longer a warning,
 warning: lint `private_no_mangle_fns` has been removed: no longer a warning, `#[no_mangle]` functions always exported
    |
    = note: requested on the command line with `-F private_no_mangle_fns`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: lint `private_no_mangle_statics` has been removed: no longer a warning, `#[no_mangle]` statics always exported
    |
    = note: requested on the command line with `-F private_no_mangle_statics`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: lint `private_no_mangle_fns` has been removed: no longer a warning, `#[no_mangle]` functions always exported
    |
    = note: requested on the command line with `-F private_no_mangle_fns`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: lint `private_no_mangle_statics` has been removed: no longer a warning, `#[no_mangle]` statics always exported
    |
    = note: requested on the command line with `-F private_no_mangle_statics`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: const items should never be `#[no_mangle]`
   --> $DIR/lint-unexported-no-mangle.rs:9:1

--- a/tests/ui/lint/lint-unknown-lint-cmdline-deny.stderr
+++ b/tests/ui/lint/lint-unknown-lint-cmdline-deny.stderr
@@ -11,20 +11,24 @@ error[E0602]: unknown lint: `dead_cod`
 error[E0602]: unknown lint: `bogus`
    |
    = note: requested on the command line with `-D bogus`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0602]: unknown lint: `dead_cod`
    |
    = help: did you mean: `dead_code`
    = note: requested on the command line with `-D dead_cod`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0602]: unknown lint: `bogus`
    |
    = note: requested on the command line with `-D bogus`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0602]: unknown lint: `dead_cod`
    |
    = help: did you mean: `dead_code`
    = note: requested on the command line with `-D dead_cod`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/lint/lint-unknown-lint-cmdline.stderr
+++ b/tests/ui/lint/lint-unknown-lint-cmdline.stderr
@@ -11,20 +11,24 @@ warning[E0602]: unknown lint: `dead_cod`
 warning[E0602]: unknown lint: `bogus`
    |
    = note: requested on the command line with `-D bogus`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning[E0602]: unknown lint: `dead_cod`
    |
    = help: did you mean: `dead_code`
    = note: requested on the command line with `-D dead_cod`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning[E0602]: unknown lint: `bogus`
    |
    = note: requested on the command line with `-D bogus`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning[E0602]: unknown lint: `dead_cod`
    |
    = help: did you mean: `dead_code`
    = note: requested on the command line with `-D dead_cod`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 6 warnings emitted
 

--- a/tests/ui/lint/must_not_suspend/gated.stderr
+++ b/tests/ui/lint/must_not_suspend/gated.stderr
@@ -18,6 +18,7 @@ LL | #![deny(must_not_suspend)]
    = note: the `must_not_suspend` lint is unstable
    = note: see issue #83310 <https://github.com/rust-lang/rust/issues/83310> for more information
    = help: add `#![feature(must_not_suspend)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `must_not_suspend`
   --> $DIR/gated.rs:4:1
@@ -28,6 +29,7 @@ LL | #![deny(must_not_suspend)]
    = note: the `must_not_suspend` lint is unstable
    = note: see issue #83310 <https://github.com/rust-lang/rust/issues/83310> for more information
    = help: add `#![feature(must_not_suspend)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/lint/reasons-erroneous.rs
+++ b/tests/ui/lint/reasons-erroneous.rs
@@ -1,51 +1,27 @@
+// compile-flags: -Zdeduplicate-diagnostics=yes
+
 #![feature(lint_reasons)]
 
 #![warn(absolute_paths_not_starting_with_crate, reason = 0)]
 //~^ ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| NOTE reason must be a string literal
 //~| NOTE reason must be a string literal
 #![warn(anonymous_parameters, reason = b"consider these, for we have condemned them")]
 //~^ ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| NOTE reason must be a string literal
 //~| NOTE reason must be a string literal
 #![warn(bare_trait_objects, reasons = "leaders to no sure land, guides their bearings lost")]
 //~^ ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| NOTE bad attribute argument
-//~| NOTE bad attribute argument
-//~| NOTE bad attribute argument
 //~| NOTE bad attribute argument
 #![warn(box_pointers, blerp = "or in league with robbers have reversed the signposts")]
 //~^ ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| NOTE bad attribute argument
-//~| NOTE bad attribute argument
-//~| NOTE bad attribute argument
 //~| NOTE bad attribute argument
 #![warn(elided_lifetimes_in_paths, reason("disrespectful to ancestors", "irresponsible to heirs"))]
 //~^ ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| NOTE bad attribute argument
-//~| NOTE bad attribute argument
-//~| NOTE bad attribute argument
 //~| NOTE bad attribute argument
 #![warn(ellipsis_inclusive_range_patterns, reason = "born barren", reason = "a freak growth")]
 //~^ ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| NOTE reason in lint attribute must come last
 //~| NOTE reason in lint attribute must come last
 #![warn(keyword_idents, reason = "root in rubble", macro_use_extern_crate)]
 //~^ ERROR malformed lint attribute
-//~| ERROR malformed lint attribute
-//~| NOTE reason in lint attribute must come last
 //~| NOTE reason in lint attribute must come last
 #![warn(missing_copy_implementations, reason)]
 //~^ WARN unknown lint

--- a/tests/ui/lint/reasons-erroneous.stderr
+++ b/tests/ui/lint/reasons-erroneous.stderr
@@ -1,5 +1,5 @@
 error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:3:58
+  --> $DIR/reasons-erroneous.rs:5:58
    |
 LL | #![warn(absolute_paths_not_starting_with_crate, reason = 0)]
    |                                                          ^ reason must be a string literal
@@ -11,121 +11,43 @@ LL | #![warn(anonymous_parameters, reason = b"consider these, for we have condem
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reason must be a string literal
 
 error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:13:29
+  --> $DIR/reasons-erroneous.rs:11:29
    |
 LL | #![warn(bare_trait_objects, reasons = "leaders to no sure land, guides their bearings lost")]
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
 
 error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:13:29
-   |
-LL | #![warn(bare_trait_objects, reasons = "leaders to no sure land, guides their bearings lost")]
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:22:23
+  --> $DIR/reasons-erroneous.rs:14:23
    |
 LL | #![warn(box_pointers, blerp = "or in league with robbers have reversed the signposts")]
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
 
 error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:22:23
-   |
-LL | #![warn(box_pointers, blerp = "or in league with robbers have reversed the signposts")]
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:31:36
+  --> $DIR/reasons-erroneous.rs:17:36
    |
 LL | #![warn(elided_lifetimes_in_paths, reason("disrespectful to ancestors", "irresponsible to heirs"))]
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
 
 error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:31:36
-   |
-LL | #![warn(elided_lifetimes_in_paths, reason("disrespectful to ancestors", "irresponsible to heirs"))]
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:40:44
+  --> $DIR/reasons-erroneous.rs:20:44
    |
 LL | #![warn(ellipsis_inclusive_range_patterns, reason = "born barren", reason = "a freak growth")]
    |                                            ^^^^^^^^^^^^^^^^^^^^^^ reason in lint attribute must come last
 
 error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:45:25
-   |
-LL | #![warn(keyword_idents, reason = "root in rubble", macro_use_extern_crate)]
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ reason in lint attribute must come last
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:3:58
-   |
-LL | #![warn(absolute_paths_not_starting_with_crate, reason = 0)]
-   |                                                          ^ reason must be a string literal
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:8:40
-   |
-LL | #![warn(anonymous_parameters, reason = b"consider these, for we have condemned them")]
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reason must be a string literal
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:13:29
-   |
-LL | #![warn(bare_trait_objects, reasons = "leaders to no sure land, guides their bearings lost")]
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:13:29
-   |
-LL | #![warn(bare_trait_objects, reasons = "leaders to no sure land, guides their bearings lost")]
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:22:23
-   |
-LL | #![warn(box_pointers, blerp = "or in league with robbers have reversed the signposts")]
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:22:23
-   |
-LL | #![warn(box_pointers, blerp = "or in league with robbers have reversed the signposts")]
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:31:36
-   |
-LL | #![warn(elided_lifetimes_in_paths, reason("disrespectful to ancestors", "irresponsible to heirs"))]
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:31:36
-   |
-LL | #![warn(elided_lifetimes_in_paths, reason("disrespectful to ancestors", "irresponsible to heirs"))]
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bad attribute argument
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:40:44
-   |
-LL | #![warn(ellipsis_inclusive_range_patterns, reason = "born barren", reason = "a freak growth")]
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^ reason in lint attribute must come last
-
-error[E0452]: malformed lint attribute input
-  --> $DIR/reasons-erroneous.rs:45:25
+  --> $DIR/reasons-erroneous.rs:23:25
    |
 LL | #![warn(keyword_idents, reason = "root in rubble", macro_use_extern_crate)]
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ reason in lint attribute must come last
 
 warning: unknown lint: `reason`
-  --> $DIR/reasons-erroneous.rs:50:39
+  --> $DIR/reasons-erroneous.rs:26:39
    |
 LL | #![warn(missing_copy_implementations, reason)]
    |                                       ^^^^^^
    |
    = note: `#[warn(unknown_lints)]` on by default
 
-error: aborting due to 20 previous errors; 1 warning emitted
+error: aborting due to 7 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0452`.

--- a/tests/ui/lint/register-tool-lint.stderr
+++ b/tests/ui/lint/register-tool-lint.stderr
@@ -13,6 +13,7 @@ LL | #![warn(abc::my_lint)]
    |         ^^^
    |
    = help: add `#![register_tool(abc)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_with_forbid.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_with_forbid.rs
@@ -1,23 +1,19 @@
+// compile-flags: -Zdeduplicate-diagnostics=yes
+
 #![feature(lint_reasons)]
 
 #[forbid(unused_variables)]
 //~^ NOTE `forbid` level set here
-//~| NOTE `forbid` level set here
 #[expect(unused_variables)]
 //~^ ERROR incompatible with previous forbid [E0453]
-//~| NOTE overruled by previous forbid
-//~| ERROR incompatible with previous forbid [E0453]
 //~| NOTE overruled by previous forbid
 fn expect_forbidden_lint_1() {}
 
 #[forbid(while_true)]
 //~^ NOTE `forbid` level set here
-//~| NOTE `forbid` level set here
 //~| NOTE the lint level is defined here
 #[expect(while_true)]
 //~^ ERROR incompatible with previous forbid [E0453]
-//~| NOTE overruled by previous forbid
-//~| ERROR incompatible with previous forbid [E0453]
 //~| NOTE overruled by previous forbid
 fn expect_forbidden_lint_2() {
     // This while loop will produce a `while_true` lint as the lint level

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_with_forbid.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_with_forbid.stderr
@@ -1,32 +1,14 @@
 error[E0453]: expect(unused_variables) incompatible with previous forbid
-  --> $DIR/expect_with_forbid.rs:6:10
+  --> $DIR/expect_with_forbid.rs:7:10
    |
 LL | #[forbid(unused_variables)]
    |          ---------------- `forbid` level set here
-...
+LL |
 LL | #[expect(unused_variables)]
    |          ^^^^^^^^^^^^^^^^ overruled by previous forbid
 
 error[E0453]: expect(while_true) incompatible with previous forbid
-  --> $DIR/expect_with_forbid.rs:17:10
-   |
-LL | #[forbid(while_true)]
-   |          ---------- `forbid` level set here
-...
-LL | #[expect(while_true)]
-   |          ^^^^^^^^^^ overruled by previous forbid
-
-error[E0453]: expect(unused_variables) incompatible with previous forbid
-  --> $DIR/expect_with_forbid.rs:6:10
-   |
-LL | #[forbid(unused_variables)]
-   |          ---------------- `forbid` level set here
-...
-LL | #[expect(unused_variables)]
-   |          ^^^^^^^^^^^^^^^^ overruled by previous forbid
-
-error[E0453]: expect(while_true) incompatible with previous forbid
-  --> $DIR/expect_with_forbid.rs:17:10
+  --> $DIR/expect_with_forbid.rs:15:10
    |
 LL | #[forbid(while_true)]
    |          ---------- `forbid` level set here
@@ -35,17 +17,17 @@ LL | #[expect(while_true)]
    |          ^^^^^^^^^^ overruled by previous forbid
 
 error: denote infinite loops with `loop { ... }`
-  --> $DIR/expect_with_forbid.rs:26:5
+  --> $DIR/expect_with_forbid.rs:22:5
    |
 LL |     while true {}
    |     ^^^^^^^^^^ help: use `loop`
    |
 note: the lint level is defined here
-  --> $DIR/expect_with_forbid.rs:13:10
+  --> $DIR/expect_with_forbid.rs:12:10
    |
 LL | #[forbid(while_true)]
    |          ^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0453`.

--- a/tests/ui/lub-glb/old-lub-glb-object.stderr
+++ b/tests/ui/lub-glb/old-lub-glb-object.stderr
@@ -15,6 +15,7 @@ LL |         _ => y,
    |
    = note: expected trait object `dyn for<'a, 'b> Foo<&'a u8, &'b u8>`
               found trait object `dyn for<'a> Foo<&'a u8, &'a u8>`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/builtin-std-paths-fail.stderr
+++ b/tests/ui/macros/builtin-std-paths-fail.stderr
@@ -15,12 +15,16 @@ error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
    |
 LL |     core::RustcDecodable,
    |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
   --> $DIR/builtin-std-paths-fail.rs:4:11
    |
 LL |     core::RustcDecodable,
    |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0433]: failed to resolve: could not find `bench` in `core`
   --> $DIR/builtin-std-paths-fail.rs:7:9
@@ -63,12 +67,16 @@ error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
    |
 LL |     std::RustcDecodable,
    |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
   --> $DIR/builtin-std-paths-fail.rs:16:10
    |
 LL |     std::RustcDecodable,
    |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0433]: failed to resolve: could not find `bench` in `std`
   --> $DIR/builtin-std-paths-fail.rs:19:8

--- a/tests/ui/macros/meta-item-absolute-path.stderr
+++ b/tests/ui/macros/meta-item-absolute-path.stderr
@@ -9,6 +9,8 @@ error[E0433]: failed to resolve: maybe a missing crate `Absolute`?
    |
 LL | #[derive(::Absolute)]
    |            ^^^^^^^^ maybe a missing crate `Absolute`?
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/native-library-link-flags/modifiers-override.stderr
+++ b/tests/ui/native-library-link-flags/modifiers-override.stderr
@@ -21,6 +21,8 @@ error: overriding linking modifiers from command line is not supported
    |
 LL | extern "C" {}
    | ^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/nll/closure-malformed-projection-input-issue-102800.stderr
+++ b/tests/ui/nll/closure-malformed-projection-input-issue-102800.stderr
@@ -15,6 +15,7 @@ LL |     let _: for<'a> fn(<&'a () as Trait>::Ty) = |_| {};
    |
    = note: `&'0 ()` must implement `Trait`, for any lifetime `'0`...
    = note: ...but `Trait` is actually implemented for the type `&'static ()`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/issue-97997.stderr
+++ b/tests/ui/nll/issue-97997.stderr
@@ -15,6 +15,7 @@ LL |     <fn(&u8) as Foo>::ASSOC;
    |
    = note: `Foo` would have to be implemented for the type `for<'a> fn(&'a u8)`
    = note: ...but `Foo` is actually implemented for the type `fn(&'0 u8)`, for some specific lifetime `'0`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/missing-universe-cause-issue-114907.stderr
+++ b/tests/ui/nll/missing-universe-cause-issue-114907.stderr
@@ -38,6 +38,7 @@ LL |     accept(callback);
    |
    = note: closure with signature `fn(&'2 ())` must implement `FnOnce<(&'1 (),)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 (),)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0308]: mismatched types
   --> $DIR/missing-universe-cause-issue-114907.rs:33:5
@@ -73,6 +74,8 @@ error: higher-ranked subtype error
    |
 LL |     accept(callback);
    |                     ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/nll/relate_tys/impl-fn-ignore-binder-via-bottom.stderr
+++ b/tests/ui/nll/relate_tys/impl-fn-ignore-binder-via-bottom.stderr
@@ -15,6 +15,7 @@ LL |     let _x = <fn(&())>::make_f();
    |
    = note: `Y` would have to be implemented for the type `for<'a> fn(&'a ())`
    = note: ...but `Y` is actually implemented for the type `fn(&'0 ())`, for some specific lifetime `'0`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: implementation of `Y` is not general enough
   --> $DIR/impl-fn-ignore-binder-via-bottom.rs:30:14
@@ -24,6 +25,7 @@ LL |     let _x = <fn(&())>::make_f();
    |
    = note: `Y` would have to be implemented for the type `for<'a> fn(&'a ())`
    = note: ...but `Y` is actually implemented for the type `fn(&'0 ())`, for some specific lifetime `'0`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/type-check-pointer-comparisons.stderr
+++ b/tests/ui/nll/type-check-pointer-comparisons.stderr
@@ -61,6 +61,8 @@ LL |     x == y;
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 help: `'a` and `'b` must be the same: replace one with the other
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: lifetime may not live long enough
   --> $DIR/type-check-pointer-comparisons.rs:16:5
@@ -93,6 +95,8 @@ LL |     f == g;
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 help: `'a` and `'b` must be the same: replace one with the other
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/nll/user-annotations/normalization-2.stderr
+++ b/tests/ui/nll/user-annotations/normalization-2.stderr
@@ -131,6 +131,7 @@ help: the following changes may resolve your lifetime errors
    |
    = help: replace `'a` with `'static`
    = help: replace `'b` with `'static`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: lifetime may not live long enough
   --> $DIR/normalization-2.rs:89:5
@@ -185,6 +186,7 @@ help: the following changes may resolve your lifetime errors
    |
    = help: replace `'a` with `'static`
    = help: replace `'b` with `'static`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: lifetime may not live long enough
   --> $DIR/normalization-2.rs:117:5

--- a/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.stderr
@@ -14,6 +14,7 @@ LL | fn foo(_: &dyn Foo<Bar = ()>) {}
    |                    ^^^^^^^^ help: remove this bound
    |
    = note: this associated type has a `where Self: Sized` bound. Thus, while the associated type can be specified, it cannot be used in any way, because trait objects are not `Sized`.
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unnecessary associated type bound for not object safe associated type
   --> $DIR/assoc_type_bounds_sized_unnecessary.rs:9:20
@@ -22,6 +23,7 @@ LL | fn foo(_: &dyn Foo<Bar = ()>) {}
    |                    ^^^^^^^^ help: remove this bound
    |
    = note: this associated type has a `where Self: Sized` bound. Thus, while the associated type can be specified, it cannot be used in any way, because trait objects are not `Sized`.
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/parser/attr-stmt-expr-attr-bad.stderr
+++ b/tests/ui/parser/attr-stmt-expr-attr-bad.stderr
@@ -27,6 +27,7 @@ LL | #[cfg(FALSE)] fn e() { let _ = foo(#![attr]); }
    |
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
    = note: outer attributes, like `#[test]`, annotate the item following them
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: expected expression, found `)`
   --> $DIR/attr-stmt-expr-attr-bad.rs:7:44

--- a/tests/ui/parser/issues/issue-84117.stderr
+++ b/tests/ui/parser/issues/issue-84117.stderr
@@ -47,6 +47,7 @@ LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
    |                                         |
    |                                         while parsing the type for `inner_local`
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: you might have meant to end the type parameters here
    |
 LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str>, }
@@ -61,6 +62,8 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, fo
    |
 LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
    |                                                                 ^ expected one of 8 possible tokens
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, found `,`
   --> $DIR/issue-84117.rs:2:33

--- a/tests/ui/parser/macro/macro-repeat.stderr
+++ b/tests/ui/parser/macro/macro-repeat.stderr
@@ -9,6 +9,8 @@ error: variable 'v' is still repeating at this depth
    |
 LL |         $v
    |         ^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-and-ref.stderr
+++ b/tests/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-and-ref.stderr
@@ -307,6 +307,7 @@ LL |         ref a @ Ok(ref mut b) | ref a @ Err(ref mut b) if { drop(b); false 
    |                                                                  ^ move occurs because `b` has type `&mut U`, which does not implement the `Copy` trait
    |
    = note: variables bound in patterns cannot be moved from until after the end of the pattern guard
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0507]: cannot move out of `a` in pattern guard
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:109:66
@@ -323,6 +324,7 @@ LL |         ref mut a @ Ok(ref b) | ref mut a @ Err(ref b) if { drop(a); false 
    |                                                                  ^ move occurs because `a` has type `&mut Result<U, U>`, which does not implement the `Copy` trait
    |
    = note: variables bound in patterns cannot be moved from until after the end of the pattern guard
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0502]: cannot borrow value as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:117:9

--- a/tests/ui/pattern/patkind-litrange-no-expr.stderr
+++ b/tests/ui/pattern/patkind-litrange-no-expr.stderr
@@ -9,6 +9,8 @@ error: arbitrary expressions aren't allowed in patterns
    |
 LL |     Arith = 1 + 1,
    |             ^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/privacy/effective_visibilities.stderr
+++ b/tests/ui/privacy/effective_visibilities.stderr
@@ -45,6 +45,8 @@ error: not in the table
    |
 LL |         struct PrivStruct;
    |         ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: Direct: pub(crate), Reexported: pub, Reachable: pub, ReachableThroughImplTrait: pub
   --> $DIR/effective_visibilities.rs:25:9
@@ -81,6 +83,8 @@ error: Direct: pub(crate), Reexported: pub, Reachable: pub, ReachableThroughImpl
    |
 LL |             A(
    |             ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: Direct: pub(crate), Reexported: pub, Reachable: pub, ReachableThroughImplTrait: pub
   --> $DIR/effective_visibilities.rs:38:17

--- a/tests/ui/privacy/effective_visibilities_full_priv.stderr
+++ b/tests/ui/privacy/effective_visibilities_full_priv.stderr
@@ -9,6 +9,8 @@ error: not in the table
    |
 LL |     struct Priv;
    |     ^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: Direct: pub(crate), Reexported: pub(crate), Reachable: pub(crate), ReachableThroughImplTrait: pub(crate)
   --> $DIR/effective_visibilities_full_priv.rs:13:5

--- a/tests/ui/privacy/privacy1.stderr
+++ b/tests/ui/privacy/privacy1.stderr
@@ -21,6 +21,7 @@ note: the module `baz` is defined here
    |
 LL |     mod baz {
    |     ^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0603]: module `baz` is private
   --> $DIR/privacy1.rs:141:18

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.stderr
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.stderr
@@ -22,6 +22,7 @@ LL | #[derive(Print)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 2 warnings emitted
 

--- a/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
+++ b/tests/ui/proc-macro/macro-namespace-reserved-2.stderr
@@ -143,6 +143,7 @@ LL | #[derive(my_macro)]
    |          ^^^^^^^^
    |
    = note: `my_macro` is in scope, but it is a function-like macro
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 20 previous errors
 

--- a/tests/ui/proc-macro/pretty-print-hack-show.local.stderr
+++ b/tests/ui/proc-macro/pretty-print-hack-show.local.stderr
@@ -18,6 +18,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
@@ -28,6 +29,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
@@ -38,6 +40,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
@@ -58,6 +61,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
@@ -68,6 +72,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
@@ -78,6 +83,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/proc-macro/pretty-print-hack-show.remapped.stderr
+++ b/tests/ui/proc-macro/pretty-print-hack-show.remapped.stderr
@@ -18,6 +18,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
@@ -28,6 +29,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs:4:6
@@ -38,6 +40,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
@@ -58,6 +61,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
@@ -68,6 +72,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: using an old version of `rental`
   --> $DIR/pretty-print-hack/rental-0.5.5/src/lib.rs:4:6
@@ -78,6 +83,7 @@ LL | enum ProceduralMasqueradeDummyType {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `rental` crate will stop compiling in future versions of Rust; please update to `rental` v0.5.6, or switch to one of the `rental` alternatives
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/proc-macro/resolve-error.stderr
+++ b/tests/ui/proc-macro/resolve-error.stderr
@@ -44,6 +44,8 @@ error: cannot find derive macro `attr_proc_macra` in this scope
    |
 LL | #[derive(attr_proc_macra)]
    |          ^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot find derive macro `Dlona` in this scope
   --> $DIR/resolve-error.rs:40:10
@@ -66,6 +68,8 @@ LL | #[derive(Dlona)]
    |
 LL | pub fn derive_clonea(input: TokenStream) -> TokenStream {
    | ------------------------------------------------------- similarly named derive macro `Clona` defined here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot find derive macro `Dlone` in this scope
   --> $DIR/resolve-error.rs:35:10
@@ -84,6 +88,8 @@ LL | #[derive(Dlone)]
   --> $SRC_DIR/core/src/clone.rs:LL:COL
    |
    = note: similarly named derive macro `Clone` defined here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot find attribute `FooWithLongNan` in this scope
   --> $DIR/resolve-error.rs:32:3
@@ -123,6 +129,8 @@ LL | #[derive(FooWithLongNan)]
    |
 LL | pub fn derive_foo(input: TokenStream) -> TokenStream {
    | ---------------------------------------------------- similarly named derive macro `FooWithLongName` defined here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/recursion_limit/empty.stderr
+++ b/tests/ui/recursion_limit/empty.stderr
@@ -13,6 +13,8 @@ LL | #![recursion_limit = ""]
    | ^^^^^^^^^^^^^^^^^^^^^--^
    |                      |
    |                      `limit` must be a non-negative integer
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/recursion_limit/invalid_digit.stderr
+++ b/tests/ui/recursion_limit/invalid_digit.stderr
@@ -13,6 +13,8 @@ LL | #![recursion_limit = "-100"]
    | ^^^^^^^^^^^^^^^^^^^^^------^
    |                      |
    |                      not a valid integer
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/recursion_limit/overflow.stderr
+++ b/tests/ui/recursion_limit/overflow.stderr
@@ -13,6 +13,8 @@ LL | #![recursion_limit = "999999999999999999999999"]
    | ^^^^^^^^^^^^^^^^^^^^^--------------------------^
    |                      |
    |                      `limit` is too large
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/regions/regions-close-object-into-object-4.stderr
+++ b/tests/ui/regions/regions-close-object-into-object-4.stderr
@@ -26,6 +26,7 @@ error[E0310]: the parameter type `U` may not live long enough
 LL |     Box::new(B(&*v)) as Box<dyn X>
    |     ^^^^^^^^^^^^^^^^ ...so that the type `U` will meet its required lifetime bounds
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider adding an explicit lifetime bound...
    |
 LL | fn i<'a, T, U: 'static>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {

--- a/tests/ui/regions/regions-close-object-into-object-5.stderr
+++ b/tests/ui/regions/regions-close-object-into-object-5.stderr
@@ -26,6 +26,7 @@ error[E0310]: the parameter type `T` may not live long enough
 LL |     Box::new(B(&*v)) as Box<dyn X>
    |     ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider adding an explicit lifetime bound...
    |
 LL | fn f<'a, T: 'static, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {

--- a/tests/ui/repr/repr-align-assign.stderr
+++ b/tests/ui/repr/repr-align-assign.stderr
@@ -15,12 +15,16 @@ error[E0693]: incorrect `repr(align)` attribute format
    |
 LL | #[repr(align=8)]
    |        ^^^^^^^ help: use parentheses instead: `align(8)`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0693]: incorrect `repr(align)` attribute format
   --> $DIR/repr-align-assign.rs:9:8
    |
 LL | #[repr(align="8")]
    |        ^^^^^^^^^ help: use parentheses instead: `align(8)`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/repr/repr-align.stderr
+++ b/tests/ui/repr/repr-align.stderr
@@ -39,36 +39,48 @@ error[E0589]: invalid `repr(align)` attribute: not an unsuffixed integer
    |
 LL | #[repr(align(16.0))]
    |        ^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0589]: invalid `repr(align)` attribute: not a power of two
   --> $DIR/repr-align.rs:7:8
    |
 LL | #[repr(align(15))]
    |        ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0589]: invalid `repr(align)` attribute: larger than 2^29
   --> $DIR/repr-align.rs:11:8
    |
 LL | #[repr(align(4294967296))]
    |        ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0589]: invalid `repr(align)` attribute: not an unsuffixed integer
   --> $DIR/repr-align.rs:18:8
    |
 LL | #[repr(align(16.0))]
    |        ^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0589]: invalid `repr(align)` attribute: not a power of two
   --> $DIR/repr-align.rs:22:8
    |
 LL | #[repr(align(15))]
    |        ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0589]: invalid `repr(align)` attribute: larger than 2^29
   --> $DIR/repr-align.rs:26:8
    |
 LL | #[repr(align(4294967296))]
    |        ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/rfcs/rfc-1623-static/rfc1623-2.stderr
+++ b/tests/ui/rfcs/rfc-1623-static/rfc1623-2.stderr
@@ -15,6 +15,7 @@ LL |     f: &id,
    |
    = note: expected trait `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
               found trait `Fn<(&Foo<'_>,)>`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/rfc1623-2.rs:28:8

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/issue-102156.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/issue-102156.stderr
@@ -13,6 +13,7 @@ LL | use core::convert::{From, TryFrom};
    |     ^^^^ maybe a missing crate `core`?
    |
    = help: consider adding `extern crate core` to use the `core` crate
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
@@ -9,6 +9,8 @@ error: ~const can only be applied to `#[const_trait]` traits
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.ny.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.ny.stderr
@@ -9,6 +9,8 @@ error: ~const can only be applied to `#[const_trait]` traits
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
@@ -9,6 +9,8 @@ error: ~const can only be applied to `#[const_trait]` traits
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: ~const can only be applied to `#[const_trait]` traits
   --> $DIR/super-traits-fail-3.rs:17:24

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
@@ -9,6 +9,8 @@ error: ~const can only be applied to `#[const_trait]` traits
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
+++ b/tests/ui/rust-2018/edition-lint-fully-qualified-paths.stderr
@@ -20,6 +20,7 @@ LL |     let _: <foo::Baz as ::foo::Foo>::Bar = ();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
   --> $DIR/edition-lint-fully-qualified-paths.rs:25:13

--- a/tests/ui/rust-2018/edition-lint-nested-empty-paths.stderr
+++ b/tests/ui/rust-2018/edition-lint-nested-empty-paths.stderr
@@ -29,6 +29,7 @@ LL | use foo::{bar::{XX, baz::{}}};
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
   --> $DIR/edition-lint-nested-empty-paths.rs:27:5
@@ -47,6 +48,7 @@ LL | use foo::{bar::{baz::{}, baz1::{}}};
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/rust-2018/edition-lint-nested-paths.stderr
+++ b/tests/ui/rust-2018/edition-lint-nested-paths.stderr
@@ -20,6 +20,7 @@ LL | use foo::{a, b};
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
   --> $DIR/edition-lint-nested-paths.rs:23:13
@@ -38,6 +39,7 @@ LL |         use foo::{self as x, c};
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/rust-2018/edition-lint-paths.stderr
+++ b/tests/ui/rust-2018/edition-lint-paths.stderr
@@ -38,6 +38,7 @@ LL |     use {main, Bar as SomethingElse};
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
   --> $DIR/edition-lint-paths.rs:25:9
@@ -47,6 +48,7 @@ LL |     use {main, Bar as SomethingElse};
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
   --> $DIR/edition-lint-paths.rs:40:5

--- a/tests/ui/rust-2018/uniform-paths/cross-crate.stderr
+++ b/tests/ui/rust-2018/uniform-paths/cross-crate.stderr
@@ -33,6 +33,7 @@ note: the tool module imported here
    |
 LL | use cross_crate::*;
    |     ^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rust-2018/uniform-paths/prelude-fail-2.stderr
+++ b/tests/ui/rust-2018/uniform-paths/prelude-fail-2.stderr
@@ -51,6 +51,7 @@ note: the tool module imported here
    |
 LL | use rustfmt as imported_rustfmt;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot use a tool module through an import
   --> $DIR/prelude-fail-2.rs:19:13
@@ -63,6 +64,7 @@ note: the tool module imported here
    |
 LL |     pub use rustfmt as imported_rustfmt;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/sanitize/sanitizer-cfi-is-incompatible-with-saniziter-kcfi.aarch64.stderr
+++ b/tests/ui/sanitize/sanitizer-cfi-is-incompatible-with-saniziter-kcfi.aarch64.stderr
@@ -3,6 +3,8 @@ error: cfi sanitizer is not supported for this target
 error: `-Zsanitizer=cfi` is incompatible with `-Zsanitizer=kcfi`
 
 error: `-Zsanitizer=cfi` is incompatible with `-Zsanitizer=kcfi`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/sanitize/sanitizer-cfi-is-incompatible-with-saniziter-kcfi.x86_64.stderr
+++ b/tests/ui/sanitize/sanitizer-cfi-is-incompatible-with-saniziter-kcfi.x86_64.stderr
@@ -3,6 +3,8 @@ error: cfi sanitizer is not supported for this target
 error: `-Zsanitizer=cfi` is incompatible with `-Zsanitizer=kcfi`
 
 error: `-Zsanitizer=cfi` is incompatible with `-Zsanitizer=kcfi`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/issue-61963.stderr
+++ b/tests/ui/suggestions/issue-61963.stderr
@@ -37,6 +37,7 @@ LL |     bar: Box<Bar>,
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL |     bar: Box<dyn Bar>,
@@ -50,6 +51,7 @@ LL |     bar: Box<Bar>,
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL |     bar: Box<dyn Bar>,
@@ -63,6 +65,7 @@ LL | pub struct Foo {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | dyn pub struct Foo {
@@ -76,6 +79,7 @@ LL | pub struct Foo {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | dyn pub struct Foo {
@@ -89,6 +93,7 @@ LL | pub struct Foo {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: use `dyn`
    |
 LL | dyn pub struct Foo {

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -164,6 +164,7 @@ note: union defined here, with 2 lifetime parameters: `'t`, `'k`
    |
 LL | pub union Qux<'t, 'k, I> {
    |           ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -182,6 +183,7 @@ note: union defined here, with 2 lifetime parameters: `'t`, `'k`
    |
 LL | pub union Qux<'t, 'k, I> {
    |           ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -200,6 +202,7 @@ note: union defined here, with 2 lifetime parameters: `'t`, `'k`
    |
 LL | pub union Qux<'t, 'k, I> {
    |           ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -218,6 +221,7 @@ note: union defined here, with 2 lifetime parameters: `'t`, `'k`
    |
 LL | pub union Qux<'t, 'k, I> {
    |           ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -254,6 +258,7 @@ note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
    |
 LL | trait Tar<'t, 'k, I> {}
    |       ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -272,6 +277,7 @@ note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
    |
 LL | trait Tar<'t, 'k, I> {}
    |       ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -290,6 +296,7 @@ note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
    |
 LL | trait Tar<'t, 'k, I> {}
    |       ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -308,6 +315,7 @@ note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
    |
 LL | trait Tar<'t, 'k, I> {}
    |       ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());

--- a/tests/ui/tool-attributes/tool-attributes-misplaced-1.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-misplaced-1.stderr
@@ -9,6 +9,8 @@ error: cannot find derive macro `rustfmt` in this scope
    |
 LL | #[derive(rustfmt)]
    |          ^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot find attribute `rustfmt` in this scope
   --> $DIR/tool-attributes-misplaced-1.rs:9:3

--- a/tests/ui/tool_lints.stderr
+++ b/tests/ui/tool_lints.stderr
@@ -13,6 +13,7 @@ LL | #[warn(foo::bar)]
    |        ^^^
    |
    = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/issue-38404.stderr
+++ b/tests/ui/traits/issue-38404.stderr
@@ -25,6 +25,7 @@ LL | trait A<T>: std::ops::Add<Self> + Sized {}
    |             ^^^^^^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
 LL | trait B<T>: A<T> {}
    |       - this trait cannot be made into an object...
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/issue-59029-1.stderr
+++ b/tests/ui/traits/issue-59029-1.stderr
@@ -9,6 +9,8 @@ error[E0220]: associated type `Res` not found for `Self`
    |
 LL | trait MkSvc<Target, Req> = Svc<Target> where Self::Res: Svc<Req>;
    |                                                    ^^^ there is a similarly named associated type `Res` in the trait `Svc`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/tuple/tuple-struct-fields/test2.stderr
+++ b/tests/ui/tuple/tuple-struct-fields/test2.stderr
@@ -22,6 +22,8 @@ error[E0412]: cannot find type `foo` in this scope
    |
 LL |     define_struct! { (foo) }
    |                       ^^^ not found in this scope
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/tuple/tuple-struct-fields/test3.stderr
+++ b/tests/ui/tuple/tuple-struct-fields/test3.stderr
@@ -22,6 +22,8 @@ error[E0412]: cannot find type `foo` in this scope
    |
 LL |     define_struct! { foo }
    |                      ^^^ not found in this scope
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
@@ -36,6 +36,7 @@ note: `V` could also refer to the associated type defined here
    |
 LL |     type V;
    |     ^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
@@ -21,6 +21,8 @@ LL | trait Trait: Copy<dyn Send> {}
    |              ^^^^---------- help: remove these generics
    |              |
    |              expected 0 generic arguments
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:8:21

--- a/tests/ui/unknown-lint-tool-name.stderr
+++ b/tests/ui/unknown-lint-tool-name.stderr
@@ -21,6 +21,7 @@ LL | #![deny(foo::bar)]
    |         ^^^
    |
    = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
   --> $DIR/unknown-lint-tool-name.rs:4:9
@@ -29,6 +30,7 @@ LL | #[allow(foo::bar)]
    |         ^^^
    |
    = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/unknown-unstable-lints/deny-unstable-lint-command-line.stderr
+++ b/tests/ui/unknown-unstable-lints/deny-unstable-lint-command-line.stderr
@@ -8,11 +8,13 @@ error: unknown lint: `test_unstable_lint`
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `-Zcrate-attr="feature(test_unstable_lint)"` to the command-line options to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unknown lint: `test_unstable_lint`
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `-Zcrate-attr="feature(test_unstable_lint)"` to the command-line options to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/unknown-unstable-lints/deny-unstable-lint-inline.stderr
+++ b/tests/ui/unknown-unstable-lints/deny-unstable-lint-inline.stderr
@@ -20,6 +20,7 @@ LL | #![allow(test_unstable_lint)]
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `#![feature(test_unstable_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unknown lint: `test_unstable_lint`
   --> $DIR/deny-unstable-lint-inline.rs:4:1
@@ -29,6 +30,7 @@ LL | #![allow(test_unstable_lint)]
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `#![feature(test_unstable_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/unknown-unstable-lints/warn-unknown-unstable-lint-command-line.stderr
+++ b/tests/ui/unknown-unstable-lints/warn-unknown-unstable-lint-command-line.stderr
@@ -8,11 +8,13 @@ warning: unknown lint: `test_unstable_lint`
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `-Zcrate-attr="feature(test_unstable_lint)"` to the command-line options to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `test_unstable_lint`
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `-Zcrate-attr="feature(test_unstable_lint)"` to the command-line options to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/unknown-unstable-lints/warn-unknown-unstable-lint-inline.stderr
+++ b/tests/ui/unknown-unstable-lints/warn-unknown-unstable-lint-inline.stderr
@@ -20,6 +20,7 @@ LL | #![allow(test_unstable_lint)]
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `#![feature(test_unstable_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `test_unstable_lint`
   --> $DIR/warn-unknown-unstable-lint-inline.rs:4:1
@@ -29,6 +30,7 @@ LL | #![allow(test_unstable_lint)]
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `#![feature(test_unstable_lint)]` to the crate attributes to enable
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 3 warnings emitted
 

--- a/tests/ui/use/use-super-global-path.stderr
+++ b/tests/ui/use/use-super-global-path.stderr
@@ -9,6 +9,8 @@ error[E0433]: failed to resolve: global paths cannot start with `super`
    |
 LL |     use ::super::{S, Z};
    |           ^^^^^ global paths cannot start with `super`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0433]: failed to resolve: global paths cannot start with `super`
   --> $DIR/use-super-global-path.rs:11:15


### PR DESCRIPTION
Helps explain why there may be a difference between manual testing and the test suite output and highlights them as something to potentially look into

For existing duplicate diagnostics I just blessed them other than a few files that had other `NOTE` annotations in