### PR TITLE
Handle `ReErased` in responses in new solver

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -825,6 +825,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(TEST, rustc_strict_coherence, Normal, template!(Word), WarnFollowing),
     rustc_attr!(TEST, rustc_variance, Normal, template!(Word), WarnFollowing),
     rustc_attr!(TEST, rustc_variance_of_opaques, Normal, template!(Word), WarnFollowing),
+    rustc_attr!(TEST, rustc_hidden_type_of_opaques, Normal, template!(Word), WarnFollowing),
     rustc_attr!(TEST, rustc_layout, Normal, template!(List: "field1, field2, ..."), WarnFollowing),
     rustc_attr!(TEST, rustc_abi, Normal, template!(List: "field1, field2, ..."), WarnFollowing),
     rustc_attr!(TEST, rustc_regions, Normal, template!(Word), WarnFollowing),

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -339,6 +339,8 @@ hir_analysis_transparent_non_zero_sized_enum = the variant of a transparent {$de
     .label = needs at most one field with non-trivial size or alignment, but has {$field_count}
     .labels = this field has non-zero size or requires alignment
 
+hir_analysis_type_of = {$type_of}
+
 hir_analysis_typeof_reserved_keyword_used =
     `typeof` is a reserved keyword but unimplemented
     .suggestion = consider replacing `typeof(...)` with an actual type

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -14,14 +14,11 @@
 //! At present, however, we do run collection across all items in the
 //! crate as a kind of pass. This should eventually be factored away.
 
-use crate::astconv::AstConv;
-use crate::check::intrinsic::intrinsic_operation_unsafety;
-use crate::errors;
-use hir::def::DefKind;
 use rustc_data_structures::captures::Captures;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{Applicability, DiagnosticBuilder, ErrorGuaranteed, StashKey};
 use rustc_hir as hir;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId};
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{GenericParamKind, Node};
@@ -39,6 +36,11 @@ use rustc_trait_selection::traits::error_reporting::suggestions::NextTypeParamNa
 use rustc_trait_selection::traits::ObligationCtxt;
 use std::iter;
 use std::ops::Bound;
+
+use crate::astconv::AstConv;
+use crate::check::intrinsic::intrinsic_operation_unsafety;
+use crate::errors;
+pub use type_of::test_opaque_hidden_types;
 
 mod generics_of;
 mod item_bounds;

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -11,6 +11,7 @@ use rustc_span::{Span, DUMMY_SP};
 
 use super::ItemCtxt;
 use super::{bad_placeholder, is_suggestable_infer_ty};
+pub use opaque::test_opaque_hidden_types;
 
 mod opaque;
 

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -468,6 +468,14 @@ pub(crate) struct VariancesOf {
 }
 
 #[derive(Diagnostic)]
+#[diag(hir_analysis_type_of)]
+pub(crate) struct TypeOf<'tcx> {
+    #[primary_span]
+    pub span: Span,
+    pub type_of: Ty<'tcx>,
+}
+
+#[derive(Diagnostic)]
 #[diag(hir_analysis_pass_to_variadic_function, code = "E0617")]
 pub(crate) struct PassToVariadicFunction<'tcx, 'a> {
     #[primary_span]

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -214,6 +214,10 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
         tcx.hir().for_each_module(|module| tcx.ensure().check_mod_item_types(module))
     });
 
+    if tcx.features().rustc_attrs {
+        tcx.sess.track_errors(|| collect::test_opaque_hidden_types(tcx))?;
+    }
+
     // Freeze definitions as we don't add new ones at this point. This improves performance by
     // allowing lock-free access to them.
     tcx.untracked().definitions.freeze();

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1369,6 +1369,7 @@ symbols! {
         rustc_evaluate_where_clauses,
         rustc_expected_cgu_reuse,
         rustc_has_incoherent_inherent_impls,
+        rustc_hidden_type_of_opaques,
         rustc_host,
         rustc_if_this_changed,
         rustc_inherit_overflow_checks,

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.current.stderr
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.current.stderr
@@ -1,0 +1,14 @@
+error: {foo<ReEarlyBound(DefId(..), 0, 'a)>::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
+  --> $DIR/erased-regions-in-hidden-ty.rs:11:36
+   |
+LL | fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {
+   |                                    ^^^^^^^^^^^^^^^^^^^
+
+error: Opaque(DefId(..), [ReErased])
+  --> $DIR/erased-regions-in-hidden-ty.rs:17:13
+   |
+LL | fn bar() -> impl Fn() + 'static {
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.next.stderr
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.next.stderr
@@ -1,0 +1,14 @@
+error: {foo<ReEarlyBound(DefId(..), 0, 'a)>::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
+  --> $DIR/erased-regions-in-hidden-ty.rs:11:36
+   |
+LL | fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {
+   |                                    ^^^^^^^^^^^^^^^^^^^
+
+error: Opaque(DefId(..), [ReErased])
+  --> $DIR/erased-regions-in-hidden-ty.rs:17:13
+   |
+LL | fn bar() -> impl Fn() + 'static {
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
@@ -1,14 +1,22 @@
 // revisions: current next
+// compile-flags: -Zverbose
 //[next] compile-flags: -Ztrait-solver=next
-// check-pass
+// normalize-stderr-test "DefId\([^\)]+\)" -> "DefId(..)"
+
+#![feature(rustc_attrs)]
+#![rustc_hidden_type_of_opaques]
 
 // Make sure that the compiler can handle `ReErased` in the hidden type of an opaque.
 
 fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {
+//~^ ERROR 0, 'a)>::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
+// Can't write whole type because of lack of path sanitization
     || ()
 }
 
 fn bar() -> impl Fn() + 'static {
+//~^ ERROR , [ReErased])
+// Can't write whole type because of lack of path sanitization
     foo(&vec![])
 }
 

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
@@ -1,0 +1,15 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+// check-pass
+
+// Make sure that the compiler can handle `ReErased` in the hidden type of an opaque.
+
+fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {
+    || ()
+}
+
+fn bar() -> impl Fn() + 'static {
+    foo(&vec![])
+}
+
+fn main() {}


### PR DESCRIPTION
There are legitimate cases in the compiler where we return `ReErased` for lifetimes that are uncaptured in the hidden type of an opaque. For example, in the test committed below, we ignore ignore the bivariant lifetimes of an opaque when it's inferred as the hidden type of another opaque. This may result in a `type_of(Opaque)` call returning a type that references `ReErased`. Let's handle this gracefully in the new solver.

Also added a `rustc_hidden_type_of_opaques` attr to print hidden types. This seems useful for opaques.

r? lcnr