### PR TITLE
Pretty print `Fn` traits in `rustc_on_unimplemented`

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -316,6 +316,7 @@ symbols! {
         ToOwned,
         ToString,
         TokenStream,
+        Trait,
         Try,
         TryCaptureGeneric,
         TryCapturePrintable,

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -56,7 +56,7 @@ use crate::marker::Tuple;
 #[lang = "fn"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
-#[rustc_on_unimplemented(
+#[cfg_attr(not(bootstrap), rustc_on_unimplemented(
     on(
         Args = "()",
         note = "wrap the `{Self}` in a closure with no arguments: `|| {{ /* code */ }}`"
@@ -67,9 +67,9 @@ use crate::marker::Tuple;
         // SAFETY: tidy is not smart enough to tell that the below unsafe block is a string
         label = "call the function in a closure: `|| unsafe {{ /* code */ }}`"
     ),
-    message = "expected a `{Fn}<{Args}>` closure, found `{Self}`",
-    label = "expected an `Fn<{Args}>` closure, found `{Self}`"
-)]
+    message = "expected a `{Trait}` closure, found `{Self}`",
+    label = "expected an `{Trait}` closure, found `{Self}`"
+))]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
 // FIXME(effects) #[const_trait]
@@ -143,7 +143,7 @@ pub trait Fn<Args: Tuple>: FnMut<Args> {
 #[lang = "fn_mut"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
-#[rustc_on_unimplemented(
+#[cfg_attr(not(bootstrap), rustc_on_unimplemented(
     on(
         Args = "()",
         note = "wrap the `{Self}` in a closure with no arguments: `|| {{ /* code */ }}`"
@@ -154,9 +154,9 @@ pub trait Fn<Args: Tuple>: FnMut<Args> {
         // SAFETY: tidy is not smart enough to tell that the below unsafe block is a string
         label = "call the function in a closure: `|| unsafe {{ /* code */ }}`"
     ),
-    message = "expected a `{FnMut}<{Args}>` closure, found `{Self}`",
-    label = "expected an `FnMut<{Args}>` closure, found `{Self}`"
-)]
+    message = "expected a `{Trait}` closure, found `{Self}`",
+    label = "expected an `{Trait}` closure, found `{Self}`"
+))]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
 // FIXME(effects) #[const_trait]
@@ -222,7 +222,7 @@ pub trait FnMut<Args: Tuple>: FnOnce<Args> {
 #[lang = "fn_once"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
-#[rustc_on_unimplemented(
+#[cfg_attr(not(bootstrap), rustc_on_unimplemented(
     on(
         Args = "()",
         note = "wrap the `{Self}` in a closure with no arguments: `|| {{ /* code */ }}`"
@@ -233,9 +233,9 @@ pub trait FnMut<Args: Tuple>: FnOnce<Args> {
         // SAFETY: tidy is not smart enough to tell that the below unsafe block is a string
         label = "call the function in a closure: `|| unsafe {{ /* code */ }}`"
     ),
-    message = "expected a `{FnOnce}<{Args}>` closure, found `{Self}`",
-    label = "expected an `FnOnce<{Args}>` closure, found `{Self}`"
-)]
+    message = "expected a `{Trait}` closure, found `{Self}`",
+    label = "expected an `{Trait}` closure, found `{Self}`"
+))]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 #[must_use = "closures are lazy and do nothing unless called"]
 // FIXME(effects) #[const_trait]

--- a/tests/ui/closures/closure-expected.rs
+++ b/tests/ui/closures/closure-expected.rs
@@ -1,5 +1,5 @@
 fn main() {
     let x = Some(1);
     let y = x.or_else(4);
-    //~^ ERROR expected a `FnOnce<()>` closure, found `{integer}`
+    //~^ ERROR expected a `FnOnce()` closure, found `{integer}`
 }

--- a/tests/ui/closures/closure-expected.stderr
+++ b/tests/ui/closures/closure-expected.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
+error[E0277]: expected a `FnOnce()` closure, found `{integer}`
   --> $DIR/closure-expected.rs:3:23
    |
 LL |     let y = x.or_else(4);
-   |               ------- ^ expected an `FnOnce<()>` closure, found `{integer}`
+   |               ------- ^ expected an `FnOnce()` closure, found `{integer}`
    |               |
    |               required by a bound introduced by this call
    |

--- a/tests/ui/closures/coerce-unsafe-to-closure.stderr
+++ b/tests/ui/closures/coerce-unsafe-to-closure.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce<(&str,)>` closure, found `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
+error[E0277]: expected a `FnOnce(&str)` closure, found `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
   --> $DIR/coerce-unsafe-to-closure.rs:2:44
    |
 LL |     let x: Option<&[u8]> = Some("foo").map(std::mem::transmute);

--- a/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.rs
+++ b/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.rs
@@ -1,6 +1,6 @@
 fn main() {
     let number = 2;
-    Some(true).filter({ //~ ERROR expected a `FnOnce<(&bool,)>` closure, found `bool`
+    Some(true).filter({ //~ ERROR expected a `FnOnce(&bool)` closure, found `bool`
         if number % 2 == 0 {
             number == 0
         } else {

--- a/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.stderr
+++ b/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce<(&bool,)>` closure, found `bool`
+error[E0277]: expected a `FnOnce(&bool)` closure, found `bool`
   --> $DIR/block_instead_of_closure_in_arg.rs:3:23
    |
 LL |        Some(true).filter({
@@ -12,7 +12,7 @@ LL | ||             number != 0
 LL | ||         }
    | ||_________- this tail expression is of type `bool`
 LL | |      });
-   | |______^ expected an `FnOnce<(&bool,)>` closure, found `bool`
+   | |______^ expected an `FnOnce(&bool)` closure, found `bool`
    |
    = help: the trait `for<'a> FnOnce<(&'a bool,)>` is not implemented for `bool`
 note: required by a bound in `Option::<T>::filter`

--- a/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.rs
+++ b/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.rs
@@ -1,6 +1,6 @@
 const x: usize =42;
 fn main() {
-    let p = Some(45).and_then({|x| //~ ERROR expected a `FnOnce<({integer},)>` closure, found `Option<usize>`
+    let p = Some(45).and_then({|x| //~ ERROR expected a `FnOnce({integer})` closure, found `Option<usize>`
         1 + 1;
         Some(x * 2)
     });

--- a/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.stderr
+++ b/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce<({integer},)>` closure, found `Option<usize>`
+error[E0277]: expected a `FnOnce({integer})` closure, found `Option<usize>`
   --> $DIR/ruby_style_closure_successful_parse.rs:3:31
    |
 LL |       let p = Some(45).and_then({|x|
@@ -9,7 +9,7 @@ LL | |         1 + 1;
 LL | |         Some(x * 2)
    | |         ----------- this tail expression is of type `Option<usize>`
 LL | |     });
-   | |_____^ expected an `FnOnce<({integer},)>` closure, found `Option<usize>`
+   | |_____^ expected an `FnOnce({integer})` closure, found `Option<usize>`
    |
    = help: the trait `FnOnce<({integer},)>` is not implemented for `Option<usize>`
 note: required by a bound in `Option::<T>::and_then`

--- a/tests/ui/extern/extern-wrong-value-type.rs
+++ b/tests/ui/extern/extern-wrong-value-type.rs
@@ -7,5 +7,5 @@ fn main() {
     // extern functions are extern "C" fn
     let _x: extern "C" fn() = f; // OK
     is_fn(f);
-    //~^ ERROR expected a `Fn<()>` closure, found `extern "C" fn() {f}`
+    //~^ ERROR expected a `Fn()` closure, found `extern "C" fn() {f}`
 }

--- a/tests/ui/extern/extern-wrong-value-type.stderr
+++ b/tests/ui/extern/extern-wrong-value-type.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<()>` closure, found `extern "C" fn() {f}`
+error[E0277]: expected a `Fn()` closure, found `extern "C" fn() {f}`
   --> $DIR/extern-wrong-value-type.rs:9:11
    |
 LL |     is_fn(f);
-   |     ----- ^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`
+   |     ----- ^ expected an `Fn()` closure, found `extern "C" fn() {f}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/fn/fn-trait-formatting.rs
+++ b/tests/ui/fn/fn-trait-formatting.rs
@@ -17,5 +17,5 @@ fn main() {
     //~| found struct `Box<dyn FnMut() -> isize>`
 
     needs_fn(1);
-    //~^ ERROR expected a `Fn<(isize,)>` closure, found `{integer}`
+    //~^ ERROR expected a `Fn(isize)` closure, found `{integer}`
 }

--- a/tests/ui/fn/fn-trait-formatting.stderr
+++ b/tests/ui/fn/fn-trait-formatting.stderr
@@ -39,11 +39,11 @@ LL |     let _: () = Box::new(|| -> isize { unimplemented!() }) as Box<dyn FnMut
    = note: expected unit type `()`
                  found struct `Box<dyn FnMut() -> isize>`
 
-error[E0277]: expected a `Fn<(isize,)>` closure, found `{integer}`
+error[E0277]: expected a `Fn(isize)` closure, found `{integer}`
   --> $DIR/fn-trait-formatting.rs:19:14
    |
 LL |     needs_fn(1);
-   |     -------- ^ expected an `Fn<(isize,)>` closure, found `{integer}`
+   |     -------- ^ expected an `Fn(isize)` closure, found `{integer}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.rs
+++ b/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.rs
@@ -10,7 +10,7 @@ trait Fun {
 
 impl<T> Fun for T {
     type F<'a> = Self;
-    //~^ ERROR expected a `Fn<()>` closure, found `T`
+    //~^ ERROR expected a `Fn()` closure, found `T`
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
+++ b/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<()>` closure, found `T`
+error[E0277]: expected a `Fn()` closure, found `T`
   --> $DIR/issue-68642-broken-llvm-ir.rs:12:18
    |
 LL |     type F<'a> = Self;
-   |                  ^^^^ expected an `Fn<()>` closure, found `T`
+   |                  ^^^^ expected an `Fn()` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fun::F`

--- a/tests/ui/generic-associated-types/issue-68643-broken-mir.rs
+++ b/tests/ui/generic-associated-types/issue-68643-broken-mir.rs
@@ -10,7 +10,7 @@ trait Fun {
 
 impl<T> Fun for T {
     type F<'a> = Self;
-    //~^ ERROR expected a `Fn<()>` closure, found `T`
+    //~^ ERROR expected a `Fn()` closure, found `T`
 }
 
 pub fn main() {

--- a/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
+++ b/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<()>` closure, found `T`
+error[E0277]: expected a `Fn()` closure, found `T`
   --> $DIR/issue-68643-broken-mir.rs:12:18
    |
 LL |     type F<'a> = Self;
-   |                  ^^^^ expected an `Fn<()>` closure, found `T`
+   |                  ^^^^ expected an `Fn()` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fun::F`

--- a/tests/ui/generic-associated-types/issue-68644-codegen-selection.rs
+++ b/tests/ui/generic-associated-types/issue-68644-codegen-selection.rs
@@ -10,7 +10,7 @@ trait Fun {
 
 impl<T> Fun for T {
     type F<'a> = Self;
-    //~^ ERROR expected a `Fn<()>` closure, found `T`
+    //~^ ERROR expected a `Fn()` closure, found `T`
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<()>` closure, found `T`
+error[E0277]: expected a `Fn()` closure, found `T`
   --> $DIR/issue-68644-codegen-selection.rs:12:18
    |
 LL |     type F<'a> = Self;
-   |                  ^^^^ expected an `Fn<()>` closure, found `T`
+   |                  ^^^^ expected an `Fn()` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fun::F`

--- a/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.rs
+++ b/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.rs
@@ -10,7 +10,7 @@ trait Fun {
 
 impl<T> Fun for T {
     type F<'a> = Self;
-    //~^ ERROR expected a `Fn<()>` closure, found `T`
+    //~^ ERROR expected a `Fn()` closure, found `T`
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
+++ b/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<()>` closure, found `T`
+error[E0277]: expected a `Fn()` closure, found `T`
   --> $DIR/issue-68645-codegen-fulfillment.rs:12:18
    |
 LL |     type F<'a> = Self;
-   |                  ^^^^ expected an `Fn<()>` closure, found `T`
+   |                  ^^^^ expected an `Fn()` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fun::F`

--- a/tests/ui/higher-ranked/trait-bounds/fn-ptr.classic.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/fn-ptr.classic.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<(&'w (),)>` closure, found `fn(&'w ())`
+error[E0277]: expected a `Fn(&'w ())` closure, found `fn(&'w ())`
   --> $DIR/fn-ptr.rs:12:5
    |
 LL |     ice();
-   |     ^^^ expected an `Fn<(&'w (),)>` closure, found `fn(&'w ())`
+   |     ^^^ expected an `Fn(&'w ())` closure, found `fn(&'w ())`
    |
    = help: the trait `for<'w> Fn<(&'w (),)>` is not implemented for `fn(&'w ())`
 note: required by a bound in `ice`

--- a/tests/ui/higher-ranked/trait-bounds/fn-ptr.rs
+++ b/tests/ui/higher-ranked/trait-bounds/fn-ptr.rs
@@ -10,5 +10,5 @@ where
 
 fn main() {
     ice();
-    //[classic]~^ ERROR expected a `Fn<(&'w (),)>` closure, found `fn(&'w ())`
+    //[classic]~^ ERROR expected a `Fn(&'w ())` closure, found `fn(&'w ())`
 }

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<(<_ as ATC<'a>>::Type,)>` closure, found `F`
+error[E0277]: expected a `Fn(<_ as ATC<'a>>::Type)` closure, found `F`
   --> $DIR/issue-62529-3.rs:25:14
    |
 LL |         call(f, ());
-   |         ---- ^ expected an `Fn<(<_ as ATC<'a>>::Type,)>` closure, found `F`
+   |         ---- ^ expected an `Fn(<_ as ATC<'a>>::Type)` closure, found `F`
    |         |
    |         required by a bound introduced by this call
    |

--- a/tests/ui/implied-bounds/issue-100690.rs
+++ b/tests/ui/implied-bounds/issue-100690.rs
@@ -35,8 +35,8 @@ impl<'a, T: 'a> Handle<'a, T, UIView<'a, T>, Result<(), io::Error>> for TUIHandl
         F: FnOnce(&mut UIView<'a, T>) -> Result<(), io::Error> + Send + 'static,
     {
         real_dispatch(f)
-        //~^ ERROR expected a `FnOnce<(&mut UIView<'_, T>,)>` closure, found `F`
-        //~| NOTE expected an `FnOnce<(&mut UIView<'_, T>,)>` closure, found `F`
+        //~^ ERROR expected a `FnOnce(&mut UIView<'_, T>)` closure, found `F`
+        //~| NOTE expected an `FnOnce(&mut UIView<'_, T>)` closure, found `F`
         //~| NOTE expected a closure with arguments
         //~| NOTE required by a bound introduced by this call
     }

--- a/tests/ui/implied-bounds/issue-100690.stderr
+++ b/tests/ui/implied-bounds/issue-100690.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `FnOnce<(&mut UIView<'_, T>,)>` closure, found `F`
+error[E0277]: expected a `FnOnce(&mut UIView<'_, T>)` closure, found `F`
   --> $DIR/issue-100690.rs:37:23
    |
 LL |         real_dispatch(f)
-   |         ------------- ^ expected an `FnOnce<(&mut UIView<'_, T>,)>` closure, found `F`
+   |         ------------- ^ expected an `FnOnce(&mut UIView<'_, T>)` closure, found `F`
    |         |
    |         required by a bound introduced by this call
    |

--- a/tests/ui/intrinsics/const-eval-select-bad.rs
+++ b/tests/ui/intrinsics/const-eval-select-bad.rs
@@ -8,8 +8,8 @@ const fn not_fn_items() {
     //~^ ERROR this argument must be a function item
     //~| ERROR this argument must be a function item
     const_eval_select((), 42, 0xDEADBEEF);
-    //~^ ERROR expected a `FnOnce<()>` closure
-    //~| ERROR expected a `FnOnce<()>` closure
+    //~^ ERROR expected a `FnOnce()` closure
+    //~| ERROR expected a `FnOnce()` closure
     //~| ERROR this argument must be a function item
     //~| ERROR this argument must be a function item
 }

--- a/tests/ui/intrinsics/const-eval-select-bad.stderr
+++ b/tests/ui/intrinsics/const-eval-select-bad.stderr
@@ -25,11 +25,11 @@ LL |     const_eval_select((), 42, 0xDEADBEEF);
    = note: expected a function item, found {integer}
    = help: consult the documentation on `const_eval_select` for more information
 
-error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
+error[E0277]: expected a `FnOnce()` closure, found `{integer}`
   --> $DIR/const-eval-select-bad.rs:10:27
    |
 LL |     const_eval_select((), 42, 0xDEADBEEF);
-   |     -----------------     ^^ expected an `FnOnce<()>` closure, found `{integer}`
+   |     -----------------     ^^ expected an `FnOnce()` closure, found `{integer}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -47,11 +47,11 @@ LL |     const_eval_select((), 42, 0xDEADBEEF);
    = note: expected a function item, found {integer}
    = help: consult the documentation on `const_eval_select` for more information
 
-error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
+error[E0277]: expected a `FnOnce()` closure, found `{integer}`
   --> $DIR/const-eval-select-bad.rs:10:31
    |
 LL |     const_eval_select((), 42, 0xDEADBEEF);
-   |     -----------------         ^^^^^^^^^^ expected an `FnOnce<()>` closure, found `{integer}`
+   |     -----------------         ^^^^^^^^^^ expected an `FnOnce()` closure, found `{integer}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/issues/issue-22034.rs
+++ b/tests/ui/issues/issue-22034.rs
@@ -6,6 +6,6 @@ fn main() {
     let ptr: *mut () = core::ptr::null_mut();
     let _: &mut dyn Fn() = unsafe {
         &mut *(ptr as *mut dyn Fn())
-        //~^ ERROR expected a `Fn<()>` closure, found `()`
+        //~^ ERROR expected a `Fn()` closure, found `()`
     };
 }

--- a/tests/ui/issues/issue-22034.stderr
+++ b/tests/ui/issues/issue-22034.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<()>` closure, found `()`
+error[E0277]: expected a `Fn()` closure, found `()`
   --> $DIR/issue-22034.rs:8:16
    |
 LL |         &mut *(ptr as *mut dyn Fn())
-   |                ^^^ expected an `Fn<()>` closure, found `()`
+   |                ^^^ expected an `Fn()` closure, found `()`
    |
    = help: the trait `Fn<()>` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`

--- a/tests/ui/issues/issue-23966.stderr
+++ b/tests/ui/issues/issue-23966.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `FnMut<(_, char)>` closure, found `()`
+error[E0277]: expected a `FnMut(_, char)` closure, found `()`
   --> $DIR/issue-23966.rs:2:32
    |
 LL |     "".chars().fold(|_, _| (), ());
-   |                ----            ^^ expected an `FnMut<(_, char)>` closure, found `()`
+   |                ----            ^^ expected an `FnMut(_, char)` closure, found `()`
    |                |
    |                required by a bound introduced by this call
    |

--- a/tests/ui/issues/issue-59494.rs
+++ b/tests/ui/issues/issue-59494.rs
@@ -19,5 +19,5 @@ fn main() {
     let g = |(a, _)| a;
     let t7 = |env| |a| |b| t7p(f, g)(((env, a), b));
     let t8 = t8n(t7, t7p(f, g));
-    //~^ ERROR: expected a `Fn<(_,)>` closure, found `impl Fn(((_, _), _))` [E0277]
+    //~^ ERROR: expected a `Fn(_)` closure, found `impl Fn(((_, _), _))` [E0277]
 }

--- a/tests/ui/issues/issue-59494.stderr
+++ b/tests/ui/issues/issue-59494.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<(_,)>` closure, found `impl Fn(((_, _), _))`
+error[E0277]: expected a `Fn(_)` closure, found `impl Fn(((_, _), _))`
   --> $DIR/issue-59494.rs:21:22
    |
 LL |     let t8 = t8n(t7, t7p(f, g));
-   |              ---     ^^^^^^^^^ expected an `Fn<(_,)>` closure, found `impl Fn(((_, _), _))`
+   |              ---     ^^^^^^^^^ expected an `Fn(_)` closure, found `impl Fn(((_, _), _))`
    |              |
    |              required by a bound introduced by this call
    |

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
@@ -4,14 +4,14 @@
 use std::future::Future;
 
 async fn wrapper<F>(f: F)
-//~^ ERROR: expected a `FnOnce<(&'a mut i32,)>` closure, found `i32`
-//~| ERROR: expected a `FnOnce<(&'a mut i32,)>` closure, found `i32`
-//~| ERROR: expected a `FnOnce<(&'a mut i32,)>` closure, found `i32`
+//~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 where
     F:,
     for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
 {
-    //~^ ERROR: expected a `FnOnce<(&'a mut i32,)>` closure, found `i32`
+    //~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
     let mut i = 41;
     &mut i;
 }

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce<(&'a mut i32,)>` closure, found `i32`
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:1
    |
 LL | / async fn wrapper<F>(f: F)
@@ -8,19 +8,19 @@ LL | |
 LL | | where
 LL | |     F:,
 LL | |     for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
-   | |______________________________________________________________________________^ expected an `FnOnce<(&'a mut i32,)>` closure, found `i32`
+   | |______________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
    = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
 
-error[E0277]: expected a `FnOnce<(&'a mut i32,)>` closure, found `i32`
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:10
    |
 LL | async fn wrapper<F>(f: F)
-   |          ^^^^^^^ expected an `FnOnce<(&'a mut i32,)>` closure, found `i32`
+   |          ^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
    = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
 
-error[E0277]: expected a `FnOnce<(&'a mut i32,)>` closure, found `i32`
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:13:1
    |
 LL | / {
@@ -28,11 +28,11 @@ LL | |
 LL | |     let mut i = 41;
 LL | |     &mut i;
 LL | | }
-   | |_^ expected an `FnOnce<(&'a mut i32,)>` closure, found `i32`
+   | |_^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
    = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
 
-error[E0277]: expected a `FnOnce<(&'a mut i32,)>` closure, found `i32`
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:1
    |
 LL | / async fn wrapper<F>(f: F)
@@ -42,7 +42,7 @@ LL | |
 LL | | where
 LL | |     F:,
 LL | |     for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
-   | |______________________________________________________________________________^ expected an `FnOnce<(&'a mut i32,)>` closure, found `i32`
+   | |______________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
    = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
 

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
@@ -24,9 +24,9 @@ fn main() {
     let _ = produces_string().and_then(takes_str_but_too_many_refs);
     //~^ ERROR type mismatch in function arguments
     let _ = produces_string().and_then(takes_str_but_wrong_abi);
-    //~^ ERROR expected a `FnOnce<(String,)>` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+    //~^ ERROR expected a `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
     let _ = produces_string().and_then(takes_str_but_unsafe);
-    //~^ ERROR expected a `FnOnce<(String,)>` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+    //~^ ERROR expected a `FnOnce(String)` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
     let _ = produces_string().and_then(no_args);
     //~^ ERROR function is expected to take 1 argument, but it takes 0 arguments
     let _ = Some(TypeWithoutDeref).and_then(takes_str_but_too_many_refs);

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
@@ -14,11 +14,11 @@ LL |     let _ = produces_string().and_then(takes_str_but_too_many_refs);
 note: required by a bound in `Option::<T>::and_then`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
-error[E0277]: expected a `FnOnce<(String,)>` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+error[E0277]: expected a `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
   --> $DIR/suggest-option-asderef-unfixable.rs:26:40
    |
 LL |     let _ = produces_string().and_then(takes_str_but_wrong_abi);
-   |                               -------- ^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce<(String,)>` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+   |                               -------- ^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
    |                               |
    |                               required by a bound introduced by this call
    |
@@ -26,7 +26,7 @@ LL |     let _ = produces_string().and_then(takes_str_but_wrong_abi);
 note: required by a bound in `Option::<T>::and_then`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
-error[E0277]: expected a `FnOnce<(String,)>` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+error[E0277]: expected a `FnOnce(String)` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
   --> $DIR/suggest-option-asderef-unfixable.rs:28:40
    |
 LL |     let _ = produces_string().and_then(takes_str_but_unsafe);

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
@@ -21,14 +21,14 @@ fn call_once(f: impl FnOnce()) {
 }
 
 fn main() {
-    call(foo); //~ ERROR expected a `Fn<()>` closure, found `fn() {foo}`
-    call_mut(foo); //~ ERROR expected a `FnMut<()>` closure, found `fn() {foo}`
-    call_once(foo); //~ ERROR expected a `FnOnce<()>` closure, found `fn() {foo}`
+    call(foo); //~ ERROR expected a `Fn()` closure, found `fn() {foo}`
+    call_mut(foo); //~ ERROR expected a `FnMut()` closure, found `fn() {foo}`
+    call_once(foo); //~ ERROR expected a `FnOnce()` closure, found `fn() {foo}`
 
     call(foo_unsafe);
-    //~^ ERROR expected a `Fn<()>` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected a `Fn()` closure, found `unsafe fn() {foo_unsafe}`
     call_mut(foo_unsafe);
-    //~^ ERROR expected a `FnMut<()>` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected a `FnMut()` closure, found `unsafe fn() {foo_unsafe}`
     call_once(foo_unsafe);
-    //~^ ERROR expected a `FnOnce<()>` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected a `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
 }

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<()>` closure, found `fn() {foo}`
+error[E0277]: expected a `Fn()` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:24:10
    |
 LL |     call(foo);
-   |     ---- ^^^ expected an `Fn<()>` closure, found `fn() {foo}`
+   |     ---- ^^^ expected an `Fn()` closure, found `fn() {foo}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -15,11 +15,11 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected a `FnMut<()>` closure, found `fn() {foo}`
+error[E0277]: expected a `FnMut()` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:25:14
    |
 LL |     call_mut(foo);
-   |     -------- ^^^ expected an `FnMut<()>` closure, found `fn() {foo}`
+   |     -------- ^^^ expected an `FnMut()` closure, found `fn() {foo}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -32,11 +32,11 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(f: impl FnMut()) {
    |                     ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected a `FnOnce<()>` closure, found `fn() {foo}`
+error[E0277]: expected a `FnOnce()` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:26:15
    |
 LL |     call_once(foo);
-   |     --------- ^^^ expected an `FnOnce<()>` closure, found `fn() {foo}`
+   |     --------- ^^^ expected an `FnOnce()` closure, found `fn() {foo}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -49,7 +49,7 @@ note: required by a bound in `call_once`
 LL | fn call_once(f: impl FnOnce()) {
    |                      ^^^^^^^^ required by this bound in `call_once`
 
-error[E0277]: expected a `Fn<()>` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected a `Fn()` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:28:10
    |
 LL |     call(foo_unsafe);
@@ -67,7 +67,7 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected a `FnMut<()>` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected a `FnMut()` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:30:14
    |
 LL |     call_mut(foo_unsafe);
@@ -85,7 +85,7 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(f: impl FnMut()) {
    |                     ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected a `FnOnce<()>` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected a `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:32:15
    |
 LL |     call_once(foo_unsafe);

--- a/tests/ui/suggestions/issue-104961.fixed
+++ b/tests/ui/suggestions/issue-104961.fixed
@@ -2,12 +2,12 @@
 
 fn foo(x: &str) -> bool {
     x.starts_with(&("hi".to_string() + " you"))
-    //~^ ERROR expected a `FnMut<(char,)>` closure, found `String`
+    //~^ ERROR expected a `FnMut(char)` closure, found `String`
 }
 
 fn foo2(x: &str) -> bool {
     x.starts_with(&"hi".to_string())
-    //~^ ERROR expected a `FnMut<(char,)>` closure, found `String`
+    //~^ ERROR expected a `FnMut(char)` closure, found `String`
 }
 
 fn main() {

--- a/tests/ui/suggestions/issue-104961.rs
+++ b/tests/ui/suggestions/issue-104961.rs
@@ -2,12 +2,12 @@
 
 fn foo(x: &str) -> bool {
     x.starts_with("hi".to_string() + " you")
-    //~^ ERROR expected a `FnMut<(char,)>` closure, found `String`
+    //~^ ERROR expected a `FnMut(char)` closure, found `String`
 }
 
 fn foo2(x: &str) -> bool {
     x.starts_with("hi".to_string())
-    //~^ ERROR expected a `FnMut<(char,)>` closure, found `String`
+    //~^ ERROR expected a `FnMut(char)` closure, found `String`
 }
 
 fn main() {

--- a/tests/ui/suggestions/issue-104961.stderr
+++ b/tests/ui/suggestions/issue-104961.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnMut<(char,)>` closure, found `String`
+error[E0277]: expected a `FnMut(char)` closure, found `String`
   --> $DIR/issue-104961.rs:4:19
    |
 LL |     x.starts_with("hi".to_string() + " you")
@@ -15,7 +15,7 @@ help: consider borrowing here
 LL |     x.starts_with(&("hi".to_string() + " you"))
    |                   ++                         +
 
-error[E0277]: expected a `FnMut<(char,)>` closure, found `String`
+error[E0277]: expected a `FnMut(char)` closure, found `String`
   --> $DIR/issue-104961.rs:9:19
    |
 LL |     x.starts_with("hi".to_string())

--- a/tests/ui/suggestions/issue-62843.stderr
+++ b/tests/ui/suggestions/issue-62843.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnMut<(char,)>` closure, found `String`
+error[E0277]: expected a `FnMut(char)` closure, found `String`
   --> $DIR/issue-62843.rs:4:32
    |
 LL |     println!("{:?}", line.find(pattern));

--- a/tests/ui/trait-bounds/mismatch-fn-trait.stderr
+++ b/tests/ui/trait-bounds/mismatch-fn-trait.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `FnMut<(i32,)>` closure, found `impl FnMut(u32)`
+error[E0277]: expected a `FnMut(i32)` closure, found `impl FnMut(u32)`
   --> $DIR/mismatch-fn-trait.rs:4:10
    |
 LL |     take(f)
-   |     ---- ^ expected an `FnMut<(i32,)>` closure, found `impl FnMut(u32)`
+   |     ---- ^ expected an `FnMut(i32)` closure, found `impl FnMut(u32)`
    |     |
    |     required by a bound introduced by this call
    |
@@ -14,11 +14,11 @@ note: required by a bound in `take`
 LL | fn take(_f: impl FnMut(i32)) {}
    |                  ^^^^^^^^^^ required by this bound in `take`
 
-error[E0277]: expected a `FnMut<(i32,)>` closure, found `impl FnMut(i32, i32)`
+error[E0277]: expected a `FnMut(i32)` closure, found `impl FnMut(i32, i32)`
   --> $DIR/mismatch-fn-trait.rs:9:10
    |
 LL |     take(f)
-   |     ---- ^ expected an `FnMut<(i32,)>` closure, found `impl FnMut(i32, i32)`
+   |     ---- ^ expected an `FnMut(i32)` closure, found `impl FnMut(i32, i32)`
    |     |
    |     required by a bound introduced by this call
    |
@@ -29,11 +29,11 @@ note: required by a bound in `take`
 LL | fn take(_f: impl FnMut(i32)) {}
    |                  ^^^^^^^^^^ required by this bound in `take`
 
-error[E0277]: expected a `FnMut<(i32,)>` closure, found `impl FnMut()`
+error[E0277]: expected a `FnMut(i32)` closure, found `impl FnMut()`
   --> $DIR/mismatch-fn-trait.rs:14:10
    |
 LL |     take(f)
-   |     ---- ^ expected an `FnMut<(i32,)>` closure, found `impl FnMut()`
+   |     ---- ^ expected an `FnMut(i32)` closure, found `impl FnMut()`
    |     |
    |     required by a bound introduced by this call
    |
@@ -44,11 +44,11 @@ note: required by a bound in `take`
 LL | fn take(_f: impl FnMut(i32)) {}
    |                  ^^^^^^^^^^ required by this bound in `take`
 
-error[E0277]: expected a `FnMut<(i32,)>` closure, found `impl FnOnce(i32)`
+error[E0277]: expected a `FnMut(i32)` closure, found `impl FnOnce(i32)`
   --> $DIR/mismatch-fn-trait.rs:19:10
    |
 LL |     take(f)
-   |     ---- ^ expected an `FnMut<(i32,)>` closure, found `impl FnOnce(i32)`
+   |     ---- ^ expected an `FnMut(i32)` closure, found `impl FnOnce(i32)`
    |     |
    |     required by a bound introduced by this call
    |
@@ -59,11 +59,11 @@ note: required by a bound in `take`
 LL | fn take(_f: impl FnMut(i32)) {}
    |                  ^^^^^^^^^^ required by this bound in `take`
 
-error[E0277]: expected a `FnMut<(i32,)>` closure, found `impl FnOnce(u32)`
+error[E0277]: expected a `FnMut(i32)` closure, found `impl FnOnce(u32)`
   --> $DIR/mismatch-fn-trait.rs:24:10
    |
 LL |     take(f)
-   |     ---- ^ expected an `FnMut<(i32,)>` closure, found `impl FnOnce(u32)`
+   |     ---- ^ expected an `FnMut(i32)` closure, found `impl FnOnce(u32)`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.rs
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.rs
@@ -11,5 +11,5 @@ fn f<T: for<'r> X<'r> + ?Sized>() {
 
 fn main() {
     f::<dyn for<'x> X<'x, F = i32>>();
-    //~^ expected a `FnOnce<(&i32,)>` closure, found `i32`
+    //~^ expected a `FnOnce(&i32)` closure, found `i32`
 }

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.stderr
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `FnOnce<(&i32,)>` closure, found `i32`
+error[E0277]: expected a `FnOnce(&i32)` closure, found `i32`
   --> $DIR/check-trait-object-bounds-2.rs:13:9
    |
 LL |     f::<dyn for<'x> X<'x, F = i32>>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce<(&i32,)>` closure, found `i32`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce(&i32)` closure, found `i32`
    |
    = help: the trait `for<'a> FnOnce<(&'a i32,)>` is not implemented for `i32`
 note: required by a bound in `f`

--- a/tests/ui/traits/bound/assoc-fn-bound-root-obligation.rs
+++ b/tests/ui/traits/bound/assoc-fn-bound-root-obligation.rs
@@ -1,7 +1,7 @@
 fn strip_lf(s: &str) -> &str {
     s.strip_suffix(b'\n').unwrap_or(s)
-    //~^ ERROR expected a `FnMut<(char,)>` closure, found `u8`
-    //~| NOTE expected an `FnMut<(char,)>` closure, found `u8`
+    //~^ ERROR expected a `FnMut(char)` closure, found `u8`
+    //~| NOTE expected an `FnMut(char)` closure, found `u8`
     //~| HELP the trait `FnMut<(char,)>` is not implemented for `u8`
     //~| HELP the following other types implement trait `Pattern<'a>`:
     //~| NOTE required for `u8` to implement `Pattern<'_>`

--- a/tests/ui/traits/bound/assoc-fn-bound-root-obligation.stderr
+++ b/tests/ui/traits/bound/assoc-fn-bound-root-obligation.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `FnMut<(char,)>` closure, found `u8`
+error[E0277]: expected a `FnMut(char)` closure, found `u8`
   --> $DIR/assoc-fn-bound-root-obligation.rs:2:7
    |
 LL |     s.strip_suffix(b'\n').unwrap_or(s)
-   |       ^^^^^^^^^^^^ expected an `FnMut<(char,)>` closure, found `u8`
+   |       ^^^^^^^^^^^^ expected an `FnMut(char)` closure, found `u8`
    |
    = help: the trait `FnMut<(char,)>` is not implemented for `u8`
    = help: the following other types implement trait `Pattern<'a>`:

--- a/tests/ui/traits/new-solver/fn-trait.rs
+++ b/tests/ui/traits/new-solver/fn-trait.rs
@@ -18,15 +18,15 @@ fn main() {
     require_fn(f);
     require_fn(f as fn() -> i32);
     require_fn(f as unsafe fn() -> i32);
-    //~^ ERROR: expected a `Fn<()>` closure, found `unsafe fn() -> i32`
+    //~^ ERROR: expected a `Fn()` closure, found `unsafe fn() -> i32`
     //~| ERROR: type mismatch resolving `<unsafe fn() -> i32 as FnOnce<()>>::Output == i32`
     require_fn(g);
-    //~^ ERROR: expected a `Fn<()>` closure, found `extern "C" fn() -> i32 {g}`
+    //~^ ERROR: expected a `Fn()` closure, found `extern "C" fn() -> i32 {g}`
     //~| ERROR: type mismatch resolving `<extern "C" fn() -> i32 {g} as FnOnce<()>>::Output == i32`
     require_fn(g as extern "C" fn() -> i32);
-    //~^ ERROR: expected a `Fn<()>` closure, found `extern "C" fn() -> i32`
+    //~^ ERROR: expected a `Fn()` closure, found `extern "C" fn() -> i32`
     //~| ERROR: type mismatch resolving `<extern "C" fn() -> i32 as FnOnce<()>>::Output == i32`
     require_fn(h);
-    //~^ ERROR: expected a `Fn<()>` closure, found `unsafe fn() -> i32 {h}`
+    //~^ ERROR: expected a `Fn()` closure, found `unsafe fn() -> i32 {h}`
     //~| ERROR: type mismatch resolving `<unsafe fn() -> i32 {h} as FnOnce<()>>::Output == i32`
 }

--- a/tests/ui/traits/new-solver/fn-trait.stderr
+++ b/tests/ui/traits/new-solver/fn-trait.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn<()>` closure, found `unsafe fn() -> i32`
+error[E0277]: expected a `Fn()` closure, found `unsafe fn() -> i32`
   --> $DIR/fn-trait.rs:20:16
    |
 LL |     require_fn(f as unsafe fn() -> i32);
@@ -29,11 +29,11 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                               ^^^ required by this bound in `require_fn`
 
-error[E0277]: expected a `Fn<()>` closure, found `extern "C" fn() -> i32 {g}`
+error[E0277]: expected a `Fn()` closure, found `extern "C" fn() -> i32 {g}`
   --> $DIR/fn-trait.rs:23:16
    |
 LL |     require_fn(g);
-   |     ---------- ^ expected an `Fn<()>` closure, found `extern "C" fn() -> i32 {g}`
+   |     ---------- ^ expected an `Fn()` closure, found `extern "C" fn() -> i32 {g}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -59,11 +59,11 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                               ^^^ required by this bound in `require_fn`
 
-error[E0277]: expected a `Fn<()>` closure, found `extern "C" fn() -> i32`
+error[E0277]: expected a `Fn()` closure, found `extern "C" fn() -> i32`
   --> $DIR/fn-trait.rs:26:16
    |
 LL |     require_fn(g as extern "C" fn() -> i32);
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `Fn<()>` closure, found `extern "C" fn() -> i32`
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `Fn()` closure, found `extern "C" fn() -> i32`
    |     |
    |     required by a bound introduced by this call
    |
@@ -89,7 +89,7 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                               ^^^ required by this bound in `require_fn`
 
-error[E0277]: expected a `Fn<()>` closure, found `unsafe fn() -> i32 {h}`
+error[E0277]: expected a `Fn()` closure, found `unsafe fn() -> i32 {h}`
   --> $DIR/fn-trait.rs:29:16
    |
 LL |     require_fn(h);

--- a/tests/ui/traits/suggest-dereferences/root-obligation.fixed
+++ b/tests/ui/traits/suggest-dereferences/root-obligation.fixed
@@ -4,7 +4,7 @@ fn get_vowel_count(string: &str) -> usize {
     string
         .chars()
         .filter(|c| "aeiou".contains(*c))
-        //~^ ERROR expected a `Fn<(char,)>` closure, found `char`
+        //~^ ERROR expected a `Fn(char)` closure, found `char`
         .count()
 }
 

--- a/tests/ui/traits/suggest-dereferences/root-obligation.rs
+++ b/tests/ui/traits/suggest-dereferences/root-obligation.rs
@@ -4,7 +4,7 @@ fn get_vowel_count(string: &str) -> usize {
     string
         .chars()
         .filter(|c| "aeiou".contains(c))
-        //~^ ERROR expected a `Fn<(char,)>` closure, found `char`
+        //~^ ERROR expected a `Fn(char)` closure, found `char`
         .count()
 }
 

--- a/tests/ui/traits/suggest-dereferences/root-obligation.stderr
+++ b/tests/ui/traits/suggest-dereferences/root-obligation.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<(char,)>` closure, found `char`
+error[E0277]: expected a `Fn(char)` closure, found `char`
   --> $DIR/root-obligation.rs:6:38
    |
 LL |         .filter(|c| "aeiou".contains(c))
-   |                             -------- ^ expected an `Fn<(char,)>` closure, found `char`
+   |                             -------- ^ expected an `Fn(char)` closure, found `char`
    |                             |
    |                             required by a bound introduced by this call
    |

--- a/tests/ui/type-alias-impl-trait/issue-63279.rs
+++ b/tests/ui/type-alias-impl-trait/issue-63279.rs
@@ -3,11 +3,11 @@
 type Closure = impl FnOnce();
 
 fn c() -> Closure {
-    //~^ ERROR: expected a `FnOnce<()>` closure, found `()`
+    //~^ ERROR: expected a `FnOnce()` closure, found `()`
     || -> Closure { || () }
     //~^ ERROR: mismatched types
     //~| ERROR: mismatched types
-    //~| ERROR: expected a `FnOnce<()>` closure, found `()`
+    //~| ERROR: expected a `FnOnce()` closure, found `()`
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-63279.stderr
@@ -1,17 +1,17 @@
-error[E0277]: expected a `FnOnce<()>` closure, found `()`
+error[E0277]: expected a `FnOnce()` closure, found `()`
   --> $DIR/issue-63279.rs:5:11
    |
 LL | fn c() -> Closure {
-   |           ^^^^^^^ expected an `FnOnce<()>` closure, found `()`
+   |           ^^^^^^^ expected an `FnOnce()` closure, found `()`
    |
    = help: the trait `FnOnce<()>` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
 
-error[E0277]: expected a `FnOnce<()>` closure, found `()`
+error[E0277]: expected a `FnOnce()` closure, found `()`
   --> $DIR/issue-63279.rs:7:11
    |
 LL |     || -> Closure { || () }
-   |           ^^^^^^^ expected an `FnOnce<()>` closure, found `()`
+   |           ^^^^^^^ expected an `FnOnce()` closure, found `()`
    |
    = help: the trait `FnOnce<()>` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`

--- a/tests/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<(isize,)>` closure, found `S`
+error[E0277]: expected a `Fn(isize)` closure, found `S`
   --> $DIR/unboxed-closures-fnmut-as-fn.rs:27:21
    |
 LL |     let x = call_it(&S, 22);
-   |             ------- ^^ expected an `Fn<(isize,)>` closure, found `S`
+   |             ------- ^^ expected an `Fn(isize)` closure, found `S`
    |             |
    |             required by a bound introduced by this call
    |

--- a/tests/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn<(&isize,)>` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `Fn(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
@@ -14,7 +14,7 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut<(&isize,)>` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `FnMut(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
@@ -30,7 +30,7 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `FnOnce(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);

--- a/tests/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -1,8 +1,8 @@
-error[E0277]: expected a `Fn<(&isize,)>` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `Fn(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
-   |             ------- ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   |             ------- ^^^^^^^ expected an `Fn(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
    |             |
    |             required by a bound introduced by this call
    |
@@ -13,11 +13,11 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut<(&isize,)>` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `FnMut(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
-   |             ----------- ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   |             ----------- ^^^^^^^^^^^ expected an `FnMut(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
    |             |
    |             required by a bound introduced by this call
    |
@@ -28,11 +28,11 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `FnOnce(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);
-   |             ------------ ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   |             ------------ ^^^^^^ expected an `FnOnce(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
    |             |
    |             required by a bound introduced by this call
    |

--- a/tests/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected a `Fn(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:21:21
    |
 LL |     let x = call_it(&square, 22);
@@ -14,7 +14,7 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected a `FnMut(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:26:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
@@ -30,7 +30,7 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected a `FnOnce(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:31:26
    |
 LL |     let z = call_it_once(square, 22);

--- a/tests/ui/unsafe/initializing-ranged-via-ctor.stderr
+++ b/tests/ui/unsafe/initializing-ranged-via-ctor.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce<({integer},)>` closure, found `unsafe fn(u8) -> NonZeroAndOneU8 {NonZeroAndOneU8}`
+error[E0277]: expected a `FnOnce({integer})` closure, found `unsafe fn(u8) -> NonZeroAndOneU8 {NonZeroAndOneU8}`
   --> $DIR/initializing-ranged-via-ctor.rs:9:34
    |
 LL |     println!("{:?}", Some(1).map(NonZeroAndOneU8).unwrap());


### PR DESCRIPTION
I don't think that users really ever should need to think about `Fn*` traits' tupled args for a simple trait error.

r? diagnostics