### PR TITLE
Fix normalization of ZST

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/alloc.rs
+++ b/compiler/rustc_smir/src/rustc_smir/alloc.rs
@@ -41,8 +41,18 @@ pub fn new_allocation<'tcx>(
             allocation.stable(tables)
         }
         ConstValue::ZeroSized => {
-            let align =
-                tables.tcx.layout_of(rustc_middle::ty::ParamEnv::empty().and(ty)).unwrap().align;
+            let mut ty = ty;
+            match ty.kind() {
+                rustc_middle::ty::FnDef(def, _) => {
+                    ty = tables.tcx.type_of(def).skip_binder();
+                }
+                _ => (),
+            }
+            let align = tables
+                .tcx
+                .layout_of(rustc_middle::ty::ParamEnv::reveal_all().and(ty))
+                .unwrap()
+                .align;
             new_empty_allocation(align.abi)
         }
         ConstValue::Slice { data, meta } => {


### PR DESCRIPTION
Before this change we were trying to normalize aliased generic type, which caused normalization err now, we reveal all and, get type behind the alias.

Fixes https://github.com/rust-lang/project-stable-mir/issues/38

r? @oli-obk 