### PR TITLE
Pass rustc shim flags using environment variable

### DIFF
--- a/src/bootstrap/bin/_helper.rs
+++ b/src/bootstrap/bin/_helper.rs
@@ -14,6 +14,7 @@ fn parse_rustc_verbose() -> usize {
 /// Parses the value of the "RUSTC_STAGE" environment variable and returns it as a `String`.
 ///
 /// If "RUSTC_STAGE" was not set, the program will be terminated with 101.
+#[allow(unused)]
 fn parse_rustc_stage() -> String {
     std::env::var("RUSTC_STAGE").unwrap_or_else(|_| {
         // Don't panic here; it's reasonable to try and run these shims directly. Give a helpful error instead.

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -27,7 +27,6 @@ fn main() {
     let args = env::args_os().skip(1).collect::<Vec<_>>();
     let arg = |name| args.windows(2).find(|args| args[0] == name).and_then(|args| args[1].to_str());
 
-    let stage = parse_rustc_stage();
     let verbose = parse_rustc_verbose();
 
     // Detect whether or not we're a build script depending on whether --target
@@ -108,9 +107,6 @@ fn main() {
             cmd.arg("-Ztls-model=initial-exec");
         }
     } else {
-        // FIXME(rust-lang/cargo#5754) we shouldn't be using special env vars
-        // here, but rather Cargo should know what flags to pass rustc itself.
-
         // Find any host flags that were passed by bootstrap.
         // The flags are stored in a RUSTC_HOST_FLAGS variable, separated by spaces.
         if let Ok(flags) = std::env::var("RUSTC_HOST_FLAGS") {
@@ -118,17 +114,6 @@ fn main() {
                 cmd.arg(flag);
             }
         }
-
-        // Cargo doesn't pass RUSTFLAGS to proc_macros:
-        // https://github.com/rust-lang/cargo/issues/4423
-        // Thus, if we are on stage 0, we explicitly set `--cfg=bootstrap`.
-        // We also declare that the flag is expected, which we need to do to not
-        // get warnings about it being unexpected.
-        if stage == "0" {
-            cmd.arg("--cfg=bootstrap");
-        }
-        cmd.arg("-Zunstable-options");
-        cmd.arg("--check-cfg=values(bootstrap)");
     }
 
     if let Ok(map) = env::var("RUSTC_DEBUGINFO_MAP") {

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -111,20 +111,11 @@ fn main() {
         // FIXME(rust-lang/cargo#5754) we shouldn't be using special env vars
         // here, but rather Cargo should know what flags to pass rustc itself.
 
-        // Override linker if necessary.
-        if let Ok(host_linker) = env::var("RUSTC_HOST_LINKER") {
-            cmd.arg(format!("-Clinker={host_linker}"));
-        }
-        if env::var_os("RUSTC_HOST_FUSE_LD_LLD").is_some() {
-            cmd.arg("-Clink-args=-fuse-ld=lld");
-        }
-
-        if let Ok(s) = env::var("RUSTC_HOST_CRT_STATIC") {
-            if s == "true" {
-                cmd.arg("-C").arg("target-feature=+crt-static");
-            }
-            if s == "false" {
-                cmd.arg("-C").arg("target-feature=-crt-static");
+        // Find any host flags that were passed by bootstrap.
+        // The flags are stored in a RUSTC_HOST_FLAGS variable, separated by spaces.
+        if let Ok(flags) = std::env::var("RUSTC_HOST_FLAGS") {
+            for flag in flags.split(' ') {
+                cmd.arg(flag);
             }
         }
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1174,9 +1174,6 @@ impl<'a> Builder<'a> {
         if let Some(linker) = self.linker(compiler.host) {
             cmd.env("RUSTDOC_LINKER", linker);
         }
-        if self.is_fuse_ld_lld(compiler.host) {
-            cmd.env("RUSTDOC_FUSE_LD_LLD", "1");
-        }
         cmd
     }
 
@@ -1659,7 +1656,6 @@ impl<'a> Builder<'a> {
         }
         if self.is_fuse_ld_lld(compiler.host) {
             cargo.env("RUSTC_HOST_FUSE_LD_LLD", "1");
-            cargo.env("RUSTDOC_FUSE_LD_LLD", "1");
         }
 
         if let Some(target_linker) = self.linker(target) {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1438,6 +1438,20 @@ impl<'a> Builder<'a> {
             }
         }
 
+        // FIXME(rust-lang/cargo#5754) we shouldn't be using special command arguments
+        // to the host invocation here, but rather Cargo should know what flags to pass rustc
+        // itself.
+        if stage == 0 {
+            hostflags.arg("--cfg=bootstrap");
+        }
+        // Cargo doesn't pass RUSTFLAGS to proc_macros:
+        // https://github.com/rust-lang/cargo/issues/4423
+        // Thus, if we are on stage 0, we explicitly set `--cfg=bootstrap`.
+        // We also declare that the flag is expected, which we need to do to not
+        // get warnings about it being unexpected.
+        hostflags.arg("-Zunstable-options");
+        hostflags.arg("--check-cfg=values(bootstrap)");
+
         // FIXME: It might be better to use the same value for both `RUSTFLAGS` and `RUSTDOCFLAGS`,
         // but this breaks CI. At the very least, stage0 `rustdoc` needs `--cfg bootstrap`. See
         // #71458.

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1654,10 +1654,10 @@ impl<'a> Builder<'a> {
         }
 
         if let Some(host_linker) = self.linker(compiler.host) {
-            hostflags.flag(format!("-Clinker={}", host_linker.display()));
+            hostflags.arg(format!("-Clinker={}", host_linker.display()));
         }
         if self.is_fuse_ld_lld(compiler.host) {
-            hostflags.flag("-Clink-args=-fuse-ld=lld");
+            hostflags.arg("-Clink-args=-fuse-ld=lld");
         }
 
         if let Some(target_linker) = self.linker(target) {
@@ -1742,7 +1742,7 @@ impl<'a> Builder<'a> {
 
         if let Some(x) = self.crt_static(compiler.host) {
             let sign = if x { "+" } else { "-" };
-            hostflags.flag(format!("-Ctarget-feature={sign}crt-static"));
+            hostflags.arg(format!("-Ctarget-feature={sign}crt-static"));
         }
 
         if let Some(map_to) = self.build.debuginfo_map_to(GitRepo::Rustc) {
@@ -2244,7 +2244,7 @@ impl HostFlags {
     const SEPARATOR: &'static str = " ";
 
     /// Adds a host rustc flag.
-    fn flag<S: Into<String>>(&mut self, flag: S) {
+    fn arg<S: Into<String>>(&mut self, flag: S) {
         let value = flag.into().trim().to_string();
         assert!(!value.contains(Self::SEPARATOR));
         self.rustc.push(value);


### PR DESCRIPTION
This PR implements a generalized way of passing of host flags to the `rustc` shim in bootstrap, as proposed [here](https://github.com/rust-lang/rust/pull/116278#discussion_r1346979960).

I tried to implement the bootstrap side using `OsString`, but then I realized that the shim code was using `env::var` before anyway, instead of `env::var_os`, so I just settled on a `String`. The shim side is still general and uses `env::vars_os` now.

I'm not sure if we actually need to do something with the `rustdoc` shim. It *seems* to me that the env. vars passed to it (`RUSTDOC_LINKER`) and (`RUSTDOC_LLD_NO_THREADS`) could just be passed to cargo directly (or rather, the commands that they invoke in the shim could be passed directly). I'm not sure why are they set by the shim.

r? @onur-ozkan
CC @petrochenkov