### PR TITLE
Pass flags to `rustdoc` shim without env. vars

### DIFF
--- a/src/bootstrap/src/bin/rustdoc.rs
+++ b/src/bootstrap/src/bin/rustdoc.rs
@@ -3,7 +3,6 @@
 //! See comments in `src/bootstrap/rustc.rs` for more information.
 
 use std::env;
-use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -51,15 +50,6 @@ fn main() {
     // also in the sysroot.
     if env::var_os("RUSTC_FORCE_UNSTABLE").is_some() {
         cmd.arg("-Z").arg("force-unstable-if-unmarked");
-    }
-    if let Some(linker) = env::var_os("RUSTDOC_LINKER") {
-        let mut arg = OsString::from("-Clinker=");
-        arg.push(&linker);
-        cmd.arg(arg);
-    }
-    if let Ok(no_threads) = env::var("RUSTDOC_LLD_NO_THREADS") {
-        cmd.arg("-Clink-arg=-fuse-ld=lld");
-        cmd.arg(format!("-Clink-arg=-Wl,{no_threads}"));
     }
     // Cargo doesn't pass RUSTDOCFLAGS to proc_macros:
     // https://github.com/rust-lang/cargo/issues/4423

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -29,8 +29,8 @@ use crate::utils;
 use crate::utils::cache::{Interned, INTERNER};
 use crate::utils::exec::BootstrapCommand;
 use crate::utils::helpers::{
-    self, add_link_lib_path, add_rustdoc_lld_flags, dylib_path, dylib_path_var, output, t,
-    target_supports_cranelift_backend, up_to_date,
+    self, add_link_lib_path, add_rustdoc_cargo_lld_flags, add_rustdoc_lld_flags, dylib_path,
+    dylib_path_var, output, t, target_supports_cranelift_backend, up_to_date, LldThreads,
 };
 use crate::utils::render_tests::{add_flags_and_try_run_tests, try_run_tests};
 use crate::{envify, CLang, DocTests, GitRepo, Mode};
@@ -271,13 +271,14 @@ impl Step for Cargotest {
 
         let _time = helpers::timeit(&builder);
         let mut cmd = builder.tool_cmd(Tool::CargoTest);
-        builder.run_delaying_failure(
-            cmd.arg(&cargo)
-                .arg(&out_dir)
-                .args(builder.config.test_args())
-                .env("RUSTC", builder.rustc(compiler))
-                .env("RUSTDOC", builder.rustdoc(compiler)),
-        );
+        let mut cmd = cmd
+            .arg(&cargo)
+            .arg(&out_dir)
+            .args(builder.config.test_args())
+            .env("RUSTC", builder.rustc(compiler))
+            .env("RUSTDOC", builder.rustdoc(compiler));
+        add_rustdoc_cargo_lld_flags(&mut cmd, builder, compiler.host, LldThreads::No);
+        builder.run_delaying_failure(cmd);
     }
 }
 
@@ -862,7 +863,7 @@ impl Step for RustdocTheme {
             .env("CFG_RELEASE_CHANNEL", &builder.config.channel)
             .env("RUSTDOC_REAL", builder.rustdoc(self.compiler))
             .env("RUSTC_BOOTSTRAP", "1");
-        add_rustdoc_lld_flags(&mut cmd, builder, self.compiler.host, true);
+        add_rustdoc_lld_flags(&mut cmd, builder, self.compiler.host, LldThreads::No);
 
         builder.run_delaying_failure(&mut cmd);
     }
@@ -1036,6 +1037,8 @@ impl Step for RustdocGUI {
 
         cmd.env("RUSTDOC", builder.rustdoc(self.compiler))
             .env("RUSTC", builder.rustc(self.compiler));
+
+        add_rustdoc_cargo_lld_flags(&mut cmd, builder, self.compiler.host, LldThreads::No);
 
         for path in &builder.paths {
             if let Some(p) = helpers::is_valid_test_suite_arg(path, "tests/rustdoc-gui", builder) {

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -29,7 +29,7 @@ use crate::utils;
 use crate::utils::cache::{Interned, INTERNER};
 use crate::utils::exec::BootstrapCommand;
 use crate::utils::helpers::{
-    self, add_link_lib_path, dylib_path, dylib_path_var, output, t,
+    self, add_link_lib_path, add_rustdoc_lld_flags, dylib_path, dylib_path_var, output, t,
     target_supports_cranelift_backend, up_to_date,
 };
 use crate::utils::render_tests::{add_flags_and_try_run_tests, try_run_tests};
@@ -862,15 +862,8 @@ impl Step for RustdocTheme {
             .env("CFG_RELEASE_CHANNEL", &builder.config.channel)
             .env("RUSTDOC_REAL", builder.rustdoc(self.compiler))
             .env("RUSTC_BOOTSTRAP", "1");
-        if let Some(linker) = builder.linker(self.compiler.host) {
-            cmd.env("RUSTDOC_LINKER", linker);
-        }
-        if builder.is_fuse_ld_lld(self.compiler.host) {
-            cmd.env(
-                "RUSTDOC_LLD_NO_THREADS",
-                helpers::lld_flag_no_threads(self.compiler.host.contains("windows")),
-            );
-        }
+        add_rustdoc_lld_flags(&mut cmd, builder, self.compiler.host, true);
+
         builder.run_delaying_failure(&mut cmd);
     }
 }

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -18,7 +18,9 @@ use crate::core::build_steps::{check, clean, compile, dist, doc, install, run, s
 use crate::core::config::flags::{Color, Subcommand};
 use crate::core::config::{DryRun, SplitDebuginfo, TargetSelection};
 use crate::utils::cache::{Cache, Interned, INTERNER};
-use crate::utils::helpers::{self, add_dylib_path, add_link_lib_path, exe, libdir, output, t};
+use crate::utils::helpers::{
+    self, add_dylib_path, add_link_lib_path, add_rustdoc_lld_flags, exe, libdir, output, t,
+};
 use crate::Crate;
 use crate::EXTRA_CHECK_CFGS;
 use crate::{Build, CLang, DocTests, GitRepo, Mode};
@@ -1173,9 +1175,7 @@ impl<'a> Builder<'a> {
         cmd.env_remove("MAKEFLAGS");
         cmd.env_remove("MFLAGS");
 
-        if let Some(linker) = self.linker(compiler.host) {
-            cmd.env("RUSTDOC_LINKER", linker);
-        }
+        add_rustdoc_lld_flags(&mut cmd, self, compiler.host, false);
         cmd
     }
 

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -18,9 +18,8 @@ use crate::core::build_steps::{check, clean, compile, dist, doc, install, run, s
 use crate::core::config::flags::{Color, Subcommand};
 use crate::core::config::{DryRun, SplitDebuginfo, TargetSelection};
 use crate::utils::cache::{Cache, Interned, INTERNER};
-use crate::utils::helpers::{
-    self, add_dylib_path, add_link_lib_path, add_rustdoc_lld_flags, exe, libdir, output, t,
-};
+use crate::utils::helpers::{self, add_dylib_path, add_link_lib_path, add_rustdoc_lld_flags, exe};
+use crate::utils::helpers::{libdir, output, t, LldThreads};
 use crate::Crate;
 use crate::EXTRA_CHECK_CFGS;
 use crate::{Build, CLang, DocTests, GitRepo, Mode};
@@ -1175,7 +1174,7 @@ impl<'a> Builder<'a> {
         cmd.env_remove("MAKEFLAGS");
         cmd.env_remove("MFLAGS");
 
-        add_rustdoc_lld_flags(&mut cmd, self, compiler.host, false);
+        add_rustdoc_lld_flags(&mut cmd, self, compiler.host, LldThreads::Yes);
         cmd
     }
 

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -5,6 +5,7 @@
 
 use build_helper::util::fail;
 use std::env;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -377,7 +378,6 @@ fn absolute_unix(path: &Path) -> io::Result<PathBuf> {
 
 #[cfg(windows)]
 fn absolute_windows(path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
-    use std::ffi::OsString;
     use std::io::Error;
     use std::os::windows::ffi::{OsStrExt, OsStringExt};
     use std::ptr::null_mut;
@@ -471,21 +471,63 @@ pub fn extract_beta_rev(version: &str) -> Option<String> {
     count
 }
 
+pub enum LldThreads {
+    Yes,
+    No,
+}
+
 pub fn add_rustdoc_lld_flags(
     cmd: &mut Command,
     builder: &Builder<'_>,
     target: TargetSelection,
-    single_threaded: bool,
+    lld_threads: LldThreads,
 ) {
+    cmd.args(build_rustdoc_lld_flags(builder, target, lld_threads));
+}
+
+pub fn add_rustdoc_cargo_lld_flags(
+    cmd: &mut Command,
+    builder: &Builder<'_>,
+    target: TargetSelection,
+    lld_threads: LldThreads,
+) {
+    let args = build_rustdoc_lld_flags(builder, target, lld_threads);
+    let mut flags = cmd
+        .get_envs()
+        .find_map(|(k, v)| if k == OsStr::new("RUSTDOCFLAGS") { v } else { None })
+        .unwrap_or_default()
+        .to_os_string();
+    for arg in args {
+        if !flags.is_empty() {
+            flags.push(" ");
+        }
+        flags.push(arg);
+    }
+    if !flags.is_empty() {
+        cmd.env("RUSTDOCFLAGS", flags);
+    }
+}
+
+fn build_rustdoc_lld_flags(
+    builder: &Builder<'_>,
+    target: TargetSelection,
+    lld_threads: LldThreads,
+) -> Vec<OsString> {
+    let mut args = vec![];
+
     if let Some(linker) = builder.linker(target) {
         let mut flag = std::ffi::OsString::from("-Clinker=");
         flag.push(linker);
-        cmd.arg(flag);
+        args.push(flag);
     }
     if builder.is_fuse_ld_lld(target) {
-        cmd.arg("-Clink-arg=-fuse-ld=lld");
-        if single_threaded {
-            cmd.arg(format!("-Clink-arg=-Wl,{}", lld_flag_no_threads(target.contains("windows"))));
+        args.push(OsString::from("-Clink-arg=-fuse-ld=lld"));
+        if matches!(lld_threads, LldThreads::No) {
+            args.push(OsString::from(format!(
+                "-Clink-arg=-Wl,{}",
+                lld_flag_no_threads(target.contains("windows"))
+            )));
         }
     }
+    args
 }

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -470,3 +470,22 @@ pub fn extract_beta_rev(version: &str) -> Option<String> {
 
     count
 }
+
+pub fn add_rustdoc_lld_flags(
+    cmd: &mut Command,
+    builder: &Builder<'_>,
+    target: TargetSelection,
+    single_threaded: bool,
+) {
+    if let Some(linker) = builder.linker(target) {
+        let mut flag = std::ffi::OsString::from("-Clinker=");
+        flag.push(linker);
+        cmd.arg(flag);
+    }
+    if builder.is_fuse_ld_lld(target) {
+        cmd.arg("-Clink-arg=-fuse-ld=lld");
+        if single_threaded {
+            cmd.arg(format!("-Clink-arg=-Wl,{}", lld_flag_no_threads(target.contains("windows"))));
+        }
+    }
+}


### PR DESCRIPTION
Discussed here: https://github.com/rust-lang/rust/pull/116448#issuecomment-1748785961. Since it was not really documented why these flags were passed through the shim, I guess that the only way to find out if it's really needed... is to remove it :)

r? @petrochenkov