### PR TITLE
Enable new bors try branch to run on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ name: CI
       - try
       - try-perf
       - automation/bors/try
-      - automation/bors/try-merge
       - master
   pull_request:
     branches:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -282,7 +282,6 @@ on:
       - try
       - try-perf
       - automation/bors/try
-      - automation/bors/try-merge
       - master
   pull_request:
     branches:

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -47,7 +47,8 @@ source "$ci_dir/shared.sh"
 
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
-if ! isCI || isCiBranch auto || isCiBranch beta || isCiBranch try || isCiBranch try-perf; then
+if ! isCI || isCiBranch auto || isCiBranch beta || isCiBranch try || isCiBranch try-perf || \
+  isCiBranch automation/bors/try; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.metrics"
     HAS_METRICS=1

--- a/src/ci/scripts/verify-channel.sh
+++ b/src/ci/scripts/verify-channel.sh
@@ -8,7 +8,7 @@ IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
-if isCiBranch auto || isCiBranch try || isCiBranch try-perf; then
+if isCiBranch auto || isCiBranch try || isCiBranch try-perf || isCiBranch automation/bors/try; then
     echo "channel verification is only executed on PR builds"
     exit
 fi


### PR DESCRIPTION
Needed to fix [this error](https://github.com/rust-lang/rust/actions/runs/6420044833/job/17431256956). Inspired by https://github.com/rust-lang/rust/pull/99988

Also, removes `try-merge` from the workflow. It shouldn't have been added in https://github.com/rust-lang/rust/pull/116353.

r? @Mark-Simulacrum