### PR TITLE
Do not assert that hidden types don't have erased regions.

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -3116,9 +3116,6 @@ fn bind_generator_hidden_types_above<'tcx>(
             bty.instantiate(tcx, args)
         })
         .collect();
-    if considering_regions {
-        debug_assert!(!hidden_types.has_erased_regions());
-    }
     let bound_vars =
         tcx.mk_bound_variable_kinds_from_iter(bound_vars.iter().chain(
             (num_bound_variables..counter).map(|_| ty::BoundVariableKind::Region(ty::BrAnon)),


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/116306

`args` can have erased regions.
In the linked issue, this is reached by computing whether a large type is `Freeze` to compute its ABI.

I do not have a minimized test to include.