### PR TITLE
Properly export function defined in test which uses global_asm!()

### DIFF
--- a/tests/ui/asm/x86_64/issue-96797.rs
+++ b/tests/ui/asm/x86_64/issue-96797.rs
@@ -14,10 +14,10 @@ fn my_func() {}
 global_asm!("
 .globl call_foobar
 .type call_foobar,@function
-.section .text.call_foobar,\"ax\",@progbits
+.pushsection .text.call_foobar,\"ax\",@progbits
 call_foobar: jmp {}
 .size call_foobar, .-call_foobar
-.text
+.popsection
 ", sym foobar);
 
 fn foobar() {}

--- a/tests/ui/asm/x86_64/issue-96797.rs
+++ b/tests/ui/asm/x86_64/issue-96797.rs
@@ -11,7 +11,14 @@ use std::arch::global_asm;
 #[no_mangle]
 fn my_func() {}
 
-global_asm!("call_foobar: jmp {}", sym foobar);
+global_asm!("
+.globl call_foobar
+.type call_foobar,@function
+.section .text.call_foobar,\"ax\",@progbits
+call_foobar: jmp {}
+.size call_foobar, .-call_foobar
+.text
+", sym foobar);
 
 fn foobar() {}
 


### PR DESCRIPTION
Currently the test passes with the LLVM backend as the codegen unit partitioning logic happens to place both the global_asm!() and the function which calls the function defined by the global_asm!() in the same CGU. With the Cranelift backend it breaks however as it will place all assembly in separate codegen units to be passed to an external linker.