### PR TITLE
rustdoc-search: fix bug with multi-item impl trait

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1555,7 +1555,7 @@ function initSearch(rawSearchIndex) {
                         return false;
                     }
                 }
-            } else if (fnType.id !== null) {
+            } else {
                 if (queryElem.id === typeNameIdOfArrayOrSlice &&
                     (fnType.id === typeNameIdOfSlice || fnType.id === typeNameIdOfArray)
                 ) {

--- a/tests/rustdoc-js/impl-trait.js
+++ b/tests/rustdoc-js/impl-trait.js
@@ -1,3 +1,4 @@
+// exact-check
 // ignore-order
 
 const EXPECTED = [
@@ -20,9 +21,16 @@ const EXPECTED = [
     {
         'query': '-> Aaaaaaa',
         'others': [
-            { 'path': 'impl_trait::Ccccccc', 'name': 'fffffff' },
-            { 'path': 'impl_trait::Ccccccc', 'name': 'ddddddd' },
             { 'path': 'impl_trait', 'name': 'bbbbbbb' },
+            { 'path': 'impl_trait::Ccccccc', 'name': 'ddddddd' },
+            { 'path': 'impl_trait::Ccccccc', 'name': 'fffffff' },
+            { 'path': 'impl_trait::Ccccccc', 'name': 'ggggggg' },
+        ],
+    },
+    {
+        'query': '-> Bbbbbbb',
+        'others': [
+            { 'path': 'impl_trait::Ccccccc', 'name': 'ggggggg' },
         ],
     },
     {
@@ -31,13 +39,14 @@ const EXPECTED = [
             { 'path': 'impl_trait', 'name': 'Aaaaaaa' },
         ],
         'in_args': [
-            { 'path': 'impl_trait::Ccccccc', 'name': 'fffffff' },
             { 'path': 'impl_trait::Ccccccc', 'name': 'eeeeeee' },
+            { 'path': 'impl_trait::Ccccccc', 'name': 'fffffff' },
         ],
         'returned': [
-            { 'path': 'impl_trait::Ccccccc', 'name': 'fffffff' },
-            { 'path': 'impl_trait::Ccccccc', 'name': 'ddddddd' },
             { 'path': 'impl_trait', 'name': 'bbbbbbb' },
+            { 'path': 'impl_trait::Ccccccc', 'name': 'ddddddd' },
+            { 'path': 'impl_trait::Ccccccc', 'name': 'fffffff' },
+            { 'path': 'impl_trait::Ccccccc', 'name': 'ggggggg' },
         ],
     },
 ];

--- a/tests/rustdoc-js/impl-trait.rs
+++ b/tests/rustdoc-js/impl-trait.rs
@@ -1,6 +1,9 @@
 pub trait Aaaaaaa {}
 
+pub trait Bbbbbbb {}
+
 impl Aaaaaaa for () {}
+impl Bbbbbbb for () {}
 
 pub fn bbbbbbb() -> impl Aaaaaaa {
     ()
@@ -17,5 +20,8 @@ impl Ccccccc {
     }
     pub fn fffffff(&self, x: impl Aaaaaaa) -> impl Aaaaaaa {
         x
+    }
+    pub fn ggggggg(&self) -> impl Aaaaaaa + Bbbbbbb {
+        ()
     }
 }


### PR DESCRIPTION
Preview searches:

- https://notriddle.com/rustdoc-html-demo-5/compiler-doc-impl-trait-bugfix/index.html?search=-%3E%20globalctxt

- https://notriddle.com/rustdoc-html-demo-5/compiler-doc-impl-trait-bugfix/index.html?search=globalctxt