### PR TITLE
Copy 1-/2-element arrays as scalars, not vectors

### DIFF
--- a/tests/assembly/x86_64-array-pair-load-store-merge.rs
+++ b/tests/assembly/x86_64-array-pair-load-store-merge.rs
@@ -1,0 +1,18 @@
+// assembly-output: emit-asm
+// compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
+// only-x86_64
+// ignore-sgx
+
+// This is emitted in a way that results in two loads and two stores in LLVM-IR.
+// Confirm that that doesn't mean 4 instructions in assembly.
+
+// CHECK-LABEL: array_copy_2_elements:
+#[no_mangle]
+pub fn array_copy_2_elements(a: &[u8; 2], p: &mut [u8; 2]) {
+    // CHECK-NOT: byte
+    // CHECK-NOT: mov
+    // CHECK: mov{{.+}}, word ptr
+    // CHECK-NEXT: mov word ptr
+    // CHECK-NEXT: ret
+    *p = *a;
+}

--- a/tests/codegen/array-clone.rs
+++ b/tests/codegen/array-clone.rs
@@ -1,4 +1,5 @@
 // compile-flags: -O
+// min-llvm-version: 17 (earlier versions have trouble merging the loads)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/array-codegen.rs
+++ b/tests/codegen/array-codegen.rs
@@ -32,3 +32,25 @@ pub fn array_copy(a: &[u8; 4], p: &mut [u8; 4]) {
     // CHECK: store <4 x i8> %[[TEMP2]], ptr %p, align 1
     *p = *a;
 }
+
+// CHECK-LABEL: @array_copy_1_element
+#[no_mangle]
+pub fn array_copy_1_element(a: &[u8; 1], p: &mut [u8; 1]) {
+    // CHECK: %[[LOCAL:.+]] = alloca [1 x i8], align 1
+    // CHECK: %[[TEMP1:.+]] = load [1 x i8], ptr %a, align 1
+    // CHECK: store [1 x i8] %[[TEMP1]], ptr %[[LOCAL]], align 1
+    // CHECK: %[[TEMP2:.+]] = load [1 x i8], ptr %[[LOCAL]], align 1
+    // CHECK: store [1 x i8] %[[TEMP2]], ptr %p, align 1
+    *p = *a;
+}
+
+// CHECK-LABEL: @array_copy_2_elements
+#[no_mangle]
+pub fn array_copy_2_elements(a: &[u8; 2], p: &mut [u8; 2]) {
+    // CHECK: %[[LOCAL:.+]] = alloca [2 x i8], align 1
+    // CHECK: %[[TEMP1:.+]] = load [2 x i8], ptr %a, align 1
+    // CHECK: store [2 x i8] %[[TEMP1]], ptr %[[LOCAL]], align 1
+    // CHECK: %[[TEMP2:.+]] = load [2 x i8], ptr %[[LOCAL]], align 1
+    // CHECK: store [2 x i8] %[[TEMP2]], ptr %p, align 1
+    *p = *a;
+}

--- a/tests/codegen/array-optimized.rs
+++ b/tests/codegen/array-optimized.rs
@@ -1,0 +1,35 @@
+// compile-flags: -O
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @array_copy_1_element
+#[no_mangle]
+pub fn array_copy_1_element(a: &[u8; 1], p: &mut [u8; 1]) {
+    // CHECK-NOT: alloca
+    // CHECK: %[[TEMP:.+]] = load i8, ptr %a, align 1
+    // CHECK: store i8 %[[TEMP]], ptr %p, align 1
+    // CHECK: ret
+    *p = *a;
+}
+
+// CHECK-LABEL: @array_copy_2_elements
+#[no_mangle]
+pub fn array_copy_2_elements(a: &[u8; 2], p: &mut [u8; 2]) {
+    // CHECK-NOT: alloca
+    // CHECK: %[[TEMP1:.+]] = load i8, ptr %a, align 1
+    // CHECK: %[[TEMP2:.+]] = load i8, ptr
+    // CHECK: store i8 %[[TEMP1]], ptr %p, align 1
+    // CHECK: store i8 %[[TEMP2]], ptr
+    // CHECK: ret
+    *p = *a;
+}
+
+// CHECK-LABEL: @array_copy_4_elements
+#[no_mangle]
+pub fn array_copy_4_elements(a: &[u8; 4], p: &mut [u8; 4]) {
+    // CHECK-NOT: alloca
+    // CHECK: %[[TEMP:.+]] = load <4 x i8>, ptr %a, align 1
+    // CHECK: store <4 x i8> %[[TEMP]], ptr %p, align 1
+    // CHECK: ret
+    *p = *a;
+}


### PR DESCRIPTION
For `[T; 1]` it's silly to copy as `<1 x T>` when we can just copy as `T`.
And treat `[T; 2]` as a scalar pair (like `(T, T)`) when copying it.

Inspired by https://github.com/rust-lang/rust/issues/101210#issuecomment-1732470941, which pointed out that `Option<[u8; 1]>` was codegenning worse than `Option<u8>`.

(I'm not sure *why* LLVM doesn't optimize out `<1 x u8>`, but might as well just not emit it in the first place in this codepath.)