### PR TITLE
[perf] Do not reuse internal `TokenStream` in `proc_macro::TokenStream`

### DIFF
--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -301,7 +301,7 @@ pub struct AttributesData {
 /// Today's `TokenTree`s can still contain AST via `token::Interpolated` for
 /// backwards compatibility.
 #[derive(Clone, Debug, Default, Encodable, Decodable)]
-pub struct TokenStream(pub(crate) Lrc<Vec<TokenTree>>);
+pub struct TokenStream(pub Lrc<Vec<TokenTree>>);
 
 /// Similar to `proc_macro::Spacing`, but for tokens.
 ///

--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -59,9 +59,7 @@ impl<'a> TokenTreesReader<'a> {
                             if let Some(glued) = self.token.glue(&next_tok) {
                                 self.token = glued;
                             } else {
-                                let this_spacing =
-                                    if next_tok.is_op() { Spacing::Joint } else { Spacing::Alone };
-                                break (this_spacing, next_tok);
+                                break (Spacing::Joint, next_tok);
                             }
                         } else {
                             break (Spacing::Alone, next_tok);

--- a/tests/ui/proc-macro/auxiliary/issue-76399.rs
+++ b/tests/ui/proc-macro/auxiliary/issue-76399.rs
@@ -1,0 +1,13 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro]
+pub fn m(_input: TokenStream) -> TokenStream {
+    eprintln!("{:#?}", TokenStream::from(TokenTree::Punct(Punct::new(':', Spacing::Joint))));
+    TokenStream::new()
+}

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
@@ -1371,7 +1371,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
     },
     Punct {
         ch: '<',
-        spacing: Joint,
+        spacing: Alone,
         span: $DIR/issue-75930-derive-cfg.rs:25:11: 25:12 (#0),
     },
     Ident {

--- a/tests/ui/proc-macro/issue-76399.rs
+++ b/tests/ui/proc-macro/issue-76399.rs
@@ -1,0 +1,8 @@
+// check-pass
+// aux-build:issue-76399.rs
+
+extern crate issue_76399;
+
+issue_76399::m!();
+
+fn main() {}

--- a/tests/ui/proc-macro/issue-76399.stderr
+++ b/tests/ui/proc-macro/issue-76399.stderr
@@ -1,0 +1,7 @@
+TokenStream [
+    Punct {
+        ch: ':',
+        spacing: Joint,
+        span: #5 bytes(70..87),
+    },
+]


### PR DESCRIPTION
Use a separate type instead, so that we need to convert from one `TokenStream` to another and back on proc macro boundaries.
I want to check how much it affects performance.

This PR also implements the suggestion to censor token jointness at proc macro boundary from https://github.com/rust-lang/rust/pull/114571 (since we now have such a boundary).
This PR is also somewhat related to https://github.com/rust-lang/rust/pull/101419.

I don't like the result and will likely close this after the perf test.