### PR TITLE
Extend `impl`'s `def_span` to include its where clauses

### DIFF
--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -970,12 +970,15 @@ impl<'hir> Map<'hir> {
                 // SyntaxContext of the visibility.
                 sig.span.find_ancestor_in_same_ctxt(*outer_span).unwrap_or(*outer_span)
             }
+            // Impls, including their where clauses.
+            Node::Item(Item {
+                kind: ItemKind::Impl(Impl { generics, .. }),
+                span: outer_span,
+                ..
+            }) => until_within(*outer_span, generics.where_clause_span),
             // Constants and Statics.
             Node::Item(Item {
-                kind:
-                    ItemKind::Const(ty, ..)
-                    | ItemKind::Static(ty, ..)
-                    | ItemKind::Impl(Impl { self_ty: ty, .. }),
+                kind: ItemKind::Const(ty, ..) | ItemKind::Static(ty, ..),
                 span: outer_span,
                 ..
             })

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -31,7 +31,7 @@ LL |     const VAL: T;
    |     ------------ `VAL` from trait
 ...
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/associated-types/associated-types-coherence-failure.stderr
+++ b/tests/ui/associated-types/associated-types-coherence-failure.stderr
@@ -2,19 +2,19 @@ error[E0119]: conflicting implementations of trait `IntoCow<'_, _>` for type `Co
   --> $DIR/associated-types-coherence-failure.rs:21:1
    |
 LL | impl<'a, B: ?Sized> IntoCow<'a, B> for <B as ToOwned>::Owned where B: ToOwned {
-   | ------------------------------------------------------------ first implementation here
+   | ----------------------------------------------------------------------------- first implementation here
 ...
 LL | impl<'a, B: ?Sized> IntoCow<'a, B> for Cow<'a, B> where B: ToOwned {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Cow<'_, _>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Cow<'_, _>`
 
 error[E0119]: conflicting implementations of trait `IntoCow<'_, _>` for type `&_`
   --> $DIR/associated-types-coherence-failure.rs:28:1
    |
 LL | impl<'a, B: ?Sized> IntoCow<'a, B> for <B as ToOwned>::Owned where B: ToOwned {
-   | ------------------------------------------------------------ first implementation here
+   | ----------------------------------------------------------------------------- first implementation here
 ...
 LL | impl<'a, B: ?Sized> IntoCow<'a, B> for &'a B where B: ToOwned {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `&_`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `&_`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-types/hr-associated-type-bound-2.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-2.stderr
@@ -1,8 +1,10 @@
 error[E0275]: overflow evaluating the requirement `for<'b> u32: X<'b>`
   --> $DIR/hr-associated-type-bound-2.rs:11:1
    |
-LL | impl X<'_> for u32
-   | ^^^^^^^^^^^^^^^^^^
+LL | / impl X<'_> for u32
+LL | | where
+LL | |     for<'b> <Self as X<'b>>::U: Clone,
+   | |______________________________________^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`hr_associated_type_bound_2`)
 note: required for `u32` to implement `for<'b> X<'b>`

--- a/tests/ui/associated-types/impl-wf-cycle-1.stderr
+++ b/tests/ui/associated-types/impl-wf-cycle-1.stderr
@@ -1,8 +1,12 @@
 error[E0275]: overflow evaluating the requirement `<(T,) as Grault>::A == _`
   --> $DIR/impl-wf-cycle-1.rs:15:1
    |
-LL | impl<T: Grault> Grault for (T,)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / impl<T: Grault> Grault for (T,)
+LL | |
+LL | | where
+LL | |     Self::A: Baz,
+LL | |     Self::B: Fiz,
+   | |_________________^
    |
 note: required for `(T,)` to implement `Grault`
   --> $DIR/impl-wf-cycle-1.rs:15:17

--- a/tests/ui/associated-types/impl-wf-cycle-2.stderr
+++ b/tests/ui/associated-types/impl-wf-cycle-2.stderr
@@ -1,8 +1,11 @@
 error[E0275]: overflow evaluating the requirement `<(T,) as Grault>::A == _`
   --> $DIR/impl-wf-cycle-2.rs:7:1
    |
-LL | impl<T: Grault> Grault for (T,)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / impl<T: Grault> Grault for (T,)
+LL | |
+LL | | where
+LL | |     Self::A: Copy,
+   | |__________________^
    |
 note: required for `(T,)` to implement `Grault`
   --> $DIR/impl-wf-cycle-2.rs:7:17

--- a/tests/ui/coherence/coherence-overlap-downstream.next.stderr
+++ b/tests/ui/coherence/coherence-overlap-downstream.next.stderr
@@ -10,7 +10,7 @@ error[E0119]: conflicting implementations of trait `Foo<_>` for type `i32`
   --> $DIR/coherence-overlap-downstream.rs:17:1
    |
 LL | impl<X, T> Foo<X> for T where T: Bar<X> {}
-   | ----------------------- first implementation here
+   | --------------------------------------- first implementation here
 LL | impl<X> Foo<X> for i32 {}
    | ^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `i32`
    |

--- a/tests/ui/coherence/coherence-overlap-downstream.old.stderr
+++ b/tests/ui/coherence/coherence-overlap-downstream.old.stderr
@@ -10,7 +10,7 @@ error[E0119]: conflicting implementations of trait `Foo<_>` for type `i32`
   --> $DIR/coherence-overlap-downstream.rs:17:1
    |
 LL | impl<X, T> Foo<X> for T where T: Bar<X> {}
-   | ----------------------- first implementation here
+   | --------------------------------------- first implementation here
 LL | impl<X> Foo<X> for i32 {}
    | ^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `i32`
    |

--- a/tests/ui/coherence/coherence-overlap-upstream.stderr
+++ b/tests/ui/coherence/coherence-overlap-upstream.stderr
@@ -2,7 +2,7 @@ error[E0119]: conflicting implementations of trait `Foo` for type `i16`
   --> $DIR/coherence-overlap-upstream.rs:13:1
    |
 LL | impl<T> Foo for T where T: Remote {}
-   | ----------------- first implementation here
+   | --------------------------------- first implementation here
 LL | impl Foo for i16 {}
    | ^^^^^^^^^^^^^^^^ conflicting implementation for `i16`
    |

--- a/tests/ui/coherence/coherence-wasm-bindgen.stderr
+++ b/tests/ui/coherence/coherence-wasm-bindgen.stderr
@@ -1,11 +1,17 @@
 error: conflicting implementations of trait `IntoWasmAbi` for type `&dyn Fn(&_) -> _`
   --> $DIR/coherence-wasm-bindgen.rs:28:1
    |
-LL | impl<'a, 'b, A, R> IntoWasmAbi for &'a (dyn Fn(A) -> R + 'b)
-   | ------------------------------------------------------------ first implementation here
+LL | / impl<'a, 'b, A, R> IntoWasmAbi for &'a (dyn Fn(A) -> R + 'b)
+LL | | where
+LL | |     A: FromWasmAbi,
+LL | |     R: ReturnWasmAbi,
+   | |_____________________- first implementation here
 ...
-LL | impl<'a, 'b, A, R> IntoWasmAbi for &'a (dyn for<'x> Fn(&'x A) -> R + 'b)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `&dyn Fn(&_) -> _`
+LL | / impl<'a, 'b, A, R> IntoWasmAbi for &'a (dyn for<'x> Fn(&'x A) -> R + 'b)
+LL | | where
+LL | |     A: RefFromWasmAbi,
+LL | |     R: ReturnWasmAbi,
+   | |_____________________^ conflicting implementation for `&dyn Fn(&_) -> _`
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #56105 <https://github.com/rust-lang/rust/issues/56105>

--- a/tests/ui/coherence/inter-crate-ambiguity-causes-notes.next.stderr
+++ b/tests/ui/coherence/inter-crate-ambiguity-causes-notes.next.stderr
@@ -1,11 +1,14 @@
 error[E0119]: conflicting implementations of trait `From<()>` for type `S`
   --> $DIR/inter-crate-ambiguity-causes-notes.rs:12:1
    |
-LL | impl From<()> for S {
-   | ------------------- first implementation here
+LL |   impl From<()> for S {
+   |   ------------------- first implementation here
 ...
-LL | impl<I> From<I> for S
-   | ^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `S`
+LL | / impl<I> From<I> for S
+LL | |
+LL | | where
+LL | |     I: Iterator<Item = ()>,
+   | |___________________________^ conflicting implementation for `S`
    |
    = note: upstream crates may add a new impl of trait `std::iter::Iterator` for type `()` in future versions
 

--- a/tests/ui/coherence/inter-crate-ambiguity-causes-notes.old.stderr
+++ b/tests/ui/coherence/inter-crate-ambiguity-causes-notes.old.stderr
@@ -1,11 +1,14 @@
 error[E0119]: conflicting implementations of trait `From<()>` for type `S`
   --> $DIR/inter-crate-ambiguity-causes-notes.rs:12:1
    |
-LL | impl From<()> for S {
-   | ------------------- first implementation here
+LL |   impl From<()> for S {
+   |   ------------------- first implementation here
 ...
-LL | impl<I> From<I> for S
-   | ^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `S`
+LL | / impl<I> From<I> for S
+LL | |
+LL | | where
+LL | |     I: Iterator<Item = ()>,
+   | |___________________________^ conflicting implementation for `S`
    |
    = note: upstream crates may add a new impl of trait `std::iter::Iterator` for type `()` in future versions
 

--- a/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.stderr
+++ b/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.stderr
@@ -1,11 +1,16 @@
 error: implementations of `PartialEq<Interval<_>>` for `Interval<_>` will conflict in the future
   --> $DIR/warn-when-cycle-is-error-in-coherence.rs:13:1
    |
-LL | #[derive(PartialEq, Default)]
-   |          --------- the second impl is here
+LL |   #[derive(PartialEq, Default)]
+   |            --------- the second impl is here
 ...
-LL | impl<T, Q> PartialEq<Q> for Interval<T>
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the first impl is here
+LL | / impl<T, Q> PartialEq<Q> for Interval<T>
+LL | |
+LL | |
+LL | | where
+LL | |     T: Borrow<Q>,
+LL | |     Q: ?Sized + PartialOrd,
+   | |___________________________^ the first impl is here
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #114040 <https://github.com/rust-lang/rust/issues/114040>

--- a/tests/ui/const-generics/generic_const_exprs/issue-80742.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-80742.stderr
@@ -3,7 +3,7 @@ error: internal compiler error: compiler/rustc_const_eval/src/interpret/step.rs:
 
 Box<dyn Any>
 query stack during panic:
-#0 [eval_to_allocation_raw] const-evaluating + checking `<impl at $DIR/issue-80742.rs:25:1: 25:18>::{constant#0}`
+#0 [eval_to_allocation_raw] const-evaluating + checking `<impl at $DIR/issue-80742.rs:25:1: 27:32>::{constant#0}`
 #1 [eval_to_valtree] evaluating type-level constant
 end of query stack
 error: aborting due to previous error

--- a/tests/ui/error-codes/E0374.stderr
+++ b/tests/ui/error-codes/E0374.stderr
@@ -1,8 +1,9 @@
 error[E0374]: the trait `CoerceUnsized` may only be implemented for a coercion between structures
   --> $DIR/E0374.rs:8:1
    |
-LL | impl<T, U> CoerceUnsized<Foo<U>> for Foo<T>
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / impl<T, U> CoerceUnsized<Foo<U>> for Foo<T>
+LL | |     where T: CoerceUnsized<U> {}
+   | |_____________________________^
    |
    = note: expected a single field to be coerced, none found
 

--- a/tests/ui/error-codes/E0377.stderr
+++ b/tests/ui/error-codes/E0377.stderr
@@ -2,7 +2,7 @@ error[E0377]: the trait `CoerceUnsized` may only be implemented for a coercion b
   --> $DIR/E0377.rs:12:1
    |
 LL | impl<T, U> CoerceUnsized<Bar<U>> for Foo<T> where T: CoerceUnsized<U> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected coercion between the same definition; expected `Foo`, found `Bar`
 

--- a/tests/ui/error-codes/E0476.stderr
+++ b/tests/ui/error-codes/E0476.stderr
@@ -2,7 +2,7 @@ error[E0119]: conflicting implementations of trait `CoerceUnsized<&Wrapper<_>>` 
   --> $DIR/E0476.rs:9:1
    |
 LL | impl<'a, 'b, T, S> CoerceUnsized<&'a Wrapper<T>> for &'b Wrapper<S> where S: Unsize<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `core`:
            - impl<'a, 'b, T, U> CoerceUnsized<&'a U> for &'b T
@@ -12,7 +12,7 @@ error[E0476]: lifetime of the source pointer does not outlive lifetime bound of 
   --> $DIR/E0476.rs:9:1
    |
 LL | impl<'a, 'b, T, S> CoerceUnsized<&'a Wrapper<T>> for &'b Wrapper<S> where S: Unsize<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: object type is valid for the lifetime `'a` as defined here
   --> $DIR/E0476.rs:9:6

--- a/tests/ui/invalid_dispatch_from_dyn_impls.stderr
+++ b/tests/ui/invalid_dispatch_from_dyn_impls.stderr
@@ -1,16 +1,20 @@
 error[E0378]: the trait `DispatchFromDyn` may only be implemented for structs containing the field being coerced, ZST fields with 1 byte alignment, and nothing else
   --> $DIR/invalid_dispatch_from_dyn_impls.rs:10:1
    |
-LL | impl<T, U> DispatchFromDyn<WrapperWithExtraField<U>> for WrapperWithExtraField<T>
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / impl<T, U> DispatchFromDyn<WrapperWithExtraField<U>> for WrapperWithExtraField<T>
+LL | | where
+LL | |     T: DispatchFromDyn<U>,
+   | |__________________________^
    |
    = note: extra field `1` of type `i32` is not allowed
 
 error[E0378]: implementing the `DispatchFromDyn` trait requires multiple coercions
   --> $DIR/invalid_dispatch_from_dyn_impls.rs:21:1
    |
-LL | impl<T: ?Sized, U: ?Sized> DispatchFromDyn<MultiplePointers<U>> for MultiplePointers<T>
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / impl<T: ?Sized, U: ?Sized> DispatchFromDyn<MultiplePointers<U>> for MultiplePointers<T>
+LL | | where
+LL | |     T: Unsize<U>,
+   | |_________________^
    |
    = note: the trait `DispatchFromDyn` may only be implemented for a coercion between structures with a single field being coerced
    = note: currently, 2 fields need coercions: `ptr1` (`*const T` to `*const U`), `ptr2` (`*const T` to `*const U`)
@@ -26,14 +30,18 @@ LL | impl<T: ?Sized, U: ?Sized> DispatchFromDyn<NothingToCoerce<T>> for NothingT
 error[E0378]: structs implementing `DispatchFromDyn` may not have `#[repr(packed)]` or `#[repr(C)]`
   --> $DIR/invalid_dispatch_from_dyn_impls.rs:37:1
    |
-LL | impl<T: ?Sized, U: ?Sized> DispatchFromDyn<HasReprC<U>> for HasReprC<T>
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / impl<T: ?Sized, U: ?Sized> DispatchFromDyn<HasReprC<U>> for HasReprC<T>
+LL | | where
+LL | |     T: Unsize<U>,
+   | |_________________^
 
 error[E0378]: the trait `DispatchFromDyn` may only be implemented for structs containing the field being coerced, ZST fields with 1 byte alignment, and nothing else
   --> $DIR/invalid_dispatch_from_dyn_impls.rs:46:1
    |
-LL | impl<T: ?Sized, U: ?Sized> DispatchFromDyn<OverAligned<U>> for OverAligned<T>
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / impl<T: ?Sized, U: ?Sized> DispatchFromDyn<OverAligned<U>> for OverAligned<T>
+LL | |     where
+LL | |         T: Unsize<U>,
+   | |_____________________^
    |
    = note: extra field `1` of type `OverAlignedZst` is not allowed
 

--- a/tests/ui/issues/issue-43355.stderr
+++ b/tests/ui/issues/issue-43355.stderr
@@ -2,7 +2,7 @@ error[E0119]: conflicting implementations of trait `Trait1<Box<_>>` for type `A`
   --> $DIR/issue-43355.rs:13:1
    |
 LL | impl<X, T> Trait1<X> for T where T: Trait2<X> {
-   | -------------------------- first implementation here
+   | --------------------------------------------- first implementation here
 ...
 LL | impl<X> Trait1<Box<X>> for A {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `A`

--- a/tests/ui/issues/issue-77919.stderr
+++ b/tests/ui/issues/issue-77919.stderr
@@ -27,7 +27,7 @@ LL |     const VAL: T;
    |     ------------ `VAL` from trait
 ...
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/never_type/never-from-impl-is-reserved.stderr
+++ b/tests/ui/never_type/never-from-impl-is-reserved.stderr
@@ -5,7 +5,7 @@ LL | impl MyTrait for MyFoo {}
    | ---------------------- first implementation here
 LL | // This will conflict with the first impl if we impl `for<T> T: From<!>`.
 LL | impl<T> MyTrait for T where T: From<!> {}
-   | ^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyFoo`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyFoo`
    |
    = note: permitting this impl would forbid us from adding `impl<T> From<!> for T` later; see rust-lang/rust#64715 for details
 

--- a/tests/ui/privacy/private-in-public-warn.stderr
+++ b/tests/ui/privacy/private-in-public-warn.stderr
@@ -246,7 +246,7 @@ error: trait `traits_where::PrivTr` is more private than the item `traits_where:
   --> $DIR/private-in-public-warn.rs:68:5
    |
 LL |     impl<T> Pub<T> where T: PrivTr {}
-   |     ^^^^^^^^^^^^^^ implementation `traits_where::Pub<T>` is reachable at visibility `pub(crate)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation `traits_where::Pub<T>` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
   --> $DIR/private-in-public-warn.rs:55:5

--- a/tests/ui/privacy/private-in-public.stderr
+++ b/tests/ui/privacy/private-in-public.stderr
@@ -208,7 +208,7 @@ warning: trait `traits_where::PrivTr` is more private than the item `traits_wher
   --> $DIR/private-in-public.rs:52:5
    |
 LL |     impl<T> Pub<T> where T: PrivTr {
-   |     ^^^^^^^^^^^^^^ implementation `traits_where::Pub<T>` is reachable at visibility `pub(crate)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation `traits_where::Pub<T>` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
   --> $DIR/private-in-public.rs:42:5

--- a/tests/ui/privacy/where-priv-type.stderr
+++ b/tests/ui/privacy/where-priv-type.stderr
@@ -41,8 +41,11 @@ LL | struct PrivTy;
 warning: type `PrivTy` is more private than the item `S`
   --> $DIR/where-priv-type.rs:39:1
    |
-LL | impl S
-   | ^^^^^^ implementation `S` is reachable at visibility `pub`
+LL | / impl S
+LL | |
+LL | | where
+LL | |     PrivTy:
+   | |___________^ implementation `S` is reachable at visibility `pub`
    |
 note: but type `PrivTy` is only usable at visibility `pub(crate)`
   --> $DIR/where-priv-type.rs:8:1

--- a/tests/ui/privacy/where-pub-type-impls-priv-trait.stderr
+++ b/tests/ui/privacy/where-pub-type-impls-priv-trait.stderr
@@ -41,8 +41,11 @@ LL | trait PrivTr {}
 warning: trait `PrivTr` is more private than the item `S`
   --> $DIR/where-pub-type-impls-priv-trait.rs:41:1
    |
-LL | impl S
-   | ^^^^^^ implementation `S` is reachable at visibility `pub`
+LL | / impl S
+LL | |
+LL | | where
+LL | |     PubTy: PrivTr
+   | |_________________^ implementation `S` is reachable at visibility `pub`
    |
 note: but trait `PrivTr` is only usable at visibility `pub(crate)`
   --> $DIR/where-pub-type-impls-priv-trait.rs:10:1

--- a/tests/ui/specialization/issue-52050.stderr
+++ b/tests/ui/specialization/issue-52050.stderr
@@ -11,11 +11,13 @@ LL | #![feature(specialization)]
 error[E0119]: conflicting implementations of trait `IntoPyDictPointer` for type `()`
   --> $DIR/issue-52050.rs:28:1
    |
-LL | impl<I> IntoPyDictPointer for I
-   | ------------------------------- first implementation here
+LL | / impl<I> IntoPyDictPointer for I
+LL | | where
+LL | |     I: Iterator,
+   | |________________- first implementation here
 ...
-LL | impl IntoPyDictPointer for ()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
+LL |   impl IntoPyDictPointer for ()
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
    |
    = note: upstream crates may add a new impl of trait `std::iter::Iterator` for type `()` in future versions
 

--- a/tests/ui/trait-bounds/impl-bound-with-references-error.stderr
+++ b/tests/ui/trait-bounds/impl-bound-with-references-error.stderr
@@ -12,8 +12,11 @@ LL + use std::borrow::Cow;
 error[E0119]: conflicting implementations of trait `From<LabelText>` for type `LabelText`
   --> $DIR/impl-bound-with-references-error.rs:9:1
    |
-LL | impl<T> From<T> for LabelText
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / impl<T> From<T> for LabelText
+LL | |
+LL | | where
+LL | |     T: Into<Cow<'static, str>>,
+   | |_______________________________^
    |
    = note: conflicting implementation in crate `core`:
            - impl<T> From<T> for T;

--- a/tests/ui/traits/issue-33140-hack-boundaries.stderr
+++ b/tests/ui/traits/issue-33140-hack-boundaries.stderr
@@ -60,7 +60,7 @@ error[E0119]: conflicting implementations of trait `Trait5` for type `(dyn Send 
 LL | impl Trait5 for dyn Send {}
    | ------------------------ first implementation here
 LL | impl Trait5 for dyn Send where u32: Copy {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + 'static)`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/traits/new-solver/coherence/issue-102048.stderr
+++ b/tests/ui/traits/new-solver/coherence/issue-102048.stderr
@@ -1,11 +1,15 @@
 error[E0119]: conflicting implementations of trait `Trait<for<'a> fn(<_ as WithAssoc1<'a>>::Assoc, <_ as WithAssoc2<'a>>::Assoc)>` for type `(_, _)`
   --> $DIR/issue-102048.rs:39:1
    |
-LL | impl<T, U> Trait<for<'a> fn(<T as WithAssoc1<'a>>::Assoc, <U as WithAssoc2<'a>>::Assoc)> for (T, U)
-   | --------------------------------------------------------------------------------------------------- first implementation here
+LL | / impl<T, U> Trait<for<'a> fn(<T as WithAssoc1<'a>>::Assoc, <U as WithAssoc2<'a>>::Assoc)> for (T, U)
+LL | | where
+LL | |     T: for<'a> WithAssoc1<'a> + for<'a> WithAssoc2<'a, Assoc = i32>,
+LL | |     U: for<'a> WithAssoc2<'a>,
+   | |______________________________- first implementation here
 ...
-LL | impl<T, U> Trait<for<'a> fn(<U as WithAssoc1<'a>>::Assoc, u32)> for (T, U) where
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(_, _)`
+LL | / impl<T, U> Trait<for<'a> fn(<U as WithAssoc1<'a>>::Assoc, u32)> for (T, U) where
+LL | |     U: for<'a> WithAssoc1<'a>
+   | |_____________________________^ conflicting implementation for `(_, _)`
 
 error: aborting due to previous error
 

--- a/tests/ui/traits/new-solver/dont-ice-on-assoc-projection.stderr
+++ b/tests/ui/traits/new-solver/dont-ice-on-assoc-projection.stderr
@@ -13,7 +13,7 @@ error[E0119]: conflicting implementations of trait `Foo` for type `()`
 LL | impl Foo for () {}
    | --------------- first implementation here
 LL | impl<T> Foo for T where T: Bar<ASSOC = 0> {}
-   | ^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Typically, we highlight the def-span of an impl in a diagnostic due to either:
1. coherence error
2. trait evaluation cycle
3. invalid implementation of built-in trait

I find that an impl's where clauses are very often required to understanding why these errors come about, which is unfortunate since where clauses may be located on different lines and don't show up in the error. This PR expands the def-span of impls to include these where clauses.

r? cjgillot since you've touched this code a while back to make some spans shorter, but you can also reassign to wg-diagnostics or compiler if you're busy or have no strong opinions.