### PR TITLE
Remove unnecessary tmp variable in default_read_exact

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -513,8 +513,7 @@ pub(crate) fn default_read_exact<R: Read + ?Sized>(this: &mut R, mut buf: &mut [
         match this.read(buf) {
             Ok(0) => break,
             Ok(n) => {
-                let tmp = buf;
-                buf = &mut tmp[n..];
+                buf = &mut buf[n..];
             }
             Err(ref e) if e.is_interrupted() => {}
             Err(e) => return Err(e),


### PR DESCRIPTION
This `tmp` variable has existed since the original implementation (added in ff81920f03866674080ac63b565cc9d30f80c450), but it's not necessary (maybe non-lexical lifetimes helped?).

It's common to read std source code to understand how things actually work, and this tripped me up on my first read.