### PR TITLE
linker: Remove `-Zgcc-ld` option

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -168,8 +168,6 @@ codegen_ssa_multiple_main_functions = entry symbol `main` declared multiple time
 
 codegen_ssa_no_natvis_directory = error enumerating natvis directory: {$error}
 
-codegen_ssa_option_gcc_only = option `-Z gcc-ld` is used even though linker flavor is not gcc
-
 codegen_ssa_processing_dymutil_failed = processing debug info with `dsymutil` failed: {$status}
     .note = {$output}
 

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -490,10 +490,6 @@ pub struct RlibArchiveBuildFailure {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa_option_gcc_only)]
-pub struct OptionGccOnly;
-
-#[derive(Diagnostic)]
 pub enum ExtractBundledLibsError<'a> {
     #[diag(codegen_ssa_extract_bundled_libs_open_file)]
     OpenFile { rlib: &'a Path, error: Box<dyn std::error::Error> },

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -3167,9 +3167,9 @@ impl PpMode {
 pub(crate) mod dep_tracking {
     use super::{
         BranchProtection, CFGuard, CFProtection, CrateType, DebugInfo, DebugInfoCompression,
-        ErrorOutputType, InstrumentCoverage, InstrumentXRay, LdImpl, LinkerPluginLto,
-        LocationDetail, LtoCli, OomStrategy, OptLevel, OutFileName, OutputType, OutputTypes,
-        Passes, ResolveDocLinks, SourceFileHashAlgorithm, SplitDwarfKind, SwitchWithOptPath,
+        ErrorOutputType, InstrumentCoverage, InstrumentXRay, LinkerPluginLto, LocationDetail,
+        LtoCli, OomStrategy, OptLevel, OutFileName, OutputType, OutputTypes, Passes,
+        ResolveDocLinks, SourceFileHashAlgorithm, SplitDwarfKind, SwitchWithOptPath,
         SymbolManglingVersion, TraitSolver, TrimmedDefPaths,
     };
     use crate::lint;
@@ -3266,7 +3266,6 @@ pub(crate) mod dep_tracking {
         SymbolManglingVersion,
         SourceFileHashAlgorithm,
         TrimmedDefPaths,
-        Option<LdImpl>,
         OutFileName,
         OutputType,
         RealFileName,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -412,7 +412,6 @@ mod desc {
         "one of supported split-debuginfo modes (`off`, `packed`, or `unpacked`)";
     pub const parse_split_dwarf_kind: &str =
         "one of supported split dwarf modes (`split` or `single`)";
-    pub const parse_gcc_ld: &str = "one of: no value, `lld`";
     pub const parse_link_self_contained: &str = "one of: `y`, `yes`, `on`, `n`, `no`, `off`, or a list of enabled (`+` prefix) and disabled (`-` prefix) \
         components: `crto`, `libc`, `unwind`, `linker`, `sanitizers`, `mingw`";
     pub const parse_stack_protector: &str =
@@ -1202,15 +1201,6 @@ mod parse {
         true
     }
 
-    pub(crate) fn parse_gcc_ld(slot: &mut Option<LdImpl>, v: Option<&str>) -> bool {
-        match v {
-            None => *slot = None,
-            Some("lld") => *slot = Some(LdImpl::Lld),
-            _ => return false,
-        }
-        true
-    }
-
     pub(crate) fn parse_stack_protector(slot: &mut StackProtector, v: Option<&str>) -> bool {
         match v.and_then(|s| StackProtector::from_str(s).ok()) {
             Some(ssp) => *slot = ssp,
@@ -1521,7 +1511,6 @@ options! {
         "whether each function should go in its own section"),
     future_incompat_test: bool = (false, parse_bool, [UNTRACKED],
         "forces all lints to be future incompatible, used for internal testing (default: no)"),
-    gcc_ld: Option<LdImpl> = (None, parse_gcc_ld, [TRACKED], "implementation of ld used by cc"),
     graphviz_dark_mode: bool = (false, parse_bool, [UNTRACKED],
         "use dark-themed colors in graphviz output (default: no)"),
     graphviz_font: String = ("Courier, monospace".to_string(), parse_string, [UNTRACKED],
@@ -1905,9 +1894,4 @@ written to standard error output)"),
 pub enum WasiExecModel {
     Command,
     Reactor,
-}
-
-#[derive(Clone, Copy, Hash)]
-pub enum LdImpl {
-    Lld,
 }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1677,15 +1677,17 @@ impl Step for Assemble {
             let src_exe = exe("lld", target_compiler.host);
             let dst_exe = exe("rust-lld", target_compiler.host);
             builder.copy(&lld_install.join("bin").join(&src_exe), &libdir_bin.join(&dst_exe));
-            // for `-Z gcc-ld=lld`
-            let gcc_ld_dir = libdir_bin.join("gcc-ld");
-            t!(fs::create_dir(&gcc_ld_dir));
+            let self_contained_lld_dir = libdir_bin.join("gcc-ld");
+            t!(fs::create_dir(&self_contained_lld_dir));
             let lld_wrapper_exe = builder.ensure(crate::tool::LldWrapper {
                 compiler: build_compiler,
                 target: target_compiler.host,
             });
             for name in crate::LLD_FILE_NAMES {
-                builder.copy(&lld_wrapper_exe, &gcc_ld_dir.join(exe(name, target_compiler.host)));
+                builder.copy(
+                    &lld_wrapper_exe,
+                    &self_contained_lld_dir.join(exe(name, target_compiler.host)),
+                );
             }
         }
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -471,14 +471,15 @@ impl Step for Rustc {
                 let src_dir = builder.sysroot_libdir(compiler, host).parent().unwrap().join("bin");
                 let rust_lld = exe("rust-lld", compiler.host);
                 builder.copy(&src_dir.join(&rust_lld), &dst_dir.join(&rust_lld));
-                // for `-Z gcc-ld=lld`
-                let gcc_lld_src_dir = src_dir.join("gcc-ld");
-                let gcc_lld_dst_dir = dst_dir.join("gcc-ld");
-                t!(fs::create_dir(&gcc_lld_dst_dir));
+                let self_contained_lld_src_dir = src_dir.join("gcc-ld");
+                let self_contained_lld_dst_dir = dst_dir.join("gcc-ld");
+                t!(fs::create_dir(&self_contained_lld_dst_dir));
                 for name in crate::LLD_FILE_NAMES {
                     let exe_name = exe(name, compiler.host);
-                    builder
-                        .copy(&gcc_lld_src_dir.join(&exe_name), &gcc_lld_dst_dir.join(&exe_name));
+                    builder.copy(
+                        &self_contained_lld_src_dir.join(&exe_name),
+                        &self_contained_lld_dst_dir.join(&exe_name),
+                    );
                 }
             }
 

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -241,8 +241,8 @@ impl CachedNeedsConditions {
             profiler_support: std::env::var_os("RUSTC_PROFILER_SUPPORT").is_some(),
             xray: config.target_cfg().xray,
 
-            // For tests using the `needs-rust-lld` directive (e.g. for `-Zgcc-ld=lld`), we need to find
-            // whether `rust-lld` is present in the compiler under test.
+            // For tests using the `needs-rust-lld` directive (e.g. for `-Clink-self-contained=+linker`),
+            // we need to find whether `rust-lld` is present in the compiler under test.
             //
             // The --compile-lib-path is the path to host shared libraries, but depends on the OS. For
             // example:

--- a/src/tools/lld-wrapper/src/main.rs
+++ b/src/tools/lld-wrapper/src/main.rs
@@ -4,8 +4,8 @@
 //! two arguments the `<flavor>` command line interface is used to process the remaining arguments.
 //! If no `-flavor` argument is present the flavor is determined by the executable name.
 //!
-//! In Rust with `-Z gcc-ld=lld` we have gcc or clang invoke rust-lld. Since there is no way to
-//! make gcc/clang pass `-flavor <flavor>` as the first two arguments in the linker invocation
+//! With `-Clink-self-contained=+linker` we have gcc or clang invoke rust-lld. Since there is no way
+//! to make gcc/clang pass `-flavor <flavor>` as the first two arguments in the linker invocation
 //! and since Windows does not support symbolic links for files this wrapper is used in place of a
 //! symbolic link. It execs `../rust-lld -flavor <flavor>` by propagating the flavor argument
 //! obtained from the wrapper's name as the first two arguments.

--- a/tests/run-make/issue-71519/Makefile
+++ b/tests/run-make/issue-71519/Makefile
@@ -1,8 +1,0 @@
-include ../tools.mk
-
-# ignore-msvc
-# needs-rust-lld
-# ignore-s390x lld does not yet support s390x as target
-all:
-	RUSTC_LOG=rustc_codegen_ssa::back::link=info $(RUSTC) -Z gcc-ld=lld -C link-args=-Wl,-v main.rs 2> $(TMPDIR)/output.txt
-	$(CGREP) -e "^LLD [0-9]+\.[0-9]+\.[0-9]+" < $(TMPDIR)/output.txt

--- a/tests/run-make/issue-71519/main.rs
+++ b/tests/run-make/issue-71519/main.rs
@@ -1,4 +1,0 @@
-// test linking using cc with rust-lld injected into search path as ld
-// see rust-lang/rust#71519 for more info
-
-fn main() {}


### PR DESCRIPTION
It is subsumed by `-Clinker-flavor=*-lld-cc -Clink-self-contained=+linker` options now.

r? @lqd 