### PR TITLE
Stabilize `Ready::into_inner()`

### DIFF
--- a/library/core/src/future/ready.rs
+++ b/library/core/src/future/ready.rs
@@ -34,13 +34,12 @@ impl<T> Ready<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ready_into_inner)]
     /// use std::future;
     ///
     /// let a = future::ready(1);
     /// assert_eq!(a.into_inner(), 1);
     /// ```
-    #[unstable(feature = "ready_into_inner", issue = "101196")]
+    #[stable(feature = "ready_into_inner", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
     pub fn into_inner(self) -> T {


### PR DESCRIPTION
This PR stabilizes `Ready::into_inner()`.

Tracking issue: #101196.
Implementation PR: #101189.

Closes #101196.