### PR TITLE
delay a bug when encountering an ambiguity in MIR typeck

### DIFF
--- a/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.current.stderr
+++ b/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.current.stderr
@@ -1,0 +1,20 @@
+error: internal compiler error: no errors encountered even though `delay_span_bug` issued
+
+error: internal compiler error: ambiguity performing ParamEnvAnd { param_env: ParamEnv { caller_bounds: [], reveal: UserFacing }, value: ProvePredicate { predicate: Binder { value: ProjectionPredicate(AliasTy { args: [FnDef(DefId(get_rpit), []), ()], def_id: DefId(ops::function::FnOnce::Output) }, Term::Ty(Alias(Opaque, AliasTy { args: [], def_id: DefId(Opaque::{opaque#0}) }))), bound_vars: [] } } }
+  --> $DIR/rpit_tait_equality_in_canonical_query.rs:28:5
+   |
+LL |     query(get_rpit);
+   |     ^^^^^^^^^^^^^^^
+   |
+  --> $DIR/rpit_tait_equality_in_canonical_query.rs:28:5
+   |
+LL |     query(get_rpit);
+   |     ^^^^^^^^^^^^^^^
+
+
+
+
+query stack during panic:
+end of query stack
+error: aborting due to 2 previous errors
+

--- a/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.rs
+++ b/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.rs
@@ -7,7 +7,14 @@
 
 // revisions: current next
 //[next] compile-flags: -Ztrait-solver=next
-// check-pass
+//[next] check-pass
+
+//[current] known-bug: #108498
+//[current] failure-status: 101
+//[current] normalize-stderr-test: "DefId\(.*?\]::" -> "DefId("
+//[current] normalize-stderr-test: "(?m)^note: .*\n" -> ""
+//[current] normalize-stderr-test: "(?m)^ *\d+: .*\n" -> ""
+//[current] normalize-stderr-test: "(?m)^ *at .*\n" -> ""
 
 #![feature(type_alias_impl_trait)]
 


### PR DESCRIPTION
We shouldn't have any trait selection ambiguities in MIR typeck.

See https://github.com/rust-lang/rust/pull/114586#issuecomment-1751967321

r? @oli-obk @compiler-errors @lcnr