### PR TITLE
Do not run optimizations on trivial MIR.

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -613,6 +613,15 @@ fn inner_optimized_mir(tcx: TyCtxt<'_>, did: LocalDefId) -> Body<'_> {
         return body;
     }
 
+    // If `mir_drops_elaborated_and_const_checked` found that the current body has unsatisfiable
+    // predicates, it will shrink the MIR to a single `unreachable` terminator.
+    // More generally, if MIR is a lone `unreachable`, there is nothing to optimize.
+    if let TerminatorKind::Unreachable = body.basic_blocks[START_BLOCK].terminator().kind
+        && body.basic_blocks[START_BLOCK].statements.is_empty()
+    {
+        return body;
+    }
+
     run_optimization_passes(tcx, &mut body);
 
     body

--- a/tests/ui/consts/issue-67696-const-prop-ice.rs
+++ b/tests/ui/consts/issue-67696-const-prop-ice.rs
@@ -1,5 +1,5 @@
 // check-pass
-// compile-flags: --emit=mir,link
+// compile-flags: --emit=mir,link -Zmir-opt-level=4
 // Checks that we don't ICE due to attempting to run const prop
 // on a function with unsatisifable 'where' clauses
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/116513

The bug was introduced in https://github.com/rust-lang/rust/pull/110728, which put the check too early in the query chain.

cc @oli-obk @ouz-a 