### PR TITLE
Implement `OnceCell/Lock::try_insert()`

### DIFF
--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -128,8 +128,7 @@ impl<T> OnceCell<T> {
         // checked that slot is currently `None`, so this write
         // maintains the `inner`'s invariant.
         let slot = unsafe { &mut *self.inner.get() };
-        *slot = Some(value);
-        Ok(self.get().unwrap())
+        Ok(slot.insert(value))
     }
 
     /// Gets the contents of the cell, initializing it with `f`
@@ -213,10 +212,9 @@ impl<T> OnceCell<T> {
         let val = outlined_call(f)?;
         // Note that *some* forms of reentrant initialization might lead to
         // UB (see `reentrant_init` test). I believe that just removing this
-        // `assert`, while keeping `set/get` would be sound, but it seems
+        // `panic`, while keeping `try_insert` would be sound, but it seems
         // better to panic, rather than to silently use an old value.
-        assert!(self.set(val).is_ok(), "reentrant init");
-        Ok(self.get().unwrap())
+        if let Ok(val) = self.try_insert(val) { Ok(val) } else { panic!("reentrant init") }
     }
 
     /// Consumes the cell, returning the wrapped value.


### PR DESCRIPTION
I took inspiration from [`once_cell`](https://crates.io/crates/once_cell):
- [`once_cell::unsync::OnceCell::try_insert()`](https://github.com/matklad/once_cell/blob/874f9373abd7feaf923a3b3c34bfb3383529c671/src/lib.rs#L551-L563)
- [`once_cell::sync::OnceCell::try_insert()`](https://github.com/matklad/once_cell/blob/874f9373abd7feaf923a3b3c34bfb3383529c671/src/lib.rs#L1080-L1087)

I tried to change as little code as possible in the first commit and applied some obvious optimizations in the second one.

ACP: https://github.com/rust-lang/libs-team/issues/276
Tracking issue: #116693