### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,9 +2150,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2433,7 +2433,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             }
 
             err.multipart_suggestion_verbose(
-                format!("{msg}..."),
+                format!("{msg}"),
                 suggs,
                 Applicability::MaybeIncorrect, // Issue #41966
             );

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -66,13 +66,12 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::lang_items::LangItem;
-use rustc_hir::Node;
 use rustc_middle::dep_graph::DepContext;
 use rustc_middle::ty::print::with_forced_trimmed_paths;
 use rustc_middle::ty::relate::{self, RelateResult, TypeRelation};
 use rustc_middle::ty::{
-    self, error::TypeError, List, Region, Ty, TyCtxt, TypeFoldable, TypeSuperVisitable,
-    TypeVisitable, TypeVisitableExt,
+    self, error::TypeError, IsSuggestable, List, Region, Ty, TyCtxt, TypeFoldable,
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt,
 };
 use rustc_span::{sym, symbol::kw, BytePos, DesugaringKind, Pos, Span};
 use rustc_target::spec::abi;
@@ -2317,126 +2316,6 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         bound_kind: GenericKind<'tcx>,
         sub: Region<'tcx>,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        // Attempt to obtain the span of the parameter so we can
-        // suggest adding an explicit lifetime bound to it.
-        let generics = self.tcx.generics_of(generic_param_scope);
-        // type_param_span is (span, has_bounds)
-        let mut is_synthetic = false;
-        let mut ast_generics = None;
-        let type_param_span = match bound_kind {
-            GenericKind::Param(ref param) => {
-                // Account for the case where `param` corresponds to `Self`,
-                // which doesn't have the expected type argument.
-                if !(generics.has_self && param.index == 0) {
-                    let type_param = generics.type_param(param, self.tcx);
-                    is_synthetic = type_param.kind.is_synthetic();
-                    type_param.def_id.as_local().map(|def_id| {
-                        // Get the `hir::Param` to verify whether it already has any bounds.
-                        // We do this to avoid suggesting code that ends up as `T: 'a'b`,
-                        // instead we suggest `T: 'a + 'b` in that case.
-                        let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
-                        ast_generics = self.tcx.hir().get_generics(hir_id.owner.def_id);
-                        let bounds =
-                            ast_generics.and_then(|g| g.bounds_span_for_suggestions(def_id));
-                        // `sp` only covers `T`, change it so that it covers
-                        // `T:` when appropriate
-                        if let Some(span) = bounds {
-                            (span, true)
-                        } else {
-                            let sp = self.tcx.def_span(def_id);
-                            (sp.shrink_to_hi(), false)
-                        }
-                    })
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        };
-
-        let new_lt = {
-            let mut possible = (b'a'..=b'z').map(|c| format!("'{}", c as char));
-            let lts_names =
-                iter::successors(Some(generics), |g| g.parent.map(|p| self.tcx.generics_of(p)))
-                    .flat_map(|g| &g.params)
-                    .filter(|p| matches!(p.kind, ty::GenericParamDefKind::Lifetime))
-                    .map(|p| p.name.as_str())
-                    .collect::<Vec<_>>();
-            possible
-                .find(|candidate| !lts_names.contains(&&candidate[..]))
-                .unwrap_or("'lt".to_string())
-        };
-
-        let mut add_lt_suggs: Vec<Option<_>> = vec![];
-        if is_synthetic {
-            if let Some(ast_generics) = ast_generics {
-                let named_lifetime_param_exist = ast_generics.params.iter().any(|p| {
-                    matches!(
-                        p.kind,
-                        hir::GenericParamKind::Lifetime { kind: hir::LifetimeParamKind::Explicit }
-                    )
-                });
-                if named_lifetime_param_exist && let [param, ..] = ast_generics.params
-                {
-                    add_lt_suggs.push(Some((
-                        self.tcx.def_span(param.def_id).shrink_to_lo(),
-                        format!("{new_lt}, "),
-                    )));
-                } else {
-                    add_lt_suggs
-                        .push(Some((ast_generics.span.shrink_to_hi(), format!("<{new_lt}>"))));
-                }
-            }
-        } else {
-            if let [param, ..] = &generics.params[..] && let Some(def_id) = param.def_id.as_local()
-            {
-                add_lt_suggs
-                    .push(Some((self.tcx.def_span(def_id).shrink_to_lo(), format!("{new_lt}, "))));
-            }
-        }
-
-        if let Some(ast_generics) = ast_generics {
-            for p in ast_generics.params {
-                if p.is_elided_lifetime() {
-                    if self
-                        .tcx
-                        .sess
-                        .source_map()
-                        .span_to_prev_source(p.span.shrink_to_hi())
-                        .ok()
-                        .is_some_and(|s| *s.as_bytes().last().unwrap() == b'&')
-                    {
-                        add_lt_suggs
-                            .push(Some(
-                                (
-                                    p.span.shrink_to_hi(),
-                                    if let Ok(snip) = self.tcx.sess.source_map().span_to_next_source(p.span)
-                                        && snip.starts_with(' ')
-                                    {
-                                        new_lt.to_string()
-                                    } else {
-                                        format!("{new_lt} ")
-                                    }
-                                )
-                            ));
-                    } else {
-                        add_lt_suggs.push(Some((p.span.shrink_to_hi(), format!("<{new_lt}>"))));
-                    }
-                }
-            }
-        }
-
-        let labeled_user_string = match bound_kind {
-            GenericKind::Param(ref p) => format!("the parameter type `{p}`"),
-            GenericKind::Alias(ref p) => match p.kind(self.tcx) {
-                ty::AliasKind::Projection | ty::AliasKind::Inherent => {
-                    format!("the associated type `{p}`")
-                }
-                ty::AliasKind::Weak => format!("the type alias `{p}`"),
-                ty::AliasKind::Opaque => format!("the opaque type `{p}`"),
-            },
-        };
-
         if let Some(SubregionOrigin::CompareImplItemObligation {
             span,
             impl_item_def_id,
@@ -2451,165 +2330,33 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             );
         }
 
-        fn binding_suggestion<'tcx, S: fmt::Display>(
-            err: &mut Diagnostic,
-            type_param_span: Option<(Span, bool)>,
-            bound_kind: GenericKind<'tcx>,
-            sub: S,
-            add_lt_suggs: Vec<Option<(Span, String)>>,
-        ) {
-            let msg = "consider adding an explicit lifetime bound";
-            if let Some((sp, has_lifetimes)) = type_param_span {
-                let suggestion =
-                    if has_lifetimes { format!(" + {sub}") } else { format!(": {sub}") };
-                let mut suggestions = vec![(sp, suggestion)];
-                for add_lt_sugg in add_lt_suggs.into_iter().flatten() {
-                    suggestions.push(add_lt_sugg);
+        let labeled_user_string = match bound_kind {
+            GenericKind::Param(ref p) => format!("the parameter type `{p}`"),
+            GenericKind::Alias(ref p) => match p.kind(self.tcx) {
+                ty::AliasKind::Projection | ty::AliasKind::Inherent => {
+                    format!("the associated type `{p}`")
                 }
-                err.multipart_suggestion_verbose(
-                    format!("{msg}..."),
-                    suggestions,
-                    Applicability::MaybeIncorrect, // Issue #41966
-                );
-            } else {
-                let consider = format!("{msg} `{bound_kind}: {sub}`...");
-                err.help(consider);
-            }
-        }
-
-        let new_binding_suggestion =
-            |err: &mut Diagnostic, type_param_span: Option<(Span, bool)>| {
-                let msg = "consider introducing an explicit lifetime bound";
-                if let Some((sp, has_lifetimes)) = type_param_span {
-                    let suggestion =
-                        if has_lifetimes { format!(" + {new_lt}") } else { format!(": {new_lt}") };
-                    let mut sugg =
-                        vec![(sp, suggestion), (span.shrink_to_hi(), format!(" + {new_lt}"))];
-                    for lt in add_lt_suggs.clone().into_iter().flatten() {
-                        sugg.push(lt);
-                        sugg.rotate_right(1);
-                    }
-                    // `MaybeIncorrect` due to issue #41966.
-                    err.multipart_suggestion(msg, sugg, Applicability::MaybeIncorrect);
-                }
-            };
-
-        #[derive(Debug)]
-        enum SubOrigin<'hir> {
-            GAT(&'hir hir::Generics<'hir>),
-            Impl,
-            Trait,
-            Fn,
-            Unknown,
-        }
-        let sub_origin = 'origin: {
-            match *sub {
-                ty::ReEarlyBound(ty::EarlyBoundRegion { def_id, .. }) => {
-                    let node = self.tcx.hir().get_if_local(def_id).unwrap();
-                    match node {
-                        Node::GenericParam(param) => {
-                            for h in self.tcx.hir().parent_iter(param.hir_id) {
-                                break 'origin match h.1 {
-                                    Node::ImplItem(hir::ImplItem {
-                                        kind: hir::ImplItemKind::Type(..),
-                                        generics,
-                                        ..
-                                    })
-                                    | Node::TraitItem(hir::TraitItem {
-                                        kind: hir::TraitItemKind::Type(..),
-                                        generics,
-                                        ..
-                                    }) => SubOrigin::GAT(generics),
-                                    Node::ImplItem(hir::ImplItem {
-                                        kind: hir::ImplItemKind::Fn(..),
-                                        ..
-                                    })
-                                    | Node::TraitItem(hir::TraitItem {
-                                        kind: hir::TraitItemKind::Fn(..),
-                                        ..
-                                    })
-                                    | Node::Item(hir::Item {
-                                        kind: hir::ItemKind::Fn(..), ..
-                                    }) => SubOrigin::Fn,
-                                    Node::Item(hir::Item {
-                                        kind: hir::ItemKind::Trait(..),
-                                        ..
-                                    }) => SubOrigin::Trait,
-                                    Node::Item(hir::Item {
-                                        kind: hir::ItemKind::Impl(..), ..
-                                    }) => SubOrigin::Impl,
-                                    _ => continue,
-                                };
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                _ => {}
-            }
-            SubOrigin::Unknown
+                ty::AliasKind::Weak => format!("the type alias `{p}`"),
+                ty::AliasKind::Opaque => format!("the opaque type `{p}`"),
+            },
         };
-        debug!(?sub_origin);
 
-        let mut err = match (*sub, sub_origin) {
-            // In the case of GATs, we have to be careful. If we a type parameter `T` on an impl,
-            // but a lifetime `'a` on an associated type, then we might need to suggest adding
-            // `where T: 'a`. Importantly, this is on the GAT span, not on the `T` declaration.
-            (ty::ReEarlyBound(ty::EarlyBoundRegion { name: _, .. }), SubOrigin::GAT(generics)) => {
-                // Does the required lifetime have a nice name we can print?
-                let mut err = struct_span_err!(
-                    self.tcx.sess,
-                    span,
-                    E0309,
-                    "{} may not live long enough",
-                    labeled_user_string
-                );
-                let pred = format!("{bound_kind}: {sub}");
-                let suggestion = format!("{} {}", generics.add_where_or_trailing_comma(), pred,);
-                err.span_suggestion(
-                    generics.tail_span_for_predicate_suggestion(),
-                    "consider adding a where clause",
-                    suggestion,
-                    Applicability::MaybeIncorrect,
-                );
-                err
-            }
-            (
-                ty::ReEarlyBound(ty::EarlyBoundRegion { name, .. })
-                | ty::ReFree(ty::FreeRegion { bound_region: ty::BrNamed(_, name), .. }),
-                _,
-            ) if name != kw::UnderscoreLifetime => {
-                // Does the required lifetime have a nice name we can print?
-                let mut err = struct_span_err!(
-                    self.tcx.sess,
-                    span,
-                    E0309,
-                    "{} may not live long enough",
-                    labeled_user_string
-                );
-                // Explicitly use the name instead of `sub`'s `Display` impl. The `Display` impl
-                // for the bound is not suitable for suggestions when `-Zverbose` is set because it
-                // uses `Debug` output, so we handle it specially here so that suggestions are
-                // always correct.
-                binding_suggestion(&mut err, type_param_span, bound_kind, name, vec![]);
-                err
-            }
-
-            (ty::ReStatic, _) => {
-                // Does the required lifetime have a nice name we can print?
-                let mut err = struct_span_err!(
-                    self.tcx.sess,
-                    span,
-                    E0310,
-                    "{} may not live long enough",
-                    labeled_user_string
-                );
-                binding_suggestion(&mut err, type_param_span, bound_kind, "'static", vec![]);
-                err
-            }
-
+        let mut err = match sub.kind() {
+            ty::ReEarlyBound(_) | ty::ReFree(_) if sub.has_name() => struct_span_err!(
+                self.tcx.sess,
+                span,
+                E0309,
+                "{} may not live long enough",
+                labeled_user_string
+            ),
+            ty::ReStatic => struct_span_err!(
+                self.tcx.sess,
+                span,
+                E0310,
+                "{} may not live long enough",
+                labeled_user_string
+            ),
             _ => {
-                // If not, be less specific.
                 let mut err = struct_span_err!(
                     self.tcx.sess,
                     span,
@@ -2625,35 +2372,190 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     "...",
                     None,
                 );
-                if let Some(infer::RelateParamBound(_, t, _)) = origin {
-                    let t = self.resolve_vars_if_possible(t);
-                    match t.kind() {
-                        // We've got:
-                        // fn get_later<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
-                        // suggest:
-                        // fn get_later<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
-                        ty::Closure(..) | ty::Alias(ty::Opaque, ..) => {
-                            new_binding_suggestion(&mut err, type_param_span);
-                        }
-                        _ => {
-                            binding_suggestion(
-                                &mut err,
-                                type_param_span,
-                                bound_kind,
-                                new_lt,
-                                add_lt_suggs,
-                            );
-                        }
-                    }
-                }
                 err
             }
         };
+
+        'suggestion: {
+            let msg = "consider adding an explicit lifetime bound";
+
+            if (bound_kind, sub).has_infer_regions()
+                || (bound_kind, sub).has_placeholders()
+                || !bound_kind.is_suggestable(self.tcx, false)
+            {
+                let lt_name = sub.get_name_or_anon().to_string();
+                err.help(format!("{msg} `{bound_kind}: {lt_name}`..."));
+                break 'suggestion;
+            }
+
+            let mut generic_param_scope = generic_param_scope;
+            while self.tcx.def_kind(generic_param_scope) == DefKind::OpaqueTy {
+                generic_param_scope = self.tcx.local_parent(generic_param_scope);
+            }
+
+            // type_param_sugg_span is (span, has_bounds)
+            let (type_scope, type_param_sugg_span) = match bound_kind {
+                GenericKind::Param(ref param) => {
+                    let generics = self.tcx.generics_of(generic_param_scope);
+                    let def_id = generics.type_param(param, self.tcx).def_id.expect_local();
+                    let scope = self.tcx.local_def_id_to_hir_id(def_id).owner.def_id;
+                    // Get the `hir::Param` to verify whether it already has any bounds.
+                    // We do this to avoid suggesting code that ends up as `T: 'a'b`,
+                    // instead we suggest `T: 'a + 'b` in that case.
+                    let hir_generics = self.tcx.hir().get_generics(scope).unwrap();
+                    let sugg_span = match hir_generics.bounds_span_for_suggestions(def_id) {
+                        Some(span) => Some((span, true)),
+                        // If `param` corresponds to `Self`, no usable suggestion span.
+                        None if generics.has_self && param.index == 0 => None,
+                        None => Some((self.tcx.def_span(def_id).shrink_to_hi(), false)),
+                    };
+                    (scope, sugg_span)
+                }
+                _ => (generic_param_scope, None),
+            };
+            let suggestion_scope = {
+                let lifetime_scope = match sub.kind() {
+                    ty::ReStatic => hir::def_id::CRATE_DEF_ID,
+                    _ => match self.tcx.is_suitable_region(sub) {
+                        Some(info) => info.def_id,
+                        None => generic_param_scope,
+                    },
+                };
+                match self.tcx.is_descendant_of(type_scope.into(), lifetime_scope.into()) {
+                    true => type_scope,
+                    false => lifetime_scope,
+                }
+            };
+
+            let mut suggs = vec![];
+            let lt_name = self.suggest_name_region(sub, &mut suggs);
+
+            if let Some((sp, has_lifetimes)) = type_param_sugg_span
+                && suggestion_scope == type_scope
+            {
+                let suggestion =
+                    if has_lifetimes { format!(" + {lt_name}") } else { format!(": {lt_name}") };
+                suggs.push((sp, suggestion))
+            } else {
+                let generics = self.tcx.hir().get_generics(suggestion_scope).unwrap();
+                let pred = format!("{bound_kind}: {lt_name}");
+                let suggestion = format!("{} {}", generics.add_where_or_trailing_comma(), pred,);
+                suggs.push((generics.tail_span_for_predicate_suggestion(), suggestion))
+            }
+
+            err.multipart_suggestion_verbose(
+                format!("{msg}..."),
+                suggs,
+                Applicability::MaybeIncorrect, // Issue #41966
+            );
+        }
 
         if let Some(origin) = origin {
             self.note_region_origin(&mut err, &origin);
         }
         err
+    }
+
+    pub fn suggest_name_region(
+        &self,
+        lifetime: Region<'tcx>,
+        add_lt_suggs: &mut Vec<(Span, String)>,
+    ) -> String {
+        struct LifetimeReplaceVisitor<'tcx, 'a> {
+            tcx: TyCtxt<'tcx>,
+            needle: hir::LifetimeName,
+            new_lt: &'a str,
+            add_lt_suggs: &'a mut Vec<(Span, String)>,
+        }
+
+        impl<'hir, 'tcx> hir::intravisit::Visitor<'hir> for LifetimeReplaceVisitor<'tcx, '_> {
+            fn visit_lifetime(&mut self, lt: &'hir hir::Lifetime) {
+                if lt.res == self.needle {
+                    let (pos, span) = lt.suggestion_position();
+                    let new_lt = &self.new_lt;
+                    let sugg = match pos {
+                        hir::LifetimeSuggestionPosition::Normal => format!("{new_lt}"),
+                        hir::LifetimeSuggestionPosition::Ampersand => format!("{new_lt} "),
+                        hir::LifetimeSuggestionPosition::ElidedPath => format!("<{new_lt}>"),
+                        hir::LifetimeSuggestionPosition::ElidedPathArgument => {
+                            format!("{new_lt}, ")
+                        }
+                        hir::LifetimeSuggestionPosition::ObjectDefault => format!("+ {new_lt}"),
+                    };
+                    self.add_lt_suggs.push((span, sugg));
+                }
+            }
+
+            fn visit_ty(&mut self, ty: &'hir hir::Ty<'hir>) {
+                let hir::TyKind::OpaqueDef(item_id, _, _) = ty.kind else {
+                    return hir::intravisit::walk_ty(self, ty);
+                };
+                let opaque_ty = self.tcx.hir().item(item_id).expect_opaque_ty();
+                if let Some(&(_, b)) =
+                    opaque_ty.lifetime_mapping.iter().find(|&(a, _)| a.res == self.needle)
+                {
+                    let prev_needle =
+                        std::mem::replace(&mut self.needle, hir::LifetimeName::Param(b));
+                    for bound in opaque_ty.bounds {
+                        self.visit_param_bound(bound);
+                    }
+                    self.needle = prev_needle;
+                }
+            }
+        }
+
+        let (lifetime_def_id, lifetime_scope) = match self.tcx.is_suitable_region(lifetime) {
+            Some(info) if !lifetime.has_name() => {
+                (info.boundregion.get_id().unwrap().expect_local(), info.def_id)
+            }
+            _ => return lifetime.get_name_or_anon().to_string(),
+        };
+
+        let new_lt = {
+            let generics = self.tcx.generics_of(lifetime_scope);
+            let mut used_names =
+                iter::successors(Some(generics), |g| g.parent.map(|p| self.tcx.generics_of(p)))
+                    .flat_map(|g| &g.params)
+                    .filter(|p| matches!(p.kind, ty::GenericParamDefKind::Lifetime))
+                    .map(|p| p.name)
+                    .collect::<Vec<_>>();
+            if let Some(hir_id) = self.tcx.opt_local_def_id_to_hir_id(lifetime_scope) {
+                // consider late-bound lifetimes ...
+                used_names.extend(self.tcx.late_bound_vars(hir_id).into_iter().filter_map(|p| {
+                    match p {
+                        ty::BoundVariableKind::Region(lt) => lt.get_name(),
+                        _ => None,
+                    }
+                }))
+            }
+            (b'a'..=b'z')
+                .map(|c| format!("'{}", c as char))
+                .find(|candidate| !used_names.iter().any(|e| e.as_str() == candidate))
+                .unwrap_or("'lt".to_string())
+        };
+
+        let mut visitor = LifetimeReplaceVisitor {
+            tcx: self.tcx,
+            needle: hir::LifetimeName::Param(lifetime_def_id),
+            add_lt_suggs,
+            new_lt: &new_lt,
+        };
+        match self.tcx.hir().expect_owner(lifetime_scope) {
+            hir::OwnerNode::Item(i) => visitor.visit_item(i),
+            hir::OwnerNode::ForeignItem(i) => visitor.visit_foreign_item(i),
+            hir::OwnerNode::ImplItem(i) => visitor.visit_impl_item(i),
+            hir::OwnerNode::TraitItem(i) => visitor.visit_trait_item(i),
+            hir::OwnerNode::Crate(_) => bug!("OwnerNode::Crate doesn't not have generics"),
+        }
+
+        let ast_generics = self.tcx.hir().get_generics(lifetime_scope).unwrap();
+        let sugg = ast_generics
+            .span_for_lifetime_suggestion()
+            .map(|span| (span, format!("{new_lt}, ")))
+            .unwrap_or_else(|| (ast_generics.span, format!("<{new_lt}>")));
+        add_lt_suggs.push(sugg);
+
+        new_lt
     }
 
     fn report_sub_sup_conflict(

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-libc = { version = "0.2.148", default-features = false, features = ['rustc-dep-of-std'], public = true }
+libc = { version = "0.2.149", default-features = false, features = ['rustc-dep-of-std'], public = true }
 compiler_builtins = { version = "0.1.100" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -954,6 +954,13 @@ class RustBuild(object):
         if deny_warnings:
             env["RUSTFLAGS"] += " -Dwarnings"
 
+        # Add RUSTFLAGS_BOOTSTRAP to RUSTFLAGS for bootstrap compilation.
+        # Note that RUSTFLAGS_BOOTSTRAP should always be added to the end of
+        # RUSTFLAGS to be actually effective (e.g., if we have `-Dwarnings` in
+        # RUSTFLAGS, passing `-Awarnings` from RUSTFLAGS_BOOTSTRAP should override it).
+        if "RUSTFLAGS_BOOTSTRAP" in env:
+            env["RUSTFLAGS"] += " " + env["RUSTFLAGS_BOOTSTRAP"]
+
         env["PATH"] = os.path.join(self.bin_root(), "bin") + \
             os.pathsep + env["PATH"]
         if not os.path.isfile(self.cargo()):

--- a/tests/run-make/wasm-override-linker/Makefile
+++ b/tests/run-make/wasm-override-linker/Makefile
@@ -1,0 +1,11 @@
+include ../tools.mk
+
+ifeq ($(TARGET),wasm32-unknown-unknown)
+all:
+	$(RUSTC) foo.rs --crate-type cdylib --target $(TARGET) -C linker=$(CLANG)
+else ifeq ($(TARGET),wasm64-unknown-unknown)
+all:
+	$(RUSTC) foo.rs --crate-type cdylib --target $(TARGET) -C linker=$(CLANG)
+else
+all:
+endif

--- a/tests/run-make/wasm-override-linker/foo.rs
+++ b/tests/run-make/wasm-override-linker/foo.rs
@@ -1,0 +1,6 @@
+#![crate_type = "cdylib"]
+
+#[no_mangle]
+pub extern "C" fn add(a: i32, b: i32) -> i32 {
+    a + b
+}

--- a/tests/ui/associated-inherent-types/regionck-1.stderr
+++ b/tests/ui/associated-inherent-types/regionck-1.stderr
@@ -2,7 +2,9 @@ error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regionck-1.rs:9:30
    |
 LL |     type NoTyOutliv<'a, T> = &'a T;
-   |                              ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
+   |                     --       ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
+   |                     |
+   |                     the parameter type `T` must be valid for the lifetime `'a` as defined here...
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/associated-inherent-types/regionck-1.stderr
+++ b/tests/ui/associated-inherent-types/regionck-1.stderr
@@ -6,7 +6,7 @@ LL |     type NoTyOutliv<'a, T> = &'a T;
    |                     |
    |                     the parameter type `T` must be valid for the lifetime `'a` as defined here...
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     type NoTyOutliv<'a, T: 'a> = &'a T;
    |                          ++++

--- a/tests/ui/associated-inherent-types/regionck-1.stderr
+++ b/tests/ui/associated-inherent-types/regionck-1.stderr
@@ -2,9 +2,12 @@ error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regionck-1.rs:9:30
    |
 LL |     type NoTyOutliv<'a, T> = &'a T;
-   |                              ^^^^^- help: consider adding a where clause: `where T: 'a`
-   |                              |
-   |                              ...so that the reference type `&'a T` does not outlive the data it points at
+   |                              ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL |     type NoTyOutliv<'a, T: 'a> = &'a T;
+   |                          ++++
 
 error[E0491]: in type `&'a &'b ()`, reference has a longer lifetime than the data it references
   --> $DIR/regionck-1.rs:10:31

--- a/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
+++ b/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
@@ -14,6 +14,10 @@ note: ...so that the reference type `&(T, U)` does not outlive the data it point
    |
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound...
+   |
+LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: Debug + Sized, U: Hash, U: 'a;
+   |                 ++++  ++           ++                                       +++++++
 
 error[E0311]: the parameter type `T` may not live long enough
   --> $DIR/async-generics-and-bounds.rs:12:5
@@ -31,6 +35,10 @@ note: ...so that the reference type `&(T, U)` does not outlive the data it point
    |
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound...
+   |
+LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: Debug + Sized, U: Hash, T: 'a;
+   |                 ++++  ++           ++                                       +++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
+++ b/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
@@ -2,18 +2,11 @@ error[E0311]: the parameter type `U` may not live long enough
   --> $DIR/async-generics-and-bounds.rs:12:5
    |
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |            |
+   |     |            the parameter type `U` must be valid for the anonymous lifetime as defined here...
+   |     ...so that the reference type `&(T, U)` does not outlive the data it points at
    |
-note: the parameter type `U` must be valid for the anonymous lifetime as defined here...
-  --> $DIR/async-generics-and-bounds.rs:12:18
-   |
-LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
-   |                  ^
-note: ...so that the reference type `&(T, U)` does not outlive the data it points at
-  --> $DIR/async-generics-and-bounds.rs:12:5
-   |
-LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider adding an explicit lifetime bound...
    |
 LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: Debug + Sized, U: Hash, U: 'a;
@@ -23,18 +16,11 @@ error[E0311]: the parameter type `T` may not live long enough
   --> $DIR/async-generics-and-bounds.rs:12:5
    |
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |            |
+   |     |            the parameter type `T` must be valid for the anonymous lifetime as defined here...
+   |     ...so that the reference type `&(T, U)` does not outlive the data it points at
    |
-note: the parameter type `T` must be valid for the anonymous lifetime as defined here...
-  --> $DIR/async-generics-and-bounds.rs:12:18
-   |
-LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
-   |                  ^
-note: ...so that the reference type `&(T, U)` does not outlive the data it points at
-  --> $DIR/async-generics-and-bounds.rs:12:5
-   |
-LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider adding an explicit lifetime bound...
    |
 LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: Debug + Sized, U: Hash, T: 'a;

--- a/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
+++ b/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
@@ -7,7 +7,7 @@ LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
    |     |            the parameter type `U` must be valid for the anonymous lifetime as defined here...
    |     ...so that the reference type `&(T, U)` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: Debug + Sized, U: Hash, U: 'a;
    |                 ++++  ++           ++                                       +++++++
@@ -21,7 +21,7 @@ LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
    |     |            the parameter type `T` must be valid for the anonymous lifetime as defined here...
    |     ...so that the reference type `&(T, U)` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: Debug + Sized, U: Hash, T: 'a;
    |                 ++++  ++           ++                                       +++++++

--- a/tests/ui/async-await/in-trait/async-generics.stderr
+++ b/tests/ui/async-await/in-trait/async-generics.stderr
@@ -7,7 +7,7 @@ LL |     async fn foo(&self) -> &(T, U);
    |     |            the parameter type `U` must be valid for the anonymous lifetime as defined here...
    |     ...so that the reference type `&(T, U)` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where U: 'a;
    |                 ++++  ++           ++        +++++++++++
@@ -21,7 +21,7 @@ LL |     async fn foo(&self) -> &(T, U);
    |     |            the parameter type `T` must be valid for the anonymous lifetime as defined here...
    |     ...so that the reference type `&(T, U)` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: 'a;
    |                 ++++  ++           ++        +++++++++++

--- a/tests/ui/async-await/in-trait/async-generics.stderr
+++ b/tests/ui/async-await/in-trait/async-generics.stderr
@@ -2,18 +2,11 @@ error[E0311]: the parameter type `U` may not live long enough
   --> $DIR/async-generics.rs:9:5
    |
 LL |     async fn foo(&self) -> &(T, U);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^
+   |     |            |
+   |     |            the parameter type `U` must be valid for the anonymous lifetime as defined here...
+   |     ...so that the reference type `&(T, U)` does not outlive the data it points at
    |
-note: the parameter type `U` must be valid for the anonymous lifetime as defined here...
-  --> $DIR/async-generics.rs:9:18
-   |
-LL |     async fn foo(&self) -> &(T, U);
-   |                  ^
-note: ...so that the reference type `&(T, U)` does not outlive the data it points at
-  --> $DIR/async-generics.rs:9:5
-   |
-LL |     async fn foo(&self) -> &(T, U);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider adding an explicit lifetime bound...
    |
 LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where U: 'a;
@@ -23,18 +16,11 @@ error[E0311]: the parameter type `T` may not live long enough
   --> $DIR/async-generics.rs:9:5
    |
 LL |     async fn foo(&self) -> &(T, U);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^
+   |     |            |
+   |     |            the parameter type `T` must be valid for the anonymous lifetime as defined here...
+   |     ...so that the reference type `&(T, U)` does not outlive the data it points at
    |
-note: the parameter type `T` must be valid for the anonymous lifetime as defined here...
-  --> $DIR/async-generics.rs:9:18
-   |
-LL |     async fn foo(&self) -> &(T, U);
-   |                  ^
-note: ...so that the reference type `&(T, U)` does not outlive the data it points at
-  --> $DIR/async-generics.rs:9:5
-   |
-LL |     async fn foo(&self) -> &(T, U);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider adding an explicit lifetime bound...
    |
 LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: 'a;

--- a/tests/ui/async-await/in-trait/async-generics.stderr
+++ b/tests/ui/async-await/in-trait/async-generics.stderr
@@ -14,6 +14,10 @@ note: ...so that the reference type `&(T, U)` does not outlive the data it point
    |
 LL |     async fn foo(&self) -> &(T, U);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound...
+   |
+LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where U: 'a;
+   |                 ++++  ++           ++        +++++++++++
 
 error[E0311]: the parameter type `T` may not live long enough
   --> $DIR/async-generics.rs:9:5
@@ -31,6 +35,10 @@ note: ...so that the reference type `&(T, U)` does not outlive the data it point
    |
 LL |     async fn foo(&self) -> &(T, U);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound...
+   |
+LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: 'a;
+   |                 ++++  ++           ++        +++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/builtin-superkinds/builtin-superkinds-self-type.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-self-type.stderr
@@ -12,7 +12,7 @@ note: ...that is required by this bound
    |
 LL | trait Foo : Sized+Sync+'static {
    |                        ^^^^^^^
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl <T: Sync + 'static> Foo for T { }
    |               +++++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-self-type.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-self-type.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/builtin-superkinds-self-type.rs:10:16
    |
 LL | impl <T: Sync> Foo for T { }
-   |                ^^^ ...so that the type `T` will meet its required lifetime bounds...
+   |                ^^^
+   |                |
+   |                the parameter type `T` must be valid for the static lifetime...
+   |                ...so that the type `T` will meet its required lifetime bounds...
    |
 note: ...that is required by this bound
   --> $DIR/builtin-superkinds-self-type.rs:6:24

--- a/tests/ui/coercion/issue-53475.stderr
+++ b/tests/ui/coercion/issue-53475.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/issue-53475.rs:10:1
    |
 LL | impl<T> CoerceUnsized<Foo<dyn Any>> for Foo<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | the parameter type `T` must be valid for the static lifetime...
+   | ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/coercion/issue-53475.stderr
+++ b/tests/ui/coercion/issue-53475.stderr
@@ -7,7 +7,7 @@ LL | impl<T> CoerceUnsized<Foo<dyn Any>> for Foo<T> {}
    | the parameter type `T` must be valid for the static lifetime...
    | ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<T: 'static> CoerceUnsized<Foo<dyn Any>> for Foo<T> {}
    |       +++++++++

--- a/tests/ui/consts/issue-102117.stderr
+++ b/tests/ui/consts/issue-102117.stderr
@@ -7,7 +7,7 @@ LL |                 type_id: TypeId::of::<T>(),
    |                          the parameter type `T` must be valid for the static lifetime...
    |                          ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     pub fn new<T: 'static>() -> &'static Self {
    |                 +++++++++
@@ -22,7 +22,7 @@ LL |                 type_id: TypeId::of::<T>(),
    |                          ...so that the type `T` will meet its required lifetime bounds
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     pub fn new<T: 'static>() -> &'static Self {
    |                 +++++++++

--- a/tests/ui/consts/issue-102117.stderr
+++ b/tests/ui/consts/issue-102117.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/issue-102117.rs:19:26
    |
 LL |                 type_id: TypeId::of::<T>(),
-   |                          ^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |                          ^^^^^^^^^^^^^^^^^
+   |                          |
+   |                          the parameter type `T` must be valid for the static lifetime...
+   |                          ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -13,7 +16,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/issue-102117.rs:19:26
    |
 LL |                 type_id: TypeId::of::<T>(),
-   |                          ^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |                          ^^^^^^^^^^^^^^^^^
+   |                          |
+   |                          the parameter type `T` must be valid for the static lifetime...
+   |                          ...so that the type `T` will meet its required lifetime bounds
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider adding an explicit lifetime bound...

--- a/tests/ui/error-codes/E0311.fixed
+++ b/tests/ui/error-codes/E0311.fixed
@@ -2,7 +2,7 @@
 
 #![allow(warnings)]
 
-fn no_restriction<'a, T: 'a>(x: &'a ()) -> &() {
+fn no_restriction<'a, T: 'a>(x: &'a ()) -> &'a () {
     with_restriction::<T>(x) //~ ERROR E0311
 }
 

--- a/tests/ui/error-codes/E0311.stderr
+++ b/tests/ui/error-codes/E0311.stderr
@@ -6,7 +6,7 @@ LL | fn no_restriction<T>(x: &()) -> &() {
 LL |     with_restriction::<T>(x)
    |     ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn no_restriction<'a, T: 'a>(x: &'a ()) -> &'a () {
    |                   +++  ++++      ++         ++

--- a/tests/ui/error-codes/E0311.stderr
+++ b/tests/ui/error-codes/E0311.stderr
@@ -1,19 +1,11 @@
 error[E0311]: the parameter type `T` may not live long enough
   --> $DIR/E0311.rs:6:5
    |
-LL |     with_restriction::<T>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the parameter type `T` must be valid for the anonymous lifetime defined here...
-  --> $DIR/E0311.rs:5:25
-   |
 LL | fn no_restriction<T>(x: &()) -> &() {
-   |                         ^^^
-note: ...so that the type `T` will meet its required lifetime bounds
-  --> $DIR/E0311.rs:6:5
-   |
+   |                         --- the parameter type `T` must be valid for the anonymous lifetime defined here...
 LL |     with_restriction::<T>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL | fn no_restriction<'a, T: 'a>(x: &'a ()) -> &'a () {

--- a/tests/ui/error-codes/E0311.stderr
+++ b/tests/ui/error-codes/E0311.stderr
@@ -16,8 +16,8 @@ LL |     with_restriction::<T>(x)
    |     ^^^^^^^^^^^^^^^^^^^^^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn no_restriction<'a, T: 'a>(x: &'a ()) -> &() {
-   |                   +++  ++++      ++
+LL | fn no_restriction<'a, T: 'a>(x: &'a ()) -> &'a () {
+   |                   +++  ++++      ++         ++
 
 error: aborting due to previous error
 

--- a/tests/ui/fn/implied-bounds-unnorm-associated-type-5.stderr
+++ b/tests/ui/fn/implied-bounds-unnorm-associated-type-5.stderr
@@ -2,7 +2,9 @@ error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/implied-bounds-unnorm-associated-type-5.rs:6:13
    |
 LL | impl<'a, T> Trait<'a> for T {
-   |             ^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
+   |      --     ^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
+   |      |
+   |      the parameter type `T` must be valid for the lifetime `'a` as defined here...
    |
 note: ...that is required by this bound
   --> $DIR/implied-bounds-unnorm-associated-type-5.rs:1:18

--- a/tests/ui/fn/implied-bounds-unnorm-associated-type-5.stderr
+++ b/tests/ui/fn/implied-bounds-unnorm-associated-type-5.stderr
@@ -11,7 +11,7 @@ note: ...that is required by this bound
    |
 LL | trait Trait<'a>: 'a {
    |                  ^^
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<'a, T: 'a> Trait<'a> for T {
    |           ++++

--- a/tests/ui/generic-associated-types/issue-84931.stderr
+++ b/tests/ui/generic-associated-types/issue-84931.stderr
@@ -6,7 +6,7 @@ LL |     type Item<'a> = &'a mut T;
    |               |
    |               the parameter type `T` must be valid for the lifetime `'a` as defined here...
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     type Item<'a> = &'a mut T where T: 'a;
    |                               +++++++++++

--- a/tests/ui/generic-associated-types/issue-84931.stderr
+++ b/tests/ui/generic-associated-types/issue-84931.stderr
@@ -2,7 +2,9 @@ error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/issue-84931.rs:14:21
    |
 LL |     type Item<'a> = &'a mut T;
-   |                     ^^^^^^^^^ ...so that the reference type `&'a mut T` does not outlive the data it points at
+   |               --    ^^^^^^^^^ ...so that the reference type `&'a mut T` does not outlive the data it points at
+   |               |
+   |               the parameter type `T` must be valid for the lifetime `'a` as defined here...
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/generic-associated-types/issue-84931.stderr
+++ b/tests/ui/generic-associated-types/issue-84931.stderr
@@ -2,9 +2,12 @@ error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/issue-84931.rs:14:21
    |
 LL |     type Item<'a> = &'a mut T;
-   |                     ^^^^^^^^^- help: consider adding a where clause: `where T: 'a`
-   |                     |
-   |                     ...so that the reference type `&'a mut T` does not outlive the data it points at
+   |                     ^^^^^^^^^ ...so that the reference type `&'a mut T` does not outlive the data it points at
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL |     type Item<'a> = &'a mut T where T: 'a;
+   |                               +++++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -122,7 +122,7 @@ LL |     x
    |     the parameter type `T` must be valid for the static lifetime...
    |     ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn ty_param_wont_outlive_static<T:Debug + 'static>(x: T) -> impl Debug + 'static {
    |                                         +++++++++

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -117,7 +117,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:43:5
    |
 LL |     x
-   |     ^ ...so that the type `T` will meet its required lifetime bounds
+   |     ^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/impl-trait/type_parameters_captured.stderr
+++ b/tests/ui/impl-trait/type_parameters_captured.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/type_parameters_captured.rs:8:5
    |
 LL |     x
-   |     ^ ...so that the type `T` will meet its required lifetime bounds
+   |     ^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/impl-trait/type_parameters_captured.stderr
+++ b/tests/ui/impl-trait/type_parameters_captured.stderr
@@ -7,7 +7,7 @@ LL |     x
    |     the parameter type `T` must be valid for the static lifetime...
    |     ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn foo<T: 'static>(x: T) -> impl Any + 'static {
    |         +++++++++

--- a/tests/ui/impl-trait/unactionable_diagnostic.fixed
+++ b/tests/ui/impl-trait/unactionable_diagnostic.fixed
@@ -14,7 +14,7 @@ fn foo<'x, P>(
 }
 
 pub fn bar<'t, T: 't>(
-    //~^ HELP: consider adding an explicit lifetime bound...
+    //~^ HELP: consider adding an explicit lifetime bound
     post: T,
     x: &'t Foo,
 ) -> &'t impl Trait {

--- a/tests/ui/impl-trait/unactionable_diagnostic.rs
+++ b/tests/ui/impl-trait/unactionable_diagnostic.rs
@@ -14,7 +14,7 @@ fn foo<'x, P>(
 }
 
 pub fn bar<'t, T>(
-    //~^ HELP: consider adding an explicit lifetime bound...
+    //~^ HELP: consider adding an explicit lifetime bound
     post: T,
     x: &'t Foo,
 ) -> &'t impl Trait {

--- a/tests/ui/impl-trait/unactionable_diagnostic.stderr
+++ b/tests/ui/impl-trait/unactionable_diagnostic.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/unactionable_diagnostic.rs:21:5
    |
+LL | pub fn bar<'t, T>(
+   |            -- the parameter type `T` must be valid for the lifetime `'t` as defined here...
+...
 LL |     foo(post, x)
    |     ^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/impl-trait/unactionable_diagnostic.stderr
+++ b/tests/ui/impl-trait/unactionable_diagnostic.stderr
@@ -7,7 +7,7 @@ LL | pub fn bar<'t, T>(
 LL |     foo(post, x)
    |     ^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | pub fn bar<'t, T: 't>(
    |                 ++++

--- a/tests/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
+++ b/tests/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
@@ -17,8 +17,8 @@ LL |     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() {
    |
 help: consider adding an explicit lifetime bound...
    |
-LL | impl<K: 'a> Nested<K> {
-   |       ++++
+LL |     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() where K: 'a {
+   |                                                     +++++++++++
 
 error[E0309]: the parameter type `M` may not live long enough
   --> $DIR/lifetime-doesnt-live-long-enough.rs:44:36
@@ -39,17 +39,19 @@ LL |     fn foo<'a, L: X<&'a Nested<K>>>();
    |
 help: consider adding an explicit lifetime bound...
    |
-LL | trait X<K: 'a>: Sized {
-   |          ++++
+LL |     fn foo<'a, L: X<&'a Nested<K>>>() where K: 'a;
+   |                                       +++++++++++
 
 error[E0309]: the parameter type `Self` may not live long enough
   --> $DIR/lifetime-doesnt-live-long-enough.rs:28:19
    |
 LL |     fn bar<'a, L: X<&'a Nested<Self>>>();
-   |                   ^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<Self>` does not outlive the data it points at
    |
-   = help: consider adding an explicit lifetime bound `Self: 'a`...
-   = note: ...so that the reference type `&'a Nested<Self>` does not outlive the data it points at
+help: consider adding an explicit lifetime bound...
+   |
+LL |     fn bar<'a, L: X<&'a Nested<Self>>>() where Self: 'a;
+   |                                          ++++++++++++++
 
 error[E0309]: the parameter type `L` may not live long enough
   --> $DIR/lifetime-doesnt-live-long-enough.rs:32:22

--- a/tests/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
+++ b/tests/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
@@ -7,7 +7,7 @@ LL |     foo: &'static T
    |          the parameter type `T` must be valid for the static lifetime...
    |          ...so that the reference type `&'static T` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | struct Foo<T: 'static> {
    |             +++++++++
@@ -20,7 +20,7 @@ LL |     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() {
    |                          |
    |                          the parameter type `K` must be valid for the lifetime `'a` as defined here...
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() where K: 'a {
    |                                                     +++++++++++
@@ -33,7 +33,7 @@ LL |     fn generic_in_child<'a, 'b, L: X<&'a Nested<M>>, M: 'b>() {
    |                         |
    |                         the parameter type `M` must be valid for the lifetime `'a` as defined here...
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn generic_in_child<'a, 'b, L: X<&'a Nested<M>>, M: 'b + 'a>() {
    |                                                            ++++
@@ -46,7 +46,7 @@ LL |     fn foo<'a, L: X<&'a Nested<K>>>();
    |            |
    |            the parameter type `K` must be valid for the lifetime `'a` as defined here...
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn foo<'a, L: X<&'a Nested<K>>>() where K: 'a;
    |                                       +++++++++++
@@ -59,7 +59,7 @@ LL |     fn bar<'a, L: X<&'a Nested<Self>>>();
    |            |
    |            the parameter type `Self` must be valid for the lifetime `'a` as defined here...
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn bar<'a, L: X<&'a Nested<Self>>>() where Self: 'a;
    |                                          ++++++++++++++
@@ -72,7 +72,7 @@ LL |     fn baz<'a, L, M: X<&'a Nested<L>>>() {
    |            |
    |            the parameter type `L` must be valid for the lifetime `'a` as defined here...
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn baz<'a, L: 'a, M: X<&'a Nested<L>>>() {
    |                 ++++

--- a/tests/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
+++ b/tests/ui/lifetimes/lifetime-doesnt-live-long-enough.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/lifetime-doesnt-live-long-enough.rs:19:10
    |
 LL |     foo: &'static T
-   |          ^^^^^^^^^^ ...so that the reference type `&'static T` does not outlive the data it points at
+   |          ^^^^^^^^^^
+   |          |
+   |          the parameter type `T` must be valid for the static lifetime...
+   |          ...so that the reference type `&'static T` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -13,7 +16,9 @@ error[E0309]: the parameter type `K` may not live long enough
   --> $DIR/lifetime-doesnt-live-long-enough.rs:41:33
    |
 LL |     fn generic_in_parent<'a, L: X<&'a Nested<K>>>() {
-   |                                 ^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<K>` does not outlive the data it points at
+   |                          --     ^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<K>` does not outlive the data it points at
+   |                          |
+   |                          the parameter type `K` must be valid for the lifetime `'a` as defined here...
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -24,7 +29,9 @@ error[E0309]: the parameter type `M` may not live long enough
   --> $DIR/lifetime-doesnt-live-long-enough.rs:44:36
    |
 LL |     fn generic_in_child<'a, 'b, L: X<&'a Nested<M>>, M: 'b>() {
-   |                                    ^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<M>` does not outlive the data it points at
+   |                         --         ^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<M>` does not outlive the data it points at
+   |                         |
+   |                         the parameter type `M` must be valid for the lifetime `'a` as defined here...
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -35,7 +42,9 @@ error[E0309]: the parameter type `K` may not live long enough
   --> $DIR/lifetime-doesnt-live-long-enough.rs:24:19
    |
 LL |     fn foo<'a, L: X<&'a Nested<K>>>();
-   |                   ^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<K>` does not outlive the data it points at
+   |            --     ^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<K>` does not outlive the data it points at
+   |            |
+   |            the parameter type `K` must be valid for the lifetime `'a` as defined here...
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -46,7 +55,9 @@ error[E0309]: the parameter type `Self` may not live long enough
   --> $DIR/lifetime-doesnt-live-long-enough.rs:28:19
    |
 LL |     fn bar<'a, L: X<&'a Nested<Self>>>();
-   |                   ^^^^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<Self>` does not outlive the data it points at
+   |            --     ^^^^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<Self>` does not outlive the data it points at
+   |            |
+   |            the parameter type `Self` must be valid for the lifetime `'a` as defined here...
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -57,7 +68,9 @@ error[E0309]: the parameter type `L` may not live long enough
   --> $DIR/lifetime-doesnt-live-long-enough.rs:32:22
    |
 LL |     fn baz<'a, L, M: X<&'a Nested<L>>>() {
-   |                      ^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<L>` does not outlive the data it points at
+   |            --        ^^^^^^^^^^^^^^^^ ...so that the reference type `&'a Nested<L>` does not outlive the data it points at
+   |            |
+   |            the parameter type `L` must be valid for the lifetime `'a` as defined here...
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/issue_74400.rs:12:5
    |
 LL |     f(data, identity)
-   |     ^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^^^^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -7,7 +7,7 @@ LL |     f(data, identity)
    |     the parameter type `T` must be valid for the static lifetime...
    |     ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn g<T: 'static>(data: &[T]) {
    |       +++++++++

--- a/tests/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.fixed
+++ b/tests/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.fixed
@@ -2,7 +2,7 @@
 
 #![allow(warnings)]
 
-fn no_restriction<'a, T: 'a>(x: &'a ()) -> &() {
+fn no_restriction<'a, T: 'a>(x: &'a ()) -> &'a () {
     with_restriction::<T>(x) //~ ERROR the parameter type `T` may not live long enough
 }
 

--- a/tests/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.stderr
+++ b/tests/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.stderr
@@ -1,19 +1,11 @@
 error[E0311]: the parameter type `T` may not live long enough
   --> $DIR/suggest-introducing-and-adding-missing-lifetime.rs:6:5
    |
-LL |     with_restriction::<T>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the parameter type `T` must be valid for the anonymous lifetime defined here...
-  --> $DIR/suggest-introducing-and-adding-missing-lifetime.rs:5:25
-   |
 LL | fn no_restriction<T>(x: &()) -> &() {
-   |                         ^^^
-note: ...so that the type `T` will meet its required lifetime bounds
-  --> $DIR/suggest-introducing-and-adding-missing-lifetime.rs:6:5
-   |
+   |                         --- the parameter type `T` must be valid for the anonymous lifetime defined here...
 LL |     with_restriction::<T>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL | fn no_restriction<'a, T: 'a>(x: &'a ()) -> &'a () {

--- a/tests/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.stderr
+++ b/tests/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.stderr
@@ -6,7 +6,7 @@ LL | fn no_restriction<T>(x: &()) -> &() {
 LL |     with_restriction::<T>(x)
    |     ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn no_restriction<'a, T: 'a>(x: &'a ()) -> &'a () {
    |                   +++  ++++      ++         ++

--- a/tests/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.stderr
+++ b/tests/ui/lifetimes/suggest-introducing-and-adding-missing-lifetime.stderr
@@ -16,8 +16,8 @@ LL |     with_restriction::<T>(x)
    |     ^^^^^^^^^^^^^^^^^^^^^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn no_restriction<'a, T: 'a>(x: &'a ()) -> &() {
-   |                   +++  ++++      ++
+LL | fn no_restriction<'a, T: 'a>(x: &'a ()) -> &'a () {
+   |                   +++  ++++      ++         ++
 
 error: aborting due to previous error
 

--- a/tests/ui/marker_trait_attr/overlapping-impl-1-modulo-regions.stderr
+++ b/tests/ui/marker_trait_attr/overlapping-impl-1-modulo-regions.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/overlapping-impl-1-modulo-regions.rs:14:21
    |
 LL | impl<T: Copy> F for T {}
-   |                     ^ ...so that the type `T` will meet its required lifetime bounds
+   |                     ^
+   |                     |
+   |                     the parameter type `T` must be valid for the static lifetime...
+   |                     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/marker_trait_attr/overlapping-impl-1-modulo-regions.stderr
+++ b/tests/ui/marker_trait_attr/overlapping-impl-1-modulo-regions.stderr
@@ -7,7 +7,7 @@ LL | impl<T: Copy> F for T {}
    |                     the parameter type `T` must be valid for the static lifetime...
    |                     ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<T: Copy + 'static> F for T {}
    |              +++++++++

--- a/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -25,6 +25,9 @@ LL | |     T: Trait<'a>,
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/propagate-from-trait-match.rs:43:9
    |
+LL | fn supply<'a, T>(value: T)
+   |           -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |         require(value);
    |         ^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -31,7 +31,7 @@ LL | fn supply<'a, T>(value: T)
 LL |         require(value);
    |         ^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: Trait<'a> + 'a,
    |                  ++++

--- a/tests/ui/nll/issue-98589-closures-relate-named-regions.stderr
+++ b/tests/ui/nll/issue-98589-closures-relate-named-regions.stderr
@@ -37,6 +37,8 @@ LL |     || { None::<&'a &'b ()>; };
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/issue-98589-closures-relate-named-regions.rs:26:10
    |
+LL | fn test_early_type<'a: 'a, T>() {
+   |                    -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     || { None::<&'a T>; };
    |          ^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -48,6 +50,8 @@ LL | fn test_early_type<'a: 'a, T: 'a>() {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/issue-98589-closures-relate-named-regions.rs:32:10
    |
+LL | fn test_late_type<'a, T>() {
+   |                   -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     || { None::<&'a T>; };
    |          ^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/issue-98589-closures-relate-named-regions.stderr
+++ b/tests/ui/nll/issue-98589-closures-relate-named-regions.stderr
@@ -42,7 +42,7 @@ LL | fn test_early_type<'a: 'a, T>() {
 LL |     || { None::<&'a T>; };
    |          ^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test_early_type<'a: 'a, T: 'a>() {
    |                             ++++
@@ -55,7 +55,7 @@ LL | fn test_late_type<'a, T>() {
 LL |     || { None::<&'a T>; };
    |          ^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test_late_type<'a, T: 'a>() {
    |                        ++++

--- a/tests/ui/nll/issue-98693.stderr
+++ b/tests/ui/nll/issue-98693.stderr
@@ -7,7 +7,7 @@ LL |         assert_static::<T>();
    |         the parameter type `T` must be valid for the static lifetime...
    |         ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test<T: 'static>() {
    |          +++++++++

--- a/tests/ui/nll/issue-98693.stderr
+++ b/tests/ui/nll/issue-98693.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/issue-98693.rs:16:9
    |
 LL |         assert_static::<T>();
-   |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         the parameter type `T` must be valid for the static lifetime...
+   |         ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/nll/member-constraints/min-choice-reject-ambiguous.stderr
+++ b/tests/ui/nll/member-constraints/min-choice-reject-ambiguous.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/min-choice-reject-ambiguous.rs:17:5
    |
+LL | fn test_b<'a, 'b, 'c, T>() -> impl Cap<'a> + Cap<'b> + Cap<'c>
+   |           -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     type_test::<'_, T>() // This should pass if we pick 'b.
    |     ^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -12,6 +15,9 @@ LL |     T: 'b + 'a,
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/min-choice-reject-ambiguous.rs:28:5
    |
+LL | fn test_c<'a, 'b, 'c, T>() -> impl Cap<'a> + Cap<'b> + Cap<'c>
+   |           -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     type_test::<'_, T>() // This should pass if we pick 'c.
    |     ^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/member-constraints/min-choice-reject-ambiguous.stderr
+++ b/tests/ui/nll/member-constraints/min-choice-reject-ambiguous.stderr
@@ -7,7 +7,7 @@ LL | fn test_b<'a, 'b, 'c, T>() -> impl Cap<'a> + Cap<'b> + Cap<'c>
 LL |     type_test::<'_, T>() // This should pass if we pick 'b.
    |     ^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: 'b + 'a,
    |           ++++
@@ -21,7 +21,7 @@ LL | fn test_c<'a, 'b, 'c, T>() -> impl Cap<'a> + Cap<'b> + Cap<'c>
 LL |     type_test::<'_, T>() // This should pass if we pick 'c.
    |     ^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: 'c + 'a,
    |           ++++

--- a/tests/ui/nll/ty-outlives/impl-trait-outlives.stderr
+++ b/tests/ui/nll/ty-outlives/impl-trait-outlives.stderr
@@ -7,7 +7,7 @@ LL | fn no_region<'a, T>(x: Box<T>) -> impl Debug + 'a
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: Debug + 'a,
    |              ++++
@@ -21,7 +21,7 @@ LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: 'b + Debug + 'a,
    |                   ++++

--- a/tests/ui/nll/ty-outlives/impl-trait-outlives.stderr
+++ b/tests/ui/nll/ty-outlives/impl-trait-outlives.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/impl-trait-outlives.rs:11:5
    |
+LL | fn no_region<'a, T>(x: Box<T>) -> impl Debug + 'a
+   |              -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -12,6 +15,9 @@ LL |     T: Debug + 'a,
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/impl-trait-outlives.rs:26:5
    |
+LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
+   |                 -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/ty-outlives/projection-implied-bounds.stderr
+++ b/tests/ui/nll/ty-outlives/projection-implied-bounds.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/projection-implied-bounds.rs:30:36
    |
 LL |     twice(value, |value_ref, item| invoke2(value_ref, item));
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    the parameter type `T` must be valid for the static lifetime...
+   |                                    ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/nll/ty-outlives/projection-implied-bounds.stderr
+++ b/tests/ui/nll/ty-outlives/projection-implied-bounds.stderr
@@ -7,7 +7,7 @@ LL |     twice(value, |value_ref, item| invoke2(value_ref, item));
    |                                    the parameter type `T` must be valid for the static lifetime...
    |                                    ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn generic2<T: Iterator + 'static>(value: T) {
    |                         +++++++++

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -26,10 +26,12 @@ error[E0309]: the associated type `<T as Iterator>::Item` may not live long enou
   --> $DIR/projection-no-regions-closure.rs:25:31
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                               ^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Iterator>::Item: 'a`...
-   = note: ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
+help: consider adding an explicit lifetime bound...
+   |
+LL |     T: Iterator, <T as Iterator>::Item: 'a
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 note: external requirements
   --> $DIR/projection-no-regions-closure.rs:34:23
@@ -83,10 +85,12 @@ error[E0309]: the associated type `<T as Iterator>::Item` may not live long enou
   --> $DIR/projection-no-regions-closure.rs:42:31
    |
 LL |     with_signature(x, |mut y| Box::new(y.next()))
-   |                               ^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Iterator>::Item: 'a`...
-   = note: ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
+help: consider adding an explicit lifetime bound...
+   |
+LL |     T: 'b + Iterator, <T as Iterator>::Item: 'a
+   |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 note: external requirements
   --> $DIR/projection-no-regions-closure.rs:52:23

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -31,7 +31,7 @@ LL | fn no_region<'a, T>(x: Box<T>) -> Box<dyn Anything + 'a>
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                               ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: Iterator, <T as Iterator>::Item: 'a
    |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -93,7 +93,7 @@ LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<dyn Anything + 'a>
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                               ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: 'b + Iterator, <T as Iterator>::Item: 'a
    |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -25,6 +25,9 @@ LL | |     T: Iterator,
 error[E0309]: the associated type `<T as Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-closure.rs:25:31
    |
+LL | fn no_region<'a, T>(x: Box<T>) -> Box<dyn Anything + 'a>
+   |              -- the associated type `<T as Iterator>::Item` must be valid for the lifetime `'a` as defined here...
+...
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                               ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
@@ -84,6 +87,9 @@ LL | |     T: 'b + Iterator,
 error[E0309]: the associated type `<T as Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-closure.rs:42:31
    |
+LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<dyn Anything + 'a>
+   |                 -- the associated type `<T as Iterator>::Item` must be valid for the lifetime `'a` as defined here...
+...
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                               ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
@@ -2,19 +2,23 @@ error[E0309]: the associated type `<T as Iterator>::Item` may not live long enou
   --> $DIR/projection-no-regions-fn.rs:13:5
    |
 LL |     Box::new(x.next())
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Iterator>::Item: 'a`...
-   = note: ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
+help: consider adding an explicit lifetime bound...
+   |
+LL |     T: Iterator, <T as Iterator>::Item: 'a
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0309]: the associated type `<T as Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-fn.rs:28:5
    |
 LL |     Box::new(x.next())
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Iterator>::Item: 'a`...
-   = note: ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
+help: consider adding an explicit lifetime bound...
+   |
+LL |     T: 'b + Iterator, <T as Iterator>::Item: 'a
+   |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the associated type `<T as Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-fn.rs:13:5
    |
+LL | fn no_region<'a, T>(mut x: T) -> Box<dyn Anything + 'a>
+   |              -- the associated type `<T as Iterator>::Item` must be valid for the lifetime `'a` as defined here...
+...
 LL |     Box::new(x.next())
    |     ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
@@ -12,6 +15,9 @@ LL |     T: Iterator, <T as Iterator>::Item: 'a
 error[E0309]: the associated type `<T as Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-fn.rs:28:5
    |
+LL | fn wrong_region<'a, 'b, T>(mut x: T) -> Box<dyn Anything + 'a>
+   |                 -- the associated type `<T as Iterator>::Item` must be valid for the lifetime `'a` as defined here...
+...
 LL |     Box::new(x.next())
    |     ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
@@ -7,7 +7,7 @@ LL | fn no_region<'a, T>(mut x: T) -> Box<dyn Anything + 'a>
 LL |     Box::new(x.next())
    |     ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: Iterator, <T as Iterator>::Item: 'a
    |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -21,7 +21,7 @@ LL | fn wrong_region<'a, 'b, T>(mut x: T) -> Box<dyn Anything + 'a>
 LL |     Box::new(x.next())
    |     ^^^^^^^^^^^^^^^^^^ ...so that the type `<T as Iterator>::Item` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: 'b + Iterator, <T as Iterator>::Item: 'a
    |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -27,6 +27,9 @@ LL | |     T: Anything<'b>,
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:45:39
    |
+LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                          -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                                       ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -77,6 +80,9 @@ LL | |     'a: 'a,
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-one-region-closure.rs:56:39
    |
+LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
+   |                           -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                                       ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -33,7 +33,7 @@ LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                                       ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: Anything<'b> + 'a,
    |                     ++++
@@ -86,7 +86,7 @@ LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                                       ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: Anything<'b> + 'a,
    |                     ++++

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -26,11 +26,13 @@ LL | |     T: Anything<'b, 'c>,
 error[E0309]: the associated type `<T as Anything<'?5, '?6>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:38:39
    |
+LL | fn no_relationships_late<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
+   |                          -- the associated type `<T as Anything<'?5, '?6>>::AssocType` must be valid for the lifetime `'a` as defined here...
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                                       ^^^^^^^^^^^^^^^^
+   |                                       ^^^^^^^^^^^^^^^^ ...so that the type `<T as Anything<'?5, '?6>>::AssocType` will meet its required lifetime bounds
    |
    = help: consider adding an explicit lifetime bound `<T as Anything<'?5, '?6>>::AssocType: 'a`...
-   = note: ...so that the type `<T as Anything<'?5, '?6>>::AssocType` will meet its required lifetime bounds
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
@@ -60,11 +62,13 @@ LL | |     'a: 'a,
 error[E0309]: the associated type `<T as Anything<'?6, '?7>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:39
    |
+LL | fn no_relationships_early<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
+   |                           -- the associated type `<T as Anything<'?6, '?7>>::AssocType` must be valid for the lifetime `'a` as defined here...
+...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                                       ^^^^^^^^^^^^^^^^
+   |                                       ^^^^^^^^^^^^^^^^ ...so that the type `<T as Anything<'?6, '?7>>::AssocType` will meet its required lifetime bounds
    |
    = help: consider adding an explicit lifetime bound `<T as Anything<'?6, '?7>>::AssocType: 'a`...
-   = note: ...so that the type `<T as Anything<'?6, '?7>>::AssocType` will meet its required lifetime bounds
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:61:29

--- a/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-bound.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-bound.stderr
@@ -1,11 +1,13 @@
 error[E0309]: the associated type `<T as MyTrait<'_>>::Output` may not live long enough
   --> $DIR/projection-where-clause-env-wrong-bound.rs:15:5
    |
+LL | fn foo1<'a, 'b, T>() -> &'a ()
+   |         -- the associated type `<T as MyTrait<'_>>::Output` must be valid for the lifetime `'a` as defined here...
+...
 LL |     bar::<T::Output>()
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ ...so that the type `<T as MyTrait<'_>>::Output` will meet its required lifetime bounds
    |
    = help: consider adding an explicit lifetime bound `<T as MyTrait<'_>>::Output: 'a`...
-   = note: ...so that the type `<T as MyTrait<'_>>::Output` will meet its required lifetime bounds
 
 error: aborting due to previous error
 

--- a/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.stderr
@@ -1,11 +1,13 @@
 error[E0309]: the associated type `<T as MyTrait<'_>>::Output` may not live long enough
   --> $DIR/projection-where-clause-env-wrong-lifetime.rs:14:5
    |
+LL | fn foo1<'a, 'b, T>() -> &'a ()
+   |         -- the associated type `<T as MyTrait<'_>>::Output` must be valid for the lifetime `'a` as defined here...
+...
 LL |     bar::<<T as MyTrait<'a>>::Output>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `<T as MyTrait<'_>>::Output` will meet its required lifetime bounds
    |
    = help: consider adding an explicit lifetime bound `<T as MyTrait<'_>>::Output: 'a`...
-   = note: ...so that the type `<T as MyTrait<'_>>::Output` will meet its required lifetime bounds
 
 error: aborting due to previous error
 

--- a/tests/ui/nll/ty-outlives/projection-where-clause-none.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-none.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/projection-where-clause-none.rs:14:5
    |
+LL | fn foo<'a, T>() -> &'a ()
+   |        -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     bar::<T::Output>()
    |     ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/ty-outlives/projection-where-clause-none.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-none.stderr
@@ -7,7 +7,7 @@ LL | fn foo<'a, T>() -> &'a ()
 LL |     bar::<T::Output>()
    |     ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: MyTrait<'a> + 'a,
    |                    ++++

--- a/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -51,7 +51,7 @@ LL | fn generic_fail<'a, T>(cell: Cell<&'a ()>, value: T) {
 LL |     twice(cell, value, |a, b| invoke(a, b));
    |                               ^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn generic_fail<'a, T: 'a>(cell: Cell<&'a ()>, value: T) {
    |                      ++++

--- a/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -46,6 +46,8 @@ LL | fn generic_fail<'a, T>(cell: Cell<&'a ()>, value: T) {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-approximate-lower-bound.rs:29:31
    |
+LL | fn generic_fail<'a, T>(cell: Cell<&'a ()>, value: T) {
+   |                 -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     twice(cell, value, |a, b| invoke(a, b));
    |                               ^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -25,6 +25,9 @@ LL | |     T: Debug,
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:26:27
    |
+LL | fn no_region<'a, T>(x: Box<T>) -> Box<dyn Debug + 'a>
+   |              -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     with_signature(x, |y| y)
    |                           ^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -36,6 +39,9 @@ LL |     T: Debug + 'a,
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-return-type.rs:41:5
    |
+LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<Debug + 'a>
+   |                 -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -31,7 +31,7 @@ LL | fn no_region<'a, T>(x: Box<T>) -> Box<dyn Debug + 'a>
 LL |     with_signature(x, |y| y)
    |                           ^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: Debug + 'a,
    |              ++++
@@ -45,7 +45,7 @@ LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<Debug + 'a>
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: 'b + Debug + 'a,
    |                   ++++

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -30,7 +30,7 @@ LL | fn no_region<'a, T>(a: Cell<&'a ()>, b: T) {
 LL |         require(&x, &y)
    |         ^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn no_region<'a, T: 'a>(a: Cell<&'a ()>, b: T) {
    |                   ++++
@@ -93,7 +93,7 @@ LL | fn wrong_region<'a, 'b, T>(a: Cell<&'a ()>, b: T)
 LL |         require(&x, &y)
    |         ^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: 'b + 'a,
    |           ++++

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -24,6 +24,9 @@ LL | fn no_region<'a, T>(a: Cell<&'a ()>, b: T) {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:32:9
    |
+LL | fn no_region<'a, T>(a: Cell<&'a ()>, b: T) {
+   |              -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |         require(&x, &y)
    |         ^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -84,6 +87,9 @@ LL | |     T: 'b,
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-closure-outlives-from-where-clause.rs:65:9
    |
+LL | fn wrong_region<'a, 'b, T>(a: Cell<&'a ()>, b: T)
+   |                 -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |         require(&x, &y)
    |         ^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/ty-outlives/ty-param-fn-body.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-fn-body.stderr
@@ -1,6 +1,8 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-fn-body.rs:17:5
    |
+LL | fn region_static<'a, T>(cell: Cell<&'a usize>, t: T) {
+   |                  -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     outlives(cell, t)
    |     ^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/ty-outlives/ty-param-fn-body.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-fn-body.stderr
@@ -6,7 +6,7 @@ LL | fn region_static<'a, T>(cell: Cell<&'a usize>, t: T) {
 LL |     outlives(cell, t)
    |     ^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn region_static<'a, T: 'a>(cell: Cell<&'a usize>, t: T) {
    |                       ++++

--- a/tests/ui/nll/ty-outlives/ty-param-fn.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-fn.stderr
@@ -7,7 +7,7 @@ LL | fn no_region<'a, T>(x: Box<T>) -> Box<Debug + 'a>
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: Debug + 'a,
    |              ++++
@@ -21,7 +21,7 @@ LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<Debug + 'a>
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     T: 'b + Debug + 'a,
    |                   ++++

--- a/tests/ui/nll/ty-outlives/ty-param-fn.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-fn.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-fn.rs:9:5
    |
+LL | fn no_region<'a, T>(x: Box<T>) -> Box<Debug + 'a>
+   |              -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -12,6 +15,9 @@ LL |     T: Debug + 'a,
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/ty-param-fn.rs:24:5
    |
+LL | fn wrong_region<'a, 'b, T>(x: Box<T>) -> Box<Debug + 'a>
+   |                 -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     x
    |     ^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/nll/user-annotations/normalization-infer.stderr
+++ b/tests/ui/nll/user-annotations/normalization-infer.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `A` may not live long enough
   --> $DIR/normalization-infer.rs:11:12
    |
 LL |     let _: <(_,) as Tr>::Ty = a;
-   |            ^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
+   |            ^^^^^^^^^^^^^^^^
+   |            |
+   |            the parameter type `A` must be valid for the static lifetime...
+   |            ...so that the type `A` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -13,7 +16,10 @@ error[E0310]: the parameter type `B` may not live long enough
   --> $DIR/normalization-infer.rs:12:5
    |
 LL |     Some::<<(_,) as Tr>::Ty>(b);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `B` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     the parameter type `B` must be valid for the static lifetime...
+   |     ...so that the type `B` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -24,7 +30,10 @@ error[E0310]: the parameter type `C` may not live long enough
   --> $DIR/normalization-infer.rs:13:11
    |
 LL |     || -> <(_,) as Tr>::Ty { c };
-   |           ^^^^^^^^^^^^^^^^ ...so that the type `C` will meet its required lifetime bounds
+   |           ^^^^^^^^^^^^^^^^
+   |           |
+   |           the parameter type `C` must be valid for the static lifetime...
+   |           ...so that the type `C` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -35,7 +44,10 @@ error[E0310]: the parameter type `D` may not live long enough
   --> $DIR/normalization-infer.rs:14:6
    |
 LL |     |d: <(_,) as Tr>::Ty| -> D { d };
-   |      ^ ...so that the type `D` will meet its required lifetime bounds
+   |      ^
+   |      |
+   |      the parameter type `D` must be valid for the static lifetime...
+   |      ...so that the type `D` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -46,7 +58,10 @@ error[E0310]: the parameter type `A` may not live long enough
   --> $DIR/normalization-infer.rs:28:12
    |
 LL |     let _: Alias<_, _> = (a, 0u8);
-   |            ^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
+   |            ^^^^^^^^^^^
+   |            |
+   |            the parameter type `A` must be valid for the static lifetime...
+   |            ...so that the type `A` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -57,7 +72,10 @@ error[E0310]: the parameter type `B` may not live long enough
   --> $DIR/normalization-infer.rs:29:5
    |
 LL |     Some::<Alias<_, _>>((b, 0u8));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `B` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     the parameter type `B` must be valid for the static lifetime...
+   |     ...so that the type `B` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -68,7 +86,10 @@ error[E0310]: the parameter type `C` may not live long enough
   --> $DIR/normalization-infer.rs:30:11
    |
 LL |     || -> Alias<_, _> { (c, 0u8) };
-   |           ^^^^^^^^^^^ ...so that the type `C` will meet its required lifetime bounds
+   |           ^^^^^^^^^^^
+   |           |
+   |           the parameter type `C` must be valid for the static lifetime...
+   |           ...so that the type `C` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/nll/user-annotations/normalization-infer.stderr
+++ b/tests/ui/nll/user-annotations/normalization-infer.stderr
@@ -7,7 +7,7 @@ LL |     let _: <(_,) as Tr>::Ty = a;
    |            the parameter type `A` must be valid for the static lifetime...
    |            ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test1<A: 'static, B, C, D>(a: A, b: B, c: C) {
    |           +++++++++
@@ -21,7 +21,7 @@ LL |     Some::<<(_,) as Tr>::Ty>(b);
    |     the parameter type `B` must be valid for the static lifetime...
    |     ...so that the type `B` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test1<A, B: 'static, C, D>(a: A, b: B, c: C) {
    |              +++++++++
@@ -35,7 +35,7 @@ LL |     || -> <(_,) as Tr>::Ty { c };
    |           the parameter type `C` must be valid for the static lifetime...
    |           ...so that the type `C` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test1<A, B, C: 'static, D>(a: A, b: B, c: C) {
    |                 +++++++++
@@ -49,7 +49,7 @@ LL |     |d: <(_,) as Tr>::Ty| -> D { d };
    |      the parameter type `D` must be valid for the static lifetime...
    |      ...so that the type `D` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test1<A, B, C, D: 'static>(a: A, b: B, c: C) {
    |                    +++++++++
@@ -63,7 +63,7 @@ LL |     let _: Alias<_, _> = (a, 0u8);
    |            the parameter type `A` must be valid for the static lifetime...
    |            ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test2<A: 'static, B, C>(a: A, b: B, c: C) {
    |           +++++++++
@@ -77,7 +77,7 @@ LL |     Some::<Alias<_, _>>((b, 0u8));
    |     the parameter type `B` must be valid for the static lifetime...
    |     ...so that the type `B` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test2<A, B: 'static, C>(a: A, b: B, c: C) {
    |              +++++++++
@@ -91,7 +91,7 @@ LL |     || -> Alias<_, _> { (c, 0u8) };
    |           the parameter type `C` must be valid for the static lifetime...
    |           ...so that the type `C` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn test2<A, B, C: 'static>(a: A, b: B, c: C) {
    |                 +++++++++

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-GAT.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-GAT.stderr
@@ -1,17 +1,11 @@
 error[E0311]: the parameter type `Self` may not live long enough
    |
-note: the parameter type `Self` must be valid for the lifetime `'a` as defined here...
-  --> $DIR/object-safety-supertrait-mentions-GAT.rs:9:26
-   |
-LL | trait SuperTrait<T>: for<'a> GatTrait<Gat<'a> = T> {
-   |                          ^^
-   = help: consider adding an explicit lifetime bound `Self: 'a`...
-   = note: ...so that the type `Self` will meet its required lifetime bounds...
 note: ...that is required by this bound
   --> $DIR/object-safety-supertrait-mentions-GAT.rs:6:15
    |
 LL |         Self: 'a;
    |               ^^
+   = help: consider adding an explicit lifetime bound `Self: 'a`...
 
 error: associated item referring to unboxed trait object for its own trait
   --> $DIR/object-safety-supertrait-mentions-GAT.rs:10:20

--- a/tests/ui/regions/closure-in-projection-issue-97405.stderr
+++ b/tests/ui/regions/closure-in-projection-issue-97405.stderr
@@ -3,27 +3,33 @@ error[E0310]: the associated type `<impl Iterator as Iterator>::Item` may not li
    |
 LL |     assert_static(opaque(async move { t; }).next());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     the associated type `<impl Iterator as Iterator>::Item` must be valid for the static lifetime...
+   |     ...so that the type `<impl Iterator as Iterator>::Item` will meet its required lifetime bounds
    |
    = help: consider adding an explicit lifetime bound `<impl Iterator as Iterator>::Item: 'static`...
-   = note: ...so that the type `<impl Iterator as Iterator>::Item` will meet its required lifetime bounds
 
 error[E0310]: the associated type `<impl Iterator as Iterator>::Item` may not live long enough
   --> $DIR/closure-in-projection-issue-97405.rs:26:5
    |
 LL |     assert_static(opaque(move || { t; }).next());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     the associated type `<impl Iterator as Iterator>::Item` must be valid for the static lifetime...
+   |     ...so that the type `<impl Iterator as Iterator>::Item` will meet its required lifetime bounds
    |
    = help: consider adding an explicit lifetime bound `<impl Iterator as Iterator>::Item: 'static`...
-   = note: ...so that the type `<impl Iterator as Iterator>::Item` will meet its required lifetime bounds
 
 error[E0310]: the associated type `<impl Iterator as Iterator>::Item` may not live long enough
   --> $DIR/closure-in-projection-issue-97405.rs:28:5
    |
 LL |     assert_static(opaque(opaque(async move { t; }).next()).next());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     the associated type `<impl Iterator as Iterator>::Item` must be valid for the static lifetime...
+   |     ...so that the type `<impl Iterator as Iterator>::Item` will meet its required lifetime bounds
    |
    = help: consider adding an explicit lifetime bound `<impl Iterator as Iterator>::Item: 'static`...
-   = note: ...so that the type `<impl Iterator as Iterator>::Item` will meet its required lifetime bounds
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/regions/regions-close-associated-type-into-object.stderr
+++ b/tests/ui/regions/regions-close-associated-type-into-object.stderr
@@ -2,7 +2,10 @@ error[E0310]: the associated type `<T as Iter>::Item` may not live long enough
   --> $DIR/regions-close-associated-type-into-object.rs:15:5
    |
 LL |     Box::new(item)
-   |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^
+   |     |
+   |     the associated type `<T as Iter>::Item` must be valid for the static lifetime...
+   |     ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -13,7 +16,10 @@ error[E0310]: the associated type `<T as Iter>::Item` may not live long enough
   --> $DIR/regions-close-associated-type-into-object.rs:22:5
    |
 LL |     Box::new(item)
-   |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^
+   |     |
+   |     the associated type `<T as Iter>::Item` must be valid for the static lifetime...
+   |     ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -23,6 +29,9 @@ LL |     where Box<T::Item> : X, <T as Iter>::Item: 'static
 error[E0309]: the associated type `<T as Iter>::Item` may not live long enough
   --> $DIR/regions-close-associated-type-into-object.rs:28:5
    |
+LL | fn bad3<'a, T: Iter>(v: T) -> Box<dyn X + 'a>
+   |         -- the associated type `<T as Iter>::Item` must be valid for the lifetime `'a` as defined here...
+...
 LL |     Box::new(item)
    |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
@@ -34,6 +43,9 @@ LL | fn bad3<'a, T: Iter>(v: T) -> Box<dyn X + 'a> where <T as Iter>::Item: 'a
 error[E0309]: the associated type `<T as Iter>::Item` may not live long enough
   --> $DIR/regions-close-associated-type-into-object.rs:35:5
    |
+LL | fn bad4<'a, T: Iter>(v: T) -> Box<dyn X + 'a>
+   |         -- the associated type `<T as Iter>::Item` must be valid for the lifetime `'a` as defined here...
+...
 LL |     Box::new(item)
    |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |

--- a/tests/ui/regions/regions-close-associated-type-into-object.stderr
+++ b/tests/ui/regions/regions-close-associated-type-into-object.stderr
@@ -2,37 +2,45 @@ error[E0310]: the associated type `<T as Iter>::Item` may not live long enough
   --> $DIR/regions-close-associated-type-into-object.rs:15:5
    |
 LL |     Box::new(item)
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Iter>::Item: 'static`...
-   = note: ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
+help: consider adding an explicit lifetime bound...
+   |
+LL | fn bad1<T: Iter>(v: T) -> Box<dyn X + 'static> where <T as Iter>::Item: 'static
+   |                                                ++++++++++++++++++++++++++++++++
 
 error[E0310]: the associated type `<T as Iter>::Item` may not live long enough
   --> $DIR/regions-close-associated-type-into-object.rs:22:5
    |
 LL |     Box::new(item)
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Iter>::Item: 'static`...
-   = note: ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
+help: consider adding an explicit lifetime bound...
+   |
+LL |     where Box<T::Item> : X, <T as Iter>::Item: 'static
+   |                           ++++++++++++++++++++++++++++
 
 error[E0309]: the associated type `<T as Iter>::Item` may not live long enough
   --> $DIR/regions-close-associated-type-into-object.rs:28:5
    |
 LL |     Box::new(item)
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Iter>::Item: 'a`...
-   = note: ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
+help: consider adding an explicit lifetime bound...
+   |
+LL | fn bad3<'a, T: Iter>(v: T) -> Box<dyn X + 'a> where <T as Iter>::Item: 'a
+   |                                               +++++++++++++++++++++++++++
 
 error[E0309]: the associated type `<T as Iter>::Item` may not live long enough
   --> $DIR/regions-close-associated-type-into-object.rs:35:5
    |
 LL |     Box::new(item)
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Iter>::Item: 'a`...
-   = note: ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
+help: consider adding an explicit lifetime bound...
+   |
+LL |     where Box<T::Item> : X, <T as Iter>::Item: 'a
+   |                           +++++++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/regions/regions-close-associated-type-into-object.stderr
+++ b/tests/ui/regions/regions-close-associated-type-into-object.stderr
@@ -7,7 +7,7 @@ LL |     Box::new(item)
    |     the associated type `<T as Iter>::Item` must be valid for the static lifetime...
    |     ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn bad1<T: Iter>(v: T) -> Box<dyn X + 'static> where <T as Iter>::Item: 'static
    |                                                ++++++++++++++++++++++++++++++++
@@ -21,7 +21,7 @@ LL |     Box::new(item)
    |     the associated type `<T as Iter>::Item` must be valid for the static lifetime...
    |     ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     where Box<T::Item> : X, <T as Iter>::Item: 'static
    |                           ++++++++++++++++++++++++++++
@@ -35,7 +35,7 @@ LL | fn bad3<'a, T: Iter>(v: T) -> Box<dyn X + 'a>
 LL |     Box::new(item)
    |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn bad3<'a, T: Iter>(v: T) -> Box<dyn X + 'a> where <T as Iter>::Item: 'a
    |                                               +++++++++++++++++++++++++++
@@ -49,7 +49,7 @@ LL | fn bad4<'a, T: Iter>(v: T) -> Box<dyn X + 'a>
 LL |     Box::new(item)
    |     ^^^^^^^^^^^^^^ ...so that the type `<T as Iter>::Item` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     where Box<T::Item> : X, <T as Iter>::Item: 'a
    |                           +++++++++++++++++++++++

--- a/tests/ui/regions/regions-close-object-into-object-4.stderr
+++ b/tests/ui/regions/regions-close-object-into-object-4.stderr
@@ -7,7 +7,7 @@ LL |     Box::new(B(&*v)) as Box<dyn X>
    |     the parameter type `U` must be valid for the static lifetime...
    |     ...so that the type `U` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn i<'a, T, U: 'static>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
    |              +++++++++
@@ -21,7 +21,7 @@ LL |     Box::new(B(&*v)) as Box<dyn X>
    |     the parameter type `U` must be valid for the static lifetime...
    |     ...so that the type `U` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn i<'a, T, U: 'static>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
    |              +++++++++
@@ -36,7 +36,7 @@ LL |     Box::new(B(&*v)) as Box<dyn X>
    |     ...so that the type `U` will meet its required lifetime bounds
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn i<'a, T, U: 'static>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
    |              +++++++++
@@ -76,7 +76,7 @@ LL |     Box::new(B(&*v)) as Box<dyn X>
    |              the parameter type `U` must be valid for the static lifetime...
    |              ...so that the type `U` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn i<'a, T, U: 'static>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
    |              +++++++++

--- a/tests/ui/regions/regions-close-object-into-object-4.stderr
+++ b/tests/ui/regions/regions-close-object-into-object-4.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:9:5
    |
 LL |     Box::new(B(&*v)) as Box<dyn X>
-   |     ^^^^^^^^ ...so that the type `U` will meet its required lifetime bounds
+   |     ^^^^^^^^
+   |     |
+   |     the parameter type `U` must be valid for the static lifetime...
+   |     ...so that the type `U` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -13,7 +16,10 @@ error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:9:5
    |
 LL |     Box::new(B(&*v)) as Box<dyn X>
-   |     ^^^^^^^^^^^^^^^^ ...so that the type `U` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^^^
+   |     |
+   |     the parameter type `U` must be valid for the static lifetime...
+   |     ...so that the type `U` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -24,7 +30,10 @@ error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:9:5
    |
 LL |     Box::new(B(&*v)) as Box<dyn X>
-   |     ^^^^^^^^^^^^^^^^ ...so that the type `U` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^^^
+   |     |
+   |     the parameter type `U` must be valid for the static lifetime...
+   |     ...so that the type `U` will meet its required lifetime bounds
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider adding an explicit lifetime bound...
@@ -62,7 +71,10 @@ error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/regions-close-object-into-object-4.rs:9:14
    |
 LL |     Box::new(B(&*v)) as Box<dyn X>
-   |              ^^^^^^ ...so that the type `U` will meet its required lifetime bounds
+   |              ^^^^^^
+   |              |
+   |              the parameter type `U` must be valid for the static lifetime...
+   |              ...so that the type `U` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/regions/regions-close-object-into-object-5.stderr
+++ b/tests/ui/regions/regions-close-object-into-object-5.stderr
@@ -7,7 +7,7 @@ LL |     Box::new(B(&*v)) as Box<dyn X>
    |     the parameter type `T` must be valid for the static lifetime...
    |     ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn f<'a, T: 'static, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
    |           +++++++++
@@ -21,7 +21,7 @@ LL |     Box::new(B(&*v)) as Box<dyn X>
    |     the parameter type `T` must be valid for the static lifetime...
    |     ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn f<'a, T: 'static, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
    |           +++++++++
@@ -36,7 +36,7 @@ LL |     Box::new(B(&*v)) as Box<dyn X>
    |     ...so that the type `T` will meet its required lifetime bounds
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn f<'a, T: 'static, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
    |           +++++++++
@@ -59,7 +59,7 @@ LL |     Box::new(B(&*v)) as Box<dyn X>
    |              the parameter type `T` must be valid for the static lifetime...
    |              ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn f<'a, T: 'static, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
    |           +++++++++

--- a/tests/ui/regions/regions-close-object-into-object-5.stderr
+++ b/tests/ui/regions/regions-close-object-into-object-5.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-object-into-object-5.rs:17:5
    |
 LL |     Box::new(B(&*v)) as Box<dyn X>
-   |     ^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |     ^^^^^^^^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -13,7 +16,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-object-into-object-5.rs:17:5
    |
 LL |     Box::new(B(&*v)) as Box<dyn X>
-   |     ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^^^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -24,7 +30,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-object-into-object-5.rs:17:5
    |
 LL |     Box::new(B(&*v)) as Box<dyn X>
-   |     ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^^^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider adding an explicit lifetime bound...
@@ -45,7 +54,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-object-into-object-5.rs:17:14
    |
 LL |     Box::new(B(&*v)) as Box<dyn X>
-   |              ^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |              ^^^^^^
+   |              |
+   |              the parameter type `T` must be valid for the static lifetime...
+   |              ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/regions/regions-close-over-type-parameter-1.stderr
+++ b/tests/ui/regions/regions-close-over-type-parameter-1.stderr
@@ -7,7 +7,7 @@ LL |     Box::new(v) as Box<dyn SomeTrait + 'static>
    |     the parameter type `A` must be valid for the static lifetime...
    |     ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn make_object1<A: SomeTrait + 'static>(v: A) -> Box<dyn SomeTrait + 'static> {
    |                              +++++++++
@@ -20,7 +20,7 @@ LL | fn make_object3<'a, 'b, A: SomeTrait + 'a>(v: A) -> Box<dyn SomeTrait + 'b>
 LL |     Box::new(v) as Box<dyn SomeTrait + 'b>
    |     ^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn make_object3<'a, 'b, A: SomeTrait + 'a + 'b>(v: A) -> Box<dyn SomeTrait + 'b> {
    |                                           ++++

--- a/tests/ui/regions/regions-close-over-type-parameter-1.stderr
+++ b/tests/ui/regions/regions-close-over-type-parameter-1.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `A` may not live long enough
   --> $DIR/regions-close-over-type-parameter-1.rs:11:5
    |
 LL |     Box::new(v) as Box<dyn SomeTrait + 'static>
-   |     ^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^
+   |     |
+   |     the parameter type `A` must be valid for the static lifetime...
+   |     ...so that the type `A` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -12,6 +15,8 @@ LL | fn make_object1<A: SomeTrait + 'static>(v: A) -> Box<dyn SomeTrait + 'stati
 error[E0309]: the parameter type `A` may not live long enough
   --> $DIR/regions-close-over-type-parameter-1.rs:20:5
    |
+LL | fn make_object3<'a, 'b, A: SomeTrait + 'a>(v: A) -> Box<dyn SomeTrait + 'b> {
+   |                     -- the parameter type `A` must be valid for the lifetime `'b` as defined here...
 LL |     Box::new(v) as Box<dyn SomeTrait + 'b>
    |     ^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |

--- a/tests/ui/regions/regions-close-param-into-object.stderr
+++ b/tests/ui/regions/regions-close-param-into-object.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-param-into-object.rs:6:5
    |
 LL |     Box::new(v)
-   |     ^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -13,7 +16,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-param-into-object.rs:12:5
    |
 LL |     Box::new(v)
-   |     ^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^
+   |     |
+   |     the parameter type `T` must be valid for the static lifetime...
+   |     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -23,6 +29,9 @@ LL | fn p2<T: 'static>(v: Box<T>) -> Box<dyn X + 'static>
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-param-into-object.rs:18:5
    |
+LL | fn p3<'a,T>(v: T) -> Box<dyn X + 'a>
+   |       -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     Box::new(v)
    |     ^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -34,6 +43,9 @@ LL |     where T : X + 'a
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-param-into-object.rs:24:5
    |
+LL | fn p4<'a,T>(v: Box<T>) -> Box<dyn X + 'a>
+   |       -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+...
 LL |     Box::new(v)
    |     ^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/regions/regions-close-param-into-object.stderr
+++ b/tests/ui/regions/regions-close-param-into-object.stderr
@@ -7,7 +7,7 @@ LL |     Box::new(v)
    |     the parameter type `T` must be valid for the static lifetime...
    |     ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     where T : X + 'static
    |                 +++++++++
@@ -21,7 +21,7 @@ LL |     Box::new(v)
    |     the parameter type `T` must be valid for the static lifetime...
    |     ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn p2<T: 'static>(v: Box<T>) -> Box<dyn X + 'static>
    |        +++++++++
@@ -35,7 +35,7 @@ LL | fn p3<'a,T>(v: T) -> Box<dyn X + 'a>
 LL |     Box::new(v)
    |     ^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     where T : X + 'a
    |                 ++++
@@ -49,7 +49,7 @@ LL | fn p4<'a,T>(v: Box<T>) -> Box<dyn X + 'a>
 LL |     Box::new(v)
    |     ^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn p4<'a,T: 'a>(v: Box<T>) -> Box<dyn X + 'a>
    |           ++++

--- a/tests/ui/regions/regions-implied-bounds-projection-gap-1.stderr
+++ b/tests/ui/regions/regions-implied-bounds-projection-gap-1.stderr
@@ -7,7 +7,7 @@ LL | {
 LL |     wf::<&'x T>();
    |     ^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn func<'x, T:Trait1<'x> + 'x>(t: &'x T::Foo)
    |                          ++++

--- a/tests/ui/regions/regions-implied-bounds-projection-gap-1.stderr
+++ b/tests/ui/regions/regions-implied-bounds-projection-gap-1.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-implied-bounds-projection-gap-1.rs:16:5
    |
+LL | fn func<'x, T:Trait1<'x>>(t: &'x T::Foo)
+   |         -- the parameter type `T` must be valid for the lifetime `'x` as defined here...
+LL | {
 LL |     wf::<&'x T>();
    |     ^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/regions/regions-infer-bound-from-trait-self.stderr
+++ b/tests/ui/regions/regions-infer-bound-from-trait-self.stderr
@@ -2,10 +2,12 @@ error[E0309]: the parameter type `Self` may not live long enough
   --> $DIR/regions-infer-bound-from-trait-self.rs:46:9
    |
 LL |         check_bound(x, self)
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `Self` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `Self: 'a`...
-   = note: ...so that the type `Self` will meet its required lifetime bounds
+help: consider adding an explicit lifetime bound...
+   |
+LL | trait InheritsFromNothing<'a> : Sized where Self: 'a {
+   |                                       ++++++++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/regions/regions-infer-bound-from-trait-self.stderr
+++ b/tests/ui/regions/regions-infer-bound-from-trait-self.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the parameter type `Self` may not live long enough
   --> $DIR/regions-infer-bound-from-trait-self.rs:46:9
    |
+LL | trait InheritsFromNothing<'a> : Sized {
+   |                           -- the parameter type `Self` must be valid for the lifetime `'a` as defined here...
+LL |     fn foo(self, x: Inv<'a>) {
 LL |         check_bound(x, self)
    |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `Self` will meet its required lifetime bounds
    |

--- a/tests/ui/regions/regions-infer-bound-from-trait-self.stderr
+++ b/tests/ui/regions/regions-infer-bound-from-trait-self.stderr
@@ -7,7 +7,7 @@ LL |     fn foo(self, x: Inv<'a>) {
 LL |         check_bound(x, self)
    |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `Self` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | trait InheritsFromNothing<'a> : Sized where Self: 'a {
    |                                       ++++++++++++++

--- a/tests/ui/regions/regions-infer-bound-from-trait.stderr
+++ b/tests/ui/regions/regions-infer-bound-from-trait.stderr
@@ -1,6 +1,8 @@
 error[E0309]: the parameter type `A` may not live long enough
   --> $DIR/regions-infer-bound-from-trait.rs:33:5
    |
+LL | fn bar1<'a,A>(x: Inv<'a>, a: A) {
+   |         -- the parameter type `A` must be valid for the lifetime `'a` as defined here...
 LL |     check_bound(x, a)
    |     ^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |
@@ -12,6 +14,8 @@ LL | fn bar1<'a,A: 'a>(x: Inv<'a>, a: A) {
 error[E0309]: the parameter type `A` may not live long enough
   --> $DIR/regions-infer-bound-from-trait.rs:37:5
    |
+LL | fn bar2<'a,'b,A:Is<'b>>(x: Inv<'a>, y: Inv<'b>, a: A) {
+   |         -- the parameter type `A` must be valid for the lifetime `'a` as defined here...
 LL |     check_bound(x, a)
    |     ^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |

--- a/tests/ui/regions/regions-infer-bound-from-trait.stderr
+++ b/tests/ui/regions/regions-infer-bound-from-trait.stderr
@@ -6,7 +6,7 @@ LL | fn bar1<'a,A>(x: Inv<'a>, a: A) {
 LL |     check_bound(x, a)
    |     ^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn bar1<'a,A: 'a>(x: Inv<'a>, a: A) {
    |             ++++
@@ -19,7 +19,7 @@ LL | fn bar2<'a,'b,A:Is<'b>>(x: Inv<'a>, y: Inv<'b>, a: A) {
 LL |     check_bound(x, a)
    |     ^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn bar2<'a,'b,A:Is<'b> + 'a>(x: Inv<'a>, y: Inv<'b>, a: A) {
    |                        ++++

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/dont-infer-static.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/dont-infer-static.stderr
@@ -12,7 +12,7 @@ note: ...that is required by this bound
    |
 LL | struct Bar<T: 'static> {
    |               ^^^^^^^
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | struct Foo<U: 'static> {
    |             +++++++++

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/dont-infer-static.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/dont-infer-static.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `U` may not live long enough
   --> $DIR/dont-infer-static.rs:6:10
    |
 LL |     bar: Bar<U>
-   |          ^^^^^^ ...so that the type `U` will meet its required lifetime bounds...
+   |          ^^^^^^
+   |          |
+   |          the parameter type `U` must be valid for the static lifetime...
+   |          ...so that the type `U` will meet its required lifetime bounds...
    |
 note: ...that is required by this bound
   --> $DIR/dont-infer-static.rs:8:15

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
@@ -1,6 +1,8 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-enum-not-wf.rs:17:18
    |
+LL | enum Ref1<'a, T> {
+   |           -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     Ref1Variant1(RequireOutlives<'a, T>),
    |                  ^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -12,6 +14,9 @@ LL | enum Ref1<'a, T: 'a> {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-enum-not-wf.rs:22:25
    |
+LL | enum Ref2<'a, T> {
+   |           -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+LL |     Ref2Variant1,
 LL |     Ref2Variant2(isize, RequireOutlives<'a, T>),
    |                         ^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -23,6 +28,8 @@ LL | enum Ref2<'a, T: 'a> {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-enum-not-wf.rs:35:23
    |
+LL | enum RefDouble<'a, 'b, T> {
+   |                    -- the parameter type `T` must be valid for the lifetime `'b` as defined here...
 LL |     RefDoubleVariant1(&'a RequireOutlives<'b, T>),
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.stderr
@@ -6,7 +6,7 @@ LL | enum Ref1<'a, T> {
 LL |     Ref1Variant1(RequireOutlives<'a, T>),
    |                  ^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | enum Ref1<'a, T: 'a> {
    |                ++++
@@ -20,7 +20,7 @@ LL |     Ref2Variant1,
 LL |     Ref2Variant2(isize, RequireOutlives<'a, T>),
    |                         ^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | enum Ref2<'a, T: 'a> {
    |                ++++
@@ -33,7 +33,7 @@ LL | enum RefDouble<'a, 'b, T> {
 LL |     RefDoubleVariant1(&'a RequireOutlives<'b, T>),
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | enum RefDouble<'a, 'b, T: 'b> {
    |                         ++++

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-struct-not-wf.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-struct-not-wf.stderr
@@ -1,6 +1,8 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-struct-not-wf.rs:13:16
    |
+LL | impl<'a, T> Trait<'a, T> for usize {
+   |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Out = &'a T;
    |                ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
    |
@@ -12,6 +14,8 @@ LL | impl<'a, T: 'a> Trait<'a, T> for usize {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/regions-struct-not-wf.rs:21:16
    |
+LL | impl<'a, T> Trait<'a, T> for u32 {
+   |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Out = RefOk<'a, T>;
    |                ^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
    |

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-struct-not-wf.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-struct-not-wf.stderr
@@ -6,7 +6,7 @@ LL | impl<'a, T> Trait<'a, T> for usize {
 LL |     type Out = &'a T;
    |                ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<'a, T: 'a> Trait<'a, T> for usize {
    |           ++++
@@ -24,7 +24,7 @@ note: ...that is required by this bound
    |
 LL | struct RefOk<'a, T:'a> {
    |                    ^^
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<'a, T: 'a> Trait<'a, T> for u32 {
    |           ++++

--- a/tests/ui/suggestions/lifetimes/issue-105544.fixed
+++ b/tests/ui/suggestions/lifetimes/issue-105544.fixed
@@ -2,7 +2,7 @@
 
 #![allow(warnings)]
 
-fn foo<'a>(d: impl Sized + 'a, p: &'a mut ()) -> impl Sized + '_ { //~ NOTE the parameter type `impl Sized` must be valid for the anonymous lifetime defined here...
+fn foo<'a>(d: impl Sized + 'a, p: &'a mut ()) -> impl Sized + 'a { //~ NOTE the parameter type `impl Sized` must be valid for the anonymous lifetime defined here...
 //~^ HELP consider adding an explicit lifetime bound
     (d, p)
     //~^ ERROR the parameter type `impl Sized` may not live long enough
@@ -15,14 +15,14 @@ fn foo1<'b>(d: impl Sized + 'b, p: &'b mut ()) -> impl Sized + '_ {
     //~^ ERROR the parameter type `impl Sized` may not live long enough
 }
 
-fn foo2<'b, 'a>(d: impl Sized + 'a + 'b, p: &'b mut ()) -> impl Sized + '_ { //~ NOTE the parameter type `impl Sized + 'a` must be valid for the anonymous lifetime defined here...
+fn foo2<'b, 'a>(d: impl Sized + 'a + 'b, p: &'b mut ()) -> impl Sized + 'b { //~ NOTE the parameter type `impl Sized + 'a` must be valid for the anonymous lifetime defined here...
 //~^ HELP consider adding an explicit lifetime bound
     (d, p)
     //~^ ERROR the parameter type `impl Sized + 'a` may not live long enough
     //~| NOTE ...so that the type `impl Sized + 'a` will meet its required lifetime bounds
 }
 
-fn bar<'a, T : Sized + 'a>(d: T, p: &'a mut ()) -> impl Sized + '_ { //~ NOTE the parameter type `T` must be valid for the anonymous lifetime defined here...
+fn bar<'a, T : Sized + 'a>(d: T, p: &'a  mut ()) -> impl Sized + 'a { //~ NOTE the parameter type `T` must be valid for the anonymous lifetime defined here...
 //~^ HELP consider adding an explicit lifetime bound
     (d, p)
     //~^ ERROR the parameter type `T` may not live long enough
@@ -35,7 +35,7 @@ fn bar1<'b, T : Sized + 'b>(d: T, p: &'b mut ()) -> impl Sized + '_ {
     //~^ ERROR the parameter type `T` may not live long enough
 }
 
-fn bar2<'b, 'a, T : Sized + 'a + 'b>(d: T, p: &'b mut ()) -> impl Sized + '_ { //~ NOTE the parameter type `T` must be valid for the anonymous lifetime defined here...
+fn bar2<'b, 'a, T : Sized + 'a + 'b>(d: T, p: &'b mut ()) -> impl Sized + 'b { //~ NOTE the parameter type `T` must be valid for the anonymous lifetime defined here...
 //~^ HELP consider adding an explicit lifetime bound
     (d, p)
     //~^ ERROR the parameter type `T` may not live long enough

--- a/tests/ui/suggestions/lifetimes/issue-105544.fixed
+++ b/tests/ui/suggestions/lifetimes/issue-105544.fixed
@@ -11,7 +11,7 @@ fn foo<'a>(d: impl Sized + 'a, p: &'a mut ()) -> impl Sized + 'a { //~ NOTE the 
 
 fn foo1<'b>(d: impl Sized + 'b, p: &'b mut ()) -> impl Sized + '_ {
 //~^ NOTE the parameter type `impl Sized` must be valid for the lifetime `'b` as defined here...
-//~| HELP consider adding an explicit lifetime bound...
+//~| HELP consider adding an explicit lifetime bound
     (d, p) //~ NOTE ...so that the type `impl Sized` will meet its required lifetime bounds
     //~^ ERROR the parameter type `impl Sized` may not live long enough
 }
@@ -32,7 +32,7 @@ fn bar<'a, T : Sized + 'a>(d: T, p: &'a  mut ()) -> impl Sized + 'a { //~ NOTE t
 
 fn bar1<'b, T : Sized + 'b>(d: T, p: &'b mut ()) -> impl Sized + '_ {
 //~^ NOTE the parameter type `T` must be valid for the lifetime `'b` as defined here...
-//~| HELP consider adding an explicit lifetime bound...
+//~| HELP consider adding an explicit lifetime bound
     (d, p) //~ NOTE ...so that the type `T` will meet its required lifetime bounds
     //~^ ERROR the parameter type `T` may not live long enough
 }

--- a/tests/ui/suggestions/lifetimes/issue-105544.fixed
+++ b/tests/ui/suggestions/lifetimes/issue-105544.fixed
@@ -10,7 +10,8 @@ fn foo<'a>(d: impl Sized + 'a, p: &'a mut ()) -> impl Sized + 'a { //~ NOTE the 
 }
 
 fn foo1<'b>(d: impl Sized + 'b, p: &'b mut ()) -> impl Sized + '_ {
-//~^ HELP consider adding an explicit lifetime bound...
+//~^ NOTE the parameter type `impl Sized` must be valid for the lifetime `'b` as defined here...
+//~| HELP consider adding an explicit lifetime bound...
     (d, p) //~ NOTE ...so that the type `impl Sized` will meet its required lifetime bounds
     //~^ ERROR the parameter type `impl Sized` may not live long enough
 }
@@ -30,7 +31,8 @@ fn bar<'a, T : Sized + 'a>(d: T, p: &'a  mut ()) -> impl Sized + 'a { //~ NOTE t
 }
 
 fn bar1<'b, T : Sized + 'b>(d: T, p: &'b mut ()) -> impl Sized + '_ {
-//~^ HELP consider adding an explicit lifetime bound...
+//~^ NOTE the parameter type `T` must be valid for the lifetime `'b` as defined here...
+//~| HELP consider adding an explicit lifetime bound...
     (d, p) //~ NOTE ...so that the type `T` will meet its required lifetime bounds
     //~^ ERROR the parameter type `T` may not live long enough
 }

--- a/tests/ui/suggestions/lifetimes/issue-105544.rs
+++ b/tests/ui/suggestions/lifetimes/issue-105544.rs
@@ -11,7 +11,7 @@ fn foo(d: impl Sized, p: &mut ()) -> impl Sized + '_ { //~ NOTE the parameter ty
 
 fn foo1<'b>(d: impl Sized, p: &'b mut ()) -> impl Sized + '_ {
 //~^ NOTE the parameter type `impl Sized` must be valid for the lifetime `'b` as defined here...
-//~| HELP consider adding an explicit lifetime bound...
+//~| HELP consider adding an explicit lifetime bound
     (d, p) //~ NOTE ...so that the type `impl Sized` will meet its required lifetime bounds
     //~^ ERROR the parameter type `impl Sized` may not live long enough
 }
@@ -32,7 +32,7 @@ fn bar<T : Sized>(d: T, p: & mut ()) -> impl Sized + '_ { //~ NOTE the parameter
 
 fn bar1<'b, T : Sized>(d: T, p: &'b mut ()) -> impl Sized + '_ {
 //~^ NOTE the parameter type `T` must be valid for the lifetime `'b` as defined here...
-//~| HELP consider adding an explicit lifetime bound...
+//~| HELP consider adding an explicit lifetime bound
     (d, p) //~ NOTE ...so that the type `T` will meet its required lifetime bounds
     //~^ ERROR the parameter type `T` may not live long enough
 }

--- a/tests/ui/suggestions/lifetimes/issue-105544.rs
+++ b/tests/ui/suggestions/lifetimes/issue-105544.rs
@@ -10,7 +10,8 @@ fn foo(d: impl Sized, p: &mut ()) -> impl Sized + '_ { //~ NOTE the parameter ty
 }
 
 fn foo1<'b>(d: impl Sized, p: &'b mut ()) -> impl Sized + '_ {
-//~^ HELP consider adding an explicit lifetime bound...
+//~^ NOTE the parameter type `impl Sized` must be valid for the lifetime `'b` as defined here...
+//~| HELP consider adding an explicit lifetime bound...
     (d, p) //~ NOTE ...so that the type `impl Sized` will meet its required lifetime bounds
     //~^ ERROR the parameter type `impl Sized` may not live long enough
 }
@@ -30,7 +31,8 @@ fn bar<T : Sized>(d: T, p: & mut ()) -> impl Sized + '_ { //~ NOTE the parameter
 }
 
 fn bar1<'b, T : Sized>(d: T, p: &'b mut ()) -> impl Sized + '_ {
-//~^ HELP consider adding an explicit lifetime bound...
+//~^ NOTE the parameter type `T` must be valid for the lifetime `'b` as defined here...
+//~| HELP consider adding an explicit lifetime bound...
     (d, p) //~ NOTE ...so that the type `T` will meet its required lifetime bounds
     //~^ ERROR the parameter type `T` may not live long enough
 }

--- a/tests/ui/suggestions/lifetimes/issue-105544.stderr
+++ b/tests/ui/suggestions/lifetimes/issue-105544.stderr
@@ -7,7 +7,7 @@ LL |
 LL |     (d, p)
    |     ^^^^^^ ...so that the type `impl Sized` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn foo<'a>(d: impl Sized + 'a, p: &'a mut ()) -> impl Sized + 'a {
    |       ++++               ++++      ++                         ~~
@@ -21,7 +21,7 @@ LL | fn foo1<'b>(d: impl Sized, p: &'b mut ()) -> impl Sized + '_ {
 LL |     (d, p)
    |     ^^^^^^ ...so that the type `impl Sized` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn foo1<'b>(d: impl Sized + 'b, p: &'b mut ()) -> impl Sized + '_ {
    |                           ++++
@@ -35,7 +35,7 @@ LL |
 LL |     (d, p)
    |     ^^^^^^ ...so that the type `impl Sized + 'a` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn foo2<'b, 'a>(d: impl Sized + 'a + 'b, p: &'b mut ()) -> impl Sized + 'b {
    |         +++                        ++++      ++                         ~~
@@ -49,7 +49,7 @@ LL |
 LL |     (d, p)
    |     ^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn bar<'a, T : Sized + 'a>(d: T, p: &'a  mut ()) -> impl Sized + 'a {
    |        +++           ++++            ++                          ~~
@@ -63,7 +63,7 @@ LL | fn bar1<'b, T : Sized>(d: T, p: &'b mut ()) -> impl Sized + '_ {
 LL |     (d, p)
    |     ^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn bar1<'b, T : Sized + 'b>(d: T, p: &'b mut ()) -> impl Sized + '_ {
    |                       ++++
@@ -77,7 +77,7 @@ LL |
 LL |     (d, p)
    |     ^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn bar2<'b, 'a, T : Sized + 'a + 'b>(d: T, p: &'b mut ()) -> impl Sized + 'b {
    |         +++                    ++++            ++                         ~~

--- a/tests/ui/suggestions/lifetimes/issue-105544.stderr
+++ b/tests/ui/suggestions/lifetimes/issue-105544.stderr
@@ -16,8 +16,8 @@ LL |     (d, p)
    |     ^^^^^^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn foo<'a>(d: impl Sized + 'a, p: &'a mut ()) -> impl Sized + '_ {
-   |       ++++               ++++      ++
+LL | fn foo<'a>(d: impl Sized + 'a, p: &'a mut ()) -> impl Sized + 'a {
+   |       ++++               ++++      ++                         ~~
 
 error[E0309]: the parameter type `impl Sized` may not live long enough
   --> $DIR/issue-105544.rs:14:5
@@ -48,8 +48,8 @@ LL |     (d, p)
    |     ^^^^^^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn foo2<'b, 'a>(d: impl Sized + 'a + 'b, p: &'b mut ()) -> impl Sized + '_ {
-   |         +++                        ++++      ++
+LL | fn foo2<'b, 'a>(d: impl Sized + 'a + 'b, p: &'b mut ()) -> impl Sized + 'b {
+   |         +++                        ++++      ++                         ~~
 
 error[E0311]: the parameter type `T` may not live long enough
   --> $DIR/issue-105544.rs:27:5
@@ -69,8 +69,8 @@ LL |     (d, p)
    |     ^^^^^^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn bar<'a, T : Sized + 'a>(d: T, p: &'a mut ()) -> impl Sized + '_ {
-   |        +++           ++++            ++
+LL | fn bar<'a, T : Sized + 'a>(d: T, p: &'a  mut ()) -> impl Sized + 'a {
+   |        +++           ++++            ++                          ~~
 
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/issue-105544.rs:34:5
@@ -101,8 +101,8 @@ LL |     (d, p)
    |     ^^^^^^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn bar2<'b, 'a, T : Sized + 'a + 'b>(d: T, p: &'b mut ()) -> impl Sized + '_ {
-   |         +++                    ++++            ++
+LL | fn bar2<'b, 'a, T : Sized + 'a + 'b>(d: T, p: &'b mut ()) -> impl Sized + 'b {
+   |         +++                    ++++            ++                         ~~
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/suggestions/lifetimes/issue-105544.stderr
+++ b/tests/ui/suggestions/lifetimes/issue-105544.stderr
@@ -1,27 +1,23 @@
 error[E0311]: the parameter type `impl Sized` may not live long enough
   --> $DIR/issue-105544.rs:7:5
    |
-LL |     (d, p)
-   |     ^^^^^^
-   |
-note: the parameter type `impl Sized` must be valid for the anonymous lifetime defined here...
-  --> $DIR/issue-105544.rs:5:26
-   |
 LL | fn foo(d: impl Sized, p: &mut ()) -> impl Sized + '_ {
-   |                          ^^^^^^^
-note: ...so that the type `impl Sized` will meet its required lifetime bounds
-  --> $DIR/issue-105544.rs:7:5
-   |
+   |                          ------- the parameter type `impl Sized` must be valid for the anonymous lifetime defined here...
+LL |
 LL |     (d, p)
-   |     ^^^^^^
+   |     ^^^^^^ ...so that the type `impl Sized` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL | fn foo<'a>(d: impl Sized + 'a, p: &'a mut ()) -> impl Sized + 'a {
    |       ++++               ++++      ++                         ~~
 
 error[E0309]: the parameter type `impl Sized` may not live long enough
-  --> $DIR/issue-105544.rs:14:5
+  --> $DIR/issue-105544.rs:15:5
    |
+LL | fn foo1<'b>(d: impl Sized, p: &'b mut ()) -> impl Sized + '_ {
+   |         -- the parameter type `impl Sized` must be valid for the lifetime `'b` as defined here...
+...
 LL |     (d, p)
    |     ^^^^^^ ...so that the type `impl Sized` will meet its required lifetime bounds
    |
@@ -31,50 +27,39 @@ LL | fn foo1<'b>(d: impl Sized + 'b, p: &'b mut ()) -> impl Sized + '_ {
    |                           ++++
 
 error[E0311]: the parameter type `impl Sized + 'a` may not live long enough
-  --> $DIR/issue-105544.rs:20:5
-   |
-LL |     (d, p)
-   |     ^^^^^^
-   |
-note: the parameter type `impl Sized + 'a` must be valid for the anonymous lifetime defined here...
-  --> $DIR/issue-105544.rs:18:36
+  --> $DIR/issue-105544.rs:21:5
    |
 LL | fn foo2<'a>(d: impl Sized + 'a, p: &mut ()) -> impl Sized + '_ {
-   |                                    ^^^^^^^
-note: ...so that the type `impl Sized + 'a` will meet its required lifetime bounds
-  --> $DIR/issue-105544.rs:20:5
-   |
+   |                                    ------- the parameter type `impl Sized + 'a` must be valid for the anonymous lifetime defined here...
+LL |
 LL |     (d, p)
-   |     ^^^^^^
+   |     ^^^^^^ ...so that the type `impl Sized + 'a` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL | fn foo2<'b, 'a>(d: impl Sized + 'a + 'b, p: &'b mut ()) -> impl Sized + 'b {
    |         +++                        ++++      ++                         ~~
 
 error[E0311]: the parameter type `T` may not live long enough
-  --> $DIR/issue-105544.rs:27:5
-   |
-LL |     (d, p)
-   |     ^^^^^^
-   |
-note: the parameter type `T` must be valid for the anonymous lifetime defined here...
-  --> $DIR/issue-105544.rs:25:28
+  --> $DIR/issue-105544.rs:28:5
    |
 LL | fn bar<T : Sized>(d: T, p: & mut ()) -> impl Sized + '_ {
-   |                            ^^^^^^^^
-note: ...so that the type `T` will meet its required lifetime bounds
-  --> $DIR/issue-105544.rs:27:5
-   |
+   |                            -------- the parameter type `T` must be valid for the anonymous lifetime defined here...
+LL |
 LL |     (d, p)
-   |     ^^^^^^
+   |     ^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL | fn bar<'a, T : Sized + 'a>(d: T, p: &'a  mut ()) -> impl Sized + 'a {
    |        +++           ++++            ++                          ~~
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/issue-105544.rs:34:5
+  --> $DIR/issue-105544.rs:36:5
    |
+LL | fn bar1<'b, T : Sized>(d: T, p: &'b mut ()) -> impl Sized + '_ {
+   |         -- the parameter type `T` must be valid for the lifetime `'b` as defined here...
+...
 LL |     (d, p)
    |     ^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -84,21 +69,14 @@ LL | fn bar1<'b, T : Sized + 'b>(d: T, p: &'b mut ()) -> impl Sized + '_ {
    |                       ++++
 
 error[E0311]: the parameter type `T` may not live long enough
-  --> $DIR/issue-105544.rs:40:5
-   |
-LL |     (d, p)
-   |     ^^^^^^
-   |
-note: the parameter type `T` must be valid for the anonymous lifetime defined here...
-  --> $DIR/issue-105544.rs:38:38
+  --> $DIR/issue-105544.rs:42:5
    |
 LL | fn bar2<'a, T : Sized + 'a>(d: T, p: &mut ()) -> impl Sized + '_ {
-   |                                      ^^^^^^^
-note: ...so that the type `T` will meet its required lifetime bounds
-  --> $DIR/issue-105544.rs:40:5
-   |
+   |                                      ------- the parameter type `T` must be valid for the anonymous lifetime defined here...
+LL |
 LL |     (d, p)
-   |     ^^^^^^
+   |     ^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL | fn bar2<'b, 'a, T : Sized + 'a + 'b>(d: T, p: &'b mut ()) -> impl Sized + 'b {

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.fixed
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.fixed
@@ -19,11 +19,16 @@ trait Test {
     fn test(&self);
 }
 
-fn func<'a, T: Test + 'a>(foo: &'a Foo<'a>, t: T) {
+fn func<'a, T: Test + 'a>(_dummy: &Foo, foo: &Foo<'a>, t: T) {
     foo.bar(move |_| {
     //~^ ERROR the parameter type `T` may not live long enough
         t.test();
     });
+}
+
+// Test that the suggested fix does not overconstrain `func`. See #115375.
+fn test_func<'a, T: Test + 'a>(dummy: &Foo, foo: &Foo<'a>, t: T) {
+    func(dummy, foo, t);
 }
 
 fn main() {}

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.rs
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.rs
@@ -19,11 +19,16 @@ trait Test {
     fn test(&self);
 }
 
-fn func<T: Test>(foo: &Foo, t: T) {
+fn func<T: Test>(_dummy: &Foo, foo: &Foo, t: T) {
     foo.bar(move |_| {
     //~^ ERROR the parameter type `T` may not live long enough
         t.test();
     });
+}
+
+// Test that the suggested fix does not overconstrain `func`. See #115375.
+fn test_func<'a, T: Test + 'a>(dummy: &Foo, foo: &Foo<'a>, t: T) {
+    func(dummy, foo, t);
 }
 
 fn main() {}

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
@@ -8,10 +8,10 @@ LL | |     });
    | |______^
    |
 note: the parameter type `T` must be valid for the anonymous lifetime defined here...
-  --> $DIR/missing-lifetimes-in-signature-2.rs:22:24
+  --> $DIR/missing-lifetimes-in-signature-2.rs:22:38
    |
-LL | fn func<T: Test>(foo: &Foo, t: T) {
-   |                        ^^^
+LL | fn func<T: Test>(_dummy: &Foo, foo: &Foo, t: T) {
+   |                                      ^^^
 note: ...so that the type `T` will meet its required lifetime bounds
   --> $DIR/missing-lifetimes-in-signature-2.rs:23:5
    |
@@ -22,8 +22,8 @@ LL | |     });
    | |______^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn func<'a, T: Test + 'a>(foo: &'a Foo<'a>, t: T) {
-   |         +++         ++++        ++    ++++
+LL | fn func<'a, T: Test + 'a>(_dummy: &Foo, foo: &Foo<'a>, t: T) {
+   |         +++         ++++                         ++++
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
@@ -1,25 +1,14 @@
 error[E0311]: the parameter type `T` may not live long enough
   --> $DIR/missing-lifetimes-in-signature-2.rs:23:5
    |
+LL |   fn func<T: Test>(_dummy: &Foo, foo: &Foo, t: T) {
+   |                                        --- the parameter type `T` must be valid for the anonymous lifetime defined here...
 LL | /     foo.bar(move |_| {
 LL | |
 LL | |         t.test();
 LL | |     });
-   | |______^
+   | |______^ ...so that the type `T` will meet its required lifetime bounds
    |
-note: the parameter type `T` must be valid for the anonymous lifetime defined here...
-  --> $DIR/missing-lifetimes-in-signature-2.rs:22:38
-   |
-LL | fn func<T: Test>(_dummy: &Foo, foo: &Foo, t: T) {
-   |                                      ^^^
-note: ...so that the type `T` will meet its required lifetime bounds
-  --> $DIR/missing-lifetimes-in-signature-2.rs:23:5
-   |
-LL | /     foo.bar(move |_| {
-LL | |
-LL | |         t.test();
-LL | |     });
-   | |______^
 help: consider adding an explicit lifetime bound...
    |
 LL | fn func<'a, T: Test + 'a>(_dummy: &Foo, foo: &Foo<'a>, t: T) {

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
@@ -9,7 +9,7 @@ LL | |         t.test();
 LL | |     });
    | |______^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn func<'a, T: Test + 'a>(_dummy: &Foo, foo: &Foo<'a>, t: T) {
    |         +++         ++++                         ++++

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -37,7 +37,7 @@ LL | |         *dest = g.get();
 LL | |     }
    | |_____^ ...so that the type `G` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL ~ fn bar<'a, G, T>(g: G, dest: &'a mut T) -> impl FnOnce() + 'a
 LL | where
@@ -56,7 +56,7 @@ LL | |         *dest = g.get();
 LL | |     }
    | |_____^ ...so that the type `G` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn qux<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + 'b
    |        +++           ++++                  ++                           ~~
@@ -72,7 +72,7 @@ LL | |             *dest = g.get();
 LL | |         }
    | |_________^ ...so that the type `G` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn qux<'c, 'b, G: Get<T> + 'b + 'c, T>(g: G, dest: &'c mut T) -> impl FnOnce() + 'c {
    |            +++                    ++++                  ++                           ~~
@@ -90,7 +90,7 @@ LL | |         *dest = g.get();
 LL | |     }
    | |_____^ ...so that the type `G` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn bat<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + 'b + 'a
    |        +++           ++++                  ++                           ~~
@@ -120,7 +120,7 @@ LL | |         *dest = g.get();
 LL | |     }
    | |_____^ ...so that the type `G` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     G: Get<T> + 'a,
    |               ++++

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -49,7 +49,7 @@ LL | |     }
    | |_____^
 help: consider adding an explicit lifetime bound...
    |
-LL ~ fn bar<'a, G, T>(g: G, dest: &'a mut T) -> impl FnOnce() + '_
+LL ~ fn bar<'a, G, T>(g: G, dest: &'a mut T) -> impl FnOnce() + 'a
 LL | where
 LL ~     G: Get<T> + 'a,
    |
@@ -78,8 +78,8 @@ LL | |     }
    | |_____^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn qux<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + '_
-   |        +++           ++++                  ++
+LL | fn qux<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + 'b
+   |        +++           ++++                  ++                           ~~
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:61:9
@@ -105,8 +105,8 @@ LL | |         }
    | |_________^
 help: consider adding an explicit lifetime bound...
    |
-LL |     fn qux<'c, 'b, G: Get<T> + 'b + 'c, T>(g: G, dest: &'c mut T) -> impl FnOnce() + '_ {
-   |            +++                    ++++                  ++
+LL |     fn qux<'c, 'b, G: Get<T> + 'b + 'c, T>(g: G, dest: &'c mut T) -> impl FnOnce() + 'c {
+   |            +++                    ++++                  ++                           ~~
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:73:5
@@ -134,8 +134,8 @@ LL | |     }
    | |_____^
 help: consider adding an explicit lifetime bound...
    |
-LL | fn bat<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + '_ + 'a
-   |        +++           ++++                  ++
+LL | fn bat<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + 'b + 'a
+   |        +++           ++++                  ++                           ~~
 
 error[E0621]: explicit lifetime required in the type of `dest`
   --> $DIR/missing-lifetimes-in-signature.rs:73:5

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -28,25 +28,15 @@ LL | fn foo<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:30:5
    |
+LL |   fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+   |                            ------ the parameter type `G` must be valid for the anonymous lifetime defined here...
+...
 LL | /     move || {
 LL | |
 LL | |         *dest = g.get();
 LL | |     }
-   | |_____^
+   | |_____^ ...so that the type `G` will meet its required lifetime bounds
    |
-note: the parameter type `G` must be valid for the anonymous lifetime defined here...
-  --> $DIR/missing-lifetimes-in-signature.rs:26:26
-   |
-LL | fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
-   |                          ^^^^^^
-note: ...so that the type `G` will meet its required lifetime bounds
-  --> $DIR/missing-lifetimes-in-signature.rs:30:5
-   |
-LL | /     move || {
-LL | |
-LL | |         *dest = g.get();
-LL | |     }
-   | |_____^
 help: consider adding an explicit lifetime bound...
    |
 LL ~ fn bar<'a, G, T>(g: G, dest: &'a mut T) -> impl FnOnce() + 'a
@@ -57,25 +47,15 @@ LL ~     G: Get<T> + 'a,
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:52:5
    |
+LL |   fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+   |                                    ------ the parameter type `G` must be valid for the anonymous lifetime defined here...
+...
 LL | /     move || {
 LL | |
 LL | |         *dest = g.get();
 LL | |     }
-   | |_____^
+   | |_____^ ...so that the type `G` will meet its required lifetime bounds
    |
-note: the parameter type `G` must be valid for the anonymous lifetime defined here...
-  --> $DIR/missing-lifetimes-in-signature.rs:48:34
-   |
-LL | fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
-   |                                  ^^^^^^
-note: ...so that the type `G` will meet its required lifetime bounds
-  --> $DIR/missing-lifetimes-in-signature.rs:52:5
-   |
-LL | /     move || {
-LL | |
-LL | |         *dest = g.get();
-LL | |     }
-   | |_____^
 help: consider adding an explicit lifetime bound...
    |
 LL | fn qux<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + 'b
@@ -84,25 +64,14 @@ LL | fn qux<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + 'b
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:61:9
    |
+LL |       fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
+   |                                                 ------ the parameter type `G` must be valid for the anonymous lifetime defined here...
 LL | /         move || {
 LL | |
 LL | |             *dest = g.get();
 LL | |         }
-   | |_________^
+   | |_________^ ...so that the type `G` will meet its required lifetime bounds
    |
-note: the parameter type `G` must be valid for the anonymous lifetime defined here...
-  --> $DIR/missing-lifetimes-in-signature.rs:60:47
-   |
-LL |     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
-   |                                               ^^^^^^
-note: ...so that the type `G` will meet its required lifetime bounds
-  --> $DIR/missing-lifetimes-in-signature.rs:61:9
-   |
-LL | /         move || {
-LL | |
-LL | |             *dest = g.get();
-LL | |         }
-   | |_________^
 help: consider adding an explicit lifetime bound...
    |
 LL |     fn qux<'c, 'b, G: Get<T> + 'b + 'c, T>(g: G, dest: &'c mut T) -> impl FnOnce() + 'c {
@@ -111,27 +80,16 @@ LL |     fn qux<'c, 'b, G: Get<T> + 'b + 'c, T>(g: G, dest: &'c mut T) -> impl F
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:73:5
    |
+LL |   fn bat<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
+   |                                    ------ the parameter type `G` must be valid for the anonymous lifetime defined here...
+...
 LL | /     move || {
 LL | |
 LL | |
 LL | |         *dest = g.get();
 LL | |     }
-   | |_____^
+   | |_____^ ...so that the type `G` will meet its required lifetime bounds
    |
-note: the parameter type `G` must be valid for the anonymous lifetime defined here...
-  --> $DIR/missing-lifetimes-in-signature.rs:69:34
-   |
-LL | fn bat<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
-   |                                  ^^^^^^
-note: ...so that the type `G` will meet its required lifetime bounds
-  --> $DIR/missing-lifetimes-in-signature.rs:73:5
-   |
-LL | /     move || {
-LL | |
-LL | |
-LL | |         *dest = g.get();
-LL | |     }
-   | |_____^
 help: consider adding an explicit lifetime bound...
    |
 LL | fn bat<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + 'b + 'a
@@ -153,6 +111,9 @@ LL | |     }
 error[E0309]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:85:5
    |
+LL |   fn bak<'a, G, T>(g: G, dest: &'a mut T) -> impl FnOnce() + 'a
+   |          -- the parameter type `G` must be valid for the lifetime `'a` as defined here...
+...
 LL | /     move || {
 LL | |
 LL | |         *dest = g.get();

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.fixed
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.fixed
@@ -1,0 +1,47 @@
+// Make sure we suggest the bound `T: 'a` in the correct scope:
+// trait, impl or associated fn.
+// run-rustfix
+
+struct Inv<'a>(Option<*mut &'a u8>);
+
+fn check_bound<'a, A: 'a>(_: A, _: Inv<'a>) {}
+
+trait Trait1<'a>: Sized where Self: 'a {
+    fn foo(self, lt: Inv<'a>) {
+        check_bound(self, lt)
+        //~^ ERROR parameter type `Self` may not live long enough
+    }
+}
+
+trait Trait2: Sized {
+    fn foo<'a>(self, lt: Inv<'a>) where Self: 'a {
+        check_bound(self, lt)
+        //~^ ERROR parameter type `Self` may not live long enough
+    }
+}
+
+trait Trait3<T> {
+    fn foo<'a>(arg: T, lt: Inv<'a>) where T: 'a {
+        check_bound(arg, lt)
+        //~^ ERROR parameter type `T` may not live long enough
+    }
+}
+
+trait Trait4<'a> {
+    fn foo<T: 'a>(arg: T, lt: Inv<'a>) {
+        check_bound(arg, lt)
+        //~^ ERROR parameter type `T` may not live long enough
+    }
+}
+
+trait Trait5<'a> {
+    fn foo(self, _: Inv<'a>);
+}
+impl<'a, T: 'a> Trait5<'a> for T {
+    fn foo(self, lt: Inv<'a>) {
+        check_bound(self, lt);
+        //~^ ERROR parameter type `T` may not live long enough
+    }
+}
+
+fn main() {}

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.rs
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.rs
@@ -1,0 +1,47 @@
+// Make sure we suggest the bound `T: 'a` in the correct scope:
+// trait, impl or associated fn.
+// run-rustfix
+
+struct Inv<'a>(Option<*mut &'a u8>);
+
+fn check_bound<'a, A: 'a>(_: A, _: Inv<'a>) {}
+
+trait Trait1<'a>: Sized {
+    fn foo(self, lt: Inv<'a>) {
+        check_bound(self, lt)
+        //~^ ERROR parameter type `Self` may not live long enough
+    }
+}
+
+trait Trait2: Sized {
+    fn foo<'a>(self, lt: Inv<'a>) {
+        check_bound(self, lt)
+        //~^ ERROR parameter type `Self` may not live long enough
+    }
+}
+
+trait Trait3<T> {
+    fn foo<'a>(arg: T, lt: Inv<'a>) {
+        check_bound(arg, lt)
+        //~^ ERROR parameter type `T` may not live long enough
+    }
+}
+
+trait Trait4<'a> {
+    fn foo<T>(arg: T, lt: Inv<'a>) {
+        check_bound(arg, lt)
+        //~^ ERROR parameter type `T` may not live long enough
+    }
+}
+
+trait Trait5<'a> {
+    fn foo(self, _: Inv<'a>);
+}
+impl<'a, T> Trait5<'a> for T {
+    fn foo(self, lt: Inv<'a>) {
+        check_bound(self, lt);
+        //~^ ERROR parameter type `T` may not live long enough
+    }
+}
+
+fn main() {}

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.stderr
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.stderr
@@ -7,7 +7,7 @@ LL |     fn foo(self, lt: Inv<'a>) {
 LL |         check_bound(self, lt)
    |         ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `Self` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | trait Trait1<'a>: Sized where Self: 'a {
    |                         ++++++++++++++
@@ -20,7 +20,7 @@ LL |     fn foo<'a>(self, lt: Inv<'a>) {
 LL |         check_bound(self, lt)
    |         ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `Self` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn foo<'a>(self, lt: Inv<'a>) where Self: 'a {
    |                                   ++++++++++++++
@@ -33,7 +33,7 @@ LL |     fn foo<'a>(arg: T, lt: Inv<'a>) {
 LL |         check_bound(arg, lt)
    |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn foo<'a>(arg: T, lt: Inv<'a>) where T: 'a {
    |                                     +++++++++++
@@ -47,7 +47,7 @@ LL |     fn foo<T>(arg: T, lt: Inv<'a>) {
 LL |         check_bound(arg, lt)
    |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn foo<T: 'a>(arg: T, lt: Inv<'a>) {
    |             ++++
@@ -61,7 +61,7 @@ LL |     fn foo(self, lt: Inv<'a>) {
 LL |         check_bound(self, lt);
    |         ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<'a, T: 'a> Trait5<'a> for T {
    |           ++++

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.stderr
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the parameter type `Self` may not live long enough
   --> $DIR/type-param-bound-scope.rs:11:9
    |
+LL | trait Trait1<'a>: Sized {
+   |              -- the parameter type `Self` must be valid for the lifetime `'a` as defined here...
+LL |     fn foo(self, lt: Inv<'a>) {
 LL |         check_bound(self, lt)
    |         ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `Self` will meet its required lifetime bounds
    |
@@ -12,6 +15,8 @@ LL | trait Trait1<'a>: Sized where Self: 'a {
 error[E0309]: the parameter type `Self` may not live long enough
   --> $DIR/type-param-bound-scope.rs:18:9
    |
+LL |     fn foo<'a>(self, lt: Inv<'a>) {
+   |            -- the parameter type `Self` must be valid for the lifetime `'a` as defined here...
 LL |         check_bound(self, lt)
    |         ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `Self` will meet its required lifetime bounds
    |
@@ -23,6 +28,8 @@ LL |     fn foo<'a>(self, lt: Inv<'a>) where Self: 'a {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/type-param-bound-scope.rs:25:9
    |
+LL |     fn foo<'a>(arg: T, lt: Inv<'a>) {
+   |            -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |         check_bound(arg, lt)
    |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -34,6 +41,9 @@ LL |     fn foo<'a>(arg: T, lt: Inv<'a>) where T: 'a {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/type-param-bound-scope.rs:32:9
    |
+LL | trait Trait4<'a> {
+   |              -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+LL |     fn foo<T>(arg: T, lt: Inv<'a>) {
 LL |         check_bound(arg, lt)
    |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |
@@ -45,6 +55,9 @@ LL |     fn foo<T: 'a>(arg: T, lt: Inv<'a>) {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/type-param-bound-scope.rs:42:9
    |
+LL | impl<'a, T> Trait5<'a> for T {
+   |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
+LL |     fn foo(self, lt: Inv<'a>) {
 LL |         check_bound(self, lt);
    |         ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
    |

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.stderr
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.stderr
@@ -1,0 +1,58 @@
+error[E0309]: the parameter type `Self` may not live long enough
+  --> $DIR/type-param-bound-scope.rs:11:9
+   |
+LL |         check_bound(self, lt)
+   |         ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `Self` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | trait Trait1<'a>: Sized where Self: 'a {
+   |                         ++++++++++++++
+
+error[E0309]: the parameter type `Self` may not live long enough
+  --> $DIR/type-param-bound-scope.rs:18:9
+   |
+LL |         check_bound(self, lt)
+   |         ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `Self` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL |     fn foo<'a>(self, lt: Inv<'a>) where Self: 'a {
+   |                                   ++++++++++++++
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/type-param-bound-scope.rs:25:9
+   |
+LL |         check_bound(arg, lt)
+   |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL |     fn foo<'a>(arg: T, lt: Inv<'a>) where T: 'a {
+   |                                     +++++++++++
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/type-param-bound-scope.rs:32:9
+   |
+LL |         check_bound(arg, lt)
+   |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL |     fn foo<T: 'a>(arg: T, lt: Inv<'a>) {
+   |             ++++
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/type-param-bound-scope.rs:42:9
+   |
+LL |         check_bound(self, lt);
+   |         ^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | impl<'a, T: 'a> Trait5<'a> for T {
+   |           ++++
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0309`.

--- a/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.fixed
+++ b/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.fixed
@@ -1,0 +1,52 @@
+// We want to suggest a bound `T: 'a` but `'a` is elided,
+// run-rustfix
+// edition: 2018
+#![allow(dead_code)]
+
+struct Inv<'a>(Option<*mut &'a u8>);
+
+fn check_bound<'a, A: 'a>(_: A, _: Inv<'a>) {}
+
+struct Elided<'a, T = ()>(Inv<'a>, T);
+
+struct MyTy<X>(X);
+
+impl<'a, X> MyTy<Elided<'a, X>> {
+    async fn foo<A: 'a>(self, arg: A, _: &str) -> &str {
+        check_bound(arg, self.0 .0);
+        //~^ ERROR parameter type `A` may not live long enough
+        ""
+    }
+}
+
+// Make sure the new lifetime name doesn't conflict with
+// other early- or late-bound lifetimes in-scope.
+impl<'a, A> MyTy<(A, &'a ())> {
+    async fn foo2<'b>(
+        arg: A,
+        lt: Inv<'b>,
+    ) -> (
+        impl Into<&'b str> + Into<&'b str> + 'b,
+        impl Into<Option<Elided<'b>>> + 'b,
+        impl Into<Option<Elided<'b, ()>>>,
+    ) where A: 'b {
+        check_bound(arg, lt);
+        //~^ ERROR parameter type `A` may not live long enough
+        ("", None, None)
+    }
+
+    // same as above but there is a late-bound lifetime named `'b`.
+    async fn bar2<'c, 'b>(_dummy: &'a u8, arg: A, lt: Inv<'c>) where A: 'c {
+        check_bound(arg, lt);
+        //~^ ERROR parameter type `A` may not live long enough
+    }
+}
+
+impl<'a, A: 'a> MyTy<Elided<'a, A>> {
+    async fn foo3(self) {
+        check_bound(self.0 .1, self.0 .0);
+        //~^ ERROR parameter type `A` may not live long enough
+    }
+}
+
+fn main() {}

--- a/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.rs
+++ b/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.rs
@@ -1,0 +1,52 @@
+// We want to suggest a bound `T: 'a` but `'a` is elided,
+// run-rustfix
+// edition: 2018
+#![allow(dead_code)]
+
+struct Inv<'a>(Option<*mut &'a u8>);
+
+fn check_bound<'a, A: 'a>(_: A, _: Inv<'a>) {}
+
+struct Elided<'a, T = ()>(Inv<'a>, T);
+
+struct MyTy<X>(X);
+
+impl<X> MyTy<Elided<'_, X>> {
+    async fn foo<A>(self, arg: A, _: &str) -> &str {
+        check_bound(arg, self.0 .0);
+        //~^ ERROR parameter type `A` may not live long enough
+        ""
+    }
+}
+
+// Make sure the new lifetime name doesn't conflict with
+// other early- or late-bound lifetimes in-scope.
+impl<'a, A> MyTy<(A, &'a ())> {
+    async fn foo2(
+        arg: A,
+        lt: Inv<'_>,
+    ) -> (
+        impl Into<&str> + Into<&'_ str> + '_,
+        impl Into<Option<Elided>> + '_,
+        impl Into<Option<Elided<()>>>,
+    ) {
+        check_bound(arg, lt);
+        //~^ ERROR parameter type `A` may not live long enough
+        ("", None, None)
+    }
+
+    // same as above but there is a late-bound lifetime named `'b`.
+    async fn bar2<'b>(_dummy: &'a u8, arg: A, lt: Inv<'_>) {
+        check_bound(arg, lt);
+        //~^ ERROR parameter type `A` may not live long enough
+    }
+}
+
+impl<A> MyTy<Elided<'_, A>> {
+    async fn foo3(self) {
+        check_bound(self.0 .1, self.0 .0);
+        //~^ ERROR parameter type `A` may not live long enough
+    }
+}
+
+fn main() {}

--- a/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.stderr
+++ b/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.stderr
@@ -1,0 +1,95 @@
+error[E0311]: the parameter type `A` may not live long enough
+  --> $DIR/type-param-missing-lifetime.rs:16:9
+   |
+LL |         check_bound(arg, self.0 .0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the parameter type `A` must be valid for the anonymous lifetime as defined here...
+  --> $DIR/type-param-missing-lifetime.rs:14:21
+   |
+LL | impl<X> MyTy<Elided<'_, X>> {
+   |                     ^^
+note: ...so that the type `A` will meet its required lifetime bounds
+  --> $DIR/type-param-missing-lifetime.rs:16:9
+   |
+LL |         check_bound(arg, self.0 .0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound...
+   |
+LL ~ impl<'a, X> MyTy<Elided<'a, X>> {
+LL ~     async fn foo<A: 'a>(self, arg: A, _: &str) -> &str {
+   |
+
+error[E0311]: the parameter type `A` may not live long enough
+  --> $DIR/type-param-missing-lifetime.rs:33:9
+   |
+LL |         check_bound(arg, lt);
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+note: the parameter type `A` must be valid for the anonymous lifetime defined here...
+  --> $DIR/type-param-missing-lifetime.rs:27:13
+   |
+LL |         lt: Inv<'_>,
+   |             ^^^^^^^
+note: ...so that the type `A` will meet its required lifetime bounds
+  --> $DIR/type-param-missing-lifetime.rs:33:9
+   |
+LL |         check_bound(arg, lt);
+   |         ^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound...
+   |
+LL ~     async fn foo2<'b>(
+LL |         arg: A,
+LL ~         lt: Inv<'b>,
+LL |     ) -> (
+LL ~         impl Into<&'b str> + Into<&'b str> + 'b,
+LL ~         impl Into<Option<Elided<'b>>> + 'b,
+LL ~         impl Into<Option<Elided<'b, ()>>>,
+LL ~     ) where A: 'b {
+   |
+
+error[E0311]: the parameter type `A` may not live long enough
+  --> $DIR/type-param-missing-lifetime.rs:40:9
+   |
+LL |         check_bound(arg, lt);
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+note: the parameter type `A` must be valid for the anonymous lifetime defined here...
+  --> $DIR/type-param-missing-lifetime.rs:39:51
+   |
+LL |     async fn bar2<'b>(_dummy: &'a u8, arg: A, lt: Inv<'_>) {
+   |                                                   ^^^^^^^
+note: ...so that the type `A` will meet its required lifetime bounds
+  --> $DIR/type-param-missing-lifetime.rs:40:9
+   |
+LL |         check_bound(arg, lt);
+   |         ^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound...
+   |
+LL |     async fn bar2<'c, 'b>(_dummy: &'a u8, arg: A, lt: Inv<'c>) where A: 'c {
+   |                   +++                                     ~~   +++++++++++
+
+error[E0311]: the parameter type `A` may not live long enough
+  --> $DIR/type-param-missing-lifetime.rs:47:9
+   |
+LL |         check_bound(self.0 .1, self.0 .0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the parameter type `A` must be valid for the anonymous lifetime as defined here...
+  --> $DIR/type-param-missing-lifetime.rs:45:21
+   |
+LL | impl<A> MyTy<Elided<'_, A>> {
+   |                     ^^
+note: ...so that the type `A` will meet its required lifetime bounds
+  --> $DIR/type-param-missing-lifetime.rs:47:9
+   |
+LL |         check_bound(self.0 .1, self.0 .0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider adding an explicit lifetime bound...
+   |
+LL | impl<'a, A: 'a> MyTy<Elided<'a, A>> {
+   |      +++  ++++              ~~
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0311`.

--- a/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.stderr
+++ b/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.stderr
@@ -7,7 +7,7 @@ LL |     async fn foo<A>(self, arg: A, _: &str) -> &str {
 LL |         check_bound(arg, self.0 .0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL ~ impl<'a, X> MyTy<Elided<'a, X>> {
 LL ~     async fn foo<A: 'a>(self, arg: A, _: &str) -> &str {
@@ -22,7 +22,7 @@ LL |         lt: Inv<'_>,
 LL |         check_bound(arg, lt);
    |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL ~     async fn foo2<'b>(
 LL |         arg: A,
@@ -42,7 +42,7 @@ LL |     async fn bar2<'b>(_dummy: &'a u8, arg: A, lt: Inv<'_>) {
 LL |         check_bound(arg, lt);
    |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     async fn bar2<'c, 'b>(_dummy: &'a u8, arg: A, lt: Inv<'c>) where A: 'c {
    |                   +++                                     ~~   +++++++++++
@@ -56,7 +56,7 @@ LL |     async fn foo3(self) {
 LL |         check_bound(self.0 .1, self.0 .0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<'a, A: 'a> MyTy<Elided<'a, A>> {
    |      +++  ++++              ~~

--- a/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.stderr
+++ b/tests/ui/suggestions/lifetimes/type-param-missing-lifetime.stderr
@@ -1,19 +1,12 @@
 error[E0311]: the parameter type `A` may not live long enough
   --> $DIR/type-param-missing-lifetime.rs:16:9
    |
-LL |         check_bound(arg, self.0 .0);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the parameter type `A` must be valid for the anonymous lifetime as defined here...
-  --> $DIR/type-param-missing-lifetime.rs:14:21
-   |
 LL | impl<X> MyTy<Elided<'_, X>> {
-   |                     ^^
-note: ...so that the type `A` will meet its required lifetime bounds
-  --> $DIR/type-param-missing-lifetime.rs:16:9
-   |
+   |                     -- the parameter type `A` must be valid for the anonymous lifetime as defined here...
+LL |     async fn foo<A>(self, arg: A, _: &str) -> &str {
 LL |         check_bound(arg, self.0 .0);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL ~ impl<'a, X> MyTy<Elided<'a, X>> {
@@ -23,19 +16,12 @@ LL ~     async fn foo<A: 'a>(self, arg: A, _: &str) -> &str {
 error[E0311]: the parameter type `A` may not live long enough
   --> $DIR/type-param-missing-lifetime.rs:33:9
    |
-LL |         check_bound(arg, lt);
-   |         ^^^^^^^^^^^^^^^^^^^^
-   |
-note: the parameter type `A` must be valid for the anonymous lifetime defined here...
-  --> $DIR/type-param-missing-lifetime.rs:27:13
-   |
 LL |         lt: Inv<'_>,
-   |             ^^^^^^^
-note: ...so that the type `A` will meet its required lifetime bounds
-  --> $DIR/type-param-missing-lifetime.rs:33:9
-   |
+   |             ------- the parameter type `A` must be valid for the anonymous lifetime defined here...
+...
 LL |         check_bound(arg, lt);
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL ~     async fn foo2<'b>(
@@ -51,19 +37,11 @@ LL ~     ) where A: 'b {
 error[E0311]: the parameter type `A` may not live long enough
   --> $DIR/type-param-missing-lifetime.rs:40:9
    |
-LL |         check_bound(arg, lt);
-   |         ^^^^^^^^^^^^^^^^^^^^
-   |
-note: the parameter type `A` must be valid for the anonymous lifetime defined here...
-  --> $DIR/type-param-missing-lifetime.rs:39:51
-   |
 LL |     async fn bar2<'b>(_dummy: &'a u8, arg: A, lt: Inv<'_>) {
-   |                                                   ^^^^^^^
-note: ...so that the type `A` will meet its required lifetime bounds
-  --> $DIR/type-param-missing-lifetime.rs:40:9
-   |
+   |                                                   ------- the parameter type `A` must be valid for the anonymous lifetime defined here...
 LL |         check_bound(arg, lt);
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL |     async fn bar2<'c, 'b>(_dummy: &'a u8, arg: A, lt: Inv<'c>) where A: 'c {
@@ -72,19 +50,12 @@ LL |     async fn bar2<'c, 'b>(_dummy: &'a u8, arg: A, lt: Inv<'c>) where A: 'c 
 error[E0311]: the parameter type `A` may not live long enough
   --> $DIR/type-param-missing-lifetime.rs:47:9
    |
-LL |         check_bound(self.0 .1, self.0 .0);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the parameter type `A` must be valid for the anonymous lifetime as defined here...
-  --> $DIR/type-param-missing-lifetime.rs:45:21
-   |
 LL | impl<A> MyTy<Elided<'_, A>> {
-   |                     ^^
-note: ...so that the type `A` will meet its required lifetime bounds
-  --> $DIR/type-param-missing-lifetime.rs:47:9
-   |
+   |                     -- the parameter type `A` must be valid for the anonymous lifetime as defined here...
+LL |     async fn foo3(self) {
 LL |         check_bound(self.0 .1, self.0 .0);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
+   |
 help: consider adding an explicit lifetime bound...
    |
 LL | impl<'a, A: 'a> MyTy<Elided<'a, A>> {

--- a/tests/ui/suggestions/suggest-impl-trait-lifetime.fixed
+++ b/tests/ui/suggestions/suggest-impl-trait-lifetime.fixed
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 
 fn foo(d: impl Debug + 'static) {
-//~^ HELP consider adding an explicit lifetime bound...
+//~^ HELP consider adding an explicit lifetime bound
     bar(d);
 //~^ ERROR the parameter type `impl Debug` may not live long enough
 //~| NOTE the parameter type `impl Debug` must be valid for the static lifetime...

--- a/tests/ui/suggestions/suggest-impl-trait-lifetime.fixed
+++ b/tests/ui/suggestions/suggest-impl-trait-lifetime.fixed
@@ -6,6 +6,7 @@ fn foo(d: impl Debug + 'static) {
 //~^ HELP consider adding an explicit lifetime bound...
     bar(d);
 //~^ ERROR the parameter type `impl Debug` may not live long enough
+//~| NOTE the parameter type `impl Debug` must be valid for the static lifetime...
 //~| NOTE ...so that the type `impl Debug` will meet its required lifetime bounds
 }
 

--- a/tests/ui/suggestions/suggest-impl-trait-lifetime.rs
+++ b/tests/ui/suggestions/suggest-impl-trait-lifetime.rs
@@ -6,6 +6,7 @@ fn foo(d: impl Debug) {
 //~^ HELP consider adding an explicit lifetime bound...
     bar(d);
 //~^ ERROR the parameter type `impl Debug` may not live long enough
+//~| NOTE the parameter type `impl Debug` must be valid for the static lifetime...
 //~| NOTE ...so that the type `impl Debug` will meet its required lifetime bounds
 }
 

--- a/tests/ui/suggestions/suggest-impl-trait-lifetime.rs
+++ b/tests/ui/suggestions/suggest-impl-trait-lifetime.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 
 fn foo(d: impl Debug) {
-//~^ HELP consider adding an explicit lifetime bound...
+//~^ HELP consider adding an explicit lifetime bound
     bar(d);
 //~^ ERROR the parameter type `impl Debug` may not live long enough
 //~| NOTE the parameter type `impl Debug` must be valid for the static lifetime...

--- a/tests/ui/suggestions/suggest-impl-trait-lifetime.stderr
+++ b/tests/ui/suggestions/suggest-impl-trait-lifetime.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `impl Debug` may not live long enough
   --> $DIR/suggest-impl-trait-lifetime.rs:7:5
    |
 LL |     bar(d);
-   |     ^^^^^^ ...so that the type `impl Debug` will meet its required lifetime bounds
+   |     ^^^^^^
+   |     |
+   |     the parameter type `impl Debug` must be valid for the static lifetime...
+   |     ...so that the type `impl Debug` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/suggestions/suggest-impl-trait-lifetime.stderr
+++ b/tests/ui/suggestions/suggest-impl-trait-lifetime.stderr
@@ -7,7 +7,7 @@ LL |     bar(d);
    |     the parameter type `impl Debug` must be valid for the static lifetime...
    |     ...so that the type `impl Debug` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | fn foo(d: impl Debug + 'static) {
    |                      +++++++++

--- a/tests/ui/type-alias-impl-trait/closure_wf_outlives.stderr
+++ b/tests/ui/type-alias-impl-trait/closure_wf_outlives.stderr
@@ -46,7 +46,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/closure_wf_outlives.rs:54:22
    |
 LL |     type Opaque<T> = impl Sized;
-   |                      ^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
+   |                      ^^^^^^^^^^
+   |                      |
+   |                      the parameter type `T` must be valid for the static lifetime...
+   |                      ...so that the type `T` will meet its required lifetime bounds...
    |
 note: ...that is required by this bound
   --> $DIR/closure_wf_outlives.rs:59:12

--- a/tests/ui/type-alias-impl-trait/closure_wf_outlives.stderr
+++ b/tests/ui/type-alias-impl-trait/closure_wf_outlives.stderr
@@ -56,7 +56,7 @@ note: ...that is required by this bound
    |
 LL |         T: 'static,
    |            ^^^^^^^
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     type Opaque<T: 'static> = impl Sized;
    |                  +++++++++

--- a/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.stderr
@@ -17,7 +17,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/generic_type_does_not_live_long_enough.rs:13:9
    |
 LL |         t
-   |         ^ ...so that the type `T` will meet its required lifetime bounds
+   |         ^
+   |         |
+   |         the parameter type `T` must be valid for the static lifetime...
+   |         ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.stderr
@@ -22,7 +22,7 @@ LL |         t
    |         the parameter type `T` must be valid for the static lifetime...
    |         ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn wrong_generic<T: 'static>(t: T) -> WrongGeneric<T> {
    |                       +++++++++

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check3.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check3.stderr
@@ -27,7 +27,7 @@ LL |     fn test<A>() where Ty<A>: 'static { assert_static::<A>() }
    |                                         the parameter type `A` must be valid for the static lifetime...
    |                                         ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn test<A: 'static>() where Ty<A>: 'static { assert_static::<A>() }
    |              +++++++++

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check3.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check3.stderr
@@ -22,7 +22,10 @@ error[E0310]: the parameter type `A` may not live long enough
   --> $DIR/implied_lifetime_wf_check3.rs:29:41
    |
 LL |     fn test<A>() where Ty<A>: 'static { assert_static::<A>() }
-   |                                         ^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
+   |                                         ^^^^^^^^^^^^^^^^^^
+   |                                         |
+   |                                         the parameter type `A` must be valid for the static lifetime...
+   |                                         ...so that the type `A` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `A` may not live long enough
   --> $DIR/implied_lifetime_wf_check4_static.rs:4:18
    |
 LL |     type Ty<A> = impl Sized + 'static;
-   |                  ^^^^^^^^^^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
+   |                  ^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  the parameter type `A` must be valid for the static lifetime...
+   |                  ...so that the type `A` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
@@ -7,7 +7,7 @@ LL |     type Ty<A> = impl Sized + 'static;
    |                  the parameter type `A` must be valid for the static lifetime...
    |                  ...so that the type `A` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     type Ty<A: 'static> = impl Sized + 'static;
    |              +++++++++

--- a/tests/ui/type-alias-impl-trait/wf-in-associated-type.fail.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-in-associated-type.fail.stderr
@@ -6,7 +6,7 @@ LL |     impl<'a, T> Trait<'a, T> for () {
 LL |         type Opaque = impl Sized + 'a;
    |                       ^^^^^^^^^^^^^^^ ...so that the type `&'a T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     impl<'a, T: 'a> Trait<'a, T> for () {
    |               ++++
@@ -19,7 +19,7 @@ LL |     impl<'a, T> Trait<'a, T> for () {
 LL |         type Opaque = impl Sized + 'a;
    |                       ^^^^^^^^^^^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     impl<'a, T: 'a> Trait<'a, T> for () {
    |               ++++

--- a/tests/ui/type-alias-impl-trait/wf-in-associated-type.fail.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-in-associated-type.fail.stderr
@@ -1,6 +1,8 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/wf-in-associated-type.rs:36:23
    |
+LL |     impl<'a, T> Trait<'a, T> for () {
+   |          -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |         type Opaque = impl Sized + 'a;
    |                       ^^^^^^^^^^^^^^^ ...so that the type `&'a T` will meet its required lifetime bounds
    |
@@ -12,6 +14,8 @@ LL |     impl<'a, T: 'a> Trait<'a, T> for () {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/wf-in-associated-type.rs:36:23
    |
+LL |     impl<'a, T> Trait<'a, T> for () {
+   |          -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |         type Opaque = impl Sized + 'a;
    |                       ^^^^^^^^^^^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
    |

--- a/tests/ui/type-alias-impl-trait/wf-nested.fail.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-nested.fail.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/wf-nested.rs:55:27
    |
 LL |     type InnerOpaque<T> = impl Sized;
-   |                           ^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
+   |                           ^^^^^^^^^^
+   |                           |
+   |                           the parameter type `T` must be valid for the static lifetime...
+   |                           ...so that the type `T` will meet its required lifetime bounds...
    |
 note: ...that is required by this bound
   --> $DIR/wf-nested.rs:12:20

--- a/tests/ui/type-alias-impl-trait/wf-nested.fail.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-nested.fail.stderr
@@ -12,7 +12,7 @@ note: ...that is required by this bound
    |
 LL | struct IsStatic<T: 'static>(T);
    |                    ^^^^^^^
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     type InnerOpaque<T: 'static> = impl Sized;
    |                       +++++++++

--- a/tests/ui/type-alias-impl-trait/wf-nested.pass_sound.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-nested.pass_sound.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/wf-nested.rs:46:17
    |
 LL |         let _ = outer.get();
-   |                 ^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |                 ^^^^^^^^^^^
+   |                 |
+   |                 the parameter type `T` must be valid for the static lifetime...
+   |                 ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/type-alias-impl-trait/wf-nested.pass_sound.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-nested.pass_sound.stderr
@@ -7,7 +7,7 @@ LL |         let _ = outer.get();
    |                 the parameter type `T` must be valid for the static lifetime...
    |                 ...so that the type `T` will meet its required lifetime bounds
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     fn test<T: 'static>() {
    |              +++++++++

--- a/tests/ui/wf/wf-impl-associated-type-region.stderr
+++ b/tests/ui/wf/wf-impl-associated-type-region.stderr
@@ -1,6 +1,8 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/wf-impl-associated-type-region.rs:10:16
    |
+LL | impl<'a, T> Foo<'a> for T {
+   |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Bar = &'a T;
    |                ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
    |

--- a/tests/ui/wf/wf-impl-associated-type-region.stderr
+++ b/tests/ui/wf/wf-impl-associated-type-region.stderr
@@ -6,7 +6,7 @@ LL | impl<'a, T> Foo<'a> for T {
 LL |     type Bar = &'a T;
    |                ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<'a, T: 'a> Foo<'a> for T {
    |           ++++

--- a/tests/ui/wf/wf-in-fn-type-static.stderr
+++ b/tests/ui/wf/wf-in-fn-type-static.stderr
@@ -7,7 +7,7 @@ LL |     x: fn() -> &'static T
    |        the parameter type `T` must be valid for the static lifetime...
    |        ...so that the reference type `&'static T` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | struct Foo<T: 'static> {
    |             +++++++++
@@ -21,7 +21,7 @@ LL |     x: fn(&'static T)
    |        the parameter type `T` must be valid for the static lifetime...
    |        ...so that the reference type `&'static T` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | struct Bar<T: 'static> {
    |             +++++++++

--- a/tests/ui/wf/wf-in-fn-type-static.stderr
+++ b/tests/ui/wf/wf-in-fn-type-static.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/wf-in-fn-type-static.rs:13:8
    |
 LL |     x: fn() -> &'static T
-   |        ^^^^^^^^^^^^^^^^^^ ...so that the reference type `&'static T` does not outlive the data it points at
+   |        ^^^^^^^^^^^^^^^^^^
+   |        |
+   |        the parameter type `T` must be valid for the static lifetime...
+   |        ...so that the reference type `&'static T` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound...
    |
@@ -13,7 +16,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/wf-in-fn-type-static.rs:18:8
    |
 LL |     x: fn(&'static T)
-   |        ^^^^^^^^^^^^^^ ...so that the reference type `&'static T` does not outlive the data it points at
+   |        ^^^^^^^^^^^^^^
+   |        |
+   |        the parameter type `T` must be valid for the static lifetime...
+   |        ...so that the reference type `&'static T` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/wf/wf-in-obj-type-static.stderr
+++ b/tests/ui/wf/wf-in-obj-type-static.stderr
@@ -7,7 +7,7 @@ LL |     x: dyn Object<&'static T>
    |        the parameter type `T` must be valid for the static lifetime...
    |        ...so that the reference type `&'static T` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | struct Foo<T: 'static> {
    |             +++++++++

--- a/tests/ui/wf/wf-in-obj-type-static.stderr
+++ b/tests/ui/wf/wf-in-obj-type-static.stderr
@@ -2,7 +2,10 @@ error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/wf-in-obj-type-static.rs:14:8
    |
 LL |     x: dyn Object<&'static T>
-   |        ^^^^^^^^^^^^^^^^^^^^^^ ...so that the reference type `&'static T` does not outlive the data it points at
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+   |        |
+   |        the parameter type `T` must be valid for the static lifetime...
+   |        ...so that the reference type `&'static T` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound...
    |

--- a/tests/ui/wf/wf-outlives-ty-in-fn-or-trait.stderr
+++ b/tests/ui/wf/wf-outlives-ty-in-fn-or-trait.stderr
@@ -1,6 +1,8 @@
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/wf-outlives-ty-in-fn-or-trait.rs:9:16
    |
+LL | impl<'a, T> Trait<'a, T> for usize {
+   |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Out = &'a fn(T);
    |                ^^^^^^^^^ ...so that the reference type `&'a fn(T)` does not outlive the data it points at
    |
@@ -12,6 +14,8 @@ LL | impl<'a, T: 'a> Trait<'a, T> for usize {
 error[E0309]: the parameter type `T` may not live long enough
   --> $DIR/wf-outlives-ty-in-fn-or-trait.rs:19:16
    |
+LL | impl<'a, T> Trait<'a, T> for u32 {
+   |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Out = &'a dyn Baz<T>;
    |                ^^^^^^^^^^^^^^ ...so that the reference type `&'a (dyn Baz<T> + 'a)` does not outlive the data it points at
    |

--- a/tests/ui/wf/wf-outlives-ty-in-fn-or-trait.stderr
+++ b/tests/ui/wf/wf-outlives-ty-in-fn-or-trait.stderr
@@ -6,7 +6,7 @@ LL | impl<'a, T> Trait<'a, T> for usize {
 LL |     type Out = &'a fn(T);
    |                ^^^^^^^^^ ...so that the reference type `&'a fn(T)` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<'a, T: 'a> Trait<'a, T> for usize {
    |           ++++
@@ -19,7 +19,7 @@ LL | impl<'a, T> Trait<'a, T> for u32 {
 LL |     type Out = &'a dyn Baz<T>;
    |                ^^^^^^^^^^^^^^ ...so that the reference type `&'a (dyn Baz<T> + 'a)` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL | impl<'a, T: 'a> Trait<'a, T> for u32 {
    |           ++++

--- a/tests/ui/wf/wf-trait-associated-type-region.stderr
+++ b/tests/ui/wf/wf-trait-associated-type-region.stderr
@@ -7,7 +7,7 @@ LL |     type Type1;
 LL |     type Type2 = &'a Self::Type1;
    |                  ^^^^^^^^^^^^^^^ ...so that the reference type `&'a <Self as SomeTrait<'a>>::Type1` does not outlive the data it points at
    |
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 LL |     type Type2 = &'a Self::Type1 where <Self as SomeTrait<'a>>::Type1: 'a;
    |                                  ++++++++++++++++++++++++++++++++++++++++

--- a/tests/ui/wf/wf-trait-associated-type-region.stderr
+++ b/tests/ui/wf/wf-trait-associated-type-region.stderr
@@ -1,6 +1,9 @@
 error[E0309]: the associated type `<Self as SomeTrait<'a>>::Type1` may not live long enough
   --> $DIR/wf-trait-associated-type-region.rs:9:18
    |
+LL | trait SomeTrait<'a> {
+   |                 -- the associated type `<Self as SomeTrait<'a>>::Type1` must be valid for the lifetime `'a` as defined here...
+LL |     type Type1;
 LL |     type Type2 = &'a Self::Type1;
    |                  ^^^^^^^^^^^^^^^ ...so that the reference type `&'a <Self as SomeTrait<'a>>::Type1` does not outlive the data it points at
    |

--- a/tests/ui/wf/wf-trait-associated-type-region.stderr
+++ b/tests/ui/wf/wf-trait-associated-type-region.stderr
@@ -2,10 +2,12 @@ error[E0309]: the associated type `<Self as SomeTrait<'a>>::Type1` may not live 
   --> $DIR/wf-trait-associated-type-region.rs:9:18
    |
 LL |     type Type2 = &'a Self::Type1;
-   |                  ^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^^^^ ...so that the reference type `&'a <Self as SomeTrait<'a>>::Type1` does not outlive the data it points at
    |
-   = help: consider adding an explicit lifetime bound `<Self as SomeTrait<'a>>::Type1: 'a`...
-   = note: ...so that the reference type `&'a <Self as SomeTrait<'a>>::Type1` does not outlive the data it points at
+help: consider adding an explicit lifetime bound...
+   |
+LL |     type Type2 = &'a Self::Type1 where <Self as SomeTrait<'a>>::Type1: 'a;
+   |                                  ++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #115882 (improve the suggestion of `generic_bound_failure`)
 - #116264 (add test for wasm linker override=clang)
 - #116527 (Bump libc dependency)
 - #116532 (Add RUSTFLAGS_BOOTSTRAP to RUSTFLAGS for bootstrap compilation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115882,116264,116527,116532)
<!-- homu-ignore:end -->