### PR TITLE
Hint optimizer about reserved capacity

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -292,6 +292,11 @@ impl<T, A: Allocator> RawVec<T, A> {
         if self.needs_to_grow(len, additional) {
             do_reserve_and_handle(self, len, additional);
         }
+
+        unsafe {
+            // Inform the optimizer that the reservation has succeeded or wasn't needed
+            core::intrinsics::assume(!self.needs_to_grow(len, additional));
+        }
     }
 
     /// A specialized version of `reserve()` used only by the hot and

--- a/tests/ui/hygiene/panic-location.run.stderr
+++ b/tests/ui/hygiene/panic-location.run.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at library/alloc/src/raw_vec.rs:545:5:
+thread 'main' panicked at library/alloc/src/raw_vec.rs:550:5:
 capacity overflow
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
The fact that `Vec` had capacity increased is not known to the optimizer, because functions like `do_reserve_and_handle` are not inlined. (#82801) Because of that, code such as:

```rust
vec.try_reserve(123)?;
vec.extend_from_slice(&s[..123]);
```

Tries to reserve the capacity **twice**. This is unnecessary code bloat.

https://rust.godbolt.org/z/YWY16Ezej

Adding a hint after reserve optimizes out the next check of `self.needs_to_grow(len, additional)`.
