### PR TITLE
diagnostic: properly deal with hygienic names on unresolved fields and imports

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2510,16 +2510,26 @@ impl<'tcx> TyCtxt<'tcx> {
     // FIXME(vincenzopalazzo): move the HirId to a LocalDefId
     pub fn adjust_ident_and_get_scope(
         self,
-        mut ident: Ident,
+        ident: Ident,
         scope: DefId,
         block: hir::HirId,
     ) -> (Ident, DefId) {
-        let scope = ident
-            .span
+        let (span, scope) = self.adjust_span_and_get_scope(ident.span, scope, block);
+        (Ident { span, ..ident }, scope)
+    }
+
+    // FIXME(vincenzopalazzo): move the HirId to a LocalDefId
+    pub fn adjust_span_and_get_scope(
+        self,
+        mut span: Span,
+        scope: DefId,
+        block: hir::HirId,
+    ) -> (Span, DefId) {
+        let scope = span
             .normalize_to_macros_2_0_and_adjust(self.expn_that_defined(scope))
             .and_then(|actual_expansion| actual_expansion.expn_data().parent_module)
             .unwrap_or_else(|| self.parent_module(block).to_def_id());
-        (ident, scope)
+        (span, scope)
     }
 
     /// Returns `true` if the debuginfo for `span` should be collapsed to the outermost expansion

--- a/tests/ui/did_you_mean/dont-suggest-hygienic-fields.rs
+++ b/tests/ui/did_you_mean/dont-suggest-hygienic-fields.rs
@@ -4,6 +4,11 @@
 
 #![feature(decl_macro)]
 
+//
+// Test cases where we should *not* suggest hygienic fields since
+// they are inaccessible in the respective syntax context:
+//
+
 macro compound($Ty:ident) {
     #[derive(Default)]
     struct $Ty {
@@ -17,6 +22,24 @@ macro component($Ty:ident) {
 
 compound! { Compound }
 component! { Component }
+
+macro inject_into_expr_bad($field:ident) {{
+    struct Casket {
+        field: (),
+    }
+
+    const CASKET: Casket = Casket { field: () };
+
+    CASKET.$field
+}}
+
+macro inject_into_pat_bad($( $any:tt )*) {{
+    struct Casket { field: () }
+
+    const CASKET: Casket = Casket { field: () };
+
+    let Casket { $( $any )* } = CASKET; //~ ERROR pattern does not mention field `field`
+}}
 
 fn main() {
     let ty = Compound::default();
@@ -32,9 +55,20 @@ fn main() {
     let ty = Component(90);
 
     let _ = ty.0; //~ ERROR no field `0` on type `Component`
+
+    let _ = inject_into_expr_bad!(field); //~ ERROR no field `field` on type `main::Casket`
+
+    inject_into_pat_bad!(field: _); //~ ERROR struct `main::Casket` does not have a field named `field`
 }
 
+//
+// Test cases where we *should* suggest hygienic fields since
+// they're accessible in the respective syntax context:
+//
+
 environment!();
+
+struct Case { field: () }
 
 macro environment() {
     struct Crate { field: () }
@@ -43,5 +77,29 @@ macro environment() {
     // precisely because they come from the same syntax context.
     const CRATE: Crate = Crate { fiel: () };
     //~^ ERROR struct `Crate` has no field named `fiel`
+    //~| HELP a field with a similar name exists
+
+    // `field` isn't in the same syntax context but in a parent one
+    // which means it's accessible and should be suggested.
+    const CASE: Case = Case { fiel: () };
+    //~^ ERROR struct `Case` has no field named `fiel`
+    //~| HELP a field with a similar name exists
+}
+
+macro inject_into_expr_good($field_def_site:ident, $field_use_site:ident) {{
+    struct Carton {
+        $field_def_site: (),
+    }
+
+    const CARTON: Carton = Carton { $field_def_site: () };
+
+    CARTON.$field_use_site
+}}
+
+fn scope() {
+    // It's immaterial that `CARTON` / the field expression as a whole isn't accessible in this
+    // syntax context, the identifier substituted for `$field_use_site` *is*.
+    let _ = inject_into_expr_good!(field, fiel);
+    //~^ ERROR no field `fiel` on type `Carton`
     //~| HELP a field with a similar name exists
 }

--- a/tests/ui/did_you_mean/dont-suggest-hygienic-fields.stderr
+++ b/tests/ui/did_you_mean/dont-suggest-hygienic-fields.stderr
@@ -1,5 +1,5 @@
 error[E0560]: struct `Crate` has no field named `fiel`
-  --> $DIR/dont-suggest-hygienic-fields.rs:44:34
+  --> $DIR/dont-suggest-hygienic-fields.rs:78:34
    |
 LL | environment!();
    | -------------- in this macro invocation
@@ -9,26 +9,37 @@ LL |     const CRATE: Crate = Crate { fiel: () };
    |
    = note: this error originates in the macro `environment` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0560]: struct `Case` has no field named `fiel`
+  --> $DIR/dont-suggest-hygienic-fields.rs:84:31
+   |
+LL | environment!();
+   | -------------- in this macro invocation
+...
+LL |     const CASE: Case = Case { fiel: () };
+   |                               ^^^^ help: a field with a similar name exists: `field`
+   |
+   = note: this error originates in the macro `environment` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0609]: no field `field` on type `Compound`
-  --> $DIR/dont-suggest-hygienic-fields.rs:24:16
+  --> $DIR/dont-suggest-hygienic-fields.rs:47:16
    |
 LL |     let _ = ty.field;
    |                ^^^^^ unknown field
 
 error[E0609]: no field `fieeld` on type `Compound`
-  --> $DIR/dont-suggest-hygienic-fields.rs:25:16
+  --> $DIR/dont-suggest-hygienic-fields.rs:48:16
    |
 LL |     let _ = ty.fieeld;
    |                ^^^^^^ unknown field
 
 error[E0026]: struct `Compound` does not have a field named `field`
-  --> $DIR/dont-suggest-hygienic-fields.rs:27:20
+  --> $DIR/dont-suggest-hygienic-fields.rs:50:20
    |
 LL |     let Compound { field } = ty;
    |                    ^^^^^ struct `Compound` does not have this field
 
 error: pattern requires `..` due to inaccessible fields
-  --> $DIR/dont-suggest-hygienic-fields.rs:27:9
+  --> $DIR/dont-suggest-hygienic-fields.rs:50:9
    |
 LL |     let Compound { field } = ty;
    |         ^^^^^^^^^^^^^^^^^^
@@ -39,12 +50,41 @@ LL |     let Compound { field, .. } = ty;
    |                         ++++
 
 error[E0609]: no field `0` on type `Component`
-  --> $DIR/dont-suggest-hygienic-fields.rs:34:16
+  --> $DIR/dont-suggest-hygienic-fields.rs:57:16
    |
 LL |     let _ = ty.0;
    |                ^ unknown field
 
-error: aborting due to 6 previous errors
+error[E0609]: no field `field` on type `main::Casket`
+  --> $DIR/dont-suggest-hygienic-fields.rs:59:35
+   |
+LL |     let _ = inject_into_expr_bad!(field);
+   |                                   ^^^^^ unknown field
 
-Some errors have detailed explanations: E0026, E0560, E0609.
+error[E0026]: struct `main::Casket` does not have a field named `field`
+  --> $DIR/dont-suggest-hygienic-fields.rs:61:26
+   |
+LL |     inject_into_pat_bad!(field: _);
+   |                          ^^^^^ struct `main::Casket` does not have this field
+
+error[E0027]: pattern does not mention field `field`
+  --> $DIR/dont-suggest-hygienic-fields.rs:41:9
+   |
+LL |     let Casket { $( $any )* } = CASKET;
+   |         ^^^^^^^^^^^^^^^^^^^^^ missing field `field`
+...
+LL |     inject_into_pat_bad!(field: _);
+   |     ------------------------------ in this macro invocation
+   |
+   = note: this error originates in the macro `inject_into_pat_bad` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `fiel` on type `Carton`
+  --> $DIR/dont-suggest-hygienic-fields.rs:102:43
+   |
+LL |     let _ = inject_into_expr_good!(field, fiel);
+   |                                           ^^^^ help: a field with a similar name exists: `field`
+
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0026, E0027, E0560, E0609.
 For more information about an error, try `rustc --explain E0026`.

--- a/tests/ui/did_you_mean/unresolved-imports-dont-suggest-hygienic-names.rs
+++ b/tests/ui/did_you_mean/unresolved-imports-dont-suggest-hygienic-names.rs
@@ -1,0 +1,27 @@
+// On unresolved imports, do not suggest hygienic names from different syntax contexts.
+#![feature(decl_macro)]
+
+mod module {
+    macro make() {
+        pub struct Struct;
+    }
+
+    make!();
+}
+
+// Do not suggest `Struct` since isn't accessible in this syntax context.
+use module::Strukt; //~ ERROR unresolved import `module::Strukt`
+
+pub struct Type;
+
+environment!();
+
+macro environment() {
+    // Just making sure that the implementation has correctly adjusted the
+    // spans to the right expansion and keeps suggesting `Type` here.
+    use crate::Typ;
+    //~^ ERROR unresolved import `crate::Typ`
+    //~| HELP a similar name exists in the module
+}
+
+fn main() {}

--- a/tests/ui/did_you_mean/unresolved-imports-dont-suggest-hygienic-names.stderr
+++ b/tests/ui/did_you_mean/unresolved-imports-dont-suggest-hygienic-names.stderr
@@ -1,0 +1,23 @@
+error[E0432]: unresolved import `module::Strukt`
+  --> $DIR/unresolved-imports-dont-suggest-hygienic-names.rs:13:5
+   |
+LL | use module::Strukt;
+   |     ^^^^^^^^^^^^^^ no `Strukt` in `module`
+
+error[E0432]: unresolved import `crate::Typ`
+  --> $DIR/unresolved-imports-dont-suggest-hygienic-names.rs:22:9
+   |
+LL | environment!();
+   | -------------- in this macro invocation
+...
+LL |     use crate::Typ;
+   |         ^^^^^^^---
+   |         |      |
+   |         |      help: a similar name exists in the module: `Type`
+   |         no `Typ` in the root
+   |
+   = note: this error originates in the macro `environment` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/did_you_mean/unresolved-imports-dont-suggest-unresolved-names.rs
+++ b/tests/ui/did_you_mean/unresolved-imports-dont-suggest-unresolved-names.rs
@@ -1,3 +1,5 @@
+// Regression test for issue #38054.
+
 use Foo; //~ ERROR unresolved
 
 use Foo1; //~ ERROR unresolved

--- a/tests/ui/did_you_mean/unresolved-imports-dont-suggest-unresolved-names.stderr
+++ b/tests/ui/did_you_mean/unresolved-imports-dont-suggest-unresolved-names.stderr
@@ -1,11 +1,11 @@
 error[E0432]: unresolved import `Foo`
-  --> $DIR/issue-38054-do-not-show-unresolved-names.rs:1:5
+  --> $DIR/unresolved-imports-dont-suggest-unresolved-names.rs:3:5
    |
 LL | use Foo;
    |     ^^^ no `Foo` in the root
 
 error[E0432]: unresolved import `Foo1`
-  --> $DIR/issue-38054-do-not-show-unresolved-names.rs:3:5
+  --> $DIR/unresolved-imports-dont-suggest-unresolved-names.rs:5:5
    |
 LL | use Foo1;
    |     ^^^^ no `Foo1` in the root


### PR DESCRIPTION
Follow-up to #116429:

* Previously I didn't *adjust* the usage-site span of struct fields to the expansion of the def-site before comparing syntax contexts which lead to us not suggesting names from “parent” syntax contexts (see the test case involving the top-level struct `Case` and the macro `environment`)
* I used to use the span of the entire field expression `e.f` / struct pattern `S { f }` when comparing  syntax contexts which wasn't correct since their constituent parts may come from different expansions, consider `$e.f` vs `e.$f` or `S { $f, $g }` with expn(`$f`) ≠ expn(`$g`). Now I use the most precise span where possible
* 2nd commit: On unresolved imports, don't suggest similarly named hygienic names from different syntax contexts

r? @compiler-errors (feel free to reassign if you're short on time)