### PR TITLE
const-eval: allow calling functions with targat features disabled at compile time in WASM

### DIFF
--- a/src/tools/miri/ci.sh
+++ b/src/tools/miri/ci.sh
@@ -110,8 +110,8 @@ case $HOST_TARGET in
     MIRI_TEST_TARGET=i686-pc-windows-gnu run_tests
     MIRI_TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal hello integer vec panic/panic concurrency/simple atomic data_race env/var
     MIRI_TEST_TARGET=aarch64-linux-android run_tests_minimal hello integer vec panic/panic
-    MIRI_TEST_TARGET=wasm32-wasi run_tests_minimal no_std integer strings
-    MIRI_TEST_TARGET=wasm32-unknown-unknown run_tests_minimal no_std integer strings
+    MIRI_TEST_TARGET=wasm32-wasi run_tests_minimal no_std integer strings wasm
+    MIRI_TEST_TARGET=wasm32-unknown-unknown run_tests_minimal no_std integer strings wasm
     MIRI_TEST_TARGET=thumbv7em-none-eabihf run_tests_minimal no_std # no_std embedded architecture
     MIRI_TEST_TARGET=tests/avr.json MIRI_NO_STD=1 run_tests_minimal no_std # JSON target file
     ;;

--- a/src/tools/miri/tests/pass/function_calls/target_feature_wasm.rs
+++ b/src/tools/miri/tests/pass/function_calls/target_feature_wasm.rs
@@ -1,0 +1,11 @@
+//@only-target-wasm32: tests WASM-specific behavior
+//@compile-flags: -C target-feature=-simd128
+
+fn main() {
+    // Calling functions with `#[target_feature]` is not unsound on WASM, see #84988
+    assert!(!cfg!(target_feature = "simd128"));
+    simd128_fn();
+}
+
+#[target_feature(enable = "simd128")]
+fn simd128_fn() {}

--- a/tests/ui/consts/const-eval/const_fn_target_feature_wasm.rs
+++ b/tests/ui/consts/const-eval/const_fn_target_feature_wasm.rs
@@ -1,0 +1,14 @@
+// only-wasm32
+// compile-flags:-C target-feature=-simd128
+// build-pass
+
+#![crate_type = "lib"]
+
+#[cfg(target_feature = "simd128")]
+compile_error!("simd128 target feature should be disabled");
+
+// Calling functions with `#[target_feature]` is not unsound on WASM, see #84988
+const A: () = simd128_fn();
+
+#[target_feature(enable = "simd128")]
+const fn simd128_fn() {}


### PR DESCRIPTION
This is not unsafe on WASM, see https://github.com/rust-lang/rust/pull/84988

r? @RalfJung 

Fixes https://github.com/rust-lang/rust/issues/116516