### PR TITLE
add `SAFETY` block on the usage of unsafe `getuid`

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -368,6 +368,10 @@ impl Build {
         // https://github.com/rust-lang/rust/blob/a8a33cf27166d3eabaffc58ed3799e054af3b0c6/src/bootstrap/bootstrap.py#L796-L797
         let is_sudo = match env::var_os("SUDO_USER") {
             Some(_sudo_user) => {
+                // SAFETY: getuid() system call is always successful and no return value is reserved
+                // to indicate an error.
+                //
+                // For more context, see https://man7.org/linux/man-pages/man2/geteuid.2.html
                 let uid = unsafe { libc::getuid() };
                 uid == 0
             }


### PR DESCRIPTION
We pointed out this unsafe usage in #109859, and as a result, we received a fix PR #116476. However, it's important to note that the `libc::getuid()` never actually fails. This PR aims to clarify its safety.