### PR TITLE
Only add non local items to `RustdocEffectiveVisibilities::extern_public`

### DIFF
--- a/src/librustdoc/visit_lib.rs
+++ b/src/librustdoc/visit_lib.rs
@@ -66,7 +66,9 @@ impl LibEmbargoVisitor<'_, '_> {
 
     fn visit_item(&mut self, def_id: DefId) {
         if self.document_hidden || !self.tcx.is_doc_hidden(def_id) {
-            self.extern_public.insert(def_id);
+            if !def_id.is_local() {
+                self.extern_public.insert(def_id);
+            }
             if self.tcx.def_kind(def_id) == DefKind::Mod {
                 self.visit_mod(def_id);
             }


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/issues/115480, I was finally able to track down the origin of the bug, still working on the fix (how to determine if a foreign trait is publically exported from the current crate in short), which led me to this small PR. It should only list foreign items and yet we don't check if they're locals before adding them to the map.

I expect a very minimal perf improvement.

r? @notriddle 