### PR TITLE
Centralize command running in boostrap (part one)

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -27,6 +27,7 @@ use crate::core::config::flags::Subcommand;
 use crate::core::config::TargetSelection;
 use crate::utils;
 use crate::utils::cache::{Interned, INTERNER};
+use crate::utils::exec::BootstrapCommand;
 use crate::utils::helpers::{
     self, add_link_lib_path, dylib_path, dylib_path_var, output, t, up_to_date,
 };
@@ -808,8 +809,8 @@ impl Step for Clippy {
 
         let _guard = builder.msg_sysroot_tool(Kind::Test, compiler.stage, "clippy", host, host);
 
-        #[allow(deprecated)] // Clippy reports errors if it blessed the outputs
-        if builder.config.try_run(&mut cargo).is_ok() {
+        // Clippy reports errors if it blessed the outputs
+        if builder.run_cmd(&mut cargo) {
             // The tests succeeded; nothing to do.
             return;
         }
@@ -3094,7 +3095,7 @@ impl Step for CodegenCranelift {
             .arg("testsuite.extended_sysroot");
         cargo.args(builder.config.test_args());
 
-        #[allow(deprecated)]
-        builder.config.try_run(&mut cargo.into()).unwrap();
+        let mut cmd: Command = cargo.into();
+        builder.run_cmd(BootstrapCommand::from(&mut cmd).fail_fast());
     }
 }

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -810,7 +810,7 @@ impl Step for Clippy {
         let _guard = builder.msg_sysroot_tool(Kind::Test, compiler.stage, "clippy", host, host);
 
         // Clippy reports errors if it blessed the outputs
-        if builder.run_cmd(&mut cargo) {
+        if builder.run_cmd(BootstrapCommand::from(&mut cargo).allow_failure()) {
             // The tests succeeded; nothing to do.
             return;
         }

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -8,6 +8,7 @@ use crate::core::build_steps::toolstate::ToolState;
 use crate::core::builder::{Builder, Cargo as CargoCommand, RunConfig, ShouldRun, Step};
 use crate::core::config::TargetSelection;
 use crate::utils::channel::GitInfo;
+use crate::utils::exec::BootstrapCommand;
 use crate::utils::helpers::{add_dylib_path, exe, t};
 use crate::Compiler;
 use crate::Mode;
@@ -109,7 +110,7 @@ impl Step for ToolBuild {
 
         let mut cargo = Command::from(cargo);
         // we check this in `is_optional_tool` in a second
-        let is_expected = builder.run_cmd(&mut cargo);
+        let is_expected = builder.run_cmd(BootstrapCommand::from(&mut cargo).allow_failure());
 
         builder.save_toolstate(
             tool,

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -108,8 +108,8 @@ impl Step for ToolBuild {
         );
 
         let mut cargo = Command::from(cargo);
-        #[allow(deprecated)] // we check this in `is_optional_tool` in a second
-        let is_expected = builder.config.try_run(&mut cargo).is_ok();
+        // we check this in `is_optional_tool` in a second
+        let is_expected = builder.run_cmd(&mut cargo);
 
         builder.save_toolstate(
             tool,

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -579,15 +579,12 @@ impl Build {
         }
 
         // Save any local changes, but avoid running `git stash pop` if there are none (since it will exit with an error).
-        #[allow(deprecated)] // diff-index reports the modifications through the exit status
-        let has_local_modifications = self
-            .config
-            .try_run(
-                Command::new("git")
-                    .args(&["diff-index", "--quiet", "HEAD"])
-                    .current_dir(&absolute_path),
-            )
-            .is_err();
+        // diff-index reports the modifications through the exit status
+        let has_local_modifications = !self.run_cmd(
+            Command::new("git")
+                .args(&["diff-index", "--quiet", "HEAD"])
+                .current_dir(&absolute_path),
+        );
         if has_local_modifications {
             self.run(Command::new("git").args(&["stash", "push"]).current_dir(&absolute_path));
         }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -581,9 +581,12 @@ impl Build {
         // Save any local changes, but avoid running `git stash pop` if there are none (since it will exit with an error).
         // diff-index reports the modifications through the exit status
         let has_local_modifications = !self.run_cmd(
-            Command::new("git")
-                .args(&["diff-index", "--quiet", "HEAD"])
-                .current_dir(&absolute_path),
+            BootstrapCommand::from(
+                Command::new("git")
+                    .args(&["diff-index", "--quiet", "HEAD"])
+                    .current_dir(&absolute_path),
+            )
+            .allow_failure(),
         );
         if has_local_modifications {
             self.run(Command::new("git").args(&["stash", "push"]).current_dir(&absolute_path));
@@ -1009,6 +1012,7 @@ impl Build {
                     BehaviorOnFailure::Exit => {
                         exit!(1);
                     }
+                    BehaviorOnFailure::Ignore => {}
                 }
                 false
             }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -997,19 +997,18 @@ impl Build {
         match result {
             Ok(_) => true,
             Err(_) => {
-                if let Some(failure_behavior) = command.failure_behavior {
-                    match failure_behavior {
-                        BehaviorOnFailure::DelayFail => {
-                            let mut failures = self.delayed_failures.borrow_mut();
-                            failures.push(format!("{command:?}"));
-                        }
-                        BehaviorOnFailure::Exit => {
+                match command.failure_behavior {
+                    BehaviorOnFailure::DelayFail => {
+                        if self.fail_fast {
                             exit!(1);
                         }
+
+                        let mut failures = self.delayed_failures.borrow_mut();
+                        failures.push(format!("{command:?}"));
                     }
-                }
-                if self.fail_fast {
-                    exit!(1);
+                    BehaviorOnFailure::Exit => {
+                        exit!(1);
+                    }
                 }
                 false
             }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -937,14 +937,18 @@ impl Build {
 
     /// Runs a command, printing out nice contextual information if it fails.
     fn run_quiet(&self, cmd: &mut Command) {
-        self.run_cmd(BootstrapCommand::from(cmd).fail_fast().output_mode(OutputMode::Suppress));
+        self.run_cmd(
+            BootstrapCommand::from(cmd).fail_fast().output_mode(OutputMode::SuppressOnSuccess),
+        );
     }
 
     /// Runs a command, printing out nice contextual information if it fails.
     /// Exits if the command failed to execute at all, otherwise returns its
     /// `status.success()`.
     fn run_quiet_delaying_failure(&self, cmd: &mut Command) -> bool {
-        self.run_cmd(BootstrapCommand::from(cmd).delay_failure().output_mode(OutputMode::Suppress))
+        self.run_cmd(
+            BootstrapCommand::from(cmd).delay_failure().output_mode(OutputMode::SuppressOnSuccess),
+        )
     }
 
     /// A centralized function for running commands that do not return output.
@@ -965,7 +969,7 @@ impl Build {
                 }),
                 matches!(mode, OutputMode::PrintAll),
             ),
-            OutputMode::Suppress => (command.command.output(), true),
+            OutputMode::SuppressOnSuccess => (command.command.output(), true),
         };
 
         let output = match output {

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+/// Wrapper around `std::process::Command`.
+#[derive(Debug)]
+pub struct BootstrapCommand<'a> {
+    pub command: &'a mut Command,
+    /// Report failure later instead of immediately.
+    pub delay_failure: bool,
+}
+
+impl<'a> BootstrapCommand<'a> {
+    pub fn delay_failure(self) -> Self {
+        Self { delay_failure: true, ..self }
+    }
+}
+
+impl<'a> From<&'a mut Command> for BootstrapCommand<'a> {
+    fn from(command: &'a mut Command) -> Self {
+        Self { command, delay_failure: false }
+    }
+}

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -9,11 +9,24 @@ pub enum BehaviorOnFailure {
     DelayFail,
 }
 
+/// How should the output of the command be handled.
+#[derive(Debug, Copy, Clone)]
+pub enum OutputMode {
+    /// Print both the output (by inheriting stdout/stderr) and also the command itself, if it
+    /// fails.
+    PrintAll,
+    /// Print the output (by inheriting stdout/stderr).
+    PrintOutput,
+    /// Suppress the output if the command succeeds, otherwise print the output.
+    Suppress,
+}
+
 /// Wrapper around `std::process::Command`.
 #[derive(Debug)]
 pub struct BootstrapCommand<'a> {
     pub command: &'a mut Command,
     pub failure_behavior: Option<BehaviorOnFailure>,
+    pub output_mode: OutputMode,
 }
 
 impl<'a> BootstrapCommand<'a> {
@@ -23,10 +36,13 @@ impl<'a> BootstrapCommand<'a> {
     pub fn fail_fast(self) -> Self {
         Self { failure_behavior: Some(BehaviorOnFailure::Exit), ..self }
     }
+    pub fn output_mode(self, output_mode: OutputMode) -> Self {
+        Self { output_mode, ..self }
+    }
 }
 
 impl<'a> From<&'a mut Command> for BootstrapCommand<'a> {
     fn from(command: &'a mut Command) -> Self {
-        Self { command, failure_behavior: None }
+        Self { command, failure_behavior: None, output_mode: OutputMode::Suppress }
     }
 }

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -25,16 +25,16 @@ pub enum OutputMode {
 #[derive(Debug)]
 pub struct BootstrapCommand<'a> {
     pub command: &'a mut Command,
-    pub failure_behavior: Option<BehaviorOnFailure>,
+    pub failure_behavior: BehaviorOnFailure,
     pub output_mode: OutputMode,
 }
 
 impl<'a> BootstrapCommand<'a> {
     pub fn delay_failure(self) -> Self {
-        Self { failure_behavior: Some(BehaviorOnFailure::DelayFail), ..self }
+        Self { failure_behavior: BehaviorOnFailure::DelayFail, ..self }
     }
     pub fn fail_fast(self) -> Self {
-        Self { failure_behavior: Some(BehaviorOnFailure::Exit), ..self }
+        Self { failure_behavior: BehaviorOnFailure::Exit, ..self }
     }
     pub fn output_mode(self, output_mode: OutputMode) -> Self {
         Self { output_mode, ..self }
@@ -43,6 +43,10 @@ impl<'a> BootstrapCommand<'a> {
 
 impl<'a> From<&'a mut Command> for BootstrapCommand<'a> {
     fn from(command: &'a mut Command) -> Self {
-        Self { command, failure_behavior: None, output_mode: OutputMode::SuppressOnSuccess }
+        Self {
+            command,
+            failure_behavior: BehaviorOnFailure::Exit,
+            output_mode: OutputMode::SuppressOnSuccess,
+        }
     }
 }

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -1,21 +1,32 @@
 use std::process::Command;
 
+/// What should be done when the command fails.
+#[derive(Debug, Copy, Clone)]
+pub enum BehaviorOnFailure {
+    /// Immediately stop bootstrap.
+    Exit,
+    /// Delay failure until the end of bootstrap invocation.
+    DelayFail,
+}
+
 /// Wrapper around `std::process::Command`.
 #[derive(Debug)]
 pub struct BootstrapCommand<'a> {
     pub command: &'a mut Command,
-    /// Report failure later instead of immediately.
-    pub delay_failure: bool,
+    pub failure_behavior: Option<BehaviorOnFailure>,
 }
 
 impl<'a> BootstrapCommand<'a> {
     pub fn delay_failure(self) -> Self {
-        Self { delay_failure: true, ..self }
+        Self { failure_behavior: Some(BehaviorOnFailure::DelayFail), ..self }
+    }
+    pub fn fail_fast(self) -> Self {
+        Self { failure_behavior: Some(BehaviorOnFailure::Exit), ..self }
     }
 }
 
 impl<'a> From<&'a mut Command> for BootstrapCommand<'a> {
     fn from(command: &'a mut Command) -> Self {
-        Self { command, delay_failure: false }
+        Self { command, failure_behavior: None }
     }
 }

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -7,6 +7,8 @@ pub enum BehaviorOnFailure {
     Exit,
     /// Delay failure until the end of bootstrap invocation.
     DelayFail,
+    /// Ignore the failure, the command can fail in an expected way.
+    Ignore,
 }
 
 /// How should the output of the command be handled.
@@ -33,9 +35,15 @@ impl<'a> BootstrapCommand<'a> {
     pub fn delay_failure(self) -> Self {
         Self { failure_behavior: BehaviorOnFailure::DelayFail, ..self }
     }
+
     pub fn fail_fast(self) -> Self {
         Self { failure_behavior: BehaviorOnFailure::Exit, ..self }
     }
+
+    pub fn allow_failure(self) -> Self {
+        Self { failure_behavior: BehaviorOnFailure::Ignore, ..self }
+    }
+
     pub fn output_mode(self, output_mode: OutputMode) -> Self {
         Self { output_mode, ..self }
     }

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -18,7 +18,7 @@ pub enum OutputMode {
     /// Print the output (by inheriting stdout/stderr).
     PrintOutput,
     /// Suppress the output if the command succeeds, otherwise print the output.
-    Suppress,
+    SuppressOnSuccess,
 }
 
 /// Wrapper around `std::process::Command`.
@@ -43,6 +43,6 @@ impl<'a> BootstrapCommand<'a> {
 
 impl<'a> From<&'a mut Command> for BootstrapCommand<'a> {
     fn from(command: &'a mut Command) -> Self {
-        Self { command, failure_behavior: None, output_mode: OutputMode::Suppress }
+        Self { command, failure_behavior: None, output_mode: OutputMode::SuppressOnSuccess }
     }
 }

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -3,7 +3,7 @@
 //! Simple things like testing the various filesystem operations here and there,
 //! not a lot of interesting happenings here unfortunately.
 
-use build_helper::util::{fail, try_run};
+use build_helper::util::fail;
 use std::env;
 use std::fs;
 use std::io;
@@ -216,12 +216,6 @@ pub fn is_valid_test_suite_arg<'a, P: AsRef<Path>>(
     }
 }
 
-pub fn run(cmd: &mut Command, print_cmd_on_fail: bool) {
-    if try_run(cmd, print_cmd_on_fail).is_err() {
-        crate::exit!(1);
-    }
-}
-
 pub fn check_run(cmd: &mut Command, print_cmd_on_fail: bool) -> bool {
     let status = match cmd.status() {
         Ok(status) => status,
@@ -237,32 +231,6 @@ pub fn check_run(cmd: &mut Command, print_cmd_on_fail: bool) -> bool {
         );
     }
     status.success()
-}
-
-pub fn run_suppressed(cmd: &mut Command) {
-    if !try_run_suppressed(cmd) {
-        crate::exit!(1);
-    }
-}
-
-pub fn try_run_suppressed(cmd: &mut Command) -> bool {
-    let output = match cmd.output() {
-        Ok(status) => status,
-        Err(e) => fail(&format!("failed to execute command: {cmd:?}\nerror: {e}")),
-    };
-    if !output.status.success() {
-        println!(
-            "\n\ncommand did not execute successfully: {:?}\n\
-             expected success, got: {}\n\n\
-             stdout ----\n{}\n\
-             stderr ----\n{}\n\n",
-            cmd,
-            output.status,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-    output.status.success()
 }
 
 pub fn make(host: &str) -> PathBuf {

--- a/src/bootstrap/src/utils/mod.rs
+++ b/src/bootstrap/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod cache;
 pub(crate) mod cc_detect;
 pub(crate) mod channel;
 pub(crate) mod dylib;
+pub(crate) mod exec;
 pub(crate) mod helpers;
 pub(crate) mod job;
 #[cfg(feature = "build-metrics")]


### PR DESCRIPTION
This PR tries to consolidate the various `run, try_run, run_quiet, run_quiet_delaying_failure, run_delaying_failure` etc. methods on `Builder`. This PR only touches command execution which doesn't produce output that would be later read by bootstrap, and it also only refactors spawning of commands that happens after a builder is created (commands executed during download & git submodule checkout are left as-is, for now).

The `run_cmd` method is quite meaty, but I expect that it will be changing rapidly soon, so I considered it easy to kept everything in a single method, and only after things settle down a bit, then maybe again split it up a bit.

I still kept the original shortcut methods like `run_quiet_delaying_failure`, but they now only delegate to `run_cmd`. I tried to keep the original behavior (or as close to it as possible) for all the various commands, but it is a giant mess, so there may be some deviations. Notably, `cmd.output()` is now always called, instead of just `status()`, which was called previously in some situations.

Apart from the refactored methods, there is also `Config::try_run`, `check_run`, methods that run commands that produce output, oh my… that's left for follow-up PRs :)

The driving goal of this (and following) refactors is to centralize command execution in bootstrap on a single place, to make command mocking feasible. 

r? @onur-ozkan