### PR TITLE
Add #[inline] to small functions in core

### DIFF
--- a/compiler/rustc_mir_transform/messages.ftl
+++ b/compiler/rustc_mir_transform/messages.ftl
@@ -42,6 +42,9 @@ mir_transform_requires_unsafe = {$details} is unsafe and requires unsafe {$op_in
     }
     .not_inherited = items do not inherit unsafety from separate enclosing items
 
+mir_transform_small_fn_without_inline = this function looks small ({$statements}) but doesn't have #[inline], consider adding it
+    .suggestion = add the inline attribute
+
 mir_transform_target_feature_call_label = call to function with `#[target_feature]`
 mir_transform_target_feature_call_note = can only be called if the required target features are available
 

--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -278,3 +278,13 @@ pub(crate) struct MustNotSuspendReason {
     pub span: Span,
     pub reason: String,
 }
+
+#[derive(Diagnostic)]
+#[diag(mir_transform_small_fn_without_inline)]
+pub struct SuggestAddingInline {
+    #[primary_span]
+    pub place: Span,
+    #[suggestion(code = "#[inline]\n", applicability = "machine-applicable")]
+    pub suggest_inline: Span,
+    pub statements: usize,
+}

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -482,6 +482,7 @@ impl Error for LayoutError {}
 // (we need this for downstream impl of trait Error)
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 impl fmt::Display for LayoutError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("invalid parameters to Layout::from_size_align")
     }

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -43,6 +43,7 @@ impl Error for AllocError {}
 // (we need this for downstream impl of trait Error)
 #[unstable(feature = "allocator_api", issue = "32838")]
 impl fmt::Display for AllocError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("memory allocation failed")
     }

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -630,6 +630,7 @@ impl TypeId {
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
+    #[inline]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
         let t: u128 = intrinsics::type_id::<T>();
         TypeId { t }

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -321,6 +321,7 @@ impl<'a, T, const N: usize> IntoIterator for &'a [T; N] {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
+    #[inline]
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
     }

--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -90,6 +90,7 @@ pub struct EscapeDefault(escape::EscapeIterInner<4>);
 /// assert_eq!(b'd', escaped.next().unwrap());
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[inline]
 pub fn escape_default(c: u8) -> EscapeDefault {
     let mut data = [Char::Null; 4];
     let range = escape::escape_ascii_into(&mut data, c);

--- a/library/core/src/ascii/ascii_char.rs
+++ b/library/core/src/ascii/ascii_char.rs
@@ -559,6 +559,7 @@ impl [AsciiChar] {
 
 #[unstable(feature = "ascii_char", issue = "110998")]
 impl fmt::Display for AsciiChar {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         <str as fmt::Display>::fmt(self.as_str(), f)
     }

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -722,6 +722,7 @@ impl Debug for BorrowError {
 
 #[stable(feature = "try_borrow", since = "1.13.0")]
 impl Display for BorrowError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt("already mutably borrowed", f)
     }
@@ -749,6 +750,7 @@ impl Debug for BorrowMutError {
 
 #[stable(feature = "try_borrow", since = "1.13.0")]
 impl Display for BorrowMutError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt("already borrowed", f)
     }

--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -264,6 +264,7 @@ pub struct CharTryFromError(());
 
 #[stable(feature = "try_from", since = "1.34.0")]
 impl fmt::Display for CharTryFromError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "converted integer out of range for `char`".fmt(f)
     }

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -152,6 +152,7 @@ pub const fn from_digit(num: u32, radix: u32) -> Option<char> {
 pub struct EscapeUnicode(escape::EscapeIterInner<10>);
 
 impl EscapeUnicode {
+    #[inline]
     fn new(chr: char) -> Self {
         let mut data = [ascii::Char::Null; 10];
         let range = escape::escape_unicode_into(&mut data, chr);

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -219,11 +219,13 @@ impl fmt::Display for EscapeUnicode {
 pub struct EscapeDefault(escape::EscapeIterInner<10>);
 
 impl EscapeDefault {
+    #[inline]
     fn printable(chr: ascii::Char) -> Self {
         let data = [chr];
         Self(escape::EscapeIterInner::from_array(data))
     }
 
+    #[inline]
     fn backslash(chr: ascii::Char) -> Self {
         let data = [ascii::Char::ReverseSolidus, chr];
         Self(escape::EscapeIterInner::from_array(data))
@@ -308,6 +310,7 @@ impl EscapeDebug {
         Self(EscapeDebugInner::Char(chr))
     }
 
+    #[inline]
     fn backslash(chr: ascii::Char) -> Self {
         let data = [ascii::Char::ReverseSolidus, chr];
         let iter = escape::EscapeIterInner::from_array(data);
@@ -318,6 +321,7 @@ impl EscapeDebug {
         Self(EscapeDebugInner::Bytes(esc.0))
     }
 
+    #[inline]
     fn clear(&mut self) {
         let bytes = escape::EscapeIterInner::from_array([]);
         self.0 = EscapeDebugInner::Bytes(bytes);
@@ -386,6 +390,7 @@ pub struct ToLowercase(CaseMappingIter);
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Iterator for ToLowercase {
     type Item = char;
+    #[inline]
     fn next(&mut self) -> Option<char> {
         self.0.next()
     }
@@ -396,6 +401,7 @@ impl Iterator for ToLowercase {
 
 #[stable(feature = "case_mapping_double_ended", since = "1.59.0")]
 impl DoubleEndedIterator for ToLowercase {
+    #[inline]
     fn next_back(&mut self) -> Option<char> {
         self.0.next_back()
     }
@@ -420,6 +426,7 @@ pub struct ToUppercase(CaseMappingIter);
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Iterator for ToUppercase {
     type Item = char;
+    #[inline]
     fn next(&mut self) -> Option<char> {
         self.0.next()
     }
@@ -430,6 +437,7 @@ impl Iterator for ToUppercase {
 
 #[stable(feature = "case_mapping_double_ended", since = "1.59.0")]
 impl DoubleEndedIterator for ToUppercase {
+    #[inline]
     fn next_back(&mut self) -> Option<char> {
         self.0.next_back()
     }
@@ -534,6 +542,7 @@ impl fmt::Display for CaseMappingIter {
 
 #[stable(feature = "char_struct_display", since = "1.16.0")]
 impl fmt::Display for ToLowercase {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
@@ -541,6 +550,7 @@ impl fmt::Display for ToLowercase {
 
 #[stable(feature = "char_struct_display", since = "1.16.0")]
 impl fmt::Display for ToUppercase {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
@@ -553,6 +563,7 @@ pub struct TryFromCharError(pub(crate) ());
 
 #[stable(feature = "u8_from_char", since = "1.59.0")]
 impl fmt::Display for TryFromCharError {
+    #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         "unicode code point out of range".fmt(fmt)
     }

--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -82,10 +82,12 @@ impl<const N: usize> EscapeIterInner<N> {
         Self::new(data, 0..M as u8)
     }
 
+    #[inline]
     pub fn as_ascii(&self) -> &[ascii::Char] {
         &self.data[usize::from(self.alive.start)..usize::from(self.alive.end)]
     }
 
+    #[inline]
     pub fn as_str(&self) -> &str {
         self.as_ascii().as_str()
     }

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -158,6 +158,7 @@ pub struct FromBytesUntilNulError(());
 
 #[stable(feature = "cstr_from_bytes_until_nul", since = "1.69.0")]
 impl fmt::Display for FromBytesUntilNulError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "data provided does not contain a nul")
     }

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -624,6 +624,7 @@ impl CStr {
     /// ```
     #[stable(feature = "cstr_to_str", since = "1.4.0")]
     #[rustc_const_stable(feature = "const_cstr_methods", since = "1.72.0")]
+    #[inline]
     pub const fn to_str(&self) -> Result<&str, str::Utf8Error> {
         // N.B., when `CStr` is changed to perform the length check in `.to_bytes()`
         // instead of in `from_ptr()`, it may be worth considering if this should

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -18,6 +18,7 @@ impl Default for PadAdapterState {
 }
 
 impl<'buf, 'state> PadAdapter<'buf, 'state> {
+    #[inline]
     fn wrap<'slot, 'fmt: 'buf + 'slot>(
         fmt: &'fmt mut fmt::Formatter<'_>,
         slot: &'slot mut Option<Self>,
@@ -91,6 +92,7 @@ pub struct DebugStruct<'a, 'b: 'a> {
     has_fields: bool,
 }
 
+#[inline]
 pub(super) fn debug_struct_new<'a, 'b>(
     fmt: &'a mut fmt::Formatter<'b>,
     name: &str,
@@ -138,6 +140,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     /// This method is equivalent to [`DebugStruct::field`], but formats the
     /// value using a provided closure rather than by calling [`Debug::fmt`].
     #[unstable(feature = "debug_closure_helpers", issue = "117729")]
+    #[inline]
     pub fn field_with<F>(&mut self, name: &str, value_fmt: F) -> &mut Self
     where
         F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
@@ -293,6 +296,7 @@ pub struct DebugTuple<'a, 'b: 'a> {
     empty_name: bool,
 }
 
+#[inline]
 pub(super) fn debug_tuple_new<'a, 'b>(
     fmt: &'a mut fmt::Formatter<'b>,
     name: &str,
@@ -326,6 +330,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// );
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
+    #[inline]
     pub fn field(&mut self, value: &dyn fmt::Debug) -> &mut Self {
         self.field_with(|f| value.fmt(f))
     }
@@ -409,6 +414,7 @@ struct DebugInner<'a, 'b: 'a> {
 }
 
 impl<'a, 'b: 'a> DebugInner<'a, 'b> {
+    #[inline]
     fn entry_with<F>(&mut self, entry_fmt: F)
     where
         F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
@@ -471,6 +477,7 @@ pub struct DebugSet<'a, 'b: 'a> {
     inner: DebugInner<'a, 'b>,
 }
 
+#[inline]
 pub(super) fn debug_set_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>) -> DebugSet<'a, 'b> {
     let result = fmt.write_str("{");
     DebugSet { inner: DebugInner { fmt, result, has_fields: false } }
@@ -614,6 +621,7 @@ pub struct DebugList<'a, 'b: 'a> {
     inner: DebugInner<'a, 'b>,
 }
 
+#[inline]
 pub(super) fn debug_list_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>) -> DebugList<'a, 'b> {
     let result = fmt.write_str("[");
     DebugList { inner: DebugInner { fmt, result, has_fields: false } }
@@ -762,6 +770,7 @@ pub struct DebugMap<'a, 'b: 'a> {
     state: PadAdapterState,
 }
 
+#[inline]
 pub(super) fn debug_map_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>) -> DebugMap<'a, 'b> {
     let result = fmt.write_str("{");
     DebugMap { fmt, result, has_fields: false, has_key: false, state: Default::default() }
@@ -836,6 +845,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// This method is equivalent to [`DebugMap::key`], but formats the
     /// key using a provided closure rather than by calling [`Debug::fmt`].
     #[unstable(feature = "debug_closure_helpers", issue = "117729")]
+    #[inline]
     pub fn key_with<F>(&mut self, key_fmt: F) -> &mut Self
     where
         F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
@@ -912,6 +922,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// This method is equivalent to [`DebugMap::value`], but formats the
     /// value using a provided closure rather than by calling [`Debug::fmt`].
     #[unstable(feature = "debug_closure_helpers", issue = "117729")]
+    #[inline]
     pub fn value_with<F>(&mut self, value_fmt: F) -> &mut Self
     where
         F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -340,6 +340,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// This method is equivalent to [`DebugTuple::field`], but formats the
     /// value using a provided closure rather than by calling [`Debug::fmt`].
     #[unstable(feature = "debug_closure_helpers", issue = "117729")]
+    #[inline]
     pub fn field_with<F>(&mut self, value_fmt: F) -> &mut Self
     where
         F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,

--- a/library/core/src/fmt/float.rs
+++ b/library/core/src/fmt/float.rs
@@ -198,6 +198,7 @@ macro_rules! floating {
     ($ty:ident) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Debug for $ty {
+            #[inline]
             fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
                 float_to_general_debug(fmt, self)
             }
@@ -205,6 +206,7 @@ macro_rules! floating {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Display for $ty {
+            #[inline]
             fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
                 float_to_decimal_display(fmt, self)
             }
@@ -212,6 +214,7 @@ macro_rules! floating {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         impl LowerExp for $ty {
+            #[inline]
             fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
                 float_to_exponential_common(fmt, self, false)
             }
@@ -219,6 +222,7 @@ macro_rules! floating {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         impl UpperExp for $ty {
+            #[inline]
             fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
                 float_to_exponential_common(fmt, self, true)
             }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -191,6 +191,7 @@ pub trait Write {
     /// assert_eq!(&buf, "world");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     fn write_fmt(&mut self, args: Arguments<'_>) -> Result {
         // We use a specialization for `Sized` types to avoid an indirection
         // through `&mut self`
@@ -434,6 +435,7 @@ impl<'a> Arguments<'a> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Debug for Arguments<'_> {
+    #[inline]
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         Display::fmt(self, fmt)
     }
@@ -441,6 +443,7 @@ impl Debug for Arguments<'_> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Display for Arguments<'_> {
+    #[inline]
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         write(fmt.buf, *self)
     }
@@ -1203,6 +1206,7 @@ impl PostPadding {
 }
 
 impl<'a> Formatter<'a> {
+    #[inline]
     fn wrap_buf<'b, 'c, F>(&'b mut self, wrap: F) -> Formatter<'c>
     where
         'b: 'c,
@@ -1492,6 +1496,7 @@ impl<'a> Formatter<'a> {
     ///
     /// Any `numfmt::Part::Copy` parts in `formatted` must contain valid UTF-8.
     unsafe fn write_formatted_parts(&mut self, formatted: &numfmt::Formatted<'_>) -> Result {
+        #[inline]
         unsafe fn write_bytes(buf: &mut dyn Write, s: &[u8]) -> Result {
             // SAFETY: This is used for `numfmt::Part::Num` and `numfmt::Part::Copy`.
             // It's safe to use for `numfmt::Part::Num` since every char `c` is between
@@ -1559,6 +1564,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(format!("{Foo:0>8}"), "Foo");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn write_str(&mut self, data: &str) -> Result {
         self.buf.write_str(data)
     }
@@ -1582,6 +1588,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(format!("{:0>8}", Foo(2)), "Foo 2");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn write_fmt(&mut self, fmt: Arguments<'_>) -> Result {
         write(self.buf, fmt)
     }
@@ -1894,6 +1901,7 @@ impl<'a> Formatter<'a> {
     /// );
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
+    #[inline]
     pub fn debug_struct<'b>(&'b mut self, name: &str) -> DebugStruct<'b, 'a> {
         builders::debug_struct_new(self, name)
     }
@@ -2048,6 +2056,7 @@ impl<'a> Formatter<'a> {
     /// );
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
+    #[inline]
     pub fn debug_tuple<'b>(&'b mut self, name: &str) -> DebugTuple<'b, 'a> {
         builders::debug_tuple_new(self, name)
     }
@@ -2173,6 +2182,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(format!("{:?}", Foo(vec![10, 11])), "[10, 11]");
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
+    #[inline]
     pub fn debug_list<'b>(&'b mut self) -> DebugList<'b, 'a> {
         builders::debug_list_new(self)
     }
@@ -2231,6 +2241,7 @@ impl<'a> Formatter<'a> {
     /// }
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
+    #[inline]
     pub fn debug_set<'b>(&'b mut self) -> DebugSet<'b, 'a> {
         builders::debug_set_new(self)
     }
@@ -2257,6 +2268,7 @@ impl<'a> Formatter<'a> {
     ///  );
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
+    #[inline]
     pub fn debug_map<'b>(&'b mut self) -> DebugMap<'b, 'a> {
         builders::debug_map_new(self)
     }
@@ -2264,14 +2276,17 @@ impl<'a> Formatter<'a> {
 
 #[stable(since = "1.2.0", feature = "formatter_write")]
 impl Write for Formatter<'_> {
+    #[inline]
     fn write_str(&mut self, s: &str) -> Result {
         self.buf.write_str(s)
     }
 
+    #[inline]
     fn write_char(&mut self, c: char) -> Result {
         self.buf.write_char(c)
     }
 
+    #[inline]
     fn write_fmt(&mut self, args: Arguments<'_>) -> Result {
         write(self.buf, args)
     }
@@ -2279,6 +2294,7 @@ impl Write for Formatter<'_> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Display for Error {
+    #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         Display::fmt("an error occurred when formatting an argument", f)
     }
@@ -2361,6 +2377,7 @@ impl Debug for str {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Display for str {
+    #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.pad(self)
     }

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -155,6 +155,7 @@ macro_rules! int_base {
     (fmt::$Trait:ident for $T:ident as $U:ident -> $Radix:ident) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl fmt::$Trait for $T {
+            #[inline]
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 $Radix.fmt_int(*self as $U, f)
             }
@@ -572,6 +573,7 @@ fn parse_u64_into<const N: usize>(mut n: u64, buf: &mut [MaybeUninit<u8>; N], cu
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for u128 {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_u128(*self, true, f)
     }

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -15,6 +15,7 @@ pub struct FlatMap<I, U: IntoIterator, F> {
 }
 
 impl<I: Iterator, U: IntoIterator, F: FnMut(I::Item) -> U> FlatMap<I, U, F> {
+    #[inline]
     pub(in crate::iter) fn new(iter: I, f: F) -> FlatMap<I, U, F> {
         FlatMap { inner: FlattenCompat::new(iter.map(f)) }
     }
@@ -25,6 +26,7 @@ impl<I: Clone, U, F: Clone> Clone for FlatMap<I, U, F>
 where
     U: Clone + IntoIterator<IntoIter: Clone>,
 {
+    #[inline]
     fn clone(&self) -> Self {
         FlatMap { inner: self.inner.clone() }
     }
@@ -159,6 +161,7 @@ pub struct Flatten<I: Iterator<Item: IntoIterator>> {
 }
 
 impl<I: Iterator<Item: IntoIterator>> Flatten<I> {
+    #[inline]
     pub(in super::super) fn new(iter: I) -> Flatten<I> {
         Flatten { inner: FlattenCompat::new(iter) }
     }
@@ -321,6 +324,7 @@ where
     I: Iterator,
 {
     /// Adapts an iterator by flattening it, for use in `flatten()` and `flat_map()`.
+    #[inline]
     fn new(iter: I) -> FlattenCompat<I, U> {
         FlattenCompat { iter: iter.fuse(), frontiter: None, backiter: None }
     }

--- a/library/core/src/iter/traits/accum.rs
+++ b/library/core/src/iter/traits/accum.rs
@@ -46,6 +46,7 @@ macro_rules! integer_sum_product {
     (@impls $zero:expr, $one:expr, #[$attr:meta], $($a:ty)*) => ($(
         #[$attr]
         impl Sum for $a {
+            #[inline]
             fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
                 iter.fold(
                     $zero,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3627,6 +3627,7 @@ pub trait Iterator {
     /// ```
     #[stable(feature = "iter_arith", since = "1.11.0")]
     #[rustc_do_not_const_check]
+    #[inline]
     fn sum<S>(self) -> S
     where
         Self: Sized,
@@ -3682,6 +3683,7 @@ pub trait Iterator {
     /// ```
     #[stable(feature = "iter_order", since = "1.5.0")]
     #[rustc_do_not_const_check]
+    #[inline]
     fn cmp<I>(self, other: I) -> Ordering
     where
         I: IntoIterator<Item = Self::Item>,

--- a/library/core/src/mem/transmutability.rs
+++ b/library/core/src/mem/transmutability.rs
@@ -91,6 +91,7 @@ impl Assume {
 impl core::ops::Add for Assume {
     type Output = Assume;
 
+    #[inline]
     fn add(self, other_assumptions: Assume) -> Assume {
         self.and(other_assumptions)
     }
@@ -102,6 +103,7 @@ impl core::ops::Add for Assume {
 impl core::ops::Sub for Assume {
     type Output = Assume;
 
+    #[inline]
     fn sub(self, other_assumptions: Assume) -> Assume {
         self.but_not(other_assumptions)
     }

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -986,6 +986,7 @@ impl fmt::Display for IpAddr {
 
 #[stable(feature = "ip_addr", since = "1.7.0")]
 impl fmt::Debug for IpAddr {
+    #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, fmt)
     }
@@ -1058,6 +1059,7 @@ impl fmt::Display for Ipv4Addr {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for Ipv4Addr {
+    #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, fmt)
     }
@@ -1929,6 +1931,7 @@ impl fmt::Display for Ipv6Addr {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for Ipv6Addr {
+    #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, fmt)
     }
@@ -2191,6 +2194,7 @@ macro_rules! bitop_impls {
 
             $(#[$attr])*
             impl $BitOpAssign<&'_ $ty> for $ty {
+                #[inline]
                 fn $bitop_assign(&mut self, rhs: &'_ $ty) {
                     self.$bitop_assign(*rhs);
                 }

--- a/library/core/src/net/parser.rs
+++ b/library/core/src/net/parser.rs
@@ -286,6 +286,7 @@ impl IpAddr {
     /// assert_eq!(IpAddr::parse_ascii(b"::1"), Ok(localhost_v6));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
+    #[inline]
     pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_ip_addr(), AddrKind::Ip)
     }
@@ -294,6 +295,7 @@ impl IpAddr {
 #[stable(feature = "ip_addr", since = "1.7.0")]
 impl FromStr for IpAddr {
     type Err = AddrParseError;
+    #[inline]
     fn from_str(s: &str) -> Result<IpAddr, AddrParseError> {
         Self::parse_ascii(s.as_bytes())
     }
@@ -325,6 +327,7 @@ impl Ipv4Addr {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl FromStr for Ipv4Addr {
     type Err = AddrParseError;
+    #[inline]
     fn from_str(s: &str) -> Result<Ipv4Addr, AddrParseError> {
         Self::parse_ascii(s.as_bytes())
     }
@@ -343,6 +346,7 @@ impl Ipv6Addr {
     /// assert_eq!(Ipv6Addr::parse_ascii(b"::1"), Ok(localhost));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
+    #[inline]
     pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_ipv6_addr(), AddrKind::Ipv6)
     }
@@ -351,6 +355,7 @@ impl Ipv6Addr {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl FromStr for Ipv6Addr {
     type Err = AddrParseError;
+    #[inline]
     fn from_str(s: &str) -> Result<Ipv6Addr, AddrParseError> {
         Self::parse_ascii(s.as_bytes())
     }
@@ -369,6 +374,7 @@ impl SocketAddrV4 {
     /// assert_eq!(SocketAddrV4::parse_ascii(b"127.0.0.1:8080"), Ok(socket));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
+    #[inline]
     pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_socket_addr_v4(), AddrKind::SocketV4)
     }
@@ -377,6 +383,7 @@ impl SocketAddrV4 {
 #[stable(feature = "socket_addr_from_str", since = "1.5.0")]
 impl FromStr for SocketAddrV4 {
     type Err = AddrParseError;
+    #[inline]
     fn from_str(s: &str) -> Result<SocketAddrV4, AddrParseError> {
         Self::parse_ascii(s.as_bytes())
     }
@@ -395,6 +402,7 @@ impl SocketAddrV6 {
     /// assert_eq!(SocketAddrV6::parse_ascii(b"[2001:db8::1]:8080"), Ok(socket));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
+    #[inline]
     pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_socket_addr_v6(), AddrKind::SocketV6)
     }
@@ -403,6 +411,7 @@ impl SocketAddrV6 {
 #[stable(feature = "socket_addr_from_str", since = "1.5.0")]
 impl FromStr for SocketAddrV6 {
     type Err = AddrParseError;
+    #[inline]
     fn from_str(s: &str) -> Result<SocketAddrV6, AddrParseError> {
         Self::parse_ascii(s.as_bytes())
     }
@@ -423,6 +432,7 @@ impl SocketAddr {
     /// assert_eq!(SocketAddr::parse_ascii(b"[::1]:8080"), Ok(socket_v6));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
+    #[inline]
     pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_socket_addr(), AddrKind::Socket)
     }
@@ -431,6 +441,7 @@ impl SocketAddr {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl FromStr for SocketAddr {
     type Err = AddrParseError;
+    #[inline]
     fn from_str(s: &str) -> Result<SocketAddr, AddrParseError> {
         Self::parse_ascii(s.as_bytes())
     }

--- a/library/core/src/net/parser.rs
+++ b/library/core/src/net/parser.rs
@@ -79,6 +79,7 @@ impl<'a> Parser<'a> {
 
     #[must_use]
     /// Read the next character from the input if it matches the target.
+    #[inline]
     fn read_given_char(&mut self, target: char) -> Option<()> {
         self.read_atomically(|p| {
             p.read_char().and_then(|c| if c == target { Some(()) } else { None })
@@ -89,6 +90,7 @@ impl<'a> Parser<'a> {
     /// character iff index > 0, then runs the parser. When used in a loop,
     /// the separator character will only be read on index > 0 (see
     /// read_ipv4_addr for an example)
+    #[inline]
     fn read_separator<T, F>(&mut self, sep: char, index: usize, inner: F) -> Option<T>
     where
         F: FnOnce(&mut Parser<'_>) -> Option<T>,
@@ -228,6 +230,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Read a `:` followed by a port in base 10.
+    #[inline]
     fn read_port(&mut self) -> Option<u16> {
         self.read_atomically(|p| {
             p.read_given_char(':')?;
@@ -236,6 +239,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Read a `%` followed by a scope ID in base 10.
+    #[inline]
     fn read_scope_id(&mut self) -> Option<u32> {
         self.read_atomically(|p| {
             p.read_given_char('%')?;

--- a/library/core/src/net/parser.rs
+++ b/library/core/src/net/parser.rs
@@ -137,6 +137,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Read an IPv4 address.
+    #[inline]
     fn read_ipv4_addr(&mut self) -> Option<Ipv4Addr> {
         self.read_atomically(|p| {
             let mut groups = [0; 4];
@@ -154,6 +155,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Read an IPv6 Address.
+    #[inline]
     fn read_ipv6_addr(&mut self) -> Option<Ipv6Addr> {
         /// Read a chunk of an IPv6 address into `groups`. Returns the number
         /// of groups read, along with a bool indicating if an embedded
@@ -242,6 +244,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Read an IPv4 address with a port.
+    #[inline]
     fn read_socket_addr_v4(&mut self) -> Option<SocketAddrV4> {
         self.read_atomically(|p| {
             let ip = p.read_ipv4_addr()?;
@@ -251,6 +254,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Read an IPv6 address with a port.
+    #[inline]
     fn read_socket_addr_v6(&mut self) -> Option<SocketAddrV6> {
         self.read_atomically(|p| {
             p.read_given_char('[')?;

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -578,6 +578,7 @@ impl fmt::Display for SocketAddr {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for SocketAddr {
+    #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, fmt)
     }
@@ -604,6 +605,7 @@ impl fmt::Display for SocketAddrV4 {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for SocketAddrV4 {
+    #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, fmt)
     }
@@ -638,6 +640,7 @@ impl fmt::Display for SocketAddrV6 {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for SocketAddrV6 {
+    #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, fmt)
     }

--- a/library/core/src/num/bignum.rs
+++ b/library/core/src/num/bignum.rs
@@ -111,6 +111,7 @@ macro_rules! define_bignum {
             /// Returns the internal digits as a slice `[a, b, c, ...]` such that the numeric
             /// value is `a + b * 2^W + c * 2^(2W) + ...` where `W` is the number of bits in
             /// the digit type.
+            #[inline]
             pub fn digits(&self) -> &[$ty] {
                 &self.base[..self.size]
             }
@@ -378,6 +379,7 @@ macro_rules! define_bignum {
         }
 
         impl crate::cmp::PartialEq for $name {
+            #[inline]
             fn eq(&self, other: &$name) -> bool {
                 self.base[..] == other.base[..]
             }
@@ -386,6 +388,7 @@ macro_rules! define_bignum {
         impl crate::cmp::Eq for $name {}
 
         impl crate::cmp::PartialOrd for $name {
+            #[inline]
             fn partial_cmp(&self, other: &$name) -> crate::option::Option<crate::cmp::Ordering> {
                 crate::option::Option::Some(self.cmp(other))
             }

--- a/library/core/src/num/dec2flt/float.rs
+++ b/library/core/src/num/dec2flt/float.rs
@@ -148,6 +148,7 @@ impl RawFloat for f32 {
         (mantissa as u64, exponent, sign)
     }
 
+    #[inline]
     fn classify(self) -> FpCategory {
         self.classify()
     }

--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -11,6 +11,7 @@ pub struct TryFromIntError(pub(crate) ());
 
 #[stable(feature = "try_from", since = "1.34.0")]
 impl fmt::Display for TryFromIntError {
+    #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         #[allow(deprecated)]
         self.description().fmt(fmt)

--- a/library/core/src/num/flt2dec/estimator.rs
+++ b/library/core/src/num/flt2dec/estimator.rs
@@ -5,6 +5,7 @@
 /// This is used to approximate `k = ceil(log_10 (mant * 2^exp))`;
 /// the true `k` is either `k_0` or `k_0+1`.
 #[doc(hidden)]
+#[inline]
 pub fn estimate_scaling_factor(mant: u64, exp: i16) -> i16 {
     // 2^(nbits-1) < mant <= 2^nbits if mant > 0
     let nbits = 64 - (mant - 1).leading_zeros() as i64;

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -82,6 +82,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::from_str_radix(\"A\", 16), Ok(10));")]
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[inline]
         pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
             from_str_radix(src, radix)
         }

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1390,6 +1390,7 @@ macro_rules! from_str_radix_int_impl {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl FromStr for $t {
             type Err = ParseIntError;
+            #[inline]
             fn from_str(src: &str) -> Result<Self, ParseIntError> {
                 from_str_radix(src, 10)
             }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -81,6 +81,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::from_str_radix(\"A\", 16), Ok(10));")]
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[inline]
         pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
             from_str_radix(src, radix)
         }

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -44,6 +44,7 @@ pub struct RangeFull;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for RangeFull {
+    #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "..")
     }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -292,6 +292,7 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
     // The pattern is a string so it can be displayed directly.
     struct Pattern<'a>(&'a str);
     impl fmt::Debug for Pattern<'_> {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.write_str(self.0)
         }

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -106,6 +106,7 @@ impl [u8] {
     #[must_use = "this returns the escaped bytes as an iterator, \
                   without modifying the original"]
     #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
+    #[inline]
     pub fn escape_ascii(&self) -> EscapeAscii<'_> {
         EscapeAscii { inner: self.iter().flat_map(EscapeByte) }
     }
@@ -241,6 +242,7 @@ impl<'a> iter::Iterator for EscapeAscii<'a> {
 
 #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
 impl<'a> iter::DoubleEndedIterator for EscapeAscii<'a> {
+    #[inline]
     fn next_back(&mut self) -> Option<u8> {
         self.inner.next_back()
     }

--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -12,6 +12,7 @@ impl<A, B> PartialEq<[B]> for [A]
 where
     A: PartialEq<B>,
 {
+    #[inline]
     fn eq(&self, other: &[B]) -> bool {
         SlicePartialEq::equal(self, other)
     }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -22,6 +22,7 @@ impl<'a, T> IntoIterator for &'a [T] {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
+    #[inline]
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
     }
@@ -32,6 +33,7 @@ impl<'a, T> IntoIterator for &'a mut [T] {
     type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;
 
+    #[inline]
     fn into_iter(self) -> IterMut<'a, T> {
         self.iter_mut()
     }

--- a/library/core/src/str/count.rs
+++ b/library/core/src/str/count.rs
@@ -131,6 +131,7 @@ fn sum_bytes_in_usize(values: usize) -> usize {
 // bytes in the string which are not continuation bytes", and is used for the
 // head and tail of the input string (the first and last item in the tuple
 // returned by `slice::align_to`).
+#[inline]
 fn char_count_general_case(s: &[u8]) -> usize {
     s.iter().filter(|&&byte| !super::validations::utf8_is_cont_byte(byte)).count()
 }

--- a/library/core/src/str/error.rs
+++ b/library/core/src/str/error.rs
@@ -141,6 +141,7 @@ pub struct ParseBoolError;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for ParseBoolError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "provided string was not `true` or `false`".fmt(f)
     }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1027,6 +1027,7 @@ impl str {
     #[must_use = "this returns the encoded string as an iterator, \
                   without modifying the original"]
     #[stable(feature = "encode_utf16", since = "1.8.0")]
+    #[inline]
     pub fn encode_utf16(&self) -> EncodeUtf16<'_> {
         EncodeUtf16 { chars: self.chars(), extra: 0 }
     }
@@ -1100,6 +1101,7 @@ impl str {
     /// assert!(!bananas.ends_with("nana"));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn ends_with<'a, P>(&'a self, pat: P) -> bool
     where
         P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
@@ -2506,6 +2508,7 @@ impl str {
     #[must_use = "this returns the escaped string as an iterator, \
                   without modifying the original"]
     #[stable(feature = "str_escape", since = "1.34.0")]
+    #[inline]
     pub fn escape_default(&self) -> EscapeDefault<'_> {
         EscapeDefault { inner: self.chars().flat_map(CharEscapeDefault) }
     }
@@ -2544,6 +2547,7 @@ impl str {
     #[must_use = "this returns the escaped string as an iterator, \
                   without modifying the original"]
     #[stable(feature = "str_escape", since = "1.34.0")]
+    #[inline]
     pub fn escape_unicode(&self) -> EscapeUnicode<'_> {
         EscapeUnicode { inner: self.chars().flat_map(CharEscapeUnicode) }
     }

--- a/library/core/src/unicode/unicode_data.rs
+++ b/library/core/src/unicode/unicode_data.rs
@@ -169,6 +169,7 @@ pub mod alphabetic {
         4, 1, 7, 1, 4, 1, 4, 1, 1, 1, 10, 1, 17, 5, 3, 1, 5, 1, 17, 0, 26, 6, 26, 6, 26, 0, 0, 32,
         0, 6, 222, 2, 0, 14, 0, 0, 0, 0, 0, 5, 0, 0,
     ];
+    #[inline]
     pub fn lookup(c: char) -> bool {
         super::skip_search(
             c as u32,
@@ -221,6 +222,7 @@ pub mod case_ignorable {
         0, 55, 4, 50, 8, 1, 14, 1, 22, 5, 1, 15, 0, 7, 1, 17, 2, 7, 1, 2, 1, 5, 5, 62, 33, 1, 160,
         14, 0, 1, 61, 4, 0, 5, 0, 7, 109, 8, 0, 5, 0, 1, 30, 96, 128, 240, 0,
     ];
+    #[inline]
     pub fn lookup(c: char) -> bool {
         super::skip_search(
             c as u32,
@@ -251,6 +253,7 @@ pub mod cased {
         25, 1, 25, 1, 31, 1, 25, 1, 31, 1, 25, 1, 31, 1, 25, 1, 31, 1, 25, 1, 8, 0, 10, 1, 20, 6, 6,
         0, 62, 0, 68, 0, 26, 6, 26, 6, 26, 0,
     ];
+    #[inline]
     pub fn lookup(c: char) -> bool {
         super::skip_search(
             c as u32,
@@ -268,6 +271,7 @@ pub mod cc {
     static OFFSETS: [u8; 5] = [
         0, 32, 95, 33, 0,
     ];
+    #[inline]
     pub fn lookup(c: char) -> bool {
         super::skip_search(
             c as u32,
@@ -315,6 +319,7 @@ pub mod grapheme_extend {
         15, 0, 7, 1, 17, 2, 7, 1, 2, 1, 5, 100, 1, 160, 7, 0, 1, 61, 4, 0, 4, 0, 7, 109, 7, 0, 96,
         128, 240, 0,
     ];
+    #[inline]
     pub fn lookup(c: char) -> bool {
         super::skip_search(
             c as u32,
@@ -419,6 +424,7 @@ pub mod lowercase {
     ];
 
     #[rustc_const_unstable(feature = "const_unicode_case_lookup", issue = "101400")]
+    #[inline]
     pub const fn lookup(c: char) -> bool {
         super::bitset_search(
             c as u32,
@@ -453,6 +459,7 @@ pub mod n {
         23, 0, 20, 12, 20, 108, 25, 0, 50, 0, 10, 0, 10, 0, 10, 0, 9, 128, 10, 0, 59, 1, 3, 1, 4,
         76, 45, 1, 15, 0, 13, 0, 10, 0,
     ];
+    #[inline]
     pub fn lookup(c: char) -> bool {
         super::skip_search(
             c as u32,
@@ -542,6 +549,7 @@ pub mod uppercase {
     ];
 
     #[rustc_const_unstable(feature = "const_unicode_case_lookup", issue = "101400")]
+    #[inline]
     pub const fn lookup(c: char) -> bool {
         super::bitset_search(
             c as u32,


### PR DESCRIPTION
I'm adding a new case to the definition of cross-crate-inlinable; we know that making the definition too broad causes huge regressions in incremental builds. So implementing broader heuristics as a machine-applicable lint means that I can `x fix --stage 1 library/core` to apply the new heuristic just to the standard library. I expect that applying the broader heuristic just to the standard library will have a different effect than applying the change globally.