### PR TITLE
Remove ability to disable some target features

### DIFF
--- a/compiler/rustc_target/src/spec/i386_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/i386_apple_ios.rs
@@ -17,6 +17,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             max_atomic_width: Some(64),
             stack_probes: StackProbeType::X86,
+            features: "+x87".into(),
             ..opts("ios", arch)
         },
     }

--- a/compiler/rustc_target/src/spec/i386_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/i386_unknown_linux_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::i686_unknown_linux_gnu::target();
     base.cpu = "i386".into();
+    base.features = "+x87".into();
     base.llvm_target = "i386-unknown-linux-gnu".into();
     base
 }

--- a/compiler/rustc_target/src/spec/i486_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/i486_unknown_linux_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::i686_unknown_linux_gnu::target();
     base.cpu = "i486".into();
+    base.features = "+x87".into();
     base.llvm_target = "i486-unknown-linux-gnu".into();
     base
 }

--- a/compiler/rustc_target/src/spec/i586_pc_nto_qnx700.rs
+++ b/compiler/rustc_target/src/spec/i586_pc_nto_qnx700.rs
@@ -11,6 +11,7 @@ pub fn target() -> Target {
         arch: "x86".into(),
         options: TargetOptions {
             cpu: "pentium4".into(),
+            features: "+x87".into(),
             max_atomic_width: Some(64),
             pre_link_args: TargetOptions::link_args(
                 LinkerFlavor::Gnu(Cc::Yes, Lld::No),

--- a/compiler/rustc_target/src/spec/i586_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/i586_pc_windows_msvc.rs
@@ -3,6 +3,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::i686_pc_windows_msvc::target();
     base.cpu = "pentium".into();
+    base.features = "+x87".into();
     base.llvm_target = "i586-pc-windows-msvc".into();
     base
 }

--- a/compiler/rustc_target/src/spec/i586_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_linux_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::i686_unknown_linux_gnu::target();
     base.cpu = "pentium".into();
+    base.features = "+x87".into();
     base.llvm_target = "i586-unknown-linux-gnu".into();
     base
 }

--- a/compiler/rustc_target/src/spec/i586_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_linux_musl.rs
@@ -3,6 +3,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::i686_unknown_linux_musl::target();
     base.cpu = "pentium".into();
+    base.features = "+x87".into();
     base.llvm_target = "i586-unknown-linux-musl".into();
     base
 }

--- a/compiler/rustc_target/src/spec/i686_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/i686_apple_darwin.rs
@@ -5,6 +5,7 @@ pub fn target() -> Target {
     // ld64 only understands i386 and not i686
     let arch = Arch::I386;
     let mut base = opts("macos", arch);
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Darwin(Cc::Yes, Lld::No), &["-m32"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/i686_linux_android.rs
+++ b/compiler/rustc_target/src/spec/i686_linux_android.rs
@@ -10,7 +10,7 @@ pub fn target() -> Target {
 
     // https://developer.android.com/ndk/guides/abis.html#x86
     base.cpu = "pentiumpro".into();
-    base.features = "+mmx,+sse,+sse2,+sse3,+ssse3".into();
+    base.features = "+x87,+mmx,+sse,+sse2,+sse3,+ssse3".into();
     base.stack_probes = StackProbeType::X86;
 
     Target {

--- a/compiler/rustc_target/src/spec/i686_pc_windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/i686_pc_windows_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, Target};
 pub fn target() -> Target {
     let mut base = super::windows_gnu_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.frame_pointer = FramePointer::Always; // Required for backtraces
     base.linker = Some("i686-w64-mingw32-gcc".into());

--- a/compiler/rustc_target/src/spec/i686_pc_windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/i686_pc_windows_gnullvm.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, Target};
 pub fn target() -> Target {
     let mut base = super::windows_gnullvm_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.frame_pointer = FramePointer::Always; // Required for backtraces
     base.linker = Some("i686-w64-mingw32-clang".into());

--- a/compiler/rustc_target/src/spec/i686_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/i686_pc_windows_msvc.rs
@@ -3,6 +3,7 @@ use crate::spec::{LinkerFlavor, Lld, Target};
 pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
 
     base.add_pre_link_args(

--- a/compiler/rustc_target/src/spec/i686_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_freebsd.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::freebsd_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32", "-Wl,-znotext"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/i686_unknown_haiku.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_haiku.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::haiku_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/i686_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_linux_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::linux_gnu_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.supported_sanitizers = SanitizerSet::ADDRESS;
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32"]);

--- a/compiler/rustc_target/src/spec/i686_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_linux_musl.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::linux_musl_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32", "-Wl,-melf_i386"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/i686_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_netbsd.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetOptions};
 pub fn target() -> Target {
     let mut base = super::netbsd_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/i686_unknown_openbsd.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_openbsd.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::openbsd_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32", "-fuse-ld=lld"]);
     base.stack_probes = StackProbeType::X86;

--- a/compiler/rustc_target/src/spec/i686_uwp_windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/i686_uwp_windows_gnu.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, Target};
 pub fn target() -> Target {
     let mut base = super::windows_uwp_gnu_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.frame_pointer = FramePointer::Always; // Required for backtraces
 

--- a/compiler/rustc_target/src/spec/i686_uwp_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/i686_uwp_windows_msvc.rs
@@ -3,6 +3,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::windows_uwp_msvc_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
 
     Target {

--- a/compiler/rustc_target/src/spec/i686_wrs_vxworks.rs
+++ b/compiler/rustc_target/src/spec/i686_wrs_vxworks.rs
@@ -3,6 +3,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target};
 pub fn target() -> Target {
     let mut base = super::vxworks_base::opts();
     base.cpu = "pentium4".into();
+    base.features = "+x87,+sse,+sse2".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32"]);
     base.stack_probes = StackProbeType::X86;


### PR DESCRIPTION
The documentation of TargetOptions.features claims that these features will always be passed to LLVM, but the logic implemented in https://github.com/rust-lang/rust/pull/83084 allows them to be disabled with -C target-feature. Change the implementation to match the documentation.

Disabling x87 on x86 changes the way functions return floats. The second commit makes x87 mandatory on the existing i686 targets. Disabling floating point usage now requires a new target. https://github.com/rust-lang/rust/issues/116344 does not fully get fixed by this (softfloat targets still have a problem with `+x87`), but it helps a lot.

In preparation for https://github.com/rust-lang/rust/pull/115919 sse and sse2 are also made mandatory.

See https://rust-lang.zulipchat.com/#narrow/stream/136281-t-opsem/topic/Float.20ABI.20hell/near/394473707 and https://github.com/rust-lang/rust/issues/116344.

**Lang team: see [nomination comment](https://github.com/rust-lang/rust/pull/116584#issuecomment-1793694772) below.**

@rustbot label: +A-abi +O-x86 +T-opsem +T-compiler