### PR TITLE
Don't accidentally detect the commit hash as an `fadd` instruction

### DIFF
--- a/tests/codegen/target-feature-inline-closure.rs
+++ b/tests/codegen/target-feature-inline-closure.rs
@@ -31,3 +31,7 @@ unsafe fn without_avx(x: __m256) -> __m256 {
     };
     add(x, x)
 }
+
+// Don't allow the above CHECK-NOT to accidentally match a commit hash in the
+// compiler version.
+// CHECK-LABEL: rustc version


### PR DESCRIPTION
I've seen some reports of `tests/codegen/target-feature-inline-closure.rs` spuriously failing because it thinks the hash in the rustc version number contains an `fadd` instruction.

https://github.com/rust-lang/rust/pull/116085#issuecomment-1751174916
https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Is.20.60tests.2Fcodegen.2Ftarget-feature-inline-closure.2Ers.60.20flakey
https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Strange.20.5Cn.20in.20output.20of.20assert.20.23108341/near/395811335

This PR tries to make that not happen by adding a `CHECK-LABEL` directive that will match the line with the rustc version string, preventing the previous `CHECK-NOT` from seeing it.