### PR TITLE
Prevent showing methods from blanket impls of not available foreign traits to show up in the search results

### DIFF
--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -221,16 +221,23 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
             _ => self.cache.stripped_mod,
         };
 
+        #[inline]
+        fn is_from_private_dep(tcx: TyCtxt<'_>, cache: &Cache, def_id: DefId) -> bool {
+            let krate = def_id.krate;
+
+            cache.masked_crates.contains(&krate) || tcx.is_private_dep(krate)
+        }
+
         // If the impl is from a masked crate or references something from a
         // masked crate then remove it completely.
         if let clean::ImplItem(ref i) = *item.kind &&
             (self.cache.masked_crates.contains(&item.item_id.krate())
                 || i.trait_
                     .as_ref()
-                    .map_or(false, |t| self.cache.masked_crates.contains(&t.def_id().krate))
+                    .map_or(false, |t| is_from_private_dep(self.tcx, self.cache, t.def_id()))
                 || i.for_
                     .def_id(self.cache)
-                    .map_or(false, |d| self.cache.masked_crates.contains(&d.krate)))
+                    .map_or(false, |d| is_from_private_dep(self.tcx, self.cache, d)))
         {
             return None;
         }
@@ -310,19 +317,7 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                                 for_: clean::Type::BorrowedRef { type_, .. },
                                 ..
                             } => type_.def_id(&self.cache),
-                            ParentStackItem::Impl { for_, trait_, .. } => {
-                                if let Some(trait_) = trait_ {
-                                    let trait_did = trait_.def_id();
-                                    // If this is a foreign trait impl but the trait documentation
-                                    // is not available, we should not allow the methods to show up
-                                    // in the search results.
-                                    if !trait_did.is_local() && self.tcx.is_private_dep(trait_did.krate)
-                                    {
-                                        return None;
-                                    }
-                                }
-                                for_.def_id(&self.cache)
-                            }
+                            ParentStackItem::Impl { for_, .. } => for_.def_id(&self.cache),
                             ParentStackItem::Type(item_id) => item_id.as_def_id(),
                         };
                         let path = did

--- a/tests/rustdoc-js/auxiliary/equivalent.rs
+++ b/tests/rustdoc-js/auxiliary/equivalent.rs
@@ -1,0 +1,15 @@
+use std::borrow::Borrow;
+
+pub trait Equivalent<K: ?Sized> {
+    fn equivalent(&self, key: &K) -> bool;
+}
+
+impl<Q: ?Sized, K: ?Sized> Equivalent<K> for Q
+where
+    Q: Eq,
+    K: Borrow<Q>,
+{
+    fn equivalent(&self, key: &K) -> bool {
+        PartialEq::eq(self, key.borrow())
+    }
+}

--- a/tests/rustdoc-js/search-non-local-trait-impl.js
+++ b/tests/rustdoc-js/search-non-local-trait-impl.js
@@ -1,0 +1,9 @@
+// exact-check
+
+// This test ensures that methods from blanket impls of not available foreign traits
+// don't show up in the search results.
+
+const EXPECTED = {
+    'query': 'equivalent',
+    'others': [],
+};

--- a/tests/rustdoc-js/search-non-local-trait-impl.rs
+++ b/tests/rustdoc-js/search-non-local-trait-impl.rs
@@ -1,0 +1,8 @@
+// aux-crate:priv:equivalent=equivalent.rs
+// compile-flags: -Zunstable-options --extern equivalent
+// edition:2018
+
+extern crate equivalent;
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct LayoutError;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/115480.

In the case that the blanket impl trait is not available in the current crate, we prevent adding its methods in the search index.

Now how I found how to fix the issue: the `equivalent` method is not generated in the documentation pages but was still added to the search index. To render impls, we iterate over `cache.impls` so I took a look at how this was generated. Inside `formats/cache.rs`, we have `CacheBuilder::populate` where we push impls into `impls` but with this condition:

```rust
if cx.cache.traits.contains_key(&trait_did) {
```

I re-used this condition in `CacheBuilder::fold_item` to prevent this method from being added in `cache.search_index` or `cache.orphan_impl_items`.

PS: If you want to double-check if the added test works, just comment the code I added in `cache.rs` and it should fail.

r? @notriddle 