### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,6 +4504,7 @@ dependencies = [
 name = "rustc_smir"
 version = "0.0.0"
 dependencies = [
+ "rustc_data_structures",
  "rustc_driver",
  "rustc_hir",
  "rustc_interface",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -229,6 +229,7 @@ Compatibility Notes
   this should only impact users of other registries, or people who don't publish
   to a registry.
   [#12291](https://github.com/rust-lang/cargo/pull/12291)
+- [Demoted `mips*-unknown-linux-gnu*` targets from host tier 2 to target tier 3 support.](https://github.com/rust-lang/rust/pull/113274)
 
 Version 1.71.1 (2023-08-03)
 ===========================

--- a/compiler/rustc_smir/Cargo.toml
+++ b/compiler/rustc_smir/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_driver = { path = "../rustc_driver" }
 rustc_hir = { path = "../rustc_hir" }
 rustc_interface = { path = "../rustc_interface" }

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -107,12 +107,13 @@ impl<'tcx> Tables<'tcx> {
 
     fn create_alloc_id(&mut self, aid: AllocId) -> stable_mir::AllocId {
         // FIXME: this becomes inefficient when we have too many ids
-        if let Some(i) = self.alloc_ids.iter().position(|a| *a == aid) {
-            return stable_mir::AllocId(i);
-        };
-        let id = self.def_ids.len();
-        self.alloc_ids.push(aid);
-        stable_mir::AllocId(id)
+        if let Some(i) = self.alloc_ids.get(&aid) {
+            return *i;
+        } else {
+            let id = self.def_ids.len();
+            self.alloc_ids.insert(aid, stable_mir::AllocId(id));
+            stable_mir::AllocId(id)
+        }
     }
 
     pub(crate) fn create_span(&mut self, span: Span) -> stable_mir::ty::Span {
@@ -136,7 +137,7 @@ pub fn run(tcx: TyCtxt<'_>, f: impl FnOnce()) {
         Tables {
             tcx,
             def_ids: fx::FxIndexMap::default(),
-            alloc_ids: vec![],
+            alloc_ids: fx::FxIndexMap::default(),
             spans: vec![],
             types: vec![],
         },

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -3,8 +3,6 @@
 //! For that, we define APIs that will temporarily be public to 3P that exposes rustc internal APIs
 //! until stable MIR is complete.
 
-use std::ops::{ControlFlow, Index};
-
 use crate::rustc_internal;
 use crate::rustc_smir::Tables;
 use rustc_data_structures::fx;
@@ -14,14 +12,18 @@ use rustc_middle::mir::interpret::AllocId;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::{CrateNum, DefId};
 use rustc_span::Span;
+use stable_mir::ty::IndexedVal;
 use stable_mir::CompilerError;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::ops::{ControlFlow, Index};
 
 impl<'tcx> Index<stable_mir::DefId> for Tables<'tcx> {
     type Output = DefId;
 
     #[inline(always)]
     fn index(&self, index: stable_mir::DefId) -> &Self::Output {
-        &self.def_ids.get_index(index.0).unwrap().0
+        &self.def_ids[index]
     }
 }
 
@@ -30,7 +32,7 @@ impl<'tcx> Index<stable_mir::ty::Span> for Tables<'tcx> {
 
     #[inline(always)]
     fn index(&self, index: stable_mir::ty::Span) -> &Self::Output {
-        &self.spans.get_index(index.0).unwrap().0
+        &self.spans[index]
     }
 }
 
@@ -96,33 +98,15 @@ impl<'tcx> Tables<'tcx> {
     }
 
     fn create_def_id(&mut self, did: DefId) -> stable_mir::DefId {
-        if let Some(i) = self.def_ids.get(&did) {
-            return *i;
-        } else {
-            let id = self.def_ids.len();
-            self.def_ids.insert(did, stable_mir::DefId(id));
-            stable_mir::DefId(id)
-        }
+        self.def_ids.create_or_fetch(did)
     }
 
     fn create_alloc_id(&mut self, aid: AllocId) -> stable_mir::AllocId {
-        if let Some(i) = self.alloc_ids.get(&aid) {
-            return *i;
-        } else {
-            let id = self.def_ids.len();
-            self.alloc_ids.insert(aid, stable_mir::AllocId(id));
-            stable_mir::AllocId(id)
-        }
+        self.alloc_ids.create_or_fetch(aid)
     }
 
     pub(crate) fn create_span(&mut self, span: Span) -> stable_mir::ty::Span {
-        if let Some(i) = self.spans.get(&span) {
-            return *i;
-        } else {
-            let id = self.spans.len();
-            self.spans.insert(span, stable_mir::ty::Span(id));
-            stable_mir::ty::Span(id)
-        }
+        self.spans.create_or_fetch(span)
     }
 }
 
@@ -134,9 +118,9 @@ pub fn run(tcx: TyCtxt<'_>, f: impl FnOnce()) {
     stable_mir::run(
         Tables {
             tcx,
-            def_ids: fx::FxIndexMap::default(),
-            alloc_ids: fx::FxIndexMap::default(),
-            spans: fx::FxIndexMap::default(),
+            def_ids: rustc_internal::IndexMap { index_map: fx::FxIndexMap::default() },
+            alloc_ids: rustc_internal::IndexMap { index_map: fx::FxIndexMap::default() },
+            spans: rustc_internal::IndexMap { index_map: fx::FxIndexMap::default() },
             types: vec![],
         },
         f,
@@ -199,5 +183,31 @@ where
                 Compilation::Stop
             }
         })
+    }
+}
+
+/// Simmilar to rustc's `FxIndexMap`, `IndexMap` with extra
+/// safety features added.
+pub struct IndexMap<K, V> {
+    index_map: fx::FxIndexMap<K, V>,
+}
+
+impl<K: PartialEq + Hash + Eq, V: Copy + Debug + PartialEq + IndexedVal> IndexMap<K, V> {
+    pub fn create_or_fetch(&mut self, key: K) -> V {
+        let len = self.index_map.len();
+        let v = self.index_map.entry(key).or_insert(V::to_val(len));
+        *v
+    }
+}
+
+impl<K: PartialEq + Hash + Eq, V: Copy + Debug + PartialEq + IndexedVal> Index<V>
+    for IndexMap<K, V>
+{
+    type Output = K;
+
+    fn index(&self, index: V) -> &Self::Output {
+        let (k, v) = self.index_map.get_index(index.to_index()).unwrap();
+        assert_eq!(*v, index, "Provided value doesn't match with indexed value");
+        k
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -196,7 +196,7 @@ impl<S, R: PartialEq> PartialEq<R> for MaybeStable<S, R> {
 pub struct Tables<'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub def_ids: FxIndexMap<DefId, stable_mir::DefId>,
-    pub alloc_ids: Vec<AllocId>,
+    pub alloc_ids: FxIndexMap<AllocId, stable_mir::AllocId>,
     pub spans: Vec<rustc_span::Span>,
     pub types: Vec<MaybeStable<stable_mir::ty::TyKind, Ty<'tcx>>>,
 }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -9,6 +9,7 @@
 
 use crate::rustc_smir::hir::def::DefKind;
 use crate::rustc_smir::stable_mir::ty::{BoundRegion, EarlyBoundRegion, Region};
+use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir as hir;
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::{alloc_range, AllocId};
@@ -194,7 +195,7 @@ impl<S, R: PartialEq> PartialEq<R> for MaybeStable<S, R> {
 
 pub struct Tables<'tcx> {
     pub tcx: TyCtxt<'tcx>,
-    pub def_ids: Vec<DefId>,
+    pub def_ids: FxIndexMap<DefId, stable_mir::DefId>,
     pub alloc_ids: Vec<AllocId>,
     pub spans: Vec<rustc_span::Span>,
     pub types: Vec<MaybeStable<stable_mir::ty::TyKind, Ty<'tcx>>>,

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -197,7 +197,7 @@ pub struct Tables<'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub def_ids: FxIndexMap<DefId, stable_mir::DefId>,
     pub alloc_ids: FxIndexMap<AllocId, stable_mir::AllocId>,
-    pub spans: Vec<rustc_span::Span>,
+    pub spans: FxIndexMap<rustc_span::Span, Span>,
     pub types: Vec<MaybeStable<stable_mir::ty::TyKind, Ty<'tcx>>>,
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -7,9 +7,9 @@
 //!
 //! For now, we are developing everything inside `rustc`, thus, we keep this module private.
 
+use crate::rustc_internal::IndexMap;
 use crate::rustc_smir::hir::def::DefKind;
 use crate::rustc_smir::stable_mir::ty::{BoundRegion, EarlyBoundRegion, Region};
-use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir as hir;
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::{alloc_range, AllocId};
@@ -195,9 +195,9 @@ impl<S, R: PartialEq> PartialEq<R> for MaybeStable<S, R> {
 
 pub struct Tables<'tcx> {
     pub tcx: TyCtxt<'tcx>,
-    pub def_ids: FxIndexMap<DefId, stable_mir::DefId>,
-    pub alloc_ids: FxIndexMap<AllocId, stable_mir::AllocId>,
-    pub spans: FxIndexMap<rustc_span::Span, Span>,
+    pub def_ids: IndexMap<DefId, stable_mir::DefId>,
+    pub alloc_ids: IndexMap<AllocId, stable_mir::AllocId>,
+    pub spans: IndexMap<rustc_span::Span, Span>,
     pub types: Vec<MaybeStable<stable_mir::ty::TyKind, Ty<'tcx>>>,
 }
 

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -22,7 +22,8 @@ use std::fmt;
 use std::fmt::Debug;
 
 use self::ty::{
-    GenericPredicates, Generics, ImplDef, ImplTrait, Span, TraitDecl, TraitDef, Ty, TyKind,
+    GenericPredicates, Generics, ImplDef, ImplTrait, IndexedVal, Span, TraitDecl, TraitDef, Ty,
+    TyKind,
 };
 
 #[macro_use]
@@ -41,7 +42,7 @@ pub type CrateNum = usize;
 
 /// A unique identification number for each item accessible for the current compilation unit.
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct DefId(pub usize);
+pub struct DefId(usize);
 
 impl Debug for DefId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -52,9 +53,28 @@ impl Debug for DefId {
     }
 }
 
+impl IndexedVal for DefId {
+    fn to_val(index: usize) -> Self {
+        DefId(index)
+    }
+
+    fn to_index(&self) -> usize {
+        self.0
+    }
+}
+
 /// A unique identification number for each provenance
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct AllocId(pub usize);
+pub struct AllocId(usize);
+
+impl IndexedVal for AllocId {
+    fn to_val(index: usize) -> Self {
+        AllocId(index)
+    }
+    fn to_index(&self) -> usize {
+        self.0
+    }
+}
 
 /// A list of crate items.
 pub type CrateItems = Vec<CrateItem>;

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -75,7 +75,7 @@ pub struct Placeholder<T> {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct Span(pub usize);
+pub struct Span(usize);
 
 impl Debug for Span {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -83,6 +83,15 @@ impl Debug for Span {
             .field("id", &self.0)
             .field("repr", &with(|cx| cx.print_span(*self)))
             .finish()
+    }
+}
+
+impl IndexedVal for Span {
+    fn to_val(index: usize) -> Self {
+        Span(index)
+    }
+    fn to_index(&self) -> usize {
+        self.0
     }
 }
 
@@ -564,4 +573,10 @@ pub enum ImplPolarity {
     Positive,
     Negative,
     Reservation,
+}
+
+pub trait IndexedVal {
+    fn to_val(index: usize) -> Self;
+
+    fn to_index(&self) -> usize;
 }

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -669,7 +669,7 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// map.insert(1, "a");
     /// ```
     #[unstable(feature = "btreemap_alloc", issue = "32838")]
-    pub fn new_in(alloc: A) -> BTreeMap<K, V, A> {
+    pub const fn new_in(alloc: A) -> BTreeMap<K, V, A> {
         BTreeMap { root: None, length: 0, alloc: ManuallyDrop::new(alloc), _marker: PhantomData }
     }
 }

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -358,7 +358,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// let mut set: BTreeSet<i32> = BTreeSet::new_in(Global);
     /// ```
     #[unstable(feature = "btreemap_alloc", issue = "32838")]
-    pub fn new_in(alloc: A) -> BTreeSet<T, A> {
+    pub const fn new_in(alloc: A) -> BTreeSet<T, A> {
         BTreeSet { map: BTreeMap::new_in(alloc) }
     }
 

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -93,10 +93,6 @@ target | notes
 `arm-unknown-linux-gnueabihf` | ARMv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
 `armv7-unknown-linux-gnueabihf` | ARMv7-A Linux, hardfloat (kernel 3.2, glibc 2.17)
 [`loongarch64-unknown-linux-gnu`](platform-support/loongarch-linux.md) | LoongArch64 Linux, LP64D ABI (kernel 5.19, glibc 2.36)
-`mips-unknown-linux-gnu` | MIPS Linux (kernel 4.4, glibc 2.23)
-`mips64-unknown-linux-gnuabi64` | MIPS64 Linux, n64 ABI (kernel 4.4, glibc 2.23)
-`mips64el-unknown-linux-gnuabi64` | MIPS64 (LE) Linux, n64 ABI (kernel 4.4, glibc 2.23)
-`mipsel-unknown-linux-gnu` | MIPS (LE) Linux (kernel 4.4, glibc 2.23)
 `powerpc-unknown-linux-gnu` | PowerPC Linux (kernel 3.2, glibc 2.17)
 `powerpc64-unknown-linux-gnu` | PPC64 Linux (kernel 3.2, glibc 2.17)
 `powerpc64le-unknown-linux-gnu` | PPC64LE Linux (kernel 3.10, glibc 2.17)
@@ -286,6 +282,10 @@ target | std | host | notes
 [`mips64-openwrt-linux-musl`](platform-support/mips64-openwrt-linux-musl.md) | ? |  | MIPS64 for OpenWrt Linux MUSL
 `mipsel-sony-psp` | * |  | MIPS (LE) Sony PlayStation Portable (PSP)
 [`mipsel-sony-psx`](platform-support/mipsel-sony-psx.md) | * |  | MIPS (LE) Sony PlayStation 1 (PSX)
+`mips-unknown-linux-gnu` | MIPS Linux (kernel 4.4, glibc 2.23)
+`mips64-unknown-linux-gnuabi64` | MIPS64 Linux, n64 ABI (kernel 4.4, glibc 2.23)
+`mips64el-unknown-linux-gnuabi64` | MIPS64 (LE) Linux, n64 ABI (kernel 4.4, glibc 2.23)
+`mipsel-unknown-linux-gnu` | MIPS (LE) Linux (kernel 4.4, glibc 2.23)
 `mipsel-unknown-linux-uclibc` | ✓ |  | MIPS (LE) Linux with uClibc
 `mipsel-unknown-none` | * |  | Bare MIPS (LE) softfloat
 [`mipsisa32r6-unknown-linux-gnu`](platform-support/mips-release-6.md) | ? |  | 32-bit MIPS Release 6 Big Endian

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -350,6 +350,11 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                             desc,
                             parent,
                             parent_idx: None,
+                            impl_id: if let Some(ParentStackItem::Impl { item_id, .. }) = self.cache.parent_stack.last() {
+                                item_id.as_def_id()
+                            } else {
+                                None
+                            },
                             search_type: get_function_type_for_search(
                                 &item,
                                 self.tcx,
@@ -369,6 +374,13 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                         parent,
                         item: item.clone(),
                         impl_generics,
+                        impl_id: if let Some(ParentStackItem::Impl { item_id, .. }) =
+                            self.cache.parent_stack.last()
+                        {
+                            item_id.as_def_id()
+                        } else {
+                            None
+                        },
                     });
                 }
                 _ => {}
@@ -539,6 +551,7 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
 
 pub(crate) struct OrphanImplItem {
     pub(crate) parent: DefId,
+    pub(crate) impl_id: Option<DefId>,
     pub(crate) item: clean::Item,
     pub(crate) impl_generics: Option<(clean::Type, clean::Generics)>,
 }

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -223,17 +223,16 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
 
         // If the impl is from a masked crate or references something from a
         // masked crate then remove it completely.
-        if let clean::ImplItem(ref i) = *item.kind {
-            if self.cache.masked_crates.contains(&item.item_id.krate())
+        if let clean::ImplItem(ref i) = *item.kind &&
+            (self.cache.masked_crates.contains(&item.item_id.krate())
                 || i.trait_
                     .as_ref()
                     .map_or(false, |t| self.cache.masked_crates.contains(&t.def_id().krate))
                 || i.for_
                     .def_id(self.cache)
-                    .map_or(false, |d| self.cache.masked_crates.contains(&d.krate))
-            {
-                return None;
-            }
+                    .map_or(false, |d| self.cache.masked_crates.contains(&d.krate)))
+        {
+            return None;
         }
 
         // Propagate a trait method's documentation to all implementors of the
@@ -334,33 +333,32 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                     // A crate has a module at its root, containing all items,
                     // which should not be indexed. The crate-item itself is
                     // inserted later on when serializing the search-index.
-                    if item.item_id.as_def_id().map_or(false, |idx| !idx.is_crate_root()) {
+                    if item.item_id.as_def_id().map_or(false, |idx| !idx.is_crate_root())
+                        && let ty = item.type_()
+                        && (ty != ItemType::StructField
+                            || u16::from_str_radix(s.as_str(), 10).is_err())
+                    {
                         let desc =
                             short_markdown_summary(&item.doc_value(), &item.link_names(self.cache));
-                        let ty = item.type_();
-                        if ty != ItemType::StructField
-                            || u16::from_str_radix(s.as_str(), 10).is_err()
-                        {
-                            // In case this is a field from a tuple struct, we don't add it into
-                            // the search index because its name is something like "0", which is
-                            // not useful for rustdoc search.
-                            self.cache.search_index.push(IndexItem {
-                                ty,
-                                name: s,
-                                path: join_with_double_colon(path),
-                                desc,
-                                parent,
-                                parent_idx: None,
-                                search_type: get_function_type_for_search(
-                                    &item,
-                                    self.tcx,
-                                    clean_impl_generics(self.cache.parent_stack.last()).as_ref(),
-                                    self.cache,
-                                ),
-                                aliases: item.attrs.get_doc_aliases(),
-                                deprecation: item.deprecation(self.tcx),
-                            });
-                        }
+                        // In case this is a field from a tuple struct, we don't add it into
+                        // the search index because its name is something like "0", which is
+                        // not useful for rustdoc search.
+                        self.cache.search_index.push(IndexItem {
+                            ty,
+                            name: s,
+                            path: join_with_double_colon(path),
+                            desc,
+                            parent,
+                            parent_idx: None,
+                            search_type: get_function_type_for_search(
+                                &item,
+                                self.tcx,
+                                clean_impl_generics(self.cache.parent_stack.last()).as_ref(),
+                                self.cache,
+                            ),
+                            aliases: item.attrs.get_doc_aliases(),
+                            deprecation: item.deprecation(self.tcx),
+                        });
                     }
                 }
                 (Some(parent), None) if is_inherent_impl_item => {

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -503,8 +503,7 @@ fn sidebar_render_assoc_items(
             .iter()
             .filter_map(|it| {
                 let trait_ = it.inner_impl().trait_.as_ref()?;
-                let encoded =
-                    id_map.derive(super::get_id_for_impl(&it.inner_impl().for_, Some(trait_), cx));
+                let encoded = id_map.derive(super::get_id_for_impl(cx.tcx(), it.impl_item.item_id));
 
                 let prefix = match it.inner_impl().polarity {
                     ty::ImplPolarity::Positive | ty::ImplPolarity::Reservation => "",

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -354,6 +354,30 @@ function preLoadCss(cssUrl) {
                 expandSection(pageId);
             }
         }
+        if (savedHash.startsWith("#impl-")) {
+            // impl-disambiguated links, used by the search engine
+            // format: impl-X[-for-Y]/method.WHATEVER
+            // turn this into method.WHATEVER[-NUMBER]
+            const splitAt = savedHash.indexOf("/");
+            if (splitAt !== -1) {
+                const implId = savedHash.slice(1, splitAt);
+                const assocId = savedHash.slice(splitAt + 1);
+                const implElem = document.getElementById(implId);
+                if (implElem && implElem.parentElement.tagName === "SUMMARY" &&
+                    implElem.parentElement.parentElement.tagName === "DETAILS") {
+                    onEachLazy(implElem.parentElement.parentElement.querySelectorAll(
+                        `[id^="${assocId}"]`),
+                        item => {
+                            const numbered = /([^-]+)-([0-9]+)/.exec(item.id);
+                            if (item.id === assocId || (numbered && numbered[1] === assocId)) {
+                                expandSection(item.id);
+                                window.location = "#" + item.id;
+                            }
+                        }
+                    );
+                }
+            }
+        }
     }
 
     function onHashChange(ev) {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -354,13 +354,13 @@ function preLoadCss(cssUrl) {
                 expandSection(pageId);
             }
         }
-        if (savedHash.startsWith("#impl-")) {
+        if (savedHash.startsWith("impl-")) {
             // impl-disambiguated links, used by the search engine
             // format: impl-X[-for-Y]/method.WHATEVER
             // turn this into method.WHATEVER[-NUMBER]
             const splitAt = savedHash.indexOf("/");
             if (splitAt !== -1) {
-                const implId = savedHash.slice(1, splitAt);
+                const implId = savedHash.slice(0, splitAt);
                 const assocId = savedHash.slice(splitAt + 1);
                 const implElem = document.getElementById(implId);
                 if (implElem && implElem.parentElement.tagName === "SUMMARY" &&

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -370,8 +370,12 @@ function preLoadCss(cssUrl) {
                         item => {
                             const numbered = /([^-]+)-([0-9]+)/.exec(item.id);
                             if (item.id === assocId || (numbered && numbered[1] === assocId)) {
-                                expandSection(item.id);
-                                window.location = "#" + item.id;
+                                openParentDetails(item);
+                                item.scrollIntoView();
+                                // Let the section expand itself before trying to highlight
+                                setTimeout(() => {
+                                    window.location.replace("#" + item.id);
+                                }, 0);
                             }
                         }
                     );

--- a/tests/rustdoc-gui/search-result-impl-disambiguation.goml
+++ b/tests/rustdoc-gui/search-result-impl-disambiguation.goml
@@ -2,7 +2,7 @@
 
 // Checks that, if a type has two methods with the same name, they both get
 // linked correctly.
-goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 
 // This should link to the inherent impl
 write: (".search-input", "ZyxwvutMethodDisambiguation -> bool")
@@ -22,7 +22,7 @@ assert-document-property: ({
 }, ENDS_WITH)
 assert: "section:target"
 
-goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 
 // This should link to the trait impl
 write: (".search-input", "ZyxwvutMethodDisambiguation, usize -> usize")

--- a/tests/rustdoc-gui/search-result-impl-disambiguation.goml
+++ b/tests/rustdoc-gui/search-result-impl-disambiguation.goml
@@ -1,0 +1,41 @@
+// ignore-tidy-linelength
+
+// Checks that, if a type has two methods with the same name, they both get
+// linked correctly.
+goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
+
+// This should link to the inherent impl
+write: (".search-input", "ZyxwvutMethodDisambiguation -> bool")
+// To be SURE that the search will be run.
+press-key: 'Enter'
+// Waiting for the search results to appear...
+wait-for: "#search-tabs"
+// Check the disambiguated link.
+assert-count: ("a.result-method", 1)
+assert-attribute: ("a.result-method", {
+    "href": "../test_docs/struct.ZyxwvutMethodDisambiguation.html#impl-ZyxwvutMethodDisambiguation/method.method_impl_disambiguation"
+})
+click: "a.result-method"
+wait-for: "#impl-ZyxwvutMethodDisambiguation"
+assert-document-property: ({
+    "URL": "struct.ZyxwvutMethodDisambiguation.html#method.method_impl_disambiguation"
+}, ENDS_WITH)
+
+goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
+
+// This should link to the trait impl
+write: (".search-input", "ZyxwvutMethodDisambiguation, usize -> usize")
+// To be SURE that the search will be run.
+press-key: 'Enter'
+// Waiting for the search results to appear...
+wait-for: "#search-tabs"
+// Check the disambiguated link.
+assert-count: ("a.result-method", 1)
+assert-attribute: ("a.result-method", {
+    "href": "../test_docs/struct.ZyxwvutMethodDisambiguation.html#impl-ZyxwvutTrait-for-ZyxwvutMethodDisambiguation/method.method_impl_disambiguation"
+})
+click: "a.result-method"
+wait-for: "#impl-ZyxwvutMethodDisambiguation"
+assert-document-property: ({
+    "URL": "struct.ZyxwvutMethodDisambiguation.html#method.method_impl_disambiguation-1"
+}, ENDS_WITH)

--- a/tests/rustdoc-gui/search-result-impl-disambiguation.goml
+++ b/tests/rustdoc-gui/search-result-impl-disambiguation.goml
@@ -20,6 +20,7 @@ wait-for: "#impl-ZyxwvutMethodDisambiguation"
 assert-document-property: ({
     "URL": "struct.ZyxwvutMethodDisambiguation.html#method.method_impl_disambiguation"
 }, ENDS_WITH)
+assert: "section:target"
 
 goto: "file://" + |DOC_PATH| + "/test_docs/index.html"
 
@@ -39,3 +40,4 @@ wait-for: "#impl-ZyxwvutMethodDisambiguation"
 assert-document-property: ({
     "URL": "struct.ZyxwvutMethodDisambiguation.html#method.method_impl_disambiguation-1"
 }, ENDS_WITH)
+assert: "section:target"

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -529,3 +529,21 @@ pub mod cfgs {
     /// Some docs.
     pub mod cfgs {}
 }
+
+pub struct ZyxwvutMethodDisambiguation;
+
+impl ZyxwvutMethodDisambiguation {
+    pub fn method_impl_disambiguation(&self) -> bool {
+        true
+    }
+}
+
+pub trait ZyxwvutTrait {
+    fn method_impl_disambiguation(&self, x: usize) -> usize;
+}
+
+impl ZyxwvutTrait for ZyxwvutMethodDisambiguation {
+    fn method_impl_disambiguation(&self, x: usize) -> usize {
+        x
+    }
+}

--- a/tests/rustdoc-js-std/simd-type-signatures.js
+++ b/tests/rustdoc-js-std/simd-type-signatures.js
@@ -1,0 +1,70 @@
+// exact-check
+// ignore-order
+// ignore-tidy-linelength
+
+// This test case verifies that the href points at the correct impl
+
+const FILTER_CRATE = "std";
+
+const EXPECTED = [
+    {
+        'query': 'simd<i16>, simd<i16> -> simd<i16>',
+        'others': [
+            {
+                'path': 'std::simd::Simd',
+                'name': 'simd_max',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci16,+LANES%3E/method.simd_max'
+            },
+            {
+                'path': 'std::simd::Simd',
+                'name': 'simd_min',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci16,+LANES%3E/method.simd_min'
+            },
+            {
+                'path': 'std::simd::Simd',
+                'name': 'simd_clamp',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci16,+LANES%3E/method.simd_clamp'
+            },
+            {
+                'path': 'std::simd::Simd',
+                'name': 'saturating_add',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdInt-for-core::simd::Simd%3Ci16,+LANES%3E/method.saturating_add'
+            },
+            {
+                'path': 'std::simd::Simd',
+                'name': 'saturating_sub',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdInt-for-core::simd::Simd%3Ci16,+LANES%3E/method.saturating_sub'
+            },
+        ],
+    },
+    {
+        'query': 'simd<i8>, simd<i8> -> simd<i8>',
+        'others': [
+            {
+                'path': 'std::simd::Simd',
+                'name': 'simd_max',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci8,+LANES%3E/method.simd_max'
+            },
+            {
+                'path': 'std::simd::Simd',
+                'name': 'simd_min',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci8,+LANES%3E/method.simd_min'
+            },
+            {
+                'path': 'std::simd::Simd',
+                'name': 'simd_clamp',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci8,+LANES%3E/method.simd_clamp'
+            },
+            {
+                'path': 'std::simd::Simd',
+                'name': 'saturating_add',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdInt-for-core::simd::Simd%3Ci8,+LANES%3E/method.saturating_add'
+            },
+            {
+                'path': 'std::simd::Simd',
+                'name': 'saturating_sub',
+                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdInt-for-core::simd::Simd%3Ci8,+LANES%3E/method.saturating_sub'
+            },
+        ],
+    },
+];

--- a/tests/rustdoc-js-std/simd-type-signatures.js
+++ b/tests/rustdoc-js-std/simd-type-signatures.js
@@ -11,29 +11,29 @@ const EXPECTED = [
         'query': 'simd<i16>, simd<i16> -> simd<i16>',
         'others': [
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'simd_max',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci16,+LANES%3E/method.simd_max'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdOrd-for-Simd%3Ci16,+LANES%3E/method.simd_max'
             },
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'simd_min',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci16,+LANES%3E/method.simd_min'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdOrd-for-Simd%3Ci16,+LANES%3E/method.simd_min'
             },
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'simd_clamp',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci16,+LANES%3E/method.simd_clamp'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdOrd-for-Simd%3Ci16,+LANES%3E/method.simd_clamp'
             },
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'saturating_add',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdInt-for-core::simd::Simd%3Ci16,+LANES%3E/method.saturating_add'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdInt-for-Simd%3Ci16,+LANES%3E/method.saturating_add'
             },
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'saturating_sub',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdInt-for-core::simd::Simd%3Ci16,+LANES%3E/method.saturating_sub'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdInt-for-Simd%3Ci16,+LANES%3E/method.saturating_sub'
             },
         ],
     },
@@ -41,29 +41,29 @@ const EXPECTED = [
         'query': 'simd<i8>, simd<i8> -> simd<i8>',
         'others': [
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'simd_max',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci8,+LANES%3E/method.simd_max'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdOrd-for-Simd%3Ci8,+LANES%3E/method.simd_max'
             },
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'simd_min',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci8,+LANES%3E/method.simd_min'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdOrd-for-Simd%3Ci8,+LANES%3E/method.simd_min'
             },
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'simd_clamp',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdOrd-for-core::simd::Simd%3Ci8,+LANES%3E/method.simd_clamp'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdOrd-for-Simd%3Ci8,+LANES%3E/method.simd_clamp'
             },
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'saturating_add',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdInt-for-core::simd::Simd%3Ci8,+LANES%3E/method.saturating_add'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdInt-for-Simd%3Ci8,+LANES%3E/method.saturating_add'
             },
             {
-                'path': 'std::simd::Simd',
+                'path': 'std::simd::prelude::Simd',
                 'name': 'saturating_sub',
-                'href': '../std/simd/struct.Simd.html#impl-core::simd::SimdInt-for-core::simd::Simd%3Ci8,+LANES%3E/method.saturating_sub'
+                'href': '../std/simd/prelude/struct.Simd.html#impl-SimdInt-for-Simd%3Ci8,+LANES%3E/method.saturating_sub'
             },
         ],
     },

--- a/tests/rustdoc-js/search-method-disambiguate.js
+++ b/tests/rustdoc-js/search-method-disambiguate.js
@@ -1,0 +1,28 @@
+// exact-check
+// ignore-order
+// ignore-tidy-linelength
+
+const FILTER_CRATE = "search_method_disambiguate";
+
+const EXPECTED = [
+    {
+        'query': 'MyTy -> bool',
+        'others': [
+            {
+                'path': 'search_method_disambiguate::MyTy',
+                'name': 'my_method',
+                'href': '../search_method_disambiguate/struct.MyTy.html#impl-X-for-MyTy%3Cbool%3E/method.my_method'
+            },
+        ],
+    },
+    {
+        'query': 'MyTy -> u8',
+        'others': [
+            {
+                'path': 'search_method_disambiguate::MyTy',
+                'name': 'my_method',
+                'href': '../search_method_disambiguate/struct.MyTy.html#impl-X-for-MyTy%3Cu8%3E/method.my_method'
+            },
+        ],
+    }
+];

--- a/tests/rustdoc-js/search-method-disambiguate.rs
+++ b/tests/rustdoc-js/search-method-disambiguate.rs
@@ -1,0 +1,22 @@
+pub trait X {
+    type InnerType;
+    fn my_method(&self) -> Self::InnerType;
+}
+
+pub struct MyTy<T> {
+    pub t: T,
+}
+
+impl X for MyTy<bool> {
+    type InnerType = bool;
+    fn my_method(&self) -> bool {
+        self.t
+    }
+}
+
+impl X for MyTy<u8> {
+    type InnerType = u8;
+    fn my_method(&self) -> u8 {
+        self.t
+    }
+}

--- a/tests/rustdoc/blanket-reexport-item.rs
+++ b/tests/rustdoc/blanket-reexport-item.rs
@@ -1,6 +1,6 @@
 #![crate_name = "foo"]
 
-// @has foo/struct.S.html '//*[@id="impl-Into%3CU%3E-for-S"]//h3[@class="code-header"]' 'impl<T, U> Into<U> for T'
+// @has foo/struct.S.html '//*[@id="impl-Into%3CU%3E-for-T"]//h3[@class="code-header"]' 'impl<T, U> Into<U> for T'
 pub struct S2 {}
 mod m {
     pub struct S {}

--- a/tests/rustdoc/const-generics/const-impl.rs
+++ b/tests/rustdoc/const-generics/const-impl.rs
@@ -31,7 +31,7 @@ impl<T> VSet<T, { Order::Unsorted }> {
 
 pub struct Escape<const S: &'static str>;
 
-// @has foo/struct.Escape.html '//*[@id="impl-Escape%3Cr%23%22%3Cscript%3Ealert(%22Escape%22);%3C/script%3E%22%23%3E"]/h3[@class="code-header"]' 'impl Escape<r#"<script>alert("Escape");</script>"#>'
+// @has foo/struct.Escape.html '//*[@id="impl-Escape%3C%22%3Cscript%3Ealert(%5C%22Escape%5C%22);%3C/script%3E%22%3E"]/h3[@class="code-header"]' 'impl Escape<r#"<script>alert("Escape");</script>"#>'
 impl Escape<r#"<script>alert("Escape");</script>"#> {
     pub fn f() {}
 }

--- a/tests/rustdoc/generic-impl.rs
+++ b/tests/rustdoc/generic-impl.rs
@@ -5,9 +5,9 @@ use std::fmt;
 // @!has foo/struct.Bar.html '//*[@id="impl-ToString-for-Bar"]' ''
 pub struct Bar;
 
-// @has foo/struct.Foo.html '//*[@id="impl-ToString-for-Foo"]//h3[@class="code-header"]' 'impl<T> ToString for T'
+// @has foo/struct.Foo.html '//*[@id="impl-ToString-for-T"]//h3[@class="code-header"]' 'impl<T> ToString for T'
 pub struct Foo;
-// @has foo/struct.Foo.html '//*[@class="sidebar-elems"]//section//a[@href="#impl-ToString-for-Foo"]' 'ToString'
+// @has foo/struct.Foo.html '//*[@class="sidebar-elems"]//section//a[@href="#impl-ToString-for-T"]' 'ToString'
 
 impl fmt::Display for Foo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/tests/rustdoc/issue-32077-type-alias-impls.rs
+++ b/tests/rustdoc/issue-32077-type-alias-impls.rs
@@ -22,7 +22,7 @@ impl Bar for GenericStruct<u32> {}
 // We check that "Aliased type" is also present as a title in the sidebar.
 // @has - '//*[@class="sidebar-elems"]//h3/a[@href="#aliased-type"]' 'Aliased type'
 // We check that we have the implementation of the type alias itself.
-// @has - '//*[@id="impl-TypedefStruct"]/h3' 'impl TypedefStruct'
+// @has - '//*[@id="impl-GenericStruct%3Cu8%3E"]/h3' 'impl TypedefStruct'
 // @has - '//*[@id="method.on_alias"]/h4' 'pub fn on_alias()'
 // @has - '//*[@id="impl-GenericStruct%3CT%3E"]/h3' 'impl<T> GenericStruct<T>'
 // @has - '//*[@id="method.on_gen"]/h4' 'pub fn on_gen(arg: T)'

--- a/tests/rustdoc/issue-78701.rs
+++ b/tests/rustdoc/issue-78701.rs
@@ -6,7 +6,7 @@
 
 // @has 'foo/struct.AnotherStruct.html'
 // @count - '//*[@class="sidebar"]//a[@href="#impl-AnAmazingTrait-for-AnotherStruct%3C()%3E"]' 1
-// @count - '//*[@class="sidebar"]//a[@href="#impl-AnAmazingTrait-for-AnotherStruct%3CT%3E"]' 1
+// @count - '//*[@class="sidebar"]//a[@href="#impl-AnAmazingTrait-for-T"]' 1
 
 pub trait Something {}
 

--- a/tests/rustdoc/primitive/primitive-generic-impl.rs
+++ b/tests/rustdoc/primitive/primitive-generic-impl.rs
@@ -1,7 +1,7 @@
 #![feature(rustc_attrs)]
 #![crate_name = "foo"]
 
-// @has foo/primitive.i32.html '//*[@id="impl-ToString-for-i32"]//h3[@class="code-header"]' 'impl<T> ToString for T'
+// @has foo/primitive.i32.html '//*[@id="impl-ToString-for-T"]//h3[@class="code-header"]' 'impl<T> ToString for T'
 
 #[rustc_doc_primitive = "i32"]
 /// Some useless docs, wouhou!

--- a/tests/rustdoc/sidebar-links-to-foreign-impl.rs
+++ b/tests/rustdoc/sidebar-links-to-foreign-impl.rs
@@ -7,8 +7,8 @@
 // @has - '//h2[@id="foreign-impls"]' 'Implementations on Foreign Types'
 // @has - '//*[@class="sidebar-elems"]//section//a[@href="#impl-Foo-for-u32"]' 'u32'
 // @has - '//*[@id="impl-Foo-for-u32"]//h3[@class="code-header"]' 'impl Foo for u32'
-// @has - "//*[@class=\"sidebar-elems\"]//section//a[@href=\"#impl-Foo-for-%26'a+str\"]" "&'a str"
-// @has - "//*[@id=\"impl-Foo-for-%26'a+str\"]//h3[@class=\"code-header\"]" "impl<'a> Foo for &'a str"
+// @has - "//*[@class=\"sidebar-elems\"]//section//a[@href=\"#impl-Foo-for-%26str\"]" "&'a str"
+// @has - "//*[@id=\"impl-Foo-for-%26str\"]//h3[@class=\"code-header\"]" "impl<'a> Foo for &'a str"
 pub trait Foo {}
 
 impl Foo for u32 {}

--- a/tests/rustdoc/src-links-auto-impls.rs
+++ b/tests/rustdoc/src-links-auto-impls.rs
@@ -5,8 +5,8 @@
 // @!has - '//*[@id="impl-Sized-for-Unsized"]//a[@class="src"]' 'source'
 // @has - '//*[@id="impl-Sync-for-Unsized"]/h3[@class="code-header"]' 'impl Sync for Unsized'
 // @!has - '//*[@id="impl-Sync-for-Unsized"]//a[@class="src"]' 'source'
-// @has - '//*[@id="impl-Any-for-Unsized"]/h3[@class="code-header"]' 'impl<T> Any for T'
-// @has - '//*[@id="impl-Any-for-Unsized"]//a[@class="src rightside"]' 'source'
+// @has - '//*[@id="impl-Any-for-T"]/h3[@class="code-header"]' 'impl<T> Any for T'
+// @has - '//*[@id="impl-Any-for-T"]//a[@class="src rightside"]' 'source'
 pub struct Unsized {
     data: [u8],
 }

--- a/tests/rustdoc/where-clause-order.rs
+++ b/tests/rustdoc/where-clause-order.rs
@@ -7,8 +7,19 @@ where
 }
 
 // @has 'foo/trait.SomeTrait.html'
-// @has - "//*[@id='impl-SomeTrait%3C(A,+B,+C,+D,+E)%3E-for-(A,+B,+C,+D,+E)']/h3" "impl<A, B, C, D, E> SomeTrait<(A, B, C, D, E)> for (A, B, C, D, E)where A: PartialOrd<A> + PartialEq<A>, B: PartialOrd<B> + PartialEq<B>, C: PartialOrd<C> + PartialEq<C>, D: PartialOrd<D> + PartialEq<D>, E: PartialOrd<E> + PartialEq<E> + ?Sized, "
+// @has - "//*[@id='impl-SomeTrait-for-(A,+B,+C,+D,+E)']/h3" "impl<A, B, C, D, E> SomeTrait<(A, B, C, D, E)> for (A, B, C, D, E)where A: PartialOrd<A> + PartialEq<A>, B: PartialOrd<B> + PartialEq<B>, C: PartialOrd<C> + PartialEq<C>, D: PartialOrd<D> + PartialEq<D>, E: PartialOrd<E> + PartialEq<E> + ?Sized, "
 impl<A, B, C, D, E> SomeTrait<(A, B, C, D, E)> for (A, B, C, D, E)
+where
+    A: PartialOrd<A> + PartialEq<A>,
+    B: PartialOrd<B> + PartialEq<B>,
+    C: PartialOrd<C> + PartialEq<C>,
+    D: PartialOrd<D> + PartialEq<D>,
+    E: PartialOrd<E> + PartialEq<E> + ?Sized,
+{
+}
+
+// @has - "//*[@id='impl-SomeTrait%3C(A,+B,+C,+D)%3E-for-(A,+B,+C,+D,+E)']/h3" "impl<A, B, C, D, E> SomeTrait<(A, B, C, D)> for (A, B, C, D, E)where A: PartialOrd<A> + PartialEq<A>, B: PartialOrd<B> + PartialEq<B>, C: PartialOrd<C> + PartialEq<C>, D: PartialOrd<D> + PartialEq<D>, E: PartialOrd<E> + PartialEq<E> + ?Sized, "
+impl<A, B, C, D, E> SomeTrait<(A, B, C, D)> for (A, B, C, D, E)
 where
     A: PartialOrd<A> + PartialEq<A>,
     B: PartialOrd<B> + PartialEq<B>,

--- a/tests/ui/consts/const-eval/unused-broken-const-late.rs
+++ b/tests/ui/consts/const-eval/unused-broken-const-late.rs
@@ -1,0 +1,20 @@
+// build-fail
+// compile-flags: -O
+//! Make sure we detect erroneous constants post-monomorphization even when they are unused. This is
+//! crucial, people rely on it for soundness. (https://github.com/rust-lang/rust/issues/112090)
+
+struct PrintName<T>(T);
+impl<T> PrintName<T> {
+    const VOID: () = panic!(); //~ERROR evaluation of `PrintName::<i32>::VOID` failed
+}
+
+fn no_codegen<T>() {
+    // Any function that is called is guaranteed to have all consts that syntactically
+    // appear in its body evaluated, even if they only appear in dead code.
+    if false {
+        let _ = PrintName::<T>::VOID;
+    }
+}
+pub fn main() {
+    no_codegen::<i32>();
+}

--- a/tests/ui/consts/const-eval/unused-broken-const-late.stderr
+++ b/tests/ui/consts/const-eval/unused-broken-const-late.stderr
@@ -1,0 +1,11 @@
+error[E0080]: evaluation of `PrintName::<i32>::VOID` failed
+  --> $DIR/unused-broken-const-late.rs:8:22
+   |
+LL |     const VOID: () = panic!();
+   |                      ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/unused-broken-const-late.rs:8:22
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/unboxed-closures/unboxed-closures-type-mismatch.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-type-mismatch.rs
@@ -1,7 +1,35 @@
 use std::ops::FnMut;
 
-pub fn main() {
+fn main() {
     let mut f = |x: isize, y: isize| -> isize { x + y };
-    let z = f(1_usize, 2);    //~ ERROR mismatched types
+    let z = f(1_usize, 2); //~ ERROR mismatched types
     println!("{}", z);
+    let mut g = |x, y| { x + y };
+    let y = g(1_i32, 2);
+    let z = g(1_usize, 2); //~ ERROR mismatched types
+    println!("{}", z);
+}
+
+trait T {
+    fn bar(&self) {
+        let identity = |x| x;
+        identity(1u8);
+        identity(1u16); //~ ERROR mismatched types
+        let identity = |x| x;
+        identity(&1u8);
+        identity(&1u16); //~ ERROR mismatched types
+    }
+}
+
+struct S;
+
+impl T  for S {
+    fn bar(&self) {
+        let identity = |x| x;
+        identity(1u8);
+        identity(1u16); //~ ERROR mismatched types
+        let identity = |x| x;
+        identity(&1u8);
+        identity(&1u16); //~ ERROR mismatched types
+    }
 }

--- a/tests/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
@@ -16,6 +16,127 @@ help: change the type of the numeric literal from `usize` to `isize`
 LL |     let z = f(1_isize, 2);
    |                 ~~~~~
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:9:15
+   |
+LL |     let z = g(1_usize, 2);
+   |             - ^^^^^^^ expected `i32`, found `usize`
+   |             |
+   |             arguments to this function are incorrect
+   |
+note: expected because the closure was earlier called with an argument of type `i32`
+  --> $DIR/unboxed-closures-type-mismatch.rs:8:15
+   |
+LL |     let y = g(1_i32, 2);
+   |             - ^^^^^ expected because this argument is of type `i32`
+   |             |
+   |             in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:7:18
+   |
+LL |     let mut g = |x, y| { x + y };
+   |                  ^
+help: change the type of the numeric literal from `usize` to `i32`
+   |
+LL |     let z = g(1_i32, 2);
+   |                 ~~~
+
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:17:18
+   |
+LL |         identity(1u16);
+   |         -------- ^^^^ expected `u8`, found `u16`
+   |         |
+   |         arguments to this function are incorrect
+   |
+note: expected because the closure was earlier called with an argument of type `u8`
+  --> $DIR/unboxed-closures-type-mismatch.rs:16:18
+   |
+LL |         identity(1u8);
+   |         -------- ^^^ expected because this argument is of type `u8`
+   |         |
+   |         in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:15:25
+   |
+LL |         let identity = |x| x;
+   |                         ^
+help: change the type of the numeric literal from `u16` to `u8`
+   |
+LL |         identity(1u8);
+   |                   ~~
+
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:20:18
+   |
+LL |         identity(&1u16);
+   |         -------- ^^^^^ expected `&u8`, found `&u16`
+   |         |
+   |         arguments to this function are incorrect
+   |
+   = note: expected reference `&u8`
+              found reference `&u16`
+note: expected because the closure was earlier called with an argument of type `&u8`
+  --> $DIR/unboxed-closures-type-mismatch.rs:19:18
+   |
+LL |         identity(&1u8);
+   |         -------- ^^^^ expected because this argument is of type `&u8`
+   |         |
+   |         in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:18:25
+   |
+LL |         let identity = |x| x;
+   |                         ^
+
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:30:18
+   |
+LL |         identity(1u16);
+   |         -------- ^^^^ expected `u8`, found `u16`
+   |         |
+   |         arguments to this function are incorrect
+   |
+note: expected because the closure was earlier called with an argument of type `u8`
+  --> $DIR/unboxed-closures-type-mismatch.rs:29:18
+   |
+LL |         identity(1u8);
+   |         -------- ^^^ expected because this argument is of type `u8`
+   |         |
+   |         in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:28:25
+   |
+LL |         let identity = |x| x;
+   |                         ^
+help: change the type of the numeric literal from `u16` to `u8`
+   |
+LL |         identity(1u8);
+   |                   ~~
+
+error[E0308]: mismatched types
+  --> $DIR/unboxed-closures-type-mismatch.rs:33:18
+   |
+LL |         identity(&1u16);
+   |         -------- ^^^^^ expected `&u8`, found `&u16`
+   |         |
+   |         arguments to this function are incorrect
+   |
+   = note: expected reference `&u8`
+              found reference `&u16`
+note: expected because the closure was earlier called with an argument of type `&u8`
+  --> $DIR/unboxed-closures-type-mismatch.rs:32:18
+   |
+LL |         identity(&1u8);
+   |         -------- ^^^^ expected because this argument is of type `&u8`
+   |         |
+   |         in this closure call
+note: closure parameter defined here
+  --> $DIR/unboxed-closures-type-mismatch.rs:31:25
+   |
+LL |         let identity = |x| x;
+   |                         ^
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #109422 (rustdoc-search: add impl disambiguator to duplicate assoc items)
 - #116250 (On type error of closure call argument, point at earlier calls that affected inference)
 - #116444 (add test for const-eval error in dead code during monomorphization)
 - #116503 (Update docs for mips target tier demotion.)
 - #116559 (Mark `new_in` as `const` for BTree collections)
 - #116560 (In smir use `FxIndexMap` to store indexed ids)
 - #116574 (Update books)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=109422,116250,116444,116503,116559,116560,116574)
<!-- homu-ignore:end -->