### PR TITLE
Add ability to get lines/filename for Span in smir

### DIFF
--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -22,8 +22,8 @@ use std::fmt;
 use std::fmt::Debug;
 
 use self::ty::{
-    GenericPredicates, Generics, ImplDef, ImplTrait, IndexedVal, Span, TraitDecl, TraitDef, Ty,
-    TyKind,
+    GenericPredicates, Generics, ImplDef, ImplTrait, IndexedVal, LineInfo, Span, TraitDecl,
+    TraitDef, Ty, TyKind,
 };
 
 #[macro_use]
@@ -108,6 +108,7 @@ pub struct Crate {
 }
 
 pub type DefKind = Opaque;
+pub type Filename = Opaque;
 
 /// Holds information about an item in the crate.
 /// For now, it only stores the item DefId. Use functions inside `rustc_internal` module to
@@ -196,13 +197,19 @@ pub trait Context {
     /// Find a crate with the given name.
     fn find_crates(&self, name: &str) -> Vec<Crate>;
 
-    /// Prints the name of given `DefId`
+    /// Returns the name of given `DefId`
     fn name_of_def_id(&self, def_id: DefId) -> String;
 
-    /// Prints a human readable form of `Span`
+    /// Returns printable, human readable form of `Span`
     fn print_span(&self, span: Span) -> String;
 
-    /// Prints the kind of given `DefId`
+    /// Return filename from given `Span`, for diagnostic purposes
+    fn get_filename(&self, span: &Span) -> Filename;
+
+    /// Return lines corresponding to this `Span`
+    fn get_lines(&self, span: &Span) -> Vec<LineInfo>;
+
+    /// Returns the `kind` of given `DefId`
     fn def_kind(&mut self, def_id: DefId) -> DefKind;
 
     /// `Span` of an item

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -201,13 +201,13 @@ pub trait Context {
     fn name_of_def_id(&self, def_id: DefId) -> String;
 
     /// Returns printable, human readable form of `Span`
-    fn print_span(&self, span: Span) -> String;
+    fn span_to_string(&self, span: Span) -> String;
 
     /// Return filename from given `Span`, for diagnostic purposes
     fn get_filename(&self, span: &Span) -> Filename;
 
     /// Return lines corresponding to this `Span`
-    fn get_lines(&self, span: &Span) -> Vec<LineInfo>;
+    fn get_lines(&self, span: &Span) -> LineInfo;
 
     /// Returns the `kind` of given `DefId`
     fn def_kind(&mut self, def_id: DefId) -> DefKind;

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -3,7 +3,7 @@ use super::{
     mir::{Body, Mutability},
     with, AllocId, DefId, Symbol,
 };
-use crate::Opaque;
+use crate::{Filename, Opaque};
 use std::fmt::{self, Debug, Formatter};
 
 #[derive(Copy, Clone)]
@@ -84,6 +84,27 @@ impl Debug for Span {
             .field("repr", &with(|cx| cx.print_span(*self)))
             .finish()
     }
+}
+
+impl Span {
+    /// Return filename for diagnostic purposes
+    pub fn get_filename(&self) -> Filename {
+        with(|c| c.get_filename(self))
+    }
+
+    /// Return lines that corespond to this `Span`
+    pub fn get_lines(&self) -> Vec<LineInfo> {
+        with(|c| c.get_lines(&self))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+/// Information you get from `Span` in a struct form.
+/// Line and col start from 1.
+pub struct LineInfo {
+    pub line_index: usize,
+    pub start_col: usize,
+    pub end_col: usize,
 }
 
 impl IndexedVal for Span {

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -81,7 +81,7 @@ impl Debug for Span {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Span")
             .field("id", &self.0)
-            .field("repr", &with(|cx| cx.print_span(*self)))
+            .field("repr", &with(|cx| cx.span_to_string(*self)))
             .finish()
     }
 }
@@ -93,7 +93,7 @@ impl Span {
     }
 
     /// Return lines that corespond to this `Span`
-    pub fn get_lines(&self) -> Vec<LineInfo> {
+    pub fn get_lines(&self) -> LineInfo {
         with(|c| c.get_lines(&self))
     }
 }
@@ -102,8 +102,9 @@ impl Span {
 /// Information you get from `Span` in a struct form.
 /// Line and col start from 1.
 pub struct LineInfo {
-    pub line_index: usize,
+    pub start_line: usize,
     pub start_col: usize,
+    pub end_line: usize,
     pub end_col: usize,
 }
 


### PR DESCRIPTION
Wasn't sure about how to structure lines, so went with safest option, also I'm not sure why `span_to_lines` returns `vec`.

Addresses https://github.com/rust-lang/project-stable-mir/issues/44 

r? @oli-obk 