### PR TITLE
Detect ruby-style closure in parser

### DIFF
--- a/tests/ui/expr/malformed_closure/missing_block_in_fn_call.fixed
+++ b/tests/ui/expr/malformed_closure/missing_block_in_fn_call.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+fn main() {
+    let _ = vec![1, 2, 3].into_iter().map(|x| {
+        let y = x; //~ ERROR expected expression, found `let` statement
+        y
+    });
+    let _: () = foo(); //~ ERROR mismatched types
+}
+
+fn foo() {}

--- a/tests/ui/expr/malformed_closure/missing_block_in_fn_call.rs
+++ b/tests/ui/expr/malformed_closure/missing_block_in_fn_call.rs
@@ -1,0 +1,10 @@
+// run-rustfix
+fn main() {
+    let _ = vec![1, 2, 3].into_iter().map(|x|
+        let y = x; //~ ERROR expected expression, found `let` statement
+        y
+    );
+    let _: () = foo; //~ ERROR mismatched types
+}
+
+fn foo() {}

--- a/tests/ui/expr/malformed_closure/missing_block_in_fn_call.stderr
+++ b/tests/ui/expr/malformed_closure/missing_block_in_fn_call.stderr
@@ -1,0 +1,38 @@
+error: expected expression, found `let` statement
+  --> $DIR/missing_block_in_fn_call.rs:4:9
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().map(|x|
+   |                                           --- while parsing the body of this closure
+LL |         let y = x;
+   |         ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+help: you might have meant to open the body of the closure
+   |
+LL ~     let _ = vec![1, 2, 3].into_iter().map(|x| {
+LL |         let y = x;
+LL |         y
+LL ~     });
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/missing_block_in_fn_call.rs:7:17
+   |
+LL |     let _: () = foo;
+   |            --   ^^^ expected `()`, found fn item
+   |            |
+   |            expected due to this
+...
+LL | fn foo() {}
+   | -------- function `foo` defined here
+   |
+   = note: expected unit type `()`
+                found fn item `fn() {foo}`
+help: use parentheses to call this function
+   |
+LL |     let _: () = foo();
+   |                    ++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/expr/malformed_closure/missing_block_in_let_binding.rs
+++ b/tests/ui/expr/malformed_closure/missing_block_in_let_binding.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let x = |x|
+        let y = x; //~ ERROR expected expression, found `let` statement
+        let _ = () + ();
+        y
+}

--- a/tests/ui/expr/malformed_closure/missing_block_in_let_binding.stderr
+++ b/tests/ui/expr/malformed_closure/missing_block_in_let_binding.stderr
@@ -1,0 +1,16 @@
+error: expected expression, found `let` statement
+  --> $DIR/missing_block_in_let_binding.rs:3:9
+   |
+LL |     let x = |x|
+   |             --- while parsing the body of this closure
+LL |         let y = x;
+   |         ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+help: you might have meant to open the body of the closure
+   |
+LL |     let x = |x| {
+   |                 +
+
+error: aborting due to previous error
+

--- a/tests/ui/expr/malformed_closure/ruby_style_closure_parse_error.fixed
+++ b/tests/ui/expr/malformed_closure/ruby_style_closure_parse_error.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+fn main() {
+    let _ = vec![1, 2, 3].into_iter().map(|x| {
+        let y = x; //~ ERROR expected expression, found `let` statement
+        y
+    });
+    let _: () = foo(); //~ ERROR mismatched types
+}
+fn foo() {}

--- a/tests/ui/expr/malformed_closure/ruby_style_closure_parse_error.rs
+++ b/tests/ui/expr/malformed_closure/ruby_style_closure_parse_error.rs
@@ -1,0 +1,9 @@
+// run-rustfix
+fn main() {
+    let _ = vec![1, 2, 3].into_iter().map({|x|
+        let y = x; //~ ERROR expected expression, found `let` statement
+        y
+    });
+    let _: () = foo; //~ ERROR mismatched types
+}
+fn foo() {}

--- a/tests/ui/expr/malformed_closure/ruby_style_closure_parse_error.stderr
+++ b/tests/ui/expr/malformed_closure/ruby_style_closure_parse_error.stderr
@@ -1,0 +1,36 @@
+error: expected expression, found `let` statement
+  --> $DIR/ruby_style_closure_parse_error.rs:4:9
+   |
+LL |     let _ = vec![1, 2, 3].into_iter().map({|x|
+   |                                            --- while parsing the body of this closure
+LL |         let y = x;
+   |         ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+help: you might have meant to open the body of the closure, instead of enclosing the closure in a block
+   |
+LL -     let _ = vec![1, 2, 3].into_iter().map({|x|
+LL +     let _ = vec![1, 2, 3].into_iter().map(|x| {
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/ruby_style_closure_parse_error.rs:7:17
+   |
+LL |     let _: () = foo;
+   |            --   ^^^ expected `()`, found fn item
+   |            |
+   |            expected due to this
+LL | }
+LL | fn foo() {}
+   | -------- function `foo` defined here
+   |
+   = note: expected unit type `()`
+                found fn item `fn() {foo}`
+help: use parentheses to call this function
+   |
+LL |     let _: () = foo();
+   |                    ++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
+++ b/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
@@ -2,9 +2,15 @@ error: expected identifier, found `:`
   --> $DIR/or-patterns-syntactic-fail.rs:11:19
    |
 LL |     let _ = |A | B: E| ();
-   |                   ^ expected identifier
+   |             ----  ^ expected identifier
+   |             |
+   |             while parsing the body of this closure
    |
    = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: you might have meant to open the body of the closure
+   |
+LL |     let _ = |A | { B: E| ();
+   |                  +
 
 error: top-level or-patterns are not allowed in function parameters
   --> $DIR/or-patterns-syntactic-fail.rs:18:13

--- a/tests/ui/parser/issues/issue-32505.rs
+++ b/tests/ui/parser/issues/issue-32505.rs
@@ -1,5 +1,6 @@
 pub fn test() {
     foo(|_|) //~ ERROR expected expression, found `)`
+    //~^ ERROR cannot find function `foo` in this scope
 }
 
 fn main() { }

--- a/tests/ui/parser/issues/issue-32505.stderr
+++ b/tests/ui/parser/issues/issue-32505.stderr
@@ -2,7 +2,21 @@ error: expected expression, found `)`
   --> $DIR/issue-32505.rs:2:12
    |
 LL |     foo(|_|)
-   |            ^ expected expression
+   |         ---^ expected expression
+   |         |
+   |         while parsing the body of this closure
+   |
+help: you might have meant to open the body of the closure
+   |
+LL |     foo(|_| {})
+   |            ++
 
-error: aborting due to previous error
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/issue-32505.rs:2:5
+   |
+LL |     foo(|_|)
+   |     ^^^ not found in this scope
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
When parsing a closure without a body that is surrounded by a block, suggest moving the opening brace after the closure head.

Fix #116608.