### PR TITLE
Speed up `Read::bytes`

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2781,13 +2781,10 @@ impl<R: Read> Iterator for Bytes<R> {
 
     #[inline]
     fn next(&mut self) -> Option<Result<u8>> {
-        loop {
-            return match self.inner.read(slice::from_mut(&mut self.byte)) {
-                Ok(0) => None,
-                Ok(..) => Some(Ok(self.byte)),
-                Err(ref e) if e.is_interrupted() => continue,
-                Err(e) => Some(Err(e)),
-            };
+        match self.inner.read_exact(slice::from_mut(&mut self.byte)) {
+            Ok(()) => Some(Ok(self.byte)),
+            Err(e) if e.kind() == ErrorKind::UnexpectedEof => None,
+            Err(e) => Some(Err(e)),
         }
     }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2778,6 +2778,7 @@ pub struct Bytes<R> {
 impl<R: Read> Iterator for Bytes<R> {
     type Item = Result<u8>;
 
+    #[inline]
     fn next(&mut self) -> Option<Result<u8>> {
         let mut byte = 0;
         loop {
@@ -2790,6 +2791,7 @@ impl<R: Read> Iterator for Bytes<R> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         SizeHint::size_hint(&self.inner)
     }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1000,7 +1000,7 @@ pub trait Read {
     where
         Self: Sized,
     {
-        Bytes { inner: self }
+        Bytes { inner: self, byte: 0 }
     }
 
     /// Creates an adapter which will chain this stream with another.
@@ -2772,6 +2772,7 @@ impl<T> SizeHint for Take<T> {
 #[derive(Debug)]
 pub struct Bytes<R> {
     inner: R,
+    byte: u8,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -2780,11 +2781,10 @@ impl<R: Read> Iterator for Bytes<R> {
 
     #[inline]
     fn next(&mut self) -> Option<Result<u8>> {
-        let mut byte = 0;
         loop {
-            return match self.inner.read(slice::from_mut(&mut byte)) {
+            return match self.inner.read(slice::from_mut(&mut self.byte)) {
                 Ok(0) => None,
-                Ok(..) => Some(Ok(byte)),
+                Ok(..) => Some(Ok(self.byte)),
                 Err(ref e) if e.is_interrupted() => continue,
                 Err(e) => Some(Err(e)),
             };


### PR DESCRIPTION
https://github.com/nnethercote/perf-book/issues/69 explains that `Read::bytes` in combination with a `BufReader` is very slow. This PR speeds it up quite a bit -- on a simple test program the runtime dropped from 320ms to 215ms -- but it's still a lot slower than alternatives. This is basically because `BufReader` has a certain amount of overhead for each `read` call, and so a configuration where every single byte requires a `read` is just a bad one for it.