### PR TITLE
Make "request changes" reviews apply `S-waiting-on-author`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -23,6 +23,12 @@ allow-unauthenticated = [
     "needs-triage",
 ]
 
+[review-submitted] 
+# This label is added when a "request changes" review is submitted. 
+reviewed_label = "S-waiting-on-author" 
+# These labels are removed when a "request changes" review is submitted. 
+review_labels = ["S-waiting-on-review"]
+
 [glacier]
 
 [ping.icebreakers-llvm]


### PR DESCRIPTION
This makes it so **assignee** requesting changes on a PR via GitHub UI adds https://github.com/rust-lang/rust/labels/S-waiting-on-author and removes https://github.com/rust-lang/rust/labels/S-waiting-on-review.

cc @compiler-errors :3