### PR TITLE
Don't ICE when encountering unresolved regions in `fully_resolve`

### DIFF
--- a/compiler/rustc_lint/src/async_fn_in_trait.rs
+++ b/compiler/rustc_lint/src/async_fn_in_trait.rs
@@ -58,7 +58,6 @@ declare_lint! {
     ///
     ///
     /// ```rust
-    /// # #![feature(return_position_impl_trait_in_trait)]
     /// use core::future::Future;
     /// pub trait Trait {
     ///     fn method(&self) -> impl Future<Output = ()> + Send { async {} }

--- a/tests/ui/async-await/in-trait/unconstrained-impl-region.rs
+++ b/tests/ui/async-await/in-trait/unconstrained-impl-region.rs
@@ -1,0 +1,19 @@
+// edition: 2021
+
+pub(crate) trait Inbox<M> {
+    async fn next(self) -> M;
+}
+
+pub(crate) trait Actor: Sized {
+    type Message;
+
+    async fn on_mount(self, _: impl Inbox<Self::Message>);
+}
+
+impl<'a> Actor for () {
+//~^ ERROR the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
+    type Message = &'a ();
+    async fn on_mount(self, _: impl Inbox<&'a ()>) {}
+}
+
+fn main() {}

--- a/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
+++ b/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
@@ -1,0 +1,9 @@
+error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-impl-region.rs:13:6
+   |
+LL | impl<'a> Actor for () {
+   |      ^^ unconstrained lifetime parameter
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0207`.


### PR DESCRIPTION
We can encounter unresolved regions due to unconstrained impl lifetime arguments because `collect_return_position_impl_trait_in_trait_tys` runs before WF actually checks that the impl is well-formed.

Fixes #116525