### PR TITLE
std library thread.rs: undo attempt at NetBSD "find parallelism"

### DIFF
--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -375,29 +375,6 @@ pub fn available_parallelism() -> io::Result<NonZeroUsize> {
                 }
             }
 
-            #[cfg(target_os = "netbsd")]
-            {
-                unsafe {
-                    let set = libc::_cpuset_create();
-                    if !set.is_null() {
-                        let mut count: usize = 0;
-                        if libc::pthread_getaffinity_np(libc::pthread_self(), libc::_cpuset_size(set), set) == 0 {
-                            for i in 0..u64::MAX {
-                                match libc::_cpuset_isset(i, set) {
-                                    -1 => break,
-                                    0 => continue,
-                                    _ => count = count + 1,
-                                }
-                            }
-                        }
-                        libc::_cpuset_destroy(set);
-                        if let Some(count) = NonZeroUsize::new(count) {
-                            return Ok(count);
-                        }
-                    }
-                }
-            }
-
             let mut cpus: libc::c_uint = 0;
             let mut cpus_size = crate::mem::size_of_val(&cpus);
 


### PR DESCRIPTION
First off, I have it on good authority this code is Just Wrong: on NetBSD, by default a given thread does not have affinity to any specific set of CPUs.

This particular change came with this pull request:

  [Rust pull request 112226](https://github.com/rust-lang/rust/pull/112226)

However, even worse, this code causes a segmentation fault for certain NetBSD target architectures in the "bootstrap" program when building rust natively on those platforms.  So far armv7/9.0, powerpc/10.0_BETA, and i386/9.3 all crash with a segmentation fault.  However, for some strange reason, this isn't consistent across the board: riscv64/current, amd64/10.0_BETA, aarch64/9.0 and sparc64/10.0_BETA all pass this hurdle.  A trivial C reimplementation also doesn't crash on any of these systems, ref. the thread which starts at

  [NetBSD current-users postings about this issue](https://mail-index.netbsd.org/current-users/2023/10/10/msg044510.html)

but also always prints 0.  However, if we get a SEGV running this code, the entire build fails, of course.

So ... while I do not have a full explanation for the SEGVs, this undoes the addition from pull request 112226, and restores the ability to build rust natively on the above flagged-as-problematical platforms.