### PR TITLE
Improve check-cfg diagnostics

### DIFF
--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -548,7 +548,11 @@ pub fn cfg_matches(
                     UNEXPECTED_CFGS,
                     cfg.span,
                     lint_node_id,
-                    "unexpected `cfg` condition value",
+                    if let Some(value) = cfg.value {
+                        format!("unexpected `cfg` condition value: `{value}`")
+                    } else {
+                        format!("unexpected `cfg` condition value: (none)")
+                    },
                     BuiltinLintDiagnostics::UnexpectedCfgValue(
                         (cfg.name, cfg.name_span),
                         cfg.value.map(|v| (v, cfg.value_span.unwrap())),
@@ -560,7 +564,7 @@ pub fn cfg_matches(
                     UNEXPECTED_CFGS,
                     cfg.span,
                     lint_node_id,
-                    "unexpected `cfg` condition name",
+                    format!("unexpected `cfg` condition name: `{}`", cfg.name),
                     BuiltinLintDiagnostics::UnexpectedCfgName(
                         (cfg.name, cfg.name_span),
                         cfg.value.map(|v| (v, cfg.value_span.unwrap())),

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -659,6 +659,7 @@ impl<'a, G: EmissionGuarantee> DiagnosticBuilder<'a, G> {
         msg: impl Into<SubdiagnosticMessage>,
     ) -> &mut Self);
     forward!(pub fn help(&mut self, msg: impl Into<SubdiagnosticMessage>) -> &mut Self);
+    forward!(pub fn help_once(&mut self, msg: impl Into<SubdiagnosticMessage>) -> &mut Self);
     forward!(pub fn span_help(
         &mut self,
         sp: impl Into<MultiSpan>,

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -758,7 +758,11 @@ pub trait LintContext: Sized {
                         possibilities.sort();
                         let possibilities = possibilities.join("`, `");
 
-                        db.help(format!("expected names are: `{possibilities}`"));
+                        // The list of expected names can be long (even by default) and
+                        // so the diagnostic produced can take a lot of space. To avoid
+                        // cloging the user output we only want to print that diagnostic
+                        // once.
+                        db.help_once(format!("expected names are: `{possibilities}`"));
                     }
                 },
                 BuiltinLintDiagnostics::UnexpectedCfgValue((name, name_span), value) => {

--- a/tests/rustdoc-ui/check-cfg/check-cfg.stderr
+++ b/tests/rustdoc-ui/check-cfg/check-cfg.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `uniz`
   --> $DIR/check-cfg.rs:5:7
    |
 LL | #[cfg(uniz)]

--- a/tests/rustdoc-ui/doctest/check-cfg-test.stderr
+++ b/tests/rustdoc-ui/doctest/check-cfg-test.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `invalid`
   --> $DIR/check-cfg-test.rs:9:7
    |
 LL | #[cfg(feature = "invalid")]

--- a/tests/ui/check-cfg/allow-same-level.stderr
+++ b/tests/ui/check-cfg/allow-same-level.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `FALSE`
   --> $DIR/allow-same-level.rs:7:7
    |
 LL | #[cfg(FALSE)]

--- a/tests/ui/check-cfg/allow-same-level.stderr
+++ b/tests/ui/check-cfg/allow-same-level.stderr
@@ -4,6 +4,7 @@ warning: unexpected `cfg` condition name
 LL | #[cfg(FALSE)]
    |       ^^^^^
    |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/check-cfg/compact-names.stderr
+++ b/tests/ui/check-cfg/compact-names.stderr
@@ -4,6 +4,7 @@ warning: unexpected `cfg` condition name
 LL | #[cfg(target(os = "linux", architecture = "arm"))]
    |                            ^^^^^^^^^^^^^^^^^^^^
    |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/check-cfg/compact-names.stderr
+++ b/tests/ui/check-cfg/compact-names.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `target_architecture`
   --> $DIR/compact-names.rs:11:28
    |
 LL | #[cfg(target(os = "linux", architecture = "arm"))]

--- a/tests/ui/check-cfg/compact-values.stderr
+++ b/tests/ui/check-cfg/compact-values.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `X`
   --> $DIR/compact-values.rs:11:28
    |
 LL | #[cfg(target(os = "linux", arch = "X"))]

--- a/tests/ui/check-cfg/diagnotics.stderr
+++ b/tests/ui/check-cfg/diagnotics.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `featur`
   --> $DIR/diagnotics.rs:4:7
    |
 LL | #[cfg(featur)]
@@ -7,7 +7,7 @@ LL | #[cfg(featur)]
    = help: expected values for `feature` are: `foo`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `featur`
   --> $DIR/diagnotics.rs:8:7
    |
 LL | #[cfg(featur = "foo")]
@@ -18,7 +18,7 @@ help: there is a config with a similar name and value
 LL | #[cfg(feature = "foo")]
    |       ~~~~~~~
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `featur`
   --> $DIR/diagnotics.rs:12:7
    |
 LL | #[cfg(featur = "fo")]
@@ -30,13 +30,13 @@ help: there is a config with a similar name and different values
 LL | #[cfg(feature = "foo")]
    |       ~~~~~~~~~~~~~~~
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `no_value`
   --> $DIR/diagnotics.rs:19:7
    |
 LL | #[cfg(no_value)]
    |       ^^^^^^^^ help: there is a config with a similar name: `no_values`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `no_value`
   --> $DIR/diagnotics.rs:23:7
    |
 LL | #[cfg(no_value = "foo")]
@@ -47,7 +47,7 @@ help: there is a config with a similar name and no value
 LL | #[cfg(no_values)]
    |       ~~~~~~~~~
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `bar`
   --> $DIR/diagnotics.rs:27:7
    |
 LL | #[cfg(no_values = "bar")]

--- a/tests/ui/check-cfg/diagnotics.stderr
+++ b/tests/ui/check-cfg/diagnotics.stderr
@@ -13,7 +13,6 @@ warning: unexpected `cfg` condition name
 LL | #[cfg(featur = "foo")]
    |       ^^^^^^^^^^^^^^
    |
-   = help: expected values for `feature` are: `foo`
 help: there is a config with a similar name and value
    |
 LL | #[cfg(feature = "foo")]

--- a/tests/ui/check-cfg/empty-names.stderr
+++ b/tests/ui/check-cfg/empty-names.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `unknown_key`
   --> $DIR/empty-names.rs:6:7
    |
 LL | #[cfg(unknown_key = "value")]

--- a/tests/ui/check-cfg/empty-names.stderr
+++ b/tests/ui/check-cfg/empty-names.stderr
@@ -4,6 +4,7 @@ warning: unexpected `cfg` condition name
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
    |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/check-cfg/empty-values.stderr
+++ b/tests/ui/check-cfg/empty-values.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `value`
   --> $DIR/empty-values.rs:6:7
    |
 LL | #[cfg(test = "value")]

--- a/tests/ui/check-cfg/invalid-cfg-name.stderr
+++ b/tests/ui/check-cfg/invalid-cfg-name.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `widnows`
   --> $DIR/invalid-cfg-name.rs:7:7
    |
 LL | #[cfg(widnows)]

--- a/tests/ui/check-cfg/invalid-cfg-value.stderr
+++ b/tests/ui/check-cfg/invalid-cfg-value.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `sedre`
   --> $DIR/invalid-cfg-value.rs:7:7
    |
 LL | #[cfg(feature = "sedre")]
@@ -9,7 +9,7 @@ LL | #[cfg(feature = "sedre")]
    = note: expected values for `feature` are: `full`, `serde`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `rand`
   --> $DIR/invalid-cfg-value.rs:14:7
    |
 LL | #[cfg(feature = "rand")]

--- a/tests/ui/check-cfg/mix.stderr
+++ b/tests/ui/check-cfg/mix.stderr
@@ -73,24 +73,18 @@ warning: unexpected `cfg` condition name: `xxx`
    |
 LL |     cfg!(xxx = "foo");
    |          ^^^^^^^^^^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:48:10
    |
 LL |     cfg!(xxx);
    |          ^^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:50:14
    |
 LL |     cfg!(any(xxx, windows));
    |              ^^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition value: `bad`
   --> $DIR/mix.rs:52:14
@@ -105,48 +99,36 @@ warning: unexpected `cfg` condition name: `xxx`
    |
 LL |     cfg!(any(windows, xxx));
    |                       ^^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:56:20
    |
 LL |     cfg!(all(unix, xxx));
    |                    ^^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name: `aa`
   --> $DIR/mix.rs:58:14
    |
 LL |     cfg!(all(aa, bb));
    |              ^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name: `bb`
   --> $DIR/mix.rs:58:18
    |
 LL |     cfg!(all(aa, bb));
    |                  ^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name: `aa`
   --> $DIR/mix.rs:61:14
    |
 LL |     cfg!(any(aa, bb));
    |              ^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name: `bb`
   --> $DIR/mix.rs:61:18
    |
 LL |     cfg!(any(aa, bb));
    |                  ^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:64:20
@@ -161,8 +143,6 @@ warning: unexpected `cfg` condition name: `xxx`
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
    |              ^^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:66:19
@@ -177,16 +157,12 @@ warning: unexpected `cfg` condition name: `xxx`
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |              ^^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:69:25
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |                         ^^^
-   |
-   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:72:14

--- a/tests/ui/check-cfg/mix.stderr
+++ b/tests/ui/check-cfg/mix.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `widnows`
   --> $DIR/mix.rs:11:7
    |
 LL | #[cfg(widnows)]
@@ -6,7 +6,7 @@ LL | #[cfg(widnows)]
    |
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: (none)
   --> $DIR/mix.rs:15:7
    |
 LL | #[cfg(feature)]
@@ -14,7 +14,7 @@ LL | #[cfg(feature)]
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `bar`
   --> $DIR/mix.rs:22:7
    |
 LL | #[cfg(feature = "bar")]
@@ -22,7 +22,7 @@ LL | #[cfg(feature = "bar")]
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:26:7
    |
 LL | #[cfg(feature = "zebra")]
@@ -30,7 +30,7 @@ LL | #[cfg(feature = "zebra")]
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `uu`
   --> $DIR/mix.rs:30:12
    |
 LL | #[cfg_attr(uu, test)]
@@ -46,13 +46,13 @@ warning: unexpected `unknown_name` as condition name
    |
    = help: was set with `--cfg` but isn't in the `--check-cfg` expected names
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `widnows`
   --> $DIR/mix.rs:39:10
    |
 LL |     cfg!(widnows);
    |          ^^^^^^^ help: there is a config with a similar name: `windows`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `bar`
   --> $DIR/mix.rs:42:10
    |
 LL |     cfg!(feature = "bar");
@@ -60,7 +60,7 @@ LL |     cfg!(feature = "bar");
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:44:10
    |
 LL |     cfg!(feature = "zebra");
@@ -68,7 +68,7 @@ LL |     cfg!(feature = "zebra");
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:46:10
    |
 LL |     cfg!(xxx = "foo");
@@ -76,7 +76,7 @@ LL |     cfg!(xxx = "foo");
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:48:10
    |
 LL |     cfg!(xxx);
@@ -84,7 +84,7 @@ LL |     cfg!(xxx);
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:50:14
    |
 LL |     cfg!(any(xxx, windows));
@@ -92,7 +92,7 @@ LL |     cfg!(any(xxx, windows));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `bad`
   --> $DIR/mix.rs:52:14
    |
 LL |     cfg!(any(feature = "bad", windows));
@@ -100,7 +100,7 @@ LL |     cfg!(any(feature = "bad", windows));
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:54:23
    |
 LL |     cfg!(any(windows, xxx));
@@ -108,7 +108,7 @@ LL |     cfg!(any(windows, xxx));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:56:20
    |
 LL |     cfg!(all(unix, xxx));
@@ -116,7 +116,7 @@ LL |     cfg!(all(unix, xxx));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `aa`
   --> $DIR/mix.rs:58:14
    |
 LL |     cfg!(all(aa, bb));
@@ -124,7 +124,7 @@ LL |     cfg!(all(aa, bb));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `bb`
   --> $DIR/mix.rs:58:18
    |
 LL |     cfg!(all(aa, bb));
@@ -132,7 +132,7 @@ LL |     cfg!(all(aa, bb));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `aa`
   --> $DIR/mix.rs:61:14
    |
 LL |     cfg!(any(aa, bb));
@@ -140,7 +140,7 @@ LL |     cfg!(any(aa, bb));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `bb`
   --> $DIR/mix.rs:61:18
    |
 LL |     cfg!(any(aa, bb));
@@ -148,7 +148,7 @@ LL |     cfg!(any(aa, bb));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:64:20
    |
 LL |     cfg!(any(unix, feature = "zebra"));
@@ -156,7 +156,7 @@ LL |     cfg!(any(unix, feature = "zebra"));
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:66:14
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
@@ -164,7 +164,7 @@ LL |     cfg!(any(xxx, feature = "zebra"));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:66:19
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
@@ -172,7 +172,7 @@ LL |     cfg!(any(xxx, feature = "zebra"));
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:69:14
    |
 LL |     cfg!(any(xxx, unix, xxx));
@@ -180,7 +180,7 @@ LL |     cfg!(any(xxx, unix, xxx));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `xxx`
   --> $DIR/mix.rs:69:25
    |
 LL |     cfg!(any(xxx, unix, xxx));
@@ -188,7 +188,7 @@ LL |     cfg!(any(xxx, unix, xxx));
    |
    = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:72:14
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
@@ -196,7 +196,7 @@ LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:72:33
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
@@ -204,7 +204,7 @@ LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |
    = note: expected values for `feature` are: `foo`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `zebra`
   --> $DIR/mix.rs:72:52
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));

--- a/tests/ui/check-cfg/mix.stderr
+++ b/tests/ui/check-cfg/mix.stderr
@@ -35,6 +35,8 @@ warning: unexpected `cfg` condition name
    |
 LL | #[cfg_attr(uu, test)]
    |            ^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected condition value `bar` for condition name `feature`
    |
@@ -71,18 +73,24 @@ warning: unexpected `cfg` condition name
    |
 LL |     cfg!(xxx = "foo");
    |          ^^^^^^^^^^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name
   --> $DIR/mix.rs:48:10
    |
 LL |     cfg!(xxx);
    |          ^^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name
   --> $DIR/mix.rs:50:14
    |
 LL |     cfg!(any(xxx, windows));
    |              ^^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition value
   --> $DIR/mix.rs:52:14
@@ -97,36 +105,48 @@ warning: unexpected `cfg` condition name
    |
 LL |     cfg!(any(windows, xxx));
    |                       ^^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name
   --> $DIR/mix.rs:56:20
    |
 LL |     cfg!(all(unix, xxx));
    |                    ^^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name
   --> $DIR/mix.rs:58:14
    |
 LL |     cfg!(all(aa, bb));
    |              ^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name
   --> $DIR/mix.rs:58:18
    |
 LL |     cfg!(all(aa, bb));
    |                  ^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name
   --> $DIR/mix.rs:61:14
    |
 LL |     cfg!(any(aa, bb));
    |              ^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name
   --> $DIR/mix.rs:61:18
    |
 LL |     cfg!(any(aa, bb));
    |                  ^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition value
   --> $DIR/mix.rs:64:20
@@ -141,6 +161,8 @@ warning: unexpected `cfg` condition name
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
    |              ^^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition value
   --> $DIR/mix.rs:66:19
@@ -155,12 +177,16 @@ warning: unexpected `cfg` condition name
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |              ^^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition name
   --> $DIR/mix.rs:69:25
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |                         ^^^
+   |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
 
 warning: unexpected `cfg` condition value
   --> $DIR/mix.rs:72:14

--- a/tests/ui/check-cfg/no-values.stderr
+++ b/tests/ui/check-cfg/no-values.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `foo`
   --> $DIR/no-values.rs:6:7
    |
 LL | #[cfg(feature = "foo")]
@@ -9,7 +9,7 @@ LL | #[cfg(feature = "foo")]
    = note: no expected value for `feature`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `foo`
   --> $DIR/no-values.rs:10:7
    |
 LL | #[cfg(test = "foo")]

--- a/tests/ui/check-cfg/order-independant.names_after.stderr
+++ b/tests/ui/check-cfg/order-independant.names_after.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: (none)
   --> $DIR/order-independant.rs:8:7
    |
 LL | #[cfg(a)]
@@ -7,7 +7,7 @@ LL | #[cfg(a)]
    = note: expected values for `a` are: `b`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `unk`
   --> $DIR/order-independant.rs:12:7
    |
 LL | #[cfg(a = "unk")]

--- a/tests/ui/check-cfg/order-independant.names_before.stderr
+++ b/tests/ui/check-cfg/order-independant.names_before.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: (none)
   --> $DIR/order-independant.rs:8:7
    |
 LL | #[cfg(a)]
@@ -7,7 +7,7 @@ LL | #[cfg(a)]
    = note: expected values for `a` are: `b`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `unk`
   --> $DIR/order-independant.rs:12:7
    |
 LL | #[cfg(a = "unk")]

--- a/tests/ui/check-cfg/stmt-no-ice.stderr
+++ b/tests/ui/check-cfg/stmt-no-ice.stderr
@@ -4,6 +4,7 @@ warning: unexpected `cfg` condition name
 LL |     #[cfg(crossbeam_loom)]
    |           ^^^^^^^^^^^^^^
    |
+   = help: expected names are: `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `sanitize`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `unix`, `windows`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/check-cfg/stmt-no-ice.stderr
+++ b/tests/ui/check-cfg/stmt-no-ice.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `crossbeam_loom`
   --> $DIR/stmt-no-ice.rs:7:11
    |
 LL |     #[cfg(crossbeam_loom)]

--- a/tests/ui/check-cfg/values-target-json.stderr
+++ b/tests/ui/check-cfg/values-target-json.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `linuz`
   --> $DIR/values-target-json.rs:13:7
    |
 LL | #[cfg(target_os = "linuz")]

--- a/tests/ui/check-cfg/well-known-names.stderr
+++ b/tests/ui/check-cfg/well-known-names.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `target_oz`
   --> $DIR/well-known-names.rs:6:7
    |
 LL | #[cfg(target_oz = "linux")]
@@ -8,7 +8,7 @@ LL | #[cfg(target_oz = "linux")]
    |
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `features`
   --> $DIR/well-known-names.rs:13:7
    |
 LL | #[cfg(features = "foo")]
@@ -16,7 +16,7 @@ LL | #[cfg(features = "foo")]
    |       |
    |       help: there is a config with a similar name: `feature`
 
-warning: unexpected `cfg` condition name
+warning: unexpected `cfg` condition name: `uniw`
   --> $DIR/well-known-names.rs:20:7
    |
 LL | #[cfg(uniw)]

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -1,4 +1,4 @@
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `linuz`
   --> $DIR/well-known-values.rs:7:7
    |
 LL | #[cfg(target_os = "linuz")]
@@ -9,7 +9,7 @@ LL | #[cfg(target_os = "linuz")]
    = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `teeos`, `tvos`, `uefi`, `unknown`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `0`
   --> $DIR/well-known-values.rs:14:7
    |
 LL | #[cfg(target_has_atomic = "0")]
@@ -19,7 +19,7 @@ LL | #[cfg(target_has_atomic = "0")]
    |
    = note: expected values for `target_has_atomic` are: (none), `128`, `16`, `32`, `64`, `8`, `ptr`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `aa`
   --> $DIR/well-known-values.rs:21:7
    |
 LL | #[cfg(unix = "aa")]
@@ -29,7 +29,7 @@ LL | #[cfg(unix = "aa")]
    |
    = note: no expected value for `unix`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `miri`
   --> $DIR/well-known-values.rs:28:7
    |
 LL | #[cfg(miri = "miri")]
@@ -39,7 +39,7 @@ LL | #[cfg(miri = "miri")]
    |
    = note: no expected value for `miri`
 
-warning: unexpected `cfg` condition value
+warning: unexpected `cfg` condition value: `linux`
   --> $DIR/well-known-values.rs:35:7
    |
 LL | #[cfg(doc = "linux")]


### PR DESCRIPTION
This PR tries to improve some of the diagnostics of check-cfg.

The main changes is the unexpected name or value being added to the main diagnostic:
```diff
- warning: unexpected `cfg` condition name
+ warning: unexpected `cfg` condition name: `widnows`
```

It also cherry-pick the better sensible logic for when we print the list of expected values when we have a matching value for a very similar name.

Address https://github.com/rust-lang/rust/pull/111072#discussion_r1356818100

r? @petrochenkov 