### PR TITLE
References refer to allocated objects

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1397,7 +1397,11 @@ mod prim_usize {}
 /// which violates any of these properties.
 ///
 /// * `t` is aligned to `align_of_val(t)`
-/// * `t` refers to a single [allocated object]
+/// * `t` is dereferenceable for `size_of_val(t)` many bytes
+///
+///  Being "dereferenceable" for N bytes means that the memory range beginning
+/// at the address `t` points to and ending N bytes later is all contained within a
+/// single [allocated object].
 ///
 /// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1389,6 +1389,18 @@ mod prim_usize {}
 /// work on references as well as they do on owned values! The implementations described here are
 /// meant for generic contexts, where the final type `T` is a type parameter or otherwise not
 /// locally known.
+///
+/// # Safety
+///
+/// For all types, `T: ?Sized`, and for all `t: &T` or `t: &mut T`, unsafe code may assume that
+/// the following properties hold. It is undefined behavior to produce a `t: &T` or `t: &mut T`
+/// which violates any of these properties.
+///
+/// * `t` is aligned to `align_of_val(t)`
+/// * `t` refers to a valid instance of `T`
+/// * `t` refers to a single [allocated object]
+///
+/// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_ref {}
 

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1393,8 +1393,9 @@ mod prim_usize {}
 /// # Safety
 ///
 /// For all types, `T: ?Sized`, and for all `t: &T` or `t: &mut T`, unsafe code may assume that
-/// the following properties hold. It is undefined behavior to produce a `t: &T` or `t: &mut T`
-/// which violates any of these properties.
+/// the following properties hold. Rust programmers must assume that, unless explicitly stated
+/// otherwise, any Rust code they did not author themselves may rely on these properties, and that
+/// violating them may cause that code to exhibit undefined behavior.
 ///
 /// * `t` is aligned to `align_of_val(t)`
 /// * `t` is dereferenceable for `size_of_val(t)` many bytes

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1399,9 +1399,8 @@ mod prim_usize {}
 /// * `t` is aligned to `align_of_val(t)`
 /// * `t` is dereferenceable for `size_of_val(t)` many bytes
 ///
-///  Being "dereferenceable" for N bytes means that the memory range beginning
-/// at the address `t` points to and ending N bytes later is all contained within a
-/// single [allocated object].
+/// If `t` points at address `a`, being "dereferenceable" for N bytes means that the memory range
+/// `[a, a + N)` is all contained within a single [allocated object].
 ///
 /// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1397,7 +1397,6 @@ mod prim_usize {}
 /// which violates any of these properties.
 ///
 /// * `t` is aligned to `align_of_val(t)`
-/// * `t` refers to a valid instance of `T`
 /// * `t` refers to a single [allocated object]
 ///
 /// [allocated object]: ptr#allocated-object

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1392,10 +1392,8 @@ mod prim_usize {}
 ///
 /// # Safety
 ///
-/// For all types, `T: ?Sized`, and for all `t: &T` or `t: &mut T`, unsafe code may assume that
-/// the following properties hold. Rust programmers must assume that, unless explicitly stated
-/// otherwise, any Rust code they did not author themselves may rely on these properties, and that
-/// violating them may cause that code to exhibit undefined behavior.
+/// For all types, `T: ?Sized`, and for all `t: &T` or `t: &mut T`, when such values cross an API
+/// boundary, the following invariants must generally be upheld:
 ///
 /// * `t` is aligned to `align_of_val(t)`
 /// * `t` is dereferenceable for `size_of_val(t)` many bytes
@@ -1403,9 +1401,16 @@ mod prim_usize {}
 /// If `t` points at address `a`, being "dereferenceable" for N bytes means that the memory range
 /// `[a, a + N)` is all contained within a single [allocated object].
 ///
-/// Note that the precise validity invariants for reference types are a work in progress. In the
-/// future, new guarantees may be added. However, the guarantees documented in this section will
-/// never be removed.
+/// For instance, this means that unsafe code in a safe function may assume these invariants are
+/// ensured of arguments passed by the caller, and it may assume that these invariants are ensured
+/// of return values from any safe functions it calls. In most cases, the inverse is also true:
+/// unsafe code must not violate these invariants when passing arguments to safe functions or
+/// returning values from safe functions; such violations may result in undefined behavior. Where
+/// exceptions to this latter requirement exist, they will be called out explicitly in documentation.
+///
+/// It is not decided yet whether unsafe code may violate these invariants temporarily on internal
+/// data. As a consequence, unsafe code which violates these invariants temporarily on internal data
+/// may become unsound in future versions of Rust depending on how this question is decided.
 ///
 /// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1403,6 +1403,10 @@ mod prim_usize {}
 /// If `t` points at address `a`, being "dereferenceable" for N bytes means that the memory range
 /// `[a, a + N)` is all contained within a single [allocated object].
 ///
+/// Note that the precise validity invariants for reference types are a work in progress. In the
+/// future, new guarantees may be added. However, the guarantees documented in this section will
+/// never be removed.
+///
 /// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_ref {}


### PR DESCRIPTION
Partially addresses https://github.com/rust-lang/unsafe-code-guidelines/issues/465