### PR TITLE
Allow bootstrap cache path to be set by environment variable

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -557,7 +557,7 @@ class RustBuild(object):
                 shutil.rmtree(bin_root)
 
             key = self.stage0_compiler.date
-            cache_dst = os.path.join(self.build_dir, "cache")
+            cache_dst = os.getenv('RUSTC_BOOTSTRAP_CACHE', os.path.join(self.build_dir, "cache"))
             rustc_cache = os.path.join(cache_dst, key)
             if not os.path.exists(rustc_cache):
                 os.makedirs(rustc_cache)

--- a/src/bootstrap/download.rs
+++ b/src/bootstrap/download.rs
@@ -529,7 +529,10 @@ impl Config {
         key: &str,
         destination: &str,
     ) {
-        let cache_dst = self.out.join("cache");
+        let cache_dst = match env::var_os("RUSTC_BOOTSTRAP_CACHE") {
+            Some(v) => PathBuf::from(v),
+            None => self.out.join("cache"),
+        };
         let cache_dir = cache_dst.join(key);
         if !cache_dir.exists() {
             t!(fs::create_dir_all(&cache_dir));
@@ -656,7 +659,10 @@ download-rustc = false
         let llvm_assertions = self.llvm_assertions;
 
         let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");
-        let cache_dst = self.out.join("cache");
+        let cache_dst = match env::var_os("RUSTC_BOOTSTRAP_CACHE") {
+            Some(v) => PathBuf::from(v),
+            None => self.out.join("cache"),
+        };
         let rustc_cache = cache_dst.join(cache_prefix);
         if !rustc_cache.exists() {
             t!(fs::create_dir_all(&rustc_cache));


### PR DESCRIPTION
This allows the bootstrap cache path to be set by the `RUSTC_BOOTSTRAP_CACHE` environment variable.

Setting the bootstrap cache path to an external location can help to speed up builds in cases where the build directory is not kept between builds, e.g. in CI or other automated build systems.