### PR TITLE
bootstrap: Add in-code hint about MAGIC_EXTRA_RUSTFLAGS

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1329,6 +1329,7 @@ impl<'a> Builder<'a> {
             if let Ok(s) = env::var("CARGOFLAGS_NOT_BOOTSTRAP") {
                 cargo.args(s.split_whitespace());
             }
+            // NOTE: MAGIC_EXTRA_RUSTFLAGS might also interest you!
             rustflags.env("RUSTFLAGS_NOT_BOOTSTRAP");
         } else {
             if let Ok(s) = env::var("CARGOFLAGS_BOOTSTRAP") {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1329,7 +1329,7 @@ impl<'a> Builder<'a> {
             if let Ok(s) = env::var("CARGOFLAGS_NOT_BOOTSTRAP") {
                 cargo.args(s.split_whitespace());
             }
-            // NOTE: MAGIC_EXTRA_RUSTFLAGS might also interest you!
+            // NOTE: See https://rustc-dev-guide.rust-lang.org/building/bootstrapping.html#passing-flags-to-commands-invoked-by-bootstrap to pass the flag as you want
             rustflags.env("RUSTFLAGS_NOT_BOOTSTRAP");
         } else {
             if let Ok(s) = env::var("CARGOFLAGS_BOOTSTRAP") {


### PR DESCRIPTION
I found `RUSTFLAGS_NOT_BOOTSTRAP` myself, but what I really needed was `MAGIC_EXTRA_RUSTFLAGS`. Add a hint about `MAGIC_EXTRA_RUSTFLAGS` next to `RUSTFLAGS_NOT_BOOTSTRAP` to make it easier for others to find in the future.

Also see https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/-Zunpretty.3Dexpanded.20rustc_middle.3F