### PR TITLE
linker: also pass debuginfo compression flags

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -626,6 +626,15 @@ impl<'a> Linker for GccLinker<'a> {
                 self.linker_arg("--strip-all");
             }
         }
+        match self.sess.opts.unstable_opts.debuginfo_compression {
+            config::DebugInfoCompression::None => {}
+            config::DebugInfoCompression::Zlib => {
+                self.linker_arg("--compress-debug-sections=zlib");
+            }
+            config::DebugInfoCompression::Zstd => {
+                self.linker_arg("--compress-debug-sections=zstd");
+            }
+        }
     }
 
     fn no_crt_objects(&mut self) {


### PR DESCRIPTION
We support compressing debuginfo during codegen, but until this patch we didn't pass the flag to the linker. Doing so means we'll respect the requested compression even when building binaries or dylibs. This produces much smaller binaries: in my testing a debug build of ripgrep goes from 85M to 32M, and the target/ directory (after a clean build in both cases) goes from 508M to 329M just by enabling zlib compression of debuginfo.