### PR TITLE
Fix AFIT lint message to mention pitfall

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -7,7 +7,7 @@ lint_array_into_iter =
 
 lint_async_fn_in_trait = use of `async fn` in public traits is discouraged as auto trait bounds cannot be specified
     .note = you can suppress this lint if you plan to use the trait only in your own code, or do not care about auto traits like `Send` on the `Future`
-    .suggestion = you can alternatively desugar to a normal `fn` that returns `impl Future` and add any desired bounds such as `Send`
+    .suggestion = you can alternatively desugar to a normal `fn` that returns `impl Future` and add any desired bounds such as `Send`, but these cannot be relaxed without a breaking API change
 
 lint_atomic_ordering_fence = memory fences cannot have `Relaxed` ordering
     .help = consider using ordering modes `Acquire`, `Release`, `AcqRel` or `SeqCst`

--- a/tests/ui/async-await/in-trait/warn.stderr
+++ b/tests/ui/async-await/in-trait/warn.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
    |
 LL | #![deny(async_fn_in_trait)]
    |         ^^^^^^^^^^^^^^^^^
-help: you can alternatively desugar to a normal `fn` that returns `impl Future` and add any desired bounds such as `Send`
+help: you can alternatively desugar to a normal `fn` that returns `impl Future` and add any desired bounds such as `Send`, but these cannot be relaxed without a breaking API change
    |
 LL -     async fn not_send();
 LL +     fn not_send() -> impl std::future::Future<Output = ()> + Send;


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/pull/116184#issuecomment-1745194387 by adding a short note. Not sure exactly of the wording -- I don't think this should be a blocker for the stabilization PR since we can iterate on this lint's messaging in the next few weeks in the worst case.

r? @tmandry cc @traviscross @jonhoo 