### PR TITLE
Revert "Invoke `backtrace-rs` buildscript in `std` buildscript"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5082,7 +5082,6 @@ version = "0.0.0"
 dependencies = [
  "addr2line",
  "alloc",
- "cc",
  "cfg-if",
  "compiler_builtins",
  "core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -36,10 +36,6 @@ object = { version = "0.32.0", default-features = false, optional = true, featur
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.3.0"
 
-[build-dependencies]
-# Dependency of the `backtrace` crate's build script
-cc = "1.0.67"
-
 [target.'cfg(any(all(target_family = "wasm", target_os = "unknown"), target_os = "xous", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
 dlmalloc = { version = "0.2.4", features = ['rustc-dep-of-std'] }
 

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -1,11 +1,5 @@
 use std::env;
 
-// backtrace-rs requires a feature check on Android targets, so
-// we need to run its build.rs as well.
-#[allow(unused_extern_crates)]
-#[path = "../backtrace/build.rs"]
-mod backtrace_build_rs;
-
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").expect("TARGET was not set");
@@ -65,6 +59,4 @@ fn main() {
     }
     println!("cargo:rustc-env=STD_ENV_ARCH={}", env::var("CARGO_CFG_TARGET_ARCH").unwrap());
     println!("cargo:rustc-cfg=backtrace_in_libstd");
-
-    backtrace_build_rs::main();
 }


### PR DESCRIPTION
This reverts commit 93677276bc495e78f74536385a16201d465fd523 because it caused issues for projects building the standard library with non-cargo build systems.

See https://github.com/rust-lang/rust/pull/116318#issuecomment-1761977900

r? workingjubilee