### PR TITLE
Make x capable of resolving symlinks

### DIFF
--- a/x
+++ b/x
@@ -11,10 +11,13 @@ set -eu
 sh -n "$0"
 
 realpath() {
-    if [ -d "$1" ]; then
-        CDPATH='' command cd "$1" && pwd -P
+    local path="$1"
+    if [ -L "$path" ]; then
+        readlink -f "$path"
+    elif [ -d "$path" ]; then
+        (cd -P "$path" && pwd)
     else
-        echo "$(realpath "$(dirname "$1")")/$(basename "$1")"
+        echo "$(realpath "$(dirname "$path")")/$(basename "$path")"
     fi
 }
 


### PR DESCRIPTION
When bootstrapping from outside of the rust source, instead of calling 'x' from the absolute path
(like /home/user/rust/x), we should be able to link 'x' from the rust source to binary paths so it can be used easily. Before this change, 'x' was not capable of finding 'x.py' when called from the linked file.