### PR TITLE
Consider alias bounds when computing liveness in NLL (but this time sound hopefully)

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -3,17 +3,13 @@ use rustc_data_structures::graph::WithSuccessors;
 use rustc_index::bit_set::{HybridBitSet, SparseBitMatrix};
 use rustc_index::interval::IntervalSet;
 use rustc_infer::infer::canonical::QueryRegionConstraints;
-use rustc_infer::infer::outlives::test_type_match;
-use rustc_infer::infer::region_constraints::VerifyIfEq;
+use rustc_infer::infer::outlives::for_liveness;
 use rustc_middle::mir::{BasicBlock, Body, ConstraintCategory, Local, Location};
 use rustc_middle::traits::query::DropckOutlivesResult;
-use rustc_middle::ty::{
-    self, RegionVid, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
-};
+use rustc_middle::ty::{RegionVid, Ty, TyCtxt, TypeVisitable, TypeVisitableExt};
 use rustc_span::DUMMY_SP;
 use rustc_trait_selection::traits::query::type_op::outlives::DropckOutlives;
 use rustc_trait_selection::traits::query::type_op::{TypeOp, TypeOpOutput};
-use std::ops::ControlFlow;
 use std::rc::Rc;
 
 use rustc_mir_dataflow::impls::MaybeInitializedPlaces;
@@ -612,107 +608,25 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
         let num_loans = typeck.borrowck_context.borrow_set.len();
         let value_loans = &mut HybridBitSet::new_empty(num_loans);
 
-        struct MakeAllRegionsLive<'a, 'b, 'tcx> {
-            typeck: &'b mut TypeChecker<'a, 'tcx>,
-            live_at: &'b IntervalSet<PointIndex>,
-            value_loans: &'b mut HybridBitSet<BorrowIndex>,
-            inflowing_loans: &'b SparseBitMatrix<RegionVid, BorrowIndex>,
-        }
-        impl<'tcx> MakeAllRegionsLive<'_, '_, 'tcx> {
-            /// We can prove that an alias is live two ways:
-            /// 1. All the components are live.
-            /// 2. There is a known outlives bound or where-clause, and that
-            ///    region is live.
-            /// We search through the item bounds and where clauses for
-            /// either `'static` or a unique outlives region, and if one is
-            /// found, we just need to prove that that region is still live.
-            /// If one is not found, then we continue to walk through the alias.
-            fn make_alias_live(&mut self, t: Ty<'tcx>) -> ControlFlow<!> {
-                let ty::Alias(_kind, alias_ty) = t.kind() else {
-                    bug!("`make_alias_live` only takes alias types");
-                };
-                let tcx = self.typeck.infcx.tcx;
-                let param_env = self.typeck.param_env;
-                let outlives_bounds: Vec<_> = tcx
-                    .item_bounds(alias_ty.def_id)
-                    .iter_instantiated(tcx, alias_ty.args)
-                    .filter_map(|clause| {
-                        if let Some(outlives) = clause.as_type_outlives_clause()
-                        && outlives.skip_binder().0 == t
-                    {
-                        Some(outlives.skip_binder().1)
-                    } else {
-                        None
-                    }
-                    })
-                    .chain(param_env.caller_bounds().iter().filter_map(|clause| {
-                        let outlives = clause.as_type_outlives_clause()?;
-                        if let Some(outlives) = outlives.no_bound_vars()
-                            && outlives.0 == t
-                        {
-                            Some(outlives.1)
-                        } else {
-                            test_type_match::extract_verify_if_eq(
-                                tcx,
-                                param_env,
-                                &outlives.map_bound(|ty::OutlivesPredicate(ty, bound)| {
-                                    VerifyIfEq { ty, bound }
-                                }),
-                                t,
-                            )
-                        }
-                    }))
-                    .collect();
-                // If we find `'static`, then we know the alias doesn't capture *any* regions.
-                // Otherwise, all of the outlives regions should be equal -- if they're not,
-                // we don't really know how to proceed, so we continue recursing through the
-                // alias.
-                if outlives_bounds.contains(&tcx.lifetimes.re_static) {
-                    ControlFlow::Continue(())
-                } else if let Some(r) = outlives_bounds.first()
-                    && outlives_bounds[1..].iter().all(|other_r| other_r == r)
-                {
-                    r.visit_with(self)
-                } else {
-                    t.super_visit_with(self)
-                }
-            }
-        }
-        impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for MakeAllRegionsLive<'_, '_, 'tcx> {
-            type BreakTy = !;
+        value.visit_with(&mut for_liveness::FreeRegionsVisitor {
+            tcx: typeck.tcx(),
+            param_env: typeck.param_env,
+            op: |r| {
+                let live_region_vid = typeck.borrowck_context.universal_regions.to_region_vid(r);
 
-            fn visit_region(&mut self, r: ty::Region<'tcx>) -> ControlFlow<Self::BreakTy> {
-                if r.is_late_bound() {
-                    return ControlFlow::Continue(());
-                }
-                let live_region_vid =
-                    self.typeck.borrowck_context.universal_regions.to_region_vid(r);
-
-                self.typeck
+                typeck
                     .borrowck_context
                     .constraints
                     .liveness_constraints
-                    .add_elements(live_region_vid, self.live_at);
+                    .add_elements(live_region_vid, live_at);
 
                 // There can only be inflowing loans for this region when we are using
                 // `-Zpolonius=next`.
-                if let Some(inflowing) = self.inflowing_loans.row(live_region_vid) {
-                    self.value_loans.union(inflowing);
+                if let Some(inflowing) = inflowing_loans.row(live_region_vid) {
+                    value_loans.union(inflowing);
                 }
-                ControlFlow::Continue(())
-            }
-
-            fn visit_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
-                if !t.has_free_regions() {
-                    ControlFlow::Continue(())
-                } else if let ty::Alias(..) = t.kind() {
-                    self.make_alias_live(t)
-                } else {
-                    t.super_visit_with(self)
-                }
-            }
-        }
-        value.visit_with(&mut MakeAllRegionsLive { typeck, live_at, value_loans, inflowing_loans });
+            },
+        });
 
         // Record the loans reaching the value.
         if !value_loans.is_empty() {

--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -619,13 +619,21 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
             inflowing_loans: &'b SparseBitMatrix<RegionVid, BorrowIndex>,
         }
         impl<'tcx> MakeAllRegionsLive<'_, '_, 'tcx> {
+            /// We can prove that an alias is live two ways:
+            /// 1. All the components are live.
+            /// 2. There is a known outlives bound or where-clause, and that
+            ///    region is live.
+            /// We search through the item bounds and where clauses for
+            /// either `'static` or a unique outlives region, and if one is
+            /// found, we just need to prove that that region is still live.
+            /// If one is not found, then we continue to walk through the alias.
             fn make_alias_live(&mut self, t: Ty<'tcx>) -> ControlFlow<!> {
                 let ty::Alias(_kind, alias_ty) = t.kind() else {
-                    bug!();
+                    bug!("`make_alias_live` only takes alias types");
                 };
                 let tcx = self.typeck.infcx.tcx;
                 let param_env = self.typeck.param_env;
-                let mut outlives_bounds = tcx
+                let outlives_bounds: Vec<_> = tcx
                     .item_bounds(alias_ty.def_id)
                     .iter_instantiated(tcx, alias_ty.args)
                     .filter_map(|clause| {
@@ -653,12 +661,16 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
                                 t,
                             )
                         }
-                    }));
-                if let Some(r) = outlives_bounds.next()
-                    && !r.is_late_bound()
-                    && outlives_bounds.all(|other_r| {
-                        other_r == r
-                    })
+                    }))
+                    .collect();
+                // If we find `'static`, then we know the alias doesn't capture *any* regions.
+                // Otherwise, all of the outlives regions should be equal -- if they're not,
+                // we don't really know how to proceed, so we continue recursing through the
+                // alias.
+                if outlives_bounds.contains(&tcx.lifetimes.re_static) {
+                    ControlFlow::Continue(())
+                } else if let Some(r) = outlives_bounds.first()
+                    && outlives_bounds[1..].iter().all(|other_r| other_r == r)
                 {
                     r.visit_with(self)
                 } else {

--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -3,6 +3,8 @@ use rustc_data_structures::graph::WithSuccessors;
 use rustc_index::bit_set::{HybridBitSet, SparseBitMatrix};
 use rustc_index::interval::IntervalSet;
 use rustc_infer::infer::canonical::QueryRegionConstraints;
+use rustc_infer::infer::outlives::test_type_match;
+use rustc_infer::infer::region_constraints::VerifyIfEq;
 use rustc_middle::mir::{BasicBlock, Body, ConstraintCategory, Local, Location};
 use rustc_middle::traits::query::DropckOutlivesResult;
 use rustc_middle::ty::{
@@ -622,6 +624,7 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
                     bug!();
                 };
                 let tcx = self.typeck.infcx.tcx;
+                let param_env = self.typeck.param_env;
                 let mut outlives_bounds = tcx
                     .item_bounds(alias_ty.def_id)
                     .iter_instantiated(tcx, alias_ty.args)
@@ -633,7 +636,24 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
                     } else {
                         None
                     }
-                    });
+                    })
+                    .chain(param_env.caller_bounds().iter().filter_map(|clause| {
+                        let outlives = clause.as_type_outlives_clause()?;
+                        if let Some(outlives) = outlives.no_bound_vars()
+                            && outlives.0 == t
+                        {
+                            Some(outlives.1)
+                        } else {
+                            test_type_match::extract_verify_if_eq(
+                                tcx,
+                                param_env,
+                                &outlives.map_bound(|ty::OutlivesPredicate(ty, bound)| {
+                                    VerifyIfEq { ty, bound }
+                                }),
+                                t,
+                            )
+                        }
+                    }));
                 if let Some(r) = outlives_bounds.next()
                     && !r.is_late_bound()
                     && outlives_bounds.all(|other_r| {

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -380,6 +380,8 @@ impl<'tcx> InferCtxt<'tcx> {
                 .collect(),
         );
 
+        // FIXME(#42940): This should use the `FreeRegionsVisitor`, but that's
+        // not currently sound until we have existential regions.
         concrete_ty.visit_with(&mut ConstrainOpaqueTypeRegionVisitor {
             tcx: self.tcx,
             op: |r| self.member_constraint(opaque_type_key, span, concrete_ty, r, &choice_regions),

--- a/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
+++ b/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
@@ -1,0 +1,121 @@
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitor};
+
+use std::ops::ControlFlow;
+
+use crate::infer::outlives::test_type_match;
+use crate::infer::region_constraints::VerifyIfEq;
+
+/// Visits free regions in the type that are relevant for liveness computation.
+/// These regions are passed to `OP`.
+///
+/// Specifically, we visit all of the regions of types recursively, except if
+/// the type is an alias, we look at the outlives bounds in the param-env
+/// and alias's item bounds. If there is a unique outlives bound, then visit
+/// that instead. If there is not a unique but there is a `'static` outlives
+/// bound, then don't visit anything. Otherwise, walk through the opaque's
+/// regions structurally.
+pub struct FreeRegionsVisitor<'tcx, OP: FnMut(ty::Region<'tcx>)> {
+    pub tcx: TyCtxt<'tcx>,
+    pub param_env: ty::ParamEnv<'tcx>,
+    pub op: OP,
+}
+
+impl<'tcx, OP> TypeVisitor<TyCtxt<'tcx>> for FreeRegionsVisitor<'tcx, OP>
+where
+    OP: FnMut(ty::Region<'tcx>),
+{
+    fn visit_binder<T: TypeVisitable<TyCtxt<'tcx>>>(
+        &mut self,
+        t: &ty::Binder<'tcx, T>,
+    ) -> ControlFlow<Self::BreakTy> {
+        t.super_visit_with(self);
+        ControlFlow::Continue(())
+    }
+
+    fn visit_region(&mut self, r: ty::Region<'tcx>) -> ControlFlow<Self::BreakTy> {
+        match *r {
+            // ignore bound regions, keep visiting
+            ty::ReLateBound(_, _) => ControlFlow::Continue(()),
+            _ => {
+                (self.op)(r);
+                ControlFlow::Continue(())
+            }
+        }
+    }
+
+    fn visit_ty(&mut self, ty: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
+        // We're only interested in types involving regions
+        if !ty.flags().intersects(ty::TypeFlags::HAS_FREE_REGIONS) {
+            return ControlFlow::Continue(());
+        }
+
+        match ty.kind() {
+            // We can prove that an alias is live two ways:
+            // 1. All the components are live.
+            //
+            // 2. There is a known outlives bound or where-clause, and that
+            //    region is live.
+            //
+            // We search through the item bounds and where clauses for
+            // either `'static` or a unique outlives region, and if one is
+            // found, we just need to prove that that region is still live.
+            // If one is not found, then we continue to walk through the alias.
+            ty::Alias(kind, ty::AliasTy { def_id, args, .. }) => {
+                let tcx = self.tcx;
+                let param_env = self.param_env;
+                let outlives_bounds: Vec<_> = tcx
+                    .item_bounds(def_id)
+                    .iter_instantiated(tcx, args)
+                    .chain(param_env.caller_bounds())
+                    .filter_map(|clause| {
+                        let outlives = clause.as_type_outlives_clause()?;
+                        if let Some(outlives) = outlives.no_bound_vars()
+                            && outlives.0 == ty
+                        {
+                            Some(outlives.1)
+                        } else {
+                            test_type_match::extract_verify_if_eq(
+                                tcx,
+                                param_env,
+                                &outlives.map_bound(|ty::OutlivesPredicate(ty, bound)| {
+                                    VerifyIfEq { ty, bound }
+                                }),
+                                ty,
+                            )
+                        }
+                    })
+                    .collect();
+                // If we find `'static`, then we know the alias doesn't capture *any* regions.
+                // Otherwise, all of the outlives regions should be equal -- if they're not,
+                // we don't really know how to proceed, so we continue recursing through the
+                // alias.
+                if outlives_bounds.contains(&tcx.lifetimes.re_static) {
+                    // no
+                } else if let Some(r) = outlives_bounds.first()
+                    && outlives_bounds[1..].iter().all(|other_r| other_r == r)
+                {
+                    assert!(r.type_flags().intersects(ty::TypeFlags::HAS_FREE_REGIONS));
+                    r.visit_with(self)?;
+                } else {
+                    // Skip lifetime parameters that are not captures.
+                    let variances = match kind {
+                        ty::Opaque => Some(self.tcx.variances_of(*def_id)),
+                        _ => None,
+                    };
+
+                    for (idx, s) in args.iter().enumerate() {
+                        if variances.map(|variances| variances[idx]) != Some(ty::Variance::Bivariant) {
+                            s.visit_with(self)?;
+                        }
+                    }
+                }
+            }
+
+            _ => {
+                ty.super_visit_with(self)?;
+            }
+        }
+
+        ControlFlow::Continue(())
+    }
+}

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -9,6 +9,7 @@ use rustc_middle::ty;
 
 pub mod components;
 pub mod env;
+pub mod for_liveness;
 pub mod obligations;
 pub mod test_type_match;
 pub mod verify;

--- a/tests/ui/borrowck/alias-liveness/gat-static.rs
+++ b/tests/ui/borrowck/alias-liveness/gat-static.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+trait Foo {
+    type Assoc<'a>
+    where
+        Self: 'a;
+
+    fn assoc(&mut self) -> Self::Assoc<'_>;
+}
+
+fn test<T>(mut t: T)
+where
+    T: Foo,
+    for<'a> T::Assoc<'a>: 'static,
+{
+    let a = t.assoc();
+    let b = t.assoc();
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/gat-static.rs
+++ b/tests/ui/borrowck/alias-liveness/gat-static.rs
@@ -8,13 +8,22 @@ trait Foo {
     fn assoc(&mut self) -> Self::Assoc<'_>;
 }
 
-fn test<T>(mut t: T)
+fn overlapping_mut<T>(mut t: T)
 where
     T: Foo,
     for<'a> T::Assoc<'a>: 'static,
 {
     let a = t.assoc();
     let b = t.assoc();
+}
+
+fn live_past_borrow<T>(mut t: T)
+where
+    T: Foo,
+    for<'a> T::Assoc<'a>: 'static {
+    let x = t.assoc();
+    drop(t);
+    drop(x);
 }
 
 fn main() {}

--- a/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.rs
+++ b/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.rs
@@ -1,0 +1,16 @@
+// known-bug: #42940
+
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+trait Outlives<'a>: 'a {}
+impl<'a, T: 'a> Outlives<'a> for T {}
+
+// Test that we treat `for<'a> Opaque: 'a` as `Opaque: 'static`
+fn test<'o>(v: &'o Vec<i32>) -> impl Captures<'o> + for<'a> Outlives<'a> {}
+
+fn statik() -> impl Sized {
+    test(&vec![])
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.stderr
+++ b/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.stderr
@@ -1,0 +1,16 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/higher-ranked-outlives-for-capture.rs:13:11
+   |
+LL |     test(&vec![])
+   |     ------^^^^^^-
+   |     |     |
+   |     |     creates a temporary value which is freed while still in use
+   |     argument requires that borrow lasts for `'static`
+LL | }
+   | - temporary value is freed at the end of this statement
+   |
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/borrowck/alias-liveness/higher-ranked.rs
+++ b/tests/ui/borrowck/alias-liveness/higher-ranked.rs
@@ -1,0 +1,16 @@
+// check-pass
+
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+trait Outlives<'a>: 'a {}
+impl<'a, T: 'a> Outlives<'a> for T {}
+
+// Test that we treat `for<'a> Opaque: 'a` as `Opaque: 'static`
+fn test<'o>(v: &'o Vec<i32>) -> impl Captures<'o> + for<'a> Outlives<'a> {}
+
+fn opaque_doesnt_use_temporary() {
+    let a = test(&vec![]);
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/opaque-capture.rs
+++ b/tests/ui/borrowck/alias-liveness/opaque-capture.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+// Check that opaques capturing early and late-bound vars correctly mark
+// regions required to be live using the item bounds.
+
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+fn captures_temp_late<'a>(x: &'a Vec<i32>) -> impl Sized + Captures<'a> + 'static {}
+fn captures_temp_early<'a: 'a>(x: &'a Vec<i32>) -> impl Sized + Captures<'a> + 'static {}
+
+fn test() {
+    let x = captures_temp_early(&vec![]);
+    let y = captures_temp_late(&vec![]);
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/opaque-type-param.rs
+++ b/tests/ui/borrowck/alias-liveness/opaque-type-param.rs
@@ -1,0 +1,14 @@
+// known-bug: #42940
+
+trait Trait {}
+impl Trait for () {}
+
+fn foo<'a>(s: &'a str) -> impl Trait + 'static {
+    bar(s)
+}
+
+fn bar<P: AsRef<str>>(s: P) -> impl Trait + 'static {
+    ()
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/opaque-type-param.stderr
+++ b/tests/ui/borrowck/alias-liveness/opaque-type-param.stderr
@@ -1,0 +1,13 @@
+error[E0700]: hidden type for `impl Trait + 'static` captures lifetime that does not appear in bounds
+  --> $DIR/opaque-type-param.rs:7:5
+   |
+LL | fn foo<'a>(s: &'a str) -> impl Trait + 'static {
+   |        --                 -------------------- opaque type defined here
+   |        |
+   |        hidden type `impl Trait + 'static` captures the lifetime `'a` as defined here
+LL |     bar(s)
+   |     ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0700`.

--- a/tests/ui/borrowck/alias-liveness/rpit-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rpit-static.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+trait Captures<'a> {}
+impl<T> Captures<'_> for T {}
+
+fn foo(x: &i32) -> impl Sized + Captures<'_> + 'static {}
+
+fn main() {
+    let y;
+    {
+        let x = 1;
+        y = foo(&x);
+    }
+}

--- a/tests/ui/borrowck/alias-liveness/rpit-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rpit-static.rs
@@ -3,12 +3,20 @@
 trait Captures<'a> {}
 impl<T> Captures<'_> for T {}
 
-fn foo(x: &i32) -> impl Sized + Captures<'_> + 'static {}
+fn foo(x: &mut i32) -> impl Sized + Captures<'_> + 'static {}
 
-fn main() {
+fn overlapping_mut() {
+    let i = &mut 1;
+    let x = foo(i);
+    let y = foo(i);
+}
+
+fn live_past_borrow() {
     let y;
     {
-        let x = 1;
-        y = foo(&x);
+        let x = &mut 1;
+        y = foo(x);
     }
 }
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/rpitit-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rpitit-static.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+trait Foo {
+    fn rpitit(&mut self) -> impl Sized + 'static;
+}
+
+fn test<T: Foo>(mut t: T) {
+    let a = t.rpitit();
+    let b = t.rpitit();
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/rpitit-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rpitit-static.rs
@@ -4,7 +4,13 @@ trait Foo {
     fn rpitit(&mut self) -> impl Sized + 'static;
 }
 
-fn test<T: Foo>(mut t: T) {
+fn live_past_borrow<T: Foo>(mut t: T) {
+    let x = t.rpitit();
+    drop(t);
+    drop(x);
+}
+
+fn overlapping_mut<T: Foo>(mut t: T) {
     let a = t.rpitit();
     let b = t.rpitit();
 }

--- a/tests/ui/borrowck/alias-liveness/rtn-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rtn-static.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Foo {
+    fn borrow(&mut self) -> impl Sized + '_;
+}
+
+// Test that the `'_` item bound in `borrow` does not cause us to
+// overlook the `'static` RTN bound.
+fn test<T: Foo<borrow(): 'static>>(mut t: T) {
+    let x = t.borrow();
+    let x = t.borrow();
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/rtn-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rtn-static.rs
@@ -7,9 +7,15 @@ trait Foo {
     fn borrow(&mut self) -> impl Sized + '_;
 }
 
+fn live_past_borrow<T: Foo<borrow(): 'static>>(mut t: T) {
+    let x = t.borrow();
+    drop(t);
+    drop(x);
+}
+
 // Test that the `'_` item bound in `borrow` does not cause us to
 // overlook the `'static` RTN bound.
-fn test<T: Foo<borrow(): 'static>>(mut t: T) {
+fn overlapping_mut<T: Foo<borrow(): 'static>>(mut t: T) {
     let x = t.borrow();
     let x = t.borrow();
 }

--- a/tests/ui/borrowck/alias-liveness/rtn-static.stderr
+++ b/tests/ui/borrowck/alias-liveness/rtn-static.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/rtn-static.rs:3:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/impl-trait/bivariant-lifetime-liveness.rs
+++ b/tests/ui/impl-trait/bivariant-lifetime-liveness.rs
@@ -1,0 +1,15 @@
+// check-pass
+// issue: 116794
+
+// Uncaptured lifetimes should not be required to be live.
+
+struct Invariant<T>(*mut T);
+
+fn opaque<'a: 'a>(_: &'a str) -> Invariant<impl Sized> {
+    Invariant(&mut ())
+}
+
+fn main() {
+    let x = opaque(&String::new());
+    drop(x);
+}


### PR DESCRIPTION
This is a revival of #116040, except removing the changes to opaque lifetime captures check to make sure that we're not triggering any unsoundness due to the lack of general existential regions and the currently-existing `ReErased` hack we use instead.

r? @aliemjay -- I appreciate you pointing out the unsoundenss in the previous iteration of this PR, and I'd like to hear that you're happy with this iteration of this PR before this goes back into FCP :>

Fixes #116794 as well

---

(mostly copied from #116040 and reworked slightly)

# Background

Right now, liveness analysis in NLL is a bit simplistic. It simply walks through all of the regions of a type and marks them as being live at points. This is problematic in the case of aliases, since it requires that we mark **all** of the regions in their args[^1] as live, leading to bugs like #42940.

In reality, we may be able to deduce that fewer regions are allowed to be present in the projected type (or "hidden type" for opaques) via item bounds or where clauses, and therefore ideally, we should be able to soundly require fewer regions to be live in the alias.

For example:
```rust
trait Captures<'a> {}
impl<T> Captures<'_> for T {}

fn capture<'o>(_: &'o mut ()) -> impl Sized + Captures<'o> + 'static {}

fn test_two_mut(mut x: ()) {
    let _f1 = capture(&mut x);
    let _f2 = capture(&mut x);
    //~^ ERROR cannot borrow `x` as mutable more than once at a time
}
```

In the example above, we should be able to deduce from the `'static` bound on `capture`'s opaque that even though `'o` is a captured region, it *can never* show up in the opaque's hidden type, and can soundly be ignored for liveness purposes.

# The Fix

We apply a simple version of RFC 1214's `OutlivesProjectionEnv` and `OutlivesProjectionTraitDef` rules to NLL's `make_all_regions_live` computation.

Specifically, when we encounter an alias type, we:
1. Look for a unique outlives bound in the param-env or item bounds for that alias. If there is more than one unique region, bail, unless any of the outlives bound's regions is `'static`, and in that case, prefer `'static`. If we find such a unique region, we can mark that outlives region as live and skip walking through the args of the opaque.
2. Otherwise, walk through the alias's args recursively, as we do today.

## Limitation: Multiple choices

This approach has some limitations. Firstly, since liveness doesn't use the same type-test logic as outlives bounds do, we can't really try several options when we're faced with a choice.

If we encounter two unique outlives regions in the param-env or bounds, we simply fall back to walking the opaque via its args. I expect this to be mostly mitigated by the special treatment of `'static`, and can be fixed in a forwards-compatible by a more sophisticated analysis in the future.

## Limitation: Opaque hidden types

Secondly, we do not employ any of these rules when considering whether the regions captured by a hidden type are valid. That causes this code (cc #42940) to fail:

```rust
trait Captures<'a> {}
impl<T> Captures<'_> for T {}

fn a() -> impl Sized + 'static {
    b(&vec![])
}

fn b<'o>(_: &'o Vec<i32>) -> impl Sized + Captures<'o> + 'static {}
```

We need to have existential regions to avoid [unsoundness](https://github.com/rust-lang/rust/pull/116040#issuecomment-1751628189) when an opaque captures a region which is not represented in its own substs but which outlives a region that does.

## Read more

Context: https://github.com/rust-lang/rust/pull/115822#issuecomment-1731153952 (for the liveness case)
More context: https://github.com/rust-lang/rust/issues/42940#issuecomment-455198309 (for the opaque capture case, which this does not fix)

[^1]: except for bivariant region args in opaques, which will become less relevant when we move onto edition 2024 capture semantics for opaques.