### PR TITLE
rustdoc: correctly clean cross-crate opaque types

### DIFF
--- a/tests/rustdoc/inline_cross/auxiliary/impl_trait.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/impl_trait.rs
@@ -1,5 +1,3 @@
-// edition:2018
-
 use std::ops::Deref;
 
 pub fn func<'a>(_x: impl Clone + Into<Vec<u8>> + 'a) {}
@@ -26,10 +24,22 @@ pub trait Auxiliary<'arena> {
     type Item<'input>;
 }
 
-pub async fn async_fn() {}
-
 pub struct Foo;
 
 impl Foo {
     pub fn method<'a>(_x: impl Clone + Into<Vec<u8>> + 'a) {}
 }
+
+// Regression test for issue #113015, subitem (1) / bevyengine/bevy#8898.
+// Check that we pick up on the return type of cross-crate opaque `Fn`s and
+// `FnMut`s (`FnOnce` already used to work fine).
+pub fn rpit_fn() -> impl Fn() -> bool {
+    || false
+}
+
+pub fn rpit_fn_mut() -> impl for<'a> FnMut(&'a str) -> &'a str {
+    |source| source
+}
+
+// FIXME(fmease): Add more tests that demonstrate the importance of checking the
+// generic args of supertrait bounds.

--- a/tests/rustdoc/inline_cross/impl_trait.rs
+++ b/tests/rustdoc/inline_cross/impl_trait.rs
@@ -1,39 +1,46 @@
-// aux-build:impl_trait_aux.rs
+// aux-crate:impl_trait=impl_trait.rs
 // edition:2018
+#![crate_name = "user"]
 
-extern crate impl_trait_aux;
-
-// @has impl_trait/fn.func.html
+// @has user/fn.func.html
 // @has - '//pre[@class="rust item-decl"]' "pub fn func<'a>(_x: impl Clone + Into<Vec<u8>> + 'a)"
 // @!has - '//pre[@class="rust item-decl"]' 'where'
-pub use impl_trait_aux::func;
+pub use impl_trait::func;
 
-// @has impl_trait/fn.func2.html
+// @has user/fn.func2.html
 // @has - '//pre[@class="rust item-decl"]' "func2<T>("
 // @has - '//pre[@class="rust item-decl"]' "_x: impl Deref<Target = Option<T>> + Iterator<Item = T>,"
 // @has - '//pre[@class="rust item-decl"]' "_y: impl Iterator<Item = u8> )"
 // @!has - '//pre[@class="rust item-decl"]' 'where'
-pub use impl_trait_aux::func2;
+pub use impl_trait::func2;
 
-// @has impl_trait/fn.func3.html
+// @has user/fn.func3.html
 // @has - '//pre[@class="rust item-decl"]' "func3("
 // @has - '//pre[@class="rust item-decl"]' "_x: impl Iterator<Item = impl Iterator<Item = u8>> + Clone)"
 // @!has - '//pre[@class="rust item-decl"]' 'where'
-pub use impl_trait_aux::func3;
+pub use impl_trait::func3;
 
-// @has impl_trait/fn.func4.html
+// @has user/fn.func4.html
 // @has - '//pre[@class="rust item-decl"]' "func4<T>("
 // @has - '//pre[@class="rust item-decl"]' "T: Iterator<Item = impl Clone>,"
-pub use impl_trait_aux::func4;
+pub use impl_trait::func4;
 
-// @has impl_trait/fn.func5.html
+// @has user/fn.func5.html
 // @has - '//pre[@class="rust item-decl"]' "func5("
 // @has - '//pre[@class="rust item-decl"]' "_f: impl for<'any> Fn(&'any str, &'any str) -> bool + for<'r> Other<T<'r> = ()>,"
 // @has - '//pre[@class="rust item-decl"]' "_a: impl for<'beta, 'alpha, '_gamma> Auxiliary<'alpha, Item<'beta> = fn(_: &'beta ())>"
 // @!has - '//pre[@class="rust item-decl"]' 'where'
-pub use impl_trait_aux::func5;
+pub use impl_trait::func5;
 
-// @has impl_trait/struct.Foo.html
+// @has user/struct.Foo.html
 // @has - '//*[@id="method.method"]//h4[@class="code-header"]' "pub fn method<'a>(_x: impl Clone + Into<Vec<u8>> + 'a)"
 // @!has - '//*[@id="method.method"]//h4[@class="code-header"]' 'where'
-pub use impl_trait_aux::Foo;
+pub use impl_trait::Foo;
+
+// @has user/fn.rpit_fn.html
+// @has - '//pre[@class="rust item-decl"]' "rpit_fn() -> impl Fn() -> bool"
+pub use impl_trait::rpit_fn;
+
+// @has user/fn.rpit_fn_mut.html
+// @has - '//pre[@class="rust item-decl"]' "rpit_fn_mut() -> impl for<'a> FnMut(&'a str) -> &'a str"
+pub use impl_trait::rpit_fn_mut;


### PR DESCRIPTION
Opening a PR for a patch I had lying around for roughly 3 months to motivate myself to finish it.
Fixes bevyengine/bevy#8898 (#113015, subitem (1)).
Part of #113015.

Before/after (cross-crate re-export scenario):

```diff
- pub fn rpit_fn() -> impl Fn()
+ pub fn rpit_fn() -> impl Fn() -> bool
- pub fn rpit_fn_mut() -> impl for<'a> FnMut(&'a str)
+ pub fn rpit_fn_mut() -> impl for<'a> FnMut(&'a str) -> &'a str
```

Draft: See FIXMEs.

r? @ghost