### PR TITLE
dont ICE when ConstKind::Expr for is_const_evaluatable

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.rs
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.rs
@@ -1,0 +1,25 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+fn foo<const N: usize>(
+    _: [u8; {
+        {
+            N
+        }
+    }],
+) {
+}
+
+fn ice<const L: usize>()
+where
+    [(); (L - 1) + 1 + L]:,
+{
+    foo::<_, L>([(); L + 1 + L]);
+    //~^ ERROR: mismatched types
+    //~^^ ERROR: unconstrained generic constant
+    //~^^^ ERROR: function takes 1 generic argument but 2 generic arguments were supplied
+    //~^^^^ ERROR: unconstrained generic constant
+    //~^^^^^ ERROR: unconstrained generic constant `{const expr}`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
@@ -1,0 +1,64 @@
+error[E0107]: function takes 1 generic argument but 2 generic arguments were supplied
+  --> $DIR/issue_114151.rs:17:5
+   |
+LL |     foo::<_, L>([(); L + 1 + L]);
+   |     ^^^      - help: remove this generic argument
+   |     |
+   |     expected 1 generic argument
+   |
+note: function defined here, with 1 generic parameter: `N`
+  --> $DIR/issue_114151.rs:4:4
+   |
+LL | fn foo<const N: usize>(
+   |    ^^^ --------------
+
+error[E0308]: mismatched types
+  --> $DIR/issue_114151.rs:17:18
+   |
+LL |     foo::<_, L>([(); L + 1 + L]);
+   |                  ^^ expected `u8`, found `()`
+
+error: unconstrained generic constant
+  --> $DIR/issue_114151.rs:17:22
+   |
+LL |     foo::<_, L>([(); L + 1 + L]);
+   |                      ^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); L + 1 + L]:`
+
+error: unconstrained generic constant
+  --> $DIR/issue_114151.rs:17:17
+   |
+LL |     foo::<_, L>([(); L + 1 + L]);
+   |     ----------- ^^^^^^^^^^^^^^^
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: try adding a `where` bound using this expression: `where [(); {
+                   {
+                       N
+                   }
+               }]:`
+note: required by a bound in `foo`
+  --> $DIR/issue_114151.rs:5:13
+   |
+LL |   fn foo<const N: usize>(
+   |      --- required by a bound in this function
+LL |       _: [u8; {
+   |  _____________^
+LL | |         {
+LL | |             N
+LL | |         }
+LL | |     }],
+   | |_____^ required by this bound in `foo`
+
+error: unconstrained generic constant `{const expr}`
+  --> $DIR/issue_114151.rs:17:5
+   |
+LL |     foo::<_, L>([(); L + 1 + L]);
+   |     ^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0107, E0308.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
The problem is that we are not handling ConstKind::Expr inside report_not_const_evaluatable_error

Fixes [#114151]