### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -128,8 +128,7 @@ impl<T> OnceCell<T> {
         // checked that slot is currently `None`, so this write
         // maintains the `inner`'s invariant.
         let slot = unsafe { &mut *self.inner.get() };
-        *slot = Some(value);
-        Ok(self.get().unwrap())
+        Ok(slot.insert(value))
     }
 
     /// Gets the contents of the cell, initializing it with `f`
@@ -213,10 +212,9 @@ impl<T> OnceCell<T> {
         let val = outlined_call(f)?;
         // Note that *some* forms of reentrant initialization might lead to
         // UB (see `reentrant_init` test). I believe that just removing this
-        // `assert`, while keeping `set/get` would be sound, but it seems
+        // `panic`, while keeping `try_insert` would be sound, but it seems
         // better to panic, rather than to silently use an old value.
-        assert!(self.set(val).is_ok(), "reentrant init");
-        Ok(self.get().unwrap())
+        if let Ok(val) = self.try_insert(val) { Ok(val) } else { panic!("reentrant init") }
     }
 
     /// Consumes the cell, returning the wrapped value.

--- a/src/tools/miri/ci.sh
+++ b/src/tools/miri/ci.sh
@@ -110,8 +110,8 @@ case $HOST_TARGET in
     MIRI_TEST_TARGET=i686-pc-windows-gnu run_tests
     MIRI_TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal hello integer vec panic/panic concurrency/simple atomic data_race env/var
     MIRI_TEST_TARGET=aarch64-linux-android run_tests_minimal hello integer vec panic/panic
-    MIRI_TEST_TARGET=wasm32-wasi run_tests_minimal no_std integer strings
-    MIRI_TEST_TARGET=wasm32-unknown-unknown run_tests_minimal no_std integer strings
+    MIRI_TEST_TARGET=wasm32-wasi run_tests_minimal no_std integer strings wasm
+    MIRI_TEST_TARGET=wasm32-unknown-unknown run_tests_minimal no_std integer strings wasm
     MIRI_TEST_TARGET=thumbv7em-none-eabihf run_tests_minimal no_std # no_std embedded architecture
     MIRI_TEST_TARGET=tests/avr.json MIRI_NO_STD=1 run_tests_minimal no_std # JSON target file
     ;;

--- a/src/tools/miri/tests/pass/function_calls/target_feature_wasm.rs
+++ b/src/tools/miri/tests/pass/function_calls/target_feature_wasm.rs
@@ -1,0 +1,11 @@
+//@only-target-wasm32: tests WASM-specific behavior
+//@compile-flags: -C target-feature=-simd128
+
+fn main() {
+    // Calling functions with `#[target_feature]` is not unsound on WASM, see #84988
+    assert!(!cfg!(target_feature = "simd128"));
+    simd128_fn();
+}
+
+#[target_feature(enable = "simd128")]
+fn simd128_fn() {}

--- a/tests/ui/consts/const-eval/const_fn_target_feature_wasm.rs
+++ b/tests/ui/consts/const-eval/const_fn_target_feature_wasm.rs
@@ -1,0 +1,14 @@
+// only-wasm32
+// compile-flags:-C target-feature=-simd128
+// build-pass
+
+#![crate_type = "lib"]
+
+#[cfg(target_feature = "simd128")]
+compile_error!("simd128 target feature should be disabled");
+
+// Calling functions with `#[target_feature]` is not unsound on WASM, see #84988
+const A: () = simd128_fn();
+
+#[target_feature(enable = "simd128")]
+const fn simd128_fn() {}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -23,6 +23,12 @@ allow-unauthenticated = [
     "needs-triage",
 ]
 
+[review-submitted] 
+# This label is added when a "request changes" review is submitted. 
+reviewed_label = "S-waiting-on-author" 
+# These labels are removed when a "request changes" review is submitted. 
+review_labels = ["S-waiting-on-review"]
+
 [glacier]
 
 [ping.icebreakers-llvm]


### PR DESCRIPTION
Successful merges:

 - #116540 (Implement `OnceCell/Lock::try_insert()`)
 - #116576 (const-eval: allow calling functions with targat features disabled at compile time in WASM)
 - #116661 (Make "request changes" reviews apply `S-waiting-on-author`)

Failed merges:

 - #116643 (x.py zsh completion support)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116540,116576,116661)
<!-- homu-ignore:end -->