### PR TITLE
Eliminate use of `#[cfg_attr(not(doc), repr(...))]`

### DIFF
--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -509,7 +509,7 @@ where
 /// ```
 ///
 #[unstable(feature = "error_generic_member_access", issue = "99301")]
-#[cfg_attr(not(doc), repr(transparent))] // work around https://github.com/rust-lang/rust/issues/90435
+#[repr(transparent)]
 pub struct Request<'a>(dyn Erased<'a> + 'a);
 
 impl<'a> Request<'a> {

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -83,11 +83,9 @@ use crate::str;
 #[rustc_has_incoherent_inherent_impls]
 #[lang = "CStr"]
 // `fn from` in `impl From<&CStr> for Box<CStr>` current implementation relies
-// on `CStr` being layout-compatible with `[u8]`.
-// However, `CStr` layout is considered an implementation detail and must not be relied upon. We
-// want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
-// `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
-#[cfg_attr(not(doc), repr(transparent))]
+// on `CStr` being layout-compatible with `[u8]`. However, `CStr` layout is
+// considered an implementation detail and must not be relied upon.
+#[repr(transparent)]
 pub struct CStr {
     // FIXME: this should not be represented with a DST slice but rather with
     //        just a raw `c_char` along with some form of marker to make

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -204,7 +204,7 @@ mod c_long_definition {
 //     be UB.
 #[doc = include_str!("c_void.md")]
 #[lang = "c_void"]
-#[cfg_attr(not(doc), repr(u8))] // work around https://github.com/rust-lang/rust/issues/90435
+#[repr(u8)]
 #[stable(feature = "core_c_void", since = "1.30.0")]
 pub enum c_void {
     #[unstable(
@@ -245,7 +245,7 @@ impl fmt::Debug for c_void {
     target_os = "uefi",
     windows,
 ))]
-#[cfg_attr(not(doc), repr(transparent))] // work around https://github.com/rust-lang/rust/issues/90435
+#[repr(transparent)]
 #[unstable(
     feature = "c_variadic",
     reason = "the `c_variadic` feature has not been properly tested on \
@@ -297,7 +297,7 @@ impl<'f> fmt::Debug for VaListImpl<'f> {
     not(target_os = "uefi"),
     not(windows),
 ))]
-#[cfg_attr(not(doc), repr(C))] // work around https://github.com/rust-lang/rust/issues/66401
+#[repr(C)]
 #[derive(Debug)]
 #[unstable(
     feature = "c_variadic",
@@ -317,7 +317,7 @@ pub struct VaListImpl<'f> {
 
 /// PowerPC ABI implementation of a `va_list`.
 #[cfg(all(target_arch = "powerpc", not(target_os = "uefi"), not(windows)))]
-#[cfg_attr(not(doc), repr(C))] // work around https://github.com/rust-lang/rust/issues/66401
+#[repr(C)]
 #[derive(Debug)]
 #[unstable(
     feature = "c_variadic",
@@ -337,7 +337,7 @@ pub struct VaListImpl<'f> {
 
 /// s390x ABI implementation of a `va_list`.
 #[cfg(target_arch = "s390x")]
-#[cfg_attr(not(doc), repr(C))] // work around https://github.com/rust-lang/rust/issues/66401
+#[repr(C)]
 #[derive(Debug)]
 #[unstable(
     feature = "c_variadic",
@@ -356,7 +356,7 @@ pub struct VaListImpl<'f> {
 
 /// x86_64 ABI implementation of a `va_list`.
 #[cfg(all(target_arch = "x86_64", not(target_os = "uefi"), not(windows)))]
-#[cfg_attr(not(doc), repr(C))] // work around https://github.com/rust-lang/rust/issues/66401
+#[repr(C)]
 #[derive(Debug)]
 #[unstable(
     feature = "c_variadic",
@@ -374,7 +374,7 @@ pub struct VaListImpl<'f> {
 }
 
 /// A wrapper for a `va_list`
-#[cfg_attr(not(doc), repr(transparent))] // work around https://github.com/rust-lang/rust/issues/90435
+#[repr(transparent)]
 #[derive(Debug)]
 #[unstable(
     feature = "c_variadic",

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -233,7 +233,7 @@ impl fmt::Debug for Context<'_> {
 ///
 /// [`Future::poll()`]: core::future::Future::poll
 /// [`Poll::Pending`]: core::task::Poll::Pending
-#[cfg_attr(not(doc), repr(transparent))] // work around https://github.com/rust-lang/rust/issues/66401
+#[repr(transparent)]
 #[stable(feature = "futures_api", since = "1.36.0")]
 pub struct Waker {
     waker: RawWaker,

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -110,12 +110,10 @@ impl crate::sealed::Sealed for OsString {}
 /// [conversions]: super#conversions
 #[cfg_attr(not(test), rustc_diagnostic_item = "OsStr")]
 #[stable(feature = "rust1", since = "1.0.0")]
-// `OsStr::from_inner` current implementation relies
-// on `OsStr` being layout-compatible with `Slice`.
-// However, `OsStr` layout is considered an implementation detail and must not be relied upon. We
-// want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
-// `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
-#[cfg_attr(not(doc), repr(transparent))]
+// `OsStr::from_inner` current implementation relies on `OsStr` being layout-
+// compatible with `Slice`. However, `OsStr` layout is considered an
+// implementation detail and must not be relied upon.
+#[repr(transparent)]
 pub struct OsStr {
     inner: Slice,
 }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1158,12 +1158,10 @@ impl FusedIterator for Ancestors<'_> {}
 /// Which method works best depends on what kind of situation you're in.
 #[cfg_attr(not(test), rustc_diagnostic_item = "PathBuf")]
 #[stable(feature = "rust1", since = "1.0.0")]
-// `PathBuf::as_mut_vec` current implementation relies
-// on `PathBuf` being layout-compatible with `Vec<u8>`.
-// However, `PathBuf` layout is considered an implementation detail and must not be relied upon. We
-// want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
-// `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
-#[cfg_attr(not(doc), repr(transparent))]
+// `PathBuf::as_mut_vec` current implementation relies on `PathBuf` being
+// layout-compatible with `Vec<u8>`. However, `PathBuf` layout is considered an
+// implementation detail and must not be relied upon.
+#[repr(transparent)]
 pub struct PathBuf {
     inner: OsString,
 }
@@ -1983,12 +1981,10 @@ impl AsRef<OsStr> for PathBuf {
 /// ```
 #[cfg_attr(not(test), rustc_diagnostic_item = "Path")]
 #[stable(feature = "rust1", since = "1.0.0")]
-// `Path::new` current implementation relies
-// on `Path` being layout-compatible with `OsStr`.
-// However, `Path` layout is considered an implementation detail and must not be relied upon. We
-// want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
-// `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
-#[cfg_attr(not(doc), repr(transparent))]
+// `Path::new` current implementation relies on `Path` being layout-compatible
+// with `OsStr`. However, `Path` layout is considered an implementation detail
+// and must not be relied upon.
+#[repr(transparent)]
 pub struct Path {
     inner: OsStr,
 }


### PR DESCRIPTION
This PR reverts #107680 and some pre-existing occurrences of the same pattern.

The issue that prompted the workaround, #90435, has since been fixed by #115439.

Tested by running `x.py doc --stage 1 library/std` and confirming that std/path/struct.PathBuf.html contains no visible `#[repr(transparent)]`. Note that `x.py doc library/std` runs using stage0 rustdoc (maybe depending on config.toml?) and will continue to render a `#[repr(transparent)]`, but that's okay and shouldn't make it into official documentation of the 1.75.0 release.

Blocked on #116882