### PR TITLE
Add Seek::seek_relative

### DIFF
--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -492,6 +492,16 @@ impl<R: ?Sized + Seek> Seek for BufReader<R> {
             )
         })
     }
+
+    /// Seeks relative to the current position.
+    ///
+    /// If the new position lies within the buffer, the buffer will not be
+    /// flushed, allowing for more efficient seeks. This method does not return
+    /// the location of the underlying reader, so the caller must track this
+    /// information themselves if it is required.
+    fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
+        self.seek_relative(offset)
+    }
 }
 
 impl<T: ?Sized> SizeHint for BufReader<T> {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1978,7 +1978,7 @@ pub trait Seek {
     ///     Ok(())
     /// }
     /// ```
-    #[unstable(feature = "seek_seek_relative", issue = "none")]
+    #[unstable(feature = "seek_seek_relative", issue = "117374")]
     fn seek_relative(&mut self, offset: i64) -> Result<()> {
         self.seek(SeekFrom::Current(offset))?;
         Ok(())

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1960,7 +1960,9 @@ pub trait Seek {
 
     /// Seeks relative to the current position.
     ///
-    /// This is equivalent to `self.seek(SeekFrom::Current(offset))`.
+    /// This is equivalent to `self.seek(SeekFrom::Current(offset))` but
+    /// doesn't return the new position which can allow some implementations
+    /// such as [`BufReader`] to perform more efficient seeks.
     ///
     /// # Example
     ///
@@ -1978,6 +1980,8 @@ pub trait Seek {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// [`BufReader`]: crate::io::BufReader
     #[unstable(feature = "seek_seek_relative", issue = "117374")]
     fn seek_relative(&mut self, offset: i64) -> Result<()> {
         self.seek(SeekFrom::Current(offset))?;

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1957,6 +1957,32 @@ pub trait Seek {
     fn stream_position(&mut self) -> Result<u64> {
         self.seek(SeekFrom::Current(0))
     }
+
+    /// Seeks relative to the current position.
+    ///
+    /// This is equivalent to `self.seek(SeekFrom::Current(offset))`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// #![feature(seek_seek_relative)]
+    /// use std::{
+    ///     io::{self, Seek},
+    ///     fs::File,
+    /// };
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut f = File::open("foo.txt")?;
+    ///     f.seek_relative(10)?;
+    ///     assert_eq!(f.stream_position()?, 10);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "seek_seek_relative", issue = "none")]
+    fn seek_relative(&mut self, offset: i64) -> Result<()> {
+        self.seek(SeekFrom::Current(offset))?;
+        Ok(())
+    }
 }
 
 /// Enumeration of possible methods to seek within an I/O object.


### PR DESCRIPTION
The `BufReader` struct has a `seek_relative` method because its `Seek::seek` implementation involved dumping the internal buffer (https://github.com/rust-lang/rust/issues/31100).

Unfortunately, there isn't really a good way to take advantage of that method in generic code. This PR adds the same method to the main `Seek` trait with the straightforward default method, and an override for `BufReader` that calls its implementation.

_Also discussed in [this](https://internals.rust-lang.org/t/add-seek-seek-relative/19546) internals.rust-lang.org thread._