### PR TITLE
Lint overlapping ranges as a separate pass

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -883,7 +883,22 @@ impl<'p, 'tcx> PatternColumn<'p, 'tcx> {
         self.patterns.is_empty()
     }
     fn head_ty(&self) -> Option<Ty<'tcx>> {
-        self.patterns.get(0).map(|p| p.ty())
+        if self.patterns.len() == 0 {
+            return None;
+        }
+        // If the type is opaque and it is revealed anywhere in the column, we take the revealed
+        // version. Otherwise we could encounter constructors for the revealed type and crash.
+        let is_opaque = |ty: Ty<'tcx>| matches!(ty.kind(), ty::Alias(ty::Opaque, ..));
+        let first_ty = self.patterns[0].ty();
+        if is_opaque(first_ty) {
+            for pat in &self.patterns {
+                let ty = pat.ty();
+                if !is_opaque(ty) {
+                    return Some(ty);
+                }
+            }
+        }
+        Some(first_ty)
     }
 
     fn analyze_ctors(&self, pcx: &PatCtxt<'_, 'p, 'tcx>) -> SplitConstructorSet<'tcx> {

--- a/tests/ui/mir/mir_match_test.rs
+++ b/tests/ui/mir/mir_match_test.rs
@@ -1,4 +1,5 @@
 #![feature(exclusive_range_pattern)]
+#![allow(overlapping_range_endpoints)]
 
 // run-pass
 

--- a/tests/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.rs
+++ b/tests/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.rs
@@ -8,7 +8,7 @@ macro_rules! m {
             $t2 => {}
             _ => {}
         }
-    }
+    };
 }
 
 fn main() {
@@ -16,9 +16,9 @@ fn main() {
     m!(0u8, 30..=40, 20..=30); //~ ERROR multiple patterns overlap on their endpoints
     m!(0u8, 20..=30, 31..=40);
     m!(0u8, 20..=30, 29..=40);
-    m!(0u8, 20.. 30, 29..=40); //~ ERROR multiple patterns overlap on their endpoints
-    m!(0u8, 20.. 30, 28..=40);
-    m!(0u8, 20.. 30, 30..=40);
+    m!(0u8, 20..30, 29..=40); //~ ERROR multiple patterns overlap on their endpoints
+    m!(0u8, 20..30, 28..=40);
+    m!(0u8, 20..30, 30..=40);
     m!(0u8, 20..=30, 30..=30);
     m!(0u8, 20..=30, 30..=31); //~ ERROR multiple patterns overlap on their endpoints
     m!(0u8, 20..=30, 29..=30);
@@ -28,7 +28,7 @@ fn main() {
     m!(0u8, 20..=30, 20);
     m!(0u8, 20..=30, 25);
     m!(0u8, 20..=30, 30);
-    m!(0u8, 20.. 30, 29);
+    m!(0u8, 20..30, 29);
     m!(0u8, 20, 20..=30);
     m!(0u8, 25, 20..=30);
     m!(0u8, 30, 20..=30);
@@ -36,19 +36,21 @@ fn main() {
     match 0u8 {
         0..=10 => {}
         20..=30 => {}
-        10..=20 => {} //~ ERROR multiple patterns overlap on their endpoints
+        10..=20 => {}
+        //~^ ERROR multiple patterns overlap on their endpoints
+        //~| ERROR multiple patterns overlap on their endpoints
         _ => {}
     }
     match (0u8, true) {
         (0..=10, true) => {}
-        (10..20, true) => {} // not detected
-        (10..20, false) => {}
+        (10..20, true) => {} //~ ERROR multiple patterns overlap on their endpoints
+        (10..20, false) => {} //~ ERROR multiple patterns overlap on their endpoints
         _ => {}
     }
     match (true, 0u8) {
         (true, 0..=10) => {}
         (true, 10..20) => {} //~ ERROR multiple patterns overlap on their endpoints
-        (false, 10..20) => {}
+        (false, 10..20) => {} //~ ERROR multiple patterns overlap on their endpoints
         _ => {}
     }
     match Some(0u8) {

--- a/tests/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
@@ -24,10 +24,10 @@ LL |     m!(0u8, 30..=40, 20..=30);
    = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
-  --> $DIR/overlapping_range_endpoints.rs:19:22
+  --> $DIR/overlapping_range_endpoints.rs:19:21
    |
-LL |     m!(0u8, 20.. 30, 29..=40);
-   |             -------  ^^^^^^^ ... with this range
+LL |     m!(0u8, 20..30, 29..=40);
+   |             ------  ^^^^^^^ ... with this range
    |             |
    |             this range overlaps on `29_u8`...
    |
@@ -59,6 +59,15 @@ error: multiple patterns overlap on their endpoints
 LL |         0..=10 => {}
    |         ------ this range overlaps on `10_u8`...
 LL |         20..=30 => {}
+LL |         10..=20 => {}
+   |         ^^^^^^^ ... with this range
+   |
+   = note: you likely meant to write mutually exclusive ranges
+
+error: multiple patterns overlap on their endpoints
+  --> $DIR/overlapping_range_endpoints.rs:39:9
+   |
+LL |         20..=30 => {}
    |         ------- this range overlaps on `20_u8`...
 LL |         10..=20 => {}
    |         ^^^^^^^ ... with this range
@@ -66,7 +75,28 @@ LL |         10..=20 => {}
    = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
-  --> $DIR/overlapping_range_endpoints.rs:50:16
+  --> $DIR/overlapping_range_endpoints.rs:46:10
+   |
+LL |         (0..=10, true) => {}
+   |          ------ this range overlaps on `10_u8`...
+LL |         (10..20, true) => {}
+   |          ^^^^^^ ... with this range
+   |
+   = note: you likely meant to write mutually exclusive ranges
+
+error: multiple patterns overlap on their endpoints
+  --> $DIR/overlapping_range_endpoints.rs:47:10
+   |
+LL |         (0..=10, true) => {}
+   |          ------ this range overlaps on `10_u8`...
+LL |         (10..20, true) => {}
+LL |         (10..20, false) => {}
+   |          ^^^^^^ ... with this range
+   |
+   = note: you likely meant to write mutually exclusive ranges
+
+error: multiple patterns overlap on their endpoints
+  --> $DIR/overlapping_range_endpoints.rs:52:16
    |
 LL |         (true, 0..=10) => {}
    |                ------ this range overlaps on `10_u8`...
@@ -76,7 +106,18 @@ LL |         (true, 10..20) => {}
    = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
-  --> $DIR/overlapping_range_endpoints.rs:56:14
+  --> $DIR/overlapping_range_endpoints.rs:53:17
+   |
+LL |         (true, 0..=10) => {}
+   |                ------ this range overlaps on `10_u8`...
+LL |         (true, 10..20) => {}
+LL |         (false, 10..20) => {}
+   |                 ^^^^^^ ... with this range
+   |
+   = note: you likely meant to write mutually exclusive ranges
+
+error: multiple patterns overlap on their endpoints
+  --> $DIR/overlapping_range_endpoints.rs:58:14
    |
 LL |         Some(0..=10) => {}
    |              ------ this range overlaps on `10_u8`...
@@ -85,5 +126,5 @@ LL |         Some(10..20) => {}
    |
    = note: you likely meant to write mutually exclusive ranges
 
-error: aborting due to 8 previous errors
+error: aborting due to 12 previous errors
 

--- a/tests/ui/type-alias-impl-trait/issue-96572-unconstrained.rs
+++ b/tests/ui/type-alias-impl-trait/issue-96572-unconstrained.rs
@@ -26,11 +26,9 @@ fn upvar() {
 fn enum_upvar() {
     type T = impl Copy;
     let foo: T = Some((1u32, 2u32));
-    let x = move || {
-        match foo {
-            None => (),
-            Some((a, b)) => (),
-        }
+    let x = move || match foo {
+        None => (),
+        Some((a, b)) => (),
     };
 }
 
@@ -63,6 +61,19 @@ mod only_pattern {
             None => {}
         }
     }
+
+    type V = impl Copy;
+
+    fn baz(baz: Option<V>) {
+        match baz {
+            _ => {}
+            Some((mut x, mut y)) => {
+                x = 42;
+                y = "foo";
+            }
+            None => {}
+        }
+    }
 }
 
 mod only_pattern_rpit {
@@ -71,11 +82,7 @@ mod only_pattern_rpit {
         let (mut x, mut y) = foo(false);
         x = 42;
         y = "foo";
-        if b {
-            panic!()
-        } else {
-            foo(true)
-        }
+        if b { panic!() } else { foo(true) }
     }
 
     fn bar(b: bool) -> Option<impl Copy> {


### PR DESCRIPTION
This reworks the [`overlapping_range_endpoints`](https://doc.rust-lang.org/beta/nightly-rustc/rustc_lint_defs/builtin/static.OVERLAPPING_RANGE_ENDPOINTS.html) lint. My motivations are:

- It was annoying to have this lint entangled with the exhaustiveness algorithm, especially wrt librarification;
- This makes the lint behave consistently.

Here's the consistency story. Take the following matches:
```rust
match (0u8, true) {
    (0..=10, true) => {}
    (10..20, true) => {}
    (10..20, false) => {}
    _ => {}
}
match (true, 0u8) {
    (true, 0..=10) => {}
    (true, 10..20) => {}
    (false, 10..20) => {}
    _ => {}
}
```
There are two semantically consistent options: option 1 we lint all overlaps between the ranges, option 2 we only lint the overlaps that could actually occur (i.e. the ones with `true`). Option 1 is what this PR does. Option 2 is possible but would require the exhaustiveness algorithm to track more things for the sake of the lint. The status quo is that we're inconsistent between the two.

Option 1 generates more false postives, but I prefer it from a maintainer's perspective. I do think the difference is minimal; cases where the difference is observable seem rare.

This PR adds a separate pass, so this will have a perf impact. Let's see how bad, it looked ok locally.