### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -445,6 +445,8 @@ Oliver Scherer <oli-obk@users.noreply.github.com> <public.oliver.schneider@kit.e
 Oliver Scherer <oli-obk@users.noreply.github.com> <oliver.schneider@kit.edu>
 Oliver Scherer <oli-obk@users.noreply.github.com> <obk8176014uqher834@olio-obk.de>
 Oliver Scherer <oli-obk@users.noreply.github.com>
+Onur Özkan <onurozkan.dev@outlook.com> <work@onurozkan.dev>
+Onur Özkan <onurozkan.dev@outlook.com>
 Ömer Sinan Ağacan <omeragacan@gmail.com>
 Ophir LOJKINE <pere.jobs@gmail.com>
 Ožbolt Menegatti <ozbolt.menegatti@gmail.com> gareins <ozbolt.menegatti@gmail.com>

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2848,7 +2848,7 @@ impl<'tcx> Ty<'tcx> {
     /// Returning true means the type is known to be pure and `Copy+Clone`.
     /// Returning `false` means nothing -- could be `Copy`, might not be.
     ///
-    /// This is mostly useful for optimizations, as there are the types
+    /// This is mostly useful for optimizations, as these are the types
     /// on which we can replace cloning with dereferencing.
     pub fn is_trivially_pure_clone_copy(self) -> bool {
         match self.kind() {

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -618,12 +618,11 @@ pub trait TryInto<T>: Sized {
 /// For example, there is no way to convert an [`i64`] into an [`i32`]
 /// using the [`From`] trait, because an [`i64`] may contain a value
 /// that an [`i32`] cannot represent and so the conversion would lose data.
-/// This might be handled by truncating the [`i64`] to an [`i32`] (essentially
-/// giving the [`i64`]'s value modulo [`i32::MAX`]) or by simply returning
-/// [`i32::MAX`], or by some other method.  The [`From`] trait is intended
-/// for perfect conversions, so the `TryFrom` trait informs the
-/// programmer when a type conversion could go bad and lets them
-/// decide how to handle it.
+/// This might be handled by truncating the [`i64`] to an [`i32`] or by
+/// simply returning [`i32::MAX`], or by some other method.  The [`From`]
+/// trait is intended for perfect conversions, so the `TryFrom` trait
+/// informs the programmer when a type conversion could go bad and lets
+/// them decide how to handle it.
 ///
 /// # Generic Implementations
 ///

--- a/src/doc/unstable-book/src/language-features/string-deref-patterns.md
+++ b/src/doc/unstable-book/src/language-features/string-deref-patterns.md
@@ -1,0 +1,45 @@
+# `string_deref_patterns`
+
+The tracking issue for this feature is: [#87121]
+
+[#87121]: https://github.com/rust-lang/rust/issues/87121
+
+------------------------
+
+This feature permits pattern matching `String` to `&str` through [its `Deref` implementation].
+
+```rust
+#![feature(string_deref_patterns)]
+
+pub enum Value {
+    String(String),
+    Number(u32),
+}
+
+pub fn is_it_the_answer(value: Value) -> bool {
+    match value {
+        Value::String("42") => true,
+        Value::Number(42) => true,
+        _ => false,
+    }
+}
+```
+
+Without this feature other constructs such as match guards have to be used.
+
+```rust
+# pub enum Value {
+#    String(String),
+#    Number(u32),
+# }
+#
+pub fn is_it_the_answer(value: Value) -> bool {
+    match value {
+        Value::String(s) if s == "42" => true,
+        Value::Number(42) => true,
+        _ => false,
+    }
+}
+```
+
+[its `Deref` implementation]: https://doc.rust-lang.org/std/string/struct.String.html#impl-Deref-for-String


### PR DESCRIPTION
Successful merges:

 - #116594 (Fix `std::convert::TryFrom` doc)
 - #116741 (Document `string_deref_patterns` feature)
 - #116748 (Fix a spot I wrote the wrong word)
 - #116753 (add 'Onur Özkan' to .mailmap)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116594,116741,116748,116753)
<!-- homu-ignore:end -->