### PR TITLE
Fix podman detection in CI scripts

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -235,7 +235,7 @@ else
   args="$args --volume /tmp/toolstate:/tmp/toolstate"
 
   id=$(id -u)
-  if [[ "$id" != 0 && "$(docker -v)" =~ ^podman ]]; then
+  if [[ "$id" != 0 && "$(docker version)" =~ Podman ]]; then
     # Rootless podman creates a separate user namespace, where an inner
     # LOCAL_USER_ID will map to a different subuid range on the host.
     # The "keep-id" mode maps the current UID directly into the container.


### PR DESCRIPTION
When docker-podman compat was set up in a way that causes "docker" to be the argv[0] of podman, the previous detection did not work. This was for example the case in the compat package from nixpkgs.

This checks the output and should work everywhere.

I tested it locally by executing
```sh
if [[ "$id" != 0 && "$(docker version)" =~ Podman ]]; then
    echo yes
else
    echo no
fi
```
which printed `no` before, and `yes` now.

fixes #113129

r? cuviper