### PR TITLE
Get `TyKind` from `DefId` in smir

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -117,6 +117,10 @@ impl<'tcx> Context for Tables<'tcx> {
         impl_trait.stable(self)
     }
 
+    fn type_of(&mut self, def_id: stable_mir::DefId) -> TyKind {
+        self.tcx.type_of(self.def_ids[def_id]).instantiate_identity().stable(self)
+    }
+
     fn mir_body(&mut self, item: stable_mir::DefId) -> stable_mir::mir::Body {
         let def_id = self[item];
         let mir = self.tcx.instance_mir(ty::InstanceDef::Item(def_id));

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -177,6 +177,10 @@ pub fn trait_impl(trait_impl: &ImplDef) -> ImplTrait {
     with(|cx| cx.trait_impl(trait_impl))
 }
 
+pub fn type_of(def_id: DefId) -> TyKind {
+    with(|cx| cx.type_of(def_id))
+}
+
 pub trait Context {
     fn entry_fn(&mut self) -> Option<CrateItem>;
     /// Retrieve all items of the local crate that have a MIR associated with them.
@@ -220,6 +224,9 @@ pub trait Context {
 
     /// Create a new `Ty` from scratch without information from rustc.
     fn mk_ty(&mut self, kind: TyKind) -> Ty;
+
+    /// Get `TyKind` from `DefId`.
+    fn type_of(&mut self, def_id: DefId) -> TyKind;
 }
 
 // A thread local variable that stores a pointer to the tables mapping between TyCtxt


### PR DESCRIPTION
Previously I couldn't find a way for me to get type of a function body, without creating extra hacks, this fixes that.

r? @oli-obk 