### PR TITLE
Inline `Bytes::next` and `Bytes::size_hint`.

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2777,6 +2777,7 @@ pub struct Bytes<R> {
 impl<R: Read> Iterator for Bytes<R> {
     type Item = Result<u8>;
 
+    #[inline]
     fn next(&mut self) -> Option<Result<u8>> {
         let mut byte = 0;
         loop {
@@ -2789,6 +2790,7 @@ impl<R: Read> Iterator for Bytes<R> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         SizeHint::size_hint(&self.inner)
     }


### PR DESCRIPTION
This greatly increases its speed. On one small test program using `Bytes::next` to iterate over a large file, execution time dropped from ~330ms to ~220ms.

r? @the8472 