### PR TITLE
Dedup Fluent invalid ptr errors in const eval

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -406,12 +406,18 @@ const_eval_upcast_mismatch =
 const_eval_validation_box_to_mut = {$front_matter}: encountered a box pointing to mutable memory in a constant
 const_eval_validation_box_to_static = {$front_matter}: encountered a box pointing to a static variable in a constant
 const_eval_validation_box_to_uninhabited = {$front_matter}: encountered a box pointing to uninhabited type {$ty}
-const_eval_validation_dangling_box_no_provenance = {$front_matter}: encountered a dangling box ({$pointer} has no provenance)
-const_eval_validation_dangling_box_out_of_bounds = {$front_matter}: encountered a dangling box (going beyond the bounds of its allocation)
-const_eval_validation_dangling_box_use_after_free = {$front_matter}: encountered a dangling box (use-after-free)
-const_eval_validation_dangling_ref_no_provenance = {$front_matter}: encountered a dangling reference ({$pointer} has no provenance)
-const_eval_validation_dangling_ref_out_of_bounds = {$front_matter}: encountered a dangling reference (going beyond the bounds of its allocation)
-const_eval_validation_dangling_ref_use_after_free = {$front_matter}: encountered a dangling reference (use-after-free)
+const_eval_validation_dangling_no_provenance = {$front_matter}: encountered a dangling {$ptr_kind ->
+    [box] box
+   *[ref] reference
+} ({$pointer} has no provenance)
+const_eval_validation_dangling_out_of_bounds = {$front_matter}: encountered a dangling {$ptr_kind ->
+    [box] box
+   *[ref] reference
+} (going beyond the bounds of its allocation)
+const_eval_validation_dangling_use_after_free = {$front_matter}: encountered a dangling {$ptr_kind ->
+    [box] box
+   *[ref] reference
+} (use-after-free)
 
 const_eval_validation_expected_bool = expected a boolean
 const_eval_validation_expected_box = expected a box
@@ -429,14 +435,10 @@ const_eval_validation_front_matter_invalid_value = constructing invalid value
 const_eval_validation_front_matter_invalid_value_with_path = constructing invalid value at {$path}
 
 const_eval_validation_invalid_bool = {$front_matter}: encountered {$value}, but expected a boolean
-const_eval_validation_invalid_box_meta = {$front_matter}: encountered invalid box metadata: total size is bigger than largest supported object
-const_eval_validation_invalid_box_slice_meta = {$front_matter}: encountered invalid box metadata: slice is bigger than largest supported object
 const_eval_validation_invalid_char = {$front_matter}: encountered {$value}, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
 
 const_eval_validation_invalid_enum_tag = {$front_matter}: encountered {$value}, but expected a valid enum tag
 const_eval_validation_invalid_fn_ptr = {$front_matter}: encountered {$value}, but expected a function pointer
-const_eval_validation_invalid_ref_meta = {$front_matter}: encountered invalid reference metadata: total size is bigger than largest supported object
-const_eval_validation_invalid_ref_slice_meta = {$front_matter}: encountered invalid reference metadata: slice is bigger than largest supported object
 const_eval_validation_invalid_vtable_ptr = {$front_matter}: encountered {$value}, but expected a vtable pointer
 const_eval_validation_mutable_ref_in_const = {$front_matter}: encountered mutable reference in a `const`
 const_eval_validation_never_val = {$front_matter}: encountered a value of the never type `!`
@@ -448,11 +450,30 @@ const_eval_validation_out_of_range = {$front_matter}: encountered {$value}, but 
 const_eval_validation_partial_pointer = {$front_matter}: encountered a partial pointer or a mix of pointers
 const_eval_validation_pointer_as_int = {$front_matter}: encountered a pointer, but {$expected}
 const_eval_validation_ptr_out_of_range = {$front_matter}: encountered a pointer, but expected something that cannot possibly fail to be {$in_range}
-const_eval_validation_ref_to_mut = {$front_matter}: encountered a reference pointing to mutable memory in a constant
-const_eval_validation_ref_to_static = {$front_matter}: encountered a reference pointing to a static variable in a constant
-const_eval_validation_ref_to_uninhabited = {$front_matter}: encountered a reference pointing to uninhabited type {$ty}
-const_eval_validation_unaligned_box = {$front_matter}: encountered an unaligned box (required {$required_bytes} byte alignment but found {$found_bytes})
-const_eval_validation_unaligned_ref = {$front_matter}: encountered an unaligned reference (required {$required_bytes} byte alignment but found {$found_bytes})
+const_eval_validation_ptr_to_mut = {$front_matter}: encountered a {$ptr_kind ->
+    [box] box
+   *[ref] reference
+} pointing to mutable memory in a constant
+const_eval_validation_ptr_to_static = {$front_matter}: encountered a {$ptr_kind ->
+    [box] box
+   *[ref] reference
+} pointing to a static variable in a constant
+const_eval_validation_ptr_to_uninhabited = {$front_matter}: encountered a {$ptr_kind ->
+    [box] box
+   *[ref] reference
+} pointing to uninhabited type {$ty}
+const_eval_validation_too_big_meta = {$front_matter}: encountered invalid {$ptr_kind ->
+    [box] box
+   *[ref] reference
+} metadata: total size is bigger than largest supported object
+const_eval_validation_too_big_slice_meta = {$front_matter}: {$ptr_kind ->
+    [box] encountered invalid box metadata: slice is bigger than largest supported object
+   *[ref] encountered invalid reference metadata: slice is bigger than largest supported object
+}
+const_eval_validation_unaligned = {$front_matter}: encountered an unaligned {$ptr_kind ->
+    [box] box
+   *[ref] reference
+} (required {$required_bytes} byte alignment but found {$found_bytes})
 const_eval_validation_uninhabited_enum_variant = {$front_matter}: encountered an uninhabited enum variant
 const_eval_validation_uninhabited_val = {$front_matter}: encountered a value of uninhabited type `{$ty}`
 const_eval_validation_uninit = {$front_matter}: encountered uninitialized memory, but {$expected}

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -406,12 +406,11 @@ const_eval_upcast_mismatch =
 const_eval_validation_box_to_mut = {$front_matter}: encountered a box pointing to mutable memory in a constant
 const_eval_validation_box_to_static = {$front_matter}: encountered a box pointing to a static variable in a constant
 const_eval_validation_box_to_uninhabited = {$front_matter}: encountered a box pointing to uninhabited type {$ty}
-const_eval_validation_dangling_box_no_provenance = {$front_matter}: encountered a dangling box ({$pointer} has no provenance)
-const_eval_validation_dangling_box_out_of_bounds = {$front_matter}: encountered a dangling box (going beyond the bounds of its allocation)
-const_eval_validation_dangling_box_use_after_free = {$front_matter}: encountered a dangling box (use-after-free)
-const_eval_validation_dangling_ref_no_provenance = {$front_matter}: encountered a dangling reference ({$pointer} has no provenance)
-const_eval_validation_dangling_ref_out_of_bounds = {$front_matter}: encountered a dangling reference (going beyond the bounds of its allocation)
-const_eval_validation_dangling_ref_use_after_free = {$front_matter}: encountered a dangling reference (use-after-free)
+const_eval_validation_dangling_err_no_provenance = {$pointer} has no provenance
+const_eval_validation_dangling_err_out_of_bounds = going beyond the bounds of its allocation
+const_eval_validation_dangling_err_use_after_free = use-after-free
+const_eval_validation_dangling_ptr_box = {$front_matter}: encountered a dangling box ({$subdiagnostic})
+const_eval_validation_dangling_ptr_ref = {$front_matter}: encountered a dangling reference ({$subdiagnostic})
 
 const_eval_validation_expected_bool = expected a boolean
 const_eval_validation_expected_box = expected a box

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -406,18 +406,12 @@ const_eval_upcast_mismatch =
 const_eval_validation_box_to_mut = {$front_matter}: encountered a box pointing to mutable memory in a constant
 const_eval_validation_box_to_static = {$front_matter}: encountered a box pointing to a static variable in a constant
 const_eval_validation_box_to_uninhabited = {$front_matter}: encountered a box pointing to uninhabited type {$ty}
-const_eval_validation_dangling_no_provenance = {$front_matter}: encountered a dangling {$ptr_kind ->
-    [box] box
-   *[ref] reference
-} ({$pointer} has no provenance)
-const_eval_validation_dangling_out_of_bounds = {$front_matter}: encountered a dangling {$ptr_kind ->
-    [box] box
-   *[ref] reference
-} (going beyond the bounds of its allocation)
-const_eval_validation_dangling_use_after_free = {$front_matter}: encountered a dangling {$ptr_kind ->
-    [box] box
-   *[ref] reference
-} (use-after-free)
+const_eval_validation_dangling_box_no_provenance = {$front_matter}: encountered a dangling box ({$pointer} has no provenance)
+const_eval_validation_dangling_box_out_of_bounds = {$front_matter}: encountered a dangling box (going beyond the bounds of its allocation)
+const_eval_validation_dangling_box_use_after_free = {$front_matter}: encountered a dangling box (use-after-free)
+const_eval_validation_dangling_ref_no_provenance = {$front_matter}: encountered a dangling reference ({$pointer} has no provenance)
+const_eval_validation_dangling_ref_out_of_bounds = {$front_matter}: encountered a dangling reference (going beyond the bounds of its allocation)
+const_eval_validation_dangling_ref_use_after_free = {$front_matter}: encountered a dangling reference (use-after-free)
 
 const_eval_validation_expected_bool = expected a boolean
 const_eval_validation_expected_box = expected a box
@@ -435,10 +429,14 @@ const_eval_validation_front_matter_invalid_value = constructing invalid value
 const_eval_validation_front_matter_invalid_value_with_path = constructing invalid value at {$path}
 
 const_eval_validation_invalid_bool = {$front_matter}: encountered {$value}, but expected a boolean
+const_eval_validation_invalid_box_meta = {$front_matter}: encountered invalid box metadata: total size is bigger than largest supported object
+const_eval_validation_invalid_box_slice_meta = {$front_matter}: encountered invalid box metadata: slice is bigger than largest supported object
 const_eval_validation_invalid_char = {$front_matter}: encountered {$value}, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
 
 const_eval_validation_invalid_enum_tag = {$front_matter}: encountered {$value}, but expected a valid enum tag
 const_eval_validation_invalid_fn_ptr = {$front_matter}: encountered {$value}, but expected a function pointer
+const_eval_validation_invalid_ref_meta = {$front_matter}: encountered invalid reference metadata: total size is bigger than largest supported object
+const_eval_validation_invalid_ref_slice_meta = {$front_matter}: encountered invalid reference metadata: slice is bigger than largest supported object
 const_eval_validation_invalid_vtable_ptr = {$front_matter}: encountered {$value}, but expected a vtable pointer
 const_eval_validation_mutable_ref_in_const = {$front_matter}: encountered mutable reference in a `const`
 const_eval_validation_never_val = {$front_matter}: encountered a value of the never type `!`
@@ -450,30 +448,11 @@ const_eval_validation_out_of_range = {$front_matter}: encountered {$value}, but 
 const_eval_validation_partial_pointer = {$front_matter}: encountered a partial pointer or a mix of pointers
 const_eval_validation_pointer_as_int = {$front_matter}: encountered a pointer, but {$expected}
 const_eval_validation_ptr_out_of_range = {$front_matter}: encountered a pointer, but expected something that cannot possibly fail to be {$in_range}
-const_eval_validation_ptr_to_mut = {$front_matter}: encountered a {$ptr_kind ->
-    [box] box
-   *[ref] reference
-} pointing to mutable memory in a constant
-const_eval_validation_ptr_to_static = {$front_matter}: encountered a {$ptr_kind ->
-    [box] box
-   *[ref] reference
-} pointing to a static variable in a constant
-const_eval_validation_ptr_to_uninhabited = {$front_matter}: encountered a {$ptr_kind ->
-    [box] box
-   *[ref] reference
-} pointing to uninhabited type {$ty}
-const_eval_validation_too_big_meta = {$front_matter}: encountered invalid {$ptr_kind ->
-    [box] box
-   *[ref] reference
-} metadata: total size is bigger than largest supported object
-const_eval_validation_too_big_slice_meta = {$front_matter}: {$ptr_kind ->
-    [box] encountered invalid box metadata: slice is bigger than largest supported object
-   *[ref] encountered invalid reference metadata: slice is bigger than largest supported object
-}
-const_eval_validation_unaligned = {$front_matter}: encountered an unaligned {$ptr_kind ->
-    [box] box
-   *[ref] reference
-} (required {$required_bytes} byte alignment but found {$found_bytes})
+const_eval_validation_ref_to_mut = {$front_matter}: encountered a reference pointing to mutable memory in a constant
+const_eval_validation_ref_to_static = {$front_matter}: encountered a reference pointing to a static variable in a constant
+const_eval_validation_ref_to_uninhabited = {$front_matter}: encountered a reference pointing to uninhabited type {$ty}
+const_eval_validation_unaligned_box = {$front_matter}: encountered an unaligned box (required {$required_bytes} byte alignment but found {$found_bytes})
+const_eval_validation_unaligned_ref = {$front_matter}: encountered an unaligned reference (required {$required_bytes} byte alignment but found {$found_bytes})
 const_eval_validation_uninhabited_enum_variant = {$front_matter}: encountered an uninhabited enum variant
 const_eval_validation_uninhabited_val = {$front_matter}: encountered a value of uninhabited type `{$ty}`
 const_eval_validation_uninit = {$front_matter}: encountered uninitialized memory, but {$expected}

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -610,9 +610,19 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
         use crate::fluent_generated::*;
         use rustc_middle::mir::interpret::ValidationErrorKind::*;
         match self.kind {
-            PtrToUninhabited { .. } => const_eval_validation_ptr_to_uninhabited,
-            PtrToStatic { .. } => const_eval_validation_ptr_to_static,
-            PtrToMut { .. } => const_eval_validation_ptr_to_mut,
+            PtrToUninhabited { ptr_kind: PointerKind::Box, .. } => {
+                const_eval_validation_box_to_uninhabited
+            }
+            PtrToUninhabited { ptr_kind: PointerKind::Ref, .. } => {
+                const_eval_validation_ref_to_uninhabited
+            }
+
+            PtrToStatic { ptr_kind: PointerKind::Box } => const_eval_validation_box_to_static,
+            PtrToStatic { ptr_kind: PointerKind::Ref } => const_eval_validation_ref_to_static,
+
+            PtrToMut { ptr_kind: PointerKind::Box } => const_eval_validation_box_to_mut,
+            PtrToMut { ptr_kind: PointerKind::Ref } => const_eval_validation_ref_to_mut,
+
             PointerAsInt { .. } => const_eval_validation_pointer_as_int,
             PartialPointer => const_eval_validation_partial_pointer,
             MutableRefInConst => const_eval_validation_mutable_ref_in_const,
@@ -627,14 +637,42 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
             UninhabitedEnumVariant => const_eval_validation_uninhabited_enum_variant,
             Uninit { .. } => const_eval_validation_uninit,
             InvalidVTablePtr { .. } => const_eval_validation_invalid_vtable_ptr,
-            InvalidMetaSliceTooLarge { .. } => const_eval_validation_too_big_slice_meta,
-            InvalidMetaTooLarge { .. } => const_eval_validation_too_big_meta,
-            UnalignedPtr { .. } => const_eval_validation_unaligned,
+            InvalidMetaSliceTooLarge { ptr_kind: PointerKind::Box } => {
+                const_eval_validation_invalid_box_slice_meta
+            }
+            InvalidMetaSliceTooLarge { ptr_kind: PointerKind::Ref } => {
+                const_eval_validation_invalid_ref_slice_meta
+            }
+
+            InvalidMetaTooLarge { ptr_kind: PointerKind::Box } => {
+                const_eval_validation_invalid_box_meta
+            }
+            InvalidMetaTooLarge { ptr_kind: PointerKind::Ref } => {
+                const_eval_validation_invalid_ref_meta
+            }
+            UnalignedPtr { ptr_kind: PointerKind::Ref, .. } => const_eval_validation_unaligned_ref,
+            UnalignedPtr { ptr_kind: PointerKind::Box, .. } => const_eval_validation_unaligned_box,
+
             NullPtr { ptr_kind: PointerKind::Box } => const_eval_validation_null_box,
             NullPtr { ptr_kind: PointerKind::Ref } => const_eval_validation_null_ref,
-            DanglingPtrNoProvenance { .. } => const_eval_validation_dangling_no_provenance,
-            DanglingPtrOutOfBounds { .. } => const_eval_validation_dangling_out_of_bounds,
-            DanglingPtrUseAfterFree { .. } => const_eval_validation_dangling_use_after_free,
+            DanglingPtrNoProvenance { ptr_kind: PointerKind::Box, .. } => {
+                const_eval_validation_dangling_box_no_provenance
+            }
+            DanglingPtrNoProvenance { ptr_kind: PointerKind::Ref, .. } => {
+                const_eval_validation_dangling_ref_no_provenance
+            }
+            DanglingPtrOutOfBounds { ptr_kind: PointerKind::Box } => {
+                const_eval_validation_dangling_box_out_of_bounds
+            }
+            DanglingPtrOutOfBounds { ptr_kind: PointerKind::Ref } => {
+                const_eval_validation_dangling_ref_out_of_bounds
+            }
+            DanglingPtrUseAfterFree { ptr_kind: PointerKind::Box } => {
+                const_eval_validation_dangling_box_use_after_free
+            }
+            DanglingPtrUseAfterFree { ptr_kind: PointerKind::Ref } => {
+                const_eval_validation_dangling_ref_use_after_free
+            }
             InvalidBool { .. } => const_eval_validation_invalid_bool,
             InvalidChar { .. } => const_eval_validation_invalid_char,
             InvalidFnPtr { .. } => const_eval_validation_invalid_fn_ptr,
@@ -696,11 +734,7 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
         }
 
         match self.kind {
-            UninhabitedVal { ty } => {
-                err.set_arg("ty", ty);
-            }
-            PtrToUninhabited { ty, ptr_kind, .. } => {
-                err.set_arg("ptr_kind", ptr_kind);
+            PtrToUninhabited { ty, .. } | UninhabitedVal { ty } => {
                 err.set_arg("ty", ty);
             }
             PointerAsInt { expected } | Uninit { expected } => {
@@ -734,28 +768,24 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
                 err.set_arg("value", value);
                 add_range_arg(range, max_value, handler, err);
             }
-            UnalignedPtr { required_bytes, found_bytes, ptr_kind } => {
-                err.set_arg("found_bytes", found_bytes);
-                err.set_arg("ptr_kind", ptr_kind);
+            UnalignedPtr { required_bytes, found_bytes, .. } => {
                 err.set_arg("required_bytes", required_bytes);
+                err.set_arg("found_bytes", found_bytes);
             }
-            DanglingPtrNoProvenance { pointer, ptr_kind } => {
+            DanglingPtrNoProvenance { pointer, .. } => {
                 err.set_arg("pointer", pointer);
-                err.set_arg("ptr_kind", ptr_kind);
-            }
-            DanglingPtrUseAfterFree { ptr_kind }
-            | DanglingPtrOutOfBounds { ptr_kind }
-            | InvalidMetaSliceTooLarge { ptr_kind }
-            | InvalidMetaTooLarge { ptr_kind }
-            | PtrToStatic { ptr_kind }
-            | PtrToMut { ptr_kind } => {
-                err.set_arg("ptr_kind", ptr_kind);
             }
             NullPtr { .. }
+            | PtrToStatic { .. }
+            | PtrToMut { .. }
             | MutableRefInConst
             | NullFnPtr
             | NeverVal
             | UnsafeCell
+            | InvalidMetaSliceTooLarge { .. }
+            | InvalidMetaTooLarge { .. }
+            | DanglingPtrUseAfterFree { .. }
+            | DanglingPtrOutOfBounds { .. }
             | UninhabitedEnumVariant
             | PartialPointer => {}
         }


### PR DESCRIPTION
I believe these forms aren't unbearable to work with, and Fluent's ability to use selectors allows us to avoid enumerating every case laboriously.

Closes #116764 if accepted.

r? @fee1-dead