### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -507,6 +507,7 @@ pub enum StashKey {
     CallAssocMethod,
     TraitMissingMethod,
     OpaqueHiddenTypeMismatch,
+    MaybeForgetReturn,
 }
 
 fn default_track_diagnostic(d: &mut Diagnostic, f: &mut dyn FnMut(&mut Diagnostic)) {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -564,7 +564,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         if !errors.is_empty() {
             self.adjust_fulfillment_errors_for_expr_obligation(&mut errors);
+            let errors_causecode = errors
+                .iter()
+                .map(|e| (e.obligation.cause.span, e.root_obligation.cause.code().clone()))
+                .collect::<Vec<_>>();
             self.err_ctxt().report_fulfillment_errors(errors);
+            self.collect_unused_stmts_for_coerce_return_ty(errors_causecode);
         }
     }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -17,7 +17,7 @@ use crate::traits::{
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
 use rustc_errors::{
     pluralize, struct_span_err, Applicability, Diagnostic, DiagnosticBuilder, ErrorGuaranteed,
-    MultiSpan, Style,
+    MultiSpan, StashKey, Style,
 };
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Namespace, Res};
@@ -2049,14 +2049,14 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 // begin with in those cases.
                 if self.tcx.lang_items().sized_trait() == Some(trait_ref.def_id()) {
                     if let None = self.tainted_by_errors() {
-                        self.emit_inference_failure_err(
+                        let err = self.emit_inference_failure_err(
                             obligation.cause.body_id,
                             span,
                             trait_ref.self_ty().skip_binder().into(),
                             ErrorCode::E0282,
                             false,
-                        )
-                        .emit();
+                        );
+                        err.stash(span, StashKey::MaybeForgetReturn);
                     }
                     return;
                 }

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -410,9 +410,12 @@ impl IpAddr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip)]
     /// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     ///
+    /// let localhost_v4 = Ipv4Addr::new(127, 0, 0, 1);
+    ///
+    /// assert_eq!(IpAddr::V4(localhost_v4).to_canonical(), localhost_v4);
+    /// assert_eq!(IpAddr::V6(localhost_v4.to_ipv6_mapped()).to_canonical(), localhost_v4);
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)).to_canonical().is_loopback(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x1)).is_loopback(), false);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x1)).to_canonical().is_loopback(), true);
@@ -420,11 +423,11 @@ impl IpAddr {
     #[inline]
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[rustc_const_unstable(feature = "const_ip", issue = "76205")]
-    #[unstable(feature = "ip", issue = "27709")]
+    #[stable(feature = "ip_to_canonical", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "ip_to_canonical", since = "CURRENT_RUSTC_VERSION")]
     pub const fn to_canonical(&self) -> IpAddr {
         match self {
-            &v4 @ IpAddr::V4(_) => v4,
+            IpAddr::V4(_) => *self,
             IpAddr::V6(v6) => v6.to_canonical(),
         }
     }
@@ -1748,11 +1751,11 @@ impl Ipv6Addr {
     ///            Some(Ipv4Addr::new(192, 10, 2, 255)));
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).to_ipv4_mapped(), None);
     /// ```
-    #[rustc_const_unstable(feature = "const_ipv6", issue = "76205")]
-    #[stable(feature = "ipv6_to_ipv4_mapped", since = "1.63.0")]
+    #[inline]
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[stable(feature = "ipv6_to_ipv4_mapped", since = "1.63.0")]
+    #[rustc_const_stable(feature = "const_ipv6_to_ipv4_mapped", since = "CURRENT_RUSTC_VERSION")]
     pub const fn to_ipv4_mapped(&self) -> Option<Ipv4Addr> {
         match self.octets() {
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d] => {
@@ -1817,11 +1820,11 @@ impl Ipv6Addr {
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x1).is_loopback(), false);
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x1).to_canonical().is_loopback(), true);
     /// ```
-    #[rustc_const_unstable(feature = "const_ipv6", issue = "76205")]
-    #[unstable(feature = "ip", issue = "27709")]
+    #[inline]
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
-    #[inline]
+    #[stable(feature = "ip_to_canonical", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "ip_to_canonical", since = "CURRENT_RUSTC_VERSION")]
     pub const fn to_canonical(&self) -> IpAddr {
         if let Some(mapped) = self.to_ipv4_mapped() {
             return IpAddr::V4(mapped);

--- a/tests/ui/inference/issue-86094-suggest-add-return-to-coerce-ret-ty.rs
+++ b/tests/ui/inference/issue-86094-suggest-add-return-to-coerce-ret-ty.rs
@@ -1,0 +1,61 @@
+struct MyError;
+
+fn foo(x: bool) -> Result<(), MyError> {
+    if x {
+        Err(MyError);
+        //~^ ERROR type annotations needed
+    }
+
+    Ok(())
+}
+
+fn bar(x: bool) -> Result<(), MyError> {
+    if x {
+        Ok(());
+        //~^ ERROR type annotations needed
+    }
+
+    Ok(())
+}
+
+fn baz(x: bool) -> Result<(), MyError> {
+    //~^ ERROR mismatched types
+    if x {
+        1;
+    }
+
+    Err(MyError);
+}
+
+fn error() -> Result<(), MyError> {
+    Err(MyError)
+}
+
+fn bak(x: bool) -> Result<(), MyError> {
+    if x {
+        //~^ ERROR mismatched types
+        error();
+    } else {
+        //~^ ERROR mismatched types
+        error();
+    }
+}
+
+fn bad(x: bool) -> Result<(), MyError> {
+    Err(MyError); //~ ERROR type annotations needed
+    Ok(())
+}
+
+fn with_closure<F, A, B>(_: F) -> i32
+where
+    F: FnOnce(A, B),
+{
+    0
+}
+
+fn a() -> i32 {
+    with_closure(|x: u32, y| {}); //~ ERROR type annotations needed
+    0
+}
+
+fn main() {}

--- a/tests/ui/inference/issue-86094-suggest-add-return-to-coerce-ret-ty.stderr
+++ b/tests/ui/inference/issue-86094-suggest-add-return-to-coerce-ret-ty.stderr
@@ -1,0 +1,98 @@
+error[E0282]: type annotations needed
+  --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:5:9
+   |
+LL |         Err(MyError);
+   |         ^^^ cannot infer type of the type parameter `T` declared on the enum `Result`
+   |
+help: consider specifying the generic arguments
+   |
+LL |         Err::<T, MyError>(MyError);
+   |            ++++++++++++++
+help: you might have meant to return this to infer its type parameters
+   |
+LL |         return Err(MyError);
+   |         ++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:14:9
+   |
+LL |         Ok(());
+   |         ^^ cannot infer type of the type parameter `E` declared on the enum `Result`
+   |
+help: consider specifying the generic arguments
+   |
+LL |         Ok::<(), E>(());
+   |           +++++++++
+help: you might have meant to return this to infer its type parameters
+   |
+LL |         return Ok(());
+   |         ++++++
+
+error[E0308]: mismatched types
+  --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:21:20
+   |
+LL | fn baz(x: bool) -> Result<(), MyError> {
+   |    ---             ^^^^^^^^^^^^^^^^^^^ expected `Result<(), MyError>`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+...
+LL |     Err(MyError);
+   |                 - help: remove this semicolon to return this value
+   |
+   = note:   expected enum `Result<(), MyError>`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:35:10
+   |
+LL |       if x {
+   |  __________^
+LL | |
+LL | |         error();
+   | |                - help: remove this semicolon to return this value
+LL | |     } else {
+   | |_____^ expected `Result<(), MyError>`, found `()`
+   |
+   = note:   expected enum `Result<(), MyError>`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:38:12
+   |
+LL |       } else {
+   |  ____________^
+LL | |
+LL | |         error();
+   | |                - help: remove this semicolon to return this value
+LL | |     }
+   | |_____^ expected `Result<(), MyError>`, found `()`
+   |
+   = note:   expected enum `Result<(), MyError>`
+           found unit type `()`
+
+error[E0282]: type annotations needed
+  --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:45:5
+   |
+LL |     Err(MyError);
+   |     ^^^ cannot infer type of the type parameter `T` declared on the enum `Result`
+   |
+help: consider specifying the generic arguments
+   |
+LL |     Err::<T, MyError>(MyError);
+   |        ++++++++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:57:27
+   |
+LL |     with_closure(|x: u32, y| {});
+   |                           ^
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     with_closure(|x: u32, y: /* Type */| {});
+   |                            ++++++++++++
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0282, E0308.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/traits/new-solver/specialization-unconstrained.stderr
+++ b/tests/ui/traits/new-solver/specialization-unconstrained.stderr
@@ -8,12 +8,6 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0282]: type annotations needed
-  --> $DIR/specialization-unconstrained.rs:14:22
-   |
-LL |    default type Id = T;
-   |                      ^ cannot infer type for associated type `<T as Default>::Id`
-
 error[E0284]: type annotations needed: cannot satisfy `<u32 as Default>::Id == ()`
   --> $DIR/specialization-unconstrained.rs:20:5
    |
@@ -25,6 +19,12 @@ note: required by a bound in `test`
    |
 LL | fn test<T: Default<Id = U>, U>() {}
    |                    ^^^^^^ required by this bound in `test`
+
+error[E0282]: type annotations needed
+  --> $DIR/specialization-unconstrained.rs:14:22
+   |
+LL |    default type Id = T;
+   |                      ^ cannot infer type for associated type `<T as Default>::Id`
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -29,6 +29,12 @@ reviewed_label = "S-waiting-on-author"
 # These labels are removed when a "request changes" review is submitted. 
 review_labels = ["S-waiting-on-review"]
 
+[review-requested]
+# Those labels are removed when PR author requests a review from an assignee
+remove_labels = ["S-waiting-on-author"]
+# Those labels are added when PR author requests a review from an assignee
+add_labels = ["S-waiting-on-review"]
+
 [glacier]
 
 [ping.icebreakers-llvm]


### PR DESCRIPTION
Successful merges:

 - #115196 (Suggest adding `return` if the for semi which can coerce to the fn return type)
 - #115955 (Stabilize `{IpAddr, Ipv6Addr}::to_canonical`)
 - #116776 (Enable `review-requested` feature for rustbot)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115196,115955,116776)
<!-- homu-ignore:end -->