### PR TITLE
Fix implied outlives check for GAT in RPITIT

### DIFF
--- a/tests/ui/impl-trait/in-trait/gat-outlives.rs
+++ b/tests/ui/impl-trait/in-trait/gat-outlives.rs
@@ -1,0 +1,17 @@
+// edition: 2021
+
+use std::future::Future;
+
+trait Trait {
+    type Gat<'a>;
+    //~^ ERROR missing required bound on `Gat`
+    async fn foo(&self) -> Self::Gat<'_>;
+}
+
+trait Trait2 {
+    type Gat<'a>;
+    //~^ ERROR missing required bound on `Gat`
+    async fn foo(&self) -> impl Future<Output = Self::Gat<'_>>;
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/gat-outlives.stderr
+++ b/tests/ui/impl-trait/in-trait/gat-outlives.stderr
@@ -1,0 +1,24 @@
+error: missing required bound on `Gat`
+  --> $DIR/gat-outlives.rs:6:5
+   |
+LL |     type Gat<'a>;
+   |     ^^^^^^^^^^^^-
+   |                 |
+   |                 help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
+error: missing required bound on `Gat`
+  --> $DIR/gat-outlives.rs:12:5
+   |
+LL |     type Gat<'a>;
+   |     ^^^^^^^^^^^^-
+   |                 |
+   |                 help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
We enforce certain `Self: 'lt` bounds for GATs to save space for more sophisticated implied bounds, but those currently operate on the HIR. Code was easily reworked to operate on def-ids so that we can properly let these suggestions propagate through synthetic associated types like RPITITs and AFITs.

r? @jackh726 or @aliemjay

Fixes #116789