### PR TITLE
Remove `DefiningAnchor::Bubble` from opaque wf check

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -1,5 +1,6 @@
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_errors::ErrorGuaranteed;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::OpaqueTyOrigin;
 use rustc_infer::infer::InferCtxt;
@@ -308,20 +309,19 @@ fn check_opaque_type_well_formed<'tcx>(
         return Ok(definition_ty);
     };
     let param_env = tcx.param_env(def_id);
-    // HACK This bubble is required for this tests to pass:
-    // nested-return-type2-tait2.rs
-    // nested-return-type2-tait3.rs
+
+    let mut parent_def_id = def_id;
+    while tcx.def_kind(parent_def_id) == DefKind::OpaqueTy {
+        parent_def_id = tcx.local_parent(parent_def_id);
+    }
+
     // FIXME(-Ztrait-solver=next): We probably should use `DefiningAnchor::Error`
     // and prepopulate this `InferCtxt` with known opaque values, rather than
     // using the `Bind` anchor here. For now it's fine.
     let infcx = tcx
         .infer_ctxt()
         .with_next_trait_solver(next_trait_solver)
-        .with_opaque_type_inference(if next_trait_solver {
-            DefiningAnchor::Bind(def_id)
-        } else {
-            DefiningAnchor::Bubble
-        })
+        .with_opaque_type_inference(DefiningAnchor::Bind(parent_def_id))
         .build();
     let ocx = ObligationCtxt::new(&infcx);
     let identity_args = GenericArgs::identity_for_item(tcx, def_id);

--- a/tests/ui/impl-trait/async_scope_creep.rs
+++ b/tests/ui/impl-trait/async_scope_creep.rs
@@ -1,6 +1,6 @@
 #![feature(type_alias_impl_trait)]
 // edition:2021
-//[rpit] check-pass
+// check-pass
 // revisions: tait rpit
 
 struct Pending {}
@@ -23,7 +23,7 @@ impl Pending {
 
     #[cfg(tait)]
     fn read_fut(&mut self) -> OpeningReadFuture<'_> {
-        self.read() //[tait]~ ERROR: cannot satisfy `impl AsyncRead + 'a == PendingReader<'a>`
+        self.read()
     }
 
     #[cfg(rpit)]

--- a/tests/ui/impl-trait/async_scope_creep.tait.stderr
+++ b/tests/ui/impl-trait/async_scope_creep.tait.stderr
@@ -1,9 +1,0 @@
-error[E0284]: type annotations needed: cannot satisfy `impl AsyncRead + 'a == PendingReader<'a>`
-  --> $DIR/async_scope_creep.rs:26:9
-   |
-LL |         self.read()
-   |         ^^^^^^^^^^^ cannot satisfy `impl AsyncRead + 'a == PendingReader<'a>`
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/impl-trait/nested-return-type2-tait2.rs
+++ b/tests/ui/impl-trait/nested-return-type2-tait2.rs
@@ -1,3 +1,5 @@
+// check-pass
+
 #![feature(type_alias_impl_trait)]
 
 trait Duh {}
@@ -17,6 +19,7 @@ impl<R: Duh, F: FnMut() -> R> Trait for F {
 
 type Sendable = impl Send;
 type Traitable = impl Trait<Assoc = Sendable>;
+//~^ WARN opaque type `Traitable` does not satisfy its associated type bounds
 
 // The `impl Send` here is then later compared against the inference var
 // created, causing the inference var to be set to `impl Send` instead of
@@ -25,7 +28,6 @@ type Traitable = impl Trait<Assoc = Sendable>;
 // type does not implement `Duh`, even if its hidden type does. So we error out.
 fn foo() -> Traitable {
     || 42
-    //~^ ERROR `Sendable: Duh` is not satisfied
 }
 
 fn main() {

--- a/tests/ui/impl-trait/nested-return-type2-tait2.stderr
+++ b/tests/ui/impl-trait/nested-return-type2-tait2.stderr
@@ -1,18 +1,13 @@
-error[E0277]: the trait bound `Sendable: Duh` is not satisfied
-  --> $DIR/nested-return-type2-tait2.rs:27:5
+warning: opaque type `Traitable` does not satisfy its associated type bounds
+  --> $DIR/nested-return-type2-tait2.rs:21:29
    |
-LL |     || 42
-   |     ^^^^^ the trait `Duh` is not implemented for `Sendable`
+LL |     type Assoc: Duh;
+   |                 --- this associated type bound is unsatisfied for `Sendable`
+...
+LL | type Traitable = impl Trait<Assoc = Sendable>;
+   |                             ^^^^^^^^^^^^^^^^
    |
-   = help: the trait `Duh` is implemented for `i32`
-note: required for `{closure@$DIR/nested-return-type2-tait2.rs:27:5: 27:7}` to implement `Trait`
-  --> $DIR/nested-return-type2-tait2.rs:14:31
-   |
-LL | impl<R: Duh, F: FnMut() -> R> Trait for F {
-   |         ---                   ^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
+   = note: `#[warn(opaque_hidden_inferred_bound)]` on by default
 
-error: aborting due to previous error
+warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/nested-return-type2-tait3.rs
+++ b/tests/ui/impl-trait/nested-return-type2-tait3.rs
@@ -1,3 +1,5 @@
+// check-pass
+
 #![feature(type_alias_impl_trait)]
 
 trait Duh {}
@@ -16,6 +18,7 @@ impl<R: Duh, F: FnMut() -> R> Trait for F {
 }
 
 type Traitable = impl Trait<Assoc = impl Send>;
+//~^ WARN opaque type `Traitable` does not satisfy its associated type bounds
 
 // The `impl Send` here is then later compared against the inference var
 // created, causing the inference var to be set to `impl Send` instead of
@@ -24,7 +27,6 @@ type Traitable = impl Trait<Assoc = impl Send>;
 // type does not implement `Duh`, even if its hidden type does. So we error out.
 fn foo() -> Traitable {
     || 42
-    //~^ ERROR `impl Send: Duh` is not satisfied
 }
 
 fn main() {

--- a/tests/ui/impl-trait/nested-return-type2-tait3.stderr
+++ b/tests/ui/impl-trait/nested-return-type2-tait3.stderr
@@ -1,18 +1,17 @@
-error[E0277]: the trait bound `impl Send: Duh` is not satisfied
-  --> $DIR/nested-return-type2-tait3.rs:26:5
+warning: opaque type `Traitable` does not satisfy its associated type bounds
+  --> $DIR/nested-return-type2-tait3.rs:20:29
    |
-LL |     || 42
-   |     ^^^^^ the trait `Duh` is not implemented for `impl Send`
+LL |     type Assoc: Duh;
+   |                 --- this associated type bound is unsatisfied for `impl Send`
+...
+LL | type Traitable = impl Trait<Assoc = impl Send>;
+   |                             ^^^^^^^^^^^^^^^^^
    |
-   = help: the trait `Duh` is implemented for `i32`
-note: required for `{closure@$DIR/nested-return-type2-tait3.rs:26:5: 26:7}` to implement `Trait`
-  --> $DIR/nested-return-type2-tait3.rs:14:31
+   = note: `#[warn(opaque_hidden_inferred_bound)]` on by default
+help: add this bound
    |
-LL | impl<R: Duh, F: FnMut() -> R> Trait for F {
-   |         ---                   ^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
+LL | type Traitable = impl Trait<Assoc = impl Send + Duh>;
+   |                                               +++++
 
-error: aborting due to previous error
+warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Set the defining anchor to `DefiningAnchor::Bind(parent_def_id)` where `parent_def_id` is the first parent def-id that isn't an opaque.

This "fixes" some of the nested-return-type wf tests. If we *do* want these to be hard-errors for TAITs, we should probably make those error separately from this check (i.e. via some check like the code in the `OPAQUE_HIDDEN_INFERRED_BOUND` lint). The fact that some of these tests fail but not all of them seems kinda coincidental.

r? oli-obk