### PR TITLE
Remove `DefiningAnchor::Bubble` from MIR validation

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -9,6 +9,7 @@ use rustc_index::IndexVec;
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::{ErrorHandled, InvalidMetaKind, ReportedErrorInfo};
 use rustc_middle::query::TyCtxtAt;
+use rustc_middle::traits::DefiningAnchor;
 use rustc_middle::ty::layout::{
     self, FnAbiError, FnAbiOfHelpers, FnAbiRequest, LayoutError, LayoutOf, LayoutOfHelpers,
     TyAndLayout,
@@ -384,7 +385,14 @@ pub(super) fn mir_assign_valid_types<'tcx>(
     // all normal lifetimes are erased, higher-ranked types with their
     // late-bound lifetimes are still around and can lead to type
     // differences.
-    if util::relate_types(tcx, param_env, Variance::Covariant, src.ty, dest.ty) {
+    if util::relate_types(
+        tcx,
+        param_env,
+        DefiningAnchor::Error,
+        Variance::Covariant,
+        src.ty,
+        dest.ty,
+    ) {
         // Make sure the layout is equal, too -- just to be safe. Miri really
         // needs layout equality. For performance reason we skip this check when
         // the types are equal. Equal types *can* have different layouts when

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -677,6 +677,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             if !mir_assign_valid_types(
                 *self.tcx,
                 self.param_env,
+                self.defining_anchor_for_body(),
                 self.layout_of(normalized_place_ty)?,
                 op.layout,
             ) {
@@ -733,7 +734,13 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 Scalar::Int(int) => Scalar::Int(int),
             })
         };
-        let layout = from_known_layout(self.tcx, self.param_env, layout, || self.layout_of(ty))?;
+        let layout = from_known_layout(
+            self.tcx,
+            self.param_env,
+            self.defining_anchor_for_body(),
+            layout,
+            || self.layout_of(ty),
+        )?;
         let op = match val_val {
             mir::ConstValue::Indirect { alloc_id, offset } => {
                 // We rely on mutability being set correctly in that allocation to prevent writes

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -579,6 +579,7 @@ where
             if !mir_assign_valid_types(
                 *self.tcx,
                 self.param_env,
+                self.defining_anchor_for_body(),
                 self.layout_of(normalized_place_ty)?,
                 place.layout,
             ) {
@@ -834,8 +835,13 @@ where
     ) -> InterpResult<'tcx> {
         // We do NOT compare the types for equality, because well-typed code can
         // actually "transmute" `&mut T` to `&T` in an assignment without a cast.
-        let layout_compat =
-            mir_assign_valid_types(*self.tcx, self.param_env, src.layout(), dest.layout());
+        let layout_compat = mir_assign_valid_types(
+            *self.tcx,
+            self.param_env,
+            self.defining_anchor_for_body(),
+            src.layout(),
+            dest.layout(),
+        );
         if !allow_transmute && !layout_compat {
             span_bug!(
                 self.cur_span(),

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -945,3 +945,14 @@ pub enum DefiningAnchor {
     /// Used to catch type mismatch errors when handling opaque types.
     Error,
 }
+
+impl DefiningAnchor {
+    /// Mostly for use in the MIR validator, which only needs to pass a `Bind`
+    /// anchor if the reveal is not yet `All` and we're validating a local body.
+    pub fn from_def_id_and_reveal(body_def_id: DefId, reveal: Reveal) -> DefiningAnchor {
+        body_def_id
+            .as_local()
+            .filter(|_| reveal == Reveal::UserFacing)
+            .map_or(DefiningAnchor::Error, |def_id| DefiningAnchor::Bind(def_id))
+    }
+}

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -8,6 +8,7 @@ use rustc_index::Idx;
 use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, CodegenFnAttrs};
 use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
+use rustc_middle::traits::DefiningAnchor;
 use rustc_middle::ty::TypeVisitableExt;
 use rustc_middle::ty::{self, Instance, InstanceDef, ParamEnv, Ty, TyCtxt};
 use rustc_session::config::OptLevel;
@@ -221,6 +222,7 @@ impl<'tcx> Inliner<'tcx> {
         if !util::relate_types(
             self.tcx,
             self.param_env,
+            DefiningAnchor::Error,
             ty::Variance::Covariant,
             output_type,
             destination_ty,
@@ -257,6 +259,7 @@ impl<'tcx> Inliner<'tcx> {
                 if !util::relate_types(
                     self.tcx,
                     self.param_env,
+                    DefiningAnchor::Error,
                     ty::Variance::Covariant,
                     input_type,
                     arg_ty,
@@ -272,6 +275,7 @@ impl<'tcx> Inliner<'tcx> {
                 if !util::relate_types(
                     self.tcx,
                     self.param_env,
+                    DefiningAnchor::Error,
                     ty::Variance::Covariant,
                     input_type,
                     arg_ty,


### PR DESCRIPTION
If we're in the MIR validator, our body is local, and our reveal mode is `Reveal::UserFacing`, then use `DefiningAnchor::Bind` -- otherwise, we should never be constraining opaques, so use `DefiningAnchor::Error` like codegen does.

r? oli-obk