### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -346,7 +346,9 @@ Lindsey Kuper <lindsey@composition.al> <lindsey@rockstargirl.org>
 Lindsey Kuper <lindsey@composition.al> <lkuper@mozilla.com>
 Liu Dingming <liudingming@bytedance.com>
 Loo Maclin <loo.maclin@protonmail.com>
-Loïc BRANSTETT <lolo.branstett@numericable.fr>
+Urgau <urgau@numericable.fr>
+Urgau <urgau@numericable.fr> <lolo.branstett@numericable.fr>
+Urgau <urgau@numericable.fr> <3616612+Urgau@users.noreply.github.com>
 Lucy <luxx4x@protonmail.com>
 Lukas H. <lukaramu@users.noreply.github.com>
 Lukas Lueg <lukas.lueg@gmail.com>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "minifier"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb022374af2f446981254e6bf9efb6e2c9e1a53176d395fca02792fd4435729"
+checksum = "5394aa376422b4b2b6c02fd9cfcb657e4ec544ae98e43d7d5d785fd0d042fd6d"
 
 [[package]]
 name = "minimal-lexical"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,30 +2971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5252,21 +5228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d38d39c754ae037a9bc3ca1580a985db7371cd14f1229172d1db9093feb6739"
 dependencies = [
  "papergrid",
- "tabled_derive",
  "unicode-width",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -1,5 +1,6 @@
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_errors::ErrorGuaranteed;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::OpaqueTyOrigin;
 use rustc_infer::infer::InferCtxt;
@@ -308,20 +309,19 @@ fn check_opaque_type_well_formed<'tcx>(
         return Ok(definition_ty);
     };
     let param_env = tcx.param_env(def_id);
-    // HACK This bubble is required for this tests to pass:
-    // nested-return-type2-tait2.rs
-    // nested-return-type2-tait3.rs
+
+    let mut parent_def_id = def_id;
+    while tcx.def_kind(parent_def_id) == DefKind::OpaqueTy {
+        parent_def_id = tcx.local_parent(parent_def_id);
+    }
+
     // FIXME(-Ztrait-solver=next): We probably should use `DefiningAnchor::Error`
     // and prepopulate this `InferCtxt` with known opaque values, rather than
     // using the `Bind` anchor here. For now it's fine.
     let infcx = tcx
         .infer_ctxt()
         .with_next_trait_solver(next_trait_solver)
-        .with_opaque_type_inference(if next_trait_solver {
-            DefiningAnchor::Bind(def_id)
-        } else {
-            DefiningAnchor::Bubble
-        })
+        .with_opaque_type_inference(DefiningAnchor::Bind(parent_def_id))
         .build();
     let ocx = ObligationCtxt::new(&infcx);
     let identity_args = GenericArgs::identity_for_item(tcx, def_id);

--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -284,6 +284,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
             self.one_bound_for_assoc_type(
                 || traits::supertraits(tcx, trait_ref),
                 trait_ref.skip_binder().print_only_trait_name(),
+                None,
                 binding.item_name,
                 path_span,
                 match binding.kind {

--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -191,10 +191,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 .collect::<Vec<_>>()[..]
             {
                 let trait_name = self.tcx().def_path_str(*best_trait);
+                let an = if suggested_name != assoc_name.name { "a similarly named" } else { "an" };
                 err.span_label(
                     assoc_name.span,
                     format!(
-                        "there is a similarly named associated type `{suggested_name}` in the \
+                        "there is {an} associated type `{suggested_name}` in the \
                          trait `{trait_name}`",
                     ),
                 );

--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -6,10 +6,9 @@ use crate::errors::{
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{pluralize, struct_span_err, Applicability, Diagnostic, ErrorGuaranteed};
 use rustc_hir as hir;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_infer::traits::FulfillmentError;
-use rustc_middle::ty::TyCtxt;
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty::{self, suggest_constraining_type_param, Ty, TyCtxt};
 use rustc_session::parse::feature_err;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::symbol::{sym, Ident};
@@ -102,6 +101,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         &self,
         all_candidates: impl Fn() -> I,
         ty_param_name: &str,
+        ty_param_def_id: Option<LocalDefId>,
         assoc_name: Ident,
         span: Span,
     ) -> ErrorGuaranteed
@@ -190,13 +190,60 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 })
                 .collect::<Vec<_>>()[..]
             {
+                let trait_name = self.tcx().def_path_str(*best_trait);
                 err.span_label(
                     assoc_name.span,
                     format!(
-                        "there is a similarly named associated type `{suggested_name}` in the trait `{}`",
-                        self.tcx().def_path_str(*best_trait)
+                        "there is a similarly named associated type `{suggested_name}` in the \
+                         trait `{trait_name}`",
                     ),
                 );
+                let hir = self.tcx().hir();
+                if let Some(def_id) = ty_param_def_id
+                    && let parent = hir.get_parent_item(hir.local_def_id_to_hir_id(def_id))
+                    && let Some(generics) = hir.get_generics(parent.def_id)
+                {
+                    if generics.bounds_for_param(def_id)
+                        .flat_map(|pred| pred.bounds.iter())
+                        .any(|b| match b {
+                            hir::GenericBound::Trait(t, ..) => {
+                                t.trait_ref.trait_def_id().as_ref() == Some(best_trait)
+                            }
+                            _ => false,
+                        })
+                    {
+                        // The type param already has a bound for `trait_name`, we just need to
+                        // change the associated type.
+                        err.span_suggestion_verbose(
+                            assoc_name.span,
+                            format!(
+                                "change the associated type name to use `{suggested_name}` from \
+                                 `{trait_name}`",
+                            ),
+                            suggested_name.to_string(),
+                            Applicability::MaybeIncorrect,
+                        );
+                    } else if suggest_constraining_type_param(
+                            self.tcx(),
+                            generics,
+                            &mut err,
+                            &ty_param_name,
+                            &trait_name,
+                            None,
+                            None,
+                        )
+                        && suggested_name != assoc_name.name
+                    {
+                        // We suggested constraining a type parameter, but the associated type on it
+                        // was also not an exact match, so we also suggest changing it.
+                        err.span_suggestion_verbose(
+                            assoc_name.span,
+                            "and also change the associated type name",
+                            suggested_name.to_string(),
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                }
                 return err.emit();
             }
         }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -364,7 +364,7 @@ fn predicate_constraint(generics: &hir::Generics<'_>, pred: ty::Predicate<'_>) -
 /// Type parameter needs more bounds. The trivial case is `T` `where T: Bound`, but
 /// it can also be an `impl Trait` param that needs to be decomposed to a type
 /// param for cleaner code.
-fn suggest_restriction<'tcx>(
+pub fn suggest_restriction<'tcx>(
     tcx: TyCtxt<'tcx>,
     item_id: LocalDefId,
     hir_generics: &hir::Generics<'tcx>,

--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -22,7 +22,6 @@ fn configure_with_args(cmd: &[String], host: &[&str], target: &[&str]) -> Config
         ..Config::parse(&["check".to_owned()])
     });
     submodule_build.update_submodule(Path::new("src/doc/book"));
-    submodule_build.update_submodule(Path::new("src/tools/rust-analyzer"));
     config.submodules = Some(false);
 
     config.ninja_in_file = false;

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1009,7 +1009,6 @@ impl Step for PlainSourceTarball {
             if builder.rust_info().is_managed_git_subrepository() {
                 // Ensure we have the submodules checked out.
                 builder.update_submodule(Path::new("src/tools/cargo"));
-                builder.update_submodule(Path::new("src/tools/rust-analyzer"));
             }
 
             // Vendor all Cargo dependencies

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1001,11 +1001,16 @@ impl Step for PlainSourceTarball {
             channel::write_commit_info_file(&plain_dst_src, info);
         }
 
-        // If we're building from git sources, we need to vendor a complete distribution.
-        if builder.rust_info().is_managed_git_subrepository() {
-            // Ensure we have the submodules checked out.
-            builder.update_submodule(Path::new("src/tools/cargo"));
-            builder.update_submodule(Path::new("src/tools/rust-analyzer"));
+        // If we're building from git or tarball sources, we need to vendor
+        // a complete distribution.
+        if builder.rust_info().is_managed_git_subrepository()
+            || builder.rust_info().is_from_tarball()
+        {
+            if builder.rust_info().is_managed_git_subrepository() {
+                // Ensure we have the submodules checked out.
+                builder.update_submodule(Path::new("src/tools/cargo"));
+                builder.update_submodule(Path::new("src/tools/rust-analyzer"));
+            }
 
             // Vendor all Cargo dependencies
             let mut cmd = Command::new(&builder.initial_cargo);

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 arrayvec = { version = "0.7", default-features = false }
 askama = { version = "0.12", default-features = false, features = ["config"] }
 itertools = "0.10.1"
-minifier = "0.2.2"
+minifier = "0.2.3"
 once_cell = "1.10.0"
 regex = "1"
 rustdoc-json-types = { path = "../rustdoc-json-types" }

--- a/src/tools/opt-dist/Cargo.toml
+++ b/src/tools/opt-dist/Cargo.toml
@@ -23,4 +23,4 @@ glob = "0.3"
 tempfile = "3.5"
 derive_builder = "0.12"
 clap = { version = "4", features = ["derive"] }
-tabled = "0.13"
+tabled = { version = "0.13", default-features = false, features = ["std"] }

--- a/tests/rustdoc-ui/issues/issue-96287.stderr
+++ b/tests/rustdoc-ui/issues/issue-96287.stderr
@@ -3,6 +3,11 @@ error[E0220]: associated type `Assoc` not found for `V`
    |
 LL | pub type Foo<V> = impl Trait<V::Assoc>;
    |                                 ^^^^^ there is a similarly named associated type `Assoc` in the trait `TraitWithAssoc`
+   |
+help: consider restricting type parameter `V`
+   |
+LL | pub type Foo<V: TraitWithAssoc> = impl Trait<V::Assoc>;
+   |               ++++++++++++++++
 
 error: aborting due to previous error
 

--- a/tests/rustdoc-ui/issues/issue-96287.stderr
+++ b/tests/rustdoc-ui/issues/issue-96287.stderr
@@ -2,7 +2,7 @@ error[E0220]: associated type `Assoc` not found for `V`
   --> $DIR/issue-96287.rs:7:33
    |
 LL | pub type Foo<V> = impl Trait<V::Assoc>;
-   |                                 ^^^^^ there is a similarly named associated type `Assoc` in the trait `TraitWithAssoc`
+   |                                 ^^^^^ there is an associated type `Assoc` in the trait `TraitWithAssoc`
    |
 help: consider restricting type parameter `V`
    |

--- a/tests/ui/impl-trait/async_scope_creep.rs
+++ b/tests/ui/impl-trait/async_scope_creep.rs
@@ -1,6 +1,6 @@
 #![feature(type_alias_impl_trait)]
 // edition:2021
-//[rpit] check-pass
+// check-pass
 // revisions: tait rpit
 
 struct Pending {}
@@ -23,7 +23,7 @@ impl Pending {
 
     #[cfg(tait)]
     fn read_fut(&mut self) -> OpeningReadFuture<'_> {
-        self.read() //[tait]~ ERROR: cannot satisfy `impl AsyncRead + 'a == PendingReader<'a>`
+        self.read()
     }
 
     #[cfg(rpit)]

--- a/tests/ui/impl-trait/async_scope_creep.tait.stderr
+++ b/tests/ui/impl-trait/async_scope_creep.tait.stderr
@@ -1,9 +1,0 @@
-error[E0284]: type annotations needed: cannot satisfy `impl AsyncRead + 'a == PendingReader<'a>`
-  --> $DIR/async_scope_creep.rs:26:9
-   |
-LL |         self.read()
-   |         ^^^^^^^^^^^ cannot satisfy `impl AsyncRead + 'a == PendingReader<'a>`
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/impl-trait/nested-return-type2-tait2.rs
+++ b/tests/ui/impl-trait/nested-return-type2-tait2.rs
@@ -1,3 +1,5 @@
+// check-pass
+
 #![feature(type_alias_impl_trait)]
 
 trait Duh {}
@@ -17,6 +19,7 @@ impl<R: Duh, F: FnMut() -> R> Trait for F {
 
 type Sendable = impl Send;
 type Traitable = impl Trait<Assoc = Sendable>;
+//~^ WARN opaque type `Traitable` does not satisfy its associated type bounds
 
 // The `impl Send` here is then later compared against the inference var
 // created, causing the inference var to be set to `impl Send` instead of
@@ -25,7 +28,6 @@ type Traitable = impl Trait<Assoc = Sendable>;
 // type does not implement `Duh`, even if its hidden type does. So we error out.
 fn foo() -> Traitable {
     || 42
-    //~^ ERROR `Sendable: Duh` is not satisfied
 }
 
 fn main() {

--- a/tests/ui/impl-trait/nested-return-type2-tait2.stderr
+++ b/tests/ui/impl-trait/nested-return-type2-tait2.stderr
@@ -1,18 +1,13 @@
-error[E0277]: the trait bound `Sendable: Duh` is not satisfied
-  --> $DIR/nested-return-type2-tait2.rs:27:5
+warning: opaque type `Traitable` does not satisfy its associated type bounds
+  --> $DIR/nested-return-type2-tait2.rs:21:29
    |
-LL |     || 42
-   |     ^^^^^ the trait `Duh` is not implemented for `Sendable`
+LL |     type Assoc: Duh;
+   |                 --- this associated type bound is unsatisfied for `Sendable`
+...
+LL | type Traitable = impl Trait<Assoc = Sendable>;
+   |                             ^^^^^^^^^^^^^^^^
    |
-   = help: the trait `Duh` is implemented for `i32`
-note: required for `{closure@$DIR/nested-return-type2-tait2.rs:27:5: 27:7}` to implement `Trait`
-  --> $DIR/nested-return-type2-tait2.rs:14:31
-   |
-LL | impl<R: Duh, F: FnMut() -> R> Trait for F {
-   |         ---                   ^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
+   = note: `#[warn(opaque_hidden_inferred_bound)]` on by default
 
-error: aborting due to previous error
+warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/nested-return-type2-tait3.rs
+++ b/tests/ui/impl-trait/nested-return-type2-tait3.rs
@@ -1,3 +1,5 @@
+// check-pass
+
 #![feature(type_alias_impl_trait)]
 
 trait Duh {}
@@ -16,6 +18,7 @@ impl<R: Duh, F: FnMut() -> R> Trait for F {
 }
 
 type Traitable = impl Trait<Assoc = impl Send>;
+//~^ WARN opaque type `Traitable` does not satisfy its associated type bounds
 
 // The `impl Send` here is then later compared against the inference var
 // created, causing the inference var to be set to `impl Send` instead of
@@ -24,7 +27,6 @@ type Traitable = impl Trait<Assoc = impl Send>;
 // type does not implement `Duh`, even if its hidden type does. So we error out.
 fn foo() -> Traitable {
     || 42
-    //~^ ERROR `impl Send: Duh` is not satisfied
 }
 
 fn main() {

--- a/tests/ui/impl-trait/nested-return-type2-tait3.stderr
+++ b/tests/ui/impl-trait/nested-return-type2-tait3.stderr
@@ -1,18 +1,17 @@
-error[E0277]: the trait bound `impl Send: Duh` is not satisfied
-  --> $DIR/nested-return-type2-tait3.rs:26:5
+warning: opaque type `Traitable` does not satisfy its associated type bounds
+  --> $DIR/nested-return-type2-tait3.rs:20:29
    |
-LL |     || 42
-   |     ^^^^^ the trait `Duh` is not implemented for `impl Send`
+LL |     type Assoc: Duh;
+   |                 --- this associated type bound is unsatisfied for `impl Send`
+...
+LL | type Traitable = impl Trait<Assoc = impl Send>;
+   |                             ^^^^^^^^^^^^^^^^^
    |
-   = help: the trait `Duh` is implemented for `i32`
-note: required for `{closure@$DIR/nested-return-type2-tait3.rs:26:5: 26:7}` to implement `Trait`
-  --> $DIR/nested-return-type2-tait3.rs:14:31
+   = note: `#[warn(opaque_hidden_inferred_bound)]` on by default
+help: add this bound
    |
-LL | impl<R: Duh, F: FnMut() -> R> Trait for F {
-   |         ---                   ^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
+LL | type Traitable = impl Trait<Assoc = impl Send + Duh>;
+   |                                               +++++
 
-error: aborting due to previous error
+warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/resolve/issue-55673.fixed
+++ b/tests/ui/resolve/issue-55673.fixed
@@ -6,14 +6,14 @@ trait Foo {
 
 fn foo<T: Foo>()
 where
-    T::Baa: std::fmt::Debug,
+    T::Bar: std::fmt::Debug,
     //~^ ERROR associated type `Baa` not found for `T`
 {
 }
 
 fn bar<T>()
 where
-    T::Baa: std::fmt::Debug,
+    T::Bar: std::fmt::Debug, T: Foo
     //~^ ERROR associated type `Baa` not found for `T`
 {
 }

--- a/tests/ui/resolve/issue-55673.stderr
+++ b/tests/ui/resolve/issue-55673.stderr
@@ -1,9 +1,29 @@
 error[E0220]: associated type `Baa` not found for `T`
-  --> $DIR/issue-55673.rs:7:8
+  --> $DIR/issue-55673.rs:9:8
    |
 LL |     T::Baa: std::fmt::Debug,
    |        ^^^ there is a similarly named associated type `Bar` in the trait `Foo`
+   |
+help: change the associated type name to use `Bar` from `Foo`
+   |
+LL |     T::Bar: std::fmt::Debug,
+   |        ~~~
 
-error: aborting due to previous error
+error[E0220]: associated type `Baa` not found for `T`
+  --> $DIR/issue-55673.rs:16:8
+   |
+LL |     T::Baa: std::fmt::Debug,
+   |        ^^^ there is a similarly named associated type `Bar` in the trait `Foo`
+   |
+help: consider further restricting type parameter `T`
+   |
+LL |     T::Baa: std::fmt::Debug, T: Foo
+   |                            ~~~~~~~~
+help: and also change the associated type name
+   |
+LL |     T::Bar: std::fmt::Debug,
+   |        ~~~
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0220`.

--- a/tests/ui/traits/issue-59029-1.stderr
+++ b/tests/ui/traits/issue-59029-1.stderr
@@ -2,13 +2,13 @@ error[E0220]: associated type `Res` not found for `Self`
   --> $DIR/issue-59029-1.rs:5:52
    |
 LL | trait MkSvc<Target, Req> = Svc<Target> where Self::Res: Svc<Req>;
-   |                                                    ^^^ there is a similarly named associated type `Res` in the trait `Svc`
+   |                                                    ^^^ there is an associated type `Res` in the trait `Svc`
 
 error[E0220]: associated type `Res` not found for `Self`
   --> $DIR/issue-59029-1.rs:5:52
    |
 LL | trait MkSvc<Target, Req> = Svc<Target> where Self::Res: Svc<Req>;
-   |                                                    ^^^ there is a similarly named associated type `Res` in the trait `Svc`
+   |                                                    ^^^ there is an associated type `Res` in the trait `Svc`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/type-alias-impl-trait/not_well_formed.fixed
+++ b/tests/ui/type-alias-impl-trait/not_well_formed.fixed
@@ -8,7 +8,7 @@ trait TraitWithAssoc {
     type Assoc;
 }
 
-type Foo<V> = impl Trait<V::Assoc>; //~ associated type `Assoc` not found for `V`
+type Foo<V: TraitWithAssoc> = impl Trait<V::Assoc>; //~ associated type `Assoc` not found for `V`
 
 trait Trait<U> {}
 

--- a/tests/ui/type-alias-impl-trait/not_well_formed.stderr
+++ b/tests/ui/type-alias-impl-trait/not_well_formed.stderr
@@ -1,8 +1,13 @@
 error[E0220]: associated type `Assoc` not found for `V`
-  --> $DIR/not_well_formed.rs:9:29
+  --> $DIR/not_well_formed.rs:11:29
    |
 LL | type Foo<V> = impl Trait<V::Assoc>;
    |                             ^^^^^ there is a similarly named associated type `Assoc` in the trait `TraitWithAssoc`
+   |
+help: consider restricting type parameter `V`
+   |
+LL | type Foo<V: TraitWithAssoc> = impl Trait<V::Assoc>;
+   |           ++++++++++++++++
 
 error: aborting due to previous error
 

--- a/tests/ui/type-alias-impl-trait/not_well_formed.stderr
+++ b/tests/ui/type-alias-impl-trait/not_well_formed.stderr
@@ -2,7 +2,7 @@ error[E0220]: associated type `Assoc` not found for `V`
   --> $DIR/not_well_formed.rs:11:29
    |
 LL | type Foo<V> = impl Trait<V::Assoc>;
-   |                             ^^^^^ there is a similarly named associated type `Assoc` in the trait `TraitWithAssoc`
+   |                             ^^^^^ there is an associated type `Assoc` in the trait `TraitWithAssoc`
    |
 help: consider restricting type parameter `V`
    |

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -402,6 +402,10 @@ message_on_add = """\
 Issue #{number} "{title}" has been added.
 """
 
+[no-merges]
+exclude_titles = ["Rollup of", "subtree update"]
+labels = ["has-merge-commits", "S-waiting-on-author"]
+
 [github-releases]
 format = "rustc"
 project-name = "Rust"


### PR DESCRIPTION
Successful merges:

 - #114157 (Enable triagebot no-merges check)
 - #116257 (Suggest trait bounds for used associated type on type param)
 - #116430 (vendoring in tarball sources)
 - #116709 (Update minifier version to 0.2.3)
 - #116786 (Update my mailmap entry)
 - #116790 (opt-dist: disable unused features for tabled crate)
 - #116802 (Remove `DefiningAnchor::Bubble` from opaque wf check)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=114157,116257,116430,116709,116786,116790,116802)
<!-- homu-ignore:end -->