### PR TITLE
Preserve unicode escapes in format string literals when pretty-printing AST

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -684,8 +684,8 @@ pub fn reconstruct_format_args_template_string(pieces: &[FormatArgsPiece]) -> St
     for piece in pieces {
         match piece {
             FormatArgsPiece::Literal(s) => {
-                for c in s.as_str().escape_debug() {
-                    template.push(c);
+                for c in s.as_str().chars() {
+                    template.extend(c.escape_debug());
                     if let '{' | '}' = c {
                         template.push(c);
                     }

--- a/tests/pretty/format-args-str-escape.pp
+++ b/tests/pretty/format-args-str-escape.pp
@@ -1,0 +1,21 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// pretty-compare-only
+// pretty-mode:expanded
+// pp-exact:format-args-str-escape.pp
+
+fn main() {
+    { ::std::io::_print(format_args!("\u{1b}[1mHello, world!\u{1b}[0m\n")); };
+    { ::std::io::_print(format_args!("\u{1b}[1mHello, world!\u{1b}[0m\n")); };
+    {
+        ::std::io::_print(format_args!("Not an escape sequence: \\u{{1B}}[1mbold\\x1B[0m\n"));
+    };
+    {
+        ::std::io::_print(format_args!("{0}\n",
+                "\x1B[1mHello, world!\x1B[0m"));
+    };
+}

--- a/tests/pretty/format-args-str-escape.rs
+++ b/tests/pretty/format-args-str-escape.rs
@@ -1,0 +1,10 @@
+// pretty-compare-only
+// pretty-mode:expanded
+// pp-exact:format-args-str-escape.pp
+
+fn main() {
+    println!("\x1B[1mHello, world!\x1B[0m");
+    println!("\u{1B}[1mHello, world!\u{1B}[0m");
+    println!("Not an escape sequence: \\u{{1B}}[1mbold\\x1B[0m");
+    println!("{}", "\x1B[1mHello, world!\x1B[0m");
+}


### PR DESCRIPTION
Fixes #116799

Thanks to @Nilstrieb for the pointer to the correct location, that was really helpful for someone unfamiliar with the codebase.