### PR TITLE
Disable missing_copy_implementations lint on non_exhaustive types

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -677,6 +677,11 @@ impl<'tcx> LateLintPass<'tcx> for MissingCopyImplementations {
         if type_implements_negative_copy_modulo_regions(cx.tcx, ty, param_env) {
             return;
         }
+        if def.is_variant_list_non_exhaustive()
+            || def.variants().iter().any(|variant| variant.is_field_list_non_exhaustive())
+        {
+            return;
+        }
 
         // We shouldn't recommend implementing `Copy` on stateful things,
         // such as iterators.

--- a/tests/ui/lint/missing-copy-implementations-non-exhaustive.rs
+++ b/tests/ui/lint/missing-copy-implementations-non-exhaustive.rs
@@ -1,0 +1,25 @@
+// Test for issue #116766.
+// Ensure that we don't suggest impl'ing `Copy` for a type if it or at least one
+// of it's variants are marked as `non_exhaustive`.
+
+// check-pass
+
+#![deny(missing_copy_implementations)]
+
+#[non_exhaustive]
+pub enum MyEnum {
+    A,
+}
+
+#[non_exhaustive]
+pub struct MyStruct {
+    foo: usize,
+}
+
+pub enum MyEnum2 {
+    #[non_exhaustive]
+    A,
+    B,
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #116766