### PR TITLE
Use `YYYY-MM-DDTHH_MM_SS` as datetime format for ICE dump files

### DIFF
--- a/compiler/rustc_driver_impl/Cargo.toml
+++ b/compiler/rustc_driver_impl/Cargo.toml
@@ -52,7 +52,7 @@ rustc_target = { path = "../rustc_target" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_ty_utils = { path = "../rustc_ty_utils" }
 serde_json = "1.0.59"
-time = { version = "0.3", default-features = false, features = ["formatting", ] }
+time = { version = "0.3", default-features = false, features = ["alloc", "formatting"] }
 tracing = { version = "0.1.35" }
 # tidy-alphabetical-end
 

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -62,7 +62,6 @@ use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 use std::time::{Instant, SystemTime};
-use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 #[allow(unused_macros)]
@@ -1307,7 +1306,13 @@ fn ice_path() -> &'static Option<PathBuf> {
             None => std::env::current_dir().unwrap_or_default(),
         };
         let now: OffsetDateTime = SystemTime::now().into();
-        let file_now = now.format(&Rfc3339).unwrap_or_default();
+        let file_now = now
+            .format(
+                // Don't use a standard datetime format because Windows doesn't support `:` in paths
+                &time::format_description::parse("[year]-[month]-[day]T[hour]_[minute]_[second]")
+                    .unwrap(),
+            )
+            .unwrap_or_default();
         let pid = std::process::id();
         path.push(format!("rustc-ice-{file_now}-{pid}.txt"));
         Some(path)

--- a/tests/run-make/dump-ice-to-disk/check.sh
+++ b/tests/run-make/dump-ice-to-disk/check.sh
@@ -11,6 +11,12 @@ export RUSTC_ICE=$TMPDIR
 $RUSTC src/lib.rs -Z treat-err-as-bug=1 1>$TMPDIR/rust-test-default-set.log 2>&1
 default_set=$(cat $TMPDIR/rustc-ice-*.txt | wc -l)
 content=$(cat $TMPDIR/rustc-ice-*.txt)
+# Ensure that the ICE dump path doesn't contain `:` because they cause problems on Windows
+windows_safe=$(echo rustc-ice-*.txt | grep ':')
+if [ ! -z "$windows_safe" ]; then
+    exit 1
+fi
+
 rm $TMPDIR/rustc-ice-*.txt
 RUST_BACKTRACE=short $RUSTC src/lib.rs -Z treat-err-as-bug=1 1>$TMPDIR/rust-test-short.log 2>&1
 short=$(cat $TMPDIR/rustc-ice-*.txt | wc -l)


### PR DESCRIPTION
Windows paths do not support `:`, so use a datetime format in ICE dump paths that Windows will accept.

CC #116809, fix #115180.