### PR TITLE
Exhaustiveness: reveal opaque types properly

### DIFF
--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -62,7 +62,8 @@ pub trait TypeCx: Sized + Clone + fmt::Debug {
     /// patterns during analysis.
     type PatData: Clone + Default;
 
-    fn is_opaque_ty(ty: Self::Ty) -> bool;
+    /// FIXME(Nadrieril): `Cx` should only give us revealed types.
+    fn reveal_opaque_ty(&self, ty: Self::Ty) -> Self::Ty;
     fn is_exhaustive_patterns_feature_on(&self) -> bool;
 
     /// The number of fields for this constructor.

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -48,22 +48,14 @@ impl<'a, 'p, 'tcx> PatternColumn<'a, 'p, 'tcx> {
     fn is_empty(&self) -> bool {
         self.patterns.is_empty()
     }
-    fn head_ty(&self) -> Option<Ty<'tcx>> {
+    fn head_ty(&self, cx: MatchCtxt<'a, 'p, 'tcx>) -> Option<Ty<'tcx>> {
         if self.patterns.len() == 0 {
             return None;
         }
-        // If the type is opaque and it is revealed anywhere in the column, we take the revealed
-        // version. Otherwise we could encounter constructors for the revealed type and crash.
-        let first_ty = self.patterns[0].ty();
-        if RustcMatchCheckCtxt::is_opaque_ty(first_ty) {
-            for pat in &self.patterns {
-                let ty = pat.ty();
-                if !RustcMatchCheckCtxt::is_opaque_ty(ty) {
-                    return Some(ty);
-                }
-            }
-        }
-        Some(first_ty)
+
+        let ty = self.patterns[0].ty();
+        // FIXME(Nadrieril): `Cx` should only give us revealed types.
+        Some(cx.tycx.reveal_opaque_ty(ty))
     }
 
     /// Do constructor splitting on the constructors of the column.
@@ -125,7 +117,7 @@ fn collect_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
     cx: MatchCtxt<'a, 'p, 'tcx>,
     column: &PatternColumn<'a, 'p, 'tcx>,
 ) -> Vec<WitnessPat<'p, 'tcx>> {
-    let Some(ty) = column.head_ty() else {
+    let Some(ty) = column.head_ty(cx) else {
         return Vec::new();
     };
     let pcx = &PlaceCtxt::new_dummy(cx, ty);
@@ -226,7 +218,7 @@ pub(crate) fn lint_overlapping_range_endpoints<'a, 'p, 'tcx>(
     cx: MatchCtxt<'a, 'p, 'tcx>,
     column: &PatternColumn<'a, 'p, 'tcx>,
 ) {
-    let Some(ty) = column.head_ty() else {
+    let Some(ty) = column.head_ty(cx) else {
         return;
     };
     let pcx = &PlaceCtxt::new_dummy(cx, ty);

--- a/tests/ui/pattern/usefulness/impl-trait.rs
+++ b/tests/ui/pattern/usefulness/impl-trait.rs
@@ -1,0 +1,146 @@
+#![feature(never_type)]
+#![feature(exhaustive_patterns)]
+#![feature(type_alias_impl_trait)]
+#![feature(non_exhaustive_omitted_patterns_lint)]
+#![deny(unreachable_patterns)]
+// Test that the lint traversal handles opaques correctly
+#![deny(non_exhaustive_omitted_patterns)]
+
+fn main() {}
+
+#[derive(Copy, Clone)]
+enum Void {}
+
+fn return_never_rpit(x: Void) -> impl Copy {
+    if false {
+        match return_never_rpit(x) {
+            _ => {}
+        }
+    }
+    x
+}
+fn friend_of_return_never_rpit(x: Void) {
+    match return_never_rpit(x) {}
+    //~^ ERROR non-empty
+}
+
+type T = impl Copy;
+fn return_never_tait(x: Void) -> T {
+    if false {
+        match return_never_tait(x) {
+            _ => {}
+        }
+    }
+    x
+}
+fn friend_of_return_never_tait(x: Void) {
+    match return_never_tait(x) {}
+    //~^ ERROR non-empty
+}
+
+fn option_never(x: Void) -> Option<impl Copy> {
+    if false {
+        match option_never(x) {
+            None => {}
+            Some(_) => {}
+        }
+        match option_never(x) {
+            None => {}
+            // FIXME: Unreachable not detected because `is_uninhabited` does not look into opaque
+            // types.
+            _ => {}
+        }
+    }
+    Some(x)
+}
+
+fn option_never2(x: Void) -> impl Copy {
+    if false {
+        match option_never2(x) {
+            None => {}
+            Some(_) => {} //~ ERROR unreachable
+        }
+        match option_never2(x) {
+            None => {}
+            _ => {} //~ ERROR unreachable
+        }
+        match option_never2(x) {
+            None => {}
+        }
+    }
+    Some(x)
+}
+
+fn inner_never(x: Void) {
+    type T = impl Copy;
+    let y: T = x;
+    match y {
+        _ => {}
+    }
+}
+
+// This one caused ICE https://github.com/rust-lang/rust/issues/117100.
+fn inner_tuple() {
+    type T = impl Copy;
+    let foo: T = Some((1u32, 2u32));
+    match foo {
+        _ => {}
+        Some((a, b)) => {} //~ ERROR unreachable
+    }
+}
+
+type U = impl Copy;
+fn unify_never(x: Void, u: U) -> U {
+    if false {
+        match u {
+            _ => {}
+        }
+    }
+    x
+}
+
+type V = impl Copy;
+fn infer_in_match(x: Option<V>) {
+    match x {
+        None => {}
+        Some((a, b)) => {}
+        Some((mut x, mut y)) => {
+            //~^ ERROR unreachable
+            x = 42;
+            y = "foo";
+        }
+    }
+}
+
+type W = impl Copy;
+#[derive(Copy, Clone)]
+struct Rec<'a> {
+    n: u32,
+    w: Option<&'a W>,
+}
+fn recursive_opaque() -> W {
+    if false {
+        match recursive_opaque() {
+            // Check for the ol' ICE when the type is recursively opaque.
+            _ => {}
+            Rec { n: 0, w: Some(Rec { n: 0, w: _ }) } => {} //~ ERROR unreachable
+        }
+    }
+    let w: Option<&'static W> = None;
+    Rec { n: 0, w }
+}
+
+type X = impl Copy;
+struct SecretelyVoid(X);
+fn nested_empty_opaque(x: Void) -> X {
+    if false {
+        let opaque_void = nested_empty_opaque(x);
+        let secretely_void = SecretelyVoid(opaque_void);
+        match secretely_void {
+            // FIXME: Unreachable not detected because `is_uninhabited` does not look into opaque
+            // types.
+            _ => {}
+        }
+    }
+    x
+}

--- a/tests/ui/pattern/usefulness/impl-trait.rs
+++ b/tests/ui/pattern/usefulness/impl-trait.rs
@@ -14,7 +14,7 @@ enum Void {}
 fn return_never_rpit(x: Void) -> impl Copy {
     if false {
         match return_never_rpit(x) {
-            _ => {}
+            _ => {} //~ ERROR unreachable
         }
     }
     x
@@ -28,7 +28,7 @@ type T = impl Copy;
 fn return_never_tait(x: Void) -> T {
     if false {
         match return_never_tait(x) {
-            _ => {}
+            _ => {} //~ ERROR unreachable
         }
     }
     x
@@ -42,7 +42,7 @@ fn option_never(x: Void) -> Option<impl Copy> {
     if false {
         match option_never(x) {
             None => {}
-            Some(_) => {}
+            Some(_) => {} //~ ERROR unreachable
         }
         match option_never(x) {
             None => {}
@@ -75,7 +75,7 @@ fn inner_never(x: Void) {
     type T = impl Copy;
     let y: T = x;
     match y {
-        _ => {}
+        _ => {} //~ ERROR unreachable
     }
 }
 
@@ -93,7 +93,7 @@ type U = impl Copy;
 fn unify_never(x: Void, u: U) -> U {
     if false {
         match u {
-            _ => {}
+            _ => {} //~ ERROR unreachable
         }
     }
     x

--- a/tests/ui/pattern/usefulness/impl-trait.stderr
+++ b/tests/ui/pattern/usefulness/impl-trait.stderr
@@ -1,0 +1,71 @@
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:61:13
+   |
+LL |             Some(_) => {}
+   |             ^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/impl-trait.rs:5:9
+   |
+LL | #![deny(unreachable_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:65:13
+   |
+LL |             _ => {}
+   |             ^
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:88:9
+   |
+LL |         _ => {}
+   |         - matches any value
+LL |         Some((a, b)) => {}
+   |         ^^^^^^^^^^^^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:107:9
+   |
+LL |         Some((mut x, mut y)) => {
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:126:13
+   |
+LL |             _ => {}
+   |             - matches any value
+LL |             Rec { n: 0, w: Some(Rec { n: 0, w: _ }) } => {}
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+
+error[E0004]: non-exhaustive patterns: type `impl Copy` is non-empty
+  --> $DIR/impl-trait.rs:23:11
+   |
+LL |     match return_never_rpit(x) {}
+   |           ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the matched value is of type `impl Copy`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match return_never_rpit(x) {
+LL +         _ => todo!(),
+LL +     }
+   |
+
+error[E0004]: non-exhaustive patterns: type `T` is non-empty
+  --> $DIR/impl-trait.rs:37:11
+   |
+LL |     match return_never_tait(x) {}
+   |           ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the matched value is of type `T`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match return_never_tait(x) {
+LL +         _ => todo!(),
+LL +     }
+   |
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/impl-trait.stderr
+++ b/tests/ui/pattern/usefulness/impl-trait.stderr
@@ -1,8 +1,8 @@
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:61:13
+  --> $DIR/impl-trait.rs:17:13
    |
-LL |             Some(_) => {}
-   |             ^^^^^^^
+LL |             _ => {}
+   |             ^
    |
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:5:9
@@ -11,10 +11,34 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
+  --> $DIR/impl-trait.rs:31:13
+   |
+LL |             _ => {}
+   |             ^
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:45:13
+   |
+LL |             Some(_) => {}
+   |             ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:61:13
+   |
+LL |             Some(_) => {}
+   |             ^^^^^^^
+
+error: unreachable pattern
   --> $DIR/impl-trait.rs:65:13
    |
 LL |             _ => {}
    |             ^
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:78:9
+   |
+LL |         _ => {}
+   |         ^
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:88:9
@@ -23,6 +47,12 @@ LL |         _ => {}
    |         - matches any value
 LL |         Some((a, b)) => {}
    |         ^^^^^^^^^^^^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:96:13
+   |
+LL |             _ => {}
+   |             ^
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:107:9
@@ -66,6 +96,6 @@ LL +         _ => todo!(),
 LL +     }
    |
 
-error: aborting due to 7 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
Previously, exhaustiveness had no clear policy around opaque types. In this PR I propose the following policy: within the body of an item that defines the hidden type of some opaque type, exhaustiveness checking on a value of that opaque type is performed using the concrete hidden type inferred in this body.

I'm not sure how consistent this is with other operations allowed on opaque types; I believe this will require FCP.

From what I can tell, this doesn't change anything for non-empty types.

The observable changes are:
- when the real type is uninhabited, matches within the defining scopes can now rely on that for exhaustiveness, e.g.:

```rust
#[derive(Copy, Clone)]
enum Void {}
fn return_never_rpit(x: Void) -> impl Copy {
    if false {
        match return_never_rpit(x) {}
    }
    x
}
```
- this properly fixes ICEs like https://github.com/rust-lang/rust/issues/117100 that occurred because a same match could have some patterns where the type is revealed and some where it is not.

Bonus subtle point: if `x` is opaque, a match like `match x { ("", "") => {} ... }` will constrain its type ([playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=901d715330eac40339b4016ac566d6c3)). This is not the case for `match x {}`: this will not constain the type, and will only compile if something else constrains the type to be empty.

Fixes https://github.com/rust-lang/rust/issues/117100

r? @oli-obk 

Edited for precision of the wording

[Included](https://github.com/rust-lang/rust/pull/116821#issuecomment-1813171764) in the FCP on this PR is this rule:

> Within the body of an item that defines the hidden type of some opaque type, exhaustiveness checking on a value of that opaque type is performed using the concrete hidden type inferred in this body.