### PR TITLE
Fix duplicate labels emitted in `render_multispan_macro_backtrace()`

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -23,7 +23,7 @@ use crate::{
 use rustc_lint_defs::pluralize;
 
 use derive_setters::Setters;
-use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
+use rustc_data_structures::fx::{FxHashMap, FxIndexMap, FxIndexSet};
 use rustc_data_structures::sync::{DynSend, IntoDynSyncSend, Lrc};
 use rustc_error_messages::{FluentArgs, SpanLabel};
 use rustc_span::hygiene::{ExpnKind, MacroKind};
@@ -370,7 +370,7 @@ pub trait Emitter: Translate {
     }
 
     fn render_multispan_macro_backtrace(&self, span: &mut MultiSpan, always_backtrace: bool) {
-        let mut new_labels: Vec<(Span, String)> = vec![];
+        let mut new_labels = FxIndexSet::default();
 
         for &sp in span.primary_spans() {
             if sp.is_dummy() {
@@ -387,7 +387,7 @@ pub trait Emitter: Translate {
                 }
 
                 if always_backtrace {
-                    new_labels.push((
+                    new_labels.insert((
                         trace.def_site,
                         format!(
                             "in this expansion of `{}`{}",
@@ -431,7 +431,7 @@ pub trait Emitter: Translate {
                             format!("this {} desugaring", kind.descr()).into()
                         }
                     };
-                    new_labels.push((
+                    new_labels.insert((
                         trace.call_site,
                         format!(
                             "in {}{}",

--- a/tests/ui/asm/aarch64/interpolated-idents.stderr
+++ b/tests/ui/asm/aarch64/interpolated-idents.stderr
@@ -33,12 +33,7 @@ LL |               asm!("", $in(x) x, $out(x) x, $lateout(x) x, $inout(x) x, $in
 LL | /     m!(in out lateout inout inlateout const sym
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack options);
-   | |                                -
-   | |________________________________|
-   | |________________________________in this macro invocation
-   | |________________________________in this macro invocation
-   | |________________________________in this macro invocation
-   |                                  in this macro invocation
+   | |________________________________- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/asm/x86_64/interpolated-idents.stderr
+++ b/tests/ui/asm/x86_64/interpolated-idents.stderr
@@ -33,12 +33,7 @@ LL |               asm!("", $in(x) x, $out(x) x, $lateout(x) x, $inout(x) x, $in
 LL | /     m!(in out lateout inout inlateout const sym
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack att_syntax options);
-   | |                                           -
-   | |___________________________________________|
-   | |___________________________________________in this macro invocation
-   | |___________________________________________in this macro invocation
-   | |___________________________________________in this macro invocation
-   |                                             in this macro invocation
+   | |___________________________________________- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
+++ b/tests/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
@@ -861,12 +861,7 @@ LL |                 $($name: 'a, $name: 'a, )+;
    |                   ^^^^^^^^^  ^^^^^^^^^
 ...
 LL |     m!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
-   |     ---------------------------------------------------------
-   |     |
-   |     in this macro invocation
-   |     in this macro invocation
-   |     in this macro invocation
-   |     in this macro invocation
+   |     --------------------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: remove these bounds

--- a/tests/ui/typeck/issue-116473-ice-wrong-span-variant-args.stderr
+++ b/tests/ui/typeck/issue-116473-ice-wrong-span-variant-args.stderr
@@ -7,10 +7,7 @@ LL |     ($variant:tt) => (if let EnumUnit::$variant::<i32, u32> {} = 5 { true }
    |                                        not allowed on this type
 ...
 LL |     recursive_tt!();
-   |     ---------------
-   |     |
-   |     in this macro invocation
-   |     in this macro invocation
+   |     --------------- in this macro invocation
    |
    = note: enum variants can't have type parameters
    = note: this error originates in the macro `recursive_tt` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -44,10 +41,7 @@ LL |     ($variant:ident) => (if let EnumUnit::$variant::<i32, u32> {} = 5 { tru
    |                                                      ^^^  ^^^ type argument not allowed
 ...
 LL |     recursive_ident!();
-   |     ------------------
-   |     |
-   |     in this macro invocation
-   |     in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: enum variants can't have type parameters
    = note: this error originates in the macro `recursive_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -81,10 +75,7 @@ LL |     ($variant:tt) => (if let EnumUnit::$variant::<i32, u32> {} = 5 { true }
    |                                        not allowed on this type
 ...
 LL |     nested1_tt!();
-   |     -------------
-   |     |
-   |     in this macro invocation
-   |     in this macro invocation
+   |     ------------- in this macro invocation
    |
    = note: enum variants can't have type parameters
    = note: this error originates in the macro `nested2_tt` which comes from the expansion of the macro `nested1_tt` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -119,10 +110,7 @@ LL |     ($variant:ident) => (if let EnumUnit::$variant::<i32, u32> {} = 5 { tru
    |                                                      ^^^  ^^^ type argument not allowed
 ...
 LL |     nested1_ident!();
-   |     ----------------
-   |     |
-   |     in this macro invocation
-   |     in this macro invocation
+   |     ---------------- in this macro invocation
    |
    = note: enum variants can't have type parameters
    = note: this error originates in the macro `nested2_ident` which comes from the expansion of the macro `nested1_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -156,10 +144,7 @@ LL |     ($arg1:tt, $arg2:tt) => (if let EnumUnit::VariantB::<$arg1, $arg2> {}
    |                                               not allowed on this type
 ...
 LL |     nested1_tt_args_in_first_macro!();
-   |     ---------------------------------
-   |     |
-   |     in this macro invocation
-   |     in this macro invocation
+   |     --------------------------------- in this macro invocation
    |
    = note: enum variants can't have type parameters
    = note: this error originates in the macro `nested1_tt_args_in_first_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -194,10 +179,7 @@ LL |     ($arg1:ident, $arg2:ident) => (if let EnumUnit::VariantB::<$arg1, $arg2
    |                                                     not allowed on this type
 ...
 LL |     nested1_ident_args_in_first_macro!();
-   |     ------------------------------------
-   |     |
-   |     in this macro invocation
-   |     in this macro invocation
+   |     ------------------------------------ in this macro invocation
    |
    = note: enum variants can't have type parameters
    = note: this error originates in the macro `nested2_ident_args_in_first_macro` which comes from the expansion of the macro `nested1_ident_args_in_first_macro` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR replaces the `Vec` used to store labels with an `FxIndexSet` in order to eliminate duplicates

Fixes #116836