### PR TITLE
A more efficient slice comparison implementation for T: !BytewiseEq

### DIFF
--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -60,7 +60,17 @@ where
             return false;
         }
 
-        self.iter().zip(other.iter()).all(|(x, y)| x == y)
+        // Implemented as explicit indexing rather
+        // than zipped iterators for performance reasons.
+        // See PR https://github.com/rust-lang/rust/pull/116846
+        for idx in 0..self.len() {
+            // bound checks are optimized away
+            if self[idx] != other[idx] {
+                return false;
+            }
+        }
+
+        true
     }
 }
 


### PR DESCRIPTION
(This is a follow up PR on #113654)

This PR changes the implementation for `[T]` slice comparison when `T: !BytewiseEq`. The previous implementation using zip was not optimized properly by the compiler, which didn't leverage the fact that both length were equal. Performance improvements are for example 20% when testing that `[Some(0_u64); 4096].as_slice() == [Some(0_u64); 4096].as_slice()`.