### PR TITLE
Disable effects in libcore again

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -219,7 +219,6 @@
 #![feature(doc_cfg)]
 #![feature(doc_cfg_hide)]
 #![feature(doc_notable_trait)]
-#![feature(effects)]
 #![feature(exhaustive_patterns)]
 #![feature(extern_types)]
 #![feature(fundamental)]

--- a/tests/ui/consts/effect_param.rs
+++ b/tests/ui/consts/effect_param.rs
@@ -1,0 +1,11 @@
+//! Ensure we don't allow accessing const effect parameters from stable Rust.
+
+fn main() {
+    i8::checked_sub::<true>(42, 43);
+    //~^ ERROR: method takes 0 generic arguments but 1 generic argument was supplied
+}
+
+const FOO: () = {
+    i8::checked_sub::<false>(42, 43);
+    //~^ ERROR: method takes 0 generic arguments but 1 generic argument was supplied
+};

--- a/tests/ui/consts/effect_param.stderr
+++ b/tests/ui/consts/effect_param.stderr
@@ -1,0 +1,19 @@
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/effect_param.rs:9:9
+   |
+LL |     i8::checked_sub::<false>(42, 43);
+   |         ^^^^^^^^^^^--------- help: remove these generics
+   |         |
+   |         expected 0 generic arguments
+
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/effect_param.rs:4:9
+   |
+LL |     i8::checked_sub::<true>(42, 43);
+   |         ^^^^^^^^^^^-------- help: remove these generics
+   |         |
+   |         expected 0 generic arguments
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
r? @fee1-dead 

This was accidentally allowed by https://github.com/rust-lang/rust/pull/114776 without feature gates