### PR TITLE
Suggest assoc fn `new` when trying to build tuple struct with private fields

### DIFF
--- a/tests/ui/privacy/suggest-box-new.fixed
+++ b/tests/ui/privacy/suggest-box-new.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+#![allow(dead_code)]
+struct U <T> {
+    wtf: Option<Box<U<T>>>,
+    x: T,
+}
+fn main() {
+    U {
+        wtf: Some(Box::new(U { //~ ERROR cannot initialize a tuple struct which contains private fields
+            wtf: None,
+            x: (),
+        })),
+        x: ()
+    };
+}

--- a/tests/ui/privacy/suggest-box-new.rs
+++ b/tests/ui/privacy/suggest-box-new.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+#![allow(dead_code)]
+struct U <T> {
+    wtf: Option<Box<U<T>>>,
+    x: T,
+}
+fn main() {
+    U {
+        wtf: Some(Box(U { //~ ERROR cannot initialize a tuple struct which contains private fields
+            wtf: None,
+            x: (),
+        })),
+        x: ()
+    };
+}

--- a/tests/ui/privacy/suggest-box-new.stderr
+++ b/tests/ui/privacy/suggest-box-new.stderr
@@ -1,0 +1,20 @@
+error[E0423]: cannot initialize a tuple struct which contains private fields
+  --> $DIR/suggest-box-new.rs:9:19
+   |
+LL |         wtf: Some(Box(U {
+   |                   ^^^
+   |
+note: constructor is not visible here due to private fields
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+   = note: private field
+   |
+   = note: private field
+help: you might have meant to use the `new` associated function
+   |
+LL |         wtf: Some(Box::new(U {
+   |                      +++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
Fix #22488.