### PR TITLE
Change my name in mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -74,6 +74,7 @@ Benoît Cortier <benoit.cortier@fried-world.eu>
 Bheesham Persaud <bheesham123@hotmail.com> Bheesham Persaud <bheesham.persaud@live.ca>
 Björn Steinbrink <bsteinbr@gmail.com> <B.Steinbrink@gmx.de>
 blake2-ppc <ulrik.sverdrup@gmail.com> <blake2-ppc>
+blyxyas <blyxyas@gmail.com> Alejandra González <blyxyas@gmail.com>
 boolean_coercion <booleancoercion@gmail.com>
 Boris Egorov <jightuse@gmail.com> <egorov@linux.com>
 bors <bors@rust-lang.org> bors[bot] <26634292+bors[bot]@users.noreply.github.com>


### PR DESCRIPTION
I changed some things about my distro (my GPG key, along with the git username). This PR sets my committer name as `blyxyas` for those commits so that it is the same as my reviewer name in `thanks`.