### PR TITLE
Add a test showing failing closure signature inference in new solver

### DIFF
--- a/tests/ui/closures/infer-signature-from-impl.next.stderr
+++ b/tests/ui/closures/infer-signature-from-impl.next.stderr
@@ -1,0 +1,16 @@
+error[E0282]: type annotations needed
+  --> $DIR/infer-signature-from-impl.rs:17:16
+   |
+LL |     needs_foo(|x| {
+   |                ^
+LL |         x.to_string();
+   |         - type must be known at this point
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     needs_foo(|x: /* Type */| {
+   |                 ++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/closures/infer-signature-from-impl.rs
+++ b/tests/ui/closures/infer-signature-from-impl.rs
@@ -1,0 +1,20 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+//[next] known-bug: trait-system-refactor-initiative#71
+//[current] check-pass
+
+trait Foo {}
+fn needs_foo<T>(_: T)
+where
+    Wrap<T>: Foo,
+{
+}
+
+struct Wrap<T>(T);
+impl<T> Foo for Wrap<T> where T: Fn(i32) {}
+
+fn main() {
+    needs_foo(|x| {
+        x.to_string();
+    });
+}


### PR DESCRIPTION
Been thinking a bit about how to make this test pass... but we don't actually have any good tests exercising this behavior in the suite.

r? lcnr