### PR TITLE
fix(bootstrap) info message show correct path now

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -183,7 +183,7 @@ pub fn setup(config: &Config, profile: Profile) {
         eprintln!();
         eprintln!(
             "note: the `tools` profile sets up the `stage2` toolchain (use \
-            `rustup toolchain link 'name' host/build/stage2` to use rustc)"
+            `rustup toolchain link 'name' build/host/stage2` to use rustc)"
         )
     }
 


### PR DESCRIPTION
running `./x setup tools` showed me a note with incorrect path