### PR TITLE
Fix x86_64-gnu-llvm-15 CI tests

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-15/script.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-15/script.sh
@@ -4,34 +4,34 @@ set -ex
 
 # Only run the stage 1 tests on merges, not on PR CI jobs.
 if [[ -z "${PR_CI_JOB}" ]]; then
-     ../x.py --stage 1 test --skip src/tools/tidy && \
-     # Run the `mir-opt` tests again but this time for a 32-bit target.
-     # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
-     # both 32-bit and 64-bit outputs updated by the PR author, before
-     # the PR is approved and tested for merging.
-     # It will also detect tests lacking `// EMIT_MIR_FOR_EACH_BIT_WIDTH`,
-     # despite having different output on 32-bit vs 64-bit targets.
-     ../x.py --stage 1 test tests/mir-opt \
-          --host='' --target=i686-unknown-linux-gnu && \
-     # Run `ui-fulldeps` in `--stage=1`, which actually uses the stage0
-     # compiler, and is sensitive to the addition of new flags.
-     ../x.py --stage 1 test tests/ui-fulldeps
+    ../x.py --stage 1 test --skip src/tools/tidy
+
+    # Run the `mir-opt` tests again but this time for a 32-bit target.
+    # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
+    # both 32-bit and 64-bit outputs updated by the PR author, before
+    # the PR is approved and tested for merging.
+    # It will also detect tests lacking `// EMIT_MIR_FOR_EACH_BIT_WIDTH`,
+    # despite having different output on 32-bit vs 64-bit targets.
+    ../x.py --stage 1 test tests/mir-opt --host='' --target=i686-unknown-linux-gnu
+
+    # Run `ui-fulldeps` in `--stage=1`, which actually uses the stage0
+    # compiler, and is sensitive to the addition of new flags.
+    ../x.py --stage 1 test tests/ui-fulldeps
 fi
 
 # NOTE: intentionally uses all of `x.py`, `x`, and `x.ps1` to make sure they all work on Linux.
-../x.py --stage 2 test --skip src/tools/tidy && \
-     # Run the `mir-opt` tests again but this time for a 32-bit target.
-     # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
-     # both 32-bit and 64-bit outputs updated by the PR author, before
-     # the PR is approved and tested for merging.
-     # It will also detect tests lacking `// EMIT_MIR_FOR_EACH_BIT_WIDTH`,
-     # despite having different output on 32-bit vs 64-bit targets.
-     ../x --stage 2 test tests/mir-opt \
-                       --host='' --target=i686-unknown-linux-gnu && \
-     # Run the UI test suite again, but in `--pass=check` mode
-     #
-     # This is intended to make sure that both `--pass=check` continues to
-     # work.
-     #
-     ../x.ps1 --stage 2 test tests/ui --pass=check \
-                       --host='' --target=i686-unknown-linux-gnu
+../x.py --stage 2 test --skip src/tools/tidy
+
+# Run the `mir-opt` tests again but this time for a 32-bit target.
+# This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have
+# both 32-bit and 64-bit outputs updated by the PR author, before
+# the PR is approved and tested for merging.
+# It will also detect tests lacking `// EMIT_MIR_FOR_EACH_BIT_WIDTH`,
+# despite having different output on 32-bit vs 64-bit targets.
+../x --stage 2 test tests/mir-opt --host='' --target=i686-unknown-linux-gnu
+
+# Run the UI test suite again, but in `--pass=check` mode
+#
+# This is intended to make sure that both `--pass=check` continues to
+# work.
+../x.ps1 --stage 2 test tests/ui --pass=check --host='' --target=i686-unknown-linux-gnu

--- a/tests/ui-fulldeps/internal-lints/span_use_eq_ctxt.rs
+++ b/tests/ui-fulldeps/internal-lints/span_use_eq_ctxt.rs
@@ -1,4 +1,6 @@
 // Test the `rustc::span_use_eq_ctxt` internal lint
+// #[cfg(bootstrap)]
+// ignore-stage1
 // compile-flags: -Z unstable-options
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/internal-lints/span_use_eq_ctxt.stderr
+++ b/tests/ui-fulldeps/internal-lints/span_use_eq_ctxt.stderr
@@ -1,11 +1,11 @@
 error: use `.eq_ctxt()` instead of `.ctxt() == .ctxt()`
-  --> $DIR/span_use_eq_ctxt.rs:12:5
+  --> $DIR/span_use_eq_ctxt.rs:14:5
    |
 LL |     s.ctxt() == t.ctxt()
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/span_use_eq_ctxt.rs:5:9
+  --> $DIR/span_use_eq_ctxt.rs:7:9
    |
 LL | #![deny(rustc::span_use_eq_ctxt)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The CI script was broken - if there was a test failure in the first command chain (inside the `if`), CI would not report the failure.

It happened because there were two command chains separated by `&&` in the script, and since `set -e` doesn't exit for chained commands, if the first chain has failed, the script would happily continue forward, ignoring any test failures.

This could be fixed e.g. by adding some `|| exit 1` to the first chain, but I suppose that the `&&` chaining is unnecessary here anyway.

Reported [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/test.20failure.20didn't.20stop.20CI).

Fixes: https://github.com/rust-lang/rust/issues/116867