### PR TITLE
When encountering sealed traits, point types that implement it

### DIFF
--- a/tests/ui/privacy/sealed-traits/sealed-trait-local.rs
+++ b/tests/ui/privacy/sealed-traits/sealed-trait-local.rs
@@ -13,7 +13,43 @@ pub mod a {
     }
 }
 
-struct S;
-impl a::Sealed for S {} //~ ERROR the trait bound `S: Hidden` is not satisfied
+pub mod c {
+    pub trait Sealed: self::d::Hidden {
+        fn foo() {}
+    }
 
+    struct X;
+    impl Sealed for X {}
+    impl self::d::Hidden for X {}
+
+    struct Y;
+    impl Sealed for Y {}
+    impl self::d::Hidden for Y {}
+
+    mod d {
+        pub trait Hidden {}
+    }
+}
+
+pub mod e {
+    pub trait Sealed: self::f::Hidden {
+        fn foo() {}
+    }
+
+    struct X;
+    impl self::f::Hidden for X {}
+
+    struct Y;
+    impl self::f::Hidden for Y {}
+    impl<T: self::f::Hidden> Sealed for T {}
+
+    mod f {
+        pub trait Hidden {}
+    }
+}
+
+struct S;
+impl a::Sealed for S {} //~ ERROR the trait bound
+impl c::Sealed for S {} //~ ERROR the trait bound
+impl e::Sealed for S {} //~ ERROR the trait bound
 fn main() {}

--- a/tests/ui/privacy/sealed-traits/sealed-trait-local.stderr
+++ b/tests/ui/privacy/sealed-traits/sealed-trait-local.stderr
@@ -1,16 +1,50 @@
-error[E0277]: the trait bound `S: Hidden` is not satisfied
-  --> $DIR/sealed-trait-local.rs:17:20
+error[E0277]: the trait bound `S: b::Hidden` is not satisfied
+  --> $DIR/sealed-trait-local.rs:52:20
    |
 LL | impl a::Sealed for S {}
-   |                    ^ the trait `Hidden` is not implemented for `S`
+   |                    ^ the trait `b::Hidden` is not implemented for `S`
    |
-note: required by a bound in `Sealed`
+note: required by a bound in `a::Sealed`
   --> $DIR/sealed-trait-local.rs:3:23
    |
 LL |     pub trait Sealed: self::b::Hidden {
    |                       ^^^^^^^^^^^^^^^ required by this bound in `Sealed`
    = note: `Sealed` is a "sealed trait", because to implement it you also need to implement `a::b::Hidden`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following type implements the trait:
+             a::X
 
-error: aborting due to previous error
+error[E0277]: the trait bound `S: d::Hidden` is not satisfied
+  --> $DIR/sealed-trait-local.rs:53:20
+   |
+LL | impl c::Sealed for S {}
+   |                    ^ the trait `d::Hidden` is not implemented for `S`
+   |
+note: required by a bound in `c::Sealed`
+  --> $DIR/sealed-trait-local.rs:17:23
+   |
+LL |     pub trait Sealed: self::d::Hidden {
+   |                       ^^^^^^^^^^^^^^^ required by this bound in `Sealed`
+   = note: `Sealed` is a "sealed trait", because to implement it you also need to implement `c::d::Hidden`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following types implement the trait:
+             c::X
+             c::Y
+
+error[E0277]: the trait bound `S: f::Hidden` is not satisfied
+  --> $DIR/sealed-trait-local.rs:54:20
+   |
+LL | impl e::Sealed for S {}
+   |                    ^ the trait `f::Hidden` is not implemented for `S`
+   |
+note: required by a bound in `e::Sealed`
+  --> $DIR/sealed-trait-local.rs:35:23
+   |
+LL |     pub trait Sealed: self::f::Hidden {
+   |                       ^^^^^^^^^^^^^^^ required by this bound in `Sealed`
+   = note: `Sealed` is a "sealed trait", because to implement it you also need to implement `e::f::Hidden`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following types implement the trait:
+             e::X
+             e::Y
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
```
error[E0277]: the trait bound `S: d::Hidden` is not satisfied
  --> $DIR/sealed-trait-local.rs:53:20
   |
LL | impl c::Sealed for S {}
   |                    ^ the trait `d::Hidden` is not implemented for `S`
   |
note: required by a bound in `c::Sealed`
  --> $DIR/sealed-trait-local.rs:17:23
   |
LL |     pub trait Sealed: self::d::Hidden {
   |                       ^^^^^^^^^^^^^^^ required by this bound in `Sealed`
   = note: `Sealed` is a "sealed trait", because to implement it you also need to implement `c::d::Hidden`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
            - c::X
            - c::Y
```

The last `help` is new.