### PR TITLE
Use shell parsing for response files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3747,6 +3747,7 @@ dependencies = [
  "rustc_trait_selection",
  "rustc_ty_utils",
  "serde_json",
+ "shlex",
  "time",
  "tracing",
  "windows",
@@ -4950,9 +4951,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "siphasher"

--- a/compiler/rustc_driver_impl/Cargo.toml
+++ b/compiler/rustc_driver_impl/Cargo.toml
@@ -52,6 +52,7 @@ rustc_target = { path = "../rustc_target" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_ty_utils = { path = "../rustc_ty_utils" }
 serde_json = "1.0.59"
+shlex = { version = "1.2" }
 time = { version = "0.3", default-features = false, features = ["alloc", "formatting"] }
 tracing = { version = "0.1.35" }
 # tidy-alphabetical-end

--- a/compiler/rustc_driver_impl/src/args.rs
+++ b/compiler/rustc_driver_impl/src/args.rs
@@ -14,7 +14,19 @@ fn arg_expand(arg: String) -> Result<Vec<String>, Error> {
             }
             Err(err) => return Err(Error::IOError(path.to_string(), err)),
         };
-        Ok(file.lines().map(ToString::to_string).collect())
+        let mut result = Vec::new();
+        for line in file.lines() {
+            match shlex::split(line) {
+                Some(v) => result.extend(v),
+                None => {
+                    return Err(Error::IOError(
+                        path.to_string(),
+                        io::Error::other("invalid shell syntax"),
+                    ));
+                }
+            }
+        }
+        Ok(result)
     } else {
         Ok(vec![arg])
     }

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -248,6 +248,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "sha1",
     "sha2",
     "sharded-slab",
+    "shlex",
     "smallvec",
     "snap",
     "stable_deref_trait",


### PR DESCRIPTION
It turns out that #116610 is inadequate, we actually need rustc to perform shell parsing on the lines in response files. This will require adding a dep to the compiler: https://crates.io/crates/shlex

Both clang and gcc do shlex parsing, so it seems reasonable to make rustc do the same. However this would technically be a breaking change if some build system was relying on being able to pass unquoted arguments with spaces in them in a response file and having rustc interpret them as a single arg. To me that scenario seems pretty unlikely, but I'd understand if people want to be more cautious.

How should we proceed? We could do any of:
- Add some tests and land as-is assuming that no one relies on the current lack of shell parsing
- Perform a crater run with this change and then do ^ with more confidence. Unfortunately crater doesn't do a good job of detecting breakages due to this change because cargo doesn't use response files. We'd expect ninja/make/bazel/buck/etc. build systems to be the ones affected by this. We could do a survey of build tools with rust support but I'd guess that because all of those tools interface with c compilers that _do_ perform shlex parsing they'd be quoting their args correctly in the first place.
- Write an MCP so that the compiler maintainers can sign off on the breaking change before we merge it.
- Add a new unstable flag such as `-Z response_file_shlex` that enables this new behavior for all response files on the command line
  - If it's necessary to be able to mix both types of response file handling, it could work like `-Bstatic`/`-Bdynamic` where they toggle it for any response files after the flag
  - We could also have the flag apply to a specific file