### PR TITLE
Do not bold main message in `--error-format=short`

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1348,7 +1348,14 @@ impl EmitterWriter {
                 buffer.append(0, "]", Style::Level(*level));
                 label_width += 2 + code.len();
             }
-            let header_style = if is_secondary { Style::HeaderMsg } else { Style::MainHeaderMsg };
+            let header_style = if is_secondary {
+                Style::HeaderMsg
+            } else if self.short_message {
+                // For short messages avoid bolding the message, as it doesn't look great (#63835).
+                Style::NoStyle
+            } else {
+                Style::MainHeaderMsg
+            };
             if *level != Level::FailureNote {
                 buffer.append(0, ": ", header_style);
                 label_width += 2;


### PR DESCRIPTION
Fix #63835.

Before:

<img width="484" alt="Screenshot 2023-10-19 at 3 52 53 PM" src="https://github.com/rust-lang/rust/assets/1606434/9bd6cbd5-a4ce-4cc3-8c5f-60a8d3ad38da">

After:

<img width="492" alt="Screenshot 2023-10-19 at 3 52 32 PM" src="https://github.com/rust-lang/rust/assets/1606434/0cf2417a-08f2-4074-860c-a88a838a4209">
