### PR TITLE
Move where doc comment meant as comment check

### DIFF
--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -632,23 +632,6 @@ impl<'a> Parser<'a> {
                         // Recover from parser, skip type error to avoid extra errors.
                         Ok(true) => true,
                         Err(mut e) => {
-                            if let TokenKind::DocComment(..) = self.token.kind
-                                && let Ok(snippet) = self.span_to_snippet(self.token.span)
-                            {
-                                let sp = self.token.span;
-                                let marker = &snippet[..3];
-                                let (comment_marker, doc_comment_marker) = marker.split_at(2);
-
-                                e.span_suggestion(
-                                    sp.with_hi(sp.lo() + BytePos(marker.len() as u32)),
-                                    format!(
-                                        "add a space before `{doc_comment_marker}` to use a regular comment",
-                                    ),
-                                    format!("{comment_marker} {doc_comment_marker}"),
-                                    Applicability::MaybeIncorrect,
-                                );
-                            }
-
                             if self.recover_colon_as_semi() {
                                 // recover_colon_as_semi has already emitted a nicer error.
                                 e.delay_as_bug();

--- a/tests/ui/parser/doc-comment-in-stmt.fixed
+++ b/tests/ui/parser/doc-comment-in-stmt.fixed
@@ -2,26 +2,26 @@
 #![allow(unused)]
 fn foo() -> bool {
     false
-    //!self.allow_ty_infer()
+    // !self.allow_ty_infer()
     //~^ ERROR found doc comment
 }
 
 fn bar() -> bool {
     false
-    /*! bar */ //~ ERROR found doc comment
+    /* ! bar */ //~ ERROR found doc comment
 }
 
 fn baz() -> i32 {
-    1 /** baz */ //~ ERROR found doc comment
+    1 /* * baz */ //~ ERROR found doc comment
 }
 
 fn quux() -> i32 {
-    2 /// quux
+    2 // / quux
     //~^ ERROR found doc comment
 }
 
 fn main() {
     let x = 0;
-    let y = x.max(1) //!foo //~ ERROR found doc comment
+    let y = x.max(1) // !foo //~ ERROR found doc comment
         .min(2);
 }

--- a/tests/ui/parser/doc-comment-in-stmt.stderr
+++ b/tests/ui/parser/doc-comment-in-stmt.stderr
@@ -1,50 +1,61 @@
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found doc comment `//!self.allow_ty_infer()`
-  --> $DIR/doc-comment-in-stmt.rs:3:5
+  --> $DIR/doc-comment-in-stmt.rs:5:5
    |
 LL |     false
    |          - expected one of `.`, `;`, `?`, `}`, or an operator
 LL |     //!self.allow_ty_infer()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ unexpected token
    |
-help: add a space before `!` to use a regular comment
+help: add a space before `!` to write a regular comment
    |
 LL |     // !self.allow_ty_infer()
-   |     ~~~~
+   |       +
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found doc comment `/*! bar */`
-  --> $DIR/doc-comment-in-stmt.rs:9:5
+  --> $DIR/doc-comment-in-stmt.rs:11:5
    |
 LL |     false
    |          - expected one of `.`, `;`, `?`, `}`, or an operator
 LL |     /*! bar */
    |     ^^^^^^^^^^ unexpected token
    |
-help: add a space before `!` to use a regular comment
+help: add a space before `!` to write a regular comment
    |
 LL |     /* ! bar */
-   |     ~~~~
+   |       +
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found doc comment `/** baz */`
-  --> $DIR/doc-comment-in-stmt.rs:13:7
+  --> $DIR/doc-comment-in-stmt.rs:15:7
    |
 LL |     1 /** baz */
    |       ^^^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
    |
-help: add a space before `*` to use a regular comment
+help: add a space before the last `*` to write a regular comment
    |
 LL |     1 /* * baz */
-   |       ~~~~
+   |         +
 
-error: expected one of `.`, `;`, `?`, `}`, or an operator, found doc comment `/*! quux */`
-  --> $DIR/doc-comment-in-stmt.rs:17:7
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found doc comment `/// quux`
+  --> $DIR/doc-comment-in-stmt.rs:19:7
    |
-LL |     2 /*! quux */
-   |       ^^^^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
+LL |     2 /// quux
+   |       ^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
    |
-help: add a space before `!` to use a regular comment
+help: add a space before the last `/` to write a regular comment
    |
-LL |     2 /* ! quux */
-   |       ~~~~
+LL |     2 // / quux
+   |         +
 
-error: aborting due to 4 previous errors
+error: expected one of `.`, `;`, `?`, `else`, or an operator, found doc comment `//!foo
+  --> $DIR/doc-comment-in-stmt.rs:25:22
+   |
+LL |     let y = x.max(1) //!foo
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected one of `.`, `;`, `?`, `else`, or an operator
+   |
+help: add a space before `!` to write a regular comment
+   |
+LL |     let y = x.max(1) // !foo
+   |                        +
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
The new place makes more sense and covers more cases beyond individual statements.

```
error: expected one of `.`, `;`, `?`, `else`, or an operator, found doc comment `//!foo
  --> $DIR/doc-comment-in-stmt.rs:25:22
   |
LL |     let y = x.max(1) //!foo
   |                      ^^^^^^ expected one of `.`, `;`, `?`, `else`, or an operator
   |
help: add a space before `!` to write a regular comment
   |
LL |     let y = x.max(1) // !foo
   |                        +
```

Fix #65329.