### PR TITLE
Prepare the `bootstrap` tool for the new check-cfg syntax

### DIFF
--- a/src/bootstrap/src/bin/rustdoc.rs
+++ b/src/bootstrap/src/bin/rustdoc.rs
@@ -70,7 +70,9 @@ fn main() {
         cmd.arg("--cfg=bootstrap");
     }
     cmd.arg("-Zunstable-options");
+    // #[cfg(bootstrap)]
     cmd.arg("--check-cfg=values(bootstrap)");
+    // cmd.arg("--check-cfg=cfg(bootstrap)");
 
     if verbose > 1 {
         eprintln!(

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1401,19 +1401,28 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Zunstable-options");
         }
 
-        // Enable cfg checking of cargo features for everything but std and also enable cfg
-        // checking of names and values.
+        // #[cfg(bootstrap)] should remove every code path where it's false
+        const USE_NEW_CHECK_CFG_SYNTAX: bool = false;
+
+        // Enable compile-time checking of `cfg` names, values and Cargo `features`.
         //
         // Note: `std`, `alloc` and `core` imports some dependencies by #[path] (like
         // backtrace, core_simd, std_float, ...), those dependencies have their own
         // features but cargo isn't involved in the #[path] process and so cannot pass the
         // complete list of features, so for that reason we don't enable checking of
         // features for std crates.
-        cargo.arg(if mode != Mode::Std {
-            "-Zcheck-cfg=names,values,output,features"
+        if USE_NEW_CHECK_CFG_SYNTAX {
+            cargo.arg("-Zcheck-cfg");
+            if mode == Mode::Std {
+                rustflags.arg("--check-cfg=cfg(feature,values(any()))");
+            }
         } else {
-            "-Zcheck-cfg=names,values,output"
-        });
+            cargo.arg(if mode != Mode::Std {
+                "-Zcheck-cfg=names,values,output,features"
+            } else {
+                "-Zcheck-cfg=names,values,output"
+            });
+        }
 
         // Add extra cfg not defined in/by rustc
         //
@@ -1433,7 +1442,12 @@ impl<'a> Builder<'a> {
                         .collect::<String>(),
                     None => String::new(),
                 };
-                rustflags.arg(&format!("--check-cfg=values({name}{values})"));
+                if USE_NEW_CHECK_CFG_SYNTAX {
+                    let values = values.strip_prefix(",").unwrap_or(&values); // remove the first `,`
+                    rustflags.arg(&format!("--check-cfg=cfg({name},values({values}))"));
+                } else {
+                    rustflags.arg(&format!("--check-cfg=values({name}{values})"));
+                }
             }
         }
 
@@ -1449,7 +1463,11 @@ impl<'a> Builder<'a> {
         // We also declare that the flag is expected, which we need to do to not
         // get warnings about it being unexpected.
         hostflags.arg("-Zunstable-options");
-        hostflags.arg("--check-cfg=values(bootstrap)");
+        if USE_NEW_CHECK_CFG_SYNTAX {
+            hostflags.arg("--check-cfg=cfg(bootstrap)");
+        } else {
+            hostflags.arg("--check-cfg=values(bootstrap)");
+        }
 
         // FIXME: It might be better to use the same value for both `RUSTFLAGS` and `RUSTDOCFLAGS`,
         // but this breaks CI. At the very least, stage0 `rustdoc` needs `--cfg bootstrap`. See

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1401,8 +1401,8 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Zunstable-options");
         }
 
-        // #[cfg(bootstrap)] should remove every code path where it's false
-        const USE_NEW_CHECK_CFG_SYNTAX: bool = false;
+        // #[cfg(bootstrap)]
+        let use_new_check_cfg_syntax = self.local_rebuild;
 
         // Enable compile-time checking of `cfg` names, values and Cargo `features`.
         //
@@ -1411,7 +1411,7 @@ impl<'a> Builder<'a> {
         // features but cargo isn't involved in the #[path] process and so cannot pass the
         // complete list of features, so for that reason we don't enable checking of
         // features for std crates.
-        if USE_NEW_CHECK_CFG_SYNTAX {
+        if use_new_check_cfg_syntax {
             cargo.arg("-Zcheck-cfg");
             if mode == Mode::Std {
                 rustflags.arg("--check-cfg=cfg(feature,values(any()))");
@@ -1442,7 +1442,7 @@ impl<'a> Builder<'a> {
                         .collect::<String>(),
                     None => String::new(),
                 };
-                if USE_NEW_CHECK_CFG_SYNTAX {
+                if use_new_check_cfg_syntax {
                     let values = values.strip_prefix(",").unwrap_or(&values); // remove the first `,`
                     rustflags.arg(&format!("--check-cfg=cfg({name},values({values}))"));
                 } else {
@@ -1463,7 +1463,7 @@ impl<'a> Builder<'a> {
         // We also declare that the flag is expected, which we need to do to not
         // get warnings about it being unexpected.
         hostflags.arg("-Zunstable-options");
-        if USE_NEW_CHECK_CFG_SYNTAX {
+        if use_new_check_cfg_syntax {
             hostflags.arg("--check-cfg=cfg(bootstrap)");
         } else {
             hostflags.arg("--check-cfg=values(bootstrap)");


### PR DESCRIPTION
This PR prepare the `bootstrap` tool for the [new check-cfg syntax](https://github.com/rust-lang/rust/pull/111072) as well as the according [changes to Cargo](https://github.com/rust-lang/cargo/pull/12845).

~~Note that while the new syntax can technically available on stage > 2, we actually cannot use it since we need a cargo version that supports the new syntax which won't happen until the next beta bump (if I understand everything correctly).~~

r? bootstrap