### PR TITLE
Mention `into_iter` on borrow errors suggestions when appropriate

### DIFF
--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -10,6 +10,10 @@ LL |     x.use_mut();
    |     - borrow later used here
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider consuming the `Vec<i32>` when turning it into an `Iterator`
+   |
+LL |     let mut x = vec![1].into_iter();
+   |                         ~~~~~~~~~
 help: consider using a `let` binding to create a longer lived value
    |
 LL ~     let binding = vec![1];


### PR DESCRIPTION
If we encounter a borrow error on `vec![1, 2, 3].iter()`, suggest `into_iter`.

Fix #68445.