### PR TITLE
Mention the syntax for `use` on `mod foo;` if `foo` doesn't exist

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -86,6 +86,7 @@ expand_module_circular =
 expand_module_file_not_found =
     file not found for module `{$name}`
     .help = to create the module `{$name}`, create file "{$default_path}" or "{$secondary_path}"
+    .note = if there is a `mod {$name}` elsewhere in the crate already, import it with `use crate::...` instead
 
 expand_module_in_block =
     cannot declare a non-inline module inside a block unless it has a path attribute

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -350,6 +350,7 @@ pub(crate) struct ModuleInBlockName {
 #[derive(Diagnostic)]
 #[diag(expand_module_file_not_found, code = "E0583")]
 #[help]
+#[note]
 pub(crate) struct ModuleFileNotFound {
     #[primary_span]
     pub span: Span,

--- a/tests/run-make/unknown-mod-stdin/unknown-mod.stderr
+++ b/tests/run-make/unknown-mod-stdin/unknown-mod.stderr
@@ -5,6 +5,7 @@ error[E0583]: file not found for module `unknown`
   | ^^^^^^^^^^^^
   |
   = help: to create the module `unknown`, create file "unknown.rs" or "unknown/mod.rs"
+  = note: if there is a `mod unknown` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0583.stderr
+++ b/tests/ui/error-codes/E0583.stderr
@@ -5,6 +5,7 @@ LL | mod module_that_doesnt_exist;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: to create the module `module_that_doesnt_exist`, create file "$DIR/module_that_doesnt_exist.rs" or "$DIR/module_that_doesnt_exist/mod.rs"
+   = note: if there is a `mod module_that_doesnt_exist` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/invalid-module-declaration/invalid-module-declaration.stderr
+++ b/tests/ui/invalid-module-declaration/invalid-module-declaration.stderr
@@ -5,6 +5,7 @@ LL | pub mod baz;
    | ^^^^^^^^^^^^
    |
    = help: to create the module `baz`, create file "$DIR/auxiliary/foo/bar/baz.rs" or "$DIR/auxiliary/foo/bar/baz/mod.rs"
+   = note: if there is a `mod baz` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod.stderr
+++ b/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod.stderr
@@ -5,6 +5,7 @@ LL | mod missing;
    | ^^^^^^^^^^^^
    |
    = help: to create the module `missing`, create file "$DIR/foo/missing.rs" or "$DIR/foo/missing/mod.rs"
+   = note: if there is a `mod missing` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod_inline.stderr
+++ b/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod_inline.stderr
@@ -5,6 +5,7 @@ LL |     mod missing;
    |     ^^^^^^^^^^^^
    |
    = help: to create the module `missing`, create file "$DIR/foo_inline/inline/missing.rs" or "$DIR/foo_inline/inline/missing/mod.rs"
+   = note: if there is a `mod missing` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/modules/special_module_name.stderr
+++ b/tests/ui/modules/special_module_name.stderr
@@ -5,6 +5,7 @@ LL | mod lib;
    | ^^^^^^^^
    |
    = help: to create the module `lib`, create file "$DIR/lib.rs" or "$DIR/lib/mod.rs"
+   = note: if there is a `mod lib` elsewhere in the crate already, import it with `use crate::...` instead
 
 error[E0583]: file not found for module `main`
   --> $DIR/special_module_name.rs:4:1
@@ -13,6 +14,7 @@ LL | mod main;
    | ^^^^^^^^^
    |
    = help: to create the module `main`, create file "$DIR/main.rs" or "$DIR/main/mod.rs"
+   = note: if there is a `mod main` elsewhere in the crate already, import it with `use crate::...` instead
 
 warning: found module declaration for lib.rs
   --> $DIR/special_module_name.rs:1:1

--- a/tests/ui/parser/mod_file_not_exist.stderr
+++ b/tests/ui/parser/mod_file_not_exist.stderr
@@ -5,6 +5,7 @@ LL | mod not_a_real_file;
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs" or "$DIR/not_a_real_file/mod.rs"
+   = note: if there is a `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::...` instead
 
 error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
   --> $DIR/mod_file_not_exist.rs:7:16

--- a/tests/ui/parser/mod_file_not_exist_windows.stderr
+++ b/tests/ui/parser/mod_file_not_exist_windows.stderr
@@ -5,6 +5,7 @@ LL | mod not_a_real_file;
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs" or "$DIR/not_a_real_file/mod.rs"
+   = note: if there is a `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::...` instead
 
 error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
   --> $DIR/mod_file_not_exist_windows.rs:7:16

--- a/tests/ui/parser/unsafe-mod.stderr
+++ b/tests/ui/parser/unsafe-mod.stderr
@@ -5,6 +5,7 @@ LL | unsafe mod n;
    | ^^^^^^^^^^^^^
    |
    = help: to create the module `n`, create file "$DIR/n.rs" or "$DIR/n/mod.rs"
+   = note: if there is a `mod n` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: module cannot be declared unsafe
   --> $DIR/unsafe-mod.rs:1:1

--- a/tests/ui/rfcs/rfc-2457-non-ascii-idents/mod_file_nonascii_forbidden.stderr
+++ b/tests/ui/rfcs/rfc-2457-non-ascii-idents/mod_file_nonascii_forbidden.stderr
@@ -5,6 +5,7 @@ LL | mod řųśť;
    | ^^^^^^^^^
    |
    = help: to create the module `řųśť`, create file "$DIR/řųśť.rs" or "$DIR/řųśť/mod.rs"
+   = note: if there is a `mod řųśť` elsewhere in the crate already, import it with `use crate::...` instead
 
 error[E0754]: trying to load file for module `řųśť` with non-ascii identifier name
   --> $DIR/mod_file_nonascii_forbidden.rs:1:5


### PR DESCRIPTION
Newcomers might get confused that `mod` is the only way of defining scopes, and that it can be used as if it were `use`.

Fix #69492.