### PR TITLE
Remove the DefPathHash check

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -332,16 +332,6 @@ impl<'tcx> Inliner<'tcx> {
         }
 
         if callee_def_id.is_local() {
-            // Avoid a cycle here by only using `instance_mir` only if we have
-            // a lower `DefPathHash` than the callee. This ensures that the callee will
-            // not inline us. This trick even works with incremental compilation,
-            // since `DefPathHash` is stable.
-            if self.tcx.def_path_hash(caller_def_id).local_hash()
-                < self.tcx.def_path_hash(callee_def_id).local_hash()
-            {
-                return Ok(());
-            }
-
             // If we know for sure that the function we're calling will itself try to
             // call us, then we avoid inlining that function.
             if self.tcx.mir_callgraph_reachable((*callee, caller_def_id.expect_local())) {

--- a/tests/mir-opt/inline/cycle.g.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/cycle.g.Inline.panic-abort.diff
@@ -4,35 +4,16 @@
   fn g() -> () {
       let mut _0: ();
       let _1: ();
-+     let mut _2: fn() {main};
-+     scope 1 (inlined f::<fn() {main}>) {
-+         debug g => _2;
-+         let mut _3: &fn() {main};
-+         let _4: ();
-+     }
   
       bb0: {
           StorageLive(_1);
--         _1 = f::<fn() {main}>(main) -> [return: bb1, unwind unreachable];
-+         StorageLive(_2);
-+         _2 = main;
-+         StorageLive(_4);
-+         StorageLive(_3);
-+         _3 = &_2;
-+         _4 = <fn() {main} as Fn<()>>::call(move _3, const ()) -> [return: bb2, unwind unreachable];
+          _1 = f::<fn() {main}>(main) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
-+         StorageDead(_4);
-+         StorageDead(_2);
           StorageDead(_1);
           _0 = const ();
           return;
-+     }
-+ 
-+     bb2: {
-+         StorageDead(_3);
-+         drop(_2) -> [return: bb1, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline/cycle.g.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.g.Inline.panic-unwind.diff
@@ -4,43 +4,16 @@
   fn g() -> () {
       let mut _0: ();
       let _1: ();
-+     let mut _2: fn() {main};
-+     scope 1 (inlined f::<fn() {main}>) {
-+         debug g => _2;
-+         let mut _3: &fn() {main};
-+         let _4: ();
-+     }
   
       bb0: {
           StorageLive(_1);
--         _1 = f::<fn() {main}>(main) -> [return: bb1, unwind continue];
-+         StorageLive(_2);
-+         _2 = main;
-+         StorageLive(_4);
-+         StorageLive(_3);
-+         _3 = &_2;
-+         _4 = <fn() {main} as Fn<()>>::call(move _3, const ()) -> [return: bb2, unwind: bb3];
+          _1 = f::<fn() {main}>(main) -> [return: bb1, unwind continue];
       }
   
       bb1: {
-+         StorageDead(_4);
-+         StorageDead(_2);
           StorageDead(_1);
           _0 = const ();
           return;
-+     }
-+ 
-+     bb2: {
-+         StorageDead(_3);
-+         drop(_2) -> [return: bb1, unwind continue];
-+     }
-+ 
-+     bb3 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb4 (cleanup): {
-+         resume;
       }
   }
   

--- a/tests/mir-opt/inline/cycle.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/cycle.main.Inline.panic-abort.diff
@@ -4,35 +4,16 @@
   fn main() -> () {
       let mut _0: ();
       let _1: ();
-+     let mut _2: fn() {g};
-+     scope 1 (inlined f::<fn() {g}>) {
-+         debug g => _2;
-+         let mut _3: &fn() {g};
-+         let _4: ();
-+     }
   
       bb0: {
           StorageLive(_1);
--         _1 = f::<fn() {g}>(g) -> [return: bb1, unwind unreachable];
-+         StorageLive(_2);
-+         _2 = g;
-+         StorageLive(_4);
-+         StorageLive(_3);
-+         _3 = &_2;
-+         _4 = <fn() {g} as Fn<()>>::call(move _3, const ()) -> [return: bb2, unwind unreachable];
+          _1 = f::<fn() {g}>(g) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
-+         StorageDead(_4);
-+         StorageDead(_2);
           StorageDead(_1);
           _0 = const ();
           return;
-+     }
-+ 
-+     bb2: {
-+         StorageDead(_3);
-+         drop(_2) -> [return: bb1, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline/cycle.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/cycle.main.Inline.panic-unwind.diff
@@ -4,43 +4,16 @@
   fn main() -> () {
       let mut _0: ();
       let _1: ();
-+     let mut _2: fn() {g};
-+     scope 1 (inlined f::<fn() {g}>) {
-+         debug g => _2;
-+         let mut _3: &fn() {g};
-+         let _4: ();
-+     }
   
       bb0: {
           StorageLive(_1);
--         _1 = f::<fn() {g}>(g) -> [return: bb1, unwind continue];
-+         StorageLive(_2);
-+         _2 = g;
-+         StorageLive(_4);
-+         StorageLive(_3);
-+         _3 = &_2;
-+         _4 = <fn() {g} as Fn<()>>::call(move _3, const ()) -> [return: bb2, unwind: bb3];
+          _1 = f::<fn() {g}>(g) -> [return: bb1, unwind continue];
       }
   
       bb1: {
-+         StorageDead(_4);
-+         StorageDead(_2);
           StorageDead(_1);
           _0 = const ();
           return;
-+     }
-+ 
-+     bb2: {
-+         StorageDead(_3);
-+         drop(_2) -> [return: bb1, unwind continue];
-+     }
-+ 
-+     bb3 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb4 (cleanup): {
-+         resume;
       }
   }
   

--- a/tests/mir-opt/inline/cycle.rs
+++ b/tests/mir-opt/inline/cycle.rs
@@ -14,16 +14,12 @@ fn f(g: impl Fn()) {
 fn g() {
     // CHECK-LABEL: fn g(
     // CHECK-NOT: inlined
-    // CHECK: (inlined f::<fn() {main}>)
-    // CHECK-NOT: inlined
     f(main);
 }
 
 // EMIT_MIR cycle.main.Inline.diff
 fn main() {
     // CHECK-LABEL: fn main(
-    // CHECK-NOT: inlined
-    // CHECK: (inlined f::<fn() {g}>)
     // CHECK-NOT: inlined
     f(g);
 }


### PR DESCRIPTION
Just wondering how much perf this is worth

So the answer is "Some, but not a lot". I suspect the better implementation here is to precompute more of the call graph, but all my attempts to do that and thus fix the perf regression have resulted in query cycles between `optimized_mir` and `cross_crate_inlinable`. 

r? @ghost