### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -86,6 +86,7 @@ expand_module_circular =
 expand_module_file_not_found =
     file not found for module `{$name}`
     .help = to create the module `{$name}`, create file "{$default_path}" or "{$secondary_path}"
+    .note = if there is a `mod {$name}` elsewhere in the crate already, import it with `use crate::...` instead
 
 expand_module_in_block =
     cannot declare a non-inline module inside a block unless it has a path attribute

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -350,6 +350,7 @@ pub(crate) struct ModuleInBlockName {
 #[derive(Diagnostic)]
 #[diag(expand_module_file_not_found, code = "E0583")]
 #[help]
+#[note]
 pub(crate) struct ModuleFileNotFound {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1557,38 +1557,24 @@ fn compare_number_of_generics<'tcx>(
                 DiagnosticId::Error("E0049".into()),
             );
 
-            let mut suffix = None;
-
+            let msg =
+                format!("expected {trait_count} {kind} parameter{}", pluralize!(trait_count),);
             if let Some(spans) = trait_spans {
                 let mut spans = spans.iter();
                 if let Some(span) = spans.next() {
-                    err.span_label(
-                        *span,
-                        format!(
-                            "expected {} {} parameter{}",
-                            trait_count,
-                            kind,
-                            pluralize!(trait_count),
-                        ),
-                    );
+                    err.span_label(*span, msg);
                 }
                 for span in spans {
                     err.span_label(*span, "");
                 }
             } else {
-                suffix = Some(format!(", expected {trait_count}"));
+                err.span_label(tcx.def_span(trait_.def_id), msg);
             }
 
             if let Some(span) = span {
                 err.span_label(
                     span,
-                    format!(
-                        "found {} {} parameter{}{}",
-                        impl_count,
-                        kind,
-                        pluralize!(impl_count),
-                        suffix.unwrap_or_default(),
-                    ),
+                    format!("found {} {} parameter{}", impl_count, kind, pluralize!(impl_count),),
                 );
             }
 

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -1,0 +1,61 @@
+//! Module containing the translation from stable mir constructs to the rustc counterpart.
+//!
+//! This module will only include a few constructs to allow users to invoke internal rustc APIs
+//! due to incomplete stable coverage.
+
+// Prefer importing stable_mir over internal rustc constructs to make this file more readable.
+use crate::rustc_smir::{MaybeStable, Tables};
+use rustc_middle::ty::{self as rustc_ty, Ty as InternalTy};
+use stable_mir::ty::{Const, GenericArgKind, GenericArgs, Region, Ty};
+use stable_mir::DefId;
+
+use super::RustcInternal;
+
+impl<'tcx> RustcInternal<'tcx> for DefId {
+    type T = rustc_span::def_id::DefId;
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        tables.def_ids[*self]
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for GenericArgs {
+    type T = rustc_ty::GenericArgsRef<'tcx>;
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        tables.tcx.mk_args_from_iter(self.0.iter().map(|arg| arg.internal(tables)))
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for GenericArgKind {
+    type T = rustc_ty::GenericArg<'tcx>;
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            GenericArgKind::Lifetime(reg) => reg.internal(tables).into(),
+            GenericArgKind::Type(ty) => ty.internal(tables).into(),
+            GenericArgKind::Const(cnst) => cnst.internal(tables).into(),
+        }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for Region {
+    type T = rustc_ty::Region<'tcx>;
+    fn internal(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+        todo!()
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for Ty {
+    type T = InternalTy<'tcx>;
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        match tables.types[self.0] {
+            MaybeStable::Stable(_) => todo!(),
+            MaybeStable::Rustc(ty) => ty,
+        }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for Const {
+    type T = rustc_ty::Const<'tcx>;
+    fn internal(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+        todo!()
+    }
+}

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -20,6 +20,8 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::{ControlFlow, Index};
 
+mod internal;
+
 impl<'tcx> Index<stable_mir::DefId> for Tables<'tcx> {
     type Output = DefId;
 
@@ -230,4 +232,12 @@ impl<K: PartialEq + Hash + Eq, V: Copy + Debug + PartialEq + IndexedVal> Index<V
         assert_eq!(*v, index, "Provided value doesn't match with indexed value");
         k
     }
+}
+
+/// Trait used to translate a stable construct to its rustc counterpart.
+///
+/// This is basically a mirror of [crate::rustc_smir::Stable].
+pub(crate) trait RustcInternal<'tcx> {
+    type T;
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T;
 }

--- a/compiler/rustc_smir/src/rustc_smir/builder.rs
+++ b/compiler/rustc_smir/src/rustc_smir/builder.rs
@@ -1,0 +1,55 @@
+//! Logic required to produce a monomorphic stable body.
+//!
+//! We first retrieve and monomorphize the rustc body representation, i.e., we generate a
+//! monomorphic body using internal representation.
+//! After that, we convert the internal representation into a stable one.
+use crate::rustc_smir::{Stable, Tables};
+use rustc_middle::mir;
+use rustc_middle::mir::visit::MutVisitor;
+use rustc_middle::ty::{self, Ty, TyCtxt};
+
+/// Builds a monomorphic body for a given instance.
+pub struct BodyBuilder<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    instance: ty::Instance<'tcx>,
+}
+
+impl<'tcx> BodyBuilder<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>, instance: ty::Instance<'tcx>) -> Self {
+        BodyBuilder { tcx, instance }
+    }
+
+    pub fn build(mut self, tables: &mut Tables<'tcx>) -> stable_mir::mir::Body {
+        let mut body = self.tcx.instance_mir(self.instance.def).clone();
+        let generics = self.tcx.generics_of(self.instance.def_id());
+        if generics.requires_monomorphization(self.tcx) {
+            self.visit_body(&mut body);
+        }
+        body.stable(tables)
+    }
+
+    fn monomorphize<T>(&self, value: T) -> T
+    where
+        T: ty::TypeFoldable<TyCtxt<'tcx>>,
+    {
+        self.instance.instantiate_mir_and_normalize_erasing_regions(
+            self.tcx,
+            ty::ParamEnv::reveal_all(),
+            ty::EarlyBinder::bind(value),
+        )
+    }
+}
+
+impl<'tcx> MutVisitor<'tcx> for BodyBuilder<'tcx> {
+    fn visit_ty_const(&mut self, ct: &mut ty::Const<'tcx>, _location: mir::Location) {
+        *ct = self.monomorphize(*ct);
+    }
+
+    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _: mir::visit::TyContext) {
+        *ty = self.monomorphize(*ty);
+    }
+
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+}

--- a/compiler/stable_mir/src/error.rs
+++ b/compiler/stable_mir/src/error.rs
@@ -4,6 +4,7 @@
 //! - [CompilerError]: This represents errors that can be raised when invoking the compiler.
 //! - [Error]: Generic error that represents the reason why a request that could not be fulfilled.
 
+use std::convert::From;
 use std::fmt::{Debug, Display, Formatter};
 use std::{error, fmt};
 
@@ -28,6 +29,12 @@ pub struct Error(String);
 impl Error {
     pub(crate) fn new(msg: String) -> Self {
         Self(msg)
+    }
+}
+
+impl From<&str> for Error {
+    fn from(value: &str) -> Self {
+        Self(value.into())
     }
 }
 

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -39,6 +39,7 @@ pub mod visitor;
 
 pub use error::*;
 use mir::mono::Instance;
+use ty::{FnDef, GenericArgs};
 
 /// Use String for now but we should replace it.
 pub type Symbol = String;
@@ -233,6 +234,9 @@ pub trait Context {
 
     /// Item requires monomorphization.
     fn requires_monomorphization(&self, def_id: DefId) -> bool;
+
+    /// Resolve an instance from the given function definition and generic arguments.
+    fn resolve_instance(&mut self, def: FnDef, args: &GenericArgs) -> Option<Instance>;
 }
 
 // A thread local variable that stores a pointer to the tables mapping between TyCtxt

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -5,8 +5,10 @@ use crate::{ty::Ty, Span};
 #[derive(Clone, Debug)]
 pub struct Body {
     pub blocks: Vec<BasicBlock>,
-    pub locals: Vec<LocalDecl>,
+    pub locals: LocalDecls,
 }
+
+type LocalDecls = Vec<LocalDecl>;
 
 #[derive(Clone, Debug)]
 pub struct LocalDecl {
@@ -344,6 +346,7 @@ pub enum Operand {
 #[derive(Clone, Debug)]
 pub struct Place {
     pub local: Local,
+    /// projection out of a place (access a field, deref a pointer, etc)
     pub projection: String,
 }
 
@@ -461,4 +464,26 @@ pub enum NullOp {
     AlignOf,
     /// Returns the offset of a field.
     OffsetOf(Vec<FieldIdx>),
+}
+
+impl Operand {
+    pub fn ty(&self, locals: &LocalDecls) -> Ty {
+        match self {
+            Operand::Copy(place) | Operand::Move(place) => place.ty(locals),
+            Operand::Constant(c) => c.ty(),
+        }
+    }
+}
+
+impl Constant {
+    pub fn ty(&self) -> Ty {
+        self.literal.ty
+    }
+}
+
+impl Place {
+    pub fn ty(&self, locals: &LocalDecls) -> Ty {
+        let _start_ty = locals[self.local].ty;
+        todo!("Implement projection")
+    }
 }

--- a/compiler/stable_mir/src/mir/mono.rs
+++ b/compiler/stable_mir/src/mir/mono.rs
@@ -1,5 +1,5 @@
 use crate::mir::Body;
-use crate::ty::{IndexedVal, Ty};
+use crate::ty::{FnDef, GenericArgs, IndexedVal, Ty};
 use crate::{with, CrateItem, DefId, Error, Opaque};
 use std::fmt::Debug;
 
@@ -40,6 +40,15 @@ impl Instance {
     /// Get the instance type with generic substitutions applied and lifetimes erased.
     pub fn ty(&self) -> Ty {
         with(|context| context.instance_ty(self.def))
+    }
+
+    /// Resolve an instance starting from a function definition and generic arguments.
+    pub fn resolve(def: FnDef, args: &GenericArgs) -> Result<Instance, crate::Error> {
+        with(|context| {
+            context.resolve_instance(def, args).ok_or_else(|| {
+                crate::Error::new(format!("Failed to resolve `{def:?}` with `{args:?}`"))
+            })
+        })
     }
 }
 

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -225,6 +225,8 @@ pub struct ImplDef(pub DefId);
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct RegionDef(pub DefId);
 
+/// A list of generic arguments.
+/// The second field is for internal usage to allow retrieving the internal representation.
 #[derive(Clone, Debug)]
 pub struct GenericArgs(pub Vec<GenericArgKind>);
 

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -226,7 +226,6 @@ pub struct ImplDef(pub DefId);
 pub struct RegionDef(pub DefId);
 
 /// A list of generic arguments.
-/// The second field is for internal usage to allow retrieving the internal representation.
 #[derive(Clone, Debug)]
 pub struct GenericArgs(pub Vec<GenericArgKind>);
 

--- a/tests/run-make/unknown-mod-stdin/unknown-mod.stderr
+++ b/tests/run-make/unknown-mod-stdin/unknown-mod.stderr
@@ -5,6 +5,7 @@ error[E0583]: file not found for module `unknown`
   | ^^^^^^^^^^^^
   |
   = help: to create the module `unknown`, create file "unknown.rs" or "unknown/mod.rs"
+  = note: if there is a `mod unknown` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/error-codes/E0583.stderr
+++ b/tests/ui/error-codes/E0583.stderr
@@ -5,6 +5,7 @@ LL | mod module_that_doesnt_exist;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: to create the module `module_that_doesnt_exist`, create file "$DIR/module_that_doesnt_exist.rs" or "$DIR/module_that_doesnt_exist/mod.rs"
+   = note: if there is a `mod module_that_doesnt_exist` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/invalid-module-declaration/invalid-module-declaration.stderr
+++ b/tests/ui/invalid-module-declaration/invalid-module-declaration.stderr
@@ -5,6 +5,7 @@ LL | pub mod baz;
    | ^^^^^^^^^^^^
    |
    = help: to create the module `baz`, create file "$DIR/auxiliary/foo/bar/baz.rs" or "$DIR/auxiliary/foo/bar/baz/mod.rs"
+   = note: if there is a `mod baz` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod.stderr
+++ b/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod.stderr
@@ -5,6 +5,7 @@ LL | mod missing;
    | ^^^^^^^^^^^^
    |
    = help: to create the module `missing`, create file "$DIR/foo/missing.rs" or "$DIR/foo/missing/mod.rs"
+   = note: if there is a `mod missing` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod_inline.stderr
+++ b/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod_inline.stderr
@@ -5,6 +5,7 @@ LL |     mod missing;
    |     ^^^^^^^^^^^^
    |
    = help: to create the module `missing`, create file "$DIR/foo_inline/inline/missing.rs" or "$DIR/foo_inline/inline/missing/mod.rs"
+   = note: if there is a `mod missing` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/modules/special_module_name.stderr
+++ b/tests/ui/modules/special_module_name.stderr
@@ -5,6 +5,7 @@ LL | mod lib;
    | ^^^^^^^^
    |
    = help: to create the module `lib`, create file "$DIR/lib.rs" or "$DIR/lib/mod.rs"
+   = note: if there is a `mod lib` elsewhere in the crate already, import it with `use crate::...` instead
 
 error[E0583]: file not found for module `main`
   --> $DIR/special_module_name.rs:4:1
@@ -13,6 +14,7 @@ LL | mod main;
    | ^^^^^^^^^
    |
    = help: to create the module `main`, create file "$DIR/main.rs" or "$DIR/main/mod.rs"
+   = note: if there is a `mod main` elsewhere in the crate already, import it with `use crate::...` instead
 
 warning: found module declaration for lib.rs
   --> $DIR/special_module_name.rs:1:1

--- a/tests/ui/object-safety/assoc_type_bounds_implicit_sized.fixed
+++ b/tests/ui/object-safety/assoc_type_bounds_implicit_sized.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+trait TraitWithAType {
+    type Item: ?Sized;
+}
+trait Trait {}
+struct A {}
+impl TraitWithAType for A {
+    type Item = dyn Trait; //~ ERROR E0277
+}
+fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds_implicit_sized.rs
+++ b/tests/ui/object-safety/assoc_type_bounds_implicit_sized.rs
@@ -1,0 +1,10 @@
+// run-rustfix
+trait TraitWithAType {
+    type Item;
+}
+trait Trait {}
+struct A {}
+impl TraitWithAType for A {
+    type Item = dyn Trait; //~ ERROR E0277
+}
+fn main() {}

--- a/tests/ui/object-safety/assoc_type_bounds_implicit_sized.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_implicit_sized.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+  --> $DIR/assoc_type_bounds_implicit_sized.rs:8:17
+   |
+LL |     type Item = dyn Trait;
+   |                 ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+note: required by a bound in `TraitWithAType::Item`
+  --> $DIR/assoc_type_bounds_implicit_sized.rs:3:5
+   |
+LL |     type Item;
+   |     ^^^^^^^^^^ required by this bound in `TraitWithAType::Item`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Item: ?Sized;
+   |              ++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/object-safety/assoc_type_bounds_sized_used.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_sized_used.stderr
@@ -33,6 +33,10 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
 LL - fn bop<T: Bop + ?Sized>() {
 LL + fn bop<T: Bop>() {
    |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Bar: Default + ?Sized
+   |                       ++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/mod_file_not_exist.stderr
+++ b/tests/ui/parser/mod_file_not_exist.stderr
@@ -5,6 +5,7 @@ LL | mod not_a_real_file;
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs" or "$DIR/not_a_real_file/mod.rs"
+   = note: if there is a `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::...` instead
 
 error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
   --> $DIR/mod_file_not_exist.rs:7:16

--- a/tests/ui/parser/unsafe-mod.stderr
+++ b/tests/ui/parser/unsafe-mod.stderr
@@ -5,6 +5,7 @@ LL | unsafe mod n;
    | ^^^^^^^^^^^^^
    |
    = help: to create the module `n`, create file "$DIR/n.rs" or "$DIR/n/mod.rs"
+   = note: if there is a `mod n` elsewhere in the crate already, import it with `use crate::...` instead
 
 error: module cannot be declared unsafe
   --> $DIR/unsafe-mod.rs:1:1

--- a/tests/ui/rfcs/rfc-2457-non-ascii-idents/mod_file_nonascii_forbidden.stderr
+++ b/tests/ui/rfcs/rfc-2457-non-ascii-idents/mod_file_nonascii_forbidden.stderr
@@ -5,6 +5,7 @@ LL | mod řųśť;
    | ^^^^^^^^^
    |
    = help: to create the module `řųśť`, create file "$DIR/řųśť.rs" or "$DIR/řųśť/mod.rs"
+   = note: if there is a `mod řųśť` elsewhere in the crate already, import it with `use crate::...` instead
 
 error[E0754]: trying to load file for module `řųśť` with non-ascii identifier name
   --> $DIR/mod_file_nonascii_forbidden.rs:1:5

--- a/tests/ui/suggestions/silenced-binding-typo.fixed
+++ b/tests/ui/suggestions/silenced-binding-typo.fixed
@@ -1,0 +1,5 @@
+// run-rustfix
+fn main() {
+    let x = 42; //~ HELP
+    let _y = x; //~ ERROR
+}

--- a/tests/ui/suggestions/silenced-binding-typo.rs
+++ b/tests/ui/suggestions/silenced-binding-typo.rs
@@ -1,0 +1,5 @@
+// run-rustfix
+fn main() {
+    let _x = 42; //~ HELP
+    let _y = x; //~ ERROR
+}

--- a/tests/ui/suggestions/silenced-binding-typo.stderr
+++ b/tests/ui/suggestions/silenced-binding-typo.stderr
@@ -1,0 +1,14 @@
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/silenced-binding-typo.rs:4:14
+   |
+LL |     let _y = x;
+   |              ^
+   |
+help: a local variable with a similar name exists, consider changing it
+   |
+LL |     let x = 42;
+   |         ~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/typeck/issue-36708.stderr
+++ b/tests/ui/typeck/issue-36708.stderr
@@ -2,7 +2,12 @@ error[E0049]: method `foo` has 1 type parameter but its trait declaration has 0 
   --> $DIR/issue-36708.rs:8:12
    |
 LL |     fn foo<T>() {}
-   |            ^ found 1 type parameter, expected 0
+   |            ^ found 1 type parameter
+   |
+  ::: $DIR/auxiliary/issue-36708.rs:4:5
+   |
+LL |     fn foo();
+   |     --------- expected 0 type parameters
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #116911 (Suggest relaxing implicit `type Assoc: Sized;` bound)
 - #116961 (Typo suggestion to change bindings with leading underscore)
 - #116964 (Add stable Instance::body() and RustcInternal trait)
 - #116992 (Mention the syntax for `use` on `mod foo;` if `foo` doesn't exist)
 - #116995 (Point at assoc fn definition on type param divergence)

Failed merges:

 - #116974 (coverage: Fix inconsistent handling of function signature spans)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116911,116961,116964,116992,116995)
<!-- homu-ignore:end -->