### PR TITLE
When not finding assoc fn on type, look for builder fn

### DIFF
--- a/tests/ui/atomic-from-mut-not-available.stderr
+++ b/tests/ui/atomic-from-mut-not-available.stderr
@@ -3,6 +3,10 @@ error[E0599]: no function or associated item named `from_mut` found for struct `
    |
 LL |     core::sync::atomic::AtomicU64::from_mut(&mut 0u64);
    |                                    ^^^^^^^^ function or associated item not found in `AtomicU64`
+   |
+note: if you're trying to build a new `AtomicU64`, consider using `AtomicU64::new` which returns `AtomicU64`
+  --> $SRC_DIR/core/src/sync/atomic.rs:LL:COL
+   = note: this error originates in the macro `atomic_int` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/tests/ui/parser/emoji-identifiers.stderr
+++ b/tests/ui/parser/emoji-identifiers.stderr
@@ -75,6 +75,12 @@ LL |     👀::full_of✨()
    |         |
    |         function or associated item not found in `👀`
    |         help: there is an associated function with a similar name: `full_of_✨`
+   |
+note: if you're trying to build a new `👀`, consider using `👀::full_of_✨` which returns `👀`
+  --> $DIR/emoji-identifiers.rs:4:5
+   |
+LL |     fn full_of_✨() -> 👀 {
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `i_like_to_😄_a_lot` in this scope
   --> $DIR/emoji-identifiers.rs:13:13

--- a/tests/ui/resolve/fn-new-doesnt-exist.rs
+++ b/tests/ui/resolve/fn-new-doesnt-exist.rs
@@ -1,0 +1,5 @@
+use std::net::TcpStream;
+
+fn main() {
+   let stream = TcpStream::new(); //~ ERROR no function or associated item named `new` found
+}

--- a/tests/ui/resolve/fn-new-doesnt-exist.stderr
+++ b/tests/ui/resolve/fn-new-doesnt-exist.stderr
@@ -1,0 +1,14 @@
+error[E0599]: no function or associated item named `new` found for struct `TcpStream` in the current scope
+  --> $DIR/fn-new-doesnt-exist.rs:4:28
+   |
+LL |    let stream = TcpStream::new();
+   |                            ^^^ function or associated item not found in `TcpStream`
+   |
+note: if you're trying to build a new `TcpStream` consider using one of the following associated functions:
+      TcpStream::connect
+      TcpStream::connect_timeout
+  --> $SRC_DIR/std/src/net/tcp.rs:LL:COL
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/resolve/issue-82865.stderr
+++ b/tests/ui/resolve/issue-82865.stderr
@@ -15,6 +15,13 @@ LL |     Box::z
 LL |     mac!();
    |     ------ in this macro invocation
    |
+note: if you're trying to build a new `Box<_, _>` consider using one of the following associated functions:
+      Box::<T>::new
+      Box::<T>::new_uninit
+      Box::<T>::new_zeroed
+      Box::<T>::try_new
+      and 18 others
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/suggestions/deref-path-method.stderr
+++ b/tests/ui/suggestions/deref-path-method.stderr
@@ -4,6 +4,13 @@ error[E0599]: no function or associated item named `contains` found for struct `
 LL |     Vec::contains(&vec, &0);
    |          ^^^^^^^^ function or associated item not found in `Vec<_, _>`
    |
+note: if you're trying to build a new `Vec<_, _>` consider using one of the following associated functions:
+      Vec::<T>::new
+      Vec::<T>::with_capacity
+      Vec::<T>::from_raw_parts
+      Vec::<T, A>::new_in
+      and 2 others
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 help: the function `contains` is implemented on `[_]`
    |
 LL |     <[_]>::contains(&vec, &0);

--- a/tests/ui/suggestions/issue-109291.stderr
+++ b/tests/ui/suggestions/issue-109291.stderr
@@ -6,6 +6,13 @@ LL |     println!("Custom backtrace: {}", std::backtrace::Backtrace::forced_capt
    |                                                                 |
    |                                                                 function or associated item not found in `Backtrace`
    |                                                                 help: there is an associated function with a similar name: `force_capture`
+   |
+note: if you're trying to build a new `Backtrace` consider using one of the following associated functions:
+      Backtrace::capture
+      Backtrace::force_capture
+      Backtrace::disabled
+      Backtrace::create
+  --> $SRC_DIR/std/src/backtrace.rs:LL:COL
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When we have a resolution error when looking at a fully qualified path on a type, look for all associated functions on inherent impls that return `Self` and mention them to the user.

```
error[E0599]: no function or associated item named `new` found for struct `TcpStream` in the current scope
   --> tests/ui/resolve/fn-new-doesnt-exist.rs:4:28
    |
4   |    let stream = TcpStream::new();
    |                            ^^^ function or associated item not found in `TcpStream`
    |
note: if you're trying to build a new `TcpStream` consider using one of the following associated functions:
      TcpStream::connect
      TcpStream::connect_timeout
   --> /home/gh-estebank/rust/library/std/src/net/tcp.rs:156:5
    |
156 |     pub fn connect<A: ToSocketAddrs>(addr: A) -> io::Result<TcpStream> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
172 |     pub fn connect_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpStream> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
Fix #69512.