### PR TITLE
fix spans for removing `.await` on `for` expressions

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1644,7 +1644,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
             // use nth(1) to skip one layer of desugaring from `IntoIter::into_iter`
             if let Some((_, hir::Node::Expr(await_expr))) = hir.parent_iter(*hir_id).nth(1)
-                && let Some(expr_span) = expr.span.find_ancestor_inside(await_expr.span)
+                && let Some(expr_span) = expr.span.find_ancestor_inside_same_ctxt(await_expr.span)
             {
                 let removal_span = self
                     .tcx

--- a/tests/ui/async-await/unnecessary-await.rs
+++ b/tests/ui/async-await/unnecessary-await.rs
@@ -31,4 +31,9 @@ async fn with_macros() {
     f!(());
 }
 
+// Regression test for issue #117014.
+async fn desugaring_span_ctxt() {
+    for x in [] {}.await //~ ERROR `()` is not a future
+}
+
 fn main() {}

--- a/tests/ui/async-await/unnecessary-await.stderr
+++ b/tests/ui/async-await/unnecessary-await.stderr
@@ -49,6 +49,19 @@ LL |     f!(());
    = note: required for `()` to implement `IntoFuture`
    = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error[E0277]: `()` is not a future
+  --> $DIR/unnecessary-await.rs:36:20
+   |
+LL |     for x in [] {}.await
+   |                   -^^^^^
+   |                   ||
+   |                   |`()` is not a future
+   |                   help: remove the `.await`
+   |
+   = help: the trait `Future` is not implemented for `()`
+   = note: () must be a future or must implement `IntoFuture` to be awaited
+   = note: required for `()` to implement `IntoFuture`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
We need to use a span with the outer syntax context of a desugared `for` expression to join it with the `.await` span.

fixes https://github.com/rust-lang/rust/issues/117014