### PR TITLE
Enable cg_clif tests for riscv64gc

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2999,7 +2999,10 @@ impl Step for CodegenCranelift {
 
         let triple = run.target.triple;
         let target_supported = if triple.contains("linux") {
-            triple.contains("x86_64") || triple.contains("aarch64") || triple.contains("s390x")
+            triple.contains("x86_64")
+                || triple.contains("aarch64")
+                || triple.contains("s390x")
+                || triple.contains("riscv64gc")
         } else if triple.contains("darwin") || triple.contains("windows") {
             triple.contains("x86_64")
         } else {


### PR DESCRIPTION
Cranelift now has support for riscv64 on Linux.