### PR TITLE
Don't crash on empty match in the `nonexhaustive_omitted_patterns` lint

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -884,6 +884,9 @@ fn collect_nonexhaustive_missing_variants<'p, 'tcx>(
     cx: &MatchCheckCtxt<'p, 'tcx>,
     column: &[&DeconstructedPat<'p, 'tcx>],
 ) -> Vec<WitnessPat<'tcx>> {
+    if column.is_empty() {
+        return Vec::new();
+    }
     let ty = column[0].ty();
     let pcx = &PatCtxt { cx, ty, span: DUMMY_SP, is_top_level: false };
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.rs
@@ -251,3 +251,10 @@ fn main() {
 pub fn takes_non_exhaustive(_: NonExhaustiveEnum) {
     let _closure = |_: NonExhaustiveEnum| {};
 }
+
+// ICE #117033
+enum Void {}
+#[deny(non_exhaustive_omitted_patterns)]
+pub fn void(v: Void) -> ! {
+    match v {}
+}


### PR DESCRIPTION
Oops

Fixes https://github.com/rust-lang/rust/issues/117033