### PR TITLE
rustdoc book doc example error

### DIFF
--- a/src/doc/rustdoc/src/write-documentation/what-to-include.md
+++ b/src/doc/rustdoc/src/write-documentation/what-to-include.md
@@ -73,7 +73,7 @@ and your test suite, this example needs some additional code:
 ``````text
 /// Example
 /// ```rust
-/// # main() -> Result<(), std::num::ParseIntError> {
+/// # fn main() -> Result<(), std::num::ParseIntError> {
 /// let fortytwo = "42".parse::<u32>()?;
 /// println!("{} + 10 = {}", fortytwo, fortytwo+10);
 /// #     Ok(())


### PR DESCRIPTION
closes #117036 

This is the minimal change required to make the second what-to-include.md example valid.
Another more modern solution could be considered:
```
/// Example
/// ```rust
/// let fortytwo = "42".parse::<u32>()?;
/// println!("{} + 10 = {}", fortytwo, fortytwo+10);
/// #     Ok::<(), <u32 as std::str::FromStr>::Err>(())
/// ```
```