### PR TITLE
Clarify UB in `get_unchecked(_mut)`

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -640,6 +640,11 @@ impl<T> [T] {
     /// Calling this method with an out-of-bounds index is *[undefined behavior]*
     /// even if the resulting reference is not used.
     ///
+    /// You can think of this like `.get(index).unwrap_unchecked()`.  It's UB
+    /// to call `.get_unchecked(len)`, even if you immediately convert to a
+    /// pointer.  And it's UB to call `.get_unchecked(..len +1)` or
+    /// `.get_unchecked(..=len)` similar.
+    ///
     /// [`get`]: slice::get
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     ///
@@ -674,6 +679,11 @@ impl<T> [T] {
     ///
     /// Calling this method with an out-of-bounds index is *[undefined behavior]*
     /// even if the resulting reference is not used.
+    ///
+    /// You can think of this like `.get_mut(index).unwrap_unchecked()`.  It's
+    /// UB to call `.get_unchecked_mut(len)`, even if you immediately convert
+    /// to a pointer.  And it's UB to call `.get_unchecked_mut(..len +1)` or
+    /// `.get_unchecked_mut(..=len)` similar.
     ///
     /// [`get_mut`]: slice::get_mut
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -642,7 +642,7 @@ impl<T> [T] {
     ///
     /// You can think of this like `.get(index).unwrap_unchecked()`.  It's UB
     /// to call `.get_unchecked(len)`, even if you immediately convert to a
-    /// pointer.  And it's UB to call `.get_unchecked(..len +1)`,
+    /// pointer.  And it's UB to call `.get_unchecked(..len + 1)`,
     /// `.get_unchecked(..=len)`, or similar.
     ///
     /// [`get`]: slice::get
@@ -682,7 +682,7 @@ impl<T> [T] {
     ///
     /// You can think of this like `.get_mut(index).unwrap_unchecked()`.  It's
     /// UB to call `.get_unchecked_mut(len)`, even if you immediately convert
-    /// to a pointer.  And it's UB to call `.get_unchecked_mut(..len +1)`,
+    /// to a pointer.  And it's UB to call `.get_unchecked_mut(..len + 1)`,
     /// `.get_unchecked_mut(..=len)`, or similar.
     ///
     /// [`get_mut`]: slice::get_mut

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -642,8 +642,8 @@ impl<T> [T] {
     ///
     /// You can think of this like `.get(index).unwrap_unchecked()`.  It's UB
     /// to call `.get_unchecked(len)`, even if you immediately convert to a
-    /// pointer.  And it's UB to call `.get_unchecked(..len +1)` or
-    /// `.get_unchecked(..=len)` similar.
+    /// pointer.  And it's UB to call `.get_unchecked(..len +1)`,
+    /// `.get_unchecked(..=len)`, or similar.
     ///
     /// [`get`]: slice::get
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
@@ -682,8 +682,8 @@ impl<T> [T] {
     ///
     /// You can think of this like `.get_mut(index).unwrap_unchecked()`.  It's
     /// UB to call `.get_unchecked_mut(len)`, even if you immediately convert
-    /// to a pointer.  And it's UB to call `.get_unchecked_mut(..len +1)` or
-    /// `.get_unchecked_mut(..=len)` similar.
+    /// to a pointer.  And it's UB to call `.get_unchecked_mut(..len +1)`,
+    /// `.get_unchecked_mut(..=len)`, or similar.
     ///
     /// [`get_mut`]: slice::get_mut
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html


### PR DESCRIPTION
Inspired by #116915, it was unclear to me what exactly "out-of-bounds index" means in `get_unchecked`.

One could [potentially](https://rust.godbolt.org/z/hxM764orW) interpret it that `get_unchecked` is just another way to write `offset`, but I think `get_unchecked(len)` is supposed to be UB even though `.offet(len)` is well-defined (as is `.get_unchecked(..len)`), so write that more directly in the docs.

**libs-api folks**: Can you confirm whether this is what you expect this to mean?  And is the situation any different for `<*const [T]>::get_unchecked`?
