### PR TITLE
coverage: Add UI tests for values accepted by `-Cinstrument-coverage`

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2470,7 +2470,7 @@ impl<'test> TestCx<'test> {
             }
             CoverageMap => {
                 rustc.arg("-Cinstrument-coverage");
-                // These tests only compile to MIR, so they don't need the
+                // These tests only compile to LLVM IR, so they don't need the
                 // profiler runtime to be present.
                 rustc.arg("-Zno-profiler-runtime");
                 // Coverage mappings are sensitive to MIR optimizations, and

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 const ISSUES_ENTRY_LIMIT: usize = 1854;
-const ROOT_ENTRY_LIMIT: usize = 865;
+const ROOT_ENTRY_LIMIT: usize = 866;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/codegen/instrument-coverage-off.rs
+++ b/tests/codegen/instrument-coverage-off.rs
@@ -1,0 +1,23 @@
+// Test that `-Cinstrument-coverage=off` does not add coverage instrumentation to LLVM IR.
+
+// needs-profiler-support
+// revisions: n no off false zero
+// [n] compile-flags: -Cinstrument-coverage=n
+// [no] compile-flags: -Cinstrument-coverage=no
+// [off] compile-flags: -Cinstrument-coverage=off
+// [false] compile-flags: -Cinstrument-coverage=false
+// [zero] compile-flags: -Cinstrument-coverage=0
+
+// CHECK-NOT: __llvm_profile_filename
+// CHECK-NOT: __llvm_coverage_mapping
+
+#![crate_type="lib"]
+
+#[inline(never)]
+fn some_function() {
+
+}
+
+pub fn some_other_function() {
+    some_function();
+}

--- a/tests/ui/instrument-coverage/bad-value.bad.stderr
+++ b/tests/ui/instrument-coverage/bad-value.bad.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `bad-value` for codegen option `instrument-coverage` - `all` (default), `except-unused-generics`, `except-unused-functions`, or `off` was expected
+

--- a/tests/ui/instrument-coverage/bad-value.blank.stderr
+++ b/tests/ui/instrument-coverage/bad-value.blank.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `` for codegen option `instrument-coverage` - `all` (default), `except-unused-generics`, `except-unused-functions`, or `off` was expected
+

--- a/tests/ui/instrument-coverage/bad-value.rs
+++ b/tests/ui/instrument-coverage/bad-value.rs
@@ -1,0 +1,5 @@
+// revisions: blank bad
+// [blank] compile-flags: -Cinstrument-coverage=
+// [bad] compile-flags: -Cinstrument-coverage=bad-value
+
+fn main() {}

--- a/tests/ui/instrument-coverage/except-unused-functions.rs
+++ b/tests/ui/instrument-coverage/except-unused-functions.rs
@@ -1,0 +1,3 @@
+// compile-flags: -Cinstrument-coverage=except-unused-functions
+
+fn main() {}

--- a/tests/ui/instrument-coverage/except-unused-functions.stderr
+++ b/tests/ui/instrument-coverage/except-unused-functions.stderr
@@ -1,0 +1,2 @@
+error: `-C instrument-coverage=except-*` requires `-Z unstable-options`
+

--- a/tests/ui/instrument-coverage/except-unused-generics.rs
+++ b/tests/ui/instrument-coverage/except-unused-generics.rs
@@ -1,0 +1,3 @@
+// compile-flags: -Cinstrument-coverage=except-unused-generics
+
+fn main() {}

--- a/tests/ui/instrument-coverage/except-unused-generics.stderr
+++ b/tests/ui/instrument-coverage/except-unused-generics.stderr
@@ -1,0 +1,2 @@
+error: `-C instrument-coverage=except-*` requires `-Z unstable-options`
+

--- a/tests/ui/instrument-coverage/off-values.rs
+++ b/tests/ui/instrument-coverage/off-values.rs
@@ -1,0 +1,9 @@
+// check-pass
+// revisions: n no off false zero
+// [n] compile-flags: -Cinstrument-coverage=n
+// [no] compile-flags: -Cinstrument-coverage=no
+// [off] compile-flags: -Cinstrument-coverage=off
+// [false] compile-flags: -Cinstrument-coverage=false
+// [zero] compile-flags: -Cinstrument-coverage=0
+
+fn main() {}

--- a/tests/ui/instrument-coverage/on-values.rs
+++ b/tests/ui/instrument-coverage/on-values.rs
@@ -1,5 +1,4 @@
-// Test that `-Cinstrument-coverage` creates expected __llvm_profile_filename symbol in LLVM IR.
-
+// check-pass
 // needs-profiler-support
 // revisions: default y yes on true all
 // [default] compile-flags: -Cinstrument-coverage
@@ -9,16 +8,4 @@
 // [true] compile-flags: -Cinstrument-coverage=true
 // [all] compile-flags: -Cinstrument-coverage=all
 
-// CHECK: @__llvm_profile_filename = {{.*}}"default_%m_%p.profraw\00"{{.*}}
-// CHECK: @__llvm_coverage_mapping
-
-#![crate_type="lib"]
-
-#[inline(never)]
-fn some_function() {
-
-}
-
-pub fn some_other_function() {
-    some_function();
-}
+fn main() {}


### PR DESCRIPTION
I wanted to clean up the code in `parse_instrument_coverage`, but it occurred to me that we currently don't have any UI tests for the various stable and unstable values supported by this flag.

---

Normally it might be overkill to individually test all the different variants of `on`/`off`, but in this case the parsing of those values is mixed in with some other custom code, so I think it's worthwhile being thorough.