### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -884,6 +884,9 @@ fn collect_nonexhaustive_missing_variants<'p, 'tcx>(
     cx: &MatchCheckCtxt<'p, 'tcx>,
     column: &[&DeconstructedPat<'p, 'tcx>],
 ) -> Vec<WitnessPat<'tcx>> {
+    if column.is_empty() {
+        return Vec::new();
+    }
     let ty = column[0].ty();
     let pcx = &PatCtxt { cx, ty, span: DUMMY_SP, is_top_level: false };
 

--- a/src/doc/rustdoc/src/write-documentation/what-to-include.md
+++ b/src/doc/rustdoc/src/write-documentation/what-to-include.md
@@ -73,7 +73,7 @@ and your test suite, this example needs some additional code:
 ``````text
 /// Example
 /// ```rust
-/// # main() -> Result<(), std::num::ParseIntError> {
+/// # fn main() -> Result<(), std::num::ParseIntError> {
 /// let fortytwo = "42".parse::<u32>()?;
 /// println!("{} + 10 = {}", fortytwo, fortytwo+10);
 /// #     Ok(())

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.rs
@@ -251,3 +251,10 @@ fn main() {
 pub fn takes_non_exhaustive(_: NonExhaustiveEnum) {
     let _closure = |_: NonExhaustiveEnum| {};
 }
+
+// ICE #117033
+enum Void {}
+#[deny(non_exhaustive_omitted_patterns)]
+pub fn void(v: Void) -> ! {
+    match v {}
+}


### PR DESCRIPTION
Successful merges:

 - #116985 (Use gdb.ValuePrinter tag class)
 - #116989 (Skip test if Unix sockets are unsupported)
 - #117034 (Don't crash on empty match in the `nonexhaustive_omitted_patterns` lint)
 - #117037 (rustdoc book doc example error)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116985,116989,117034,117037)
<!-- homu-ignore:end -->