### PR TITLE
return unfixed len if pat has reported error

### DIFF
--- a/tests/ui/consts/issue-116186.rs
+++ b/tests/ui/consts/issue-116186.rs
@@ -1,0 +1,12 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+fn something(path: [usize; N]) -> impl Clone {
+    //~^ ERROR cannot find value `N` in this scope
+    match path {
+        [] => 0, //~ ERROR cannot pattern-match on an array without a fixed length
+        _ => 1,
+    };
+}
+
+fn main() {}

--- a/tests/ui/consts/issue-116186.stderr
+++ b/tests/ui/consts/issue-116186.stderr
@@ -1,0 +1,21 @@
+error[E0425]: cannot find value `N` in this scope
+  --> $DIR/issue-116186.rs:4:28
+   |
+LL | fn something(path: [usize; N]) -> impl Clone {
+   |                            ^ not found in this scope
+   |
+help: you might be missing a const parameter
+   |
+LL | fn something<const N: /* Type */>(path: [usize; N]) -> impl Clone {
+   |             +++++++++++++++++++++
+
+error[E0730]: cannot pattern-match on an array without a fixed length
+  --> $DIR/issue-116186.rs:7:9
+   |
+LL |         [] => 0,
+   |         ^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0425, E0730.
+For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
- Fixes #116186
- Fixes #113021

This issue arises due to the creation of a fixed-length pattern, as a result of ﻿the mir body corruption. The corruption taints ﻿`tcx.eval_to_allocation_raw`, causing it to return ﻿`AlreadyReported`. Consequently, this prevents ﻿`len.try_eval_target_usize` from evaluating correctly and returns `﻿None`. Lastly, it results in the return of `﻿[usize; min_len]`.

To rectify this issue, my approach is that to return ﻿unfixed when encountering `﻿ErrorHandled::Reported`. Additionally, in instances of `﻿ErrorHandled::TooGeneric`, the previous logic has been reinstated.