### PR TITLE
Use en dashes in documentation page titles

### DIFF
--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -247,7 +247,7 @@ impl<'tcx> Context<'tcx> {
             // No need to include the namespace for primitive types and keywords
             title.push_str(&join_with_double_colon(&self.current));
         };
-        title.push_str(" - Rust");
+        title.push_str(" \u{2013} Rust");
         let tyname = it.type_();
         let desc = plain_text_summary(&it.doc_value(), &it.link_names(&self.cache()));
         let desc = if !desc.is_empty() {


### PR DESCRIPTION
In short:
> std – Rust
instead of
> std - Rust

Truly world-altering, I know.

A hyphen is used for joining compound words, like co-operate, among a few other things. But as a a separator surrounded by spaces, this should really be an en-dash.