### PR TITLE
x.ps1: remove the check for Python from Windows Store

### DIFF
--- a/x.ps1
+++ b/x.ps1
@@ -17,11 +17,6 @@ foreach ($arg in $args) {
 
 function Get-Application($app) {
     $cmd = Get-Command $app -ErrorAction SilentlyContinue -CommandType Application | Select-Object -First 1
-    if ($cmd.source -match '.*AppData\\Local\\Microsoft\\WindowsApps\\.*exe') {
-        # Windows for some reason puts a `python3.exe` executable in PATH that just opens the windows store.
-        # Ignore it.
-        return $false
-    }
     return $cmd
 }
 


### PR DESCRIPTION
When installing Python from the Windows Store, a copy of `python.exe` is installed inder the Microsoft directory in the user's local AppData directory. Currently, `x.ps1` checks for this file, because by default running `python.exe` opens a link to the Microsoft Store rather than running Python.

Once the user installs Python, however, this contains a valid interpreter. Unfortuantely, `x.ps1` can't tell the difference between a legitimate Python install and the stub.

Remove the check, as it makes it impossible to use the official version from Microsoft once it has been installed.

This resolves #117067