### PR TITLE
Remove smir from triage and add me to stablemir

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -554,13 +554,9 @@ cc = ["@davidtwco", "@compiler-errors", "@JohnTitor", "@TaKO8Ki"]
 message = "`rustc_macros::diagnostics` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@JohnTitor", "@TaKO8Ki"]
 
-[mentions."compiler/rustc_smir"]
-message = "This PR changes Stable MIR"
-cc = ["@oli-obk", "@celinval", "@spastorino", "@ouz-a"]
-
 [mentions."compiler/stable_mir"]
 message = "This PR changes Stable MIR"
-cc = ["@oli-obk", "@celinval", "@spastorino"]
+cc = ["@oli-obk", "@celinval", "@spastorino", "@ouz-a"]
 
 [mentions."compiler/rustc_target/src/spec"]
 message = """


### PR DESCRIPTION
As we discussed this in [weekly ](https://rust-lang.zulipchat.com/#narrow/stream/320896-project-stable-mir/topic/.5Bbi-weekly.5D.202023-10-20)meeting we don't really care for changes that happens in `smir`, we only care about changes that happen to `stable_mir` so I removed smir triage ping and added myself to `stable_mir` ping list