### PR TITLE
Fix closure-inherit-target-feature test for SGX platform

### DIFF
--- a/tests/assembly/closure-inherit-target-feature.rs
+++ b/tests/assembly/closure-inherit-target-feature.rs
@@ -1,4 +1,5 @@
 // only-x86_64
+// ignore-sgx Tests incompatible with LVI mitigations
 // assembly-output: emit-asm
 // make sure the feature is not enabled at compile-time
 // compile-flags: -C opt-level=3 -C target-feature=-sse4.1 -C llvm-args=-x86-asm-syntax=intel


### PR DESCRIPTION
PR #116078 adds the `closure-inherit-target-feature.rs` test that checks the generated assembly code for closures. These checks explicitly check the presence of `ret` instructions. This is incompatible with the SGX target as it explicitly rewrites all `ret` instructions to mitigate LVI vulnerabilities of certain processors. This PR simply ignores these tests for the SGX platform.

cc: @jethrogb 