### PR TITLE
Update .mailmap to promote my livename

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -31,6 +31,8 @@ Alexis Beingessner <a.beingessner@gmail.com>
 Alfie John <alfie@alfie.wtf> Alfie John <alfiej@fastmail.fm>
 Alona Enraght-Moony <code@alona.page> <nixon.emoony@gmail.com>
 Alona Enraght-Moony <code@alona.page> <nixon@caminus.local>
+Amanda Stjerna <mail@amandastjerna.se> <albin.stjerna@gmail.com>
+Amanda Stjerna <mail@amandastjerna.se> <amanda.stjerna@it.uu.se>
 Amos Onn <amosonn@gmail.com>
 Ana-Maria Mihalache <mihalacheana.maria@yahoo.com>
 Anatoly Ikorsky <aikorsky@gmail.com>


### PR DESCRIPTION
I had apparently forgotten to update the Rust mailmap file for my previous commits. I was sent here from [the about page!](https://thanks.rust-lang.org/about/).

Note that the second rule only fires for commits I do at my current place of work, but reclaim them under my personal email address that I expect to use for longer.