### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -31,52 +31,11 @@ pub fn is_builtin_attr(attr: &Attribute) -> bool {
     attr.is_doc_comment() || attr.ident().is_some_and(|ident| is_builtin_attr_name(ident.name))
 }
 
-enum AttrError {
-    MultipleItem(String),
-    UnknownMetaItem(String, &'static [&'static str]),
-    MissingSince,
-    NonIdentFeature,
-    MissingFeature,
-    MultipleStabilityLevels,
-    UnsupportedLiteral(UnsupportedLiteralReason, /* is_bytestr */ bool),
-}
-
 pub(crate) enum UnsupportedLiteralReason {
     Generic,
     CfgString,
     DeprecatedString,
     DeprecatedKvPair,
-}
-
-fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
-    match error {
-        AttrError::MultipleItem(item) => {
-            sess.emit_err(session_diagnostics::MultipleItem { span, item });
-        }
-        AttrError::UnknownMetaItem(item, expected) => {
-            sess.emit_err(session_diagnostics::UnknownMetaItem { span, item, expected });
-        }
-        AttrError::MissingSince => {
-            sess.emit_err(session_diagnostics::MissingSince { span });
-        }
-        AttrError::NonIdentFeature => {
-            sess.emit_err(session_diagnostics::NonIdentFeature { span });
-        }
-        AttrError::MissingFeature => {
-            sess.emit_err(session_diagnostics::MissingFeature { span });
-        }
-        AttrError::MultipleStabilityLevels => {
-            sess.emit_err(session_diagnostics::MultipleStabilityLevels { span });
-        }
-        AttrError::UnsupportedLiteral(reason, is_bytestr) => {
-            sess.emit_err(session_diagnostics::UnsupportedLiteral {
-                span,
-                reason,
-                is_bytestr,
-                start_point_span: sess.source_map().start_point(span),
-            });
-        }
-    }
 }
 
 #[derive(Copy, Clone, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
@@ -241,7 +200,8 @@ pub fn find_stability(
             sym::rustc_allowed_through_unstable_modules => allowed_through_unstable_modules = true,
             sym::unstable => {
                 if stab.is_some() {
-                    handle_errors(&sess.parse_sess, attr.span, AttrError::MultipleStabilityLevels);
+                    sess.parse_sess
+                        .emit_err(session_diagnostics::MultipleStabilityLevels { span: attr.span });
                     break;
                 }
 
@@ -251,7 +211,8 @@ pub fn find_stability(
             }
             sym::stable => {
                 if stab.is_some() {
-                    handle_errors(&sess.parse_sess, attr.span, AttrError::MultipleStabilityLevels);
+                    sess.parse_sess
+                        .emit_err(session_diagnostics::MultipleStabilityLevels { span: attr.span });
                     break;
                 }
                 if let Some((feature, level)) = parse_stability(sess, attr) {
@@ -295,7 +256,8 @@ pub fn find_const_stability(
             sym::rustc_promotable => promotable = true,
             sym::rustc_const_unstable => {
                 if const_stab.is_some() {
-                    handle_errors(&sess.parse_sess, attr.span, AttrError::MultipleStabilityLevels);
+                    sess.parse_sess
+                        .emit_err(session_diagnostics::MultipleStabilityLevels { span: attr.span });
                     break;
                 }
 
@@ -306,7 +268,8 @@ pub fn find_const_stability(
             }
             sym::rustc_const_stable => {
                 if const_stab.is_some() {
-                    handle_errors(&sess.parse_sess, attr.span, AttrError::MultipleStabilityLevels);
+                    sess.parse_sess
+                        .emit_err(session_diagnostics::MultipleStabilityLevels { span: attr.span });
                     break;
                 }
                 if let Some((feature, level)) = parse_stability(sess, attr) {
@@ -340,7 +303,8 @@ pub fn find_body_stability(
     for attr in attrs {
         if attr.has_name(sym::rustc_default_body_unstable) {
             if body_stab.is_some() {
-                handle_errors(&sess.parse_sess, attr.span, AttrError::MultipleStabilityLevels);
+                sess.parse_sess
+                    .emit_err(session_diagnostics::MultipleStabilityLevels { span: attr.span });
                 break;
             }
 
@@ -355,11 +319,10 @@ pub fn find_body_stability(
 
 fn insert_or_error(sess: &Session, meta: &MetaItem, item: &mut Option<Symbol>) -> Option<()> {
     if item.is_some() {
-        handle_errors(
-            &sess.parse_sess,
-            meta.span,
-            AttrError::MultipleItem(pprust::path_to_string(&meta.path)),
-        );
+        sess.parse_sess.emit_err(session_diagnostics::MultipleItem {
+            span: meta.span,
+            item: pprust::path_to_string(&meta.path),
+        });
         None
     } else if let Some(v) = meta.value_str() {
         *item = Some(v);
@@ -380,11 +343,12 @@ fn parse_stability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabilit
     let mut since = None;
     for meta in metas {
         let Some(mi) = meta.meta_item() else {
-            handle_errors(
-                &sess.parse_sess,
-                meta.span(),
-                AttrError::UnsupportedLiteral(UnsupportedLiteralReason::Generic, false),
-            );
+            sess.parse_sess.emit_err(session_diagnostics::UnsupportedLiteral {
+                span: meta.span(),
+                reason: UnsupportedLiteralReason::Generic,
+                is_bytestr: false,
+                start_point_span: sess.parse_sess.source_map().start_point(meta.span()),
+            });
             return None;
         };
 
@@ -392,14 +356,11 @@ fn parse_stability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabilit
             sym::feature => insert_or_error(sess, mi, &mut feature)?,
             sym::since => insert_or_error(sess, mi, &mut since)?,
             _ => {
-                handle_errors(
-                    &sess.parse_sess,
-                    meta.span(),
-                    AttrError::UnknownMetaItem(
-                        pprust::path_to_string(&mi.path),
-                        &["feature", "since"],
-                    ),
-                );
+                sess.parse_sess.emit_err(session_diagnostics::UnknownMetaItem {
+                    span: meta.span(),
+                    item: pprust::path_to_string(&mi.path),
+                    expected: &["feature", "since"],
+                });
                 return None;
             }
         }
@@ -417,11 +378,11 @@ fn parse_stability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabilit
             Some((feature, level))
         }
         (None, _) => {
-            handle_errors(&sess.parse_sess, attr.span, AttrError::MissingFeature);
+            sess.parse_sess.emit_err(session_diagnostics::MissingFeature { span: attr.span });
             None
         }
         _ => {
-            handle_errors(&sess.parse_sess, attr.span, AttrError::MissingSince);
+            sess.parse_sess.emit_err(session_diagnostics::MissingSince { span: attr.span });
             None
         }
     }
@@ -441,11 +402,12 @@ fn parse_unstability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabil
     let mut implied_by = None;
     for meta in metas {
         let Some(mi) = meta.meta_item() else {
-            handle_errors(
-                &sess.parse_sess,
-                meta.span(),
-                AttrError::UnsupportedLiteral(UnsupportedLiteralReason::Generic, false),
-            );
+            sess.parse_sess.emit_err(session_diagnostics::UnsupportedLiteral {
+                span: meta.span(),
+                reason: UnsupportedLiteralReason::Generic,
+                is_bytestr: false,
+                start_point_span: sess.parse_sess.source_map().start_point(meta.span()),
+            });
             return None;
         };
 
@@ -484,14 +446,11 @@ fn parse_unstability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabil
             }
             sym::implied_by => insert_or_error(sess, mi, &mut implied_by)?,
             _ => {
-                handle_errors(
-                    &sess.parse_sess,
-                    meta.span(),
-                    AttrError::UnknownMetaItem(
-                        pprust::path_to_string(&mi.path),
-                        &["feature", "reason", "issue", "soft", "implied_by"],
-                    ),
-                );
+                sess.parse_sess.emit_err(session_diagnostics::UnknownMetaItem {
+                    span: meta.span(),
+                    item: pprust::path_to_string(&mi.path),
+                    expected: &["feature", "reason", "issue", "soft", "implied_by"],
+                });
                 return None;
             }
         }
@@ -500,7 +459,7 @@ fn parse_unstability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabil
     match (feature, reason, issue) {
         (Some(feature), reason, Some(_)) => {
             if !rustc_lexer::is_ident(feature.as_str()) {
-                handle_errors(&sess.parse_sess, attr.span, AttrError::NonIdentFeature);
+                sess.parse_sess.emit_err(session_diagnostics::NonIdentFeature { span: attr.span });
                 return None;
             }
             let level = StabilityLevel::Unstable {
@@ -512,7 +471,7 @@ fn parse_unstability(sess: &Session, attr: &Attribute) -> Option<(Symbol, Stabil
             Some((feature, level))
         }
         (None, _, _) => {
-            handle_errors(&sess.parse_sess, attr.span, AttrError::MissingFeature);
+            sess.parse_sess.emit_err(session_diagnostics::MissingFeature { span: attr.span });
             return None;
         }
         _ => {
@@ -659,11 +618,12 @@ pub fn eval_condition(
         ast::MetaItemKind::List(mis) => {
             for mi in mis.iter() {
                 if !mi.is_meta_item() {
-                    handle_errors(
-                        sess,
-                        mi.span(),
-                        AttrError::UnsupportedLiteral(UnsupportedLiteralReason::Generic, false),
-                    );
+                    sess.emit_err(session_diagnostics::UnsupportedLiteral {
+                        span: mi.span(),
+                        reason: UnsupportedLiteralReason::Generic,
+                        is_bytestr: false,
+                        start_point_span: sess.source_map().start_point(mi.span()),
+                    });
                     return false;
                 }
             }
@@ -731,14 +691,12 @@ pub fn eval_condition(
             true
         }
         MetaItemKind::NameValue(lit) if !lit.kind.is_str() => {
-            handle_errors(
-                sess,
-                lit.span,
-                AttrError::UnsupportedLiteral(
-                    UnsupportedLiteralReason::CfgString,
-                    lit.kind.is_bytestr(),
-                ),
-            );
+            sess.emit_err(session_diagnostics::UnsupportedLiteral {
+                span: lit.span,
+                reason: UnsupportedLiteralReason::CfgString,
+                is_bytestr: lit.kind.is_bytestr(),
+                start_point_span: sess.source_map().start_point(lit.span),
+            });
             true
         }
         ast::MetaItemKind::Word | ast::MetaItemKind::NameValue(..) => {
@@ -795,11 +753,10 @@ pub fn find_deprecation(
             MetaItemKind::List(list) => {
                 let get = |meta: &MetaItem, item: &mut Option<Symbol>| {
                     if item.is_some() {
-                        handle_errors(
-                            &sess.parse_sess,
-                            meta.span,
-                            AttrError::MultipleItem(pprust::path_to_string(&meta.path)),
-                        );
+                        sess.parse_sess.emit_err(session_diagnostics::MultipleItem {
+                            span: meta.span,
+                            item: pprust::path_to_string(&meta.path),
+                        });
                         return false;
                     }
                     if let Some(v) = meta.value_str() {
@@ -807,14 +764,15 @@ pub fn find_deprecation(
                         true
                     } else {
                         if let Some(lit) = meta.name_value_literal() {
-                            handle_errors(
-                                &sess.parse_sess,
-                                lit.span,
-                                AttrError::UnsupportedLiteral(
-                                    UnsupportedLiteralReason::DeprecatedString,
-                                    lit.kind.is_bytestr(),
-                                ),
-                            );
+                            sess.parse_sess.emit_err(session_diagnostics::UnsupportedLiteral {
+                                span: lit.span,
+                                reason: UnsupportedLiteralReason::DeprecatedString,
+                                is_bytestr: lit.kind.is_bytestr(),
+                                start_point_span: sess
+                                    .parse_sess
+                                    .source_map()
+                                    .start_point(lit.span),
+                            });
                         } else {
                             sess.emit_err(session_diagnostics::IncorrectMetaItem {
                                 span: meta.span,
@@ -852,30 +810,28 @@ pub fn find_deprecation(
                                 }
                             }
                             _ => {
-                                handle_errors(
-                                    &sess.parse_sess,
-                                    meta.span(),
-                                    AttrError::UnknownMetaItem(
-                                        pprust::path_to_string(&mi.path),
-                                        if features.deprecated_suggestion {
-                                            &["since", "note", "suggestion"]
-                                        } else {
-                                            &["since", "note"]
-                                        },
-                                    ),
-                                );
+                                sess.parse_sess.emit_err(session_diagnostics::UnknownMetaItem {
+                                    span: meta.span(),
+                                    item: pprust::path_to_string(&mi.path),
+                                    expected: if features.deprecated_suggestion {
+                                        &["since", "note", "suggestion"]
+                                    } else {
+                                        &["since", "note"]
+                                    },
+                                });
                                 continue 'outer;
                             }
                         },
                         NestedMetaItem::Lit(lit) => {
-                            handle_errors(
-                                &sess.parse_sess,
-                                lit.span,
-                                AttrError::UnsupportedLiteral(
-                                    UnsupportedLiteralReason::DeprecatedKvPair,
-                                    false,
-                                ),
-                            );
+                            sess.parse_sess.emit_err(session_diagnostics::UnsupportedLiteral {
+                                span: lit.span,
+                                reason: UnsupportedLiteralReason::DeprecatedKvPair,
+                                is_bytestr: false,
+                                start_point_span: sess
+                                    .parse_sess
+                                    .source_map()
+                                    .start_point(lit.span),
+                            });
                             continue 'outer;
                         }
                     }
@@ -885,7 +841,7 @@ pub fn find_deprecation(
 
         if is_rustc {
             if since.is_none() {
-                handle_errors(&sess.parse_sess, attr.span, AttrError::MissingSince);
+                sess.parse_sess.emit_err(session_diagnostics::MissingSince { span: attr.span });
                 continue;
             }
 

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -644,11 +644,12 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         self.scc_universes[scc]
     }
 
-    /// Once region solving has completed, this function will return
-    /// the member constraints that were applied to the value of a given
-    /// region `r`. See `AppliedMemberConstraint`.
-    pub(crate) fn applied_member_constraints(&self, r: RegionVid) -> &[AppliedMemberConstraint] {
-        let scc = self.constraint_sccs.scc(r);
+    /// Once region solving has completed, this function will return the member constraints that
+    /// were applied to the value of a given SCC `scc`. See `AppliedMemberConstraint`.
+    pub(crate) fn applied_member_constraints(
+        &self,
+        scc: ConstraintSccIndex,
+    ) -> &[AppliedMemberConstraint] {
         binary_search_util::binary_search_slice(
             &self.member_constraints_applied,
             |applied| applied.member_region_scc,
@@ -1945,7 +1946,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             // Member constraints can also give rise to `'r: 'x` edges that
             // were not part of the graph initially, so watch out for those.
             // (But they are extremely rare; this loop is very cold.)
-            for constraint in self.applied_member_constraints(r) {
+            for constraint in self.applied_member_constraints(self.constraint_sccs.scc(r)) {
                 let p_c = &self.member_constraints[constraint.member_constraint_index];
                 let constraint = OutlivesConstraint {
                     sup: r,

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -2293,11 +2293,6 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         self.constraint_sccs.as_ref()
     }
 
-    /// Returns whether the given SCC has any member constraints.
-    pub(crate) fn scc_has_member_constraints(&self, scc: ConstraintSccIndex) -> bool {
-        self.member_constraints.indices(scc).next().is_some()
-    }
-
     /// Returns whether the given SCC is live at all points: whether the representative is a
     /// placeholder or a free region.
     pub(crate) fn scc_is_live_at_all_points(&self, scc: ConstraintSccIndex) -> bool {

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -99,7 +99,7 @@ declare_features! (
     /// Allows generators to be cloned.
     (removed, generator_clone, "1.65.0", Some(95360), None, Some("renamed to `coroutine_clone`")),
     /// Allows defining generators.
-    (removed, generators, "1.21.0", Some(43122), None, Some("renamed to `coroutine`")),
+    (removed, generators, "1.21.0", Some(43122), None, Some("renamed to `coroutines`")),
     /// Allows `impl Trait` in bindings (`let`, `const`, `static`).
     (removed, impl_trait_in_bindings, "1.55.0", Some(63065), None,
      Some("the implementation was not maintainable, the feature may get reintroduced once the current refactorings are done")),

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -3420,9 +3420,10 @@ impl DumpMonoStatsFormat {
 
 /// `-Zpolonius` values, enabling the borrow checker polonius analysis, and which version: legacy,
 /// or future prototype.
-#[derive(Clone, Copy, PartialEq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Hash, Debug, Default)]
 pub enum Polonius {
     /// The default value: disabled.
+    #[default]
     Off,
 
     /// Legacy version, using datalog and the `polonius-engine` crate. Historical value for `-Zpolonius`.
@@ -3430,12 +3431,6 @@ pub enum Polonius {
 
     /// In-tree prototype, extending the NLL infrastructure.
     Next,
-}
-
-impl Default for Polonius {
-    fn default() -> Self {
-        Polonius::Off
-    }
 }
 
 impl Polonius {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2470,7 +2470,7 @@ impl<'test> TestCx<'test> {
             }
             CoverageMap => {
                 rustc.arg("-Cinstrument-coverage");
-                // These tests only compile to MIR, so they don't need the
+                // These tests only compile to LLVM IR, so they don't need the
                 // profiler runtime to be present.
                 rustc.arg("-Zno-profiler-runtime");
                 // Coverage mappings are sensitive to MIR optimizations, and

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 const ISSUES_ENTRY_LIMIT: usize = 1854;
-const ROOT_ENTRY_LIMIT: usize = 865;
+const ROOT_ENTRY_LIMIT: usize = 866;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/codegen/instrument-coverage-off.rs
+++ b/tests/codegen/instrument-coverage-off.rs
@@ -1,0 +1,23 @@
+// Test that `-Cinstrument-coverage=off` does not add coverage instrumentation to LLVM IR.
+
+// needs-profiler-support
+// revisions: n no off false zero
+// [n] compile-flags: -Cinstrument-coverage=n
+// [no] compile-flags: -Cinstrument-coverage=no
+// [off] compile-flags: -Cinstrument-coverage=off
+// [false] compile-flags: -Cinstrument-coverage=false
+// [zero] compile-flags: -Cinstrument-coverage=0
+
+// CHECK-NOT: __llvm_profile_filename
+// CHECK-NOT: __llvm_coverage_mapping
+
+#![crate_type="lib"]
+
+#[inline(never)]
+fn some_function() {
+
+}
+
+pub fn some_other_function() {
+    some_function();
+}

--- a/tests/ui/instrument-coverage/bad-value.bad.stderr
+++ b/tests/ui/instrument-coverage/bad-value.bad.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `bad-value` for codegen option `instrument-coverage` - `all` (default), `except-unused-generics`, `except-unused-functions`, or `off` was expected
+

--- a/tests/ui/instrument-coverage/bad-value.blank.stderr
+++ b/tests/ui/instrument-coverage/bad-value.blank.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `` for codegen option `instrument-coverage` - `all` (default), `except-unused-generics`, `except-unused-functions`, or `off` was expected
+

--- a/tests/ui/instrument-coverage/bad-value.rs
+++ b/tests/ui/instrument-coverage/bad-value.rs
@@ -1,0 +1,5 @@
+// revisions: blank bad
+// [blank] compile-flags: -Cinstrument-coverage=
+// [bad] compile-flags: -Cinstrument-coverage=bad-value
+
+fn main() {}

--- a/tests/ui/instrument-coverage/except-unused-functions.rs
+++ b/tests/ui/instrument-coverage/except-unused-functions.rs
@@ -1,0 +1,3 @@
+// compile-flags: -Cinstrument-coverage=except-unused-functions
+
+fn main() {}

--- a/tests/ui/instrument-coverage/except-unused-functions.stderr
+++ b/tests/ui/instrument-coverage/except-unused-functions.stderr
@@ -1,0 +1,2 @@
+error: `-C instrument-coverage=except-*` requires `-Z unstable-options`
+

--- a/tests/ui/instrument-coverage/except-unused-generics.rs
+++ b/tests/ui/instrument-coverage/except-unused-generics.rs
@@ -1,0 +1,3 @@
+// compile-flags: -Cinstrument-coverage=except-unused-generics
+
+fn main() {}

--- a/tests/ui/instrument-coverage/except-unused-generics.stderr
+++ b/tests/ui/instrument-coverage/except-unused-generics.stderr
@@ -1,0 +1,2 @@
+error: `-C instrument-coverage=except-*` requires `-Z unstable-options`
+

--- a/tests/ui/instrument-coverage/off-values.rs
+++ b/tests/ui/instrument-coverage/off-values.rs
@@ -1,0 +1,9 @@
+// check-pass
+// revisions: n no off false zero
+// [n] compile-flags: -Cinstrument-coverage=n
+// [no] compile-flags: -Cinstrument-coverage=no
+// [off] compile-flags: -Cinstrument-coverage=off
+// [false] compile-flags: -Cinstrument-coverage=false
+// [zero] compile-flags: -Cinstrument-coverage=0
+
+fn main() {}

--- a/tests/ui/instrument-coverage/on-values.rs
+++ b/tests/ui/instrument-coverage/on-values.rs
@@ -1,5 +1,4 @@
-// Test that `-Cinstrument-coverage` creates expected __llvm_profile_filename symbol in LLVM IR.
-
+// check-pass
 // needs-profiler-support
 // revisions: default y yes on true all
 // [default] compile-flags: -Cinstrument-coverage
@@ -9,16 +8,4 @@
 // [true] compile-flags: -Cinstrument-coverage=true
 // [all] compile-flags: -Cinstrument-coverage=all
 
-// CHECK: @__llvm_profile_filename = {{.*}}"default_%m_%p.profraw\00"{{.*}}
-// CHECK: @__llvm_coverage_mapping
-
-#![crate_type="lib"]
-
-#[inline(never)]
-fn some_function() {
-
-}
-
-pub fn some_other_function() {
-    some_function();
-}
+fn main() {}

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.nll.stderr
@@ -1,0 +1,36 @@
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:18:1
+   |
+LL |     fn call(x: Self) -> Self::Output;
+   |     --------------------------------- `call` from trait
+...
+LL | impl<T: PlusOne> Callable for T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+
+error: unconstrained opaque type
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:22:19
+   |
+LL |     type Output = impl PlusOne;
+   |                   ^^^^^^^^^^^^
+   |
+   = note: `Output` must be used in combination with a concrete type within the same impl
+
+error[E0700]: hidden type for `impl PlusOne` captures lifetime that does not appear in bounds
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:28:5
+   |
+LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne {
+   |         --                     ------------ opaque type defined here
+   |         |
+   |         hidden type `<&'a mut i32 as Callable>::Output` captures the lifetime `'a` as defined here
+LL |     <&mut i32 as Callable>::call(y)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: to declare that `impl PlusOne` captures `'a`, you can add an explicit `'a` lifetime bound
+   |
+LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne + 'a {
+   |                                             ++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0046, E0700.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.polonius.stderr
@@ -1,0 +1,36 @@
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:18:1
+   |
+LL |     fn call(x: Self) -> Self::Output;
+   |     --------------------------------- `call` from trait
+...
+LL | impl<T: PlusOne> Callable for T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+
+error: unconstrained opaque type
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:22:19
+   |
+LL |     type Output = impl PlusOne;
+   |                   ^^^^^^^^^^^^
+   |
+   = note: `Output` must be used in combination with a concrete type within the same impl
+
+error[E0700]: hidden type for `impl PlusOne` captures lifetime that does not appear in bounds
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:28:5
+   |
+LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne {
+   |         --                     ------------ opaque type defined here
+   |         |
+   |         hidden type `<&'a mut i32 as Callable>::Output` captures the lifetime `'a` as defined here
+LL |     <&mut i32 as Callable>::call(y)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: to declare that `impl PlusOne` captures `'a`, you can add an explicit `'a` lifetime bound
+   |
+LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne + 'a {
+   |                                             ++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0046, E0700.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.rs
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.rs
@@ -1,0 +1,33 @@
+// This is a non-regression test for issue #116657, where NLL and `-Zpolonius=next` computed
+// different loan scopes when a member constraint was not ultimately applied.
+
+// revisions: nll polonius
+// [polonius] compile-flags: -Zpolonius=next
+
+#![feature(impl_trait_in_assoc_type)]
+
+trait Callable {
+    type Output;
+    fn call(x: Self) -> Self::Output;
+}
+
+trait PlusOne {}
+
+impl<'a> PlusOne for &'a mut i32 {}
+
+impl<T: PlusOne> Callable for T {
+    //[nll]~^ ERROR not all trait items implemented
+    //[polonius]~^^ ERROR not all trait items implemented
+
+    type Output = impl PlusOne;
+    //[nll]~^ ERROR unconstrained opaque type
+    //[polonius]~^^ ERROR unconstrained opaque type
+}
+
+fn test<'a>(y: &'a mut i32) -> impl PlusOne {
+    <&mut i32 as Callable>::call(y)
+    //[nll]~^ ERROR hidden type for `impl PlusOne` captures lifetime
+    //[polonius]~^^ ERROR hidden type for `impl PlusOne` captures lifetime
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #116960 (Location-insensitive polonius: consider a loan escaping if an SCC has member constraints applied only)
 - #116978 (Rewrite gdb pretty-printer registration)
 - #117040 (coverage: Add UI tests for values accepted by `-Cinstrument-coverage`)
 - #117064 (Eliminate rustc_attrs::builtin::handle_errors in favor of emitting errors directly)
 - #117073 (Fix suggestion for renamed coroutines feature)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116960,116978,117040,117064,117073)
<!-- homu-ignore:end -->