### PR TITLE
Warn users who set `non_exhaustive_omitted_patterns` lint level on a match arm

### DIFF
--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -221,6 +221,9 @@ mir_build_non_exhaustive_omitted_pattern = some variants are not matched explici
     .help = ensure that all variants are matched explicitly by adding the suggested match arms
     .note = the matched value is of type `{$scrut_ty}` and the `non_exhaustive_omitted_patterns` attribute was found
 
+mir_build_non_exhaustive_omitted_pattern_lint_on_arm = the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
+    .help = it used to make sense to set the lint level on an individual match arm, but that is no longer the case
+
 mir_build_non_exhaustive_patterns_type_not_empty = non-exhaustive patterns: type `{$ty}` is non-empty
     .def_note = `{$peeled_ty}` defined here
     .type_note = the matched value is of type `{$ty}`

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -221,8 +221,10 @@ mir_build_non_exhaustive_omitted_pattern = some variants are not matched explici
     .help = ensure that all variants are matched explicitly by adding the suggested match arms
     .note = the matched value is of type `{$scrut_ty}` and the `non_exhaustive_omitted_patterns` attribute was found
 
-mir_build_non_exhaustive_omitted_pattern_lint_on_arm = the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
-    .help = it used to make sense to set the lint level on an individual match arm, but that is no longer the case
+mir_build_non_exhaustive_omitted_pattern_lint_on_arm = the lint level must be set on the whole match
+    .help = it no longer has any effect to set the lint level on an individual match arm
+    .label = remove this attribute
+    .suggestion = set the lint level on the whole match
 
 mir_build_non_exhaustive_patterns_type_not_empty = non-exhaustive patterns: type `{$ty}` is non-empty
     .def_note = `{$peeled_ty}` defined here

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -789,6 +789,11 @@ pub(crate) struct NonExhaustiveOmittedPattern<'tcx> {
     pub uncovered: Uncovered<'tcx>,
 }
 
+#[derive(LintDiagnostic)]
+#[diag(mir_build_non_exhaustive_omitted_pattern_lint_on_arm)]
+#[help]
+pub(crate) struct NonExhaustiveOmittedPatternLintOnArm;
+
 #[derive(Subdiagnostic)]
 #[label(mir_build_uncovered)]
 pub(crate) struct Uncovered<'tcx> {

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -792,7 +792,14 @@ pub(crate) struct NonExhaustiveOmittedPattern<'tcx> {
 #[derive(LintDiagnostic)]
 #[diag(mir_build_non_exhaustive_omitted_pattern_lint_on_arm)]
 #[help]
-pub(crate) struct NonExhaustiveOmittedPatternLintOnArm;
+pub(crate) struct NonExhaustiveOmittedPatternLintOnArm {
+    #[label]
+    pub lint_span: Span,
+    #[suggestion(code = "#[{lint_level}({lint_name})]\n", applicability = "maybe-incorrect")]
+    pub suggest_lint_on_match: Option<Span>,
+    pub lint_level: &'static str,
+    pub lint_name: &'static str,
+}
 
 #[derive(Subdiagnostic)]
 #[label(mir_build_uncovered)]

--- a/src/tools/clippy/tests/ui/match_same_arms_non_exhaustive.rs
+++ b/src/tools/clippy/tests/ui/match_same_arms_non_exhaustive.rs
@@ -9,12 +9,12 @@ fn repeat() -> ! {
 }
 
 pub fn f(x: Ordering) {
+    #[deny(non_exhaustive_omitted_patterns)]
     match x {
         Ordering::Relaxed => println!("relaxed"),
         Ordering::Release => println!("release"),
         Ordering::Acquire => println!("acquire"),
         Ordering::AcqRel | Ordering::SeqCst => repeat(),
-        #[deny(non_exhaustive_omitted_patterns)]
         _ => repeat(),
     }
 }

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.lint.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.lint.stderr
@@ -26,44 +26,50 @@ note: the lint level is defined here
 LL |     #[cfg_attr(lint, deny(non_exhaustive_omitted_patterns))]
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
+warning: the lint level must be set on the whole match
   --> $DIR/omitted-patterns-dont-lint-on-arm.rs:34:9
    |
-LL |         _ => {}
-   |         ^
-   |
-   = help: it used to make sense to set the lint level on an individual match arm, but that is no longer the case
-note: the lint level is defined here
-  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:33:16
-   |
 LL |         #[deny(non_exhaustive_omitted_patterns)]
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
-  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:41:9
-   |
+   |                ------------------------------- remove this attribute
 LL |         _ => {}
    |         ^
    |
-   = help: it used to make sense to set the lint level on an individual match arm, but that is no longer the case
-note: the lint level is defined here
-  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:40:31
+   = help: it no longer has any effect to set the lint level on an individual match arm
+help: set the lint level on the whole match
+   |
+LL +     #[deny(non_exhaustive_omitted_patterns)]
+LL |     match val {
+   |
+
+warning: the lint level must be set on the whole match
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:42:9
    |
 LL |         #[cfg_attr(lint, deny(non_exhaustive_omitted_patterns))]
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
-  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:48:9
-   |
+   |                               ------------------------------- remove this attribute
 LL |         _ => {}
    |         ^
    |
-   = help: it used to make sense to set the lint level on an individual match arm, but that is no longer the case
-note: the lint level is defined here
-  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:47:31
+   = help: it no longer has any effect to set the lint level on an individual match arm
+help: set the lint level on the whole match
+   |
+LL +     #[deny(non_exhaustive_omitted_patterns)]
+LL |     match val {
+   |
+
+warning: the lint level must be set on the whole match
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:50:9
    |
 LL |         #[cfg_attr(lint, warn(non_exhaustive_omitted_patterns))]
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ------------------------------- remove this attribute
+LL |         _ => {}
+   |         ^
+   |
+   = help: it no longer has any effect to set the lint level on an individual match arm
+help: set the lint level on the whole match
+   |
+LL +     #[warn(non_exhaustive_omitted_patterns)]
+LL |     match val {
+   |
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 3 warnings emitted
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.lint.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.lint.stderr
@@ -1,0 +1,30 @@
+error: some variants are not matched explicitly
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:15:11
+   |
+LL |     match val {
+   |           ^^^ pattern `NonExhaustiveEnum::Struct { .. }` not covered
+   |
+   = help: ensure that all variants are matched explicitly by adding the suggested match arms
+   = note: the matched value is of type `NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
+note: the lint level is defined here
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:14:12
+   |
+LL |     #[deny(non_exhaustive_omitted_patterns)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: some variants are not matched explicitly
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:23:11
+   |
+LL |     match val {
+   |           ^^^ pattern `NonExhaustiveEnum::Struct { .. }` not covered
+   |
+   = help: ensure that all variants are matched explicitly by adding the suggested match arms
+   = note: the matched value is of type `NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
+note: the lint level is defined here
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:22:27
+   |
+LL |     #[cfg_attr(lint, deny(non_exhaustive_omitted_patterns))]
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.lint.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.lint.stderr
@@ -26,5 +26,44 @@ note: the lint level is defined here
 LL |     #[cfg_attr(lint, deny(non_exhaustive_omitted_patterns))]
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:34:9
+   |
+LL |         _ => {}
+   |         ^
+   |
+   = help: it used to make sense to set the lint level on an individual match arm, but that is no longer the case
+note: the lint level is defined here
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:33:16
+   |
+LL |         #[deny(non_exhaustive_omitted_patterns)]
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:41:9
+   |
+LL |         _ => {}
+   |         ^
+   |
+   = help: it used to make sense to set the lint level on an individual match arm, but that is no longer the case
+note: the lint level is defined here
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:40:31
+   |
+LL |         #[cfg_attr(lint, deny(non_exhaustive_omitted_patterns))]
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:48:9
+   |
+LL |         _ => {}
+   |         ^
+   |
+   = help: it used to make sense to set the lint level on an individual match arm, but that is no longer the case
+note: the lint level is defined here
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:47:31
+   |
+LL |         #[cfg_attr(lint, warn(non_exhaustive_omitted_patterns))]
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.normal.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.normal.stderr
@@ -1,0 +1,16 @@
+error: some variants are not matched explicitly
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:15:11
+   |
+LL |     match val {
+   |           ^^^ pattern `NonExhaustiveEnum::Struct { .. }` not covered
+   |
+   = help: ensure that all variants are matched explicitly by adding the suggested match arms
+   = note: the matched value is of type `NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
+note: the lint level is defined here
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:14:12
+   |
+LL |     #[deny(non_exhaustive_omitted_patterns)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.normal.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.normal.stderr
@@ -12,18 +12,20 @@ note: the lint level is defined here
 LL |     #[deny(non_exhaustive_omitted_patterns)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
+warning: the lint level must be set on the whole match
   --> $DIR/omitted-patterns-dont-lint-on-arm.rs:34:9
    |
+LL |         #[deny(non_exhaustive_omitted_patterns)]
+   |                ------------------------------- remove this attribute
 LL |         _ => {}
    |         ^
    |
-   = help: it used to make sense to set the lint level on an individual match arm, but that is no longer the case
-note: the lint level is defined here
-  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:33:16
+   = help: it no longer has any effect to set the lint level on an individual match arm
+help: set the lint level on the whole match
    |
-LL |         #[deny(non_exhaustive_omitted_patterns)]
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL +     #[deny(non_exhaustive_omitted_patterns)]
+LL |     match val {
+   |
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error; 1 warning emitted
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.normal.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.normal.stderr
@@ -12,5 +12,18 @@ note: the lint level is defined here
 LL |     #[deny(non_exhaustive_omitted_patterns)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: the `non_exhaustive_omitted_pattern` lint level must be set on the whole match
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:34:9
+   |
+LL |         _ => {}
+   |         ^
+   |
+   = help: it used to make sense to set the lint level on an individual match arm, but that is no longer the case
+note: the lint level is defined here
+  --> $DIR/omitted-patterns-dont-lint-on-arm.rs:33:16
+   |
+LL |         #[deny(non_exhaustive_omitted_patterns)]
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.rs
@@ -31,20 +31,20 @@ fn main() {
         NonExhaustiveEnum::Unit => {}
         NonExhaustiveEnum::Tuple(_) => {}
         #[deny(non_exhaustive_omitted_patterns)]
-        _ => {}
+        _ => {} //~ ERROR lint level must be set on the whole match
     }
 
     match val {
         NonExhaustiveEnum::Unit => {}
         NonExhaustiveEnum::Tuple(_) => {}
         #[cfg_attr(lint, deny(non_exhaustive_omitted_patterns))]
-        _ => {}
+        _ => {} //[lint]~ ERROR lint level must be set on the whole match
     }
 
     match val {
         NonExhaustiveEnum::Unit => {}
         NonExhaustiveEnum::Tuple(_) => {}
         #[cfg_attr(lint, warn(non_exhaustive_omitted_patterns))]
-        _ => {}
+        _ => {} //[lint]~ WARN lint level must be set on the whole match
     }
 }

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.rs
@@ -31,20 +31,23 @@ fn main() {
         NonExhaustiveEnum::Unit => {}
         NonExhaustiveEnum::Tuple(_) => {}
         #[deny(non_exhaustive_omitted_patterns)]
-        _ => {} //~ ERROR lint level must be set on the whole match
+        _ => {}
     }
+    //~^^ WARN lint level must be set on the whole match
 
     match val {
         NonExhaustiveEnum::Unit => {}
         NonExhaustiveEnum::Tuple(_) => {}
         #[cfg_attr(lint, deny(non_exhaustive_omitted_patterns))]
-        _ => {} //[lint]~ ERROR lint level must be set on the whole match
+        _ => {}
     }
+    //[lint]~^^ WARN lint level must be set on the whole match
 
     match val {
         NonExhaustiveEnum::Unit => {}
         NonExhaustiveEnum::Tuple(_) => {}
         #[cfg_attr(lint, warn(non_exhaustive_omitted_patterns))]
-        _ => {} //[lint]~ WARN lint level must be set on the whole match
+        _ => {}
     }
+    //[lint]~^^ WARN lint level must be set on the whole match
 }

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns-dont-lint-on-arm.rs
@@ -1,0 +1,50 @@
+// revisions: normal lint
+// Test that putting the lint level on a match arm emits a warning, as this was previously
+// meaningful and is no longer.
+#![feature(non_exhaustive_omitted_patterns_lint)]
+
+// aux-build:enums.rs
+extern crate enums;
+
+use enums::NonExhaustiveEnum;
+
+fn main() {
+    let val = NonExhaustiveEnum::Unit;
+
+    #[deny(non_exhaustive_omitted_patterns)]
+    match val {
+        //~^ ERROR some variants are not matched explicitly
+        NonExhaustiveEnum::Unit => {}
+        NonExhaustiveEnum::Tuple(_) => {}
+        _ => {}
+    }
+
+    #[cfg_attr(lint, deny(non_exhaustive_omitted_patterns))]
+    match val {
+        //[lint]~^ ERROR some variants are not matched explicitly
+        NonExhaustiveEnum::Unit => {}
+        NonExhaustiveEnum::Tuple(_) => {}
+        _ => {}
+    }
+
+    match val {
+        NonExhaustiveEnum::Unit => {}
+        NonExhaustiveEnum::Tuple(_) => {}
+        #[deny(non_exhaustive_omitted_patterns)]
+        _ => {}
+    }
+
+    match val {
+        NonExhaustiveEnum::Unit => {}
+        NonExhaustiveEnum::Tuple(_) => {}
+        #[cfg_attr(lint, deny(non_exhaustive_omitted_patterns))]
+        _ => {}
+    }
+
+    match val {
+        NonExhaustiveEnum::Unit => {}
+        NonExhaustiveEnum::Tuple(_) => {}
+        #[cfg_attr(lint, warn(non_exhaustive_omitted_patterns))]
+        _ => {}
+    }
+}


### PR DESCRIPTION
Before https://github.com/rust-lang/rust/pull/116734, the recommended usage of the [`non_exhaustive_omitted_patterns` lint](https://github.com/rust-lang/rust/issues/89554) was:
```rust
match Bar::A {
    Bar::A => {},
    #[warn(non_exhaustive_omitted_patterns)]
    _ => {},
}
```
After https://github.com/rust-lang/rust/pull/116734 this no longer makes sense, and recommended usage is now:
```rust
#[warn(non_exhaustive_omitted_patterns)]
match Bar::A {
    Bar::A => {},
    _ => {},
}
```

As you can guess, this silently breaks all uses of the lint that used the previous form. This is a problem in particular because `syn` recommends usage of this lint to its users in the old way. This PR emits a warning when the previous form is used so users can update.

r? @cjgillot