### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -31,6 +31,8 @@ Alexis Beingessner <a.beingessner@gmail.com>
 Alfie John <alfie@alfie.wtf> Alfie John <alfiej@fastmail.fm>
 Alona Enraght-Moony <code@alona.page> <nixon.emoony@gmail.com>
 Alona Enraght-Moony <code@alona.page> <nixon@caminus.local>
+Amanda Stjerna <mail@amandastjerna.se> <albin.stjerna@gmail.com>
+Amanda Stjerna <mail@amandastjerna.se> <amanda.stjerna@it.uu.se>
 Amos Onn <amosonn@gmail.com>
 Ana-Maria Mihalache <mihalacheana.maria@yahoo.com>
 Anatoly Ikorsky <aikorsky@gmail.com>

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -470,7 +470,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             }
         }
 
-        ty.print(printer).unwrap().into_buffer()
+        ty.print(&mut printer).unwrap();
+        printer.into_buffer()
     }
 
     /// Returns the name of the provided `Ty` (that must be a reference)'s region with a
@@ -492,7 +493,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             bug!("ty for annotation of borrow region is not a reference");
         };
 
-        region.print(printer).unwrap().into_buffer()
+        region.print(&mut printer).unwrap();
+        printer.into_buffer()
     }
 }
 

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -107,10 +107,10 @@ impl<Prov: Provenance> std::fmt::Display for ImmTy<'_, Prov> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         /// Helper function for printing a scalar to a FmtPrinter
         fn p<'a, 'tcx, Prov: Provenance>(
-            cx: FmtPrinter<'a, 'tcx>,
+            cx: &mut FmtPrinter<'a, 'tcx>,
             s: Scalar<Prov>,
             ty: Ty<'tcx>,
-        ) -> Result<FmtPrinter<'a, 'tcx>, std::fmt::Error> {
+        ) -> Result<(), std::fmt::Error> {
             match s {
                 Scalar::Int(int) => cx.pretty_print_const_scalar_int(int, ty, true),
                 Scalar::Ptr(ptr, _sz) => {
@@ -125,8 +125,9 @@ impl<Prov: Provenance> std::fmt::Display for ImmTy<'_, Prov> {
             match self.imm {
                 Immediate::Scalar(s) => {
                     if let Some(ty) = tcx.lift(self.layout.ty) {
-                        let cx = FmtPrinter::new(tcx, Namespace::ValueNS);
-                        f.write_str(&p(cx, s, ty)?.into_buffer())?;
+                        let s =
+                            FmtPrinter::print_string(tcx, Namespace::ValueNS, |cx| p(cx, s, ty))?;
+                        f.write_str(&s)?;
                         return Ok(());
                     }
                     write!(f, "{:x}: {}", s, self.layout.ty)

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -588,60 +588,60 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 self.tcx
             }
 
-            fn print_region(self, _region: ty::Region<'_>) -> Result<Self, PrintError> {
+            fn print_region(&mut self, _region: ty::Region<'_>) -> Result<(), PrintError> {
                 Err(fmt::Error)
             }
 
-            fn print_type(self, _ty: Ty<'tcx>) -> Result<Self, PrintError> {
+            fn print_type(&mut self, _ty: Ty<'tcx>) -> Result<(), PrintError> {
                 Err(fmt::Error)
             }
 
             fn print_dyn_existential(
-                self,
+                &mut self,
                 _predicates: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
-            ) -> Result<Self, PrintError> {
+            ) -> Result<(), PrintError> {
                 Err(fmt::Error)
             }
 
-            fn print_const(self, _ct: ty::Const<'tcx>) -> Result<Self, PrintError> {
+            fn print_const(&mut self, _ct: ty::Const<'tcx>) -> Result<(), PrintError> {
                 Err(fmt::Error)
             }
 
-            fn path_crate(mut self, cnum: CrateNum) -> Result<Self, PrintError> {
+            fn path_crate(&mut self, cnum: CrateNum) -> Result<(), PrintError> {
                 self.segments = vec![self.tcx.crate_name(cnum).to_string()];
-                Ok(self)
+                Ok(())
             }
             fn path_qualified(
-                self,
+                &mut self,
                 _self_ty: Ty<'tcx>,
                 _trait_ref: Option<ty::TraitRef<'tcx>>,
-            ) -> Result<Self, PrintError> {
+            ) -> Result<(), PrintError> {
                 Err(fmt::Error)
             }
 
             fn path_append_impl(
-                self,
-                _print_prefix: impl FnOnce(Self) -> Result<Self, PrintError>,
+                &mut self,
+                _print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
                 _disambiguated_data: &DisambiguatedDefPathData,
                 _self_ty: Ty<'tcx>,
                 _trait_ref: Option<ty::TraitRef<'tcx>>,
-            ) -> Result<Self, PrintError> {
+            ) -> Result<(), PrintError> {
                 Err(fmt::Error)
             }
             fn path_append(
-                mut self,
-                print_prefix: impl FnOnce(Self) -> Result<Self, PrintError>,
+                &mut self,
+                print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
                 disambiguated_data: &DisambiguatedDefPathData,
-            ) -> Result<Self, PrintError> {
-                self = print_prefix(self)?;
+            ) -> Result<(), PrintError> {
+                print_prefix(self)?;
                 self.segments.push(disambiguated_data.to_string());
-                Ok(self)
+                Ok(())
             }
             fn path_generic_args(
-                self,
-                print_prefix: impl FnOnce(Self) -> Result<Self, PrintError>,
+                &mut self,
+                print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
                 _args: &[GenericArg<'tcx>],
-            ) -> Result<Self, PrintError> {
+            ) -> Result<(), PrintError> {
                 print_prefix(self)
             }
         }
@@ -652,9 +652,8 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             // let _ = [{struct Foo; Foo}, {struct Foo; Foo}];
             if did1.krate != did2.krate {
                 let abs_path = |def_id| {
-                    AbsolutePathPrinter { tcx: self.tcx, segments: vec![] }
-                        .print_def_path(def_id, &[])
-                        .map(|p| p.segments)
+                    let mut printer = AbsolutePathPrinter { tcx: self.tcx, segments: vec![] };
+                    printer.print_def_path(def_id, &[]).map(|_| printer.segments)
                 };
 
                 // We compare strings because DefPath can be different
@@ -1058,7 +1057,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
 
         let get_lifetimes = |sig| {
             use rustc_hir::def::Namespace;
-            let (_, sig, reg) = ty::print::FmtPrinter::new(self.tcx, Namespace::TypeNS)
+            let (sig, reg) = ty::print::FmtPrinter::new(self.tcx, Namespace::TypeNS)
                 .name_all_regions(sig)
                 .unwrap();
             let lts: Vec<String> = reg.into_values().map(|kind| kind.to_string()).collect();

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -49,8 +49,8 @@ where
         let mut printer = ty::print::FmtPrinter::new(self.tcx, Namespace::TypeNS);
         printer.region_highlight_mode = self.highlight;
 
-        let s = self.value.print(printer)?.into_buffer();
-        f.write_str(&s)
+        self.value.print(&mut printer)?;
+        f.write_str(&printer.into_buffer())
     }
 }
 

--- a/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
@@ -763,9 +763,9 @@ fn foo(&self) -> Self::T { String::new() }
     }
 
     pub fn format_generic_args(&self, args: &[ty::GenericArg<'tcx>]) -> String {
-        FmtPrinter::new(self.tcx, hir::def::Namespace::TypeNS)
-            .path_generic_args(Ok, args)
-            .expect("could not write to `String`.")
-            .into_buffer()
+        FmtPrinter::print_string(self.tcx, hir::def::Namespace::TypeNS, |cx| {
+            cx.path_generic_args(|_| Ok(()), args)
+        })
+        .expect("could not write to `String`.")
     }
 }

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -998,9 +998,9 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                         ty::tls::with(|tcx| {
                             let variant_def = &tcx.adt_def(adt_did).variant(variant);
                             let args = tcx.lift(args).expect("could not lift for printing");
-                            let name = FmtPrinter::new(tcx, Namespace::ValueNS)
-                                .print_def_path(variant_def.def_id, args)?
-                                .into_buffer();
+                            let name = FmtPrinter::print_string(tcx, Namespace::ValueNS, |cx| {
+                                cx.print_def_path(variant_def.def_id, args)
+                            })?;
 
                             match variant_def.ctor_kind() {
                                 Some(CtorKind::Const) => fmt.write_str(&name),
@@ -1740,7 +1740,7 @@ fn pretty_print_const_value_tcx<'tcx>(
                         let args = tcx.lift(args).unwrap();
                         let mut cx = FmtPrinter::new(tcx, Namespace::ValueNS);
                         cx.print_alloc_ids = true;
-                        let cx = cx.print_value_path(variant_def.def_id, args)?;
+                        cx.print_value_path(variant_def.def_id, args)?;
                         fmt.write_str(&cx.into_buffer())?;
 
                         match variant_def.ctor_kind() {
@@ -1775,14 +1775,14 @@ fn pretty_print_const_value_tcx<'tcx>(
             let mut cx = FmtPrinter::new(tcx, Namespace::ValueNS);
             cx.print_alloc_ids = true;
             let ty = tcx.lift(ty).unwrap();
-            cx = cx.pretty_print_const_scalar(scalar, ty)?;
+            cx.pretty_print_const_scalar(scalar, ty)?;
             fmt.write_str(&cx.into_buffer())?;
             return Ok(());
         }
         (ConstValue::ZeroSized, ty::FnDef(d, s)) => {
             let mut cx = FmtPrinter::new(tcx, Namespace::ValueNS);
             cx.print_alloc_ids = true;
-            let cx = cx.print_value_path(*d, s)?;
+            cx.print_value_path(*d, s)?;
             fmt.write_str(&cx.into_buffer())?;
             return Ok(());
         }

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -298,9 +298,9 @@ fn fmt_instance(
     ty::tls::with(|tcx| {
         let args = tcx.lift(instance.args).expect("could not lift for printing");
 
-        let s = FmtPrinter::new_with_limit(tcx, Namespace::ValueNS, type_length)
-            .print_def_path(instance.def_id(), args)?
-            .into_buffer();
+        let mut cx = FmtPrinter::new_with_limit(tcx, Namespace::ValueNS, type_length);
+        cx.print_def_path(instance.def_id(), args)?;
+        let s = cx.into_buffer();
         f.write_str(&s)
     })?;
 

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -22,11 +22,10 @@ impl fmt::Debug for ty::TraitDef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         ty::tls::with(|tcx| {
             with_no_trimmed_paths!({
-                f.write_str(
-                    &FmtPrinter::new(tcx, Namespace::TypeNS)
-                        .print_def_path(self.def_id, &[])?
-                        .into_buffer(),
-                )
+                let s = FmtPrinter::print_string(tcx, Namespace::TypeNS, |cx| {
+                    cx.print_def_path(self.def_id, &[])
+                })?;
+                f.write_str(&s)
             })
         })
     }
@@ -36,11 +35,10 @@ impl<'tcx> fmt::Debug for ty::AdtDef<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         ty::tls::with(|tcx| {
             with_no_trimmed_paths!({
-                f.write_str(
-                    &FmtPrinter::new(tcx, Namespace::TypeNS)
-                        .print_def_path(self.did(), &[])?
-                        .into_buffer(),
-                )
+                let s = FmtPrinter::print_string(tcx, Namespace::TypeNS, |cx| {
+                    cx.print_def_path(self.did(), &[])
+                })?;
+                f.write_str(&s)
             })
         })
     }
@@ -350,9 +348,8 @@ impl<'tcx> DebugWithInfcx<TyCtxt<'tcx>> for ty::Const<'tcx> {
                 let ConstKind::Value(valtree) = lifted.kind() else {
                     bug!("we checked that this is a valtree")
                 };
-                let cx = FmtPrinter::new(tcx, Namespace::ValueNS);
-                let cx =
-                    cx.pretty_print_const_valtree(valtree, lifted.ty(), /*print_ty*/ true)?;
+                let mut cx = FmtPrinter::new(tcx, Namespace::ValueNS);
+                cx.pretty_print_const_valtree(valtree, lifted.ty(), /*print_ty*/ true)?;
                 f.write_str(&cx.into_buffer())
             });
         }

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -2,13 +2,13 @@
 //!
 //! Currently, this pass only propagates scalar values.
 
-use rustc_const_eval::interpret::{ImmTy, Immediate, InterpCx, OpTy, Projectable};
+use rustc_const_eval::interpret::{ImmTy, Immediate, InterpCx, OpTy, PlaceTy, Projectable};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::DefKind;
 use rustc_middle::mir::interpret::{AllocId, ConstAllocation, InterpResult, Scalar};
 use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
 use rustc_middle::mir::*;
-use rustc_middle::ty::layout::TyAndLayout;
+use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_mir_dataflow::value_analysis::{
     Map, PlaceIndex, State, TrackElem, ValueAnalysis, ValueAnalysisWrapper, ValueOrPlace,
@@ -16,8 +16,9 @@ use rustc_mir_dataflow::value_analysis::{
 use rustc_mir_dataflow::{lattice::FlatSet, Analysis, Results, ResultsVisitor};
 use rustc_span::def_id::DefId;
 use rustc_span::DUMMY_SP;
-use rustc_target::abi::{FieldIdx, VariantIdx};
+use rustc_target::abi::{Abi, FieldIdx, Size, VariantIdx, FIRST_VARIANT};
 
+use crate::const_prop::throw_machine_stop_str;
 use crate::MirPass;
 
 // These constants are somewhat random guesses and have not been optimized.
@@ -553,107 +554,151 @@ impl<'tcx, 'locals> Collector<'tcx, 'locals> {
 
     fn try_make_constant(
         &self,
+        ecx: &mut InterpCx<'tcx, 'tcx, DummyMachine>,
         place: Place<'tcx>,
         state: &State<FlatSet<Scalar>>,
         map: &Map,
     ) -> Option<Const<'tcx>> {
         let ty = place.ty(self.local_decls, self.patch.tcx).ty;
+        let layout = ecx.layout_of(ty).ok()?;
+
+        if layout.is_zst() {
+            return Some(Const::zero_sized(ty));
+        }
+
+        if layout.is_unsized() {
+            return None;
+        }
+
         let place = map.find(place.as_ref())?;
-        if let FlatSet::Elem(Scalar::Int(value)) = state.get_idx(place, map) {
-            Some(Const::Val(ConstValue::Scalar(value.into()), ty))
-        } else {
-            let valtree = self.try_make_valtree(place, ty, state, map)?;
-            let constant = ty::Const::new_value(self.patch.tcx, valtree, ty);
-            Some(Const::Ty(constant))
+        if layout.abi.is_scalar()
+            && let Some(value) = propagatable_scalar(place, state, map)
+        {
+            return Some(Const::Val(ConstValue::Scalar(value), ty));
         }
+
+        if matches!(layout.abi, Abi::Scalar(..) | Abi::ScalarPair(..)) {
+            let alloc_id = ecx
+                .intern_with_temp_alloc(layout, |ecx, dest| {
+                    try_write_constant(ecx, dest, place, ty, state, map)
+                })
+                .ok()?;
+            return Some(Const::Val(ConstValue::Indirect { alloc_id, offset: Size::ZERO }, ty));
+        }
+
+        None
+    }
+}
+
+fn propagatable_scalar(
+    place: PlaceIndex,
+    state: &State<FlatSet<Scalar>>,
+    map: &Map,
+) -> Option<Scalar> {
+    if let FlatSet::Elem(value) = state.get_idx(place, map) && value.try_to_int().is_ok() {
+        // Do not attempt to propagate pointers, as we may fail to preserve their identity.
+        Some(value)
+    } else {
+        None
+    }
+}
+
+#[instrument(level = "trace", skip(ecx, state, map))]
+fn try_write_constant<'tcx>(
+    ecx: &mut InterpCx<'_, 'tcx, DummyMachine>,
+    dest: &PlaceTy<'tcx>,
+    place: PlaceIndex,
+    ty: Ty<'tcx>,
+    state: &State<FlatSet<Scalar>>,
+    map: &Map,
+) -> InterpResult<'tcx> {
+    let layout = ecx.layout_of(ty)?;
+
+    // Fast path for ZSTs.
+    if layout.is_zst() {
+        return Ok(());
     }
 
-    fn try_make_valtree(
-        &self,
-        place: PlaceIndex,
-        ty: Ty<'tcx>,
-        state: &State<FlatSet<Scalar>>,
-        map: &Map,
-    ) -> Option<ty::ValTree<'tcx>> {
-        let tcx = self.patch.tcx;
-        match ty.kind() {
-            // ZSTs.
-            ty::FnDef(..) => Some(ty::ValTree::zst()),
+    // Fast path for scalars.
+    if layout.abi.is_scalar()
+        && let Some(value) = propagatable_scalar(place, state, map)
+    {
+        return ecx.write_immediate(Immediate::Scalar(value), dest);
+    }
 
-            // Scalars.
-            ty::Bool | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Char => {
-                if let FlatSet::Elem(Scalar::Int(value)) = state.get_idx(place, map) {
-                    Some(ty::ValTree::Leaf(value))
-                } else {
-                    None
-                }
-            }
+    match ty.kind() {
+        // ZSTs. Nothing to do.
+        ty::FnDef(..) => {}
 
-            // Unsupported for now.
-            ty::Array(_, _) => None,
+        // Those are scalars, must be handled above.
+        ty::Bool | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Char => throw_machine_stop_str!("primitive type with provenance"),
 
-            ty::Tuple(elem_tys) => {
-                let branches = elem_tys
-                    .iter()
-                    .enumerate()
-                    .map(|(i, ty)| {
-                        let field = map.apply(place, TrackElem::Field(FieldIdx::from_usize(i)))?;
-                        self.try_make_valtree(field, ty, state, map)
-                    })
-                    .collect::<Option<Vec<_>>>()?;
-                Some(ty::ValTree::Branch(tcx.arena.alloc_from_iter(branches.into_iter())))
-            }
-
-            ty::Adt(def, args) => {
-                if def.is_union() {
-                    return None;
-                }
-
-                let (variant_idx, variant_def, variant_place) = if def.is_enum() {
-                    let discr = map.apply(place, TrackElem::Discriminant)?;
-                    let FlatSet::Elem(Scalar::Int(discr)) = state.get_idx(discr, map) else {
-                        return None;
-                    };
-                    let discr_bits = discr.assert_bits(discr.size());
-                    let (variant, _) =
-                        def.discriminants(tcx).find(|(_, var)| discr_bits == var.val)?;
-                    let variant_place = map.apply(place, TrackElem::Variant(variant))?;
-                    let variant_int = ty::ValTree::Leaf(variant.as_u32().into());
-                    (Some(variant_int), def.variant(variant), variant_place)
-                } else {
-                    (None, def.non_enum_variant(), place)
+        ty::Tuple(elem_tys) => {
+            for (i, elem) in elem_tys.iter().enumerate() {
+                let Some(field) = map.apply(place, TrackElem::Field(FieldIdx::from_usize(i))) else {
+                    throw_machine_stop_str!("missing field in tuple")
                 };
+                let field_dest = ecx.project_field(dest, i)?;
+                try_write_constant(ecx, &field_dest, field, elem, state, map)?;
+            }
+        }
 
-                let branches = variant_def
-                    .fields
-                    .iter_enumerated()
-                    .map(|(i, field)| {
-                        let ty = field.ty(tcx, args);
-                        let field = map.apply(variant_place, TrackElem::Field(i))?;
-                        self.try_make_valtree(field, ty, state, map)
-                    })
-                    .collect::<Option<Vec<_>>>()?;
-                Some(ty::ValTree::Branch(
-                    tcx.arena.alloc_from_iter(variant_idx.into_iter().chain(branches)),
-                ))
+        ty::Adt(def, args) => {
+            if def.is_union() {
+                throw_machine_stop_str!("cannot propagate unions")
             }
 
-            // Do not attempt to support indirection in constants.
-            ty::Ref(..) | ty::RawPtr(..) | ty::FnPtr(..) | ty::Str | ty::Slice(_) => None,
+            let (variant_idx, variant_def, variant_place, variant_dest) = if def.is_enum() {
+                let Some(discr) = map.apply(place, TrackElem::Discriminant) else {
+                    throw_machine_stop_str!("missing discriminant for enum")
+                };
+                let FlatSet::Elem(Scalar::Int(discr)) = state.get_idx(discr, map) else {
+                    throw_machine_stop_str!("discriminant with provenance")
+                };
+                let discr_bits = discr.assert_bits(discr.size());
+                let Some((variant, _)) = def.discriminants(*ecx.tcx).find(|(_, var)| discr_bits == var.val) else {
+                    throw_machine_stop_str!("illegal discriminant for enum")
+                };
+                let Some(variant_place) = map.apply(place, TrackElem::Variant(variant)) else {
+                    throw_machine_stop_str!("missing variant for enum")
+                };
+                let variant_dest = ecx.project_downcast(dest, variant)?;
+                (variant, def.variant(variant), variant_place, variant_dest)
+            } else {
+                (FIRST_VARIANT, def.non_enum_variant(), place, dest.clone())
+            };
 
-            ty::Never
-            | ty::Foreign(..)
-            | ty::Alias(..)
-            | ty::Param(_)
-            | ty::Bound(..)
-            | ty::Placeholder(..)
-            | ty::Closure(..)
-            | ty::Coroutine(..)
-            | ty::Dynamic(..) => None,
-
-            ty::Error(_) | ty::Infer(..) | ty::CoroutineWitness(..) => bug!(),
+            for (i, field) in variant_def.fields.iter_enumerated() {
+                let ty = field.ty(*ecx.tcx, args);
+                let Some(field) = map.apply(variant_place, TrackElem::Field(i)) else {
+                    throw_machine_stop_str!("missing field in ADT")
+                };
+                let field_dest = ecx.project_field(&variant_dest, i.as_usize())?;
+                try_write_constant(ecx, &field_dest, field, ty, state, map)?;
+            }
+            ecx.write_discriminant(variant_idx, dest)?;
         }
+
+        // Unsupported for now.
+        ty::Array(_, _)
+
+        // Do not attempt to support indirection in constants.
+        | ty::Ref(..) | ty::RawPtr(..) | ty::FnPtr(..) | ty::Str | ty::Slice(_)
+
+        | ty::Never
+        | ty::Foreign(..)
+        | ty::Alias(..)
+        | ty::Param(_)
+        | ty::Bound(..)
+        | ty::Placeholder(..)
+        | ty::Closure(..)
+        | ty::Coroutine(..)
+        | ty::Dynamic(..) => throw_machine_stop_str!("unsupported type"),
+
+        ty::Error(_) | ty::Infer(..) | ty::CoroutineWitness(..) => bug!(),
     }
+
+    Ok(())
 }
 
 impl<'mir, 'tcx>
@@ -671,8 +716,13 @@ impl<'mir, 'tcx>
     ) {
         match &statement.kind {
             StatementKind::Assign(box (_, rvalue)) => {
-                OperandCollector { state, visitor: self, map: &results.analysis.0.map }
-                    .visit_rvalue(rvalue, location);
+                OperandCollector {
+                    state,
+                    visitor: self,
+                    ecx: &mut results.analysis.0.ecx,
+                    map: &results.analysis.0.map,
+                }
+                .visit_rvalue(rvalue, location);
             }
             _ => (),
         }
@@ -690,7 +740,12 @@ impl<'mir, 'tcx>
                 // Don't overwrite the assignment if it already uses a constant (to keep the span).
             }
             StatementKind::Assign(box (place, _)) => {
-                if let Some(value) = self.try_make_constant(place, state, &results.analysis.0.map) {
+                if let Some(value) = self.try_make_constant(
+                    &mut results.analysis.0.ecx,
+                    place,
+                    state,
+                    &results.analysis.0.map,
+                ) {
                     self.patch.assignments.insert(location, value);
                 }
             }
@@ -705,8 +760,13 @@ impl<'mir, 'tcx>
         terminator: &'mir Terminator<'tcx>,
         location: Location,
     ) {
-        OperandCollector { state, visitor: self, map: &results.analysis.0.map }
-            .visit_terminator(terminator, location);
+        OperandCollector {
+            state,
+            visitor: self,
+            ecx: &mut results.analysis.0.ecx,
+            map: &results.analysis.0.map,
+        }
+        .visit_terminator(terminator, location);
     }
 }
 
@@ -761,6 +821,7 @@ impl<'tcx> MutVisitor<'tcx> for Patch<'tcx> {
 struct OperandCollector<'tcx, 'map, 'locals, 'a> {
     state: &'a State<FlatSet<Scalar>>,
     visitor: &'a mut Collector<'tcx, 'locals>,
+    ecx: &'map mut InterpCx<'tcx, 'tcx, DummyMachine>,
     map: &'map Map,
 }
 
@@ -773,7 +834,7 @@ impl<'tcx> Visitor<'tcx> for OperandCollector<'tcx, '_, '_, '_> {
         location: Location,
     ) {
         if let PlaceElem::Index(local) = elem
-            && let Some(value) = self.visitor.try_make_constant(local.into(), self.state, self.map)
+            && let Some(value) = self.visitor.try_make_constant(self.ecx, local.into(), self.state, self.map)
         {
             self.visitor.patch.before_effect.insert((location, local.into()), value);
         }
@@ -781,7 +842,9 @@ impl<'tcx> Visitor<'tcx> for OperandCollector<'tcx, '_, '_, '_> {
 
     fn visit_operand(&mut self, operand: &Operand<'tcx>, location: Location) {
         if let Some(place) = operand.place() {
-            if let Some(value) = self.visitor.try_make_constant(place, self.state, self.map) {
+            if let Some(value) =
+                self.visitor.try_make_constant(self.ecx, place, self.state, self.map)
+            {
                 self.visitor.patch.before_effect.insert((location, place), value);
             } else if !place.projection.is_empty() {
                 // Try to propagate into `Index` projections.
@@ -804,7 +867,7 @@ impl<'mir, 'tcx: 'mir> rustc_const_eval::interpret::Machine<'mir, 'tcx> for Dumm
     }
 
     fn enforce_validity(_ecx: &InterpCx<'mir, 'tcx, Self>, _layout: TyAndLayout<'tcx>) -> bool {
-        unimplemented!()
+        false
     }
 
     fn before_access_global(
@@ -816,13 +879,13 @@ impl<'mir, 'tcx: 'mir> rustc_const_eval::interpret::Machine<'mir, 'tcx> for Dumm
         is_write: bool,
     ) -> InterpResult<'tcx> {
         if is_write {
-            crate::const_prop::throw_machine_stop_str!("can't write to global");
+            throw_machine_stop_str!("can't write to global");
         }
 
         // If the static allocation is mutable, then we can't const prop it as its content
         // might be different at runtime.
         if alloc.inner().mutability.is_mut() {
-            crate::const_prop::throw_machine_stop_str!("can't access mutable globals in ConstProp");
+            throw_machine_stop_str!("can't access mutable globals in ConstProp");
         }
 
         Ok(())
@@ -872,7 +935,7 @@ impl<'mir, 'tcx: 'mir> rustc_const_eval::interpret::Machine<'mir, 'tcx> for Dumm
         _left: &rustc_const_eval::interpret::ImmTy<'tcx, Self::Provenance>,
         _right: &rustc_const_eval::interpret::ImmTy<'tcx, Self::Provenance>,
     ) -> interpret::InterpResult<'tcx, (ImmTy<'tcx, Self::Provenance>, bool)> {
-        crate::const_prop::throw_machine_stop_str!("can't do pointer arithmetic");
+        throw_machine_stop_str!("can't do pointer arithmetic");
     }
 
     fn expose_ptr(

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -169,6 +169,9 @@ pub enum MirSpanview {
 pub enum InstrumentCoverage {
     /// Default `-C instrument-coverage` or `-C instrument-coverage=statement`
     All,
+    /// Additionally, instrument branches and output branch coverage.
+    /// `-Zunstable-options -C instrument-coverage=branch`
+    Branch,
     /// `-Zunstable-options -C instrument-coverage=except-unused-generics`
     ExceptUnusedGenerics,
     /// `-Zunstable-options -C instrument-coverage=except-unused-functions`
@@ -2747,7 +2750,10 @@ pub fn build_session_options(
         }
         (Some(InstrumentCoverage::Off | InstrumentCoverage::All), _) => {}
         (Some(_), _) if !unstable_opts.unstable_options => {
-            handler.early_error("`-C instrument-coverage=except-*` requires `-Z unstable-options`");
+            handler.early_error(
+                "`-C instrument-coverage=branch` and `-C instrument-coverage=except-*` \
+                require `-Z unstable-options`",
+            );
         }
         (None, None) => {}
         (None, ic) => {

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -389,7 +389,7 @@ mod desc {
     pub const parse_mir_spanview: &str = "`statement` (default), `terminator`, or `block`";
     pub const parse_dump_mono_stats: &str = "`markdown` (default) or `json`";
     pub const parse_instrument_coverage: &str =
-        "`all` (default), `except-unused-generics`, `except-unused-functions`, or `off`";
+        "`all` (default), `branch`, `except-unused-generics`, `except-unused-functions`, or `off`";
     pub const parse_instrument_xray: &str = "either a boolean (`yes`, `no`, `on`, `off`, etc), or a comma separated list of settings: `always` or `never` (mutually exclusive), `ignore-loops`, `instruction-threshold=N`, `skip-entry`, `skip-exit`";
     pub const parse_unpretty: &str = "`string` or `string=string`";
     pub const parse_treat_err_as_bug: &str = "either no value or a non-negative number";
@@ -931,6 +931,7 @@ mod parse {
 
         *slot = Some(match v {
             "all" => InstrumentCoverage::All,
+            "branch" => InstrumentCoverage::Branch,
             "except-unused-generics" | "except_unused_generics" => {
                 InstrumentCoverage::ExceptUnusedGenerics
             }
@@ -1356,6 +1357,7 @@ options! {
         reports (note, the compiler build config must include `profiler = true`); \
         implies `-C symbol-mangling-version=v0`. Optional values are:
         `=all` (implicit value)
+        `=branch`
         `=except-unused-generics`
         `=except-unused-functions`
         `=off` (default)"),
@@ -1597,6 +1599,7 @@ options! {
         reports (note, the compiler build config must include `profiler = true`); \
         implies `-C symbol-mangling-version=v0`. Optional values are:
         `=all` (implicit value)
+        `=branch`
         `=except-unused-generics`
         `=except-unused-functions`
         `=off` (default)"),

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -702,6 +702,10 @@ impl Session {
         self.opts.cg.instrument_coverage() != InstrumentCoverage::Off
     }
 
+    pub fn instrument_coverage_branch(&self) -> bool {
+        self.opts.cg.instrument_coverage() == InstrumentCoverage::Branch
+    }
+
     pub fn instrument_coverage_except_unused_generics(&self) -> bool {
         self.opts.cg.instrument_coverage() == InstrumentCoverage::ExceptUnusedGenerics
     }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -641,13 +641,13 @@ fn build_const(cx: &mut DocContext<'_>, def_id: DefId) -> clean::Constant {
     clean::simplify::move_bounds_to_generic_parameters(&mut generics);
 
     clean::Constant {
-        type_: clean_middle_ty(
+        type_: Box::new(clean_middle_ty(
             ty::Binder::dummy(cx.tcx.type_of(def_id).instantiate_identity()),
             cx,
             Some(def_id),
             None,
-        ),
-        generics: Box::new(generics),
+        )),
+        generics,
         kind: clean::ConstantKind::Extern { def_id },
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -259,13 +259,13 @@ fn clean_lifetime<'tcx>(lifetime: &hir::Lifetime, cx: &mut DocContext<'tcx>) -> 
 pub(crate) fn clean_const<'tcx>(constant: &hir::ConstArg, cx: &mut DocContext<'tcx>) -> Constant {
     let def_id = cx.tcx.hir().body_owner_def_id(constant.value.body).to_def_id();
     Constant {
-        type_: clean_middle_ty(
+        type_: Box::new(clean_middle_ty(
             ty::Binder::dummy(cx.tcx.type_of(def_id).instantiate_identity()),
             cx,
             Some(def_id),
             None,
-        ),
-        generics: Box::new(Generics::default()),
+        )),
+        generics: Generics::default(),
         kind: ConstantKind::Anonymous { body: constant.value.body },
     }
 }
@@ -276,8 +276,8 @@ pub(crate) fn clean_middle_const<'tcx>(
 ) -> Constant {
     // FIXME: instead of storing the stringified expression, store `self` directly instead.
     Constant {
-        type_: clean_middle_ty(constant.map_bound(|c| c.ty()), cx, None, None),
-        generics: Box::new(Generics::default()),
+        type_: Box::new(clean_middle_ty(constant.map_bound(|c| c.ty()), cx, None, None)),
+        generics: Generics::default(),
         kind: ConstantKind::TyConst { expr: constant.skip_binder().to_string().into() },
     }
 }
@@ -1216,14 +1216,14 @@ fn clean_trait_item<'tcx>(trait_item: &hir::TraitItem<'tcx>, cx: &mut DocContext
             hir::TraitItemKind::Const(ty, Some(default)) => {
                 let generics = enter_impl_trait(cx, |cx| clean_generics(trait_item.generics, cx));
                 AssocConstItem(
-                    Box::new(generics),
-                    clean_ty(ty, cx),
+                    generics,
+                    Box::new(clean_ty(ty, cx)),
                     ConstantKind::Local { def_id: local_did, body: default },
                 )
             }
             hir::TraitItemKind::Const(ty, None) => {
                 let generics = enter_impl_trait(cx, |cx| clean_generics(trait_item.generics, cx));
-                TyAssocConstItem(Box::new(generics), clean_ty(ty, cx))
+                TyAssocConstItem(generics, Box::new(clean_ty(ty, cx)))
             }
             hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(body)) => {
                 let m = clean_function(cx, sig, trait_item.generics, FunctionArgs::Body(body));
@@ -1272,7 +1272,7 @@ pub(crate) fn clean_impl_item<'tcx>(
             hir::ImplItemKind::Const(ty, expr) => {
                 let generics = clean_generics(impl_.generics, cx);
                 let default = ConstantKind::Local { def_id: local_did, body: expr };
-                AssocConstItem(Box::new(generics), clean_ty(ty, cx), default)
+                AssocConstItem(generics, Box::new(clean_ty(ty, cx)), default)
             }
             hir::ImplItemKind::Fn(ref sig, body) => {
                 let m = clean_function(cx, sig, impl_.generics, FunctionArgs::Body(body));
@@ -1311,18 +1311,18 @@ pub(crate) fn clean_middle_assoc_item<'tcx>(
     let tcx = cx.tcx;
     let kind = match assoc_item.kind {
         ty::AssocKind::Const => {
-            let ty = clean_middle_ty(
+            let ty = Box::new(clean_middle_ty(
                 ty::Binder::dummy(tcx.type_of(assoc_item.def_id).instantiate_identity()),
                 cx,
                 Some(assoc_item.def_id),
                 None,
-            );
+            ));
 
-            let mut generics = Box::new(clean_ty_generics(
+            let mut generics = clean_ty_generics(
                 cx,
                 tcx.generics_of(assoc_item.def_id),
                 tcx.explicit_predicates_of(assoc_item.def_id),
-            ));
+            );
             simplify::move_bounds_to_generic_parameters(&mut generics);
 
             let provided = match assoc_item.container {
@@ -2718,8 +2718,8 @@ fn clean_maybe_renamed_item<'tcx>(
                 StaticItem(Static { type_: clean_ty(ty, cx), mutability, expr: Some(body_id) })
             }
             ItemKind::Const(ty, generics, body_id) => ConstantItem(Constant {
-                type_: clean_ty(ty, cx),
-                generics: Box::new(clean_generics(generics, cx)),
+                type_: Box::new(clean_ty(ty, cx)),
+                generics: clean_generics(generics, cx),
                 kind: ConstantKind::Local { body: body_id, def_id },
             }),
             ItemKind::OpaqueTy(ref ty) => OpaqueTyItem(OpaqueTy {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -852,9 +852,9 @@ pub(crate) enum ItemKind {
     ProcMacroItem(ProcMacro),
     PrimitiveItem(PrimitiveType),
     /// A required associated constant in a trait declaration.
-    TyAssocConstItem(Box<Generics>, Type),
+    TyAssocConstItem(Generics, Box<Type>),
     /// An associated constant in a trait impl or a provided one in a trait declaration.
-    AssocConstItem(Box<Generics>, Type, ConstantKind),
+    AssocConstItem(Generics, Box<Type>, ConstantKind),
     /// A required associated type in a trait declaration.
     ///
     /// The bounds may be non-empty if there is a `where` clause.
@@ -2282,8 +2282,8 @@ pub(crate) struct Static {
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub(crate) struct Constant {
-    pub(crate) type_: Type,
-    pub(crate) generics: Box<Generics>,
+    pub(crate) type_: Box<Type>,
+    pub(crate) generics: Generics,
     pub(crate) kind: ConstantKind,
 }
 
@@ -2525,7 +2525,7 @@ mod size_asserts {
     static_assert_size!(Generics, 16);
     static_assert_size!(Item, 56);
     // FIXME(generic_const_items): Further reduce the size.
-    static_assert_size!(ItemKind, 72);
+    static_assert_size!(ItemKind, 56);
     static_assert_size!(PathSegment, 40);
     static_assert_size!(Type, 32);
     // tidy-alphabetical-end

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2524,7 +2524,6 @@ mod size_asserts {
     static_assert_size!(GenericParamDef, 56);
     static_assert_size!(Generics, 16);
     static_assert_size!(Item, 56);
-    // FIXME(generic_const_items): Further reduce the size.
     static_assert_size!(ItemKind, 56);
     static_assert_size!(PathSegment, 40);
     static_assert_size!(Type, 32);

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -177,7 +177,7 @@ impl FromWithTcx<clean::Constant> for Constant {
         let expr = constant.expr(tcx);
         let value = constant.value(tcx);
         let is_literal = constant.is_literal(tcx);
-        Constant { type_: constant.type_.into_tcx(tcx), expr, value, is_literal }
+        Constant { type_: (*constant.type_).into_tcx(tcx), expr, value, is_literal }
     }
 }
 
@@ -325,11 +325,11 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         }
         // FIXME(generic_const_items): Add support for generic associated consts.
         TyAssocConstItem(_generics, ty) => {
-            ItemEnum::AssocConst { type_: ty.into_tcx(tcx), default: None }
+            ItemEnum::AssocConst { type_: (*ty).into_tcx(tcx), default: None }
         }
         // FIXME(generic_const_items): Add support for generic associated consts.
         AssocConstItem(_generics, ty, default) => {
-            ItemEnum::AssocConst { type_: ty.into_tcx(tcx), default: Some(default.expr(tcx)) }
+            ItemEnum::AssocConst { type_: (*ty).into_tcx(tcx), default: Some(default.expr(tcx)) }
         }
         TyAssocTypeItem(g, b) => ItemEnum::AssocType {
             generics: g.into_tcx(tcx),

--- a/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -41,7 +41,8 @@
 +                             debug ((f: (bool, bool, u32)).2: u32) => const 123_u32;
                               let _10: std::option::Option<u16>;
                               scope 7 {
-                                  debug o => _10;
+-                                 debug o => _10;
++                                 debug o => const Option::<u16>::Some(99);
                                   let _17: u32;
                                   let _18: u32;
                                   scope 8 {
@@ -81,7 +82,7 @@
           _15 = const false;
           _16 = const 123_u32;
           StorageLive(_10);
-          _10 = Option::<u16>::Some(const 99_u16);
+          _10 = const Option::<u16>::Some(99);
           _17 = const 32_u32;
           _18 = const 32_u32;
           StorageLive(_11);

--- a/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/tests/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -42,7 +42,7 @@
                               let _10: std::option::Option<u16>;
                               scope 7 {
 -                                 debug o => _10;
-+                                 debug o => const Option::<u16>::Some(99);
++                                 debug o => const Option::<u16>::Some(99_u16);
                                   let _17: u32;
                                   let _18: u32;
                                   scope 8 {
@@ -82,7 +82,7 @@
           _15 = const false;
           _16 = const 123_u32;
           StorageLive(_10);
-          _10 = const Option::<u16>::Some(99);
+          _10 = const Option::<u16>::Some(99_u16);
           _17 = const 32_u32;
           _18 = const 32_u32;
           StorageLive(_11);
@@ -96,5 +96,9 @@
           StorageDead(_4);
           return;
       }
+  }
+  
+  ALLOC0 (size: 4, align: 2) {
+      01 00 63 00                                     │ ..c.
   }
   

--- a/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-abort.diff
@@ -43,7 +43,7 @@
 -         _6 = CheckedAdd(_4, _5);
 -         assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", move _4, move _5) -> [success: bb1, unwind unreachable];
 +         _5 = const 2_i32;
-+         _6 = CheckedAdd(const 1_i32, const 2_i32);
++         _6 = const (3, false);
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_i32, const 2_i32) -> [success: bb1, unwind unreachable];
       }
   
@@ -60,7 +60,7 @@
 -         _10 = CheckedAdd(_9, const 1_i32);
 -         assert(!move (_10.1: bool), "attempt to compute `{} + {}`, which would overflow", move _9, const 1_i32) -> [success: bb2, unwind unreachable];
 +         _9 = const i32::MAX;
-+         _10 = CheckedAdd(const i32::MAX, const 1_i32);
++         _10 = const (i32::MIN, true);
 +         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const i32::MAX, const 1_i32) -> [success: bb2, unwind unreachable];
       }
   

--- a/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-abort.diff
@@ -43,7 +43,7 @@
 -         _6 = CheckedAdd(_4, _5);
 -         assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", move _4, move _5) -> [success: bb1, unwind unreachable];
 +         _5 = const 2_i32;
-+         _6 = const (3, false);
++         _6 = const (3_i32, false);
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_i32, const 2_i32) -> [success: bb1, unwind unreachable];
       }
   
@@ -76,5 +76,13 @@
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC0 (size: 8, align: 4) {
++     00 00 00 80 01 __ __ __                         │ .....░░░
++ }
++ 
++ ALLOC1 (size: 8, align: 4) {
++     03 00 00 00 00 __ __ __                         │ .....░░░
   }
   

--- a/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
@@ -43,7 +43,7 @@
 -         _6 = CheckedAdd(_4, _5);
 -         assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", move _4, move _5) -> [success: bb1, unwind continue];
 +         _5 = const 2_i32;
-+         _6 = const (3, false);
++         _6 = const (3_i32, false);
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_i32, const 2_i32) -> [success: bb1, unwind continue];
       }
   
@@ -76,5 +76,13 @@
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC0 (size: 8, align: 4) {
++     00 00 00 80 01 __ __ __                         │ .....░░░
++ }
++ 
++ ALLOC1 (size: 8, align: 4) {
++     03 00 00 00 00 __ __ __                         │ .....░░░
   }
   

--- a/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
@@ -43,7 +43,7 @@
 -         _6 = CheckedAdd(_4, _5);
 -         assert(!move (_6.1: bool), "attempt to compute `{} + {}`, which would overflow", move _4, move _5) -> [success: bb1, unwind continue];
 +         _5 = const 2_i32;
-+         _6 = CheckedAdd(const 1_i32, const 2_i32);
++         _6 = const (3, false);
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_i32, const 2_i32) -> [success: bb1, unwind continue];
       }
   
@@ -60,7 +60,7 @@
 -         _10 = CheckedAdd(_9, const 1_i32);
 -         assert(!move (_10.1: bool), "attempt to compute `{} + {}`, which would overflow", move _9, const 1_i32) -> [success: bb2, unwind continue];
 +         _9 = const i32::MAX;
-+         _10 = CheckedAdd(const i32::MAX, const 1_i32);
++         _10 = const (i32::MIN, true);
 +         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const i32::MAX, const 1_i32) -> [success: bb2, unwind continue];
       }
   

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
-// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 // compile-flags: -Coverflow-checks=on
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 // EMIT_MIR checked.main.DataflowConstProp.diff
 #[allow(arithmetic_overflow)]

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
@@ -24,7 +24,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = E::V1(const 0_i32);
-+         _1 = const E::V1(0);
++         _1 = const E::V1(0_i32);
           StorageLive(_2);
 -         _3 = discriminant(_1);
 -         switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];
@@ -60,5 +60,9 @@
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC0 (size: 8, align: 4) {
++     00 00 00 00 00 00 00 00                         │ ........
   }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
@@ -23,7 +23,8 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = E::V1(const 0_i32);
+-         _1 = E::V1(const 0_i32);
++         _1 = const E::V1(0);
           StorageLive(_2);
 -         _3 = discriminant(_1);
 -         switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
@@ -24,7 +24,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = E::V1(const 0_i32);
-+         _1 = const E::V1(0);
++         _1 = const E::V1(0_i32);
           StorageLive(_2);
 -         _3 = discriminant(_1);
 -         switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];
@@ -60,5 +60,9 @@
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC0 (size: 8, align: 4) {
++     00 00 00 00 00 00 00 00                         │ ........
   }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
@@ -23,7 +23,8 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = E::V1(const 0_i32);
+-         _1 = E::V1(const 0_i32);
++         _1 = const E::V1(0);
           StorageLive(_2);
 -         _3 = discriminant(_1);
 -         switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
@@ -44,7 +44,8 @@
           StorageLive(_1);
           StorageLive(_2);
           _2 = const {ALLOC1: &E};
-          _1 = (*_2);
+-         _1 = (*_2);
++         _1 = const E::V1(0);
           StorageDead(_2);
           StorageLive(_3);
 -         _4 = discriminant(_1);

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
@@ -45,7 +45,7 @@
           StorageLive(_2);
           _2 = const {ALLOC1: &E};
 -         _1 = (*_2);
-+         _1 = const E::V1(0);
++         _1 = const E::V1(0_i32);
           StorageDead(_2);
           StorageLive(_3);
 -         _4 = discriminant(_1);
@@ -111,6 +111,10 @@
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC3 (size: 8, align: 4) {
++     00 00 00 00 00 00 00 00                         │ ........
   }
   
   ALLOC2 (static: RC, size: 4, align: 4) {

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
@@ -44,7 +44,8 @@
           StorageLive(_1);
           StorageLive(_2);
           _2 = const {ALLOC1: &E};
-          _1 = (*_2);
+-         _1 = (*_2);
++         _1 = const E::V1(0);
           StorageDead(_2);
           StorageLive(_3);
 -         _4 = discriminant(_1);

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
@@ -45,7 +45,7 @@
           StorageLive(_2);
           _2 = const {ALLOC1: &E};
 -         _1 = (*_2);
-+         _1 = const E::V1(0);
++         _1 = const E::V1(0_i32);
           StorageDead(_2);
           StorageLive(_3);
 -         _4 = discriminant(_1);
@@ -111,6 +111,10 @@
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC3 (size: 8, align: 4) {
++     00 00 00 00 00 00 00 00                         │ ........
   }
   
   ALLOC2 (static: RC, size: 8, align: 8) {

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-abort.diff
@@ -23,7 +23,7 @@
           StorageLive(_4);
 -         _4 = CheckedAdd(_2, _3);
 -         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind unreachable];
-+         _4 = CheckedAdd(const u8::MAX, const 1_u8);
++         _4 = const (0, true);
 +         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> [success: bb1, unwind unreachable];
       }
   

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-abort.diff
@@ -23,7 +23,7 @@
           StorageLive(_4);
 -         _4 = CheckedAdd(_2, _3);
 -         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind unreachable];
-+         _4 = const (0, true);
++         _4 = const (0_u8, true);
 +         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> [success: bb1, unwind unreachable];
       }
   
@@ -37,5 +37,9 @@
           _0 = const ();
           return;
       }
++ }
++ 
++ ALLOC0 (size: 2, align: 1) {
++     00 01                                           │ ..
   }
   

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
@@ -23,7 +23,7 @@
           StorageLive(_4);
 -         _4 = CheckedAdd(_2, _3);
 -         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind continue];
-+         _4 = const (0, true);
++         _4 = const (0_u8, true);
 +         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> [success: bb1, unwind continue];
       }
   
@@ -37,5 +37,9 @@
           _0 = const ();
           return;
       }
++ }
++ 
++ ALLOC0 (size: 2, align: 1) {
++     00 01                                           │ ..
   }
   

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
@@ -23,7 +23,7 @@
           StorageLive(_4);
 -         _4 = CheckedAdd(_2, _3);
 -         assert(!move (_4.1: bool), "attempt to compute `{} + {}`, which would overflow", _2, _3) -> [success: bb1, unwind continue];
-+         _4 = CheckedAdd(const u8::MAX, const 1_u8);
++         _4 = const (0, true);
 +         assert(!const true, "attempt to compute `{} + {}`, which would overflow", const u8::MAX, const 1_u8) -> [success: bb1, unwind continue];
       }
   

--- a/tests/mir-opt/dataflow-const-prop/repr_transparent.main.DataflowConstProp.diff
+++ b/tests/mir-opt/dataflow-const-prop/repr_transparent.main.DataflowConstProp.diff
@@ -18,7 +18,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = I32(const 0_i32);
-+         _1 = const I32(0);
++         _1 = const I32(0_i32);
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
@@ -32,12 +32,20 @@
           StorageDead(_5);
           StorageDead(_4);
 -         _2 = I32(move _3);
-+         _2 = const I32(0);
++         _2 = const I32(0_i32);
           StorageDead(_3);
           _0 = const ();
           StorageDead(_2);
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC0 (size: 4, align: 4) {
++     00 00 00 00                                     │ ....
++ }
++ 
++ ALLOC1 (size: 4, align: 4) {
++     00 00 00 00                                     │ ....
   }
   

--- a/tests/mir-opt/dataflow-const-prop/repr_transparent.main.DataflowConstProp.diff
+++ b/tests/mir-opt/dataflow-const-prop/repr_transparent.main.DataflowConstProp.diff
@@ -17,7 +17,8 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = I32(const 0_i32);
+-         _1 = I32(const 0_i32);
++         _1 = const I32(0);
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
@@ -31,7 +32,7 @@
           StorageDead(_5);
           StorageDead(_4);
 -         _2 = I32(move _3);
-+         _2 = I32(const 0_i32);
++         _2 = const I32(0);
           StorageDead(_3);
           _0 = const ();
           StorageDead(_2);

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
@@ -7,17 +7,24 @@
       let mut _3: i32;
       let mut _5: i32;
       let mut _6: i32;
-      let mut _11: BigStruct;
-      let mut _16: &&BigStruct;
-      let mut _18: S;
-      let mut _19: u8;
-      let mut _20: f32;
-      let mut _21: S;
-      let mut _22: &BigStruct;
-      let mut _23: &BigStruct;
-      let mut _24: &BigStruct;
-      let mut _25: &BigStruct;
-      let mut _26: &BigStruct;
+      let mut _10: SmallStruct;
+      let mut _14: &&SmallStruct;
+      let mut _16: f32;
+      let mut _17: std::option::Option<S>;
+      let mut _18: &[f32];
+      let mut _22: BigStruct;
+      let mut _26: &&BigStruct;
+      let mut _28: f32;
+      let mut _29: std::option::Option<S>;
+      let mut _30: &[f64];
+      let mut _31: &SmallStruct;
+      let mut _32: &SmallStruct;
+      let mut _33: &SmallStruct;
+      let mut _34: &SmallStruct;
+      let mut _35: &BigStruct;
+      let mut _36: &BigStruct;
+      let mut _37: &BigStruct;
+      let mut _38: &BigStruct;
       scope 1 {
           debug s => _1;
           let _2: i32;
@@ -26,27 +33,43 @@
               let _4: i32;
               scope 3 {
                   debug b => _4;
-                  let _7: S;
-                  let _8: u8;
-                  let _9: f32;
-                  let _10: S;
+                  let _7: f32;
+                  let _8: std::option::Option<S>;
+                  let _9: &[f32];
                   scope 4 {
                       debug a => _7;
                       debug b => _8;
                       debug c => _9;
-                      debug d => _10;
-                      let _12: S;
-                      let _13: u8;
-                      let _14: f32;
-                      let _15: S;
+                      let _11: f32;
+                      let _12: std::option::Option<S>;
+                      let _13: &[f32];
                       scope 5 {
-                          debug a => _12;
-                          debug b => _13;
-                          debug c => _14;
-                          debug d => _15;
-                          let _17: BigStruct;
+                          debug a => _11;
+                          debug b => _12;
+                          debug c => _13;
+                          let _15: SmallStruct;
                           scope 6 {
-                              debug bs => _17;
+                              debug ss => _15;
+                              let _19: f32;
+                              let _20: std::option::Option<S>;
+                              let _21: &[f64];
+                              scope 7 {
+                                  debug a => _19;
+                                  debug b => _20;
+                                  debug c => _21;
+                                  let _23: f32;
+                                  let _24: std::option::Option<S>;
+                                  let _25: &[f64];
+                                  scope 8 {
+                                      debug a => _23;
+                                      debug b => _24;
+                                      debug c => _25;
+                                      let _27: BigStruct;
+                                      scope 9 {
+                                          debug bs => _27;
+                                      }
+                                  }
+                              }
                           }
                       }
                   }
@@ -57,7 +80,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = S(const 1_i32);
-+         _1 = const S(1);
++         _1 = const S(1_i32);
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = (_1.0: i32);
@@ -77,67 +100,95 @@
 +         _4 = const 6_i32;
           StorageDead(_6);
           StorageDead(_5);
-          StorageLive(_11);
-          _11 = const _;
-          StorageLive(_7);
--         _7 = (_11.0: S);
-+         _7 = const S(1_i32);
-          StorageLive(_8);
--         _8 = (_11.1: u8);
-+         _8 = const 5_u8;
-          StorageLive(_9);
--         _9 = (_11.2: f32);
-+         _9 = const 7f32;
           StorageLive(_10);
--         _10 = (_11.3: S);
-+         _10 = const S(13_i32);
-          StorageDead(_11);
-          StorageLive(_16);
-          _16 = const {ALLOC1: &&BigStruct};
-          _22 = deref_copy (*_16);
-          StorageLive(_12);
-          _23 = deref_copy (*_16);
--         _12 = ((*_23).0: S);
-+         _12 = const S(1_i32);
-          StorageLive(_13);
-          _24 = deref_copy (*_16);
--         _13 = ((*_24).1: u8);
-+         _13 = const 5_u8;
+          _10 = const _;
+          StorageLive(_7);
+-         _7 = (_10.0: f32);
++         _7 = const 4f32;
+          StorageLive(_8);
+-         _8 = (_10.1: std::option::Option<S>);
++         _8 = const Option::<S>::Some(S(1_i32));
+          StorageLive(_9);
+          _9 = (_10.2: &[f32]);
+          StorageDead(_10);
           StorageLive(_14);
-          _25 = deref_copy (*_16);
--         _14 = ((*_25).2: f32);
-+         _14 = const 7f32;
+          _14 = const {ALLOC4: &&SmallStruct};
+          _31 = deref_copy (*_14);
+          StorageLive(_11);
+          _32 = deref_copy (*_14);
+-         _11 = ((*_32).0: f32);
++         _11 = const 9f32;
+          StorageLive(_12);
+          _33 = deref_copy (*_14);
+          _12 = ((*_33).1: std::option::Option<S>);
+          StorageLive(_13);
+          _34 = deref_copy (*_14);
+          _13 = ((*_34).2: &[f32]);
+          StorageDead(_14);
           StorageLive(_15);
-          _26 = deref_copy (*_16);
--         _15 = ((*_26).3: S);
-+         _15 = const S(13_i32);
-          StorageDead(_16);
+          StorageLive(_16);
+-         _16 = _11;
++         _16 = const 9f32;
           StorageLive(_17);
+          _17 = _12;
           StorageLive(_18);
--         _18 = _12;
-+         _18 = const S(1_i32);
+          _18 = _13;
+-         _15 = SmallStruct(move _16, move _17, move _18);
++         _15 = SmallStruct(const 9f32, move _17, move _18);
+          StorageDead(_18);
+          StorageDead(_17);
+          StorageDead(_16);
+          StorageLive(_22);
+          _22 = const _;
           StorageLive(_19);
--         _19 = _13;
-+         _19 = const 5_u8;
+-         _19 = (_22.0: f32);
++         _19 = const 25f32;
           StorageLive(_20);
--         _20 = _14;
-+         _20 = const 7f32;
+          _20 = (_22.1: std::option::Option<S>);
           StorageLive(_21);
--         _21 = _15;
--         _17 = BigStruct(move _18, move _19, move _20, move _21);
-+         _21 = const S(13_i32);
-+         _17 = const BigStruct(S(1), 5, 7f32, S(13));
+          _21 = (_22.2: &[f64]);
+          StorageDead(_22);
+          StorageLive(_26);
+          _26 = const {ALLOC5: &&BigStruct};
+          _35 = deref_copy (*_26);
+          StorageLive(_23);
+          _36 = deref_copy (*_26);
+-         _23 = ((*_36).0: f32);
++         _23 = const 82f32;
+          StorageLive(_24);
+          _37 = deref_copy (*_26);
+-         _24 = ((*_37).1: std::option::Option<S>);
++         _24 = const Option::<S>::Some(S(35_i32));
+          StorageLive(_25);
+          _38 = deref_copy (*_26);
+          _25 = ((*_38).2: &[f64]);
+          StorageDead(_26);
+          StorageLive(_27);
+          StorageLive(_28);
+-         _28 = _23;
++         _28 = const 82f32;
+          StorageLive(_29);
+-         _29 = _24;
++         _29 = const Option::<S>::Some(S(35_i32));
+          StorageLive(_30);
+          _30 = _25;
+-         _27 = BigStruct(move _28, move _29, move _30);
++         _27 = BigStruct(const 82f32, const Option::<S>::Some(S(35_i32)), move _30);
+          StorageDead(_30);
+          StorageDead(_29);
+          StorageDead(_28);
+          _0 = const ();
+          StorageDead(_27);
+          StorageDead(_25);
+          StorageDead(_24);
+          StorageDead(_23);
           StorageDead(_21);
           StorageDead(_20);
           StorageDead(_19);
-          StorageDead(_18);
-          _0 = const ();
-          StorageDead(_17);
           StorageDead(_15);
-          StorageDead(_14);
           StorageDead(_13);
           StorageDead(_12);
-          StorageDead(_10);
+          StorageDead(_11);
           StorageDead(_9);
           StorageDead(_8);
           StorageDead(_7);
@@ -146,13 +197,51 @@
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC6 (size: 8, align: 4) {
++     01 00 00 00 23 00 00 00                         │ ....#...
++ }
++ 
++ ALLOC7 (size: 8, align: 4) {
++     01 00 00 00 23 00 00 00                         │ ....#...
++ }
++ 
++ ALLOC8 (size: 8, align: 4) {
++     01 00 00 00 23 00 00 00                         │ ....#...
++ }
++ 
++ ALLOC9 (size: 8, align: 4) {
++     01 00 00 00 01 00 00 00                         │ ........
++ }
++ 
++ ALLOC10 (size: 4, align: 4) {
++     01 00 00 00                                     │ ....
   }
   
-  ALLOC1 (static: STAT, size: 4, align: 4) {
+  ALLOC5 (static: BIG_STAT, size: 4, align: 4) {
       ╾ALLOC0╼                                     │ ╾──╼
   }
   
-  ALLOC0 (size: 16, align: 4) {
-      01 00 00 00 00 00 e0 40 0d 00 00 00 05 __ __ __ │ .......@.....░░░
+  ALLOC0 (size: 20, align: 4) {
+      0x00 │ 01 00 00 00 23 00 00 00 ╾ALLOC1╼ 02 00 00 00 │ ....#...╾──╼....
+      0x10 │ 00 00 a4 42                                     │ ...B
+  }
+  
+  ALLOC1 (size: 16, align: 4) {
+      00 00 00 00 00 80 46 40 00 00 00 00 00 00 52 40 │ ......F@......R@
+  }
+  
+  ALLOC4 (static: SMALL_STAT, size: 4, align: 4) {
+      ╾ALLOC2╼                                     │ ╾──╼
+  }
+  
+  ALLOC2 (size: 20, align: 4) {
+      0x00 │ 00 00 00 00 __ __ __ __ ╾ALLOC3╼ 01 00 00 00 │ ....░░░░╾──╼....
+      0x10 │ 00 00 10 41                                     │ ...A
+  }
+  
+  ALLOC3 (size: 4, align: 4) {
+      00 00 50 41                                     │ ..PA
   }
   

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
@@ -9,11 +9,15 @@
       let mut _6: i32;
       let mut _11: BigStruct;
       let mut _16: &&BigStruct;
-      let mut _17: &BigStruct;
-      let mut _18: &BigStruct;
-      let mut _19: &BigStruct;
-      let mut _20: &BigStruct;
-      let mut _21: &BigStruct;
+      let mut _18: S;
+      let mut _19: u8;
+      let mut _20: f32;
+      let mut _21: S;
+      let mut _22: &BigStruct;
+      let mut _23: &BigStruct;
+      let mut _24: &BigStruct;
+      let mut _25: &BigStruct;
+      let mut _26: &BigStruct;
       scope 1 {
           debug s => _1;
           let _2: i32;
@@ -40,6 +44,10 @@
                           debug b => _13;
                           debug c => _14;
                           debug d => _15;
+                          let _17: BigStruct;
+                          scope 6 {
+                              debug bs => _17;
+                          }
                       }
                   }
               }
@@ -48,7 +56,8 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = S(const 1_i32);
+-         _1 = S(const 1_i32);
++         _1 = const S(1);
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = (_1.0: i32);
@@ -85,25 +94,45 @@
           StorageDead(_11);
           StorageLive(_16);
           _16 = const {ALLOC1: &&BigStruct};
-          _17 = deref_copy (*_16);
+          _22 = deref_copy (*_16);
           StorageLive(_12);
-          _18 = deref_copy (*_16);
--         _12 = ((*_18).0: S);
+          _23 = deref_copy (*_16);
+-         _12 = ((*_23).0: S);
 +         _12 = const S(1_i32);
           StorageLive(_13);
-          _19 = deref_copy (*_16);
--         _13 = ((*_19).1: u8);
+          _24 = deref_copy (*_16);
+-         _13 = ((*_24).1: u8);
 +         _13 = const 5_u8;
           StorageLive(_14);
-          _20 = deref_copy (*_16);
--         _14 = ((*_20).2: f32);
+          _25 = deref_copy (*_16);
+-         _14 = ((*_25).2: f32);
 +         _14 = const 7f32;
           StorageLive(_15);
-          _21 = deref_copy (*_16);
--         _15 = ((*_21).3: S);
+          _26 = deref_copy (*_16);
+-         _15 = ((*_26).3: S);
 +         _15 = const S(13_i32);
           StorageDead(_16);
+          StorageLive(_17);
+          StorageLive(_18);
+-         _18 = _12;
++         _18 = const S(1_i32);
+          StorageLive(_19);
+-         _19 = _13;
++         _19 = const 5_u8;
+          StorageLive(_20);
+-         _20 = _14;
++         _20 = const 7f32;
+          StorageLive(_21);
+-         _21 = _15;
+-         _17 = BigStruct(move _18, move _19, move _20, move _21);
++         _21 = const S(13_i32);
++         _17 = const BigStruct(S(1), 5, 7f32, S(13));
+          StorageDead(_21);
+          StorageDead(_20);
+          StorageDead(_19);
+          StorageDead(_18);
           _0 = const ();
+          StorageDead(_17);
           StorageDead(_15);
           StorageDead(_14);
           StorageDead(_13);

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
@@ -7,17 +7,24 @@
       let mut _3: i32;
       let mut _5: i32;
       let mut _6: i32;
-      let mut _11: BigStruct;
-      let mut _16: &&BigStruct;
-      let mut _18: S;
-      let mut _19: u8;
-      let mut _20: f32;
-      let mut _21: S;
-      let mut _22: &BigStruct;
-      let mut _23: &BigStruct;
-      let mut _24: &BigStruct;
-      let mut _25: &BigStruct;
-      let mut _26: &BigStruct;
+      let mut _10: SmallStruct;
+      let mut _14: &&SmallStruct;
+      let mut _16: f32;
+      let mut _17: std::option::Option<S>;
+      let mut _18: &[f32];
+      let mut _22: BigStruct;
+      let mut _26: &&BigStruct;
+      let mut _28: f32;
+      let mut _29: std::option::Option<S>;
+      let mut _30: &[f64];
+      let mut _31: &SmallStruct;
+      let mut _32: &SmallStruct;
+      let mut _33: &SmallStruct;
+      let mut _34: &SmallStruct;
+      let mut _35: &BigStruct;
+      let mut _36: &BigStruct;
+      let mut _37: &BigStruct;
+      let mut _38: &BigStruct;
       scope 1 {
           debug s => _1;
           let _2: i32;
@@ -26,27 +33,43 @@
               let _4: i32;
               scope 3 {
                   debug b => _4;
-                  let _7: S;
-                  let _8: u8;
-                  let _9: f32;
-                  let _10: S;
+                  let _7: f32;
+                  let _8: std::option::Option<S>;
+                  let _9: &[f32];
                   scope 4 {
                       debug a => _7;
                       debug b => _8;
                       debug c => _9;
-                      debug d => _10;
-                      let _12: S;
-                      let _13: u8;
-                      let _14: f32;
-                      let _15: S;
+                      let _11: f32;
+                      let _12: std::option::Option<S>;
+                      let _13: &[f32];
                       scope 5 {
-                          debug a => _12;
-                          debug b => _13;
-                          debug c => _14;
-                          debug d => _15;
-                          let _17: BigStruct;
+                          debug a => _11;
+                          debug b => _12;
+                          debug c => _13;
+                          let _15: SmallStruct;
                           scope 6 {
-                              debug bs => _17;
+                              debug ss => _15;
+                              let _19: f32;
+                              let _20: std::option::Option<S>;
+                              let _21: &[f64];
+                              scope 7 {
+                                  debug a => _19;
+                                  debug b => _20;
+                                  debug c => _21;
+                                  let _23: f32;
+                                  let _24: std::option::Option<S>;
+                                  let _25: &[f64];
+                                  scope 8 {
+                                      debug a => _23;
+                                      debug b => _24;
+                                      debug c => _25;
+                                      let _27: BigStruct;
+                                      scope 9 {
+                                          debug bs => _27;
+                                      }
+                                  }
+                              }
                           }
                       }
                   }
@@ -57,7 +80,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = S(const 1_i32);
-+         _1 = const S(1);
++         _1 = const S(1_i32);
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = (_1.0: i32);
@@ -77,67 +100,95 @@
 +         _4 = const 6_i32;
           StorageDead(_6);
           StorageDead(_5);
-          StorageLive(_11);
-          _11 = const _;
-          StorageLive(_7);
--         _7 = (_11.0: S);
-+         _7 = const S(1_i32);
-          StorageLive(_8);
--         _8 = (_11.1: u8);
-+         _8 = const 5_u8;
-          StorageLive(_9);
--         _9 = (_11.2: f32);
-+         _9 = const 7f32;
           StorageLive(_10);
--         _10 = (_11.3: S);
-+         _10 = const S(13_i32);
-          StorageDead(_11);
-          StorageLive(_16);
-          _16 = const {ALLOC1: &&BigStruct};
-          _22 = deref_copy (*_16);
-          StorageLive(_12);
-          _23 = deref_copy (*_16);
--         _12 = ((*_23).0: S);
-+         _12 = const S(1_i32);
-          StorageLive(_13);
-          _24 = deref_copy (*_16);
--         _13 = ((*_24).1: u8);
-+         _13 = const 5_u8;
+          _10 = const _;
+          StorageLive(_7);
+-         _7 = (_10.0: f32);
++         _7 = const 4f32;
+          StorageLive(_8);
+-         _8 = (_10.1: std::option::Option<S>);
++         _8 = const Option::<S>::Some(S(1_i32));
+          StorageLive(_9);
+          _9 = (_10.2: &[f32]);
+          StorageDead(_10);
           StorageLive(_14);
-          _25 = deref_copy (*_16);
--         _14 = ((*_25).2: f32);
-+         _14 = const 7f32;
+          _14 = const {ALLOC4: &&SmallStruct};
+          _31 = deref_copy (*_14);
+          StorageLive(_11);
+          _32 = deref_copy (*_14);
+-         _11 = ((*_32).0: f32);
++         _11 = const 9f32;
+          StorageLive(_12);
+          _33 = deref_copy (*_14);
+          _12 = ((*_33).1: std::option::Option<S>);
+          StorageLive(_13);
+          _34 = deref_copy (*_14);
+          _13 = ((*_34).2: &[f32]);
+          StorageDead(_14);
           StorageLive(_15);
-          _26 = deref_copy (*_16);
--         _15 = ((*_26).3: S);
-+         _15 = const S(13_i32);
-          StorageDead(_16);
+          StorageLive(_16);
+-         _16 = _11;
++         _16 = const 9f32;
           StorageLive(_17);
+          _17 = _12;
           StorageLive(_18);
--         _18 = _12;
-+         _18 = const S(1_i32);
+          _18 = _13;
+-         _15 = SmallStruct(move _16, move _17, move _18);
++         _15 = SmallStruct(const 9f32, move _17, move _18);
+          StorageDead(_18);
+          StorageDead(_17);
+          StorageDead(_16);
+          StorageLive(_22);
+          _22 = const _;
           StorageLive(_19);
--         _19 = _13;
-+         _19 = const 5_u8;
+-         _19 = (_22.0: f32);
++         _19 = const 25f32;
           StorageLive(_20);
--         _20 = _14;
-+         _20 = const 7f32;
+          _20 = (_22.1: std::option::Option<S>);
           StorageLive(_21);
--         _21 = _15;
--         _17 = BigStruct(move _18, move _19, move _20, move _21);
-+         _21 = const S(13_i32);
-+         _17 = const BigStruct(S(1), 5, 7f32, S(13));
+          _21 = (_22.2: &[f64]);
+          StorageDead(_22);
+          StorageLive(_26);
+          _26 = const {ALLOC5: &&BigStruct};
+          _35 = deref_copy (*_26);
+          StorageLive(_23);
+          _36 = deref_copy (*_26);
+-         _23 = ((*_36).0: f32);
++         _23 = const 82f32;
+          StorageLive(_24);
+          _37 = deref_copy (*_26);
+-         _24 = ((*_37).1: std::option::Option<S>);
++         _24 = const Option::<S>::Some(S(35_i32));
+          StorageLive(_25);
+          _38 = deref_copy (*_26);
+          _25 = ((*_38).2: &[f64]);
+          StorageDead(_26);
+          StorageLive(_27);
+          StorageLive(_28);
+-         _28 = _23;
++         _28 = const 82f32;
+          StorageLive(_29);
+-         _29 = _24;
++         _29 = const Option::<S>::Some(S(35_i32));
+          StorageLive(_30);
+          _30 = _25;
+-         _27 = BigStruct(move _28, move _29, move _30);
++         _27 = BigStruct(const 82f32, const Option::<S>::Some(S(35_i32)), move _30);
+          StorageDead(_30);
+          StorageDead(_29);
+          StorageDead(_28);
+          _0 = const ();
+          StorageDead(_27);
+          StorageDead(_25);
+          StorageDead(_24);
+          StorageDead(_23);
           StorageDead(_21);
           StorageDead(_20);
           StorageDead(_19);
-          StorageDead(_18);
-          _0 = const ();
-          StorageDead(_17);
           StorageDead(_15);
-          StorageDead(_14);
           StorageDead(_13);
           StorageDead(_12);
-          StorageDead(_10);
+          StorageDead(_11);
           StorageDead(_9);
           StorageDead(_8);
           StorageDead(_7);
@@ -146,13 +197,51 @@
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC6 (size: 8, align: 4) {
++     01 00 00 00 23 00 00 00                         │ ....#...
++ }
++ 
++ ALLOC7 (size: 8, align: 4) {
++     01 00 00 00 23 00 00 00                         │ ....#...
++ }
++ 
++ ALLOC8 (size: 8, align: 4) {
++     01 00 00 00 23 00 00 00                         │ ....#...
++ }
++ 
++ ALLOC9 (size: 8, align: 4) {
++     01 00 00 00 01 00 00 00                         │ ........
++ }
++ 
++ ALLOC10 (size: 4, align: 4) {
++     01 00 00 00                                     │ ....
   }
   
-  ALLOC1 (static: STAT, size: 8, align: 8) {
+  ALLOC5 (static: BIG_STAT, size: 8, align: 8) {
       ╾ALLOC0╼                         │ ╾──────╼
   }
   
-  ALLOC0 (size: 16, align: 4) {
-      01 00 00 00 00 00 e0 40 0d 00 00 00 05 __ __ __ │ .......@.....░░░
+  ALLOC0 (size: 32, align: 8) {
+      0x00 │ 01 00 00 00 23 00 00 00 ╾ALLOC1╼ │ ....#...╾──────╼
+      0x10 │ 02 00 00 00 00 00 00 00 00 00 a4 42 __ __ __ __ │ ...........B░░░░
+  }
+  
+  ALLOC1 (size: 16, align: 8) {
+      00 00 00 00 00 80 46 40 00 00 00 00 00 00 52 40 │ ......F@......R@
+  }
+  
+  ALLOC4 (static: SMALL_STAT, size: 8, align: 8) {
+      ╾ALLOC2╼                         │ ╾──────╼
+  }
+  
+  ALLOC2 (size: 32, align: 8) {
+      0x00 │ 00 00 00 00 __ __ __ __ ╾ALLOC3╼ │ ....░░░░╾──────╼
+      0x10 │ 01 00 00 00 00 00 00 00 00 00 10 41 __ __ __ __ │ ...........A░░░░
+  }
+  
+  ALLOC3 (size: 4, align: 4) {
+      00 00 50 41                                     │ ..PA
   }
   

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
@@ -9,11 +9,15 @@
       let mut _6: i32;
       let mut _11: BigStruct;
       let mut _16: &&BigStruct;
-      let mut _17: &BigStruct;
-      let mut _18: &BigStruct;
-      let mut _19: &BigStruct;
-      let mut _20: &BigStruct;
-      let mut _21: &BigStruct;
+      let mut _18: S;
+      let mut _19: u8;
+      let mut _20: f32;
+      let mut _21: S;
+      let mut _22: &BigStruct;
+      let mut _23: &BigStruct;
+      let mut _24: &BigStruct;
+      let mut _25: &BigStruct;
+      let mut _26: &BigStruct;
       scope 1 {
           debug s => _1;
           let _2: i32;
@@ -40,6 +44,10 @@
                           debug b => _13;
                           debug c => _14;
                           debug d => _15;
+                          let _17: BigStruct;
+                          scope 6 {
+                              debug bs => _17;
+                          }
                       }
                   }
               }
@@ -48,7 +56,8 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = S(const 1_i32);
+-         _1 = S(const 1_i32);
++         _1 = const S(1);
           StorageLive(_2);
           StorageLive(_3);
 -         _3 = (_1.0: i32);
@@ -85,25 +94,45 @@
           StorageDead(_11);
           StorageLive(_16);
           _16 = const {ALLOC1: &&BigStruct};
-          _17 = deref_copy (*_16);
+          _22 = deref_copy (*_16);
           StorageLive(_12);
-          _18 = deref_copy (*_16);
--         _12 = ((*_18).0: S);
+          _23 = deref_copy (*_16);
+-         _12 = ((*_23).0: S);
 +         _12 = const S(1_i32);
           StorageLive(_13);
-          _19 = deref_copy (*_16);
--         _13 = ((*_19).1: u8);
+          _24 = deref_copy (*_16);
+-         _13 = ((*_24).1: u8);
 +         _13 = const 5_u8;
           StorageLive(_14);
-          _20 = deref_copy (*_16);
--         _14 = ((*_20).2: f32);
+          _25 = deref_copy (*_16);
+-         _14 = ((*_25).2: f32);
 +         _14 = const 7f32;
           StorageLive(_15);
-          _21 = deref_copy (*_16);
--         _15 = ((*_21).3: S);
+          _26 = deref_copy (*_16);
+-         _15 = ((*_26).3: S);
 +         _15 = const S(13_i32);
           StorageDead(_16);
+          StorageLive(_17);
+          StorageLive(_18);
+-         _18 = _12;
++         _18 = const S(1_i32);
+          StorageLive(_19);
+-         _19 = _13;
++         _19 = const 5_u8;
+          StorageLive(_20);
+-         _20 = _14;
++         _20 = const 7f32;
+          StorageLive(_21);
+-         _21 = _15;
+-         _17 = BigStruct(move _18, move _19, move _20, move _21);
++         _21 = const S(13_i32);
++         _17 = const BigStruct(S(1), 5, 7f32, S(13));
+          StorageDead(_21);
+          StorageDead(_20);
+          StorageDead(_19);
+          StorageDead(_18);
           _0 = const ();
+          StorageDead(_17);
           StorageDead(_15);
           StorageDead(_14);
           StorageDead(_13);

--- a/tests/mir-opt/dataflow-const-prop/struct.rs
+++ b/tests/mir-opt/dataflow-const-prop/struct.rs
@@ -20,4 +20,6 @@ fn main() {
 
     static STAT: &BigStruct = &BigStruct(S(1), 5, 7., S(13));
     let BigStruct(a, b, c, d) = *STAT;
+
+    let bs = BigStruct(a, b, c, d);
 }

--- a/tests/mir-opt/dataflow-const-prop/struct.rs
+++ b/tests/mir-opt/dataflow-const-prop/struct.rs
@@ -6,7 +6,10 @@
 struct S(i32);
 
 #[derive(Copy, Clone)]
-struct BigStruct(S, u8, f32, S);
+struct SmallStruct(f32, Option<S>, &'static [f32]);
+
+#[derive(Copy, Clone)]
+struct BigStruct(f32, Option<S>, &'static [f64]);
 
 // EMIT_MIR struct.main.DataflowConstProp.diff
 fn main() {
@@ -15,11 +18,21 @@ fn main() {
     s.0 = 3;
     let b = a + s.0;
 
-    const VAL: BigStruct = BigStruct(S(1), 5, 7., S(13));
-    let BigStruct(a, b, c, d) = VAL;
+    const SMALL_VAL: SmallStruct = SmallStruct(4., Some(S(1)), &[]);
+    let SmallStruct(a, b, c) = SMALL_VAL;
 
-    static STAT: &BigStruct = &BigStruct(S(1), 5, 7., S(13));
-    let BigStruct(a, b, c, d) = *STAT;
+    static SMALL_STAT: &SmallStruct = &SmallStruct(9., None, &[13.]);
+    let SmallStruct(a, b, c) = *SMALL_STAT;
 
-    let bs = BigStruct(a, b, c, d);
+    let ss = SmallStruct(a, b, c);
+
+    const BIG_VAL: BigStruct = BigStruct(25., None, &[]);
+    let BigStruct(a, b, c) = BIG_VAL;
+
+    static BIG_STAT: &BigStruct = &BigStruct(82., Some(S(35)), &[45., 72.]);
+    let BigStruct(a, b, c) = *BIG_STAT;
+
+    // We arbitrarily limit the size of synthetized values to 4 pointers.
+    // `BigStruct` can be read, but we will keep a MIR aggregate for this.
+    let bs = BigStruct(a, b, c);
 }

--- a/tests/mir-opt/dataflow-const-prop/transmute.rs
+++ b/tests/mir-opt/dataflow-const-prop/transmute.rs
@@ -52,8 +52,8 @@ pub unsafe fn undef_union_as_integer() -> u32 {
 // EMIT_MIR transmute.unreachable_direct.DataflowConstProp.diff
 pub unsafe fn unreachable_direct() -> ! {
     // CHECK-LABEL: fn unreachable_direct(
-    // CHECK: [[unit:_.*]] = ();
-    // CHECK: move [[unit]] as Never (Transmute);
+    // CHECK: = const ();
+    // CHECK: = const ZeroSized: Never;
     let x: Never = unsafe { transmute(()) };
     match x {}
 }

--- a/tests/mir-opt/dataflow-const-prop/transmute.undef_union_as_integer.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.undef_union_as_integer.DataflowConstProp.32bit.diff
@@ -11,8 +11,10 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = ();
-          _1 = Union32 { value: move _2 };
+-         _2 = ();
+-         _1 = Union32 { value: move _2 };
++         _2 = const ();
++         _1 = Union32 { value: const () };
           StorageDead(_2);
           _0 = move _1 as u32 (Transmute);
           StorageDead(_1);

--- a/tests/mir-opt/dataflow-const-prop/transmute.undef_union_as_integer.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.undef_union_as_integer.DataflowConstProp.64bit.diff
@@ -11,8 +11,10 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = ();
-          _1 = Union32 { value: move _2 };
+-         _2 = ();
+-         _1 = Union32 { value: move _2 };
++         _2 = const ();
++         _1 = Union32 { value: const () };
           StorageDead(_2);
           _0 = move _1 as u32 (Transmute);
           StorageDead(_1);

--- a/tests/mir-opt/dataflow-const-prop/transmute.unreachable_direct.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.unreachable_direct.DataflowConstProp.32bit.diff
@@ -14,8 +14,10 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = ();
-          _1 = move _2 as Never (Transmute);
+-         _2 = ();
+-         _1 = move _2 as Never (Transmute);
++         _2 = const ();
++         _1 = const ZeroSized: Never;
           unreachable;
       }
   }

--- a/tests/mir-opt/dataflow-const-prop/transmute.unreachable_direct.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.unreachable_direct.DataflowConstProp.64bit.diff
@@ -14,8 +14,10 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = ();
-          _1 = move _2 as Never (Transmute);
+-         _2 = ();
+-         _1 = move _2 as Never (Transmute);
++         _2 = const ();
++         _1 = const ZeroSized: Never;
           unreachable;
       }
   }

--- a/tests/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.32bit.diff
@@ -33,7 +33,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = (const 1_i32, const 2_i32);
-+         _1 = const (1, 2);
++         _1 = const (1_i32, 2_i32);
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
@@ -50,7 +50,7 @@
 +         _2 = const 6_i32;
           StorageDead(_3);
 -         _1 = (const 2_i32, const 3_i32);
-+         _1 = const (2, 3);
++         _1 = const (2_i32, 3_i32);
           StorageLive(_6);
           StorageLive(_7);
           StorageLive(_8);
@@ -76,12 +76,12 @@
 +         _12 = const 6_i32;
           StorageLive(_13);
 -         _13 = _1;
-+         _13 = const (2, 3);
++         _13 = const (2_i32, 3_i32);
           StorageLive(_14);
 -         _14 = _6;
 -         _11 = (move _12, move _13, move _14);
 +         _14 = const 11_i32;
-+         _11 = const (6, (2, 3), 11);
++         _11 = (const 6_i32, const (2_i32, 3_i32), const 11_i32);
           StorageDead(_14);
           StorageDead(_13);
           StorageDead(_12);
@@ -92,5 +92,21 @@
           StorageDead(_1);
           return;
       }
++ }
++ 
++ ALLOC0 (size: 8, align: 4) {
++     02 00 00 00 03 00 00 00                         │ ........
++ }
++ 
++ ALLOC1 (size: 8, align: 4) {
++     02 00 00 00 03 00 00 00                         │ ........
++ }
++ 
++ ALLOC2 (size: 8, align: 4) {
++     02 00 00 00 03 00 00 00                         │ ........
++ }
++ 
++ ALLOC3 (size: 8, align: 4) {
++     01 00 00 00 02 00 00 00                         │ ........
   }
   

--- a/tests/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.64bit.diff
@@ -1,0 +1,112 @@
+- // MIR for `main` before DataflowConstProp
++ // MIR for `main` after DataflowConstProp
+  
+  fn main() -> () {
+      let mut _0: ();
+      let mut _1: (i32, i32);
+      let mut _3: i32;
+      let mut _4: i32;
+      let mut _5: i32;
+      let mut _7: i32;
+      let mut _8: i32;
+      let mut _9: i32;
+      let mut _10: i32;
+      let mut _12: i32;
+      let mut _13: (i32, i32);
+      let mut _14: i32;
+      scope 1 {
+          debug a => _1;
+          let _2: i32;
+          scope 2 {
+              debug b => _2;
+              let _6: i32;
+              scope 3 {
+                  debug c => _6;
+                  let _11: (i32, (i32, i32), i32);
+                  scope 4 {
+                      debug d => _11;
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+-         _1 = (const 1_i32, const 2_i32);
++         _1 = const (1_i32, 2_i32);
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+-         _4 = (_1.0: i32);
++         _4 = const 1_i32;
+          StorageLive(_5);
+-         _5 = (_1.1: i32);
+-         _3 = Add(move _4, move _5);
++         _5 = const 2_i32;
++         _3 = const 3_i32;
+          StorageDead(_5);
+          StorageDead(_4);
+-         _2 = Add(move _3, const 3_i32);
++         _2 = const 6_i32;
+          StorageDead(_3);
+-         _1 = (const 2_i32, const 3_i32);
++         _1 = const (2_i32, 3_i32);
+          StorageLive(_6);
+          StorageLive(_7);
+          StorageLive(_8);
+-         _8 = (_1.0: i32);
++         _8 = const 2_i32;
+          StorageLive(_9);
+-         _9 = (_1.1: i32);
+-         _7 = Add(move _8, move _9);
++         _9 = const 3_i32;
++         _7 = const 5_i32;
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageLive(_10);
+-         _10 = _2;
+-         _6 = Add(move _7, move _10);
++         _10 = const 6_i32;
++         _6 = const 11_i32;
+          StorageDead(_10);
+          StorageDead(_7);
+          StorageLive(_11);
+          StorageLive(_12);
+-         _12 = _2;
++         _12 = const 6_i32;
+          StorageLive(_13);
+-         _13 = _1;
++         _13 = const (2_i32, 3_i32);
+          StorageLive(_14);
+-         _14 = _6;
+-         _11 = (move _12, move _13, move _14);
++         _14 = const 11_i32;
++         _11 = (const 6_i32, const (2_i32, 3_i32), const 11_i32);
+          StorageDead(_14);
+          StorageDead(_13);
+          StorageDead(_12);
+          _0 = const ();
+          StorageDead(_11);
+          StorageDead(_6);
+          StorageDead(_2);
+          StorageDead(_1);
+          return;
+      }
++ }
++ 
++ ALLOC0 (size: 8, align: 4) {
++     02 00 00 00 03 00 00 00                         │ ........
++ }
++ 
++ ALLOC1 (size: 8, align: 4) {
++     02 00 00 00 03 00 00 00                         │ ........
++ }
++ 
++ ALLOC2 (size: 8, align: 4) {
++     02 00 00 00 03 00 00 00                         │ ........
++ }
++ 
++ ALLOC3 (size: 8, align: 4) {
++     01 00 00 00 02 00 00 00                         │ ........
+  }
+  

--- a/tests/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.diff
+++ b/tests/mir-opt/dataflow-const-prop/tuple.main.DataflowConstProp.diff
@@ -11,6 +11,9 @@
       let mut _8: i32;
       let mut _9: i32;
       let mut _10: i32;
+      let mut _12: i32;
+      let mut _13: (i32, i32);
+      let mut _14: i32;
       scope 1 {
           debug a => _1;
           let _2: i32;
@@ -19,13 +22,18 @@
               let _6: i32;
               scope 3 {
                   debug c => _6;
+                  let _11: (i32, (i32, i32), i32);
+                  scope 4 {
+                      debug d => _11;
+                  }
               }
           }
       }
   
       bb0: {
           StorageLive(_1);
-          _1 = (const 1_i32, const 2_i32);
+-         _1 = (const 1_i32, const 2_i32);
++         _1 = const (1, 2);
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
@@ -41,7 +49,8 @@
 -         _2 = Add(move _3, const 3_i32);
 +         _2 = const 6_i32;
           StorageDead(_3);
-          _1 = (const 2_i32, const 3_i32);
+-         _1 = (const 2_i32, const 3_i32);
++         _1 = const (2, 3);
           StorageLive(_6);
           StorageLive(_7);
           StorageLive(_8);
@@ -61,7 +70,23 @@
 +         _6 = const 11_i32;
           StorageDead(_10);
           StorageDead(_7);
+          StorageLive(_11);
+          StorageLive(_12);
+-         _12 = _2;
++         _12 = const 6_i32;
+          StorageLive(_13);
+-         _13 = _1;
++         _13 = const (2, 3);
+          StorageLive(_14);
+-         _14 = _6;
+-         _11 = (move _12, move _13, move _14);
++         _14 = const 11_i32;
++         _11 = const (6, (2, 3), 11);
+          StorageDead(_14);
+          StorageDead(_13);
+          StorageDead(_12);
           _0 = const ();
+          StorageDead(_11);
           StorageDead(_6);
           StorageDead(_2);
           StorageDead(_1);

--- a/tests/mir-opt/dataflow-const-prop/tuple.rs
+++ b/tests/mir-opt/dataflow-const-prop/tuple.rs
@@ -1,5 +1,6 @@
 // skip-filecheck
 // unit-test: DataflowConstProp
+// EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR tuple.main.DataflowConstProp.diff
 fn main() {

--- a/tests/mir-opt/dataflow-const-prop/tuple.rs
+++ b/tests/mir-opt/dataflow-const-prop/tuple.rs
@@ -7,4 +7,6 @@ fn main() {
     let b = a.0 + a.1 + 3;
     a = (2, 3);
     let c = a.0 + a.1 + b;
+
+    let d = (b, a, c);
 }

--- a/tests/ui/consts/issue-116186.rs
+++ b/tests/ui/consts/issue-116186.rs
@@ -1,0 +1,12 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+fn something(path: [usize; N]) -> impl Clone {
+    //~^ ERROR cannot find value `N` in this scope
+    match path {
+        [] => 0, //~ ERROR cannot pattern-match on an array without a fixed length
+        _ => 1,
+    };
+}
+
+fn main() {}

--- a/tests/ui/consts/issue-116186.stderr
+++ b/tests/ui/consts/issue-116186.stderr
@@ -1,0 +1,21 @@
+error[E0425]: cannot find value `N` in this scope
+  --> $DIR/issue-116186.rs:4:28
+   |
+LL | fn something(path: [usize; N]) -> impl Clone {
+   |                            ^ not found in this scope
+   |
+help: you might be missing a const parameter
+   |
+LL | fn something<const N: /* Type */>(path: [usize; N]) -> impl Clone {
+   |             +++++++++++++++++++++
+
+error[E0730]: cannot pattern-match on an array without a fixed length
+  --> $DIR/issue-116186.rs:7:9
+   |
+LL |         [] => 0,
+   |         ^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0425, E0730.
+For more information about an error, try `rustc --explain E0425`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -554,13 +554,9 @@ cc = ["@davidtwco", "@compiler-errors", "@JohnTitor", "@TaKO8Ki"]
 message = "`rustc_macros::diagnostics` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@JohnTitor", "@TaKO8Ki"]
 
-[mentions."compiler/rustc_smir"]
-message = "This PR changes Stable MIR"
-cc = ["@oli-obk", "@celinval", "@spastorino", "@ouz-a"]
-
 [mentions."compiler/stable_mir"]
 message = "This PR changes Stable MIR"
-cc = ["@oli-obk", "@celinval", "@spastorino"]
+cc = ["@oli-obk", "@celinval", "@spastorino", "@ouz-a"]
 
 [mentions."compiler/rustc_target/src/spec"]
 message = """


### PR DESCRIPTION
Successful merges:

 - #115796 (Generate aggregate constants in DataflowConstProp.)
 - #116094 (Introduce `-C instrument-coverage=branch` to gate branch coverage)
 - #116859 (Make `ty::print::Printer` take `&mut self` instead of `self`)
 - #117046 (return unfixed len if pat has reported error)
 - #117070 (rustdoc: wrap Type with Box instead of Generics)
 - #117074 (Remove smir from triage and add me to stablemir)
 - #117086 (Update .mailmap to promote my livename)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=115796,116094,116859,117046,117070,117074,117086)
<!-- homu-ignore:end -->