### PR TITLE
remove change-id assertion in bootstrap test

### DIFF
--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -103,7 +103,6 @@ class GenerateAndParseConfig(unittest.TestCase):
     """Test that we can serialize and deserialize a config.toml file"""
     def test_no_args(self):
         build = serialize_and_parse([])
-        self.assertEqual(build.get_toml("change-id"), '116998')
         self.assertEqual(build.get_toml("profile"), 'dist')
         self.assertIsNone(build.get_toml("llvm.download-ci-llvm"))
 


### PR DESCRIPTION
In the bootstrap test, the assertion of the change-id fails whenever we update the change-id next to a breaking change in build configurations. This commit removes the assertion, as it's not critical or useful to have.


ref https://github.com/rust-lang/rust/pull/115898#issuecomment-1775909050