### PR TITLE
rustdoc-search: show type signature on type-driven SERP

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -328,10 +328,11 @@ details:not(.toggle) summary {
 	margin-bottom: .6em;
 }
 
-code, pre, a.test-arrow, .code-header {
+code, pre, a.test-arrow, .code-header, .search-results .type-signature {
 	font-family: "Source Code Pro", monospace;
 }
-.docblock code, .docblock-short code {
+.docblock code, .docblock-short code,
+.search-results .type-signature strong {
 	border-radius: 3px;
 	padding: 0 0.125em;
 }
@@ -681,7 +682,8 @@ ul.block, .block li {
 }
 
 .docblock code, .docblock-short code,
-pre, .rustdoc.src .example-wrap {
+pre, .rustdoc.src .example-wrap,
+.search-results .type-signature strong {
 	background-color: var(--code-block-background-color);
 }
 

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1309,36 +1309,6 @@ function initSearch(rawSearchIndex) {
         }
 
         /**
-         * This function checks generics in search query `queryElem` can all be found in the
-         * search index (`fnType`),
-         *
-         * This function returns `true` if it matches, and also writes the results to mgensInout.
-         * It returns `false` if no match is found, and leaves mgensInout untouched.
-         *
-         * @param {FunctionType} fnType                - The object to check.
-         * @param {QueryElement} queryElem             - The element from the parsed query.
-         * @param {[FunctionType]} whereClause         - Trait bounds for generic items.
-         * @param {Map<number,number>|null} mgensInout - Map functions generics to query generics.
-         *
-         * @return {boolean} - Returns true if a match, false otherwise.
-         */
-        function checkGenerics(fnType, queryElem, whereClause, mgensInout) {
-            return unifyFunctionTypes(
-                fnType.generics,
-                queryElem.generics,
-                whereClause,
-                mgensInout,
-                mgens => {
-                    if (mgensInout) {
-                        for (const [fid, qid] of mgens.entries()) {
-                            mgensInout.set(fid, qid);
-                        }
-                    }
-                    return true;
-                }
-            );
-        }
-        /**
          * This function checks if a list of search query `queryElems` can all be found in the
          * search index (`fnTypes`).
          *
@@ -1561,7 +1531,7 @@ function initSearch(rawSearchIndex) {
                 ) {
                     // [] matches primitive:array or primitive:slice
                     // if it matches, then we're fine, and this is an appropriate match candidate
-                } else if (fnType.id !== queryElem.id) {
+                } else if (fnType.id !== queryElem.id || queryElem.id === null) {
                     return false;
                 }
                 // If the query elem has generics, and the function doesn't,
@@ -1649,38 +1619,15 @@ function initSearch(rawSearchIndex) {
           * @return {boolean} - Returns true if the type matches, false otherwise.
           */
         function checkType(row, elem, whereClause) {
-            if (row.id === null) {
-                // This is a pure "generic" search, no need to run other checks.
-                return row.generics.length > 0
-                    ? checkIfInList(row.generics, elem, whereClause)
-                    : false;
+            if (row.id > 0 && elem.id > 0 && elem.pathWithoutLast.length === 0 &&
+                row.generics.length === 0 && elem.generics.length === 0 &&
+                // special case
+                elem.id !== typeNameIdOfArrayOrSlice
+            ) {
+                return row.id === elem.id && typePassesFilter(elem.typeFilter, row.ty);
+            } else {
+                return unifyFunctionTypes([row], [elem], whereClause);
             }
-
-            if (row.id < 0 && elem.id >= 0) {
-                const gid = (-row.id) - 1;
-                return checkIfInList(whereClause[gid], elem, whereClause);
-            }
-
-            if (row.id < 0 && elem.id < 0) {
-                return true;
-            }
-
-            const matchesExact = row.id === elem.id;
-            const matchesArrayOrSlice = elem.id === typeNameIdOfArrayOrSlice &&
-                (row.id === typeNameIdOfSlice || row.id === typeNameIdOfArray);
-
-            if ((matchesExact || matchesArrayOrSlice) &&
-                typePassesFilter(elem.typeFilter, row.ty)) {
-                if (elem.generics.length > 0) {
-                    return checkGenerics(row, elem, whereClause, new Map());
-                }
-                return true;
-            }
-
-            // If the current item does not match, try [unboxing] the generic.
-            // [unboxing]:
-            //   https://ndmitchell.com/downloads/slides-hoogle_fast_type_searching-09_aug_2008.pdf
-            return checkIfInList(row.generics, elem, whereClause);
         }
 
         function checkPath(contains, ty, maxEditDistance) {

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1268,7 +1268,10 @@ function initSearch(rawSearchIndex) {
                         }
                     } else {
                         push(fnType.name, fnType.highlighted);
-                        if (fnType.generics && fnType.generics.some(isTransitivelyHighlighted)) {
+                        if (fnType.generics && fnType.generics.length > 0 &&
+                            (fnType.generics.some(isTransitivelyHighlighted)
+                                || row.implDisambiguator !== null)
+                        ) {
                             pushNotHighlighted("<");
                             formatTypeList(fnType.generics, ", ");
                             pushNotHighlighted(">");

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -373,8 +373,35 @@ function loadSearchJS(doc_folder, resource_suffix) {
 
     return {
         doSearch: function(queryStr, filterCrate, currentCrate) {
-            return searchModule.execQuery(searchModule.parseQuery(queryStr), searchWords,
+            const results = searchModule.execQuery(searchModule.parseQuery(queryStr), searchWords,
                 filterCrate, currentCrate);
+            for (const key in results) {
+                if (results[key]) {
+                    for (const resultKey in results[key]) {
+                        if (!Object.prototype.hasOwnProperty.call(results[key], resultKey)) {
+                            continue;
+                        }
+                        const entry = results[key][resultKey];
+                        if (!entry) {
+                            continue;
+                        }
+                        if (Object.prototype.hasOwnProperty.call(entry, "displayTypeSignature") &&
+                            entry.displayTypeSignature !== null &&
+                            entry.displayTypeSignature instanceof Array
+                        ) {
+                            entry.displayTypeSignature.forEach((value, index) => {
+                                if (index % 2 === 1) {
+                                    entry.displayTypeSignature[index] = "*" + value + "*";
+                                } else {
+                                    entry.displayTypeSignature[index] = value;
+                                }
+                            });
+                            entry.displayTypeSignature = entry.displayTypeSignature.join("");
+                        }
+                    }
+                }
+            }
+            return results;
         },
         getCorrections: function(queryStr, filterCrate, currentCrate) {
             const parsedQuery = searchModule.parseQuery(queryStr);

--- a/tests/rustdoc-gui/search-corrections.goml
+++ b/tests/rustdoc-gui/search-corrections.goml
@@ -24,7 +24,7 @@ assert-css: (".search-corrections", {
 })
 assert-text: (
     ".search-corrections",
-    "Type \"notablestructwithlongnamr\" not found. Showing results for closest type name \"notablestructwithlongname\" instead."
+    "Type \"NotableStructWithLongNamr\" not found. Showing results for closest type name \"notablestructwithlongname\" instead."
 )
 
 // Corrections do get shown on the "In Return Type" tab.
@@ -35,7 +35,7 @@ assert-css: (".search-corrections", {
 })
 assert-text: (
     ".search-corrections",
-    "Type \"notablestructwithlongnamr\" not found. Showing results for closest type name \"notablestructwithlongname\" instead."
+    "Type \"NotableStructWithLongNamr\" not found. Showing results for closest type name \"notablestructwithlongname\" instead."
 )
 
 // Now, explicit return values
@@ -52,7 +52,7 @@ assert-css: (".search-corrections", {
 })
 assert-text: (
     ".search-corrections",
-    "Type \"notablestructwithlongnamr\" not found. Showing results for closest type name \"notablestructwithlongname\" instead."
+    "Type \"NotableStructWithLongNamr\" not found. Showing results for closest type name \"notablestructwithlongname\" instead."
 )
 
 // Now, generic correction
@@ -69,7 +69,7 @@ assert-css: (".search-corrections", {
 })
 assert-text: (
     ".search-corrections",
-    "Type \"notablestructwithlongnamr\" not found and used as generic parameter. Consider searching for \"notablestructwithlongname\" instead."
+    "Type \"NotableStructWithLongNamr\" not found and used as generic parameter. Consider searching for \"notablestructwithlongname\" instead."
 )
 
 // Now, generic correction plus error
@@ -86,7 +86,7 @@ assert-css: (".search-corrections", {
 })
 assert-text: (
     ".search-corrections",
-    "Type \"notablestructwithlongnamr\" not found and used as generic parameter. Consider searching for \"notablestructwithlongname\" instead."
+    "Type \"NotableStructWithLongNamr\" not found and used as generic parameter. Consider searching for \"notablestructwithlongname\" instead."
 )
 
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
@@ -102,5 +102,5 @@ assert-css: (".error", {
 })
 assert-text: (
     ".error",
-    "Query parser error: \"Generic type parameter notablestructwithlongnamr does not accept generic parameters\"."
+    "Query parser error: \"Generic type parameter NotableStructWithLongNamr does not accept generic parameters\"."
 )

--- a/tests/rustdoc-js-std/parser-ident.js
+++ b/tests/rustdoc-js-std/parser-ident.js
@@ -2,7 +2,8 @@ const PARSED = [
     {
         query: "R<!>",
         elems: [{
-            name: "r",
+            name: "R",
+            normalizedName: "r",
             fullPath: ["r"],
             pathWithoutLast: [],
             pathLast: "r",
@@ -28,6 +29,7 @@ const PARSED = [
         query: "!",
         elems: [{
             name: "never",
+            normalizedName: "never",
             fullPath: ["never"],
             pathWithoutLast: [],
             pathLast: "never",
@@ -44,6 +46,7 @@ const PARSED = [
         query: "a!",
         elems: [{
             name: "a",
+            normalizedName: "a",
             fullPath: ["a"],
             pathWithoutLast: [],
             pathLast: "a",
@@ -78,6 +81,7 @@ const PARSED = [
         query: "!::b",
         elems: [{
             name: "!::b",
+            normalizedName: "!::b",
             fullPath: ["never", "b"],
             pathWithoutLast: ["never"],
             pathLast: "b",
@@ -126,7 +130,8 @@ const PARSED = [
             pathLast: "b",
             generics: [
                 {
-                    name: "t",
+                    name: "T",
+                    normalizedName: "t",
                     fullPath: ["t"],
                     pathWithoutLast: [],
                     pathLast: "t",

--- a/tests/rustdoc-js-std/parser-literal.js
+++ b/tests/rustdoc-js-std/parser-literal.js
@@ -2,13 +2,15 @@ const PARSED = [
     {
         query: 'R<P>',
         elems: [{
-            name: "r",
+            name: "R",
+            normalizedName: "r",
             fullPath: ["r"],
             pathWithoutLast: [],
             pathLast: "r",
             generics: [
                 {
-                    name: "p",
+                    name: "P",
+                    normalizedName: "p",
                     fullPath: ["p"],
                     pathWithoutLast: [],
                     pathLast: "p",

--- a/tests/rustdoc-js-std/parser-paths.js
+++ b/tests/rustdoc-js-std/parser-paths.js
@@ -2,7 +2,8 @@ const PARSED = [
     {
         query: 'A::B',
         elems: [{
-            name: "a::b",
+            name: "A::B",
+            normalizedName: "a::b",
             fullPath: ["a", "b"],
             pathWithoutLast: ["a"],
             pathLast: "b",
@@ -19,7 +20,8 @@ const PARSED = [
         query: 'A::B,C',
         elems: [
             {
-                name: "a::b",
+                name: "A::B",
+                normalizedName: "a::b",
                 fullPath: ["a", "b"],
                 pathWithoutLast: ["a"],
                 pathLast: "b",
@@ -27,7 +29,8 @@ const PARSED = [
                 typeFilter: -1,
             },
             {
-                name: "c",
+                name: "C",
+                normalizedName: "c",
                 fullPath: ["c"],
                 pathWithoutLast: [],
                 pathLast: "c",
@@ -45,13 +48,15 @@ const PARSED = [
         query: 'A::B<f>,C',
         elems: [
             {
-                name: "a::b",
+                name: "A::B",
+                normalizedName: "a::b",
                 fullPath: ["a", "b"],
                 pathWithoutLast: ["a"],
                 pathLast: "b",
                 generics: [
                     {
                         name: "f",
+                        normalizedName: "f",
                         fullPath: ["f"],
                         pathWithoutLast: [],
                         pathLast: "f",
@@ -61,7 +66,8 @@ const PARSED = [
                 typeFilter: -1,
             },
             {
-                name: "c",
+                name: "C",
+                normalizedName: "c",
                 fullPath: ["c"],
                 pathWithoutLast: [],
                 pathLast: "c",

--- a/tests/rustdoc-js-std/parser-returned.js
+++ b/tests/rustdoc-js-std/parser-returned.js
@@ -5,13 +5,13 @@ const PARSED = [
         foundElems: 1,
         original: "-> F<P>",
         returned: [{
-            name: "f",
+            name: "F",
             fullPath: ["f"],
             pathWithoutLast: [],
             pathLast: "f",
             generics: [
                 {
-                    name: "p",
+                    name: "P",
                     fullPath: ["p"],
                     pathWithoutLast: [],
                     pathLast: "p",
@@ -29,7 +29,7 @@ const PARSED = [
         foundElems: 1,
         original: "-> P",
         returned: [{
-            name: "p",
+            name: "P",
             fullPath: ["p"],
             pathWithoutLast: [],
             pathLast: "p",

--- a/tests/rustdoc-js-std/parser-slice-array.js
+++ b/tests/rustdoc-js-std/parser-slice-array.js
@@ -30,7 +30,7 @@ const PARSED = [
                                 pathLast: "[]",
                                 generics: [
                                     {
-                                        name: "d",
+                                        name: "D",
                                         fullPath: ["d"],
                                         pathWithoutLast: [],
                                         pathLast: "d",

--- a/tests/rustdoc-js/generics-impl.js
+++ b/tests/rustdoc-js/generics-impl.js
@@ -4,33 +4,61 @@ const EXPECTED = [
     {
         'query': 'Aaaaaaa -> u32',
         'others': [
-            { 'path': 'generics_impl::Aaaaaaa', 'name': 'bbbbbbb' },
+            {
+                'path': 'generics_impl::Aaaaaaa',
+                'name': 'bbbbbbb',
+                'displayTypeSignature': '*Aaaaaaa* -> *u32*'
+            },
         ],
     },
     {
         'query': 'Aaaaaaa -> bool',
         'others': [
-            { 'path': 'generics_impl::Aaaaaaa', 'name': 'ccccccc' },
+            {
+                'path': 'generics_impl::Aaaaaaa',
+                'name': 'ccccccc',
+                'displayTypeSignature': '*Aaaaaaa* -> *bool*'
+            },
         ],
     },
     {
         'query': 'Aaaaaaa -> usize',
         'others': [
-            { 'path': 'generics_impl::Aaaaaaa', 'name': 'read' },
+            {
+                'path': 'generics_impl::Aaaaaaa',
+                'name': 'read',
+                'displayTypeSignature': '*Aaaaaaa*, [] -> Result<*usize*>'
+            },
         ],
     },
     {
         'query': 'Read -> u64',
         'others': [
-            { 'path': 'generics_impl::Ddddddd', 'name': 'eeeeeee' },
-            { 'path': 'generics_impl::Ddddddd', 'name': 'ggggggg' },
+            {
+                'path': 'generics_impl::Ddddddd',
+                'name': 'eeeeeee',
+                'displayTypeSignature': 'impl *Read* -> *u64*'
+            },
+            {
+                'path': 'generics_impl::Ddddddd',
+                'name': 'ggggggg',
+                'displayTypeSignature': 'Ddddddd<impl *Read*> -> *u64*'
+            },
         ],
     },
     {
         'query': 'trait:Read -> u64',
         'others': [
-            { 'path': 'generics_impl::Ddddddd', 'name': 'eeeeeee' },
-            { 'path': 'generics_impl::Ddddddd', 'name': 'ggggggg' },
+            {
+                'path': 'generics_impl::Ddddddd',
+                'name': 'eeeeeee',
+                'displayTypeSignature': 'impl *Read* -> *u64*'
+            },
+            {
+                'path': 'generics_impl::Ddddddd',
+                'name': 'ggggggg',
+                'displayTypeSignature': 'Ddddddd<impl *Read*> -> *u64*'
+            },
         ],
     },
     {
@@ -40,19 +68,31 @@ const EXPECTED = [
     {
         'query': 'bool -> u64',
         'others': [
-            { 'path': 'generics_impl::Ddddddd', 'name': 'fffffff' },
+            {
+                'path': 'generics_impl::Ddddddd',
+                'name': 'fffffff',
+                'displayTypeSignature': '*bool* -> *u64*'
+            },
         ],
     },
     {
         'query': 'Ddddddd -> u64',
         'others': [
-            { 'path': 'generics_impl::Ddddddd', 'name': 'ggggggg' },
+            {
+                'path': 'generics_impl::Ddddddd',
+                'name': 'ggggggg',
+                'displayTypeSignature': '*Ddddddd* -> *u64*'
+            },
         ],
     },
     {
         'query': '-> Ddddddd',
         'others': [
-            { 'path': 'generics_impl::Ddddddd', 'name': 'hhhhhhh' },
+            {
+                'path': 'generics_impl::Ddddddd',
+                'name': 'hhhhhhh',
+                'displayTypeSignature': '-> *Ddddddd*'
+            },
         ],
     },
 ];

--- a/tests/rustdoc-js/generics-match-ambiguity.js
+++ b/tests/rustdoc-js/generics-match-ambiguity.js
@@ -8,15 +8,31 @@ const EXPECTED = [
     {
         'query': 'Wrap',
         'in_args': [
-            { 'path': 'generics_match_ambiguity', 'name': 'bar' },
-            { 'path': 'generics_match_ambiguity', 'name': 'foo' },
+            {
+                'path': 'generics_match_ambiguity',
+                'name': 'bar',
+                'displayTypeSignature': '*Wrap*, Wrap'
+            },
+            {
+                'path': 'generics_match_ambiguity',
+                'name': 'foo',
+                'displayTypeSignature': '*Wrap*, Wrap'
+            },
         ],
     },
     {
         'query': 'Wrap<i32>',
         'in_args': [
-            { 'path': 'generics_match_ambiguity', 'name': 'bar' },
-            { 'path': 'generics_match_ambiguity', 'name': 'foo' },
+            {
+                'path': 'generics_match_ambiguity',
+                'name': 'bar',
+                'displayTypeSignature': '*Wrap*<*i32*, u32>, Wrap'
+            },
+            {
+                'path': 'generics_match_ambiguity',
+                'name': 'foo',
+                'displayTypeSignature': '*Wrap*<*i32*>, Wrap'
+            },
         ],
     },
     {

--- a/tests/rustdoc-js/search-method-disambiguate.js
+++ b/tests/rustdoc-js/search-method-disambiguate.js
@@ -11,7 +11,8 @@ const EXPECTED = [
             {
                 'path': 'search_method_disambiguate::MyTy',
                 'name': 'my_method',
-                'href': '../search_method_disambiguate/struct.MyTy.html#impl-X-for-MyTy%3Cbool%3E/method.my_method'
+                'href': '../search_method_disambiguate/struct.MyTy.html#impl-X-for-MyTy%3Cbool%3E/method.my_method',
+                'displayTypeSignature': '*MyTy*<bool> -> *bool*',
             },
         ],
     },
@@ -21,7 +22,8 @@ const EXPECTED = [
             {
                 'path': 'search_method_disambiguate::MyTy',
                 'name': 'my_method',
-                'href': '../search_method_disambiguate/struct.MyTy.html#impl-X-for-MyTy%3Cu8%3E/method.my_method'
+                'href': '../search_method_disambiguate/struct.MyTy.html#impl-X-for-MyTy%3Cu8%3E/method.my_method',
+                'displayTypeSignature': '*MyTy*<u8> -> *u8*',
             },
         ],
     }

--- a/tests/rustdoc-js/type-parameters.js
+++ b/tests/rustdoc-js/type-parameters.js
@@ -5,79 +5,79 @@ const EXPECTED = [
     {
         query: '-> trait:Some',
         others: [
-            { path: 'foo', name: 'alef' },
-            { path: 'foo', name: 'alpha' },
+            { path: 'foo', name: 'alef', displayTypeSignature: '-> impl *Some*' },
+            { path: 'foo', name: 'alpha', displayTypeSignature: '-> impl *Some*' },
         ],
     },
     {
         query: '-> generic:T',
         others: [
-            { path: 'foo', name: 'bet' },
-            { path: 'foo', name: 'alef' },
-            { path: 'foo', name: 'beta' },
+            { path: 'foo', name: 'bet', displayTypeSignature: '_ -> *T*' },
+            { path: 'foo', name: 'alef', displayTypeSignature: '-> *T*' },
+            { path: 'foo', name: 'beta', displayTypeSignature: 'T -> *T*' },
         ],
     },
     {
         query: 'A -> B',
         others: [
-            { path: 'foo', name: 'bet' },
+            { path: 'foo', name: 'bet', displayTypeSignature: '*A* -> *B*' },
         ],
     },
     {
         query: 'A -> A',
         others: [
-            { path: 'foo', name: 'beta' },
+            { path: 'foo', name: 'beta', displayTypeSignature: '*A* -> *A*' },
         ],
     },
     {
         query: 'A, A',
         others: [
-            { path: 'foo', name: 'alternate' },
+            { path: 'foo', name: 'alternate', displayTypeSignature: '*A*, *A*' },
         ],
     },
     {
         query: 'A, B',
         others: [
-            { path: 'foo', name: 'other' },
+            { path: 'foo', name: 'other', displayTypeSignature: '*A*, *B*' },
         ],
     },
     {
         query: 'Other, Other',
         others: [
-            { path: 'foo', name: 'other' },
-            { path: 'foo', name: 'alternate' },
+            { path: 'foo', name: 'other', displayTypeSignature: 'impl *Other*, impl *Other*' },
+            { path: 'foo', name: 'alternate', displayTypeSignature: 'impl *Other*, impl *Other*' },
         ],
     },
     {
         query: 'generic:T',
         in_args: [
-            { path: 'foo', name: 'bet' },
-            { path: 'foo', name: 'beta' },
-            { path: 'foo', name: 'other' },
-            { path: 'foo', name: 'alternate' },
+            { path: 'foo', name: 'bet', displayTypeSignature: '*T* -> _' },
+            { path: 'foo', name: 'beta', displayTypeSignature: '*T* -> T' },
+            { path: 'foo', name: 'other', displayTypeSignature: '*T*, _' },
+            { path: 'foo', name: 'alternate', displayTypeSignature: '*T*, T' },
         ],
     },
     {
         query: 'generic:Other',
         in_args: [
-            { path: 'foo', name: 'bet' },
-            { path: 'foo', name: 'beta' },
-            { path: 'foo', name: 'other' },
-            { path: 'foo', name: 'alternate' },
+            { path: 'foo', name: 'bet', displayTypeSignature: '*Other* -> _' },
+            { path: 'foo', name: 'beta', displayTypeSignature: '*Other* -> Other' },
+            { path: 'foo', name: 'other', displayTypeSignature: '*Other*, _' },
+            { path: 'foo', name: 'alternate', displayTypeSignature: '*Other*, Other' },
         ],
     },
     {
         query: 'trait:Other',
         in_args: [
-            { path: 'foo', name: 'other' },
-            { path: 'foo', name: 'alternate' },
+            { path: 'foo', name: 'other', displayTypeSignature: '_, impl *Other*' },
+            { path: 'foo', name: 'alternate', displayTypeSignature: 'impl *Other*, impl *Other*' },
         ],
     },
     {
         query: 'Other',
         in_args: [
-            { path: 'foo', name: 'other' },
-            { path: 'foo', name: 'alternate' },
+            { path: 'foo', name: 'other', displayTypeSignature: '_, impl *Other*' },
+            { path: 'foo', name: 'alternate', displayTypeSignature: 'impl *Other*, impl *Other*' },
         ],
     },
     {


### PR DESCRIPTION
## Preview

<details><summary>Screenshots of what these pages looked like before</summary>

![image](https://github.com/rust-lang/rust/assets/1593513/311d24eb-d000-4ecb-b913-c621cb215787)
![image](https://github.com/rust-lang/rust/assets/1593513/ebe76a5e-b5dd-4771-b4c3-b9feee8b34c7)

</details>

Preview page:

* https://notriddle.com/rustdoc-html-demo-5/display-signature/std/index.html?search=vec%3CU%3E%20-%3E%20%5BT%5D
* https://notriddle.com/rustdoc-html-demo-5/display-signature/std/index.html?search=option%3Ct%3E%20-%3E%20result%3Ct%3E

Desktop screenshots:
![image](https://github.com/rust-lang/rust/assets/1593513/f61388ea-ea5b-4623-b03c-a7d52cecde8a)
![image](https://github.com/rust-lang/rust/assets/1593513/b0d9f3b9-0b2c-4f46-b717-04084bf80088)
![image](https://github.com/rust-lang/rust/assets/1593513/317f3742-d8a0-4301-bec1-bb8887282874)

Mobile screenshot:
![image](https://github.com/rust-lang/rust/assets/1593513/564e9be6-3541-48c7-a830-0d5e150be157)

## Description

This displays the function signature, as rustdoc understands it, on the In Parameters, In Return Types, and In Function Signature pages, but not in the In Names page, since it's not used there. It also highlights the matching parts, to clarify why a function is considered a good match.

## Rationale

Since the point of this feature is to answer the question "why this a match," it's important that it communicates a few things:

* **How do I use this?** This UI shows types as Rustdoc sees them, using Rustdoc's search syntax, rather than the syntax used by normal Rust. It's supposed to act as a built-in, context-sensitive tutorial, since you can type a name in, switch to the In Parameters tab, and see what you could've typed to get a particular result.
* **Which type parameters got matched to other type parameters?** Since names aren't relevant to matching, it shows the type parameters that the *user* wrote, not the ones that exist in the original source code (consider the above screenshot, that shows how `T` and `U` both got matched even though this particular result is a bit counterintuitive).
* **How does the search engine even work, anyway?** It's important that this page accurately shows you what unboxing occurred and which mappings got followed. That's why parts of the highlighter are baked into the type unification function: it doesn't just show you where your atoms occur, but actually shows you which ones *got matched*.

This change also allows us to stop de-duplicating these results, so it's a follow-up for https://github.com/rust-lang/rust/pull/109422#issuecomment-1491121921. This PR doesn't remove the deduplication logic for the name-based search, because it seems like showing all of the Simd add functions in that context would be more annoying than useful, because it could push the result that you want off the screen, and there's no way to narrow down to a particular one without switching to an entirely different style of search.

## Future possibilities

This needs merged with https://github.com/rust-lang/rust/pull/116085. This branch is not currently based on that one.

Other future possibilities, copied directly from there:

* ~~This system has no ranking algorithm. We should fix that.~~
  - [x] https://github.com/rust-lang/rust/pull/118402 added a very basic ranking algorithm.
* ~~The unification algorithm is complex and slow. Smart data structures, like bloom filters, can help.~~
  - [x] https://github.com/rust-lang/rust/pull/118402 added a very basic ranking algorithm.
* Should add support for tuples, references, and raw pointers.'
  - [x] https://github.com/rust-lang/rust/pull/118194