### PR TITLE
Print variadic argument pattern in HIR pretty printer

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1737,14 +1737,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn lower_fn_params_to_names(&mut self, decl: &FnDecl) -> &'hir [Ident] {
-        // Skip the `...` (`CVarArgs`) trailing arguments from the AST,
-        // as they are not explicit in HIR/Ty function signatures.
-        // (instead, the `c_variadic` flag is set to `true`)
-        let mut inputs = &decl.inputs[..];
-        if decl.c_variadic() {
-            inputs = &inputs[..inputs.len() - 1];
-        }
-        self.arena.alloc_from_iter(inputs.iter().map(|param| match param.pat.kind {
+        self.arena.alloc_from_iter(decl.inputs.iter().map(|param| match param.pat.kind {
             PatKind::Ident(_, ident, _) => self.lower_ident(ident),
             _ => Ident::new(kw::Empty, self.lower_span(param.pat.span)),
         }))

--- a/tests/pretty/hir-fn-variadic.pp
+++ b/tests/pretty/hir-fn-variadic.pp
@@ -9,7 +9,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 
 extern "C" {
-    fn foo(x: i32, ...);
+    fn foo(x: i32, va1: ...);
 }
 
 unsafe extern "C" fn bar(_: i32, mut va2: ...) -> usize { va2.arg::<usize>() }

--- a/tests/pretty/hir-fn-variadic.pp
+++ b/tests/pretty/hir-fn-variadic.pp
@@ -1,0 +1,15 @@
+// pretty-compare-only
+// pretty-mode:hir
+// pp-exact:hir-fn-variadic.pp
+
+#![feature(c_variadic)]
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+
+extern "C" {
+    fn foo(x: i32, ...);
+}
+
+unsafe extern "C" fn bar(_: i32, mut va2: ...) -> usize { va2.arg::<usize>() }

--- a/tests/pretty/hir-fn-variadic.rs
+++ b/tests/pretty/hir-fn-variadic.rs
@@ -1,0 +1,13 @@
+// pretty-compare-only
+// pretty-mode:hir
+// pp-exact:hir-fn-variadic.pp
+
+#![feature(c_variadic)]
+
+extern "C" {
+    pub fn foo(x: i32, va1: ...);
+}
+
+pub unsafe extern "C" fn bar(_: i32, mut va2: ...) -> usize {
+    va2.arg::<usize>()
+}


### PR DESCRIPTION
Variadic argument name/pattern was ignored during HIR pretty printing.
Could not figure out why it only works on normal functions (`va2`) and not in foreign ones (`va1`).