### PR TITLE
Fix unwrap suggestion for async fn

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -1747,19 +1747,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
     ) -> bool {
-        let ty::Adt(adt, args) = found.kind() else { return false };
+        let ty::Adt(adt, args) = found.kind() else {
+            return false;
+        };
         let ret_ty_matches = |diagnostic_item| {
-            if let Some(ret_ty) = self
-                    .ret_coercion
-                    .as_ref()
-                    .map(|c| self.resolve_vars_if_possible(c.borrow().expected_ty()))
-                    && let ty::Adt(kind, _) = ret_ty.kind()
-                    && self.tcx.get_diagnostic_item(diagnostic_item) == Some(kind.did())
-                {
-                    true
-                } else {
-                    false
-                }
+            let Some(sig) = self.body_fn_sig() else {
+                return false;
+            };
+            let ty::Adt(kind, _) = sig.output().kind() else {
+                return false;
+            };
+            self.tcx.is_diagnostic_item(diagnostic_item, kind.did())
         };
 
         // don't suggest anything like `Ok(ok_val).unwrap()` , `Some(some_val).unwrap()`,

--- a/tests/ui/mismatched_types/async-unwrap-suggestion.rs
+++ b/tests/ui/mismatched_types/async-unwrap-suggestion.rs
@@ -1,0 +1,22 @@
+// edition: 2021
+
+async fn dont_suggest() -> i32 {
+    if false {
+        return Ok(6);
+        //~^ ERROR mismatched types
+    }
+
+    5
+}
+
+async fn do_suggest() -> i32 {
+    if false {
+        let s = Ok(6);
+        return s;
+        //~^ ERROR mismatched types
+    }
+
+    5
+}
+
+fn main() {}

--- a/tests/ui/mismatched_types/async-unwrap-suggestion.stderr
+++ b/tests/ui/mismatched_types/async-unwrap-suggestion.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/async-unwrap-suggestion.rs:5:16
+   |
+LL |         return Ok(6);
+   |                ^^^^^ expected `i32`, found `Result<{integer}, _>`
+   |
+   = note: expected type `i32`
+              found enum `Result<{integer}, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/async-unwrap-suggestion.rs:15:16
+   |
+LL |         return s;
+   |                ^ expected `i32`, found `Result<{integer}, _>`
+   |
+   = note: expected type `i32`
+              found enum `Result<{integer}, _>`
+help: consider using `Result::expect` to unwrap the `Result<{integer}, _>` value, panicking if the value is a `Result::Err`
+   |
+LL |         return s.expect("REASON");
+   |                 +++++++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Use `body_fn_sig` to get the expected return type of the function instead of `ret_coercion` in `FnCtxt`. This avoids accessing the `ret_coercion` when it's already mutably borrowed (e.g. when checking `return` expressions).

Fixes #117144

r? @chenyukang 