### PR TITLE
Work around the fact that `check_mod_type_wf` may spuriously return `ErrorGuaranteed`

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -205,14 +205,18 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
         })?;
     }
 
-    tcx.sess.time("wf_checking", || {
+    let errs = tcx.sess.time("wf_checking", || {
         tcx.hir().try_par_for_each_module(|module| tcx.ensure().check_mod_type_wf(module))
-    })?;
+    });
 
     // NOTE: This is copy/pasted in librustdoc/core.rs and should be kept in sync.
     tcx.sess.time("item_types_checking", || {
         tcx.hir().for_each_module(|module| tcx.ensure().check_mod_item_types(module))
     });
+
+    // HACK: `check_mod_type_wf` may spuriously emit errors due to `delay_span_bug`, even if those errors
+    // only actually get emitted in `check_mod_item_types`.
+    errs?;
 
     if tcx.features().rustc_attrs {
         tcx.sess.track_errors(|| collect::test_opaque_hidden_types(tcx))?;

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -24,6 +24,16 @@ help: you might be missing a type parameter
 LL | impl<N, M, VAL> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |          +++++
 
-error: aborting due to 2 previous errors
+error[E0046]: not all trait items implemented, missing: `VAL`
+  --> $DIR/ice-6252.rs:11:1
+   |
+LL |     const VAL: T;
+   |     ------------ `VAL` from trait
+...
+LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
 
-For more information about this error, try `rustc --explain E0412`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0046, E0412.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/associated-consts/issue-105330.rs
+++ b/tests/ui/associated-consts/issue-105330.rs
@@ -14,5 +14,6 @@ fn foo<A: TraitWAssocConst<A=32>>() { //~ ERROR E0658
 
 fn main<A: TraitWAssocConst<A=32>>() {
     //~^ ERROR E0658
+    //~| ERROR E0131
     foo::<Demo>();
 }

--- a/tests/ui/associated-consts/issue-105330.stderr
+++ b/tests/ui/associated-consts/issue-105330.stderr
@@ -39,7 +39,13 @@ error[E0562]: `impl Trait` only allowed in function and inherent method argument
 LL | impl TraitWAssocConst for impl Demo {
    |                           ^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error[E0131]: `main` function is not allowed to have generic parameters
+  --> $DIR/issue-105330.rs:15:8
+   |
+LL | fn main<A: TraitWAssocConst<A=32>>() {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `main` cannot have generic parameters
 
-Some errors have detailed explanations: E0404, E0562, E0658.
-For more information about an error, try `rustc --explain E0404`.
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0131, E0404, E0562, E0658.
+For more information about an error, try `rustc --explain E0131`.

--- a/tests/ui/associated-inherent-types/generic-associated-types-bad.item.stderr
+++ b/tests/ui/associated-inherent-types/generic-associated-types-bad.item.stderr
@@ -10,6 +10,18 @@ note: required by a bound in `Ty::Pr`
 LL |     type Pr<T: Copy> = T;
    |                ^^^^ required by this bound in `Ty::Pr`
 
-error: aborting due to previous error
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/generic-associated-types-bad.rs:16:27
+   |
+LL | const _: Ty::Pr<String> = String::new();
+   |                           ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by a bound in `Ty::Pr`
+  --> $DIR/generic-associated-types-bad.rs:10:16
+   |
+LL |     type Pr<T: Copy> = T;
+   |                ^^^^ required by this bound in `Ty::Pr`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-inherent-types/generic-associated-types-bad.local.stderr
+++ b/tests/ui/associated-inherent-types/generic-associated-types-bad.local.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Vec<()>: Copy` is not satisfied
-  --> $DIR/generic-associated-types-bad.rs:20:12
+  --> $DIR/generic-associated-types-bad.rs:21:12
    |
 LL |     let _: Ty::Pr<Vec<()>>;
    |            ^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Vec<()>`

--- a/tests/ui/associated-inherent-types/generic-associated-types-bad.region.stderr
+++ b/tests/ui/associated-inherent-types/generic-associated-types-bad.region.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/generic-associated-types-bad.rs:25:12
+  --> $DIR/generic-associated-types-bad.rs:26:12
    |
 LL | fn user<'a>() {
    |         -- lifetime `'a` defined here

--- a/tests/ui/associated-inherent-types/generic-associated-types-bad.rs
+++ b/tests/ui/associated-inherent-types/generic-associated-types-bad.rs
@@ -14,6 +14,7 @@ impl Ty {
 
 #[cfg(item)]
 const _: Ty::Pr<String> = String::new(); //[item]~ the trait bound `String: Copy` is not satisfied
+//[item]~^ the trait bound `String: Copy` is not satisfied
 
 fn main() {
     #[cfg(local)]

--- a/tests/ui/associated-types/associated-types-no-suitable-supertrait.rs
+++ b/tests/ui/associated-types/associated-types-no-suitable-supertrait.rs
@@ -21,6 +21,7 @@ trait Other {
 impl<T:Get> Other for T {
     fn uhoh<U:Get>(&self, foo: U, bar: <(T, U) as Get>::Value) {}
     //~^ ERROR the trait bound `(T, U): Get` is not satisfied
+    //~| ERROR the trait bound `(T, U): Get` is not satisfied
 }
 
 fn main() { }

--- a/tests/ui/associated-types/associated-types-no-suitable-supertrait.stderr
+++ b/tests/ui/associated-types/associated-types-no-suitable-supertrait.stderr
@@ -21,6 +21,18 @@ help: consider further restricting `Self`
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}
    |                                                              +++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `(T, U): Get` is not satisfied
+  --> $DIR/associated-types-no-suitable-supertrait.rs:22:5
+   |
+LL |     fn uhoh<U:Get>(&self, foo: U, bar: <(T, U) as Get>::Value) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `(T, U)`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/associated-types-no-suitable-supertrait.rs:12:1
+   |
+LL | trait Get {
+   | ^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/coherence/coherence-impl-trait-for-trait-object-safe.rs
+++ b/tests/ui/coherence/coherence-impl-trait-for-trait-object-safe.rs
@@ -6,5 +6,6 @@
 trait NotObjectSafe { fn eq(&self, other: Self); }
 impl NotObjectSafe for dyn NotObjectSafe { }
 //~^ ERROR E0038
+//~| ERROR E0046
 
 fn main() { }

--- a/tests/ui/coherence/coherence-impl-trait-for-trait-object-safe.stderr
+++ b/tests/ui/coherence/coherence-impl-trait-for-trait-object-safe.stderr
@@ -13,6 +13,15 @@ LL | trait NotObjectSafe { fn eq(&self, other: Self); }
    |       this trait cannot be made into an object...
    = help: consider moving `eq` to another trait
 
-error: aborting due to previous error
+error[E0046]: not all trait items implemented, missing: `eq`
+  --> $DIR/coherence-impl-trait-for-trait-object-safe.rs:7:1
+   |
+LL | trait NotObjectSafe { fn eq(&self, other: Self); }
+   |                       -------------------------- `eq` from trait
+LL | impl NotObjectSafe for dyn NotObjectSafe { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `eq` in implementation
 
-For more information about this error, try `rustc --explain E0038`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0038, E0046.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
@@ -1,0 +1,13 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+trait Q {
+    const ASSOC: usize;
+}
+
+impl<const N: u64> Q for [u8; N] {}
+//~^ ERROR not all trait items implemented
+
+pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+
+pub fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `ASSOC`
+  --> $DIR/type_mismatch.rs:8:1
+   |
+LL |     const ASSOC: usize;
+   |     ------------------ `ASSOC` from trait
+...
+LL | impl<const N: u64> Q for [u8; N] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `ASSOC` in implementation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0046`.

--- a/tests/ui/consts/const-unsized.rs
+++ b/tests/ui/consts/const-unsized.rs
@@ -2,15 +2,19 @@ use std::fmt::Debug;
 
 const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
 //~^ ERROR the size for values of type
+//~| ERROR the size for values of type
 
 const CONST_FOO: str = *"foo";
 //~^ ERROR the size for values of type
+//~| ERROR the size for values of type
 
 static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
 //~^ ERROR the size for values of type
+//~| ERROR the size for values of type
 
 static STATIC_BAR: str = *"bar";
 //~^ ERROR the size for values of type
+//~| ERROR the size for values of type
 
 fn main() {
     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -7,7 +7,7 @@ LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/const-unsized.rs:6:18
+  --> $DIR/const-unsized.rs:7:18
    |
 LL | const CONST_FOO: str = *"foo";
    |                  ^^^ doesn't have a size known at compile-time
@@ -15,7 +15,7 @@ LL | const CONST_FOO: str = *"foo";
    = help: the trait `Sized` is not implemented for `str`
 
 error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
-  --> $DIR/const-unsized.rs:9:18
+  --> $DIR/const-unsized.rs:11:18
    |
 LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
    |                  ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -23,13 +23,49 @@ LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/const-unsized.rs:12:20
+  --> $DIR/const-unsized.rs:15:20
    |
 LL | static STATIC_BAR: str = *"bar";
    |                    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
 
-error: aborting due to 4 previous errors
+error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
+  --> $DIR/const-unsized.rs:3:35
+   |
+LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = note: constant expressions must have a statically known size
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/const-unsized.rs:7:24
+   |
+LL | const CONST_FOO: str = *"foo";
+   |                        ^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: constant expressions must have a statically known size
+
+error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
+  --> $DIR/const-unsized.rs:11:37
+   |
+LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = note: constant expressions must have a statically known size
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/const-unsized.rs:15:26
+   |
+LL | static STATIC_BAR: str = *"bar";
+   |                          ^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: constant expressions must have a statically known size
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/generic-associated-types/issue-84931.rs
+++ b/tests/ui/generic-associated-types/issue-84931.rs
@@ -12,7 +12,8 @@ struct StreamingSliceIter<'a, T> {
 
 impl<'b, T: 'b> StreamingIter for StreamingSliceIter<'b, T> {
     type Item<'a> = &'a mut T;
-    //~^ the parameter type
+    //~^ ERROR: the parameter type
+    //~| ERROR: does not fulfill the required lifetime
     fn next(&mut self) -> Option<&mut T> {
         loop {}
     }

--- a/tests/ui/generic-associated-types/issue-84931.stderr
+++ b/tests/ui/generic-associated-types/issue-84931.stderr
@@ -11,6 +11,26 @@ help: consider adding an explicit lifetime bound
 LL |     type Item<'a> = &'a mut T where T: 'a;
    |                               +++++++++++
 
-error: aborting due to previous error
+error[E0477]: the type `StreamingSliceIter<'b, T>` does not fulfill the required lifetime
+  --> $DIR/issue-84931.rs:14:21
+   |
+LL |     type Item<'a> where Self: 'a;
+   |     ------------- definition of `Item` from trait
+...
+LL |     type Item<'a> = &'a mut T;
+   |                     ^^^^^^^^^
+   |
+note: type must outlive the lifetime `'a` as defined here
+  --> $DIR/issue-84931.rs:14:15
+   |
+LL |     type Item<'a> = &'a mut T;
+   |               ^^
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type Item<'a> = &'a mut T where Self: 'a;
+   |                               ++++++++++++++
 
-For more information about this error, try `rustc --explain E0309`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0309, E0477.
+For more information about an error, try `rustc --explain E0309`.

--- a/tests/ui/generic-associated-types/unsatisfied-item-lifetime-bound.rs
+++ b/tests/ui/generic-associated-types/unsatisfied-item-lifetime-bound.rs
@@ -7,6 +7,7 @@ pub trait X {
 
 impl X for () {
     type Y<'a> = &'a ();
+    //~^ ERROR lifetime bound not satisfied
 }
 
 struct B<'a, T: for<'r> X<Y<'r> = &'r ()>> {

--- a/tests/ui/generic-associated-types/unsatisfied-item-lifetime-bound.stderr
+++ b/tests/ui/generic-associated-types/unsatisfied-item-lifetime-bound.stderr
@@ -12,44 +12,64 @@ LL | #![warn(unused_lifetimes)]
    |         ^^^^^^^^^^^^^^^^
 
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/unsatisfied-item-lifetime-bound.rs:13:8
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:14:8
    |
 LL |     f: <T as X>::Y<'a>,
    |        ^^^^^^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
-  --> $DIR/unsatisfied-item-lifetime-bound.rs:12:10
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:13:10
    |
 LL | struct B<'a, T: for<'r> X<Y<'r> = &'r ()>> {
    |          ^^
    = note: but lifetime parameter must outlive the static lifetime
 
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/unsatisfied-item-lifetime-bound.rs:18:8
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:19:8
    |
 LL |     f: <T as X>::Y<'a>,
    |        ^^^^^^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
-  --> $DIR/unsatisfied-item-lifetime-bound.rs:17:10
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:18:10
    |
 LL | struct C<'a, T: X> {
    |          ^^
    = note: but lifetime parameter must outlive the static lifetime
 
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/unsatisfied-item-lifetime-bound.rs:23:8
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:24:8
    |
 LL |     f: <() as X>::Y<'a>,
    |        ^^^^^^^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
-  --> $DIR/unsatisfied-item-lifetime-bound.rs:22:10
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:23:10
    |
 LL | struct D<'a> {
    |          ^^
    = note: but lifetime parameter must outlive the static lifetime
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error[E0478]: lifetime bound not satisfied
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:9:18
+   |
+LL |     type Y<'a: 'static>;
+   |     ------------------- definition of `Y` from trait
+...
+LL |     type Y<'a> = &'a ();
+   |                  ^^^^^^
+   |
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:9:12
+   |
+LL |     type Y<'a> = &'a ();
+   |            ^^
+   = note: but lifetime parameter must outlive the static lifetime
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type Y<'a> = &'a () where 'a: 'static;
+   |                         +++++++++++++++++
+
+error: aborting due to 4 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0478`.

--- a/tests/ui/issues/issue-19380.rs
+++ b/tests/ui/issues/issue-19380.rs
@@ -14,5 +14,6 @@ struct Bar {
 
 const FOO : Foo = Foo;
 const BAR : Bar = Bar { foos: &[&FOO]};
+//~^ ERROR E0038
 
 fn main() { }

--- a/tests/ui/issues/issue-19380.stderr
+++ b/tests/ui/issues/issue-19380.stderr
@@ -20,6 +20,29 @@ help: alternatively, consider constraining `qiz` so it does not apply to trait o
 LL |   fn qiz() where Self: Sized;
    |            +++++++++++++++++
 
-error: aborting due to previous error
+error[E0038]: the trait `Qiz` cannot be made into an object
+  --> $DIR/issue-19380.rs:16:33
+   |
+LL | const BAR : Bar = Bar { foos: &[&FOO]};
+   |                                 ^^^^ `Qiz` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-19380.rs:2:6
+   |
+LL | trait Qiz {
+   |       --- this trait cannot be made into an object...
+LL |   fn qiz();
+   |      ^^^ ...because associated function `qiz` has no `self` parameter
+   = note: required for the cast from `&Foo` to `&'static (dyn Qiz + 'static)`
+help: consider turning `qiz` into a method by giving it a `&self` argument
+   |
+LL |   fn qiz(&self);
+   |          +++++
+help: alternatively, consider constraining `qiz` so it does not apply to trait objects
+   |
+LL |   fn qiz() where Self: Sized;
+   |            +++++++++++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/issues/issue-24446.rs
+++ b/tests/ui/issues/issue-24446.rs
@@ -2,6 +2,8 @@ fn main() {
     static foo: dyn Fn() -> u32 = || -> u32 {
         //~^ ERROR the size for values of type
         //~| ERROR cannot be shared between threads safely
+        //~| ERROR the size for values of type
+        //~| ERROR mismatched types
         0
     };
 }

--- a/tests/ui/issues/issue-24446.stderr
+++ b/tests/ui/issues/issue-24446.stderr
@@ -15,6 +15,39 @@ LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
 
-error: aborting due to 2 previous errors
+error[E0277]: the size for values of type `(dyn Fn() -> u32 + 'static)` cannot be known at compilation time
+  --> $DIR/issue-24446.rs:2:35
+   |
+LL |       static foo: dyn Fn() -> u32 = || -> u32 {
+   |  ___________________________________^
+LL | |
+LL | |
+LL | |
+LL | |
+LL | |         0
+LL | |     };
+   | |_____^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
+   = note: constant expressions must have a statically known size
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0308]: mismatched types
+  --> $DIR/issue-24446.rs:2:35
+   |
+LL |       static foo: dyn Fn() -> u32 = || -> u32 {
+   |  ___________________________________^
+LL | |
+LL | |
+LL | |
+LL | |
+LL | |         0
+LL | |     };
+   | |_____^ expected `dyn Fn`, found closure
+   |
+   = note: expected trait object `(dyn Fn() -> u32 + 'static)`
+                   found closure `{closure@$DIR/issue-24446.rs:2:35: 2:44}`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/issues/issue-77919.rs
+++ b/tests/ui/issues/issue-77919.rs
@@ -10,3 +10,4 @@ struct Multiply<N, M> {
 }
 impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
 //~^ ERROR cannot find type `VAL` in this scope
+//~| ERROR not all trait items implemented

--- a/tests/ui/issues/issue-77919.stderr
+++ b/tests/ui/issues/issue-77919.stderr
@@ -20,6 +20,16 @@ help: you might be missing a type parameter
 LL | impl<N, M, VAL> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |          +++++
 
-error: aborting due to 2 previous errors
+error[E0046]: not all trait items implemented, missing: `VAL`
+  --> $DIR/issue-77919.rs:11:1
+   |
+LL |     const VAL: T;
+   |     ------------ `VAL` from trait
+...
+LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
 
-For more information about this error, try `rustc --explain E0412`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0046, E0412.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/layout/issue-84108.rs
+++ b/tests/ui/layout/issue-84108.rs
@@ -9,6 +9,8 @@ static FOO: (dyn AsRef<OsStr>, u8) = ("hello", 42);
 const BAR: (&Path, [u8], usize) = ("hello", [], 42);
 //~^ ERROR cannot find type `Path` in this scope
 //~| ERROR the size for values of type `[u8]` cannot be known at compilation time
+//~| ERROR mismatched types
 
 static BAZ: ([u8], usize) = ([], 0);
 //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+//~| ERROR mismatched types

--- a/tests/ui/layout/issue-84108.stderr
+++ b/tests/ui/layout/issue-84108.stderr
@@ -30,7 +30,7 @@ LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-84108.rs:13:13
+  --> $DIR/issue-84108.rs:14:13
    |
 LL | static BAZ: ([u8], usize) = ([], 0);
    |             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -38,7 +38,25 @@ LL | static BAZ: ([u8], usize) = ([], 0);
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: aborting due to 4 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-84108.rs:9:45
+   |
+LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
+   |                                             ^^ expected `[u8]`, found `[_; 0]`
+   |
+   = note: expected slice `[u8]`
+              found array `[_; 0]`
 
-Some errors have detailed explanations: E0277, E0412.
+error[E0308]: mismatched types
+  --> $DIR/issue-84108.rs:14:30
+   |
+LL | static BAZ: ([u8], usize) = ([], 0);
+   |                              ^^ expected `[u8]`, found `[_; 0]`
+   |
+   = note: expected slice `[u8]`
+              found array `[_; 0]`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0308, E0412.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/proc-macro/bad-projection.rs
+++ b/tests/ui/proc-macro/bad-projection.rs
@@ -13,3 +13,5 @@ trait Project {
 #[proc_macro]
 pub fn uwu() -> <() as Project>::Assoc {}
 //~^ ERROR the trait bound `(): Project` is not satisfied
+//~| ERROR the trait bound `(): Project` is not satisfied
+//~| ERROR function is expected to take 1 argument, but it takes 0 arguments

--- a/tests/ui/proc-macro/bad-projection.stderr
+++ b/tests/ui/proc-macro/bad-projection.stderr
@@ -10,6 +10,32 @@ help: this trait has no implementations, consider adding one
 LL | trait Project {
    | ^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error[E0593]: function is expected to take 1 argument, but it takes 0 arguments
+  --> $DIR/bad-projection.rs:14:1
+   |
+LL | pub fn uwu() -> <() as Project>::Assoc {}
+   | --------------------------------------^^^
+   | |
+   | expected function that takes 1 argument
+   | takes 0 arguments
+   | required by a bound introduced by this call
+   |
+note: required by a bound in `ProcMacro::bang`
+  --> $SRC_DIR/proc_macro/src/bridge/client.rs:LL:COL
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0277]: the trait bound `(): Project` is not satisfied
+  --> $DIR/bad-projection.rs:14:1
+   |
+LL | pub fn uwu() -> <() as Project>::Assoc {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Project` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/bad-projection.rs:9:1
+   |
+LL | trait Project {
+   | ^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0593.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/simd/array-trait.rs
+++ b/tests/ui/simd/array-trait.rs
@@ -22,6 +22,7 @@ impl Simd for i32x4 {
 #[derive(Copy, Clone)]
 pub struct T<S: Simd>([S::Lane; S::SIZE]);
 //~^ ERROR unconstrained generic constant
+//~| ERROR SIMD vector element type should be a primitive scalar
 
 extern "platform-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;

--- a/tests/ui/simd/array-trait.stderr
+++ b/tests/ui/simd/array-trait.stderr
@@ -6,5 +6,12 @@ LL | pub struct T<S: Simd>([S::Lane; S::SIZE]);
    |
    = help: try adding a `where` bound using this expression: `where [(); S::SIZE]:`
 
-error: aborting due to previous error
+error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
+  --> $DIR/array-trait.rs:23:1
+   |
+LL | pub struct T<S: Simd>([S::Lane; S::SIZE]);
+   | ^^^^^^^^^^^^^^^^^^^^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0077`.

--- a/tests/ui/specialization/min_specialization/issue-79224.rs
+++ b/tests/ui/specialization/min_specialization/issue-79224.rs
@@ -19,6 +19,7 @@ impl<B: ?Sized> Display for Cow<'_, B> {
     //~^ ERROR: the trait bound `B: Clone` is not satisfied [E0277]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         //~^ ERROR: the trait bound `B: Clone` is not satisfied [E0277]
+        //~| ERROR: the trait bound `B: Clone` is not satisfied [E0277]
         write!(f, "foo")
     }
 }

--- a/tests/ui/specialization/min_specialization/issue-79224.stderr
+++ b/tests/ui/specialization/min_specialization/issue-79224.stderr
@@ -22,6 +22,18 @@ help: consider further restricting this bound
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `B: Clone` is not satisfied
+  --> $DIR/issue-79224.rs:20:5
+   |
+LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `B`
+   |
+   = note: required for `B` to implement `ToOwned`
+help: consider further restricting this bound
+   |
+LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
+   |                +++++++++++++++++++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/bound/on-structs-and-enums-static.rs
+++ b/tests/ui/traits/bound/on-structs-and-enums-static.rs
@@ -8,7 +8,7 @@ struct Foo<T:Trait> {
 
 static X: Foo<usize> = Foo {
 //~^ ERROR E0277
-    x: 1,
+    x: 1, //~ ERROR: E0277
 };
 
 fn main() {

--- a/tests/ui/traits/bound/on-structs-and-enums-static.stderr
+++ b/tests/ui/traits/bound/on-structs-and-enums-static.stderr
@@ -15,6 +15,23 @@ note: required by a bound in `Foo`
 LL | struct Foo<T:Trait> {
    |              ^^^^^ required by this bound in `Foo`
 
-error: aborting due to previous error
+error[E0277]: the trait bound `usize: Trait` is not satisfied
+  --> $DIR/on-structs-and-enums-static.rs:11:8
+   |
+LL |     x: 1,
+   |        ^ the trait `Trait` is not implemented for `usize`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/on-structs-and-enums-static.rs:1:1
+   |
+LL | trait Trait {
+   | ^^^^^^^^^^^
+note: required by a bound in `Foo`
+  --> $DIR/on-structs-and-enums-static.rs:5:14
+   |
+LL | struct Foo<T:Trait> {
+   |              ^^^^^ required by this bound in `Foo`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/new-solver/specialization-transmute.rs
+++ b/tests/ui/traits/new-solver/specialization-transmute.rs
@@ -10,7 +10,7 @@ trait Default {
 }
 
 impl<T> Default for T {
-    default type Id = T;
+    default type Id = T; //~ ERROR: type annotations needed
     // This will be fixed by #111994
     fn intu(&self) -> &Self::Id { //~ ERROR type annotations needed
         self

--- a/tests/ui/traits/new-solver/specialization-transmute.stderr
+++ b/tests/ui/traits/new-solver/specialization-transmute.stderr
@@ -16,6 +16,13 @@ LL |     fn intu(&self) -> &Self::Id {
    |
    = note: cannot satisfy `<T as Default>::Id == _`
 
-error: aborting due to previous error; 1 warning emitted
+error[E0282]: type annotations needed
+  --> $DIR/specialization-transmute.rs:13:23
+   |
+LL |     default type Id = T;
+   |                       ^ cannot infer type for associated type `<T as Default>::Id`
 
-For more information about this error, try `rustc --explain E0284`.
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0282, E0284.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/type-alias-impl-trait/generic_underconstrained.rs
+++ b/tests/ui/type-alias-impl-trait/generic_underconstrained.rs
@@ -8,5 +8,6 @@ type Underconstrained<T: Trait> = impl Send;
 // no `Trait` bound
 fn underconstrain<T>(_: T) -> Underconstrained<T> {
     //~^ ERROR the trait bound `T: Trait`
+    //~| ERROR the trait bound `T: Trait`
     unimplemented!()
 }

--- a/tests/ui/type-alias-impl-trait/generic_underconstrained.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_underconstrained.stderr
@@ -14,6 +14,27 @@ help: consider restricting type parameter `T`
 LL | fn underconstrain<T: Trait>(_: T) -> Underconstrained<T> {
    |                    +++++++
 
-error: aborting due to previous error
+error[E0277]: the trait bound `T: Trait` is not satisfied
+  --> $DIR/generic_underconstrained.rs:9:51
+   |
+LL |   fn underconstrain<T>(_: T) -> Underconstrained<T> {
+   |  ___________________________________________________^
+LL | |
+LL | |
+LL | |     unimplemented!()
+LL | | }
+   | |_^ the trait `Trait` is not implemented for `T`
+   |
+note: required by a bound on the type alias `Underconstrained`
+  --> $DIR/generic_underconstrained.rs:6:26
+   |
+LL | type Underconstrained<T: Trait> = impl Send;
+   |                          ^^^^^ required by this bound
+help: consider restricting type parameter `T`
+   |
+LL | fn underconstrain<T: Trait>(_: T) -> Underconstrained<T> {
+   |                    +++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/type-alias-impl-trait/generic_underconstrained2.rs
+++ b/tests/ui/type-alias-impl-trait/generic_underconstrained2.rs
@@ -7,6 +7,7 @@ type Underconstrained<T: std::fmt::Debug> = impl Send;
 // not a defining use, because it doesn't define *all* possible generics
 fn underconstrained<U>(_: U) -> Underconstrained<U> {
     //~^ ERROR `U` doesn't implement `Debug`
+    //~| ERROR `U` doesn't implement `Debug`
     5u32
 }
 
@@ -15,5 +16,6 @@ type Underconstrained2<T: std::fmt::Debug> = impl Send;
 // not a defining use, because it doesn't define *all* possible generics
 fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
     //~^ ERROR `V` doesn't implement `Debug`
+    //~| ERROR `V` doesn't implement `Debug`
     5u32
 }

--- a/tests/ui/type-alias-impl-trait/generic_underconstrained2.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_underconstrained2.stderr
@@ -15,13 +15,13 @@ LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
    |                      +++++++++++++++++
 
 error[E0277]: `V` doesn't implement `Debug`
-  --> $DIR/generic_underconstrained2.rs:16:43
+  --> $DIR/generic_underconstrained2.rs:17:43
    |
 LL | fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
    |                                           ^^^^^^^^^^^^^^^^^^^^ `V` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
 note: required by a bound on the type alias `Underconstrained2`
-  --> $DIR/generic_underconstrained2.rs:13:27
+  --> $DIR/generic_underconstrained2.rs:14:27
    |
 LL | type Underconstrained2<T: std::fmt::Debug> = impl Send;
    |                           ^^^^^^^^^^^^^^^ required by this bound
@@ -30,6 +30,48 @@ help: consider restricting type parameter `V`
 LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
    |                          +++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0277]: `U` doesn't implement `Debug`
+  --> $DIR/generic_underconstrained2.rs:8:53
+   |
+LL |   fn underconstrained<U>(_: U) -> Underconstrained<U> {
+   |  _____________________________________________________^
+LL | |
+LL | |
+LL | |     5u32
+LL | | }
+   | |_^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+note: required by a bound on the type alias `Underconstrained`
+  --> $DIR/generic_underconstrained2.rs:5:26
+   |
+LL | type Underconstrained<T: std::fmt::Debug> = impl Send;
+   |                          ^^^^^^^^^^^^^^^ required by this bound
+help: consider restricting type parameter `U`
+   |
+LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
+   |                      +++++++++++++++++
+
+error[E0277]: `V` doesn't implement `Debug`
+  --> $DIR/generic_underconstrained2.rs:17:64
+   |
+LL |   fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
+   |  ________________________________________________________________^
+LL | |
+LL | |
+LL | |     5u32
+LL | | }
+   | |_^ `V` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+note: required by a bound on the type alias `Underconstrained2`
+  --> $DIR/generic_underconstrained2.rs:14:27
+   |
+LL | type Underconstrained2<T: std::fmt::Debug> = impl Send;
+   |                           ^^^^^^^^^^^^^^^ required by this bound
+help: consider restricting type parameter `V`
+   |
+LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
+   |                          +++++++++++++++++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.rs
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.rs
@@ -36,6 +36,7 @@ impl<'a, T> SomeTrait for &'a Bar<T> {
     fn dummy1(self: &&'a Bar<T>) { }
     fn dummy2(self: &Bar<T>) {} //~ ERROR mismatched `self` parameter type
     //~^ ERROR mismatched `self` parameter type
+    //~| ERROR has an incompatible type for trait
     fn dummy3(self: &&Bar<T>) {}
     //~^ ERROR mismatched `self` parameter type
     //~| expected reference `&'a Bar<T>`

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -64,7 +64,7 @@ LL |     fn dummy2(self: &Bar<T>) {}
    |                     ^^^^^^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/ufcs-explicit-self-bad.rs:39:21
+  --> $DIR/ufcs-explicit-self-bad.rs:40:21
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                     ^^^^^^^^ lifetime mismatch
@@ -72,7 +72,7 @@ LL |     fn dummy3(self: &&Bar<T>) {}
    = note: expected reference `&'a Bar<T>`
               found reference `&Bar<T>`
 note: the anonymous lifetime defined here...
-  --> $DIR/ufcs-explicit-self-bad.rs:39:22
+  --> $DIR/ufcs-explicit-self-bad.rs:40:22
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                      ^^^^^^^
@@ -83,7 +83,7 @@ LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/ufcs-explicit-self-bad.rs:39:21
+  --> $DIR/ufcs-explicit-self-bad.rs:40:21
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                     ^^^^^^^^ lifetime mismatch
@@ -96,12 +96,29 @@ note: the lifetime `'a` as defined here...
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
 note: ...does not necessarily outlive the anonymous lifetime defined here
-  --> $DIR/ufcs-explicit-self-bad.rs:39:22
+  --> $DIR/ufcs-explicit-self-bad.rs:40:22
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                      ^^^^^^^
 
-error: aborting due to 7 previous errors
+error[E0053]: method `dummy2` has an incompatible type for trait
+  --> $DIR/ufcs-explicit-self-bad.rs:37:21
+   |
+LL |     fn dummy2(self: &Bar<T>) {}
+   |               ------^^^^^^^
+   |               |     |
+   |               |     expected `&'a Bar<T>`, found `Bar<T>`
+   |               help: change the self-receiver type to match the trait: `&self`
+   |
+note: type in trait
+  --> $DIR/ufcs-explicit-self-bad.rs:31:15
+   |
+LL |     fn dummy2(&self);
+   |               ^^^^^
+   = note: expected signature `fn(&&'a Bar<T>)`
+              found signature `fn(&Bar<T>)`
 
-Some errors have detailed explanations: E0307, E0308.
-For more information about an error, try `rustc --explain E0307`.
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0053, E0307, E0308.
+For more information about an error, try `rustc --explain E0053`.

--- a/tests/ui/union/issue-81199.rs
+++ b/tests/ui/union/issue-81199.rs
@@ -4,6 +4,7 @@ union PtrRepr<T: ?Sized> {
     mut_ptr: *mut T,
     components: PtrComponents<T>,
     //~^ ERROR the trait bound
+    //~| ERROR field must implement `Copy`
 }
 
 #[repr(C)]

--- a/tests/ui/union/issue-81199.stderr
+++ b/tests/ui/union/issue-81199.stderr
@@ -5,7 +5,7 @@ LL |     components: PtrComponents<T>,
    |                 ^^^^^^^^^^^^^^^^ the trait `Pointee` is not implemented for `T`
    |
 note: required by a bound in `PtrComponents`
-  --> $DIR/issue-81199.rs:10:25
+  --> $DIR/issue-81199.rs:11:25
    |
 LL | struct PtrComponents<T: Pointee + ?Sized> {
    |                         ^^^^^^^ required by this bound in `PtrComponents`
@@ -14,6 +14,19 @@ help: consider further restricting this bound
 LL | union PtrRepr<T: ?Sized + Pointee> {
    |                         +++++++++
 
-error: aborting due to previous error
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/issue-81199.rs:5:5
+   |
+LL |     components: PtrComponents<T>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     components: std::mem::ManuallyDrop<PtrComponents<T>>,
+   |                 +++++++++++++++++++++++                +
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0740.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/union/union-unsized.mirunsafeck.stderr
+++ b/tests/ui/union/union-unsized.mirunsafeck.stderr
@@ -17,7 +17,7 @@ LL |     a: Box<str>,
    |        ++++   +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/union-unsized.rs:13:8
+  --> $DIR/union-unsized.rs:14:8
    |
 LL |     b: str,
    |        ^^^ doesn't have a size known at compile-time
@@ -34,6 +34,31 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     b: Box<str>,
    |        ++++   +
 
-error: aborting due to 2 previous errors
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/union-unsized.rs:5:5
+   |
+LL |     a: str,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     a: std::mem::ManuallyDrop<str>,
+   |        +++++++++++++++++++++++   +
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/union-unsized.rs:14:5
+   |
+LL |     b: str,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     b: std::mem::ManuallyDrop<str>,
+   |        +++++++++++++++++++++++   +
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0740.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/union/union-unsized.rs
+++ b/tests/ui/union/union-unsized.rs
@@ -4,6 +4,7 @@
 union U {
     a: str,
     //~^ ERROR the size for values of type
+    //~| ERROR field must implement `Copy`
 
     b: u8,
 }
@@ -12,6 +13,7 @@ union W {
     a: u8,
     b: str,
     //~^ ERROR the size for values of type
+    //~| ERROR field must implement `Copy`
 }
 
 fn main() {}

--- a/tests/ui/union/union-unsized.thirunsafeck.stderr
+++ b/tests/ui/union/union-unsized.thirunsafeck.stderr
@@ -17,7 +17,7 @@ LL |     a: Box<str>,
    |        ++++   +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/union-unsized.rs:13:8
+  --> $DIR/union-unsized.rs:14:8
    |
 LL |     b: str,
    |        ^^^ doesn't have a size known at compile-time
@@ -34,6 +34,31 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     b: Box<str>,
    |        ++++   +
 
-error: aborting due to 2 previous errors
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/union-unsized.rs:5:5
+   |
+LL |     a: str,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     a: std::mem::ManuallyDrop<str>,
+   |        +++++++++++++++++++++++   +
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/union-unsized.rs:14:5
+   |
+LL |     b: str,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     b: std::mem::ManuallyDrop<str>,
+   |        +++++++++++++++++++++++   +
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0740.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/unsized/unsized-trait-impl-self-type.rs
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.rs
@@ -9,6 +9,7 @@ struct S5<Y>(Y);
 
 impl<X: ?Sized> T3<X> for S5<X> {
     //~^ ERROR the size for values of type
+    //~| ERROR not all trait items implemented
 }
 
 fn main() { }

--- a/tests/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -24,6 +24,16 @@ LL - impl<X: ?Sized> T3<X> for S5<X> {
 LL + impl<X> T3<X> for S5<X> {
    |
 
-error: aborting due to previous error
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/unsized-trait-impl-self-type.rs:10:1
+   |
+LL |     fn foo(&self, z: &Z);
+   |     --------------------- `foo` from trait
+...
+LL | impl<X: ?Sized> T3<X> for S5<X> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0046, E0277.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.rs
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.rs
@@ -7,6 +7,7 @@ trait T2<Z> {
 struct S4<Y: ?Sized>(Box<Y>);
 impl<X: ?Sized> T2<X> for S4<X> {
     //~^ ERROR the size for values of type
+    //~| ERROR not all trait items implemented
 }
 
 fn main() { }

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -21,6 +21,16 @@ help: consider relaxing the implicit `Sized` restriction
 LL | trait T2<Z: ?Sized> {
    |           ++++++++
 
-error: aborting due to previous error
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/unsized-trait-impl-trait-arg.rs:8:1
+   |
+LL |     fn foo(&self, z: Z);
+   |     -------------------- `foo` from trait
+...
+LL | impl<X: ?Sized> T2<X> for S4<X> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0046, E0277.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/unsized/unsized7.rs
+++ b/tests/ui/unsized/unsized7.rs
@@ -11,6 +11,7 @@ trait T1<Z: T> {
 struct S3<Y: ?Sized>(Box<Y>);
 impl<X: ?Sized + T> T1<X> for S3<X> {
     //~^ ERROR the size for values of type
+    //~| ERROR not all trait items implemented
 }
 
 fn main() { }

--- a/tests/ui/unsized/unsized7.stderr
+++ b/tests/ui/unsized/unsized7.stderr
@@ -21,6 +21,16 @@ help: consider relaxing the implicit `Sized` restriction
 LL | trait T1<Z: T + ?Sized> {
    |               ++++++++
 
-error: aborting due to previous error
+error[E0046]: not all trait items implemented, missing: `dummy`
+  --> $DIR/unsized7.rs:12:1
+   |
+LL |     fn dummy(&self) -> Z;
+   |     --------------------- `dummy` from trait
+...
+LL | impl<X: ?Sized + T> T1<X> for S3<X> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `dummy` in implementation
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0046, E0277.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/wf/hir-wf-check-erase-regions.rs
+++ b/tests/ui/wf/hir-wf-check-erase-regions.rs
@@ -5,6 +5,7 @@ pub struct Table<T, const N: usize>([Option<T>; N]);
 
 impl<'a, T, const N: usize> IntoIterator for &'a Table<T, N> {
     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>; //~ ERROR `&'a T` is not an iterator
+    //~^ ERROR `&'a T` is not an iterator
     type Item = &'a T;
 
     fn into_iter(self) -> Self::IntoIter { //~ ERROR `&'a T` is not an iterator

--- a/tests/ui/wf/hir-wf-check-erase-regions.stderr
+++ b/tests/ui/wf/hir-wf-check-erase-regions.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
 
 error[E0277]: `&'a T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:10:27
+  --> $DIR/hir-wf-check-erase-regions.rs:11:27
    |
 LL |     fn into_iter(self) -> Self::IntoIter {
    |                           ^^^^^^^^^^^^^^ `&'a T` is not an iterator
@@ -22,6 +22,18 @@ LL |     fn into_iter(self) -> Self::IntoIter {
 note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
 
-error: aborting due to 2 previous errors
+error[E0277]: `&'a T` is not an iterator
+  --> $DIR/hir-wf-check-erase-regions.rs:7:21
+   |
+LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'a T` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `&'a T`
+   = help: the trait `Iterator` is implemented for `&mut I`
+   = note: required for `Flatten<std::slice::Iter<'a, T>>` to implement `Iterator`
+note: required by a bound in `std::iter::IntoIterator::IntoIter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/wf/issue-110157.rs
+++ b/tests/ui/wf/issue-110157.rs
@@ -2,6 +2,7 @@ struct NeedsDropTypes<'tcx, F>(std::marker::PhantomData<&'tcx F>);
 
 impl<'tcx, F, I> Iterator for NeedsDropTypes<'tcx, F>
 //~^ ERROR type annotations needed
+//~| ERROR not all trait items implemented
 where
     F: Fn(&Missing) -> Result<I, ()>,
     //~^ ERROR cannot find type `Missing` in this scope

--- a/tests/ui/wf/issue-110157.stderr
+++ b/tests/ui/wf/issue-110157.stderr
@@ -1,11 +1,11 @@
 error[E0412]: cannot find type `Missing` in this scope
-  --> $DIR/issue-110157.rs:6:12
+  --> $DIR/issue-110157.rs:7:12
    |
 LL |     F: Fn(&Missing) -> Result<I, ()>,
    |            ^^^^^^^ not found in this scope
 
 error[E0412]: cannot find type `Missing` in this scope
-  --> $DIR/issue-110157.rs:8:24
+  --> $DIR/issue-110157.rs:9:24
    |
 LL |     I: Iterator<Item = Missing>,
    |                        ^^^^^^^ not found in this scope
@@ -26,7 +26,22 @@ LL | impl<'tcx, F, I> Iterator for NeedsDropTypes<'tcx, F>
 LL |     I: Iterator<Item = Missing>,
    |        ------------------------ unsatisfied trait bound introduced here
 
-error: aborting due to 3 previous errors
+error[E0046]: not all trait items implemented, missing: `Item`, `next`
+  --> $DIR/issue-110157.rs:3:1
+   |
+LL | / impl<'tcx, F, I> Iterator for NeedsDropTypes<'tcx, F>
+LL | |
+LL | |
+LL | | where
+LL | |     F: Fn(&Missing) -> Result<I, ()>,
+LL | |
+LL | |     I: Iterator<Item = Missing>,
+   | |________________________________^ missing `Item`, `next` in implementation
+   |
+   = help: implement the missing item: `type Item = /* Type */;`
+   = help: implement the missing item: `fn next(&mut self) -> Option<<Self as Iterator>::Item> { todo!() }`
 
-Some errors have detailed explanations: E0283, E0412.
-For more information about an error, try `rustc --explain E0283`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0046, E0283, E0412.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/wf/wf-const-type.rs
+++ b/tests/ui/wf/wf-const-type.rs
@@ -9,6 +9,7 @@ struct NotCopy;
 
 const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
 //~^ ERROR E0277
+//~| ERROR E0277
 
 
 fn main() { }

--- a/tests/ui/wf/wf-const-type.stderr
+++ b/tests/ui/wf/wf-const-type.stderr
@@ -16,6 +16,24 @@ LL + #[derive(Copy)]
 LL | struct NotCopy;
    |
 
-error: aborting due to previous error
+error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
+  --> $DIR/wf-const-type.rs:10:50
+   |
+LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
+   |                                                  ^^^^ the trait `Copy` is not implemented for `NotCopy`
+   |
+   = note: required for `Option<NotCopy>` to implement `Copy`
+note: required by a bound in `IsCopy`
+  --> $DIR/wf-const-type.rs:7:17
+   |
+LL | struct IsCopy<T:Copy> { t: T }
+   |                 ^^^^ required by this bound in `IsCopy`
+help: consider annotating `NotCopy` with `#[derive(Copy)]`
+   |
+LL + #[derive(Copy)]
+LL | struct NotCopy;
+   |
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/wf/wf-static-type.rs
+++ b/tests/ui/wf/wf-static-type.rs
@@ -9,6 +9,7 @@ struct NotCopy;
 
 static FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
 //~^ ERROR E0277
+//~| ERROR E0277
 
 
 fn main() { }

--- a/tests/ui/wf/wf-static-type.stderr
+++ b/tests/ui/wf/wf-static-type.stderr
@@ -16,6 +16,24 @@ LL + #[derive(Copy)]
 LL | struct NotCopy;
    |
 
-error: aborting due to previous error
+error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
+  --> $DIR/wf-static-type.rs:10:51
+   |
+LL | static FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
+   |                                                   ^^^^ the trait `Copy` is not implemented for `NotCopy`
+   |
+   = note: required for `Option<NotCopy>` to implement `Copy`
+note: required by a bound in `IsCopy`
+  --> $DIR/wf-static-type.rs:7:17
+   |
+LL | struct IsCopy<T:Copy> { t: T }
+   |                 ^^^^ required by this bound in `IsCopy`
+help: consider annotating `NotCopy` with `#[derive(Copy)]`
+   |
+LL + #[derive(Copy)]
+LL | struct NotCopy;
+   |
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Even if that error is only emitted by `check_mod_item_types`.

fixes https://github.com/rust-lang/rust/issues/117153

A cleaner refactoring would merge/chain these queries in ways that ensure we only actually get an `ErrorGuaranteed` if there was an error emitted.