### PR TITLE
Fix some coroutine sentences that don't make sense anymore.

### DIFF
--- a/library/core/src/ops/coroutine.rs
+++ b/library/core/src/ops/coroutine.rs
@@ -29,7 +29,7 @@ pub enum CoroutineState<Y, R> {
 
 /// The trait implemented by builtin coroutine types.
 ///
-/// Coroutines, also commonly referred to as coroutines, are currently an
+/// Coroutines are currently an
 /// experimental language feature in Rust. Added in [RFC 2033] coroutines are
 /// currently intended to primarily provide a building block for async/await
 /// syntax but will likely extend to also providing an ergonomic definition for

--- a/src/doc/unstable-book/src/language-features/coroutines.md
+++ b/src/doc/unstable-book/src/language-features/coroutines.md
@@ -18,7 +18,7 @@ Coroutines are an extra-unstable feature in the compiler right now. Added in
 [RFC 2033] they're mostly intended right now as a information/constraint
 gathering phase. The intent is that experimentation can happen on the nightly
 compiler before actual stabilization. A further RFC will be required to
-stabilize coroutines/coroutines and will likely contain at least a few small
+stabilize coroutines and will likely contain at least a few small
 tweaks to the overall design.
 
 [RFC 2033]: https://github.com/rust-lang/rfcs/pull/2033


### PR DESCRIPTION
These happened during the `generator` -> `coroutine` rename.

Found thanks to @pthariensflame for their thorough review of the `generator` -> `coroutine` rename https://github.com/rust-lang/rust/pull/116958#issuecomment-1777756937