### PR TITLE
Add support for i586-unknown-netbsd as target.

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -258,7 +258,9 @@ fn main() {
     {
         println!("cargo:rustc-link-lib=z");
     } else if target.contains("netbsd") {
-        // Building for i586 or i686, we need -latomic for 64-bit atomics
+        // On NetBSD/i386, gcc and g++ is built for i486 (to maximize backward compat)
+        // However, LLVM insists on using 64-bit atomics.
+        // This gives rise to a need to link rust itself with -latomic for these targets
         if target.starts_with("i586")
            || target.starts_with("i686")
         {

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -258,6 +258,12 @@ fn main() {
     {
         println!("cargo:rustc-link-lib=z");
     } else if target.contains("netbsd") {
+        // Building for i586 or i686, we need -latomic for 64-bit atomics
+        if target.starts_with("i586")
+           || target.starts_with("i686")
+        {
+            println!("cargo:rustc-link-lib=atomic");
+        }
         println!("cargo:rustc-link-lib=z");
         println!("cargo:rustc-link-lib=execinfo");
     }

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -261,9 +261,7 @@ fn main() {
         // On NetBSD/i386, gcc and g++ is built for i486 (to maximize backward compat)
         // However, LLVM insists on using 64-bit atomics.
         // This gives rise to a need to link rust itself with -latomic for these targets
-        if target.starts_with("i586")
-           || target.starts_with("i686")
-        {
+        if target.starts_with("i586") || target.starts_with("i686") {
             println!("cargo:rustc-link-lib=atomic");
         }
         println!("cargo:rustc-link-lib=z");

--- a/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
@@ -1,13 +1,10 @@
-use crate::spec::{Cc, Lld, LinkerFlavor, StackProbeType, Target, TargetOptions};
+use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::netbsd_base::opts();
     base.cpu = "pentium".into();
     base.max_atomic_width = Some(64);
-    base.pre_link_args
-        .entry(LinkerFlavor::Gnu(Cc::Yes, Lld::No))
-        .or_default()
-        .push("-m32".into());
+    base.pre_link_args.entry(LinkerFlavor::Gnu(Cc::Yes, Lld::No)).or_default().push("-m32".into());
     base.stack_probes = StackProbeType::Call;
 
     Target {

--- a/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
@@ -1,0 +1,22 @@
+use crate::spec::{Cc, Lld, LinkerFlavor, StackProbeType, Target, TargetOptions};
+
+pub fn target() -> Target {
+    let mut base = super::netbsd_base::opts();
+    base.cpu = "pentium".into();
+    base.max_atomic_width = Some(64);
+    base.pre_link_args
+        .entry(LinkerFlavor::Gnu(Cc::Yes, Lld::No))
+        .or_default()
+        .push("-m32".into());
+    base.stack_probes = StackProbeType::Call;
+
+    Target {
+        llvm_target: "i586-unknown-netbsdelf".into(),
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-\
+            f64:32:64-f80:32-n8:16:32-S128"
+            .into(),
+        arch: "x86".into(),
+        options: TargetOptions { mcount: "__mcount".into(), ..base },
+    }
+}

--- a/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
@@ -1,10 +1,9 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetOptions};
+use crate::spec::{StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::netbsd_base::opts();
     base.cpu = "pentium".into();
     base.max_atomic_width = Some(64);
-    base.pre_link_args.entry(LinkerFlavor::Gnu(Cc::Yes, Lld::No)).or_default().push("-m32".into());
     base.stack_probes = StackProbeType::Call;
 
     Target {

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1426,6 +1426,7 @@ supported_targets! {
     ("aarch64_be-unknown-netbsd", aarch64_be_unknown_netbsd),
     ("armv6-unknown-netbsd-eabihf", armv6_unknown_netbsd_eabihf),
     ("armv7-unknown-netbsd-eabihf", armv7_unknown_netbsd_eabihf),
+    ("i586-unknown-netbsd", i586_unknown_netbsd),
     ("i686-unknown-netbsd", i686_unknown_netbsd),
     ("powerpc-unknown-netbsd", powerpc_unknown_netbsd),
     ("riscv64gc-unknown-netbsd", riscv64gc_unknown_netbsd),

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -152,6 +152,7 @@ target | std | notes
 `i586-pc-windows-msvc` | * | 32-bit Windows w/o SSE [^x86_32-floats-x87]
 `i586-unknown-linux-gnu` | ✓ | 32-bit Linux w/o SSE (kernel 3.2, glibc 2.17) [^x86_32-floats-x87]
 `i586-unknown-linux-musl` | ✓ | 32-bit Linux w/o SSE, MUSL [^x86_32-floats-x87]
+[`i586-unknown-netbsd`](platform-support/netbsd.md) |  ✓ | 32-bir x86, restricted to Pentium
 [`i686-linux-android`](platform-support/android.md) | ✓ | 32-bit x86 Android [^x86_32-floats-return-ABI]
 `i686-unknown-freebsd` | ✓ | 32-bit FreeBSD [^x86_32-floats-return-ABI]
 `i686-unknown-linux-musl` | ✓ | 32-bit Linux with MUSL [^x86_32-floats-return-ABI]

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -152,7 +152,7 @@ target | std | notes
 `i586-pc-windows-msvc` | * | 32-bit Windows w/o SSE [^x86_32-floats-x87]
 `i586-unknown-linux-gnu` | ✓ | 32-bit Linux w/o SSE (kernel 3.2, glibc 2.17) [^x86_32-floats-x87]
 `i586-unknown-linux-musl` | ✓ | 32-bit Linux w/o SSE, MUSL [^x86_32-floats-x87]
-[`i586-unknown-netbsd`](platform-support/netbsd.md) |  ✓ | 32-bir x86, restricted to Pentium
+[`i586-unknown-netbsd`](platform-support/netbsd.md) |  ✓ | 32-bit x86, restricted to Pentium
 [`i686-linux-android`](platform-support/android.md) | ✓ | 32-bit x86 Android [^x86_32-floats-return-ABI]
 `i686-unknown-freebsd` | ✓ | 32-bit FreeBSD [^x86_32-floats-return-ABI]
 `i686-unknown-linux-musl` | ✓ | 32-bit Linux with MUSL [^x86_32-floats-return-ABI]


### PR DESCRIPTION
This restricts instructions to those offered by Pentium, to support e.g. AMD Geode.

There is already an entry for this target in the NetBSD platform support page at

  src/doc/rustc/src/platform-support/netbsd.md

...so this should forestall its removal.

Additional fixes are needed for some vendored modules, this is the changes in the rust compiler core itself.