### PR TITLE
mark ty::Const::Error when meet unsupport ty for const generic params

### DIFF
--- a/tests/ui/const-generics/default-ty-closure.rs
+++ b/tests/ui/const-generics/default-ty-closure.rs
@@ -1,0 +1,6 @@
+// https://github.com/rust-lang/rust/issues/116796
+
+struct X<const FN: fn() = { || {} }>;
+//~^ ERROR using function pointers as const generic parameters is forbidden
+
+fn main() {}

--- a/tests/ui/const-generics/default-ty-closure.stderr
+++ b/tests/ui/const-generics/default-ty-closure.stderr
@@ -1,0 +1,10 @@
+error: using function pointers as const generic parameters is forbidden
+  --> $DIR/default-ty-closure.rs:3:20
+   |
+LL | struct X<const FN: fn() = { || {} }>;
+   |                    ^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Close #116796

