### PR TITLE
constrain safety preconditions of `layout_for_ptr` functionality

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -181,10 +181,14 @@ impl Layout {
     ///     - a [slice], then the length of the slice tail must be an initialized
     ///       integer, and the size of the *entire value*
     ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
+    ///       The pointer address plus the size of the entire value must not
+    ///       overflow the address space.
     ///     - a [trait object], then the vtable part of the pointer must point
     ///       to a valid vtable for the type `T` acquired by an unsizing coercion,
     ///       and the size of the *entire value*
     ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
+    ///       The pointer address plus the size of the entire value must not
+    ///       overflow the address space.
     ///     - an (unstable) [extern type], then this function is always safe to
     ///       call, but may panic or otherwise return the wrong value, as the
     ///       extern type's layout is not known. This is the same behavior as

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -359,10 +359,13 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///     - a [slice], then the length of the slice tail must be an initialized
 ///       integer, and the size of the *entire value*
 ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
+///       The pointer address plus the size of the entire value must not
+///       overflow the address space.
 ///     - a [trait object], then the vtable part of the pointer must point
 ///       to a valid vtable acquired by an unsizing coercion, and the size
 ///       of the *entire value* (dynamic tail length + statically sized prefix)
-///       must fit in `isize`.
+///       must fit in `isize`. The pointer address plus the size of the entire
+///       value must not overflow the address space.
 ///     - an (unstable) [extern type], then this function is always safe to
 ///       call, but may panic or otherwise return the wrong value, as the
 ///       extern type's layout is not known. This is the same behavior as
@@ -506,10 +509,15 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///     - a [slice], then the length of the slice tail must be an initialized
 ///       integer, and the size of the *entire value*
 ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
+///       The pointer address plus the size of the entire value must not
+///       overflow the address space. The value one-past-the-end of this range
+///       must also be within the address space.
 ///     - a [trait object], then the vtable part of the pointer must point
 ///       to a valid vtable acquired by an unsizing coercion, and the size
 ///       of the *entire value* (dynamic tail length + statically sized prefix)
-///       must fit in `isize`.
+///       must fit in `isize`. The pointer address plus the size of the entire
+///       value must not overflow the address space. The value one-past-the-end
+///       of this range must also be within the address space.
 ///     - an (unstable) [extern type], then this function is always safe to
 ///       call, but may panic or otherwise return the wrong value, as the
 ///       extern type's layout is not known. This is the same behavior as


### PR DESCRIPTION
This commit implements the recommendation of https://github.com/rust-lang/rust/issues/69835#issuecomment-1779590064 to make the safety preconditions of the raw pointer layout utilities more conservative, as to ease the path towards stabilization. In the future, we may (if we choose) remove some of these restrictions without breaking forwards compatibility.