### PR TITLE
Don't treat asserts as a call in cross-crate inlining

### DIFF
--- a/tests/codegen-llvm/cross-crate-inlining/auxiliary/leaf.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/auxiliary/leaf.rs
@@ -23,3 +23,8 @@ fn inner() -> String {
 pub fn leaf_with_intrinsic(a: &[u64; 2], b: &[u64; 2]) -> bool {
     a == b
 }
+
+// This function's optimized MIR contains assert terminators, not calls.
+pub fn leaf_with_assert(a: i32, b: i32) -> i32 {
+    a / b
+}

--- a/tests/codegen-llvm/cross-crate-inlining/leaf-inlining.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/leaf-inlining.rs
@@ -25,3 +25,12 @@ pub fn leaf_with_intrinsic_outer(a: &[u64; 2], b: &[u64; 2]) -> bool {
     // CHECK-NOT: call {{.*}}leaf_with_intrinsic
     leaf::leaf_with_intrinsic(a, b)
 }
+
+// Check that we inline functions with assert terminators
+#[no_mangle]
+pub fn leaf_with_assert(a: i32, b: i32) -> i32 {
+    // CHECK-NOT: call {{.*}}leaf_with_assert
+    // CHECK: sdiv i32 %a, %b
+    // CHECK-NOT: call {{.*}}leaf_with_assert
+    leaf::leaf_with_assert(a, b)
+}

--- a/tests/codegen-units/item-collection/implicit-panic-call.rs
+++ b/tests/codegen-units/item-collection/implicit-panic-call.rs
@@ -1,5 +1,6 @@
 // rust-lang/rust#90405
 // Ensure implicit panic calls are collected
+//@ compile-flags: -Zcross-crate-inline-threshold=never
 
 #![feature(lang_items)]
 #![feature(no_core)]


### PR DESCRIPTION
Making functions with calls in their bodies automatically cross-crate-inlinable tends to tank incremental build times. Though assert terminators are _like_ calls, they don't exhibit the same behavior.