### PR TITLE
Avoid unnecessary builds/rebuilds of `rust-demangler`

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1567,7 +1567,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             cmd.arg("--coverage-dump-path").arg(coverage_dump);
         }
 
-        if mode == "run-make" || mode == "run-coverage" {
+        if mode == "run-coverage" {
             let rust_demangler = builder
                 .ensure(tool::RustDemangler {
                     compiler,

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1568,9 +1568,11 @@ note: if you're sure you want to do this, please open an issue as to why. In the
         }
 
         if mode == "run-coverage" {
+            // The demangler doesn't need the current compiler, so we can avoid
+            // unnecessary rebuilds by using the bootstrap compiler instead.
             let rust_demangler = builder
                 .ensure(tool::RustDemangler {
-                    compiler,
+                    compiler: compiler.with_stage(0),
                     target: compiler.host,
                     extra_features: Vec::new(),
                 })

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3546,10 +3546,6 @@ impl<'test> TestCx<'test> {
             cmd.env("RUSTDOC", cwd.join(rustdoc));
         }
 
-        if let Some(ref rust_demangler) = self.config.rust_demangler_path {
-            cmd.env("RUST_DEMANGLER", cwd.join(rust_demangler));
-        }
-
         if let Some(ref node) = self.config.nodejs {
             cmd.env("NODE", node);
         }


### PR DESCRIPTION
This is a combination of two loosely-related changes:

- Don't build `rust-demangler` as a dependency of `tests/run-make`, because after #112300 none of the remaining run-make tests actually use it. (If future run-make tests ever do need the demangler, it'll be easy to add it back.)
- For `tests/run-coverage`, build the demangler with the stage 0 compiler instead of the current-stage compiler. This avoids having to uselessly rebuild the demangler after modifying and rebuilding the compiler itself.