### PR TITLE
Silence redundant cycle error

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -3071,6 +3071,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 );
             }
         };
+        err.delay_as_bug();
         err
     }
 

--- a/tests/ui/impl-trait/auto-trait-leak.rs
+++ b/tests/ui/impl-trait/auto-trait-leak.rs
@@ -18,7 +18,6 @@ fn cycle1() -> impl Clone {
 
 fn cycle2() -> impl Clone {
     send(cycle1().clone());
-    //~^ ERROR: cannot check whether the hidden type of opaque type satisfies auto traits
 
     Rc::new(String::from("foo"))
 }

--- a/tests/ui/impl-trait/auto-trait-leak.stderr
+++ b/tests/ui/impl-trait/auto-trait-leak.stderr
@@ -59,30 +59,6 @@ LL | fn cycle1() -> impl Clone {
    |                ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: cannot check whether the hidden type of opaque type satisfies auto traits
-  --> $DIR/auto-trait-leak.rs:20:10
-   |
-LL |     send(cycle1().clone());
-   |     ---- ^^^^^^^^^^^^^^^^
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: opaque type is declared here
-  --> $DIR/auto-trait-leak.rs:11:16
-   |
-LL | fn cycle1() -> impl Clone {
-   |                ^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/auto-trait-leak.rs:19:4
-   |
-LL | fn cycle2() -> impl Clone {
-   |    ^^^^^^
-note: required by a bound in `send`
-  --> $DIR/auto-trait-leak.rs:4:12
-   |
-LL | fn send<T: Send>(_: T) {}
-   |            ^^^^ required by this bound in `send`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage3.rs
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage3.rs
@@ -14,7 +14,6 @@ mod m {
 
     pub fn bar() {
         is_send(foo());
-        //~^ ERROR: cannot check whether the hidden type of `auto_trait_leakage3[211d]::m::Foo::{opaque#0}
     }
 
     fn is_send<T: Send>(_: T) {}

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage3.stderr
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage3.stderr
@@ -37,30 +37,6 @@ LL |     pub type Foo = impl std::fmt::Debug;
    |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: cannot check whether the hidden type of `auto_trait_leakage3[211d]::m::Foo::{opaque#0}` satisfies auto traits
-  --> $DIR/auto-trait-leakage3.rs:16:17
-   |
-LL |         is_send(foo());
-   |         ------- ^^^^^
-   |         |
-   |         required by a bound introduced by this call
-   |
-note: opaque type is declared here
-  --> $DIR/auto-trait-leakage3.rs:7:20
-   |
-LL |     pub type Foo = impl std::fmt::Debug;
-   |                    ^^^^^^^^^^^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/auto-trait-leakage3.rs:15:12
-   |
-LL |     pub fn bar() {
-   |            ^^^
-note: required by a bound in `is_send`
-  --> $DIR/auto-trait-leakage3.rs:20:19
-   |
-LL |     fn is_send<T: Send>(_: T) {}
-   |                   ^^^^ required by this bound in `is_send`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/type-alias-impl-trait/inference-cycle.rs
+++ b/tests/ui/type-alias-impl-trait/inference-cycle.rs
@@ -14,7 +14,6 @@ mod m {
 
     pub fn bar() {
         is_send(foo()); // Today: error
-        //~^ ERROR: cannot check whether the hidden type of `inference_cycle[4ecc]::m::Foo::{opaque#0}` satisfies auto traits
     }
 
     fn baz() -> Foo {

--- a/tests/ui/type-alias-impl-trait/inference-cycle.stderr
+++ b/tests/ui/type-alias-impl-trait/inference-cycle.stderr
@@ -37,30 +37,6 @@ LL |     pub type Foo = impl std::fmt::Debug;
    |                    ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: cannot check whether the hidden type of `inference_cycle[4ecc]::m::Foo::{opaque#0}` satisfies auto traits
-  --> $DIR/inference-cycle.rs:16:17
-   |
-LL |         is_send(foo()); // Today: error
-   |         ------- ^^^^^
-   |         |
-   |         required by a bound introduced by this call
-   |
-note: opaque type is declared here
-  --> $DIR/inference-cycle.rs:5:20
-   |
-LL |     pub type Foo = impl std::fmt::Debug;
-   |                    ^^^^^^^^^^^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/inference-cycle.rs:15:12
-   |
-LL |     pub fn bar() {
-   |            ^^^
-note: required by a bound in `is_send`
-  --> $DIR/inference-cycle.rs:24:19
-   |
-LL |     fn is_send<T: Send>(_: T) {}
-   |                   ^^^^ required by this bound in `is_send`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/type-alias-impl-trait/reveal_local.rs
+++ b/tests/ui/type-alias-impl-trait/reveal_local.rs
@@ -13,7 +13,6 @@ fn not_good() {
     // Error: this function does not constrain `Foo` to any particular
     // hidden type, so it cannot rely on `Send` being true.
     is_send::<Foo>();
-    //~^ ERROR: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits
 }
 
 fn not_gooder() -> Foo {
@@ -23,7 +22,6 @@ fn not_gooder() -> Foo {
     // while we could know this from the hidden type, it would
     // need extra roundabout logic to support it.
     is_send::<Foo>();
-    //~^ ERROR: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits
 
     x
 }

--- a/tests/ui/type-alias-impl-trait/reveal_local.stderr
+++ b/tests/ui/type-alias-impl-trait/reveal_local.stderr
@@ -37,28 +37,6 @@ LL | type Foo = impl Debug;
    |            ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits
-  --> $DIR/reveal_local.rs:15:15
-   |
-LL |     is_send::<Foo>();
-   |               ^^^
-   |
-note: opaque type is declared here
-  --> $DIR/reveal_local.rs:5:12
-   |
-LL | type Foo = impl Debug;
-   |            ^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/reveal_local.rs:12:4
-   |
-LL | fn not_good() {
-   |    ^^^^^^^^
-note: required by a bound in `is_send`
-  --> $DIR/reveal_local.rs:10:15
-   |
-LL | fn is_send<T: Send>() {}
-   |               ^^^^ required by this bound in `is_send`
-
 error[E0391]: cycle detected when computing type of opaque `Foo::{opaque#0}`
   --> $DIR/reveal_local.rs:5:12
    |
@@ -66,7 +44,7 @@ LL | type Foo = impl Debug;
    |            ^^^^^^^^^^
    |
 note: ...which requires type-checking `not_gooder`...
-  --> $DIR/reveal_local.rs:19:1
+  --> $DIR/reveal_local.rs:18:1
    |
 LL | fn not_gooder() -> Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -78,28 +56,6 @@ LL | type Foo = impl Debug;
    |            ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits
-  --> $DIR/reveal_local.rs:25:15
-   |
-LL |     is_send::<Foo>();
-   |               ^^^
-   |
-note: opaque type is declared here
-  --> $DIR/reveal_local.rs:5:12
-   |
-LL | type Foo = impl Debug;
-   |            ^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/reveal_local.rs:19:4
-   |
-LL | fn not_gooder() -> Foo {
-   |    ^^^^^^^^^^
-note: required by a bound in `is_send`
-  --> $DIR/reveal_local.rs:10:15
-   |
-LL | fn is_send<T: Send>() {}
-   |               ^^^^ required by this bound in `is_send`
-
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
`SelectionError::OpaqueTypeAutoTraitLeakageUnknown` occurs when a prior cycle error has been emitted already. Silence the error and turn it into a delayed bug.

CC #117233.

r? @oli-obk