### PR TITLE
Match `wasm32-unknown-unknown` ABI with `clang`

### DIFF
--- a/compiler/rustc_target/src/spec/wasm32_unknown_unknown.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_unknown.rs
@@ -11,7 +11,6 @@
 //! Group nowadays at <https://github.com/rustwasm>.
 
 use super::{wasm_base, Cc, LinkerFlavor, Target};
-use crate::spec::abi::Abi;
 
 pub fn target() -> Target {
     let mut options = wasm_base::options();

--- a/compiler/rustc_target/src/spec/wasm32_unknown_unknown.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_unknown.rs
@@ -17,16 +17,6 @@ pub fn target() -> Target {
     let mut options = wasm_base::options();
     options.os = "unknown".into();
 
-    // This is a default for backwards-compatibility with the original
-    // definition of this target oh-so-long-ago. Once the "wasm" ABI is
-    // stable and the wasm-bindgen project has switched to using it then there's
-    // no need for this and it can be removed.
-    //
-    // Currently this is the reason that this target's ABI is mismatched with
-    // clang's ABI. This means that, in the limit, you can't merge C and Rust
-    // code on this target due to this ABI mismatch.
-    options.default_adjusted_cabi = Some(Abi::Wasm);
-
     options.add_pre_link_args(
         LinkerFlavor::WasmLld(Cc::No),
         &[


### PR DESCRIPTION
Currently, `wasm-bindgen` does not support `wasm32-wasi` target.

The goal is to make `wasm-bindgen` support `wasm32-wasi` target, and this PR is a part of that effort which aims to match the ABI of `wasm-32-unknown-unknown` target to that of `wasm32-wasi` and `clang`.

There are discussions going on at [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) repository about extending the support to `wasm32-wasi`. In short, `wasm-bindgen` needs a consistent C ABI between `wasm32-unknown-unknown` and `wasm32-wasi` to support both of them. 

- https://github.com/rustwasm/wasm-bindgen/issues/3421

These links might also be helpful:

- https://github.com/rustwasm/wasm-bindgen/issues/3454
- https://github.com/rustwasm/wasm-bindgen/pull/3324
- https://github.com/rust-lang/rust/issues/71871
- https://github.com/wasmerio/wasmer-js/issues/332
- https://github.com/rustwasm/wasm-pack/issues/654

Take a look at the comment by @alexcrichton who wrote this code. We can understand why this legacy ABI was introduced in the first place from [this post](https://github.com/rust-lang/rust/pull/83763#issue-848848294).

>   This is a default for backwards-compatibility with the original definition of this target oh-so-long-ago. Once the "wasm" ABI is stable and the wasm-bindgen project has switched to using it then there's no need for this and it can be removed. Currently this is the reason that this target's ABI is mismatched with clang's ABI. This means that, in the limit, you can't merge C and Rust code on this target due to this ABI mismatch.

After more than 2 years, `wasm32-unknown-unknown` still uses the legacy ABI. `wasm-bindgen` says that Rust should switch to the new ABI first, but Rust is saying that `wasm-bindgen` should support the new ABI first. It's somewhat like a chicken-egg problem.

Up until now, this legacy ABI was working fine. However recently `wasm32-wasi` started becoming a thing and the Rust ecosystem is actively being built around it. That's why I and some other contributors came up to suggest this change. Since most of the users do not use C ABI directly, but instead generate `.wasm` and `.js` code with `wasm-bindgen`, they will just need to update `wasm-bindgen` and re-generate the code. Appropriate warning and version-specific workaround should be provided from Rust compiler, though.

To narrow the focus on web browsers, many native functionalities including `std::thread`, `std::time::Instant`, `std::fs` are not working right now with `wasm32-unknown-unknown`. This limitation prevents many crates like `tokio` and `rayon` from working on the web, leaving the vast majority of Rust ecosystem being fallen out from the web platform. Consequently, fragmentation arises as many crates now ship with separated wasm and non-wasm versions, simply because they can't use `std`.

If `wasm-bindgen` gets to support `wasm32-wasi`, various crates will be able to use thread, time, file, network operations on the web only with `std` without any custom JavaScript glue, just like they do on native platforms. JavaScript polyfill libraries(such as [`wasmer-js`](https://github.com/wasmerio/wasmer-js), [`browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim)) claims that they can handle that WASI syscalls, utilizing existing web APIs to mimic native functionalities.

I hope we can achieve consensus between Rust developers and `wasm-bindgen` developers soon enough!