### PR TITLE
NVPTX: Allow PassMode::Direct for ptx kernels for now

### DIFF
--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -362,8 +362,13 @@ impl<'ll, 'tcx> FnAbiLlvmExt<'ll, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
                         // currently use this mode so we have to allow it -- but we absolutely
                         // shouldn't let any more targets do that.
                         // (Also see <https://github.com/rust-lang/rust/issues/115666>.)
+                        //
+                        // The unstable api `PtxKernel` also uses Direct for now.
+                        // It needs to switch to something else before stabilization can happen.
+                        // (Tracking issue abi_ptx: https://github.com/rust-lang/rust/issues/38788)
                         assert!(
-                            matches!(&*cx.tcx.sess.target.arch, "wasm32" | "wasm64"),
+                            matches!(&*cx.tcx.sess.target.arch, "wasm32" | "wasm64")
+                                || self.conv == Conv::PtxKernel,
                             "`PassMode::Direct` for aggregates only allowed on wasm targets\nProblematic type: {:#?}",
                             arg.layout,
                         );

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -365,7 +365,7 @@ impl<'ll, 'tcx> FnAbiLlvmExt<'ll, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
                         //
                         // The unstable abi `PtxKernel` also uses Direct for now.
                         // It needs to switch to something else before stabilization can happen.
-                        // (Tracking issue abi_ptx: https://github.com/rust-lang/rust/issues/38788)
+                        // (See issue: https://github.com/rust-lang/rust/issues/117271)
                         assert!(
                             matches!(&*cx.tcx.sess.target.arch, "wasm32" | "wasm64")
                                 || self.conv == Conv::PtxKernel,

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -363,13 +363,13 @@ impl<'ll, 'tcx> FnAbiLlvmExt<'ll, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
                         // shouldn't let any more targets do that.
                         // (Also see <https://github.com/rust-lang/rust/issues/115666>.)
                         //
-                        // The unstable api `PtxKernel` also uses Direct for now.
+                        // The unstable abi `PtxKernel` also uses Direct for now.
                         // It needs to switch to something else before stabilization can happen.
                         // (Tracking issue abi_ptx: https://github.com/rust-lang/rust/issues/38788)
                         assert!(
                             matches!(&*cx.tcx.sess.target.arch, "wasm32" | "wasm64")
                                 || self.conv == Conv::PtxKernel,
-                            "`PassMode::Direct` for aggregates only allowed on wasm targets\nProblematic type: {:#?}",
+                            "`PassMode::Direct` for aggregates only allowed on wasm and `extern \"ptx-kernel\"` fns\nProblematic type: {:#?}",
                             arg.layout,
                         );
                     }


### PR DESCRIPTION
Upgrading the nvptx toolchain to the newest nightly makes it hit the assert that links to https://github.com/rust-lang/rust/issues/115666

It seems like most targets get around this by using `PassMode::Indirect`. That is impossible for the kernel as it's not a normal call, but instead the arguments are copied from CPU to GPU and the passed pointer would be invalid when it reached the GPU.

I also made an experiment with `PassMode::Cast` but at least the most simple version of this broke the assembly API tests.

I added  fixing the pass mode in my unofficial tracking issue list (I do not have the necessary permissions to update to official one). https://github.com/rust-lang/rust/issues/38788#issuecomment-1079021853

Since the ptx_abi is currently unstable and have been working with `PassMode::Direct` for more than a year now, the steps above is hopefully sufficient to enable it as an exception until I can prioritize to fix it. I'm currently looking at steps to enable the CI for nvptx64 again and would prefer to finish that first.