### PR TITLE
Declare rustc_target's dependency on object/macho

### DIFF
--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -19,4 +19,4 @@ rustc_index = { path = "../rustc_index" }
 [dependencies.object]
 version = "0.32.0"
 default-features = false
-features = ["elf"]
+features = ["elf", "macho"]


### PR DESCRIPTION
Without this, `cargo check` fails in crates that depend on rustc_target.

<details>
<summary>`cargo check` diagnostics</summary>

```console
    Checking rustc_target v0.0.0
error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:176:17
    |
176 |         object::macho::PLATFORM_MACOS => Some((13, 1)),
    |                 ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:177:17
    |
177 |         object::macho::PLATFORM_IOS
    |                 ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:178:19
    |
178 |         | object::macho::PLATFORM_IOSSIMULATOR
    |                   ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:179:19
    |
179 |         | object::macho::PLATFORM_TVOS
    |                   ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:180:19
    |
180 |         | object::macho::PLATFORM_TVOSSIMULATOR
    |                   ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:181:19
    |
181 |         | object::macho::PLATFORM_MACCATALYST => Some((16, 2)),
    |                   ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:182:17
    |
182 |         object::macho::PLATFORM_WATCHOS | object::macho::PLATFORM_WATCHOSSIMULATOR => Some((9, 1)),
    |                 ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:182:51
    |
182 |         object::macho::PLATFORM_WATCHOS | object::macho::PLATFORM_WATCHOSSIMULATOR => Some((9, 1)),
    |                                                   ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:189:33
    |
189 |         ("macos", _) => object::macho::PLATFORM_MACOS,
    |                                 ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:190:38
    |
190 |         ("ios", "macabi") => object::macho::PLATFORM_MACCATALYST,
    |                                      ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:191:35
    |
191 |         ("ios", "sim") => object::macho::PLATFORM_IOSSIMULATOR,
    |                                   ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:192:31
    |
192 |         ("ios", _) => object::macho::PLATFORM_IOS,
    |                               ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:193:39
    |
193 |         ("watchos", "sim") => object::macho::PLATFORM_WATCHOSSIMULATOR,
    |                                       ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:194:35
    |
194 |         ("watchos", _) => object::macho::PLATFORM_WATCHOS,
    |                                   ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:195:36
    |
195 |         ("tvos", "sim") => object::macho::PLATFORM_TVOSSIMULATOR,
    |                                    ^^^^^ could not find `macho` in `object`

error[E0433]: failed to resolve: could not find `macho` in `object`
   --> compiler/rustc_target/src/spec/apple_base.rs:196:32
    |
196 |         ("tvos", _) => object::macho::PLATFORM_TVOS,
    |                                ^^^^^ could not find `macho` in `object`
```
</details>

`rustc_target` unconditionally contains its `spec` module (i.e. there is no `#[cfg]` on the `mod spec;`). The `spec/mod.rs` also does not start with `#![cfg]`.

https://github.com/rust-lang/rust/blob/aa91057796695679e95329947d9f497cb5bdc5da/compiler/rustc_target/src/lib.rs#L37

Similarly, the `spec` module unconditionally contains `apple_base`.

https://github.com/rust-lang/rust/blob/aa91057796695679e95329947d9f497cb5bdc5da/compiler/rustc_target/src/spec/mod.rs#L62

And, `apple_base` unconditionally refers to `object::macho`.

https://github.com/rust-lang/rust/blob/aa91057796695679e95329947d9f497cb5bdc5da/compiler/rustc_target/src/spec/apple_base.rs#L176

So I figure there is no way `object::macho` isn't needed by rustc.

`object::macho` only exists if the `object` crate's "macho" feature is enabled. https://github.com/gimli-rs/object/blob/0.32.0/src/lib.rs#L111-L112