### PR TITLE
Create a new ConstantKind variant (ZeroSized) for StableMIR

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -1284,11 +1284,15 @@ impl<'tcx> Stable<'tcx> for ty::Const<'tcx> {
         let kind = match self.kind() {
             ty::Value(val) => {
                 let const_val = tables.tcx.valtree_to_const_val((self.ty(), val));
-                stable_mir::ty::ConstantKind::Allocated(alloc::new_allocation(
-                    self.ty(),
-                    const_val,
-                    tables,
-                ))
+                if matches!(const_val, mir::ConstValue::ZeroSized) {
+                    ConstantKind::ZeroSized
+                } else {
+                    stable_mir::ty::ConstantKind::Allocated(alloc::new_allocation(
+                        self.ty(),
+                        const_val,
+                        tables,
+                    ))
+                }
             }
             ty::ParamCt(param) => stable_mir::ty::ConstantKind::Param(param.stable(tables)),
             ty::ErrorCt(_) => unreachable!(),
@@ -1401,6 +1405,11 @@ impl<'tcx> Stable<'tcx> for rustc_middle::mir::Const<'tcx> {
                 let ty = ty.stable(tables);
                 let id = tables.intern_const(*self);
                 Const::new(kind, ty, id)
+            }
+            mir::Const::Val(val, ty) if matches!(val, mir::ConstValue::ZeroSized) => {
+                let ty = ty.stable(tables);
+                let id = tables.intern_const(*self);
+                Const::new(ConstantKind::ZeroSized, ty, id)
             }
             mir::Const::Val(val, ty) => {
                 let kind = ConstantKind::Allocated(alloc::new_allocation(ty, val, tables));

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -444,6 +444,9 @@ pub enum ConstantKind {
     Allocated(Allocation),
     Unevaluated(UnevaluatedConst),
     Param(ParamConst),
+    /// Store ZST constants.
+    /// We have to special handle these constants since its type might be generic.
+    ZeroSized,
 }
 
 #[derive(Clone, Debug)]

--- a/compiler/stable_mir/src/visitor.rs
+++ b/compiler/stable_mir/src/visitor.rs
@@ -50,7 +50,7 @@ impl Visitable for Const {
         match &self.kind() {
             super::ty::ConstantKind::Allocated(alloc) => alloc.visit(visitor)?,
             super::ty::ConstantKind::Unevaluated(uv) => uv.visit(visitor)?,
-            super::ty::ConstantKind::Param(_) => {}
+            super::ty::ConstantKind::Param(_) | super::ty::ConstantKind::ZeroSized => {}
         }
         self.ty().visit(visitor)
     }


### PR DESCRIPTION
ZeroSized constants can be represented as `mir::Const::Val` even if their layout is not yet known. In those cases, CrateItem::body() was crashing when trying to convert a `ConstValue::ZeroSized` into its stable counterpart  `ConstantKind::Allocated`.

Instead, we now map `ConstValue::ZeroSized` into a new variant: `ConstantKind::ZeroSized`.

**Note:** I didn't add any new test here since we already have covering tests in our project repository which I manually confirmed that will fix the issue.