### PR TITLE
handle the case when the change-id isn't found

### DIFF
--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -110,28 +110,28 @@ fn check_version(config: &Config) -> Option<String> {
 
     let latest_config_id = CONFIG_CHANGE_HISTORY.last().unwrap();
     if let Some(id) = config.change_id {
-        if &id != latest_config_id {
-            let change_links: Vec<String> = find_recent_config_change_ids(id)
-                .iter()
-                .map(|id| format!("https://github.com/rust-lang/rust/pull/{id}"))
-                .collect();
-            if !change_links.is_empty() {
-                msg.push_str("WARNING: there have been changes to x.py since you last updated.\n");
-                msg.push_str("To see more detail about these changes, visit the following PRs:\n");
-
-                for link in change_links {
-                    msg.push_str(&format!("  - {link}\n"));
-                }
-
-                msg.push_str("WARNING: there have been changes to x.py since you last updated.\n");
-
-                msg.push_str("note: to silence this warning, ");
-                msg.push_str(&format!(
-                    "update `config.toml` to use `change-id = {latest_config_id}` instead"
-                ));
-            }
-        } else {
+        if &id == latest_config_id {
             return None;
+        }
+
+        let change_links: Vec<String> = find_recent_config_change_ids(id)
+            .iter()
+            .map(|id| format!("https://github.com/rust-lang/rust/pull/{id}"))
+            .collect();
+        if !change_links.is_empty() {
+            msg.push_str("WARNING: there have been changes to x.py since you last updated.\n");
+            msg.push_str("To see more detail about these changes, visit the following PRs:\n");
+
+            for link in change_links {
+                msg.push_str(&format!("  - {link}\n"));
+            }
+
+            msg.push_str("WARNING: there have been changes to x.py since you last updated.\n");
+
+            msg.push_str("note: to silence this warning, ");
+            msg.push_str(&format!(
+                "update `config.toml` to use `change-id = {latest_config_id}` instead"
+            ));
         }
     } else {
         msg.push_str("WARNING: The `change-id` is missing in the `config.toml`. This means that you will not be able to track the major changes made to the bootstrap configurations.\n");

--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -109,31 +109,35 @@ fn check_version(config: &Config) -> Option<String> {
     }
 
     let latest_config_id = CONFIG_CHANGE_HISTORY.last().unwrap();
-    let suggestion = if let Some(id) = config.change_id {
+    if let Some(id) = config.change_id {
         if &id != latest_config_id {
-            msg.push_str("WARNING: there have been changes to x.py since you last updated.\n");
             let change_links: Vec<String> = find_recent_config_change_ids(id)
                 .iter()
                 .map(|id| format!("https://github.com/rust-lang/rust/pull/{id}"))
                 .collect();
             if !change_links.is_empty() {
+                msg.push_str("WARNING: there have been changes to x.py since you last updated.\n");
                 msg.push_str("To see more detail about these changes, visit the following PRs:\n");
+
                 for link in change_links {
                     msg.push_str(&format!("  - {link}\n"));
                 }
+
+                msg.push_str("WARNING: there have been changes to x.py since you last updated.\n");
+
+                msg.push_str("note: to silence this warning, ");
+                msg.push_str(&format!(
+                    "update `config.toml` to use `change-id = {latest_config_id}` instead"
+                ));
             }
-            msg.push_str("WARNING: there have been changes to x.py since you last updated.\n");
-            format!("update `config.toml` to use `change-id = {latest_config_id}` instead")
         } else {
             return None;
         }
     } else {
         msg.push_str("WARNING: The `change-id` is missing in the `config.toml`. This means that you will not be able to track the major changes made to the bootstrap configurations.\n");
-        format!("add `change-id = {latest_config_id}` at the top of `config.toml`")
+        msg.push_str("note: to silence this warning, ");
+        msg.push_str(&format!("add `change-id = {latest_config_id}` at the top of `config.toml`"));
     };
-
-    msg.push_str("note: to silence this warning, ");
-    msg.push_str(&suggestion);
 
     Some(msg)
 }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1849,10 +1849,19 @@ fn envify(s: &str) -> String {
 }
 
 pub fn find_recent_config_change_ids(current_id: usize) -> Vec<usize> {
-    let index = CONFIG_CHANGE_HISTORY
-        .iter()
-        .position(|&id| id == current_id)
-        .expect(&format!("Value `{}` was not found in `CONFIG_CHANGE_HISTORY`.", current_id));
+    if !CONFIG_CHANGE_HISTORY.contains(&current_id) {
+        // If the current change-id is greater than the most recent one,
+        // return an empty list; otherwise, return the full list.
+        if let Some(max_id) = CONFIG_CHANGE_HISTORY.iter().max() {
+            if &current_id > max_id {
+                return Vec::new();
+            }
+        }
+
+        return CONFIG_CHANGE_HISTORY.to_vec();
+    }
+
+    let index = CONFIG_CHANGE_HISTORY.iter().position(|&id| id == current_id).unwrap();
 
     CONFIG_CHANGE_HISTORY
         .iter()

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -75,8 +75,9 @@ const LLD_FILE_NAMES: &[&str] = &["ld.lld", "ld64.lld", "lld-link", "wasm-ld"];
 /// You can visit `https://github.com/rust-lang/rust/pull/{any-id-from-the-list}` to
 /// check for more details regarding each change.
 ///
-/// If you make any major changes (such as adding new values or changing default values), please
-/// ensure that the associated PR ID is added to the end of this list.
+/// If you make any major changes (such as adding new values or changing default values),
+/// please ensure that the associated PR ID is added to the end of this list.
+/// This is necessary because the list must be sorted by the merge date.
 pub const CONFIG_CHANGE_HISTORY: &[usize] = &[115898, 116998, 117435, 116881];
 
 /// Extra --check-cfg to add when building
@@ -1850,8 +1851,10 @@ fn envify(s: &str) -> String {
 
 pub fn find_recent_config_change_ids(current_id: usize) -> Vec<usize> {
     if !CONFIG_CHANGE_HISTORY.contains(&current_id) {
-        // If the current change-id is greater than the most recent one,
-        // return an empty list; otherwise, return the full list.
+        // If the current change-id is greater than the most recent one, return
+        // an empty list (it may be due to switching from a recent branch to an
+        // older one); otherwise, return the full list (assuming the user provided
+        // the incorrect change-id by accident).
         if let Some(max_id) = CONFIG_CHANGE_HISTORY.iter().max() {
             if &current_id > max_id {
                 return Vec::new();


### PR DESCRIPTION
When we switch back and forth between the old and recent branches, if there was a breaking change in the bootstrap configuration in between, we have to update the change-id in the build configuration with each checkout, which can be exhausting. This change fixes that.

r? saethlin