### PR TITLE
core::net: Rename `parse_ascii()` fns to `from_bytes()`

### DIFF
--- a/library/core/src/net/parser.rs
+++ b/library/core/src/net/parser.rs
@@ -282,11 +282,11 @@ impl IpAddr {
     /// let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     /// let localhost_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
     ///
-    /// assert_eq!(IpAddr::parse_ascii(b"127.0.0.1"), Ok(localhost_v4));
-    /// assert_eq!(IpAddr::parse_ascii(b"::1"), Ok(localhost_v6));
+    /// assert_eq!(IpAddr::from_bytes(b"127.0.0.1"), Ok(localhost_v4));
+    /// assert_eq!(IpAddr::from_bytes(b"::1"), Ok(localhost_v6));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
-    pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
+    pub fn from_bytes(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_ip_addr(), AddrKind::Ip)
     }
 }
@@ -295,7 +295,7 @@ impl IpAddr {
 impl FromStr for IpAddr {
     type Err = AddrParseError;
     fn from_str(s: &str) -> Result<IpAddr, AddrParseError> {
-        Self::parse_ascii(s.as_bytes())
+        Self::from_bytes(s.as_bytes())
     }
 }
 
@@ -309,10 +309,10 @@ impl Ipv4Addr {
     ///
     /// let localhost = Ipv4Addr::new(127, 0, 0, 1);
     ///
-    /// assert_eq!(Ipv4Addr::parse_ascii(b"127.0.0.1"), Ok(localhost));
+    /// assert_eq!(Ipv4Addr::from_bytes(b"127.0.0.1"), Ok(localhost));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
-    pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
+    pub fn from_bytes(b: &[u8]) -> Result<Self, AddrParseError> {
         // don't try to parse if too long
         if b.len() > 15 {
             Err(AddrParseError(AddrKind::Ipv4))
@@ -326,7 +326,7 @@ impl Ipv4Addr {
 impl FromStr for Ipv4Addr {
     type Err = AddrParseError;
     fn from_str(s: &str) -> Result<Ipv4Addr, AddrParseError> {
-        Self::parse_ascii(s.as_bytes())
+        Self::from_bytes(s.as_bytes())
     }
 }
 
@@ -340,10 +340,10 @@ impl Ipv6Addr {
     ///
     /// let localhost = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
     ///
-    /// assert_eq!(Ipv6Addr::parse_ascii(b"::1"), Ok(localhost));
+    /// assert_eq!(Ipv6Addr::from_bytes(b"::1"), Ok(localhost));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
-    pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
+    pub fn from_bytes(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_ipv6_addr(), AddrKind::Ipv6)
     }
 }
@@ -352,7 +352,7 @@ impl Ipv6Addr {
 impl FromStr for Ipv6Addr {
     type Err = AddrParseError;
     fn from_str(s: &str) -> Result<Ipv6Addr, AddrParseError> {
-        Self::parse_ascii(s.as_bytes())
+        Self::from_bytes(s.as_bytes())
     }
 }
 
@@ -366,10 +366,10 @@ impl SocketAddrV4 {
     ///
     /// let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
     ///
-    /// assert_eq!(SocketAddrV4::parse_ascii(b"127.0.0.1:8080"), Ok(socket));
+    /// assert_eq!(SocketAddrV4::from_bytes(b"127.0.0.1:8080"), Ok(socket));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
-    pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
+    pub fn from_bytes(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_socket_addr_v4(), AddrKind::SocketV4)
     }
 }
@@ -378,7 +378,7 @@ impl SocketAddrV4 {
 impl FromStr for SocketAddrV4 {
     type Err = AddrParseError;
     fn from_str(s: &str) -> Result<SocketAddrV4, AddrParseError> {
-        Self::parse_ascii(s.as_bytes())
+        Self::from_bytes(s.as_bytes())
     }
 }
 
@@ -392,10 +392,10 @@ impl SocketAddrV6 {
     ///
     /// let socket = SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
     ///
-    /// assert_eq!(SocketAddrV6::parse_ascii(b"[2001:db8::1]:8080"), Ok(socket));
+    /// assert_eq!(SocketAddrV6::from_bytes(b"[2001:db8::1]:8080"), Ok(socket));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
-    pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
+    pub fn from_bytes(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_socket_addr_v6(), AddrKind::SocketV6)
     }
 }
@@ -404,7 +404,7 @@ impl SocketAddrV6 {
 impl FromStr for SocketAddrV6 {
     type Err = AddrParseError;
     fn from_str(s: &str) -> Result<SocketAddrV6, AddrParseError> {
-        Self::parse_ascii(s.as_bytes())
+        Self::from_bytes(s.as_bytes())
     }
 }
 
@@ -419,11 +419,11 @@ impl SocketAddr {
     /// let socket_v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     /// let socket_v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
     ///
-    /// assert_eq!(SocketAddr::parse_ascii(b"127.0.0.1:8080"), Ok(socket_v4));
-    /// assert_eq!(SocketAddr::parse_ascii(b"[::1]:8080"), Ok(socket_v6));
+    /// assert_eq!(SocketAddr::from_bytes(b"127.0.0.1:8080"), Ok(socket_v4));
+    /// assert_eq!(SocketAddr::from_bytes(b"[::1]:8080"), Ok(socket_v6));
     /// ```
     #[unstable(feature = "addr_parse_ascii", issue = "101035")]
-    pub fn parse_ascii(b: &[u8]) -> Result<Self, AddrParseError> {
+    pub fn from_bytes(b: &[u8]) -> Result<Self, AddrParseError> {
         Parser::new(b).parse_with(|p| p.read_socket_addr(), AddrKind::Socket)
     }
 }
@@ -432,7 +432,7 @@ impl SocketAddr {
 impl FromStr for SocketAddr {
     type Err = AddrParseError;
     fn from_str(s: &str) -> Result<SocketAddr, AddrParseError> {
-        Self::parse_ascii(s.as_bytes())
+        Self::from_bytes(s.as_bytes())
     }
 }
 


### PR DESCRIPTION
We are operating on u8 (aka. byte) values here. ASCII only allows values from 0-127.

This would also be consistent with the naming of `OsStr::from_bytes()`.

Related:
- https://github.com/rust-lang/rust/issues/101035
- https://github.com/rust-lang/rust/pull/94890
- https://github.com/rust-lang/libs-team/issues/287
- https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/addr_parse_ascii.20feature/near/398650220