### PR TITLE
Account for `ref` and `mut` in the wrong place for pattern ident renaming

### DIFF
--- a/tests/ui/pattern/incorrect-placement-of-pattern-modifiers.fixed
+++ b/tests/ui/pattern/incorrect-placement-of-pattern-modifiers.fixed
@@ -1,0 +1,18 @@
+// run-rustfix
+struct S {
+    field_name: (),
+}
+
+fn main() {
+    match (S {field_name: ()}) {
+        S {field_name: ref _foo} => {} //~ ERROR expected `,`
+    }
+    match (S {field_name: ()}) {
+        S {field_name: mut _foo} => {} //~ ERROR expected `,`
+    }
+    match (S {field_name: ()}) {
+        S {field_name: ref mut _foo} => {} //~ ERROR expected `,`
+    }
+    // Verify that we recover enough to run typeck.
+    let _: usize = 3usize; //~ ERROR mismatched types
+}

--- a/tests/ui/pattern/incorrect-placement-of-pattern-modifiers.rs
+++ b/tests/ui/pattern/incorrect-placement-of-pattern-modifiers.rs
@@ -1,0 +1,18 @@
+// run-rustfix
+struct S {
+    field_name: (),
+}
+
+fn main() {
+    match (S {field_name: ()}) {
+        S {ref field_name: _foo} => {} //~ ERROR expected `,`
+    }
+    match (S {field_name: ()}) {
+        S {mut field_name: _foo} => {} //~ ERROR expected `,`
+    }
+    match (S {field_name: ()}) {
+        S {ref mut field_name: _foo} => {} //~ ERROR expected `,`
+    }
+    // Verify that we recover enough to run typeck.
+    let _: usize = 3u8; //~ ERROR mismatched types
+}

--- a/tests/ui/pattern/incorrect-placement-of-pattern-modifiers.stderr
+++ b/tests/ui/pattern/incorrect-placement-of-pattern-modifiers.stderr
@@ -1,0 +1,58 @@
+error: expected `,`
+  --> $DIR/incorrect-placement-of-pattern-modifiers.rs:8:26
+   |
+LL |         S {ref field_name: _foo} => {}
+   |         -                ^
+   |         |
+   |         while parsing the fields for this pattern
+   |
+help: the pattern modifiers belong after the `:`
+   |
+LL -         S {ref field_name: _foo} => {}
+LL +         S {field_name: ref _foo} => {}
+   |
+
+error: expected `,`
+  --> $DIR/incorrect-placement-of-pattern-modifiers.rs:11:26
+   |
+LL |         S {mut field_name: _foo} => {}
+   |         -                ^
+   |         |
+   |         while parsing the fields for this pattern
+   |
+help: the pattern modifiers belong after the `:`
+   |
+LL -         S {mut field_name: _foo} => {}
+LL +         S {field_name: mut _foo} => {}
+   |
+
+error: expected `,`
+  --> $DIR/incorrect-placement-of-pattern-modifiers.rs:14:30
+   |
+LL |         S {ref mut field_name: _foo} => {}
+   |         -                    ^
+   |         |
+   |         while parsing the fields for this pattern
+   |
+help: the pattern modifiers belong after the `:`
+   |
+LL -         S {ref mut field_name: _foo} => {}
+LL +         S {field_name: ref mut _foo} => {}
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/incorrect-placement-of-pattern-modifiers.rs:17:20
+   |
+LL |     let _: usize = 3u8;
+   |            -----   ^^^ expected `usize`, found `u8`
+   |            |
+   |            expected due to this
+   |
+help: change the type of the numeric literal from `u8` to `usize`
+   |
+LL |     let _: usize = 3usize;
+   |                     ~~~~~
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
If the user writes `S { ref field: name }` instead of `S { field: ref name }`, we suggest the correct code.

Fix #72298.