### PR TITLE
Detect misparsed binop caused by missing semi

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -961,7 +961,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     /// Check if the expression that could not be assigned to was a typoed expression that
-    fn check_for_missing_semi(&self, expr: &'tcx hir::Expr<'tcx>, err: &mut Diagnostic) {
+    pub fn check_for_missing_semi(
+        &self,
+        expr: &'tcx hir::Expr<'tcx>,
+        err: &mut DiagnosticBuilder<'_, ErrorGuaranteed>,
+    ) -> bool {
         if let hir::ExprKind::Binary(binop, lhs, rhs) = expr.kind
             && let hir::BinOpKind::Mul = binop.node
             && self.tcx.sess.source_map().is_multiline(lhs.span.between(rhs.span))
@@ -977,7 +981,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ";".to_string(),
                 Applicability::MachineApplicable,
             );
+            return true;
         }
+        false
     }
 
     // Check if an expression `original_expr_id` comes from the condition of a while loop,

--- a/tests/ui/binop/false-binop-caused-by-missing-semi.fixed
+++ b/tests/ui/binop/false-binop-caused-by-missing-semi.fixed
@@ -3,7 +3,7 @@ fn foo() {}
 fn main() {
     let mut y = 42;
     let x = &mut y;
-    foo()
+    foo();
     *x = 0;  //~ ERROR invalid left-hand side of assignment
     let _ = x;
     println!("{y}");

--- a/tests/ui/binop/false-binop-caused-by-missing-semi.rs
+++ b/tests/ui/binop/false-binop-caused-by-missing-semi.rs
@@ -1,0 +1,9 @@
+fn foo() {}
+fn main() {
+    let mut y = 42;
+    let x = &mut y;
+    foo()
+    *x = 0;  //~ ERROR invalid left-hand side of assignment
+    //~^ ERROR cannot multiply `()` by `&mut {integer}`
+    println!("{y}");
+}

--- a/tests/ui/binop/false-binop-caused-by-missing-semi.stderr
+++ b/tests/ui/binop/false-binop-caused-by-missing-semi.stderr
@@ -1,18 +1,5 @@
-error[E0369]: cannot multiply `()` by `&mut {integer}`
-  --> $DIR/false-binop-caused-by-missing-semi.rs:6:5
-   |
-LL |     foo()
-   |     ----- ()
-LL |     *x = 0;
-   |     ^- &mut {integer}
-   |
-help: you might have meant to write a semicolon here
-   |
-LL |     foo();
-   |          +
-
 error[E0070]: invalid left-hand side of assignment
-  --> $DIR/false-binop-caused-by-missing-semi.rs:6:8
+  --> $DIR/false-binop-caused-by-missing-semi.rs:7:8
    |
 LL | /     foo()
 LL | |     *x = 0;
@@ -25,7 +12,6 @@ help: you might have meant to write a semicolon here
 LL |     foo();
    |          +
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0070, E0369.
-For more information about an error, try `rustc --explain E0070`.
+For more information about this error, try `rustc --explain E0070`.

--- a/tests/ui/binop/false-binop-caused-by-missing-semi.stderr
+++ b/tests/ui/binop/false-binop-caused-by-missing-semi.stderr
@@ -1,0 +1,31 @@
+error[E0369]: cannot multiply `()` by `&mut {integer}`
+  --> $DIR/false-binop-caused-by-missing-semi.rs:6:5
+   |
+LL |     foo()
+   |     ----- ()
+LL |     *x = 0;
+   |     ^- &mut {integer}
+   |
+help: you might have meant to write a semicolon here
+   |
+LL |     foo();
+   |          +
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/false-binop-caused-by-missing-semi.rs:6:8
+   |
+LL | /     foo()
+LL | |     *x = 0;
+   | |      - ^
+   | |______|
+   |        cannot assign to this expression
+   |
+help: you might have meant to write a semicolon here
+   |
+LL |     foo();
+   |          +
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0070, E0369.
+For more information about an error, try `rustc --explain E0070`.


### PR DESCRIPTION
When encountering

```rust
foo()
*bar = baz;
```

We currently emit potentially two errors, one for the return type of
`foo` not being multiplicative by the type of `bar`, and another for
`foo() * bar` not being assignable.

We now check for this case and suggest adding a semicolon in the right
place and emit only a single error.

Fix #80446.