### PR TITLE
Set max_atomic_width for riscv32*-esp-espidf to 32

### DIFF
--- a/compiler/rustc_target/src/spec/riscv32imac_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/riscv32imac_esp_espidf.rs
@@ -17,7 +17,7 @@ pub fn target() -> Target {
 
             // As RiscV32IMAC architecture does natively support atomics,
             // automatically enable the support for the Rust STD library.
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(32),
             atomic_cas: true,
 
             features: "+m,+a,+c".into(),

--- a/compiler/rustc_target/src/spec/riscv32imc_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/riscv32imc_esp_espidf.rs
@@ -16,11 +16,11 @@ pub fn target() -> Target {
             cpu: "generic-rv32".into(),
 
             // While the RiscV32IMC architecture does not natively support atomics, ESP-IDF does support
-            // the __atomic* and __sync* GCC builtins, so setting `max_atomic_width` to `Some(64)`
+            // the __atomic* and __sync* GCC builtins, so setting `max_atomic_width` to `Some(32)`
             // and `atomic_cas` to `true` will cause the compiler to emit libcalls to these builtins.
             //
             // Support for atomics is necessary for the Rust STD library, which is supported by the ESP-IDF framework.
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(32),
             atomic_cas: true,
 
             features: "+m,+c".into(),


### PR DESCRIPTION
Fixes #117305

> Since riscv32 does not have 64-bit atomic instructions, I do not believe there is any way to fix this problem other than setting max_atomic_width of these targets to 32.

This is a breaking change because Atomic\*64 will become unavailable, but all affected targets are tier 3, and the current Atomic*64 violates the standard library's API contract and can cause problems with code that rely on the standard library's atomic types being lock-free.

r? @Amanieu 
cc @ivmarkov @MabezDev