### PR TITLE
change default output mode of `BootstrapCommand`

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -586,7 +586,11 @@ impl Build {
                     .args(&["diff-index", "--quiet", "HEAD"])
                     .current_dir(&absolute_path),
             )
-            .allow_failure(),
+            .allow_failure()
+            .output_mode(match self.is_verbose() {
+                true => OutputMode::PrintAll,
+                false => OutputMode::PrintOutput,
+            }),
         );
         if has_local_modifications {
             self.run(Command::new("git").args(&["stash", "push"]).current_dir(&absolute_path));

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -54,7 +54,7 @@ impl<'a> From<&'a mut Command> for BootstrapCommand<'a> {
         Self {
             command,
             failure_behavior: BehaviorOnFailure::Exit,
-            output_mode: OutputMode::SuppressOnSuccess,
+            output_mode: OutputMode::PrintAll,
         }
     }
 }


### PR DESCRIPTION
`SuppressOnSuccess` on `BootstrapCommand` is a problematic default mode as it affects the logs during the bootstrapping (as shown in the screenshot below). The default behavior should be to print everything unless we explicitly modify the behavior within build steps.

![image](https://github.com/rust-lang/rust/assets/39852038/8dbaaeb2-0656-4ff9-8e48-1ac0734a913f)

Fixes #117315

cc @Kobzol 