### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -258,7 +258,9 @@ fn main() {
     {
         println!("cargo:rustc-link-lib=z");
     } else if target.contains("netbsd") {
-        // Building for i586 or i686, we need -latomic for 64-bit atomics
+        // On NetBSD/i386, gcc and g++ is built for i486 (to maximize backward compat)
+        // However, LLVM insists on using 64-bit atomics.
+        // This gives rise to a need to link rust itself with -latomic for these targets
         if target.starts_with("i586")
            || target.starts_with("i686")
         {

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -258,6 +258,12 @@ fn main() {
     {
         println!("cargo:rustc-link-lib=z");
     } else if target.contains("netbsd") {
+        // Building for i586 or i686, we need -latomic for 64-bit atomics
+        if target.starts_with("i586")
+           || target.starts_with("i686")
+        {
+            println!("cargo:rustc-link-lib=atomic");
+        }
         println!("cargo:rustc-link-lib=z");
         println!("cargo:rustc-link-lib=execinfo");
     }

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -261,9 +261,7 @@ fn main() {
         // On NetBSD/i386, gcc and g++ is built for i486 (to maximize backward compat)
         // However, LLVM insists on using 64-bit atomics.
         // This gives rise to a need to link rust itself with -latomic for these targets
-        if target.starts_with("i586")
-           || target.starts_with("i686")
-        {
+        if target.starts_with("i586") || target.starts_with("i686") {
             println!("cargo:rustc-link-lib=atomic");
         }
         println!("cargo:rustc-link-lib=z");

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -12,8 +12,6 @@ pub use self::pretty::*;
 
 pub type PrintError = std::fmt::Error;
 
-// FIXME(eddyb) false positive, the lifetime parameters are used with `P:  Printer<...>`.
-#[allow(unused_lifetimes)]
 pub trait Print<'tcx, P> {
     fn print(&self, cx: &mut P) -> Result<(), PrintError>;
 }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2719,11 +2719,8 @@ macro_rules! define_print {
     (($self:ident, $cx:ident): $($ty:ty $print:block)+) => {
         $(impl<'tcx, P: PrettyPrinter<'tcx>> Print<'tcx, P> for $ty {
             fn print(&$self, $cx: &mut P) -> Result<(), PrintError> {
-                #[allow(unused_mut)]
-                let mut $cx = $cx;
                 define_scoped_cx!($cx);
                 let _: () = $print;
-                #[allow(unreachable_code)]
                 Ok(())
             }
         })+

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -53,7 +53,6 @@ macro_rules! p {
 }
 macro_rules! define_scoped_cx {
     ($cx:ident) => {
-        #[allow(unused_macros)]
         macro_rules! scoped_cx {
             () => {
                 $cx
@@ -408,8 +407,6 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         def_id: DefId,
         callers: &mut Vec<DefId>,
     ) -> Result<bool, PrintError> {
-        define_scoped_cx!(self);
-
         debug!("try_print_visible_def_path: def_id={:?}", def_id);
 
         // If `def_id` is a direct or injected extern crate, return the
@@ -1868,8 +1865,6 @@ impl<'tcx> Printer<'tcx> for FmtPrinter<'_, 'tcx> {
         def_id: DefId,
         args: &'tcx [GenericArg<'tcx>],
     ) -> Result<(), PrintError> {
-        define_scoped_cx!(self);
-
         if args.is_empty() {
             match self.try_print_trimmed_def_path(def_id)? {
                 true => return Ok(()),
@@ -2400,8 +2395,6 @@ impl<'tcx> FmtPrinter<'_, 'tcx> {
         let do_continue = |cx: &mut Self, cont: Symbol| {
             let _ = write!(cx, "{cont}");
         };
-
-        define_scoped_cx!(self);
 
         let possible_names = ('a'..='z').rev().map(|s| Symbol::intern(&format!("'{s}")));
 

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -19,4 +19,4 @@ rustc_index = { path = "../rustc_index" }
 [dependencies.object]
 version = "0.32.0"
 default-features = false
-features = ["elf"]
+features = ["elf", "macho"]

--- a/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
@@ -1,13 +1,10 @@
-use crate::spec::{Cc, Lld, LinkerFlavor, StackProbeType, Target, TargetOptions};
+use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::netbsd_base::opts();
     base.cpu = "pentium".into();
     base.max_atomic_width = Some(64);
-    base.pre_link_args
-        .entry(LinkerFlavor::Gnu(Cc::Yes, Lld::No))
-        .or_default()
-        .push("-m32".into());
+    base.pre_link_args.entry(LinkerFlavor::Gnu(Cc::Yes, Lld::No)).or_default().push("-m32".into());
     base.stack_probes = StackProbeType::Call;
 
     Target {

--- a/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
@@ -1,0 +1,22 @@
+use crate::spec::{Cc, Lld, LinkerFlavor, StackProbeType, Target, TargetOptions};
+
+pub fn target() -> Target {
+    let mut base = super::netbsd_base::opts();
+    base.cpu = "pentium".into();
+    base.max_atomic_width = Some(64);
+    base.pre_link_args
+        .entry(LinkerFlavor::Gnu(Cc::Yes, Lld::No))
+        .or_default()
+        .push("-m32".into());
+    base.stack_probes = StackProbeType::Call;
+
+    Target {
+        llvm_target: "i586-unknown-netbsdelf".into(),
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-\
+            f64:32:64-f80:32-n8:16:32-S128"
+            .into(),
+        arch: "x86".into(),
+        options: TargetOptions { mcount: "__mcount".into(), ..base },
+    }
+}

--- a/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_netbsd.rs
@@ -1,10 +1,9 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetOptions};
+use crate::spec::{StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::netbsd_base::opts();
     base.cpu = "pentium".into();
     base.max_atomic_width = Some(64);
-    base.pre_link_args.entry(LinkerFlavor::Gnu(Cc::Yes, Lld::No)).or_default().push("-m32".into());
     base.stack_probes = StackProbeType::Call;
 
     Target {

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1426,6 +1426,7 @@ supported_targets! {
     ("aarch64_be-unknown-netbsd", aarch64_be_unknown_netbsd),
     ("armv6-unknown-netbsd-eabihf", armv6_unknown_netbsd_eabihf),
     ("armv7-unknown-netbsd-eabihf", armv7_unknown_netbsd_eabihf),
+    ("i586-unknown-netbsd", i586_unknown_netbsd),
     ("i686-unknown-netbsd", i686_unknown_netbsd),
     ("powerpc-unknown-netbsd", powerpc_unknown_netbsd),
     ("riscv64gc-unknown-netbsd", riscv64gc_unknown_netbsd),

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -586,7 +586,11 @@ impl Build {
                     .args(&["diff-index", "--quiet", "HEAD"])
                     .current_dir(&absolute_path),
             )
-            .allow_failure(),
+            .allow_failure()
+            .output_mode(match self.is_verbose() {
+                true => OutputMode::PrintAll,
+                false => OutputMode::PrintOutput,
+            }),
         );
         if has_local_modifications {
             self.run(Command::new("git").args(&["stash", "push"]).current_dir(&absolute_path));

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -54,7 +54,7 @@ impl<'a> From<&'a mut Command> for BootstrapCommand<'a> {
         Self {
             command,
             failure_behavior: BehaviorOnFailure::Exit,
-            output_mode: OutputMode::SuppressOnSuccess,
+            output_mode: OutputMode::PrintAll,
         }
     }
 }

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -152,6 +152,7 @@ target | std | notes
 `i586-pc-windows-msvc` | * | 32-bit Windows w/o SSE [^x86_32-floats-x87]
 `i586-unknown-linux-gnu` | ✓ | 32-bit Linux w/o SSE (kernel 3.2, glibc 2.17) [^x86_32-floats-x87]
 `i586-unknown-linux-musl` | ✓ | 32-bit Linux w/o SSE, MUSL [^x86_32-floats-x87]
+[`i586-unknown-netbsd`](platform-support/netbsd.md) |  ✓ | 32-bir x86, restricted to Pentium
 [`i686-linux-android`](platform-support/android.md) | ✓ | 32-bit x86 Android [^x86_32-floats-return-ABI]
 `i686-unknown-freebsd` | ✓ | 32-bit FreeBSD [^x86_32-floats-return-ABI]
 `i686-unknown-linux-musl` | ✓ | 32-bit Linux with MUSL [^x86_32-floats-return-ABI]

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -152,7 +152,7 @@ target | std | notes
 `i586-pc-windows-msvc` | * | 32-bit Windows w/o SSE [^x86_32-floats-x87]
 `i586-unknown-linux-gnu` | ✓ | 32-bit Linux w/o SSE (kernel 3.2, glibc 2.17) [^x86_32-floats-x87]
 `i586-unknown-linux-musl` | ✓ | 32-bit Linux w/o SSE, MUSL [^x86_32-floats-x87]
-[`i586-unknown-netbsd`](platform-support/netbsd.md) |  ✓ | 32-bir x86, restricted to Pentium
+[`i586-unknown-netbsd`](platform-support/netbsd.md) |  ✓ | 32-bit x86, restricted to Pentium
 [`i686-linux-android`](platform-support/android.md) | ✓ | 32-bit x86 Android [^x86_32-floats-return-ABI]
 `i686-unknown-freebsd` | ✓ | 32-bit FreeBSD [^x86_32-floats-return-ABI]
 `i686-unknown-linux-musl` | ✓ | 32-bit Linux with MUSL [^x86_32-floats-return-ABI]


### PR DESCRIPTION
Successful merges:

 - #117170 (Add support for i586-unknown-netbsd as target.)
 - #117259 (Declare rustc_target's dependency on object/macho)
 - #117322 (change default output mode of `BootstrapCommand`)
 - #117325 (Small ty::print cleanups)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=117170,117259,117322,117325)
<!-- homu-ignore:end -->