### PR TITLE
Suggests compiler to update if on older version when using `unstable` feature

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -207,6 +207,7 @@ hir_analysis_missing_trait_item_unstable = not all trait items implemented, miss
     .note = default implementation of `{$missing_item_name}` is unstable
     .some_note = use of unstable library feature '{$feature}': {$reason}
     .none_note = use of unstable library feature '{$feature}'
+    .note = if you are on an old compiler version you may need to update your compiler
 
 hir_analysis_missing_type_params =
     the type {$parameterCount ->


### PR DESCRIPTION
Part of Issue #117318

Added additional `note` suggesting compiler update in the `.ftl` file when calling `unstable` feature error diagnostic in either case of `Some` or `None`.

Potential addition would be to check the `system time` and compare with the last successful build.