### PR TITLE
Remove legacy bitcode defaults from all Apple specs

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_ios.rs
@@ -18,19 +18,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+neon,+fp-armv8,+apple-a7".into(),
             max_atomic_width: Some(128),
-            forces_embed_bitcode: true,
             frame_pointer: FramePointer::NonLeaf,
-            // Taken from a clang build on Xcode 11.4.1.
-            // These arguments are not actually invoked - they just have
-            // to look right to pass App Store validation.
-            bitcode_llvm_cmdline: "-triple\0\
-                arm64-apple-ios11.0.0\0\
-                -emit-obj\0\
-                -disable-llvm-passes\0\
-                -target-abi\0\
-                darwinpcs\0\
-                -Os\0"
-                .into(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_macabi.rs
@@ -17,17 +17,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+neon,+fp-armv8,+apple-a12".into(),
             max_atomic_width: Some(128),
-            forces_embed_bitcode: true,
             frame_pointer: FramePointer::NonLeaf,
-            // Taken from a clang build on Xcode 11.4.1.
-            // These arguments are not actually invoked - they just have
-            // to look right to pass App Store validation.
-            bitcode_llvm_cmdline: "-triple\0\
-                arm64-apple-ios-macabi\0\
-                -emit-obj\0\
-                -disable-llvm-passes\0\
-                -Os\0"
-                .into(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_sim.rs
@@ -18,19 +18,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+neon,+fp-armv8,+apple-a7".into(),
             max_atomic_width: Some(128),
-            forces_embed_bitcode: true,
             frame_pointer: FramePointer::NonLeaf,
-            // Taken from a clang build on Xcode 11.4.1.
-            // These arguments are not actually invoked - they just have
-            // to look right to pass App Store validation.
-            bitcode_llvm_cmdline: "-triple\0\
-                arm64-apple-ios14.0-simulator\0\
-                -emit-obj\0\
-                -disable-llvm-passes\0\
-                -target-abi\0\
-                darwinpcs\0\
-                -Os\0"
-                .into(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos.rs
@@ -11,7 +11,6 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+neon,+fp-armv8,+apple-a7".into(),
             max_atomic_width: Some(128),
-            forces_embed_bitcode: true,
             frame_pointer: FramePointer::NonLeaf,
             ..opts("tvos", arch)
         },

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos_sim.rs
@@ -11,20 +11,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+neon,+fp-armv8,+apple-a7".into(),
             max_atomic_width: Some(128),
-            forces_embed_bitcode: true,
             frame_pointer: FramePointer::NonLeaf,
-            // Taken from (and slightly modified) the aarch64-apple-ios-sim spec which says:
-            // Taken from a clang build on Xcode 11.4.1.
-            // These arguments are not actually invoked - they just have
-            // to look right to pass App Store validation.
-            bitcode_llvm_cmdline: "-triple\0\
-                arm64-apple-tvos15.0-simulator\0\
-                -emit-obj\0\
-                -disable-llvm-passes\0\
-                -target-abi\0\
-                darwinpcs\0\
-                -Os\0"
-                .into(),
             ..opts("tvos", arch)
         },
     }

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos_sim.rs
@@ -15,19 +15,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+neon,+fp-armv8,+apple-a7".into(),
             max_atomic_width: Some(128),
-            forces_embed_bitcode: true,
             frame_pointer: FramePointer::NonLeaf,
-            // Taken from a clang build on Xcode 11.4.1.
-            // These arguments are not actually invoked - they just have
-            // to look right to pass App Store validation.
-            bitcode_llvm_cmdline: "-triple\0\
-                arm64-apple-watchos5.0-simulator\0\
-                -emit-obj\0\
-                -disable-llvm-passes\0\
-                -target-abi\0\
-                darwinpcs\0\
-                -Os\0"
-                .into(),
             ..opts("watchos", arch)
         },
     }

--- a/compiler/rustc_target/src/spec/targets/arm64_32_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/targets/arm64_32_apple_watchos.rs
@@ -11,19 +11,8 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+v8a,+neon,+fp-armv8,+apple-a7".into(),
             max_atomic_width: Some(128),
-            forces_embed_bitcode: true,
             dynamic_linking: false,
             position_independent_executables: true,
-            // These arguments are not actually invoked - they just have
-            // to look right to pass App Store validation.
-            bitcode_llvm_cmdline: "-triple\0\
-                arm64_32-apple-watchos5.0.0\0\
-                -emit-obj\0\
-                -disable-llvm-passes\0\
-                -target-abi\0\
-                darwinpcs\0\
-                -Os\0"
-                .into(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armv7k_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7k_apple_watchos.rs
@@ -11,19 +11,8 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+v7,+vfp4,+neon".into(),
             max_atomic_width: Some(64),
-            forces_embed_bitcode: true,
             dynamic_linking: false,
             position_independent_executables: true,
-            // These arguments are not actually invoked - they just have
-            // to look right to pass App Store validation.
-            bitcode_llvm_cmdline: "-triple\0\
-                armv7k-apple-watchos3.0.0\0\
-                -emit-obj\0\
-                -disable-llvm-passes\0\
-                -target-abi\0\
-                darwinpcs\0\
-                -Os\0"
-                .into(),
             ..opts("watchos", arch)
         },
     }

--- a/compiler/rustc_target/src/spec/targets/x86_64_apple_watchos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_apple_watchos_sim.rs
@@ -12,18 +12,6 @@ pub fn target() -> Target {
         options: TargetOptions {
             max_atomic_width: Some(128),
             stack_probes: StackProbeType::X86,
-            forces_embed_bitcode: true,
-            // Taken from a clang build on Xcode 11.4.1.
-            // These arguments are not actually invoked - they just have
-            // to look right to pass App Store validation.
-            bitcode_llvm_cmdline: "-triple\0\
-                x86_64-apple-watchos5.0-simulator\0\
-                -emit-obj\0\
-                -disable-llvm-passes\0\
-                -target-abi\0\
-                darwinpcs\0\
-                -Os\0"
-                .into(),
             ..opts("watchos", arch)
         },
     }


### PR DESCRIPTION
Xcode 14 [deprecated bitcode with warnings](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes#Deprecations) and now [Xcode 15 has dropped it completely](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Deprecations). `rustc` should follow what the platform tooling is doing as well since it just increases binary sizes for no gain at this point.

`cc` made a [similar change last month](https://github.com/rust-lang/cc-rs/pull/812).

Two things show this should have minimal impact:
- Apple has stopped accepting apps built with versions of Xcode (<14) that generate bitcode
- The app store has been stripping bitcode off IPA releases for over 2 years now.

I didn't nuke all the bitcode changes added in https://github.com/rust-lang/rust/pull/71970/ since maybe another target in the future could need mandatory bitcode embedding.

Staticlibs built for iOS still link correctly with XCode 15 against a test app when using a compiler built from this branch.

cc @thomcc @keith 