### PR TITLE
Ignore RPIT duplicated lifetimes in `opaque_types_defined_by`

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -460,7 +460,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Checks whether each generic argument is simply a unique generic parameter.
     pub fn uses_unique_generic_params(
         self,
-        args: GenericArgsRef<'tcx>,
+        args: &[ty::GenericArg<'tcx>],
         ignore_regions: CheckRegions,
     ) -> Result<(), NotUniqueParam<'tcx>> {
         let mut seen = GrowableBitSet::default();

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -154,7 +154,14 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for OpaqueTypeCollector<'tcx> {
 
                 self.opaques.push(alias_ty.def_id.expect_local());
 
-                match self.tcx.uses_unique_generic_params(alias_ty.args, CheckRegions::Bound) {
+                let parent_count = self.tcx.generics_of(alias_ty.def_id).parent_count;
+                // Only check that the parent generics of the TAIT/RPIT are unique.
+                // the args owned by the opaque are going to always be duplicate
+                // lifetime params for RPITs, and empty for TAITs.
+                match self
+                    .tcx
+                    .uses_unique_generic_params(&alias_ty.args[..parent_count], CheckRegions::Bound)
+                {
                     Ok(()) => {
                         // FIXME: implement higher kinded lifetime bounds on nested opaque types. They are not
                         // supported at all, so this is sound to do, but once we want to support them, you'll

--- a/tests/ui/type-alias-impl-trait/duplicate-lifetimes-from-rpit-containing-tait.rs
+++ b/tests/ui/type-alias-impl-trait/duplicate-lifetimes-from-rpit-containing-tait.rs
@@ -1,0 +1,13 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+type Opaque<'lt> = impl Sized + 'lt;
+
+fn test<'a>(
+    arg: impl Iterator<Item = &'a u8>,
+) -> impl Iterator<Item = Opaque<'a>> {
+    arg
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/duplicate-lifetimes-from-rpit-containing-tait2.rs
+++ b/tests/ui/type-alias-impl-trait/duplicate-lifetimes-from-rpit-containing-tait2.rs
@@ -1,0 +1,15 @@
+// check-pass
+// edition: 2021
+
+#![feature(type_alias_impl_trait)]
+
+struct Foo<'a>(&'a ());
+
+impl<'a> Foo<'a> {
+    async fn new() -> () {
+        type T = impl Sized;
+        let _: T = ();
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
An RPIT's or TAIT's own generics are kinda useless -- so just ignore them. For TAITs, they will always be empty, and for RPITs, they're always duplicated lifetimes.

Fixes #115013.