### PR TITLE
Avoid the path trimming ICE lint in error reporting

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -145,16 +145,12 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 assert!(dest.layout.is_sized());
                 assert_eq!(cast_ty, dest.layout.ty); // we otherwise ignore `cast_ty` enirely...
                 if src.layout.size != dest.layout.size {
-                    let src_bytes = src.layout.size.bytes();
-                    let dest_bytes = dest.layout.size.bytes();
-                    let src_ty = format!("{}", src.layout.ty);
-                    let dest_ty = format!("{}", dest.layout.ty);
                     throw_ub_custom!(
                         fluent::const_eval_invalid_transmute,
-                        src_bytes = src_bytes,
-                        dest_bytes = dest_bytes,
-                        src = src_ty,
-                        dest = dest_ty,
+                        src_bytes = src.layout.size.bytes(),
+                        dest_bytes = dest.layout.size.bytes(),
+                        src = src.layout.ty,
+                        dest = dest.layout.ty,
                     );
                 }
 


### PR DESCRIPTION
Types or really anything in MIR should never be formatted without path trimming disabled, because its formatting often tries to construct trimmed paths. In this case, the lint turns a nice error report into an irrelevant ICE.