### PR TITLE
Correctly handle nested or-patterns in exhaustiveness

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -931,7 +931,7 @@ impl<'p, 'tcx> PatternColumn<'p, 'tcx> {
             let specialized = pat.specialize(pcx, &ctor);
             for (subpat, column) in specialized.iter().zip(&mut specialized_columns) {
                 if subpat.is_or_pat() {
-                    column.patterns.extend(subpat.iter_fields())
+                    column.patterns.extend(subpat.flatten_or_pat())
                 } else {
                     column.patterns.push(subpat)
                 }

--- a/tests/ui/or-patterns/exhaustiveness-pass.rs
+++ b/tests/ui/or-patterns/exhaustiveness-pass.rs
@@ -35,4 +35,10 @@ fn main() {
         ((0, 0) | (1, 0),) => {}
         _ => {}
     }
+
+    // This one caused ICE https://github.com/rust-lang/rust/issues/117378
+    match (0u8, 0) {
+        (x @ 0 | x @ (1 | 2), _) => {}
+        (3.., _) => {}
+    }
 }


### PR DESCRIPTION
I had assumed nested or-patterns were flattened, and they mostly are but not always.

Fixes https://github.com/rust-lang/rust/issues/117378