### PR TITLE
Poison check_well_formed if method receivers are invalid to prevent typeck from running on it

### DIFF
--- a/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
@@ -1,0 +1,13 @@
+error[E0658]: `R` cannot be used as the type of `self` without the `arbitrary_self_types` feature
+  --> $DIR/arbitrary-self-from-method-substs.rs:8:43
+   |
+LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32 {
+   |                                           ^
+   |
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
+   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs.rs:14:5
+  --> $DIR/arbitrary-self-from-method-substs.rs:16:5
    |
 LL |     foo.get::<&Foo>();
    |     ^^^ expected `&Foo`, found `Foo`

--- a/tests/ui/self/arbitrary-self-from-method-substs.rs
+++ b/tests/ui/self/arbitrary-self-from-method-substs.rs
@@ -1,10 +1,12 @@
-#![feature(arbitrary_self_types)]
+// revisions: default feature
+#![cfg_attr(feature, feature(arbitrary_self_types))]
 
 use std::ops::Deref;
 
 struct Foo(u32);
 impl Foo {
-    fn get<R: Deref<Target=Self>>(self: R) -> u32 {
+    fn get<R: Deref<Target = Self>>(self: R) -> u32 {
+        //[default]~^ ERROR: `R` cannot be used as the type of `self`
         self.0
     }
 }
@@ -12,5 +14,5 @@ impl Foo {
 fn main() {
     let mut foo = Foo(1);
     foo.get::<&Foo>();
-    //~^ ERROR mismatched types
+    //[feature]~^ ERROR mismatched types
 }


### PR DESCRIPTION
fixes #117379

Though if some code invokes typeck without having first invoked `check_well_formed` then we'll encounter this ICE again. This can happen in const and const fn bodies if they are evaluated due to other `check_well_formed` checks or similar