### PR TITLE
Improve some diagnostics around `?Trait` bounds

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -96,7 +96,7 @@ pub struct CopyImplOnTypeWithDtor {
 #[diag(hir_analysis_multiple_relaxed_default_bounds, code = "E0203")]
 pub struct MultipleRelaxedDefaultBounds {
     #[primary_span]
-    pub span: Span,
+    pub spans: Vec<Span>,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/issues/issue-37534.rs
+++ b/tests/ui/issues/issue-37534.rs
@@ -1,6 +1,6 @@
-struct Foo<T: ?Hash> { }
+struct Foo<T: ?Hash> {}
 //~^ ERROR expected trait, found derive macro `Hash`
 //~^^ ERROR parameter `T` is never used
-//~^^^ WARN default bound relaxed for a type parameter, but this does nothing
+//~^^^ WARN relaxing a default bound only does something for `?Sized`
 
-fn main() { }
+fn main() {}

--- a/tests/ui/issues/issue-37534.stderr
+++ b/tests/ui/issues/issue-37534.stderr
@@ -1,7 +1,7 @@
 error[E0404]: expected trait, found derive macro `Hash`
   --> $DIR/issue-37534.rs:1:16
    |
-LL | struct Foo<T: ?Hash> { }
+LL | struct Foo<T: ?Hash> {}
    |                ^^^^ not a trait
    |
 help: consider importing this trait instead
@@ -9,16 +9,16 @@ help: consider importing this trait instead
 LL + use std::hash::Hash;
    |
 
-warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
-  --> $DIR/issue-37534.rs:1:12
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/issue-37534.rs:1:15
    |
-LL | struct Foo<T: ?Hash> { }
-   |            ^
+LL | struct Foo<T: ?Hash> {}
+   |               ^^^^^
 
 error[E0392]: parameter `T` is never used
   --> $DIR/issue-37534.rs:1:12
    |
-LL | struct Foo<T: ?Hash> { }
+LL | struct Foo<T: ?Hash> {}
    |            ^ unused parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`

--- a/tests/ui/issues/issue-87199.rs
+++ b/tests/ui/issues/issue-87199.rs
@@ -6,11 +6,11 @@
 
 // Check that these function definitions only emit warnings, not errors
 fn arg<T: ?Send>(_: T) {}
-//~^ warning: default bound relaxed for a type parameter, but this does nothing
+//~^ warning: relaxing a default bound only does something for `?Sized`
 fn ref_arg<T: ?Send>(_: &T) {}
-//~^ warning: default bound relaxed for a type parameter, but this does nothing
+//~^ warning: relaxing a default bound only does something for `?Sized`
 fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
-//~^ warning: default bound relaxed for a type parameter, but this does nothing
+//~^ warning: relaxing a default bound only does something for `?Sized`
 
 // Check that there's no `?Sized` relaxation!
 fn main() {

--- a/tests/ui/issues/issue-87199.stderr
+++ b/tests/ui/issues/issue-87199.stderr
@@ -1,20 +1,20 @@
-warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
-  --> $DIR/issue-87199.rs:8:8
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/issue-87199.rs:8:11
    |
 LL | fn arg<T: ?Send>(_: T) {}
-   |        ^
+   |           ^^^^^
 
-warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
-  --> $DIR/issue-87199.rs:10:12
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/issue-87199.rs:10:15
    |
 LL | fn ref_arg<T: ?Send>(_: &T) {}
-   |            ^
+   |               ^^^^^
 
-warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
-  --> $DIR/issue-87199.rs:12:13
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/issue-87199.rs:12:40
    |
 LL | fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                        ^^^^^
 
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
   --> $DIR/issue-87199.rs:18:15

--- a/tests/ui/unsized/maybe-bounds-where.rs
+++ b/tests/ui/unsized/maybe-bounds-where.rs
@@ -11,11 +11,11 @@ trait Trait<'a> {}
 
 struct S4<T>(T) where for<'a> T: ?Trait<'a>;
 //~^ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
-//~| WARN default bound relaxed for a type parameter
+//~| WARN relaxing a default bound only does something for `?Sized`
 
 struct S5<T>(*const T) where T: ?Trait<'static> + ?Sized;
 //~^ ERROR type parameter has more than one relaxed default bound
-//~| WARN default bound relaxed for a type parameter
+//~| WARN relaxing a default bound only does something for `?Sized`
 
 impl<T> S1<T> {
     fn f() where T: ?Sized {}

--- a/tests/ui/unsized/maybe-bounds-where.stderr
+++ b/tests/ui/unsized/maybe-bounds-where.stderr
@@ -28,23 +28,23 @@ error: `?Trait` bounds are only permitted at the point where a type parameter is
 LL |     fn f() where T: ?Sized {}
    |                     ^^^^^^
 
-warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
-  --> $DIR/maybe-bounds-where.rs:12:11
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/maybe-bounds-where.rs:12:34
    |
 LL | struct S4<T>(T) where for<'a> T: ?Trait<'a>;
-   |           ^
+   |                                  ^^^^^^^^^^
 
 error[E0203]: type parameter has more than one relaxed default bound, only one is supported
-  --> $DIR/maybe-bounds-where.rs:16:11
+  --> $DIR/maybe-bounds-where.rs:16:33
    |
 LL | struct S5<T>(*const T) where T: ?Trait<'static> + ?Sized;
-   |           ^
+   |                                 ^^^^^^^^^^^^^^^   ^^^^^^
 
-warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
-  --> $DIR/maybe-bounds-where.rs:16:11
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/maybe-bounds-where.rs:16:33
    |
 LL | struct S5<T>(*const T) where T: ?Trait<'static> + ?Sized;
-   |           ^
+   |                                 ^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors; 2 warnings emitted
 


### PR DESCRIPTION
* uses better spans
* clarifies a message that was only talking about generic params, but applies to `dyn ?Trait` and `impl ?Trait` as well