### PR TITLE
Don't normalize to an un-revealed opaque when we hit the recursion limit

### DIFF
--- a/tests/ui/type-alias-impl-trait/infinite-cycle-involving-weak.rs
+++ b/tests/ui/type-alias-impl-trait/infinite-cycle-involving-weak.rs
@@ -1,0 +1,8 @@
+#![feature(type_alias_impl_trait)]
+
+type T = impl Copy;
+//~^ ERROR cannot resolve opaque type
+
+static STATIC: T = None::<&'static T>;
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/infinite-cycle-involving-weak.stderr
+++ b/tests/ui/type-alias-impl-trait/infinite-cycle-involving-weak.stderr
@@ -1,0 +1,9 @@
+error[E0720]: cannot resolve opaque type
+  --> $DIR/infinite-cycle-involving-weak.rs:3:10
+   |
+LL | type T = impl Copy;
+   |          ^^^^^^^^^ cannot resolve opaque type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0720`.


### PR DESCRIPTION
Currently, we will normalize `Opaque := Option<&Opaque>` to something like `Option<&Option<&Option<&...Opaque>>>`, hitting a limit and bottoming out in an unnormalized opaque after the recursion limit gets hit.

Unfortunately, during `layout_of`, we'll simply recurse and try again if the type normalizes to something different than the type:
https://github.com/rust-lang/rust/blob/e6e931dda5fffbae0fd87c5b1af753cc95556880/compiler/rustc_ty_utils/src/layout.rs#L58-L60

That means then we'll try to normalize `Option<&Option<&Option<&...Opaque>>>` again, substituting `Opaque` into itself even deeper. Eventually this will get to the point that we're just stack-overflowing on a really deep type before even hitting an opaque again.

To fix this, we just bottom out into `ty::Error` instead of the unrevealed opaque type.

Fixes #117412

r? @oli-obk