### PR TITLE
Also consider TAIT to be uncomputable if the MIR body is tainted

### DIFF
--- a/tests/ui/type-alias-impl-trait/unconstrained-due-to-bad-pattern.rs
+++ b/tests/ui/type-alias-impl-trait/unconstrained-due-to-bad-pattern.rs
@@ -1,0 +1,14 @@
+#![feature(type_alias_impl_trait)]
+
+type Tait = impl Copy;
+// Make sure that this TAIT isn't considered unconstrained...
+
+fn empty_opaque() -> Tait {
+    if false {
+        match empty_opaque() {}
+        //~^ ERROR non-empty
+    }
+    0u8
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/unconstrained-due-to-bad-pattern.stderr
+++ b/tests/ui/type-alias-impl-trait/unconstrained-due-to-bad-pattern.stderr
@@ -1,0 +1,17 @@
+error[E0004]: non-exhaustive patterns: type `Tait` is non-empty
+  --> $DIR/unconstrained-due-to-bad-pattern.rs:8:15
+   |
+LL |         match empty_opaque() {}
+   |               ^^^^^^^^^^^^^^
+   |
+   = note: the matched value is of type `Tait`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~         match empty_opaque() {
+LL +             _ => todo!(),
+LL +         }
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
Not totally sure if this is the best solution. We could, alternatively, look at the hir typeck results and try to take a type from there instead of just falling back to type error, inferring `u8` instead of `{type error}`. Not certain it really matters, though.

Happy to iterate on this.

Fixes #117413

r? @oli-obk cc @Nadrieril 