### PR TITLE
Make `#![allow_internal_unstable(..)]` work with `stmt_expr_attributes`

### DIFF
--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -449,7 +449,9 @@ impl<'a> StripUnconfigured<'a> {
     /// If attributes are not allowed on expressions, emit an error for `attr`
     #[instrument(level = "trace", skip(self))]
     pub(crate) fn maybe_emit_expr_attr_err(&self, attr: &Attribute) {
-        if self.features.is_some_and(|features| !features.stmt_expr_attributes) {
+        if self.features.is_some_and(|features| !features.stmt_expr_attributes)
+            && !attr.span.allows_unstable(sym::stmt_expr_attributes)
+        {
             let mut err = feature_err(
                 &self.sess.parse_sess,
                 sym::stmt_expr_attributes,

--- a/tests/ui/internal/internal-unstable.rs
+++ b/tests/ui/internal/internal-unstable.rs
@@ -28,6 +28,14 @@ macro_rules! bar {
     }}
 }
 
+#[allow_internal_unstable(stmt_expr_attributes)]
+macro_rules! internal_attr {
+    ($e: expr) => {
+        #[allow(overflowing_literals)]
+        $e
+    }
+}
+
 fn main() {
     // ok, the instability is contained.
     call_unstable_allow!();
@@ -51,4 +59,6 @@ fn main() {
         #[allow_internal_unstable]
         _ => {}
     }
+
+    assert_eq!(internal_attr!(1e100_f32), f32::INFINITY);
 }

--- a/tests/ui/internal/internal-unstable.stderr
+++ b/tests/ui/internal/internal-unstable.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'function'
-  --> $DIR/internal-unstable.rs:40:25
+  --> $DIR/internal-unstable.rs:48:25
    |
 LL |     pass_through_allow!(internal_unstable::unstable());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     pass_through_allow!(internal_unstable::unstable());
    = help: add `#![feature(function)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'function'
-  --> $DIR/internal-unstable.rs:42:27
+  --> $DIR/internal-unstable.rs:50:27
    |
 LL |     pass_through_noallow!(internal_unstable::unstable());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     pass_through_noallow!(internal_unstable::unstable());
    = help: add `#![feature(function)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'function'
-  --> $DIR/internal-unstable.rs:46:22
+  --> $DIR/internal-unstable.rs:54:22
    |
 LL |     println!("{:?}", internal_unstable::unstable());
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     println!("{:?}", internal_unstable::unstable());
    = help: add `#![feature(function)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'function'
-  --> $DIR/internal-unstable.rs:48:10
+  --> $DIR/internal-unstable.rs:56:10
    |
 LL |     bar!(internal_unstable::unstable());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This is a necessary first step to fixing #117304, as explained in https://github.com/rust-lang/rust/issues/117304#issuecomment-1784414453.

@rustbot label T-compiler