### PR TITLE
Null terminate `core::panic::Location` file strings

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -126,6 +126,7 @@
 #![feature(const_caller_location)]
 #![feature(const_cell_into_inner)]
 #![feature(const_char_from_u32_unchecked)]
+#![feature(const_cstr_from_ptr)]
 #![feature(const_eval_select)]
 #![feature(const_exact_div)]
 #![feature(const_float_bits_conv)]


### PR DESCRIPTION
This shrinks `Location` by a usize, making it 24->16 bytes on x86-64. This reduces binary size. I quickly measure `cargo install ripgrep`, which was reduced by 0.3%. That's not a lot, but it's something and the code change is quite simple. From some quick measurements, I expect librustc_driver to shrink by more, but rustc-perf should give us more numbers.

The change to const interning is necessary, see https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/topic/unsupported.20untyped.20pointer.20in.20constant.20error/near/399446285