### PR TITLE
Improve `print_tts` by making `space_between` smarter

### DIFF
--- a/compiler/rustc_ast_pretty/src/lib.rs
+++ b/compiler/rustc_ast_pretty/src/lib.rs
@@ -5,6 +5,8 @@
 #![deny(rustc::diagnostic_outside_of_impl)]
 #![feature(associated_type_bounds)]
 #![feature(box_patterns)]
+#![feature(if_let_guard)]
+#![feature(let_chains)]
 #![feature(with_negative_coherence)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -302,6 +302,7 @@ symbols! {
         Saturating,
         Send,
         SeqCst,
+        Sized,
         SliceIndex,
         SliceIter,
         Some,

--- a/tests/pretty/ast-stmt-expr-attr.rs
+++ b/tests/pretty/ast-stmt-expr-attr.rs
@@ -113,11 +113,11 @@ fn syntax() {
     let _ = #[attr] continue;
     let _ = #[attr] return;
     let _ = #[attr] foo!();
-    let _ = #[attr] foo!(#! [attr]);
+    let _ = #[attr] foo!(# ![attr]);
     let _ = #[attr] foo![];
-    let _ = #[attr] foo![#! [attr]];
+    let _ = #[attr] foo![# ![attr]];
     let _ = #[attr] foo! {};
-    let _ = #[attr] foo! { #! [attr] };
+    let _ = #[attr] foo! { # ![attr] };
     let _ = #[attr] Foo { bar: baz };
     let _ = #[attr] Foo { ..foo };
     let _ = #[attr] Foo { bar: baz, ..foo };

--- a/tests/pretty/cast-lt.pp
+++ b/tests/pretty/cast-lt.pp
@@ -8,6 +8,6 @@ extern crate std;
 // pretty-mode:expanded
 // pp-exact:cast-lt.pp
 
-macro_rules! negative { ($e : expr) => { $e < 0 } }
+macro_rules! negative { ($e: expr) => { $e < 0 } }
 
 fn main() { (1 as i32) < 0; }

--- a/tests/pretty/delimited-token-groups.rs
+++ b/tests/pretty/delimited-token-groups.rs
@@ -2,14 +2,14 @@
 
 #![feature(rustc_attrs)]
 
-macro_rules! mac { ($($tt : tt) *) => () }
+macro_rules! mac { ($($tt: tt) *) => () }
 
 mac! {
-    struct S { field1 : u8, field2 : u16, } impl Clone for S
+    struct S { field1: u8, field2: u16, } impl Clone for S
     {
         fn clone() -> S
         {
-            panic! () ;
+            panic!();
 
         }
     }
@@ -17,8 +17,8 @@ mac! {
 
 mac! {
     a(aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
-    aaaaaaaa aaaaaaaa) a
-    [aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+    aaaaaaaa aaaaaaaa)
+    a[aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
     aaaaaaaa aaaaaaaa] a
     {
         aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa

--- a/tests/pretty/macro.rs
+++ b/tests/pretty/macro.rs
@@ -2,6 +2,6 @@
 
 #![feature(decl_macro)]
 
-pub(crate) macro mac { ($arg : expr) => { $arg + $arg } }
+pub(crate) macro mac { ($arg: expr) => { $arg + $arg } }
 
 fn main() {}

--- a/tests/pretty/macro_rules.rs
+++ b/tests/pretty/macro_rules.rs
@@ -1,19 +1,19 @@
 // pp-exact
 
-macro_rules! brace { () => {} ; }
+macro_rules! brace { () => {}; }
 
-macro_rules! bracket[() => {} ;];
+macro_rules! bracket[() => {};];
 
-macro_rules! paren(() => {} ;);
+macro_rules! paren(() => {};);
 
 macro_rules! matcher_brackets {
-    (paren) => {} ; (bracket) => {} ; (brace) => {} ;
+    (paren) => {}; (bracket) => {}; (brace) => {};
 }
 
 macro_rules! all_fragments {
-    ($b : block, $e : expr, $i : ident, $it : item, $l : lifetime, $lit :
-    literal, $m : meta, $p : pat, $pth : path, $s : stmt, $tt : tt, $ty : ty,
-    $vis : vis) => {} ;
+    ($b: block, $e: expr, $i: ident, $it: item, $l: lifetime, $lit: literal,
+    $m: meta, $p: pat, $pth: path, $s: stmt, $tt: tt, $ty: ty, $vis: vis) =>
+    {};
 }
 
 fn main() {}

--- a/tests/pretty/offset_of.rs
+++ b/tests/pretty/offset_of.rs
@@ -1,4 +1,4 @@
 // pp-exact
 #![feature(offset_of)]
 
-fn main() { std::mem::offset_of!(std :: ops :: Range < usize >, end); }
+fn main() { std::mem::offset_of!(std::ops::Range < usize > , end); }

--- a/tests/pretty/stmt_expr_attributes.rs
+++ b/tests/pretty/stmt_expr_attributes.rs
@@ -113,7 +113,7 @@ fn _8() {
 }
 
 fn _9() {
-    macro_rules! stmt_mac { () => { let _ = () ; } }
+    macro_rules! stmt_mac { () => { let _ = (); } }
 
     #[rustc_dummy]
     stmt_mac!();

--- a/tests/run-make/rustc-macro-dep-files/foo.rs
+++ b/tests/run-make/rustc-macro-dep-files/foo.rs
@@ -7,6 +7,6 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(A)]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
-    assert!(input.contains("struct A ;"));
+    assert!(input.contains("struct A;"));
     "struct B;".parse().unwrap()
 }

--- a/tests/ui/async-await/issues/issue-60674.stdout
+++ b/tests/ui/async-await/issues/issue-60674.stdout
@@ -1,3 +1,3 @@
-async fn f(mut x : u8) {}
-async fn g((mut x, y, mut z) : (u8, u8, u8)) {}
-async fn g(mut x : u8, (a, mut b, c) : (u8, u8, u8), y : u8) {}
+async fn f(mut x: u8) {}
+async fn g((mut x, y, mut z): (u8, u8, u8)) {}
+async fn g(mut x: u8, (a, mut b, c): (u8, u8, u8), y: u8) {}

--- a/tests/ui/hygiene/unpretty-debug.stdout
+++ b/tests/ui/hygiene/unpretty-debug.stdout
@@ -8,7 +8,7 @@
 #![feature /* 0#0 */(no_core)]
 #![no_core /* 0#0 */]
 
-macro_rules! foo /* 0#0 */ { ($x : ident) => { y + $x } }
+macro_rules! foo /* 0#0 */ { ($x: ident) => { y + $x } }
 
 fn bar /* 0#0 */() {
     let x /* 0#0 */ = 1;

--- a/tests/ui/infinite/issue-41731-infinite-macro-print.stderr
+++ b/tests/ui/infinite/issue-41731-infinite-macro-print.stderr
@@ -14,13 +14,13 @@ LL |     stack!("overflow");
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `stack! { "overflow" }`
-   = note: to `print! (stack! ("overflow")) ;`
-   = note: expanding `print! { stack! ("overflow") }`
-   = note: to `{ $crate :: io :: _print($crate :: format_args! (stack! ("overflow"))) ; }`
+   = note: to `print!(stack!("overflow"));`
+   = note: expanding `print! { stack!("overflow") }`
+   = note: to `{ $crate::io::_print($crate::format_args!(stack!("overflow"))); }`
    = note: expanding `stack! { "overflow" }`
-   = note: to `print! (stack! ("overflow")) ;`
-   = note: expanding `print! { stack! ("overflow") }`
-   = note: to `{ $crate :: io :: _print($crate :: format_args! (stack! ("overflow"))) ; }`
+   = note: to `print!(stack!("overflow"));`
+   = note: expanding `print! { stack!("overflow") }`
+   = note: to `{ $crate::io::_print($crate::format_args!(stack!("overflow"))); }`
 
 error: format argument must be a string literal
   --> $DIR/issue-41731-infinite-macro-print.rs:14:5

--- a/tests/ui/infinite/issue-41731-infinite-macro-println.stderr
+++ b/tests/ui/infinite/issue-41731-infinite-macro-println.stderr
@@ -14,13 +14,13 @@ LL |     stack!("overflow");
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `stack! { "overflow" }`
-   = note: to `println! (stack! ("overflow")) ;`
-   = note: expanding `println! { stack! ("overflow") }`
-   = note: to `{ $crate :: io :: _print($crate :: format_args_nl! (stack! ("overflow"))) ; }`
+   = note: to `println!(stack!("overflow"));`
+   = note: expanding `println! { stack!("overflow") }`
+   = note: to `{ $crate::io::_print($crate::format_args_nl!(stack!("overflow"))); }`
    = note: expanding `stack! { "overflow" }`
-   = note: to `println! (stack! ("overflow")) ;`
-   = note: expanding `println! { stack! ("overflow") }`
-   = note: to `{ $crate :: io :: _print($crate :: format_args_nl! (stack! ("overflow"))) ; }`
+   = note: to `println!(stack!("overflow"));`
+   = note: expanding `println! { stack!("overflow") }`
+   = note: to `{ $crate::io::_print($crate::format_args_nl!(stack!("overflow"))); }`
 
 error: format argument must be a string literal
   --> $DIR/issue-41731-infinite-macro-println.rs:14:5

--- a/tests/ui/macros/stringify.rs
+++ b/tests/ui/macros/stringify.rs
@@ -801,3 +801,32 @@ fn test_vis() {
     assert_eq!(inherited_vis!(struct), "");
     assert_eq!(stringify!(), "");
 }
+
+macro_rules! p {
+    ([$($tt:tt)*], $s:literal) => {
+        assert_eq!(stringify!($($tt)*), $s);
+    };
+}
+
+#[test]
+fn test_punct() {
+    // For all these cases, we must preserve spaces between the tokens.
+    // Otherwise, any old proc macro that parses pretty-printed code might glue
+    // together tokens that shouldn't be glued.
+    p!([ = = < < <= <= == == != != >= >= > > ], "= = < < <= <= == == != != >= >= > >");
+    p!([ && && & & || || | | ! ! ], "&& && & & || || | |!!"); // FIXME
+    p!([ ~ ~ @ @ # # ], "~ ~ @ @ # #");
+    p!([ . . .. .. ... ... ..= ..=], ".... .. ... ... ..= ..="); // FIXME
+    p!([ , , ; ; : : :: :: ], ",, ; ; : : :: ::"); // FIXME
+    p!([ -> -> <- <- => =>], "-> -> <- <- => =>");
+    p!([ $ $ ? ? ' ' ], "$$? ? ' '"); // FIXME
+    p!([ + + += += - - -= -= * * *= *= / / /= /= ], "+ + += += - - -= -= * * *= *= / / /= /=");
+    p!([ % % %= %= ^ ^ ^= ^= << << <<= <<= >> >> >>= >>= ],
+        "% % %= %= ^ ^ ^= ^= << << <<= <<= >> >> >>= >>=");
+
+    // For these one we must insert spaces between adjacent tokens, again due
+    // to proc macros.
+    p!([ +! ?= |> >>@ --> <-- $$ =====> ], "+! ? = | > >> @ - -> <- - $$== == =>"); // FIXME
+    p!([ ,; ;, ** @@ $+$ >< <> ?? +== ], ", ; ;, * * @ @ $+ $> < < > ? ? += ="); // FIXME
+    p!([ :#!@|$=&*,+;*~? ], ": #! @ | $= & *, + ; * ~ ?"); // FIXME
+}

--- a/tests/ui/macros/stringify.rs
+++ b/tests/ui/macros/stringify.rs
@@ -58,19 +58,13 @@ fn test_block() {
     c1!(block, [ {} ], "{}");
     c1!(block, [ { true } ], "{ true }");
     c1!(block, [ { return } ], "{ return }");
-    c2!(block, [ {
-            return;
-        } ],
-        "{ return; }",
-        "{ return ; }"
-    );
-    c2!(block,
+    c1!(block, [ { return; } ], "{ return; }");
+    c1!(block,
         [ {
             let _;
             true
         } ],
-        "{ let _; true }",
-        "{ let _ ; true }"
+        "{ let _; true }"
     );
 }
 
@@ -87,17 +81,17 @@ fn test_expr() {
 
     // ExprKind::Call
     c1!(expr, [ f() ], "f()");
-    c2!(expr, [ f::<u8>() ], "f::<u8>()", "f :: < u8 > ()");
-    c2!(expr, [ f::<1>() ], "f::<1>()", "f :: < 1 > ()");
-    c2!(expr, [ f::<'a, u8, 1>() ], "f::<'a, u8, 1>()", "f :: < 'a, u8, 1 > ()");
+    c2!(expr, [ f::<u8>() ], "f::<u8>()", "f:: < u8 >()");
+    c2!(expr, [ f::<1>() ], "f::<1>()", "f:: < 1 >()");
+    c2!(expr, [ f::<'a, u8, 1>() ], "f::<'a, u8, 1>()", "f:: < 'a, u8, 1 >()");
     c1!(expr, [ f(true) ], "f(true)");
     c2!(expr, [ f(true,) ], "f(true)", "f(true,)");
     c2!(expr, [ ()() ], "()()", "() ()");
 
     // ExprKind::MethodCall
     c1!(expr, [ x.f() ], "x.f()");
-    c2!(expr, [ x.f::<u8>() ], "x.f::<u8>()", "x.f :: < u8 > ()");
-    c2!(expr, [ x.collect::<Vec<_>>() ], "x.collect::<Vec<_>>()", "x.collect :: < Vec < _ >> ()");
+    c2!(expr, [ x.f::<u8>() ], "x.f::<u8>()", "x.f:: < u8 >()");
+    c2!(expr, [ x.collect::<Vec<_>>() ], "x.collect::<Vec<_>>()", "x.collect:: < Vec < _ >>()");
 
     // ExprKind::Tup
     c1!(expr, [ () ], "()");
@@ -109,17 +103,17 @@ fn test_expr() {
     c1!(expr, [ true || false ], "true || false");
     c1!(expr, [ true || false && false ], "true || false && false");
     c1!(expr, [ a < 1 && 2 < b && c > 3 && 4 > d ], "a < 1 && 2 < b && c > 3 && 4 > d");
-    c2!(expr, [ a & b & !c ], "a & b & !c", "a & b &! c"); // FIXME
+    c1!(expr, [ a & b & !c ], "a & b & !c");
     c2!(expr,
         [ a + b * c - d + -1 * -2 - -3],
         "a + b * c - d + -1 * -2 - -3",
         "a + b * c - d + - 1 * - 2 - - 3"
     );
-    c2!(expr, [ x = !y ], "x = !y", "x =! y"); // FIXME
+    c1!(expr, [ x = !y ], "x = !y");
 
     // ExprKind::Unary
     c2!(expr, [ *expr ], "*expr", "* expr");
-    c2!(expr, [ !expr ], "!expr", "! expr");
+    c1!(expr, [ !expr ], "!expr");
     c2!(expr, [ -expr ], "-expr", "- expr");
 
     // ExprKind::Lit
@@ -138,11 +132,10 @@ fn test_expr() {
 
     // ExprKind::If
     c1!(expr, [ if true {} ], "if true {}");
-    c2!(expr, [ if !true {} ], "if !true {}", "if! true {}"); // FIXME
-    c2!(expr,
+    c1!(expr, [ if !true {} ], "if !true {}");
+    c1!(expr,
         [ if ::std::blah() { } else { } ],
-        "if ::std::blah() {} else {}",
-        "if :: std :: blah() {} else {}"
+        "if ::std::blah() {} else {}"
     );
     c1!(expr, [ if let true = true {} else {} ], "if let true = true {} else {}");
     c1!(expr,
@@ -158,7 +151,7 @@ fn test_expr() {
         } ],
         "if true {} else if false {} else {}"
     );
-    c2!(expr,
+    c1!(expr,
         [ if true {
             return;
         } else if false {
@@ -166,22 +159,21 @@ fn test_expr() {
         } else {
             0
         } ],
-        "if true { return; } else if false { 0 } else { 0 }",
-        "if true { return ; } else if false { 0 } else { 0 }"
+        "if true { return; } else if false { 0 } else { 0 }"
     );
 
     // ExprKind::While
     c1!(expr, [ while true {} ], "while true {}");
-    c2!(expr, [ 'a: while true {} ], "'a: while true {}", "'a : while true {}");
+    c1!(expr, [ 'a: while true {} ], "'a: while true {}");
     c1!(expr, [ while let true = true {} ], "while let true = true {}");
 
     // ExprKind::ForLoop
     c1!(expr, [ for _ in x {} ], "for _ in x {}");
-    c2!(expr, [ 'a: for _ in x {} ], "'a: for _ in x {}", "'a : for _ in x {}");
+    c1!(expr, [ 'a: for _ in x {} ], "'a: for _ in x {}");
 
     // ExprKind::Loop
     c1!(expr, [ loop {} ], "loop {}");
-    c2!(expr, [ 'a: loop {} ], "'a: loop {}", "'a : loop {}");
+    c1!(expr, [ 'a: loop {} ], "'a: loop {}");
 
     // ExprKind::Match
     c1!(expr, [ match self {} ], "match self {}");
@@ -202,7 +194,7 @@ fn test_expr() {
     // ExprKind::Closure
     c1!(expr, [ || {} ], "|| {}");
     c2!(expr, [ |x| {} ], "|x| {}", "| x | {}");
-    c2!(expr, [ |x: u8| {} ], "|x: u8| {}", "| x : u8 | {}");
+    c2!(expr, [ |x: u8| {} ], "|x: u8| {}", "| x: u8 | {}");
     c1!(expr, [ || () ], "|| ()");
     c1!(expr, [ move || self ], "move || self");
     c1!(expr, [ async || self ], "async || self");
@@ -217,7 +209,7 @@ fn test_expr() {
     // ExprKind::Block
     c1!(expr, [ {} ], "{}");
     c1!(expr, [ unsafe {} ], "unsafe {}");
-    c2!(expr, [ 'a: {} ], "'a: {}", "'a : {}");
+    c1!(expr, [ 'a: {} ], "'a: {}");
     c1!(expr, [ #[attr] {} ], "#[attr] {}");
     c2!(expr,
         [
@@ -228,7 +220,7 @@ fn test_expr() {
         "{\n\
         \x20   #![attr]\n\
         }",
-        "{ #! [attr] }"
+        "{ # ![attr] }"
     );
 
     // ExprKind::Async
@@ -252,7 +244,7 @@ fn test_expr() {
     c1!(expr, [ expr.0 ], "expr.0");
 
     // ExprKind::Index
-    c2!(expr, [ expr[true] ], "expr[true]", "expr [true]");
+    c1!(expr, [ expr[true] ], "expr[true]");
 
     // ExprKind::Range
     c1!(expr, [ .. ], "..");
@@ -268,12 +260,12 @@ fn test_expr() {
 
     // ExprKind::Path
     c1!(expr, [ thing ], "thing");
-    c2!(expr, [ m::thing ], "m::thing", "m :: thing");
-    c2!(expr, [ self::thing ], "self::thing", "self :: thing");
-    c2!(expr, [ crate::thing ], "crate::thing", "crate :: thing");
-    c2!(expr, [ Self::thing ], "Self::thing", "Self :: thing");
-    c2!(expr, [ <Self as T>::thing ], "<Self as T>::thing", "< Self as T > :: thing");
-    c2!(expr, [ Self::<'static> ], "Self::<'static>", "Self :: < 'static >");
+    c1!(expr, [ m::thing ], "m::thing");
+    c1!(expr, [ self::thing ], "self::thing");
+    c1!(expr, [ crate::thing ], "crate::thing");
+    c1!(expr, [ Self::thing ], "Self::thing");
+    c2!(expr, [ <Self as T>::thing ], "<Self as T>::thing", "< Self as T > ::thing");
+    c2!(expr, [ Self::<'static> ], "Self::<'static>", "Self:: < 'static >");
 
     // ExprKind::AddrOf
     c2!(expr, [ &expr ], "&expr", "& expr");
@@ -300,8 +292,8 @@ fn test_expr() {
     // ExprKind::OffsetOf: untestable because this test works pre-expansion.
 
     // ExprKind::MacCall
-    c2!(expr, [ mac!(...) ], "mac!(...)", "mac! (...)");
-    c2!(expr, [ mac![...] ], "mac![...]", "mac! [...]");
+    c1!(expr, [ mac!(...) ], "mac!(...)");
+    c1!(expr, [ mac![...] ], "mac![...]");
     c1!(expr, [ mac! { ... } ], "mac! { ... }");
 
     // ExprKind::Struct
@@ -309,23 +301,23 @@ fn test_expr() {
     c2!(expr,
         [ <Struct as Trait>::Type {} ],
         "<Struct as Trait>::Type {}",
-        "< Struct as Trait > :: Type {}"
+        "< Struct as Trait > ::Type {}"
     );
     c1!(expr, [ Struct { .. } ], "Struct { .. }");
     c2!(expr, [ Struct { ..base } ], "Struct { ..base }", "Struct { .. base }");
     c1!(expr, [ Struct { x } ], "Struct { x }");
     c1!(expr, [ Struct { x, .. } ], "Struct { x, .. }");
     c2!(expr, [ Struct { x, ..base } ], "Struct { x, ..base }", "Struct { x, .. base }");
-    c2!(expr, [ Struct { x: true } ], "Struct { x: true }", "Struct { x : true }");
-    c2!(expr, [ Struct { x: true, .. } ], "Struct { x: true, .. }", "Struct { x : true, .. }");
+    c1!(expr, [ Struct { x: true } ], "Struct { x: true }");
+    c1!(expr, [ Struct { x: true, .. } ], "Struct { x: true, .. }");
     c2!(expr,
         [ Struct { x: true, ..base } ],
         "Struct { x: true, ..base }",
-        "Struct { x : true, .. base }"
+        "Struct { x: true, .. base }"
     );
 
     // ExprKind::Repeat
-    c2!(expr, [ [(); 0] ], "[(); 0]", "[() ; 0]");
+    c1!(expr, [ [(); 0] ], "[(); 0]");
 
     // ExprKind::Paren
     c1!(expr, [ (expr) ], "(expr)");
@@ -355,30 +347,29 @@ fn test_expr() {
 #[test]
 fn test_item() {
     // ItemKind::ExternCrate
-    c2!(item, [ extern crate std; ], "extern crate std;", "extern crate std ;");
-    c2!(item,
+    c1!(item, [ extern crate std; ], "extern crate std;");
+    c1!(item,
         [ pub extern crate self as std; ],
-        "pub extern crate self as std;",
-        "pub extern crate self as std ;"
+        "pub extern crate self as std;"
     );
 
     // ItemKind::Use
     c2!(item,
         [ pub use crate::{a, b::c}; ],
         "pub use crate::{a, b::c};",
-        "pub use crate :: { a, b :: c } ;"
+        "pub use crate::{ a, b::c };"
     );
-    c2!(item, [ pub use A::*; ], "pub use A::*;", "pub use A :: * ;");
+    c2!(item, [ pub use A::*; ], "pub use A::*;", "pub use A:: * ;");
 
     // ItemKind::Static
-    c2!(item, [ pub static S: () = {}; ], "pub static S: () = {};", "pub static S : () = {} ;");
-    c2!(item, [ static mut S: () = {}; ], "static mut S: () = {};", "static mut S : () = {} ;");
-    c2!(item, [ static S: (); ], "static S: ();", "static S : () ;");
-    c2!(item, [ static mut S: (); ], "static mut S: ();", "static mut S : () ;");
+    c1!(item, [ pub static S: () = {}; ], "pub static S: () = {};");
+    c1!(item, [ static mut S: () = {}; ], "static mut S: () = {};");
+    c1!(item, [ static S: (); ], "static S: ();");
+    c1!(item, [ static mut S: (); ], "static mut S: ();");
 
     // ItemKind::Const
-    c2!(item, [ pub const S: () = {}; ], "pub const S: () = {};", "pub const S : () = {} ;");
-    c2!(item, [ const S: (); ], "const S: ();", "const S : () ;");
+    c1!(item, [ pub const S: () = {}; ], "pub const S: () = {};");
+    c1!(item, [ const S: (); ], "const S: ();");
 
     // ItemKind::Fn
     c1!(item,
@@ -388,18 +379,18 @@ fn test_item() {
     c2!(item,
         [ fn g<T>(t: Vec<Vec<Vec<T>>>) {} ],
         "fn g<T>(t: Vec<Vec<Vec<T>>>) {}",
-        "fn g < T > (t : Vec < Vec < Vec < T >> >) {}"
+        "fn g< T >(t: Vec < Vec < Vec < T >> >) {}"
     );
     c2!(item,
         [ fn h<'a>(t: &'a Vec<Cell<dyn D>>) {} ],
         "fn h<'a>(t: &'a Vec<Cell<dyn D>>) {}",
-        "fn h < 'a > (t : & 'a Vec < Cell < dyn D >>) {}"
+        "fn h< 'a >(t: & 'a Vec < Cell < dyn D >>) {}"
     );
 
     // ItemKind::Mod
-    c2!(item, [ pub mod m; ], "pub mod m;", "pub mod m ;");
+    c1!(item, [ pub mod m; ], "pub mod m;");
     c1!(item, [ mod m {} ], "mod m {}");
-    c2!(item, [ unsafe mod m; ], "unsafe mod m;", "unsafe mod m ;");
+    c1!(item, [ unsafe mod m; ], "unsafe mod m;");
     c1!(item, [ unsafe mod m {} ], "unsafe mod m {}");
 
     // ItemKind::ForeignMod
@@ -422,7 +413,7 @@ fn test_item() {
             = T;
         ],
         "pub default type Type<'a>: Bound where Self: 'a = T;",
-        "pub default type Type < 'a > : Bound where Self : 'a, = T ;"
+        "pub default type Type < 'a > : Bound where Self: 'a, = T;"
     );
 
     // ItemKind::Enum
@@ -455,13 +446,13 @@ fn test_item() {
         \x20       t: T,\n\
         \x20   },\n\
         }",
-        "enum Enum < T > where T : 'a, { Unit, Tuple(T), Struct { t : T }, }"
+        "enum Enum < T > where T: 'a, { Unit, Tuple(T), Struct { t: T }, }"
     );
 
     // ItemKind::Struct
-    c2!(item, [ pub struct Unit; ], "pub struct Unit;", "pub struct Unit ;");
-    c2!(item, [ struct Tuple(); ], "struct Tuple();", "struct Tuple() ;");
-    c2!(item, [ struct Tuple(T); ], "struct Tuple(T);", "struct Tuple(T) ;");
+    c1!(item, [ pub struct Unit; ], "pub struct Unit;");
+    c1!(item, [ struct Tuple(); ], "struct Tuple();");
+    c1!(item, [ struct Tuple(T); ], "struct Tuple(T);");
     c1!(item, [ struct Struct {} ], "struct Struct {}");
     c2!(item,
         [
@@ -475,7 +466,7 @@ fn test_item() {
         "struct Struct<T> where T: 'a {\n\
         \x20   t: T,\n\
         }",
-        "struct Struct < T > where T : 'a, { t : T, }"
+        "struct Struct < T > where T: 'a, { t: T, }"
     );
 
     // ItemKind::Union
@@ -489,7 +480,7 @@ fn test_item() {
         "union Union<T> where T: 'a {\n\
         \x20   t: T,\n\
         }",
-        "union Union < T > where T : 'a { t : T, }"
+        "union Union < T > where T: 'a { t: T, }"
     );
 
     // ItemKind::Trait
@@ -503,30 +494,30 @@ fn test_item() {
             }
         ],
         "trait Trait<'a>: Sized where Self: 'a {}",
-        "trait Trait < 'a > : Sized where Self : 'a, {}"
+        "trait Trait < 'a > : Sized where Self: 'a, {}"
     );
 
     // ItemKind::TraitAlias
     c2!(item,
         [ pub trait Trait<T> = Sized where T: 'a; ],
         "pub trait Trait<T> = Sized where T: 'a;",
-        "pub trait Trait < T > = Sized where T : 'a ;"
+        "pub trait Trait < T > = Sized where T: 'a;"
     );
 
     // ItemKind::Impl
     c1!(item, [ pub impl Struct {} ], "pub impl Struct {}");
-    c2!(item, [ impl<T> Struct<T> {} ], "impl<T> Struct<T> {}", "impl < T > Struct < T > {}");
+    c2!(item, [ impl<T> Struct<T> {} ], "impl<T> Struct<T> {}", "impl< T > Struct < T > {}");
     c1!(item, [ pub impl Trait for Struct {} ], "pub impl Trait for Struct {}");
     c2!(item,
         [ impl<T> const Trait for T {} ],
         "impl<T> const Trait for T {}",
-        "impl < T > const Trait for T {}"
+        "impl< T > const Trait for T {}"
     );
-    c2!(item, [ impl ~const Struct {} ], "impl ~const Struct {}", "impl ~ const Struct {}");
+    c1!(item, [ impl ~const Struct {} ], "impl ~const Struct {}");
 
     // ItemKind::MacCall
-    c2!(item, [ mac!(...); ], "mac!(...);", "mac! (...) ;");
-    c2!(item, [ mac![...]; ], "mac![...];", "mac! [...] ;");
+    c1!(item, [ mac!(...); ], "mac!(...);");
+    c1!(item, [ mac![...]; ], "mac![...];");
     c1!(item, [ mac! { ... } ], "mac! { ... }");
 
     // ItemKind::MacroDef
@@ -536,7 +527,7 @@ fn test_item() {
                 () => {};
             }
         ],
-        "macro_rules! stringify { () => {} ; }"
+        "macro_rules! stringify { () => {}; }"
     );
     c2!(item,
         [ pub macro stringify() {} ],
@@ -550,7 +541,7 @@ fn test_meta() {
     c1!(meta, [ k ], "k");
     c1!(meta, [ k = "v" ], "k = \"v\"");
     c1!(meta, [ list(k1, k2 = "v") ], "list(k1, k2 = \"v\")");
-    c2!(meta, [ serde::k ], "serde::k", "serde :: k");
+    c1!(meta, [ serde::k ], "serde::k");
 }
 
 #[test]
@@ -567,30 +558,30 @@ fn test_pat() {
 
     // PatKind::Struct
     c1!(pat, [ Struct {} ], "Struct {}");
-    c2!(pat, [ Struct::<u8> {} ], "Struct::<u8> {}", "Struct :: < u8 > {}");
-    c2!(pat, [ Struct::<'static> {} ], "Struct::<'static> {}", "Struct :: < 'static > {}");
+    c2!(pat, [ Struct::<u8> {} ], "Struct::<u8> {}", "Struct:: < u8 > {}");
+    c2!(pat, [ Struct::<'static> {} ], "Struct::<'static> {}", "Struct:: < 'static > {}");
     c1!(pat, [ Struct { x } ], "Struct { x }");
-    c2!(pat, [ Struct { x: _x } ], "Struct { x: _x }", "Struct { x : _x }");
+    c1!(pat, [ Struct { x: _x } ], "Struct { x: _x }");
     c1!(pat, [ Struct { .. } ], "Struct { .. }");
     c1!(pat, [ Struct { x, .. } ], "Struct { x, .. }");
-    c2!(pat, [ Struct { x: _x, .. } ], "Struct { x: _x, .. }", "Struct { x : _x, .. }");
+    c1!(pat, [ Struct { x: _x, .. } ], "Struct { x: _x, .. }");
     c2!(pat,
         [ <Struct as Trait>::Type {} ],
         "<Struct as Trait>::Type {}",
-        "< Struct as Trait > :: Type {}"
+        "< Struct as Trait > ::Type {}"
     );
 
     // PatKind::TupleStruct
     c1!(pat, [ Tuple() ], "Tuple()");
-    c2!(pat, [ Tuple::<u8>() ], "Tuple::<u8>()", "Tuple :: < u8 > ()");
-    c2!(pat, [ Tuple::<'static>() ], "Tuple::<'static>()", "Tuple :: < 'static > ()");
+    c2!(pat, [ Tuple::<u8>() ], "Tuple::<u8>()", "Tuple:: < u8 >()");
+    c2!(pat, [ Tuple::<'static>() ], "Tuple::<'static>()", "Tuple:: < 'static >()");
     c1!(pat, [ Tuple(x) ], "Tuple(x)");
     c1!(pat, [ Tuple(..) ], "Tuple(..)");
     c1!(pat, [ Tuple(x, ..) ], "Tuple(x, ..)");
     c2!(pat,
         [ <Struct as Trait>::Type() ],
         "<Struct as Trait>::Type()",
-        "< Struct as Trait > :: Type()"
+        "< Struct as Trait > ::Type()"
     );
 
     // PatKind::Or
@@ -599,10 +590,10 @@ fn test_pat() {
     c2!(pat, [ |true| false ], "true | false", "| true | false");
 
     // PatKind::Path
-    c2!(pat, [ crate::Path ], "crate::Path", "crate :: Path");
-    c2!(pat, [ Path::<u8> ], "Path::<u8>", "Path :: < u8 >");
-    c2!(pat, [ Path::<'static> ], "Path::<'static>", "Path :: < 'static >");
-    c2!(pat, [ <Struct as Trait>::Type ], "<Struct as Trait>::Type", "< Struct as Trait > :: Type");
+    c1!(pat, [ crate::Path ], "crate::Path");
+    c2!(pat, [ Path::<u8> ], "Path::<u8>", "Path:: < u8 >");
+    c2!(pat, [ Path::<'static> ], "Path::<'static>", "Path:: < 'static >");
+    c2!(pat, [ <Struct as Trait>::Type ], "<Struct as Trait>::Type", "< Struct as Trait > ::Type");
 
     // PatKind::Tuple
     c1!(pat, [ () ], "()");
@@ -639,20 +630,20 @@ fn test_pat() {
     c1!(pat, [ (pat) ], "(pat)");
 
     // PatKind::MacCall
-    c2!(pat, [ mac!(...) ], "mac!(...)", "mac! (...)");
-    c2!(pat, [ mac![...] ], "mac![...]", "mac! [...]");
+    c1!(pat, [ mac!(...) ], "mac!(...)");
+    c1!(pat, [ mac![...] ], "mac![...]");
     c1!(pat, [ mac! { ... } ], "mac! { ... }");
 }
 
 #[test]
 fn test_path() {
     c1!(path, [ thing ], "thing");
-    c2!(path, [ m::thing ], "m::thing", "m :: thing");
-    c2!(path, [ self::thing ], "self::thing", "self :: thing");
-    c2!(path, [ crate::thing ], "crate::thing", "crate :: thing");
-    c2!(path, [ Self::thing ], "Self::thing", "Self :: thing");
+    c1!(path, [ m::thing ], "m::thing");
+    c1!(path, [ self::thing ], "self::thing");
+    c1!(path, [ crate::thing ], "crate::thing");
+    c1!(path, [ Self::thing ], "Self::thing");
     c2!(path, [ Self<'static> ], "Self<'static>", "Self < 'static >");
-    c2!(path, [ Self::<'static> ], "Self<'static>", "Self :: < 'static >");
+    c2!(path, [ Self::<'static> ], "Self<'static>", "Self:: < 'static >");
     c1!(path, [ Self() ], "Self()");
     c1!(path, [ Self() -> () ], "Self() -> ()");
 }
@@ -662,16 +653,16 @@ fn test_stmt() {
     // StmtKind::Local
     c2!(stmt, [ let _ ], "let _;", "let _");
     c2!(stmt, [ let x = true ], "let x = true;", "let x = true");
-    c2!(stmt, [ let x: bool = true ], "let x: bool = true;", "let x : bool = true");
-    c2!(stmt, [ let (a, b) = (1, 2) ], "let (a, b) = (1, 2);", "let(a, b) = (1, 2)"); // FIXME
+    c2!(stmt, [ let x: bool = true ], "let x: bool = true;", "let x: bool = true");
+    c2!(stmt, [ let (a, b) = (1, 2) ], "let (a, b) = (1, 2);", "let (a, b) = (1, 2)");
     c2!(stmt,
         [ let (a, b): (u32, u32) = (1, 2) ],
         "let (a, b): (u32, u32) = (1, 2);",
-        "let(a, b) : (u32, u32) = (1, 2)"
+        "let (a, b): (u32, u32) = (1, 2)"
     );
 
     // StmtKind::Item
-    c2!(stmt, [ struct S; ], "struct S;", "struct S ;");
+    c1!(stmt, [ struct S; ], "struct S;");
     c1!(stmt, [ struct S {} ], "struct S {}");
 
     // StmtKind::Expr
@@ -684,8 +675,8 @@ fn test_stmt() {
     c1!(stmt, [ ; ], ";");
 
     // StmtKind::MacCall
-    c2!(stmt, [ mac!(...) ], "mac!(...)", "mac! (...)");
-    c2!(stmt, [ mac![...] ], "mac![...]", "mac! [...]");
+    c1!(stmt, [ mac!(...) ], "mac!(...)");
+    c1!(stmt, [ mac![...] ], "mac![...]");
     c1!(stmt, [ mac! { ... } ], "mac! { ... }");
 }
 
@@ -695,7 +686,7 @@ fn test_ty() {
     c1!(ty, [ [T] ], "[T]");
 
     // TyKind::Array
-    c2!(ty, [ [T; 0] ], "[T; 0]", "[T ; 0]");
+    c1!(ty, [ [T; 0] ], "[T; 0]");
 
     // TyKind::Ptr
     c2!(ty, [ *const T ], "*const T", "* const T");
@@ -712,9 +703,9 @@ fn test_ty() {
     c1!(ty, [ fn() ], "fn()");
     c1!(ty, [ fn() -> () ], "fn() -> ()");
     c1!(ty, [ fn(u8) ], "fn(u8)");
-    c2!(ty, [ fn(x: u8) ], "fn(x: u8)", "fn(x : u8)");
-    c2!(ty, [ for<> fn() ], "fn()", "for < > fn()");
-    c2!(ty, [ for<'a> fn() ], "for<'a> fn()", "for < 'a > fn()");
+    c1!(ty, [ fn(x: u8) ], "fn(x: u8)");
+    c2!(ty, [ for<> fn() ], "fn()", "for< > fn()");
+    c2!(ty, [ for<'a> fn() ], "for<'a> fn()", "for< 'a > fn()");
 
     // TyKind::Never
     c1!(ty, [ ! ], "!");
@@ -732,26 +723,26 @@ fn test_ty() {
     c1!(ty, [ T ], "T");
     c2!(ty, [ Ref<'a> ], "Ref<'a>", "Ref < 'a >");
     c2!(ty, [ PhantomData<T> ], "PhantomData<T>", "PhantomData < T >");
-    c2!(ty, [ PhantomData::<T> ], "PhantomData<T>", "PhantomData :: < T >");
-    c2!(ty, [ Fn() -> ! ], "Fn() -> !", "Fn() ->!");
-    c2!(ty, [ Fn(u8) -> ! ], "Fn(u8) -> !", "Fn(u8) ->!"); // FIXME
-    c2!(ty, [ <Struct as Trait>::Type ], "<Struct as Trait>::Type", "< Struct as Trait > :: Type");
+    c2!(ty, [ PhantomData::<T> ], "PhantomData<T>", "PhantomData:: < T >");
+    c1!(ty, [ Fn() -> ! ], "Fn() -> !");
+    c1!(ty, [ Fn(u8) -> ! ], "Fn(u8) -> !");
+    c2!(ty, [ <Struct as Trait>::Type ], "<Struct as Trait>::Type", "< Struct as Trait > ::Type");
 
     // TyKind::TraitObject
     c1!(ty, [ dyn Send ], "dyn Send");
     c1!(ty, [ dyn Send + 'a ], "dyn Send + 'a");
     c1!(ty, [ dyn 'a + Send ], "dyn 'a + Send");
-    c2!(ty, [ dyn ?Sized ], "dyn ?Sized", "dyn ? Sized");
-    c2!(ty, [ dyn ~const Clone ], "dyn ~const Clone", "dyn ~ const Clone");
-    c2!(ty, [ dyn for<'a> Send ], "dyn for<'a> Send", "dyn for < 'a > Send");
+    c1!(ty, [ dyn ?Sized ], "dyn ?Sized");
+    c1!(ty, [ dyn ~const Clone ], "dyn ~const Clone");
+    c2!(ty, [ dyn for<'a> Send ], "dyn for<'a> Send", "dyn for< 'a > Send");
 
     // TyKind::ImplTrait
     c1!(ty, [ impl Send ], "impl Send");
     c1!(ty, [ impl Send + 'a ], "impl Send + 'a");
     c1!(ty, [ impl 'a + Send ], "impl 'a + Send");
-    c2!(ty, [ impl ?Sized ], "impl ?Sized", "impl ? Sized");
-    c2!(ty, [ impl ~const Clone ], "impl ~const Clone", "impl ~ const Clone");
-    c2!(ty, [ impl for<'a> Send ], "impl for<'a> Send", "impl for < 'a > Send");
+    c1!(ty, [ impl ?Sized ], "impl ?Sized");
+    c1!(ty, [ impl ~const Clone ], "impl ~const Clone");
+    c2!(ty, [ impl for<'a> Send ], "impl for<'a> Send", "impl for< 'a > Send");
 
     // TyKind::Paren
     c1!(ty, [ (T) ], "(T)");
@@ -764,8 +755,8 @@ fn test_ty() {
     // TyKind::ImplicitSelf: there is no syntax for this.
 
     // TyKind::MacCall
-    c2!(ty, [ mac!(...) ], "mac!(...)", "mac! (...)");
-    c2!(ty, [ mac![...] ], "mac![...]", "mac! [...]");
+    c1!(ty, [ mac!(...) ], "mac!(...)");
+    c1!(ty, [ mac![...] ], "mac![...]");
     c1!(ty, [ mac! { ... } ], "mac! { ... }");
 
     // TyKind::Err: untestable.
@@ -786,13 +777,13 @@ fn test_vis() {
     c2!(vis, [ pub(in crate) ], "pub(in crate) ", "pub(in crate)");
     c2!(vis, [ pub(in self) ], "pub(in self) ", "pub(in self)");
     c2!(vis, [ pub(in super) ], "pub(in super) ", "pub(in super)");
-    c2!(vis, [ pub(in path::to) ], "pub(in path::to) ", "pub(in path :: to)");
-    c2!(vis, [ pub(in ::path::to) ], "pub(in ::path::to) ", "pub(in :: path :: to)");
-    c2!(vis, [ pub(in self::path::to) ], "pub(in self::path::to) ", "pub(in self :: path :: to)");
+    c2!(vis, [ pub(in path::to) ], "pub(in path::to) ", "pub(in path::to)");
+    c2!(vis, [ pub(in ::path::to) ], "pub(in ::path::to) ", "pub(in ::path::to)");
+    c2!(vis, [ pub(in self::path::to) ], "pub(in self::path::to) ", "pub(in self::path::to)");
     c2!(vis,
         [ pub(in super::path::to) ],
         "pub(in super::path::to) ",
-        "pub(in super :: path :: to)"
+        "pub(in super::path::to)"
     );
 
     // VisibilityKind::Inherited
@@ -814,19 +805,19 @@ fn test_punct() {
     // Otherwise, any old proc macro that parses pretty-printed code might glue
     // together tokens that shouldn't be glued.
     p!([ = = < < <= <= == == != != >= >= > > ], "= = < < <= <= == == != != >= >= > >");
-    p!([ && && & & || || | | ! ! ], "&& && & & || || | |!!"); // FIXME
+    p!([ && && & & || || | | ! ! ], "&& && & & || || | | ! !");
     p!([ ~ ~ @ @ # # ], "~ ~ @ @ # #");
-    p!([ . . .. .. ... ... ..= ..=], ".... .. ... ... ..= ..="); // FIXME
-    p!([ , , ; ; : : :: :: ], ",, ; ; : : :: ::"); // FIXME
+    p!([ . . .. .. ... ... ..= ..=], ". . .. .. ... ... ..= ..=");
+    p!([ , , ; ; : : :: :: ], ", , ; ; : : :: ::");
     p!([ -> -> <- <- => =>], "-> -> <- <- => =>");
-    p!([ $ $ ? ? ' ' ], "$$? ? ' '"); // FIXME
+    p!([ $ $ ? ? ' ' ], "$ $ ? ? ' '");
     p!([ + + += += - - -= -= * * *= *= / / /= /= ], "+ + += += - - -= -= * * *= *= / / /= /=");
     p!([ % % %= %= ^ ^ ^= ^= << << <<= <<= >> >> >>= >>= ],
         "% % %= %= ^ ^ ^= ^= << << <<= <<= >> >> >>= >>=");
 
     // For these one we must insert spaces between adjacent tokens, again due
     // to proc macros.
-    p!([ +! ?= |> >>@ --> <-- $$ =====> ], "+! ? = | > >> @ - -> <- - $$== == =>"); // FIXME
-    p!([ ,; ;, ** @@ $+$ >< <> ?? +== ], ", ; ;, * * @ @ $+ $> < < > ? ? += ="); // FIXME
-    p!([ :#!@|$=&*,+;*~? ], ": #! @ | $= & *, + ; * ~ ?"); // FIXME
+    p!([ +! ?= |> >>@ --> <-- $$ =====> ], "+ ! ? = | > >> @ - -> <- - $ $ == == =>");
+    p!([ ,; ;, ** @@ $+$ >< <> ?? +== ], ", ; ; , * * @ @ $ + $ > < < > ? ? += =");
+    p!([ :#!@|$=&*,+;*~? ], ": # ! @ | $ = & * , + ; * ~ ?");
 }

--- a/tests/ui/macros/stringify.rs
+++ b/tests/ui/macros/stringify.rs
@@ -115,6 +115,7 @@ fn test_expr() {
         "a + b * c - d + -1 * -2 - -3",
         "a + b * c - d + - 1 * - 2 - - 3"
     );
+    c2!(expr, [ x = !y ], "x = !y", "x =! y"); // FIXME
 
     // ExprKind::Unary
     c2!(expr, [ *expr ], "*expr", "* expr");
@@ -137,6 +138,7 @@ fn test_expr() {
 
     // ExprKind::If
     c1!(expr, [ if true {} ], "if true {}");
+    c2!(expr, [ if !true {} ], "if !true {}", "if! true {}"); // FIXME
     c2!(expr,
         [ if ::std::blah() { } else { } ],
         "if ::std::blah() {} else {}",

--- a/tests/ui/macros/trace-macro.stderr
+++ b/tests/ui/macros/trace-macro.stderr
@@ -5,5 +5,5 @@ LL |     println!("Hello, World!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `println! { "Hello, World!" }`
-   = note: to `{ $crate :: io :: _print($crate :: format_args_nl! ("Hello, World!")) ; }`
+   = note: to `{ $crate::io::_print($crate::format_args_nl!("Hello, World!")); }`
 

--- a/tests/ui/macros/trace_faulty_macros.stderr
+++ b/tests/ui/macros/trace_faulty_macros.stderr
@@ -20,7 +20,7 @@ LL |     my_faulty_macro!();
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `my_faulty_macro! {  }`
-   = note: to `my_faulty_macro! (bcd) ;`
+   = note: to `my_faulty_macro!(bcd);`
    = note: expanding `my_faulty_macro! { bcd }`
 
 error: recursion limit reached while expanding `my_recursive_macro!`
@@ -42,13 +42,13 @@ LL |     my_recursive_macro!();
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `my_recursive_macro! {  }`
-   = note: to `my_recursive_macro! () ;`
+   = note: to `my_recursive_macro!();`
    = note: expanding `my_recursive_macro! {  }`
-   = note: to `my_recursive_macro! () ;`
+   = note: to `my_recursive_macro!();`
    = note: expanding `my_recursive_macro! {  }`
-   = note: to `my_recursive_macro! () ;`
+   = note: to `my_recursive_macro!();`
    = note: expanding `my_recursive_macro! {  }`
-   = note: to `my_recursive_macro! () ;`
+   = note: to `my_recursive_macro!();`
 
 error: expected expression, found `A { a: a, b: 0, c: _, .. }`
   --> $DIR/trace_faulty_macros.rs:16:9
@@ -76,8 +76,8 @@ LL |     let a = pat_macro!();
    |             ^^^^^^^^^^^^
    |
    = note: expanding `pat_macro! {  }`
-   = note: to `pat_macro! (A { a : a, b : 0, c : _, .. }) ;`
-   = note: expanding `pat_macro! { A { a : a, b : 0, c : _, .. } }`
+   = note: to `pat_macro!(A { a: a, b: 0, c: _, .. });`
+   = note: expanding `pat_macro! { A { a: a, b: 0, c: _, .. } }`
    = note: to `A { a: a, b: 0, c: _, .. }`
 
 error: aborting due to 4 previous errors

--- a/tests/ui/proc-macro/allowed-attr-stmt-expr.stdout
+++ b/tests/ui/proc-macro/allowed-attr-stmt-expr.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): struct ItemWithSemi ;
+PRINT-ATTR INPUT (DISPLAY): struct ItemWithSemi;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -45,7 +45,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/allowed-attr-stmt-expr.rs:53:27: 53:29 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[expect_let] let string = "Hello, world!" ;
+PRINT-ATTR INPUT (DISPLAY): #[expect_let] let string = "Hello, world!";
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -87,7 +87,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/allowed-attr-stmt-expr.rs:57:33: 57:34 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[expect_my_macro_stmt] my_macro! ("{}", string) ;
+PRINT-ATTR INPUT (DISPLAY): #[expect_my_macro_stmt] my_macro!("{}", string);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -140,7 +140,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/allowed-attr-stmt-expr.rs:61:28: 61:29 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): second_make_stmt! (#[allow(dead_code)] struct Bar {}) ;
+PRINT-ATTR INPUT (DISPLAY): second_make_stmt!(#[allow(dead_code)] struct Bar {});
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "second_make_stmt",
@@ -288,7 +288,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/allowed-attr-stmt-expr.rs:68:18: 68:20 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] struct NonBracedStruct ;
+PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] struct NonBracedStruct;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',

--- a/tests/ui/proc-macro/attr-complex-fn.stdout
+++ b/tests/ui/proc-macro/attr-complex-fn.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): fn foo < T : MyTrait < MyStruct < { true } >> > () {}
+PRINT-ATTR INPUT (DISPLAY): fn foo< T: MyTrait < MyStruct < { true } >> >() {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",
@@ -76,7 +76,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/attr-complex-fn.rs:19:42: 19:44 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): impl < T > MyTrait < T > for MyStruct < { true } > { #! [rustc_dummy] }
+PRINT-ATTR INPUT (DISPLAY): impl< T > MyTrait < T > for MyStruct < { true } > { # ![rustc_dummy] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "impl",

--- a/tests/ui/proc-macro/attr-stmt-expr.stdout
+++ b/tests/ui/proc-macro/attr-stmt-expr.stdout
@@ -29,7 +29,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/attr-stmt-expr.rs:45:27: 45:29 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[expect_let] let string = "Hello, world!" ;
+PRINT-ATTR INPUT (DISPLAY): #[expect_let] let string = "Hello, world!";
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -71,7 +71,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/attr-stmt-expr.rs:49:33: 49:34 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[expect_my_macro_stmt] my_macro! ("{}", string) ;
+PRINT-ATTR INPUT (DISPLAY): #[expect_my_macro_stmt] my_macro!("{}", string);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -124,7 +124,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/attr-stmt-expr.rs:53:28: 53:29 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): second_make_stmt! (#[allow(dead_code)] struct Bar {}) ;
+PRINT-ATTR INPUT (DISPLAY): second_make_stmt!(#[allow(dead_code)] struct Bar {});
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "second_make_stmt",

--- a/tests/ui/proc-macro/attribute-after-derive.stdout
+++ b/tests/ui/proc-macro/attribute-after-derive.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): #[derive(Print)] struct AttributeDerive { #[cfg(FALSE)] field : u8, }
+PRINT-ATTR INPUT (DISPLAY): #[derive(Print)] struct AttributeDerive { #[cfg(FALSE)] field: u8, }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -130,7 +130,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: $DIR/attribute-after-derive.rs:23:24: 26:2 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): struct DeriveAttribute { #[cfg(FALSE)] field : u8, }
+PRINT-ATTR INPUT (DISPLAY): struct DeriveAttribute { #[cfg(FALSE)] field: u8, }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/tests/ui/proc-macro/attribute-spans-preserved.stdout
+++ b/tests/ui/proc-macro/attribute-spans-preserved.stdout
@@ -1,1 +1,1 @@
-fn main() { let y : u32 = "z" ; { let x : u32 = "y" ; } }
+fn main() { let y: u32 = "z"; { let x: u32 = "y"; } }

--- a/tests/ui/proc-macro/auxiliary/attr-stmt-expr-rpass.rs
+++ b/tests/ui/proc-macro/auxiliary/attr-stmt-expr-rpass.rs
@@ -10,14 +10,14 @@ use proc_macro::TokenStream;
 #[proc_macro_attribute]
 pub fn expect_let(attr: TokenStream, item: TokenStream) -> TokenStream {
     assert!(attr.to_string().is_empty());
-    assert_eq!(item.to_string(), "let string = \"Hello, world!\" ;");
+    assert_eq!(item.to_string(), "let string = \"Hello, world!\";");
     item
 }
 
 #[proc_macro_attribute]
 pub fn expect_print_stmt(attr: TokenStream, item: TokenStream) -> TokenStream {
     assert!(attr.to_string().is_empty());
-    assert_eq!(item.to_string(), "println! (\"{}\", string) ;");
+    assert_eq!(item.to_string(), "println!(\"{}\", string);");
     item
 }
 
@@ -31,7 +31,7 @@ pub fn expect_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn expect_print_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
     assert!(attr.to_string().is_empty());
-    assert_eq!(item.to_string(), "println! (\"{}\", string)");
+    assert_eq!(item.to_string(), "println!(\"{}\", string)");
     item
 }
 

--- a/tests/ui/proc-macro/auxiliary/attr-stmt-expr.rs
+++ b/tests/ui/proc-macro/auxiliary/attr-stmt-expr.rs
@@ -10,14 +10,14 @@ use proc_macro::TokenStream;
 #[proc_macro_attribute]
 pub fn expect_let(attr: TokenStream, item: TokenStream) -> TokenStream {
     assert!(attr.to_string().is_empty());
-    assert_eq!(item.to_string(), "let string = \"Hello, world!\" ;");
+    assert_eq!(item.to_string(), "let string = \"Hello, world!\";");
     item
 }
 
 #[proc_macro_attribute]
 pub fn expect_my_macro_stmt(attr: TokenStream, item: TokenStream) -> TokenStream {
     assert!(attr.to_string().is_empty());
-    assert_eq!(item.to_string(), "my_macro! (\"{}\", string) ;");
+    assert_eq!(item.to_string(), "my_macro!(\"{}\", string);");
     item
 }
 
@@ -31,7 +31,7 @@ pub fn expect_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn expect_my_macro_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
     assert!(attr.to_string().is_empty());
-    assert_eq!(item.to_string(), "my_macro! (\"{}\", string)");
+    assert_eq!(item.to_string(), "my_macro!(\"{}\", string)");
     item
 }
 

--- a/tests/ui/proc-macro/auxiliary/derive-a.rs
+++ b/tests/ui/proc-macro/auxiliary/derive-a.rs
@@ -10,6 +10,6 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(A)]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
-    assert!(input.contains("struct A ;"));
+    assert!(input.contains("struct A;"));
     "".parse().unwrap()
 }

--- a/tests/ui/proc-macro/auxiliary/derive-atob.rs
+++ b/tests/ui/proc-macro/auxiliary/derive-atob.rs
@@ -10,6 +10,6 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(AToB)]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
-    assert_eq!(input, "struct A ;");
+    assert_eq!(input, "struct A;");
     "struct B;".parse().unwrap()
 }

--- a/tests/ui/proc-macro/auxiliary/derive-b-rpass.rs
+++ b/tests/ui/proc-macro/auxiliary/derive-b-rpass.rs
@@ -10,7 +10,7 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(B, attributes(B, C))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
-    assert!(input.contains("#[B [arbitrary tokens]]"));
+    assert!(input.contains("#[B[arbitrary tokens]]"));
     assert!(input.contains("struct B {"));
     assert!(input.contains("#[C]"));
     "".parse().unwrap()

--- a/tests/ui/proc-macro/auxiliary/derive-ctod.rs
+++ b/tests/ui/proc-macro/auxiliary/derive-ctod.rs
@@ -10,6 +10,6 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(CToD)]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
-    assert_eq!(input, "struct C ;");
+    assert_eq!(input, "struct C;");
     "struct D;".parse().unwrap()
 }

--- a/tests/ui/proc-macro/auxiliary/derive-same-struct.rs
+++ b/tests/ui/proc-macro/auxiliary/derive-same-struct.rs
@@ -10,12 +10,12 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(AToB)]
 pub fn derive1(input: TokenStream) -> TokenStream {
     println!("input1: {:?}", input.to_string());
-    assert_eq!(input.to_string(), "struct A ;");
+    assert_eq!(input.to_string(), "struct A;");
     "#[derive(BToC)] struct B;".parse().unwrap()
 }
 
 #[proc_macro_derive(BToC)]
 pub fn derive2(input: TokenStream) -> TokenStream {
-    assert_eq!(input.to_string(), "struct B ;");
+    assert_eq!(input.to_string(), "struct B;");
     "struct C;".parse().unwrap()
 }

--- a/tests/ui/proc-macro/auxiliary/derive-union.rs
+++ b/tests/ui/proc-macro/auxiliary/derive-union.rs
@@ -12,7 +12,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
     assert!(input.contains("#[repr(C)]"));
     assert!(input.contains("union Test {"));
-    assert!(input.contains("a : u8,"));
+    assert!(input.contains("a: u8,"));
     assert!(input.contains("}"));
     "".parse().unwrap()
 }

--- a/tests/ui/proc-macro/auxiliary/expand-with-a-macro.rs
+++ b/tests/ui/proc-macro/auxiliary/expand-with-a-macro.rs
@@ -11,7 +11,7 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(A)]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
-    assert!(input.contains("struct A ;"));
+    assert!(input.contains("struct A;"));
     r#"
         impl A {
             fn a(&self) {

--- a/tests/ui/proc-macro/auxiliary/issue-79825.rs
+++ b/tests/ui/proc-macro/auxiliary/issue-79825.rs
@@ -8,7 +8,7 @@ use proc_macro::TokenStream;
 
 #[proc_macro_attribute]
 pub fn assert_input(args: TokenStream, input: TokenStream) -> TokenStream {
-    assert_eq!(input.to_string(), "trait Alias = Sized ;");
+    assert_eq!(input.to_string(), "trait Alias = Sized;");
     assert!(args.is_empty());
     TokenStream::new()
 }

--- a/tests/ui/proc-macro/capture-macro-rules-invoke.stdout
+++ b/tests/ui/proc-macro/capture-macro-rules-invoke.stdout
@@ -14,7 +14,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
 PRINT-BANG INPUT (DISPLAY): 1 + 1, { "a" }, let a = 1;, String, my_name, 'a, my_val = 30,
 std::option::Option, pub(in some::path) , [a b c], -30
 PRINT-BANG RE-COLLECTED (DISPLAY): 1 + 1, { "a" }, let a = 1, String, my_name, 'a, my_val = 30,
-std :: option :: Option, pub(in some :: path), [a b c], - 30
+std::option::Option, pub(in some::path), [a b c], - 30
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Group {
         delimiter: None,

--- a/tests/ui/proc-macro/cfg-eval-inner.stdout
+++ b/tests/ui/proc-macro/cfg-eval-inner.stdout
@@ -1,9 +1,9 @@
 PRINT-ATTR INPUT (DISPLAY): impl Foo <
-[u8 ;
+[u8;
 {
-    #! [rustc_dummy(cursed_inner)] #! [allow(unused)] struct Inner
-    { field : [u8 ; { #! [rustc_dummy(another_cursed_inner)] 1 }] } 0
-}] > { #! [rustc_dummy(evaluated_attr)] fn bar() {} }
+    # ![rustc_dummy(cursed_inner)] # ![allow(unused)] struct Inner
+    { field: [u8; { # ![rustc_dummy(another_cursed_inner)] 1 }] } 0
+}] > { # ![rustc_dummy(evaluated_attr)] fn bar() {} }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "impl",

--- a/tests/ui/proc-macro/cfg-eval.stdout
+++ b/tests/ui/proc-macro/cfg-eval.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): struct S1 { #[cfg(all())] #[allow()] field_true : u8, }
+PRINT-ATTR INPUT (DISPLAY): struct S1 { #[cfg(all())] #[allow()] field_true: u8, }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/tests/ui/proc-macro/derive-same-struct.stdout
+++ b/tests/ui/proc-macro/derive-same-struct.stdout
@@ -1,1 +1,1 @@
-input1: "struct A ;"
+input1: "struct A;"

--- a/tests/ui/proc-macro/doc-comment-preserved.stdout
+++ b/tests/ui/proc-macro/doc-comment-preserved.stdout
@@ -5,8 +5,8 @@ PRINT-BANG INPUT (DISPLAY): /**
 * DOC *
 *******
 */
- pub struct S ;
-PRINT-BANG RE-COLLECTED (DISPLAY): #[doc = "\n*******\n* DOC *\n* DOC *\n* DOC *\n*******\n"] pub struct S ;
+ pub struct S;
+PRINT-BANG RE-COLLECTED (DISPLAY): #[doc = "\n*******\n* DOC *\n* DOC *\n* DOC *\n*******\n"] pub struct S;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',

--- a/tests/ui/proc-macro/dollar-crate-issue-57089.stdout
+++ b/tests/ui/proc-macro/dollar-crate-issue-57089.stdout
@@ -1,4 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): struct M($crate :: S) ;
+PRINT-BANG INPUT (DISPLAY): struct M($crate::S);
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -38,7 +38,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
         span: $DIR/dollar-crate-issue-57089.rs:17:32: 17:33 (#3),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): struct A($crate :: S) ;
+PRINT-ATTR INPUT (DISPLAY): struct A($crate::S);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/tests/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/tests/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): struct A(identity! ($crate :: S)) ;
+PRINT-ATTR INPUT (DISPLAY): struct A(identity!($crate::S));
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -53,7 +53,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/dollar-crate-issue-62325.rs:19:35: 19:36 (#3),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): struct B(identity! ($crate :: S)) ;
+PRINT-ATTR INPUT (DISPLAY): struct B(identity!($crate::S));
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/tests/ui/proc-macro/dollar-crate.stdout
+++ b/tests/ui/proc-macro/dollar-crate.stdout
@@ -1,4 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): struct M($crate :: S) ;
+PRINT-BANG INPUT (DISPLAY): struct M($crate::S);
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -38,7 +38,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
         span: $DIR/dollar-crate.rs:20:36: 20:37 (#3),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): struct A($crate :: S) ;
+PRINT-ATTR INPUT (DISPLAY): struct A($crate::S);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -78,7 +78,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/dollar-crate.rs:24:32: 24:33 (#3),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): struct D($crate :: S) ;
+PRINT-DERIVE INPUT (DISPLAY): struct D($crate::S);
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -118,7 +118,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: $DIR/dollar-crate.rs:27:32: 27:33 (#3),
     },
 ]
-PRINT-BANG INPUT (DISPLAY): struct M($crate :: S) ;
+PRINT-BANG INPUT (DISPLAY): struct M($crate::S);
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -158,7 +158,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
         span: $DIR/auxiliary/dollar-crate-external.rs:7:32: 7:33 (#14),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): struct A($crate :: S) ;
+PRINT-ATTR INPUT (DISPLAY): struct A($crate::S);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -198,7 +198,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/auxiliary/dollar-crate-external.rs:11:28: 11:29 (#14),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): struct D($crate :: S) ;
+PRINT-DERIVE INPUT (DISPLAY): struct D($crate::S);
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/tests/ui/proc-macro/expand-to-derive.stdout
+++ b/tests/ui/proc-macro/expand-to-derive.stdout
@@ -1,7 +1,7 @@
 PRINT-DERIVE INPUT (DISPLAY): struct Foo
 {
-    field :
-    [bool ; { #[rustc_dummy] struct Inner { other_inner_field : u8, } 0 }]
+    field:
+    [bool; { #[rustc_dummy] struct Inner { other_inner_field: u8, } 0 }]
 }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {

--- a/tests/ui/proc-macro/expr-stmt-nonterminal-tokens.stdout
+++ b/tests/ui/proc-macro/expr-stmt-nonterminal-tokens.stdout
@@ -1,5 +1,5 @@
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = #[allow(warnings)] 0 ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = #[allow(warnings)] #[allow(warnings)] 0 ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = #[allow(warnings)] 0; 0 }, }
+PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = #[allow(warnings)] #[allow(warnings)] 0; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -122,8 +122,8 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #3 bytes(306..355),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0; } ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { 0 } ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0; }; 0 }, }
+PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { 0 }; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -202,7 +202,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #7 bytes(430..483),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { {} } ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { {} }; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -280,8 +280,8 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #11 bytes(430..483),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH; } ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { PATH } ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH; }; 0 }, }
+PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { PATH }; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -358,8 +358,8 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #15 bytes(430..483),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0 + 1; } ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { 0 + 1 } ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0 + 1; }; 0 }, }
+PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { 0 + 1 }; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -449,8 +449,8 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #19 bytes(430..483),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH + 1; } ; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { PATH + 1 } ; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH + 1; }; 0 }, }
+PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { PATH + 1 }; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",

--- a/tests/ui/proc-macro/inert-attribute-order.stdout
+++ b/tests/ui/proc-macro/inert-attribute-order.stdout
@@ -1,7 +1,7 @@
 PRINT-ATTR INPUT (DISPLAY): /// 1
-#[rustfmt :: attr2] #[doc = "3"] #[doc = "4"] #[rustfmt :: attr5] /// 6
-#[print_attr(nodebug)] struct S ;
-PRINT-ATTR RE-COLLECTED (DISPLAY): #[doc = " 1"] #[rustfmt :: attr2] #[doc = "3"] #[doc = "4"]
-#[rustfmt :: attr5] #[doc = " 6"] #[print_attr(nodebug)] struct S ;
-PRINT-ATTR INPUT (DISPLAY): #[doc = " 1"] #[rustfmt :: attr2] #[doc = "3"] #[doc = "4"]
-#[rustfmt :: attr5] #[doc = " 6"] struct S ;
+#[rustfmt::attr2] #[doc = "3"] #[doc = "4"] #[rustfmt::attr5] /// 6
+#[print_attr(nodebug)] struct S;
+PRINT-ATTR RE-COLLECTED (DISPLAY): #[doc = " 1"] #[rustfmt::attr2] #[doc = "3"] #[doc = "4"] #[rustfmt::attr5]
+#[doc = " 6"] #[print_attr(nodebug)] struct S;
+PRINT-ATTR INPUT (DISPLAY): #[doc = " 1"] #[rustfmt::attr2] #[doc = "3"] #[doc = "4"] #[rustfmt::attr5]
+#[doc = " 6"] struct S;

--- a/tests/ui/proc-macro/inner-attr-non-inline-mod.stdout
+++ b/tests/ui/proc-macro/inner-attr-non-inline-mod.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { #! [rustfmt :: skip] }
+PRINT-ATTR INPUT (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { # ![rustfmt::skip] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',

--- a/tests/ui/proc-macro/inner-attrs.stdout
+++ b/tests/ui/proc-macro/inner-attrs.stdout
@@ -6,7 +6,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): #[print_target_and_args(second)] fn foo()
-{ #! [print_target_and_args(third)] #! [print_target_and_args(fourth)] }
+{ # ![print_target_and_args(third)] # ![print_target_and_args(fourth)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -121,7 +121,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): fn foo()
-{ #! [print_target_and_args(third)] #! [print_target_and_args(fourth)] }
+{ # ![print_target_and_args(third)] # ![print_target_and_args(fourth)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",
@@ -210,7 +210,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/inner-attrs.rs:20:30: 20:35 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): fn foo() { #! [print_target_and_args(fourth)] }
+PRINT-ATTR INPUT (DISPLAY): fn foo() { # ![print_target_and_args(fourth)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",
@@ -299,8 +299,8 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
 ]
 PRINT-ATTR INPUT (DISPLAY): #[print_target_and_args(mod_second)] mod inline_mod
 {
-    #! [print_target_and_args(mod_third)] #!
-    [print_target_and_args(mod_fourth)]
+    # ![print_target_and_args(mod_third)] #
+    ![print_target_and_args(mod_fourth)]
 }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
@@ -412,8 +412,8 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
 ]
 PRINT-ATTR INPUT (DISPLAY): mod inline_mod
 {
-    #! [print_target_and_args(mod_third)] #!
-    [print_target_and_args(mod_fourth)]
+    # ![print_target_and_args(mod_third)] #
+    ![print_target_and_args(mod_fourth)]
 }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
@@ -498,7 +498,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/inner-attrs.rs:27:30: 27:39 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): mod inline_mod { #! [print_target_and_args(mod_fourth)] }
+PRINT-ATTR INPUT (DISPLAY): mod inline_mod { # ![print_target_and_args(mod_fourth)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "mod",
@@ -569,10 +569,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct MyDerivePrint
-{
-    field :
-    [u8 ; { match true { _ => { #! [rustc_dummy(third)] true } } ; 0 }]
-}
+{ field: [u8; { match true { _ => { # ![rustc_dummy(third)] true } }; 0 }] }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -705,7 +702,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/inner-attrs.rs:49:29: 49:40 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): (3, 4, { #! [cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 }) ;
+PRINT-ATTR INPUT (DISPLAY): (3, 4, { # ![cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 });
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Group {
         delimiter: Parenthesis,
@@ -819,7 +816,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/inner-attrs.rs:56:29: 56:40 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): (3, 4, { #! [cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 }) ;
+PRINT-ATTR INPUT (DISPLAY): (3, 4, { # ![cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 });
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Group {
         delimiter: Parenthesis,

--- a/tests/ui/proc-macro/input-interpolated.stdout
+++ b/tests/ui/proc-macro/input-interpolated.stdout
@@ -5,7 +5,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
         span: #0 bytes(503..504),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): const A : u8 = 0 ;
+PRINT-ATTR INPUT (DISPLAY): const A: u8 = 0;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "const",

--- a/tests/ui/proc-macro/issue-75734-pp-paren.stdout
+++ b/tests/ui/proc-macro/issue-75734-pp-paren.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): fn main() { & | _ : u8 | {} ; mul_2! (1 + 1) ; }
+PRINT-ATTR INPUT (DISPLAY): fn main() { & | _: u8 | {}; mul_2!(1 + 1); }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
@@ -1,26 +1,26 @@
 PRINT-ATTR INPUT (DISPLAY): #[print_helper(a)] #[allow(dead_code)] #[derive(Print)] #[print_helper(b)]
 struct Foo < #[cfg(FALSE)] A, B >
 {
-    #[cfg(FALSE)] first : String, #[cfg_attr(FALSE, deny(warnings))] second :
-    bool, third :
-    [u8 ;
+    #[cfg(FALSE)] first: String, #[cfg_attr(FALSE, deny(warnings))] second:
+    bool, third:
+    [u8;
     {
-        #[cfg(FALSE)] struct Bar ; #[cfg(not(FALSE))] struct Inner ;
-        #[cfg(FALSE)] let a = 25 ; match true
+        #[cfg(FALSE)] struct Bar; #[cfg(not(FALSE))] struct Inner;
+        #[cfg(FALSE)] let a = 25; match true
         {
             #[cfg(FALSE)] true => {}, #[cfg_attr(not(FALSE), allow(warnings))]
             false => {}, _ => {}
-        } ; #[print_helper(should_be_removed)] fn removed_fn()
-        { #! [cfg(FALSE)] } #[print_helper(c)] #[cfg(not(FALSE))] fn kept_fn()
-        { #! [cfg(not(FALSE))] let my_val = true ; } enum TupleEnum
+        }; #[print_helper(should_be_removed)] fn removed_fn()
+        { # ![cfg(FALSE)] } #[print_helper(c)] #[cfg(not(FALSE))] fn kept_fn()
+        { # ![cfg(not(FALSE))] let my_val = true; } enum TupleEnum
         {
             Foo(#[cfg(FALSE)] u8, #[cfg(FALSE)] bool, #[cfg(not(FALSE))] i32,
             #[cfg(FALSE)] String, u8)
         } struct
         TupleStruct(#[cfg(FALSE)] String, #[cfg(not(FALSE))] i32,
-        #[cfg(FALSE)] bool, u8) ; fn plain_removed_fn()
-        { #! [cfg_attr(not(FALSE), cfg(FALSE))] } 0
-    }], #[print_helper(d)] fourth : B
+        #[cfg(FALSE)] bool, u8); fn plain_removed_fn()
+        { # ![cfg_attr(not(FALSE), cfg(FALSE))] } 0
+    }], #[print_helper(d)] fourth: B
 }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
@@ -1274,16 +1274,16 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
 ]
 PRINT-DERIVE INPUT (DISPLAY): #[print_helper(a)] #[allow(dead_code)] #[print_helper(b)] struct Foo < B >
 {
-    second : bool, third :
-    [u8 ;
+    second: bool, third:
+    [u8;
     {
-        #[cfg(not(FALSE))] struct Inner ; match true
-        { #[allow(warnings)] false => {}, _ => {} } ; #[print_helper(c)]
+        #[cfg(not(FALSE))] struct Inner; match true
+        { #[allow(warnings)] false => {}, _ => {} }; #[print_helper(c)]
         #[cfg(not(FALSE))] fn kept_fn()
-        { #! [cfg(not(FALSE))] let my_val = true ; } enum TupleEnum
+        { # ![cfg(not(FALSE))] let my_val = true; } enum TupleEnum
         { Foo(#[cfg(not(FALSE))] i32, u8) } struct
-        TupleStruct(#[cfg(not(FALSE))] i32, u8) ; 0
-    }], #[print_helper(d)] fourth : B
+        TupleStruct(#[cfg(not(FALSE))] i32, u8); 0
+    }], #[print_helper(d)] fourth: B
 }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Punct {

--- a/tests/ui/proc-macro/issue-76182-leading-vert-pat.stdout
+++ b/tests/ui/proc-macro/issue-76182-leading-vert-pat.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): fn main() { match() { | () => () } }
+PRINT-ATTR INPUT (DISPLAY): fn main() { match () { | () => () } }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",

--- a/tests/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
+++ b/tests/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
@@ -1,7 +1,7 @@
 PRINT-BANG INPUT (DISPLAY): foo! { #[fake_attr] mod bar {
     #![doc = r" Foo"]
 } }
-PRINT-BANG DEEP-RE-COLLECTED (DISPLAY): foo! { #[fake_attr] mod bar { #! [doc = r" Foo"] } }
+PRINT-BANG DEEP-RE-COLLECTED (DISPLAY): foo! { #[fake_attr] mod bar { # ![doc = r" Foo"] } }
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "foo",

--- a/tests/ui/proc-macro/keep-expr-tokens.stdout
+++ b/tests/ui/proc-macro/keep-expr-tokens.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] { 1 + 1 ; }
+PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] { 1 + 1; }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',

--- a/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
+++ b/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
@@ -1,10 +1,10 @@
 PRINT-DERIVE INPUT (DISPLAY): struct Foo
 {
-    val :
-    [bool ;
+    val:
+    [bool;
     {
         let a = #[rustc_dummy(first)] #[rustc_dummy(second)]
-        { #! [allow(unused)] 30 } ; 0
+        { # ![allow(unused)] 30 }; 0
     }]
 }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [

--- a/tests/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/tests/ui/proc-macro/meta-macro-hygiene.stdout
@@ -32,13 +32,13 @@ macro_rules! produce_it
     */ {
     () =>
     {
-        meta_macro :: print_def_site! ($crate :: dummy! ()) ;
+        meta_macro::print_def_site!($crate::dummy!());
         // `print_def_site!` will respan the `$crate` identifier
         // with `Span::def_site()`. This should cause it to resolve
         // relative to `meta_macro`, *not* `make_macro` (despite
         // the fact that `print_def_site` is produced by a
         // `macro_rules!` macro in `make_macro`).
-    } ;
+    };
 }
 
 fn main /* 0#0 */() { ; }

--- a/tests/ui/proc-macro/nested-derive-cfg.stdout
+++ b/tests/ui/proc-macro/nested-derive-cfg.stdout
@@ -1,5 +1,5 @@
 PRINT-DERIVE INPUT (DISPLAY): struct Foo
-{ my_array : [bool ; { struct Inner { non_removed_inner_field : usize } 0 }] }
+{ my_array: [bool; { struct Inner { non_removed_inner_field: usize } 0 }] }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/tests/ui/proc-macro/nonterminal-expansion.stdout
+++ b/tests/ui/proc-macro/nonterminal-expansion.stdout
@@ -1,5 +1,4 @@
 PRINT-ATTR_ARGS INPUT (DISPLAY): a, line!(), b
-PRINT-ATTR_ARGS RE-COLLECTED (DISPLAY): a, line! (), b
 PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     Ident {
         ident: "a",

--- a/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
+++ b/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
@@ -1,5 +1,4 @@
 PRINT-BANG INPUT (DISPLAY): struct S;
-PRINT-BANG RE-COLLECTED (DISPLAY): struct S ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Group {
         delimiter: None,
@@ -51,11 +50,11 @@ macro_rules! outer
     /*
     0#0
     */ {
-    ($item : item) =>
+    ($item: item) =>
     {
-        macro inner() { print_bang! { $item } } inner! () ;
+        macro inner() { print_bang! { $item } } inner!();
 
-    } ;
+    };
 }
 
 struct S /* 0#0 */;

--- a/tests/ui/proc-macro/pretty-print-tts.stdout
+++ b/tests/ui/proc-macro/pretty-print-tts.stdout
@@ -1,4 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): { #! [rustc_dummy] let a = "hello".len() ; matches! (a, 5) ; }
+PRINT-BANG INPUT (DISPLAY): { # ![rustc_dummy] let a = "hello".len(); matches!(a, 5); }
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Group {
         delimiter: Brace,

--- a/tests/ui/proc-macro/trailing-plus.stdout
+++ b/tests/ui/proc-macro/trailing-plus.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): fn foo < T > () where T : Copy + {}
+PRINT-ATTR INPUT (DISPLAY): fn foo< T >() where T: Copy + {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",

--- a/tests/ui/proc-macro/weird-braces.stdout
+++ b/tests/ui/proc-macro/weird-braces.stdout
@@ -8,8 +8,8 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
 PRINT-ATTR INPUT (DISPLAY): #[print_target_and_args(second_outer)] impl Bar < { 1 > 0 } > for Foo <
 { true } >
 {
-    #! [print_target_and_args(first_inner)] #!
-    [print_target_and_args(second_inner)]
+    # ![print_target_and_args(first_inner)] #
+    ![print_target_and_args(second_inner)]
 }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
@@ -182,8 +182,8 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
 ]
 PRINT-ATTR INPUT (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
 {
-    #! [print_target_and_args(first_inner)] #!
-    [print_target_and_args(second_inner)]
+    # ![print_target_and_args(first_inner)] #
+    ![print_target_and_args(second_inner)]
 }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
@@ -330,7 +330,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
-{ #! [print_target_and_args(second_inner)] }
+{ # ![print_target_and_args(second_inner)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "impl",

--- a/tests/ui/rfcs/rfc-2565-param-attrs/auxiliary/param-attrs.rs
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/auxiliary/param-attrs.rs
@@ -17,27 +17,27 @@ macro_rules! checker {
     }
 }
 
-checker!(attr_extern, r#"extern "C" { fn ffi(#[a1] arg1 : i32, #[a2] ...) ; }"#);
-checker!(attr_extern_cvar, r#"unsafe extern "C" fn cvar(arg1 : i32, #[a1] mut args : ...) {}"#);
-checker!(attr_alias, "type Alias = fn(#[a1] u8, #[a2] ...) ;");
-checker!(attr_free, "fn free(#[a1] arg1 : u8) { let lam = | #[a2] W(x), #[a3] y | () ; }");
-checker!(attr_inherent_1, "fn inherent1(#[a1] self, #[a2] arg1 : u8) {}");
-checker!(attr_inherent_2, "fn inherent2(#[a1] & self, #[a2] arg1 : u8) {}");
-checker!(attr_inherent_3, "fn inherent3 < 'a > (#[a1] & 'a mut self, #[a2] arg1 : u8) {}");
-checker!(attr_inherent_4, "fn inherent4 < 'a > (#[a1] self : Box < Self >, #[a2] arg1 : u8) {}");
-checker!(attr_inherent_issue_64682, "fn inherent5(#[a1] #[a2] arg1 : u8, #[a3] arg2 : u8) {}");
-checker!(attr_trait_1, "fn trait1(#[a1] self, #[a2] arg1 : u8) ;");
-checker!(attr_trait_2, "fn trait2(#[a1] & self, #[a2] arg1 : u8) ;");
-checker!(attr_trait_3, "fn trait3 < 'a > (#[a1] & 'a mut self, #[a2] arg1 : u8) ;");
-checker!(attr_trait_4, r#"fn trait4 < 'a >
-(#[a1] self : Box < Self >, #[a2] arg1 : u8, #[a3] Vec < u8 >) ;"#);
-checker!(attr_trait_issue_64682, "fn trait5(#[a1] #[a2] arg1 : u8, #[a3] arg2 : u8) ;");
+checker!(attr_extern, r#"extern "C" { fn ffi(#[a1] arg1: i32, #[a2] ...); }"#);
+checker!(attr_extern_cvar, r#"unsafe extern "C" fn cvar(arg1: i32, #[a1] mut args: ...) {}"#);
+checker!(attr_alias, "type Alias = fn(#[a1] u8, #[a2] ...);");
+checker!(attr_free, "fn free(#[a1] arg1: u8) { let lam = | #[a2] W(x), #[a3] y | (); }");
+checker!(attr_inherent_1, "fn inherent1(#[a1] self, #[a2] arg1: u8) {}");
+checker!(attr_inherent_2, "fn inherent2(#[a1] & self, #[a2] arg1: u8) {}");
+checker!(attr_inherent_3, "fn inherent3< 'a >(#[a1] & 'a mut self, #[a2] arg1: u8) {}");
+checker!(attr_inherent_4, "fn inherent4< 'a >(#[a1] self: Box < Self > , #[a2] arg1: u8) {}");
+checker!(attr_inherent_issue_64682, "fn inherent5(#[a1] #[a2] arg1: u8, #[a3] arg2: u8) {}");
+checker!(attr_trait_1, "fn trait1(#[a1] self, #[a2] arg1: u8);");
+checker!(attr_trait_2, "fn trait2(#[a1] & self, #[a2] arg1: u8);");
+checker!(attr_trait_3, "fn trait3< 'a >(#[a1] & 'a mut self, #[a2] arg1: u8);");
+checker!(attr_trait_4,
+    r#"fn trait4< 'a >(#[a1] self: Box < Self > , #[a2] arg1: u8, #[a3] Vec < u8 >);"#);
+checker!(attr_trait_issue_64682, "fn trait5(#[a1] #[a2] arg1: u8, #[a3] arg2: u8);");
 checker!(rename_params, r#"impl Foo
 {
-    fn hello(#[angery(true)] a : i32, #[a2] b : i32, #[what = "how"] c : u32)
+    fn hello(#[angery(true)] a: i32, #[a2] b: i32, #[what = "how"] c: u32) {}
+    fn
+    hello2(#[a1] #[a2] a: i32, #[what = "how"] b: i32, #[angery(true)] c: u32)
     {} fn
-    hello2(#[a1] #[a2] a : i32, #[what = "how"] b : i32, #[angery(true)] c :
-    u32) {} fn
-    hello_self(#[a1] #[a2] & self, #[a1] #[a2] a : i32, #[what = "how"] b :
-    i32, #[angery(true)] c : u32) {}
+    hello_self(#[a1] #[a2] & self, #[a1] #[a2] a: i32, #[what = "how"] b: i32,
+    #[angery(true)] c: u32) {}
 }"#);


### PR DESCRIPTION
`space_between` currently handles a few cases that make the output nicer. It also gets some cases wrong. This PR fixes the wrong cases, and adds a bunch of extra cases, resulting in prettier output. E.g. these lines:
```
use smallvec :: SmallVec ;
assert! (mem :: size_of :: < T > () != 0) ;
```
become these lines:
```
use smallvec::SmallVec;
assert!(mem::size_of:: < T >() != 0);
```
This overlaps with #114571, but this PR has the crucial characteristic of giving the same results for all token streams, including those generated by proc macros. For that reason I think it's worth having even if/when #114571 is merged. It's also nice that this PR's improvements can be obtained by modifying only `space_between`.

r? @petrochenkov 